### PR TITLE
Allow none trace props

### DIFF
--- a/tests/models/test_trace.py
+++ b/tests/models/test_trace.py
@@ -77,3 +77,13 @@ def test_Trace_column_root_validation_with_reference_extra_paren():
     }
     trace = Trace(**data)
     assert trace.name == "development"
+
+
+def test_Trace_with_columns_without_props():
+    data = {
+        "name": "development",
+        "columns": {"x_data": "x"},
+        "model": {"sql": "select * from table"},
+    }
+    trace = Trace(**data)
+    assert trace.name == "development"

--- a/visivo/models/trace.py
+++ b/visivo/models/trace.py
@@ -200,7 +200,7 @@ class Trace(NamedModel, ParentModel):
         if isinstance(data, str):
             return data
         columns, props = (data.get("columns"), data.get("props"))
-        if columns is None:
+        if columns is None or props is None:
             return data
 
         columnKeys = list(columns.keys())


### PR DESCRIPTION
Allow traces to not have props to allow for them to be used in tables.