### PR TITLE
Serve, run, and compile a subset of items

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-0.2.0-py3-none-any.whl 
+        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl 
       
       - name: Install Dependencies
         run: cd test-projects/ror && bundle install && cd ../..
@@ -88,7 +88,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-0.2.0-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
       
       - name: Test App
         run: |
@@ -141,7 +141,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-0.2.0-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
 
       - name: Test Simple Project Run
         run: |
@@ -165,7 +165,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-0.2.0-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
       
       - name: Test App
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl 
+        run: poetry build && pip install dist/visivo-*-py3-none-any.whl 
       
       - name: Install Dependencies
         run: cd test-projects/ror && bundle install && cd ../..
@@ -88,7 +88,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-*-py3-none-any.whl 
       
       - name: Test App
         run: |
@@ -141,7 +141,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-*-py3-none-any.whl 
 
       - name: Test Simple Project Run
         run: |
@@ -165,7 +165,7 @@ jobs:
         run: poetry install
       
       - name: Install CLI Visivo Package
-        run: poetry build && pip install dist/visivo-1.0.5-py3-none-any.whl
+        run: poetry build && pip install dist/visivo-*-py3-none-any.whl 
       
       - name: Test App
         run: |

--- a/tests/commands/test_compile_phase.py
+++ b/tests/commands/test_compile_phase.py
@@ -1,0 +1,31 @@
+import os
+import json
+from tests.factories.model_factories import DashboardFactory, ProjectFactory
+from tests.support.utils import temp_file, temp_folder, temp_yml_file
+from visivo.commands.compile_phase import compile_phase
+from visivo.commands.utils import create_file_database
+from visivo.parsers.core_parser import PROFILE_FILE_NAME, PROJECT_FILE_NAME
+
+
+def test_filtered_dashboard():
+    output_dir = temp_folder()
+    project = ProjectFactory()
+    additional_dashboard = DashboardFactory(name="Other Dashboard")
+    additional_dashboard.rows[0].items[0].chart.name = "Additional Chart"
+    additional_dashboard.rows[0].items[0].chart.traces[0].name = "Additional Trace"
+    additional_dashboard.rows[0].items[0].chart.traces[0].model.name = "Additional Model"
+    project.dashboards.append(additional_dashboard)
+    create_file_database(url=project.targets[0].url(), output_dir=output_dir)
+
+    tmp = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
+    working_dir = os.path.dirname(tmp)
+
+    compile_phase(
+        default_target="target",
+        working_dir=working_dir,
+        output_dir=output_dir,
+        name_filter="dashboard",
+    )
+    assert "Additional Trace" not in os.listdir(output_dir)
+    assert "trace" in os.listdir(output_dir)
+ 

--- a/tests/commands/test_run_phase.py
+++ b/tests/commands/test_run_phase.py
@@ -1,0 +1,35 @@
+import os
+import json
+from unittest.mock import patch
+from tests.factories.model_factories import DashboardFactory, ProjectFactory
+from tests.support.utils import temp_folder, temp_yml_file
+from visivo.commands.run_phase import run_phase
+from visivo.commands.utils import create_file_database
+from visivo.parsers.core_parser import PROFILE_FILE_NAME, PROJECT_FILE_NAME
+from visivo.query.runner import Runner
+from unittest.mock import ANY
+
+
+@patch.object(Runner, '__new__')
+def test_filtered_dashboard(mock_method):
+    output_dir = temp_folder()
+    project = ProjectFactory()
+    trace = project.dashboards[0].rows[0].items[0].chart.traces[0]
+    additional_dashboard = DashboardFactory(name="Other Dashboard")
+    additional_dashboard.rows[0].items[0].chart.name = "Additional Chart"
+    additional_dashboard.rows[0].items[0].chart.traces[0].name = "Additional Trace"
+    additional_dashboard.rows[0].items[0].chart.traces[0].model.name = "Additional Model"
+    project.dashboards.append(additional_dashboard)
+    create_file_database(url=project.targets[0].url(), output_dir=output_dir)
+
+    tmp = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
+    working_dir = os.path.dirname(tmp)
+
+    run_phase(
+        default_target="target",
+        working_dir=working_dir,
+        output_dir=output_dir,
+        name_filter="dashboard",
+    )
+    mock_method.assert_called_with(Runner, **{'traces': [trace], "project":ANY, "default_target":ANY, "output_dir":ANY})
+ 

--- a/tests/commands/test_run_phase.py
+++ b/tests/commands/test_run_phase.py
@@ -10,8 +10,7 @@ from visivo.query.runner import Runner
 from unittest.mock import ANY
 
 
-@patch.object(Runner, '__new__')
-def test_filtered_dashboard(mock_method):
+def test_filtered_dashboard():
     output_dir = temp_folder()
     project = ProjectFactory()
     trace = project.dashboards[0].rows[0].items[0].chart.traces[0]
@@ -25,11 +24,11 @@ def test_filtered_dashboard(mock_method):
     tmp = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
     working_dir = os.path.dirname(tmp)
 
-    run_phase(
+    runner = run_phase(
         default_target="target",
         working_dir=working_dir,
         output_dir=output_dir,
         name_filter="dashboard",
     )
-    mock_method.assert_called_with(Runner, **{'traces': [trace], "project":ANY, "default_target":ANY, "output_dir":ANY})
- 
+    assert runner.traces == [trace]
+    

--- a/tests/commands/test_serve.py
+++ b/tests/commands/test_serve.py
@@ -24,6 +24,7 @@ def test_serve():
         working_dir=working_dir,
         output_dir=output_dir,
         default_target="target",
+        name_filter=None,
     )
 
     client = app.test_client()

--- a/tests/commands/test_serve_phase.py
+++ b/tests/commands/test_serve_phase.py
@@ -26,4 +26,5 @@ def test_get_project_json():
     working_dir = os.path.dirname(tmp)
 
     project_json = get_project_json(output_dir=working_dir, name_filter="dashboard")
+    assert len(project_json["dashboards"]) == 1
  

--- a/tests/commands/test_serve_phase.py
+++ b/tests/commands/test_serve_phase.py
@@ -1,0 +1,29 @@
+import os
+import json
+from unittest.mock import patch
+from tests.factories.model_factories import DashboardFactory, ProjectFactory
+from tests.support.utils import temp_file, temp_folder, temp_yml_file
+from visivo.commands.run_phase import run_phase
+from visivo.commands.serve_phase import get_project_json
+from visivo.commands.utils import create_file_database
+from visivo.parsers.core_parser import PROFILE_FILE_NAME, PROJECT_FILE_NAME
+from visivo.query.runner import Runner
+from unittest.mock import ANY
+
+
+def test_get_project_json():
+    output_dir = temp_folder()
+    project = ProjectFactory()
+    trace = project.dashboards[0].rows[0].items[0].chart.traces[0]
+    additional_dashboard = DashboardFactory(name="Other Dashboard")
+    additional_dashboard.rows[0].items[0].chart.name = "Additional Chart"
+    additional_dashboard.rows[0].items[0].chart.traces[0].name = "Additional Trace"
+    additional_dashboard.rows[0].items[0].chart.traces[0].model.name = "Additional Model"
+    project.dashboards.append(additional_dashboard)
+    create_file_database(url=project.targets[0].url(), output_dir=output_dir)
+
+    tmp = temp_file(contents=project.model_dump_json(), name="project.json")
+    working_dir = os.path.dirname(tmp)
+
+    project_json = get_project_json(output_dir=working_dir, name_filter="dashboard")
+ 

--- a/visivo/commands/compile.py
+++ b/visivo/commands/compile.py
@@ -1,12 +1,13 @@
 import click
-from .options import output_dir, working_dir, target
+from .options import output_dir, working_dir, target, name_filter
 
 
 @click.command()
 @target
 @working_dir
 @output_dir
-def compile(working_dir, output_dir, target):
+@name_filter
+def compile(working_dir, output_dir, target, name_filter):
     """
     Parses the files in your working directory, extracting visivo configurations and then using those configurations to build the trace queries and a project.json file in your target directory. Queries are not run on compile, just written.
     """
@@ -16,5 +17,5 @@ def compile(working_dir, output_dir, target):
 
     from visivo.commands.compile_phase import compile_phase
 
-    compile_phase(default_target=target, working_dir=working_dir, output_dir=output_dir)
+    compile_phase(default_target=target, working_dir=working_dir, output_dir=output_dir, name_filter=name_filter)
     Logger.instance().success("Done")

--- a/visivo/commands/compile_phase.py
+++ b/visivo/commands/compile_phase.py
@@ -14,7 +14,7 @@ from visivo.commands.utils import find_or_create_target
 from visivo.logging.logger import Logger
 
 
-def compile_phase(default_target: str, working_dir: str, output_dir: str):
+def compile_phase(default_target: str, working_dir: str, output_dir: str, name_filter: str = None):
     Logger.instance().debug("Compiling project")
     discover = Discover(working_directory=working_dir)
     parser = ParserFactory().build(
@@ -39,7 +39,7 @@ def compile_phase(default_target: str, working_dir: str, output_dir: str):
         fp.write(serializer.dereference().model_dump_json(exclude_none=True))
 
     dag = project.dag()
-    for trace in ParentModel.all_descendants_of_type(type=Trace, dag=dag):
+    for trace in project.filter_traces(name_filter=name_filter):
         model = ParentModel.all_descendants_of_type(
             type=Model, dag=dag, from_node=trace
         )[0]

--- a/visivo/commands/options.py
+++ b/visivo/commands/options.py
@@ -24,7 +24,15 @@ def output_dir(function):
     )(function)
     return function
 
-
+def name_filter(function):
+    click.option(
+        "-nf",
+        "--name-filter",
+        help="Run the command to only include the dag that includes the node with the given name",
+        default=None,
+    )(function)
+    return function
+    
 def target(function):
     click.option(
         "-t",
@@ -80,13 +88,6 @@ def host(function):
         "--host",
         help="Host to deploy to",
         default=f"https://app.visivo.io",
-    )(function)
-    return function
-
-
-def trace_filter(function):
-    click.option(
-        "-tf", "--trace-filter", help="Run traces that match this filter", default=".*"
     )(function)
     return function
 

--- a/visivo/commands/run.py
+++ b/visivo/commands/run.py
@@ -1,13 +1,13 @@
 import click
-from visivo.commands.options import output_dir, working_dir, target, trace_filter
+from visivo.commands.options import output_dir, working_dir, target, name_filter
 
 
 @click.command()
-@trace_filter
 @target
 @working_dir
 @output_dir
-def run(output_dir, working_dir, target, trace_filter):
+@name_filter
+def run(output_dir, working_dir, target, name_filter):
     """
     Compiles the project and then runs the trace queries to fetch data to populate in the traces. Writes all data to the target directory.
     """
@@ -22,6 +22,6 @@ def run(output_dir, working_dir, target, trace_filter):
         default_target=target,
         output_dir=output_dir,
         working_dir=working_dir,
-        trace_filter=trace_filter,
+        name_filter=name_filter,
     )
     Logger.instance().success("Done")

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -8,20 +8,19 @@ def run_phase(
     default_target: str,
     output_dir: str,
     working_dir: str,
-    trace_filter: str = ".*",
+    name_filter: str = None,
     run_only_changed: bool = False,
 ):
     project = compile_phase(
-        default_target, working_dir=working_dir, output_dir=output_dir
+        default_target, working_dir=working_dir, output_dir=output_dir, name_filter=name_filter
     )
-
-    traces = Trace.filtered(trace_filter, project.descendants_of_type(Trace))
 
     def changed(trace):
         if not run_only_changed:
             return True
         return trace.changed
 
+    traces = project.filter_traces(name_filter=name_filter)
     traces = list(filter(changed, traces))
 
     Logger.instance().debug(f"Running project with {len(traces)} traces(s)")

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -30,3 +30,4 @@ def run_phase(
         output_dir=output_dir,
     )
     runner.run()
+    return runner

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -1,6 +1,5 @@
 from visivo.logging.logger import Logger
 from visivo.query.runner import Runner
-from visivo.models.trace import Trace
 from visivo.commands.compile_phase import compile_phase
 
 

--- a/visivo/commands/serve.py
+++ b/visivo/commands/serve.py
@@ -9,7 +9,7 @@ from .options import name_filter, output_dir, working_dir, target, port, threads
 @output_dir
 @name_filter
 @port
-@thrkjeads
+@threads
 def serve(output_dir, working_dir, target, port, name_filter, threads):
     """
     Enables fast local development by spinning up a localhost server to run and view your project locally. Visivo will automatically refresh your project and re-run traces that have changed when you make updates to project files.

--- a/visivo/commands/serve.py
+++ b/visivo/commands/serve.py
@@ -9,7 +9,7 @@ from .options import name_filter, output_dir, working_dir, target, port, threads
 @output_dir
 @name_filter
 @port
-@theads
+@thrkjeads
 def serve(output_dir, working_dir, target, port, name_filter, threads):
     """
     Enables fast local development by spinning up a localhost server to run and view your project locally. Visivo will automatically refresh your project and re-run traces that have changed when you make updates to project files.

--- a/visivo/commands/serve.py
+++ b/visivo/commands/serve.py
@@ -1,14 +1,15 @@
 import click
 
-from .options import output_dir, working_dir, target, port
+from .options import name_filter, output_dir, working_dir, target, port
 
 
 @click.command()
 @target
 @working_dir
 @output_dir
+@name_filter
 @port
-def serve(output_dir, working_dir, target, port):
+def serve(output_dir, working_dir, target, port, name_filter):
     """
     Enables fast local development by spinning up a localhost server to run and view your project locally. Visivo will automatically refresh your project and re-run traces that have changed when you make updates to project files.
     """
@@ -19,6 +20,7 @@ def serve(output_dir, working_dir, target, port):
         output_dir=output_dir,
         working_dir=working_dir,
         default_target=target,
+        name_filter=name_filter,
     )
     Logger.instance().debug(f"Serving project at http://localhost:{port}")
     server.serve(host="0.0.0.0", port=port)

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -18,8 +18,11 @@ def get_project_json(output_dir, name_filter=None):
         project_json = json.load(f)
     
     if name_filter:
-        if project_json.dashboards[0]:
-            breakpoint()
+        dashboards = [d for d in project_json['dashboards'] if d["name"] == name_filter]
+        if len(dashboards) == 1:
+            project_json["dashboards"] = dashboards
+        else:
+            raise click.ClickException(f"Currently the serve command name filtering only supports filtering at the dashbaord level.  No dashboard with {name_filter} found.")
 
     return project_json
 

--- a/visivo/models/base/parent_model.py
+++ b/visivo/models/base/parent_model.py
@@ -15,36 +15,38 @@ class ParentModel(ABC):
     def child_items(self):
         return []
 
-    def dag(self):
+    def dag(self, node_permit_list=None):
         dag = nx.DiGraph()
         dag.add_node(self)
-        self.traverse_fields(items=self.child_items(), parent_item=self, dag=dag)
+        self.traverse_fields(items=self.child_items(), parent_item=self, dag=dag, node_permit_list=node_permit_list)
         return dag
 
-    def traverse_fields(self, items: List, parent_item, dag):
+    def traverse_fields(self, items: List, parent_item, dag, node_permit_list):
         for item in items:
-            dereferenced_item = item
-            if BaseModel.is_ref(item):
-                name = NamedModel.get_name(obj=item)
-                dereferenced_items = ParentModel.all_descendants_with_name(
-                    name=name, dag=dag
-                )
-                if len(dereferenced_items) == 1:
-                    dereferenced_item = dereferenced_items[0]
-                else:
-                    raise PydanticCustomError(
-                        "bad_reference",
-                        f'The reference "{item}" on item "{parent_item.id()}" does not point to an object.',
-                        parent_item.model_dump(),
+            if node_permit_list is None or item in node_permit_list: 
+                dereferenced_item = item
+                if BaseModel.is_ref(item):
+                    name = NamedModel.get_name(obj=item)
+                    dereferenced_items = ParentModel.all_descendants_with_name(
+                        name=name, dag=dag
                     )
+                    if len(dereferenced_items) == 1:
+                        dereferenced_item = dereferenced_items[0]
+                    else:
+                        raise PydanticCustomError(
+                            "bad_reference",
+                            f'The reference "{item}" on item "{parent_item.id()}" does not point to an object.',
+                            parent_item.model_dump(),
+                        )
 
-            dag.add_edge(parent_item, dereferenced_item)
-            if isinstance(dereferenced_item, ParentModel):
-                self.traverse_fields(
-                    items=dereferenced_item.child_items(),
-                    parent_item=dereferenced_item,
-                    dag=dag,
-                )
+                dag.add_edge(parent_item, dereferenced_item)
+                if isinstance(dereferenced_item, ParentModel):
+                    self.traverse_fields(
+                        items=dereferenced_item.child_items(),
+                        parent_item=dereferenced_item,
+                        dag=dag,
+                        node_permit_list=node_permit_list
+                    )
 
     @staticmethod
     def all_descendants(dag, from_node=None):
@@ -76,6 +78,25 @@ class ParentModel(ABC):
 
     def descendants_with_name(self, name: str):
         ParentModel.all_descendants_with_name(name=name, dag=self.dag())
+
+    @staticmethod
+    def all_nodes_including_named_node_in_graph(name: str, dag):
+        item = ParentModel.all_descendants_with_name(name=name, dag=dag)
+
+        if len(item) == 1:
+            item = item[0]
+        else:
+            raise click.Exception(f"No item found with name: '{name}'.")
+
+        decendants = nx.descendants(dag, item)
+        ancestors = nx.ancestors(dag, item)
+        items = decendants.union(ancestors)
+        items.add(item)
+        return items
+
+
+    def nodes_including_named_node_in_graph(self, name):
+        return ParentModel.all_nodes_including_named_node_in_graph(name=name, dag=self.dag())
 
     @staticmethod
     def filtered(pattern, objects) -> List:

--- a/visivo/models/base/parent_model.py
+++ b/visivo/models/base/parent_model.py
@@ -86,7 +86,7 @@ class ParentModel(ABC):
         if len(item) == 1:
             item = item[0]
         else:
-            raise click.Exception(f"No item found with name: '{name}'.")
+            raise click.ClickException(f"No item found with name: '{name}'.")
 
         decendants = nx.descendants(dag, item)
         ancestors = nx.ancestors(dag, item)

--- a/visivo/models/project.py
+++ b/visivo/models/project.py
@@ -66,11 +66,12 @@ class Project(NamedModel, ParentModel):
     def table_objs(self) -> List[Chart]:
         return list(filter(Table.is_obj, self.__all_tables()))
 
-    def filter_traces(self, pattern) -> List[Trace]:
-        def name_match(trace):
-            return re.search(pattern, trace.name)
-
-        return list(filter(name_match, self.trace_objs))
+    def filter_traces(self, name_filter) -> List[Trace]:
+        if name_filter:
+            included_nodes = self.nodes_including_named_node_in_graph(name=name_filter)
+        else:
+            included_nodes = self.descendants()
+        return set(self.descendants_of_type(Trace)).intersection(included_nodes)
 
     def find_target(self, name: str) -> Target:
         return next((t for t in self.targets if t.name == name), None)


### PR DESCRIPTION
This filters the traces that are run and compiled for any node with a name.  Serve was more work to support because it is a local serve that works on the project json, I only implemented the dashboard level filtering for now.

Simple Project: `visivo serve -nf "Simple Dashboard"`