### PR TITLE
Suggest installing over https instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This repo is currently copied over during deployment, please refer to https://do
 # Install
 
 ```
-python -m pip install git+ssh://git@github.com/visivo-io/visivo.git --force-reinstall
+python -m pip install git+https://github.com/visivo-io/visivo.git --force-reinstall
 ```


### PR DESCRIPTION
This is helpful for unauthenticated access, such as when installing visivo in CI or a build.

```
root@f29deb82df94:/# git clone ssh://git@github.com/visivo-io/visivo.git                                                                                                                                                                                                                                                                                                  Cloning into 'visivo'...                                                                                                                                                                                                                                                                                                                                                  
git@github.com: Permission denied (publickey).                                                                                                                                                                                                                                                                                                                            
fatal: Could not read from remote repository.          

Please make sure you have the correct access rights
and the repository exists.
```

```
root@f29deb82df94:/# git clone https://github.com/visivo-io/visivo.git
Cloning into 'visivo'...
remote: Enumerating objects: 1986, done.
remote: Counting objects: 100% (439/439), done.
remote: Compressing objects: 100% (186/186), done.
remote: Total 1986 (delta 195), reused 354 (delta 178), pack-reused 1547
Receiving objects: 100% (1986/1986), 13.83 MiB | 3.25 MiB/s, done.
Resolving deltas: 100% (957/957), done.
```