### PR TITLE
Simplify how targets are handled

### DIFF
--- a/tests/commands/test_compile_phase.py
+++ b/tests/commands/test_compile_phase.py
@@ -4,12 +4,13 @@ from tests.factories.model_factories import DashboardFactory, ProjectFactory
 from tests.support.utils import temp_file, temp_folder, temp_yml_file
 from visivo.commands.compile_phase import compile_phase
 from visivo.commands.utils import create_file_database
+from visivo.models.defaults import Defaults
 from visivo.parsers.core_parser import PROFILE_FILE_NAME, PROJECT_FILE_NAME
 
 
 def test_filtered_dashboard():
     output_dir = temp_folder()
-    project = ProjectFactory()
+    project = ProjectFactory(defaults=Defaults(target_name="target"))
     additional_dashboard = DashboardFactory(name="Other Dashboard")
     additional_dashboard.rows[0].items[0].chart.name = "Additional Chart"
     additional_dashboard.rows[0].items[0].chart.traces[0].name = "Additional Trace"

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -28,32 +28,6 @@ def test_run():
     assert response.exit_code == 0
 
 
-def test_run_with_passed_target():
-    output_dir = temp_folder()
-    project = ProjectFactory()
-
-    create_file_database(url=project.targets[0].url(), output_dir=output_dir)
-    tmp = temp_yml_file(
-        dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME
-    )
-    working_dir = os.path.dirname(tmp)
-
-    response = runner.invoke(
-        run,
-        [
-            "-w",
-            working_dir,
-            "-o",
-            output_dir,
-            "-t",
-            project.targets[0].model_dump_json(),
-        ],
-    )
-
-    assert "Running project" in response.output
-    assert response.exit_code == 0
-
-
 def test_run_with_model_ref():
     output_dir = temp_folder()
     project = ProjectFactory(model_ref=True)

--- a/tests/commands/test_run_phase.py
+++ b/tests/commands/test_run_phase.py
@@ -5,6 +5,7 @@ from tests.factories.model_factories import DashboardFactory, ProjectFactory
 from tests.support.utils import temp_folder, temp_yml_file
 from visivo.commands.run_phase import run_phase
 from visivo.commands.utils import create_file_database
+from visivo.models.defaults import Defaults
 from visivo.parsers.core_parser import PROFILE_FILE_NAME, PROJECT_FILE_NAME
 from visivo.query.runner import Runner
 from unittest.mock import ANY
@@ -12,7 +13,7 @@ from unittest.mock import ANY
 
 def test_filtered_dashboard():
     output_dir = temp_folder()
-    project = ProjectFactory()
+    project = ProjectFactory(defaults=Defaults(target_name="target"))
     trace = project.dashboards[0].rows[0].items[0].chart.traces[0]
     additional_dashboard = DashboardFactory(name="Other Dashboard")
     additional_dashboard.rows[0].items[0].chart.name = "Additional Chart"

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -14,7 +14,7 @@ def test_find_default_target_no_targets():
     message = exc_info.value.message
     assert (
         message
-        == "The project must contain a target or a target must be passed as an object on the command line."
+        == "The project must contain a target."
     )
 
 
@@ -37,7 +37,7 @@ def test_find_default_target_two_target():
     message = exc_info.value.message
     assert (
         message
-        == "When the project has multiple targets a target must be defined with a default or on the command line."
+        == "Multiple targets available and neither default target or trace target were provided."
     )
 
 

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -2,14 +2,14 @@ import pytest
 import click
 from tests.factories.model_factories import TargetFactory
 from tests.factories.model_factories import ProjectFactory
-from visivo.commands.utils import find_or_create_target
+from visivo.commands.utils import find_default_target
 
 
-def test_find_or_create_target_no_targets():
+def test_find_default_target_no_targets():
     project = ProjectFactory(targets=[])
 
     with pytest.raises(click.ClickException) as exc_info:
-        find_or_create_target(project=project, target_or_name=None)
+        find_default_target(project=project, target_name=None)
 
     message = exc_info.value.message
     assert (
@@ -18,30 +18,21 @@ def test_find_or_create_target_no_targets():
     )
 
 
-def test_find_or_create_target_no_targets_with_passed():
-    project = ProjectFactory(targets=[])
-
-    found_target = find_or_create_target(
-        project=project, target_or_name='{"name":"name", "database":"database"}'
-    )
-    assert found_target.name == "name"
-
-
-def test_find_or_create_target_one_target():
+def test_find_default_target_one_target():
     target = TargetFactory()
     project = ProjectFactory(targets=[target])
 
-    found_target = find_or_create_target(project=project, target_or_name=None)
+    found_target = find_default_target(project=project, target_name=None)
     assert found_target.name == target.name
 
 
-def test_find_or_create_target_two_target():
+def test_find_default_target_two_target():
     target_first = TargetFactory(name="first")
     target_second = TargetFactory(name="second")
     project = ProjectFactory(targets=[target_first, target_second])
 
     with pytest.raises(click.ClickException) as exc_info:
-        find_or_create_target(project=project, target_or_name=None)
+        find_default_target(project=project, target_name=None)
 
     message = exc_info.value.message
     assert (
@@ -50,22 +41,22 @@ def test_find_or_create_target_two_target():
     )
 
 
-def test_find_or_create_target_two_target_with_missing_name():
+def test_find_default_target_two_target_with_missing_name():
     target_first = TargetFactory(name="first")
     target_second = TargetFactory(name="second")
     project = ProjectFactory(targets=[target_first, target_second])
 
     with pytest.raises(click.ClickException) as exc_info:
-        find_or_create_target(project=project, target_or_name="third")
+        find_default_target(project=project, target_name="third")
 
     message = exc_info.value.message
     assert message == "Target with name: 'third' was not found in the project."
 
 
-def test_find_or_create_target_two_target_with_name():
+def test_find_default_target_two_target_with_name():
     target_first = TargetFactory(name="first")
     target_second = TargetFactory(name="second")
     project = ProjectFactory(targets=[target_first, target_second])
 
-    found_target = find_or_create_target(project=project, target_or_name="second")
+    found_target = find_default_target(project=project, target_name="second")
     assert found_target.name == target_second.name

--- a/tests/factories/model_factories.py
+++ b/tests/factories/model_factories.py
@@ -192,7 +192,6 @@ class ProjectFactory(factory.Factory):
         model = Project
 
     name = "project"
-    # defaults = factory.SubFactory(DefaultsFactory)
     targets = factory.List([factory.SubFactory(TargetFactory) for _ in range(1)])
     dashboards = factory.List([factory.SubFactory(DashboardFactory) for _ in range(1)])
     traces = []

--- a/tests/factories/model_factories.py
+++ b/tests/factories/model_factories.py
@@ -1,4 +1,5 @@
 import factory
+from visivo.models.defaults import Defaults
 from visivo.models.trace import Trace
 from visivo.models.chart import Chart
 from visivo.models.dashboard import Dashboard
@@ -180,12 +181,18 @@ class DashboardFactory(factory.Factory):
             )
         )
 
+class DefaultsFactory(factory.Factory):
+    target_name = "target"
+
+    class Meta:
+        model = Defaults
 
 class ProjectFactory(factory.Factory):
     class Meta:
         model = Project
 
     name = "project"
+    # defaults = factory.SubFactory(DefaultsFactory)
     targets = factory.List([factory.SubFactory(TargetFactory) for _ in range(1)])
     dashboards = factory.List([factory.SubFactory(DashboardFactory) for _ in range(1)])
     traces = []

--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -192,6 +192,25 @@ def test_Project_validate_default_target_does_not_exists():
     assert error["type"] == "value_error"
 
 
+def test_Project_validate_default_target_missing():
+    data = {
+        "name": "development",
+        "traces": [{"name":"trace"}],
+        "charts": [],
+        "dashboards": [],
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        Project(**data)
+
+    error = exc_info.value.errors()[0]
+    assert (
+        error["msg"]
+        == f"Value error, Dashboard name 'dashboard' is not unique in the project"
+    )
+    assert error["type"] == "value_error"
+
+
 def test_simple_Project_dag():
     project = ProjectFactory()
     dag = project.dag()

--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -123,8 +123,11 @@ def test_Project_validate_chart_names():
 def test_Project_validate_trace_names():
     trace_orig = TraceFactory()
     trace_dup = TraceFactory(name=trace_orig.name)
+    target = TargetFactory(name="target")
     data = {
         "name": "development",
+        "defaults": {"target_name":"target"},
+        "targets": [target],
         "traces": [trace_orig, trace_dup],
         "charts": [],
         "dashboards": [],
@@ -189,25 +192,6 @@ def test_Project_validate_default_target_does_not_exists():
 
     error = exc_info.value.errors()[0]
     assert error["msg"] == f"Value error, default alert '{alert.name}' does not exist"
-    assert error["type"] == "value_error"
-
-
-def test_Project_validate_default_target_missing():
-    data = {
-        "name": "development",
-        "traces": [{"name":"trace"}],
-        "charts": [],
-        "dashboards": [],
-    }
-
-    with pytest.raises(ValidationError) as exc_info:
-        Project(**data)
-
-    error = exc_info.value.errors()[0]
-    assert (
-        error["msg"]
-        == f"Value error, Dashboard name 'dashboard' is not unique in the project"
-    )
     assert error["type"] == "value_error"
 
 

--- a/tests/models/test_test_run.py
+++ b/tests/models/test_test_run.py
@@ -2,12 +2,6 @@ from datetime import datetime
 from visivo.models.test_run import TestRun, TestFailure, TestSuccess
 
 
-def test_Test_Run_simple_data():
-    data = {"target_name": "name"}
-    test_run = TestRun(**data)
-    assert test_run.target_name == "name"
-
-
 def test_Test_Run_count():
     data = {"target_name": "name"}
     test_run = TestRun(**data)

--- a/tests/parsers/test_serializer.py
+++ b/tests/parsers/test_serializer.py
@@ -1,5 +1,6 @@
 from visivo.parsers.serializer import Serializer
 from tests.factories.model_factories import (
+    DashboardFactory,
     ProjectFactory,
     TraceFactory,
     ChartFactory,
@@ -43,8 +44,9 @@ def test_Serializer_with_table_ref():
 def test_Serializer_with_table_trace_ref():
     trace = TraceFactory(name="trace_name")
     trace.model.name = "second_model"
-    project = ProjectFactory(table_item=True, traces=[trace])
-    project.dashboards[0].rows[0].items[0].table.trace = "ref(trace_name)"
+    dashboard = DashboardFactory(table_item=True)
+    dashboard.rows[0].items[0].table.trace = "ref(trace_name)"
+    project = ProjectFactory(dashboards=[dashboard], traces=[trace])
     project = Serializer(project=project).dereference()
     assert project.name == "project"
     assert project.traces == []

--- a/tests/query/test_runner.py
+++ b/tests/query/test_runner.py
@@ -12,7 +12,7 @@ def test_Runner_given_target():
     target = Target(database=f"{output_dir}/test.db", type=TypeEnum.sqlite)
     trace = TraceFactory(name="trace1")
     trace.model.name = "second_model"
-    project = ProjectFactory(targets=[target], traces=[trace])
+    project = ProjectFactory(targets=[target], traces=[trace], dashboards=[])
 
     create_file_database(url=target.url(), output_dir=output_dir)
 
@@ -36,7 +36,7 @@ def test_Runner_trace_with_default():
     target = Target(database=f"{output_dir}/test.db", type=TypeEnum.sqlite)
     trace = TraceFactory(name="trace1", target_name=target.name)
     trace.model.name = "second_model"
-    project = ProjectFactory(targets=[target], traces=[trace])
+    project = ProjectFactory(targets=[target], traces=[trace], dashboards=[])
 
     create_file_database(url=target.url(), output_dir=output_dir)
 

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -21,9 +21,8 @@ def test_TestQueryStringFactory_errors(capsys):
         ],
     }
     trace = Trace(**data)
-    trace2 = TraceFactory()
 
-    project = ProjectFactory(traces=[trace, trace2], dashboards=[])
+    project = ProjectFactory(traces=[trace], dashboards=[])
     output_dir = temp_folder()
     alert = AlertFactory()
     target = Target(
@@ -34,9 +33,8 @@ def test_TestQueryStringFactory_errors(capsys):
 
     create_file_database(url=target.url(), output_dir=output_dir)
     Runner(
-        traces=[trace, trace2],
+        traces=[trace],
         project=project,
-        target=target,
         output_dir=output_dir,
         alerts=[alert],
     ).run()

--- a/visivo/commands/compile_phase.py
+++ b/visivo/commands/compile_phase.py
@@ -10,7 +10,7 @@ from visivo.parsers.serializer import Serializer
 from visivo.query.query_string_factory import QueryStringFactory
 from visivo.query.trace_tokenizer import TraceTokenizer
 from visivo.query.query_writer import QueryWriter
-from visivo.commands.utils import find_or_create_target
+from visivo.commands.utils import find_default_target
 from visivo.logging.logger import Logger
 
 
@@ -31,7 +31,6 @@ def compile_phase(default_target: str, working_dir: str, output_dir: str, name_f
         raise click.ClickException(
             f"There was an error parsing the yml file(s):{message} {e}"
         )
-    target = find_or_create_target(project=project, target_or_name=default_target)
 
     os.makedirs(output_dir, exist_ok=True)
     with open(f"{output_dir}/project.json", "w") as fp:
@@ -43,6 +42,7 @@ def compile_phase(default_target: str, working_dir: str, output_dir: str, name_f
         model = ParentModel.all_descendants_of_type(
             type=Model, dag=dag, from_node=trace
         )[0]
+        target = find_default_target(project=project, target_name=trace.get_target_name(default_name=default_target))
         tokenized_trace = TraceTokenizer(
             trace=trace, model=model, target=target
         ).tokenize()

--- a/visivo/commands/options.py
+++ b/visivo/commands/options.py
@@ -37,7 +37,7 @@ def target(function):
     click.option(
         "-t",
         "--target",
-        help="Name of the target connection to use. This overrides the default target in the project.",
+        help="Name of the default target connection to use. This overrides the default target in the project.",
     )(function)
     return function
 

--- a/visivo/commands/test_phase.py
+++ b/visivo/commands/test_phase.py
@@ -1,7 +1,7 @@
 import sys
 import click
 from visivo.logging.logger import Logger
-from visivo.commands.utils import find_or_create_target
+from visivo.commands.utils import find_default_target
 from visivo.testing.runner import Runner
 from visivo.commands.compile_phase import compile_phase
 
@@ -13,15 +13,14 @@ def test_phase(
         default_target=default_target, working_dir=working_dir, output_dir=output_dir
     )
     Logger.instance().debug("Testing project")
-    target = find_or_create_target(project=project, target_or_name=default_target)
     alerts = list(map(lambda an: project.find_alert(name=an), alert_names))
     alerts = list(filter(None, alerts))
     test_runner = Runner(
         traces=project.trace_objs,
-        target=target,
         project=project,
         output_dir=output_dir,
         alerts=alerts,
+        default_target=default_target,
     )
     if not test_runner.run().success:
         sys.exit(1)

--- a/visivo/commands/utils.py
+++ b/visivo/commands/utils.py
@@ -9,35 +9,23 @@ from visivo.parsers.core_parser import PROFILE_FILE_NAME
 from visivo.utils import load_yaml_file
 
 
-def find_or_create_target(project: Project, target_or_name: str) -> Target:
-    if len(project.targets) == 0 and not target_or_name:
+def find_default_target(project: Project, target_name: str) -> Target:
+    if len(project.targets) == 0 and not target_name:
         raise click.ClickException(
-            f"The project must contain a target or a target must be passed as an object on the command line."
+            f"The project must contain a target."
         )
 
-    if not target_or_name and len(project.targets) == 1:
+    if not target_name and len(project.targets) == 1:
         return project.targets[0]
 
-    if not target_or_name and project.defaults and project.defaults.target_name:
-        target_or_name = project.defaults.target_name
+    if not target_name and project.defaults and project.defaults.target_name:
+        target_name = project.defaults.target_name
 
-    target = project.find_target(name=target_or_name)
+    target = project.find_target(name=target_name)
 
-    if not target and target_or_name and "{" in target_or_name:
-        try:
-            json_data = json.loads(target_or_name)
-        except:
-            raise click.ClickException(f"Target: '{target_or_name}' is not valid JSON")
-        target = Target(**json_data)
-
-    if not target and target_or_name:
+    if not target:
         raise click.ClickException(
-            f"Target with name: '{target_or_name}' was not found in the project."
-        )
-
-    if not target and not target_or_name:
-        raise click.ClickException(
-            f"When the project has multiple targets a target must be defined with a default or on the command line."
+            f"Target with name: '{target_name}' was not found in the project."
         )
 
     return target

--- a/visivo/commands/utils.py
+++ b/visivo/commands/utils.py
@@ -15,14 +15,19 @@ def find_default_target(project: Project, target_name: str) -> Target:
             f"The project must contain a target."
         )
 
-    if not target_name and len(project.targets) == 1:
-        return project.targets[0]
-
     if not target_name and project.defaults and project.defaults.target_name:
         target_name = project.defaults.target_name
 
+    if not target_name and len(project.targets) == 1:
+        return project.targets[0]
+
+    if not target_name:
+        raise click.ClickException(
+            f"Multiple targets available and neither default target or trace target were provided."
+        )
     target = project.find_target(name=target_name)
 
+   
     if not target:
         raise click.ClickException(
             f"Target with name: '{target_name}' was not found in the project."

--- a/visivo/models/project.py
+++ b/visivo/models/project.py
@@ -101,6 +101,21 @@ class Project(NamedModel, ParentModel):
             raise ValueError(f"default alert '{defaults.alert_name}' does not exist")
 
         return self
+    
+    @model_validator(mode="after")
+    def validate_traces_have_targets(self):
+        defaults = self.defaults
+        if defaults and defaults.target_name:
+            return self
+
+        if len(self.trace_objs) == 1:
+            return self
+
+        for trace in self.trace_objs:
+            if not trace.target_name:
+                raise ValueError(f"'{trace.name}' does not specify a target and project does not specify default target")
+
+        return self
 
     @model_validator(mode="after")
     def validate_dag(self):

--- a/visivo/models/test_run.py
+++ b/visivo/models/test_run.py
@@ -22,7 +22,6 @@ class TestFailure(TestResult):
 
 
 class TestRun(pydantic.BaseModel):
-    target_name: str
     started_at: datetime = datetime.now()
     finished_at: Optional[datetime] = None
     failures: List[TestFailure] = []

--- a/visivo/models/trace.py
+++ b/visivo/models/trace.py
@@ -248,3 +248,9 @@ class Trace(NamedModel, ParentModel):
                     )
 
         return data
+    
+
+    def get_target_name(self, default_name: str):
+        if self.target_name:
+            return self.target_name
+        return default_name

--- a/visivo/query/runner.py
+++ b/visivo/query/runner.py
@@ -8,7 +8,7 @@ import os
 from pandas import read_json
 from visivo.models.project import Project
 from visivo.models.trace import Trace
-from visivo.commands.utils import find_or_create_target
+from visivo.commands.utils import find_default_target
 from visivo.logging.logger import Logger
 from time import time, sleep
 import textwrap
@@ -82,12 +82,8 @@ class Runner:
     def _run_trace_query(self, queue: Queue):
         while not queue.empty():
             trace = queue.get()
-            target_or_name = trace.target_name
-            if not target_or_name:
-                target_or_name = self.default_target
-
-            target = find_or_create_target(
-                project=self.project, target_or_name=target_or_name
+            target = find_default_target(
+                project=self.project, target_name=trace.get_target_name(self.default_target)
             )
             trace_directory = f"{self.output_dir}/{trace.name}"
             trace_query_file = f"{trace_directory}/query.sql"

--- a/visivo/testing/runner.py
+++ b/visivo/testing/runner.py
@@ -38,15 +38,14 @@ class Runner:
         self.alerts = alerts
 
     def run(self):
-        test_run = TestRun(target_name=self.target.name)
+        test_run = TestRun()
         dag = self.project.dag()
         for trace in self.traces:
             model = ParentModel.all_descendants_of_type(
                 type=Model, dag=dag, from_node=trace
             )[0]
-            tokenized_trace = TraceTokenizer(
-                trace=trace, model=model, target=find_default_target(project=self.project, target_name=trace.get_target_name(default_name=self.default_target))
-            ).tokenize()
+            target=find_default_target(project=self.project, target_name=trace.get_target_name(default_name=self.default_target))
+            tokenized_trace = TraceTokenizer(trace=trace, model=model, target=target).tokenize()
             query_string_factory = QueryStringFactory(tokenized_trace=tokenized_trace)
             if not trace.tests:
                 continue
@@ -59,7 +58,7 @@ class Runner:
                 with open(f"{trace_directory}/{test.name}.sql", "w") as fp:
                     fp.write(test_query_string)
 
-                data_frame = data_frame = self.target.read_sql(test_query_string)
+                data_frame = data_frame = target.read_sql(test_query_string)
 
                 if len(data_frame) > 0:
                     failure = TestFailure(

--- a/visivo/testing/runner.py
+++ b/visivo/testing/runner.py
@@ -1,5 +1,6 @@
 # supports more generic connections than the snowflake specific connector
 from sqlalchemy import text
+from visivo.commands.utils import find_default_target
 from visivo.query.query_string_factory import QueryStringFactory
 from visivo.testing.test_query_string_factory import TestQueryStringFactory
 from visivo.query.trace_tokenizer import TraceTokenizer
@@ -25,14 +26,14 @@ class Runner:
     def __init__(
         self,
         traces: List[Trace],
-        target: Target,
         project: Project,
         output_dir: str,
+        default_target: str = None,        
         alerts: List[Alert] = [],
     ):
         self.project = project
         self.traces = traces
-        self.target = target
+        self.default_target = default_target
         self.output_dir = output_dir
         self.alerts = alerts
 
@@ -44,7 +45,7 @@ class Runner:
                 type=Model, dag=dag, from_node=trace
             )[0]
             tokenized_trace = TraceTokenizer(
-                trace=trace, model=model, target=self.target
+                trace=trace, model=model, target=find_default_target(project=self.project, target_name=trace.get_target_name(default_name=self.default_target))
             ).tokenize()
             query_string_factory = QueryStringFactory(tokenized_trace=tokenized_trace)
             if not trace.tests:


### PR DESCRIPTION
Remove the ability to pass in default target as a JSON string, and make it optional to have a default target if you only have traces that specify target names.