### PR TITLE
Working selector as item in row

### DIFF
--- a/test-projects/demo/dashboards/welcome.visivo.yml
+++ b/test-projects/demo/dashboards/welcome.visivo.yml
@@ -37,7 +37,7 @@ traces:
 dashboards:
   - name: Welcome to Visivo
     rows:
-      - height: small
+      - height: compact
         items:
           - markdown: |
               # Welcome to Visivo 
@@ -84,7 +84,7 @@ dashboards:
                       key: columns.y_data
                     - header: Dollars
                       key: props.text
-      - height: compact
+      - height: small
         items:
           - width: 2
             markdown: |

--- a/test-projects/demo/dashboards/welcome.visivo.yml
+++ b/test-projects/demo/dashboards/welcome.visivo.yml
@@ -88,7 +88,7 @@ dashboards:
         items:
           - width: 2
             markdown: |
-              ### You link your charts and tables together
+              ### Link your charts and tables together
 
               A _selector_ allows you define which data is shown.  Change this selector and watch the table and chart above change.
 

--- a/test-projects/demo/dashboards/welcome.visivo.yml
+++ b/test-projects/demo/dashboards/welcome.visivo.yml
@@ -60,9 +60,7 @@ dashboards:
           - width: 2
             chart:
               name: Fibonacci Waterfall Chart
-              selector:
-                name: Fibonacci Waterfall Selector
-                type: single
+              selector: ref(Fibonacci Waterfall Selector)
               traces:
                 - ref(Fibonacci Waterfall Trace)
       - height: medium
@@ -86,3 +84,16 @@ dashboards:
                       key: columns.y_data
                     - header: Dollars
                       key: props.text
+      - height: compact
+        items:
+          - width: 2
+            markdown: |
+              ### You link your charts and tables together
+
+              A _selector_ allows you define which data is shown.  Change this selector and watch the table and chart above change.
+
+          - selector:
+              name: Fibonacci Waterfall Selector
+              type: single
+              options:
+                - ref(Fibonacci Waterfall Trace)

--- a/tests/factories/model_factories.py
+++ b/tests/factories/model_factories.py
@@ -130,6 +130,7 @@ class SelectorFactory(factory.Factory):
 
     name = "selector"
     type = "single"
+    options = []
 
 
 class ChartFactory(factory.Factory):

--- a/tests/models/base/test_selector_model.py
+++ b/tests/models/base/test_selector_model.py
@@ -1,4 +1,6 @@
+from pydantic import ValidationError
 from visivo.models.base.selector_model import SelectorModel
+import pytest
 
 
 class TestSelectorModel(SelectorModel):
@@ -8,3 +10,20 @@ class TestSelectorModel(SelectorModel):
 def test_dumps_parent_name():
     model = TestSelectorModel(**{"name": "name"})
     assert '"parent_name":"name"' in model.model_dump_json()
+
+
+def test_options_under_object():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSelectorModel(
+            **{
+                "name": "name",
+                "selector": {"name": "selector", "options": ["ref(option1)"]},
+            }
+        )
+
+    error = exc_info.value.errors()[0]
+    assert (
+        error["msg"]
+        == "Value error, Selector 'selector' can not have options set, they are set from the parent item."
+    )
+    assert error["type"] == "value_error"

--- a/tests/models/test_item.py
+++ b/tests/models/test_item.py
@@ -34,6 +34,18 @@ def test_Item_both_chart_and_table():
     assert error["type"] == "value_error"
 
 
+def test_Item_both_chart_and_selector():
+    with pytest.raises(ValidationError) as exc_info:
+        Item(selector="ref(selector)", markdown="markdown")
+
+    error = exc_info.value.errors()[0]
+    assert (
+        error["msg"]
+        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
+    )
+    assert error["type"] == "value_error"
+
+
 def test_Item_invalid_ref_string():
     item = Item(chart="ref(chart)")
     item.chart = "ref(chart)"

--- a/tests/models/test_item.py
+++ b/tests/models/test_item.py
@@ -17,7 +17,7 @@ def test_Item_both_chart_and_markdown():
     error = exc_info.value.errors()[0]
     assert (
         error["msg"]
-        == 'Value error, only one of the "markdown", "chart", or "table" properties should be set on an item'
+        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
     )
     assert error["type"] == "value_error"
 
@@ -29,7 +29,7 @@ def test_Item_both_chart_and_table():
     error = exc_info.value.errors()[0]
     assert (
         error["msg"]
-        == 'Value error, only one of the "markdown", "chart", or "table" properties should be set on an item'
+        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
     )
     assert error["type"] == "value_error"
 

--- a/tests/models/test_selector.py
+++ b/tests/models/test_selector.py
@@ -1,0 +1,22 @@
+from visivo.models.selector import Selector
+from visivo.models.base.base_model import REF_REGEX
+from pydantic import ValidationError
+import pytest
+
+
+def test_Selector_simple_data():
+    data = {"name": "selector"}
+    selector = Selector(**data)
+    assert selector.name == "selector"
+
+
+def test_Selector_serialize_data():
+    data = {"name": "selector"}
+    selector = Selector(**data)
+    assert selector.serialize_model()["name"] == "selector"
+    assert selector.serialize_model()["options"] == []
+    assert selector.serialize_model()["type"] == "multiple"
+    assert selector.serialize_model()["parent_name"] == "selector"
+
+    selector.set_parent_name("parent_name")
+    assert selector.serialize_model()["parent_name"] == "parent_name"

--- a/tests/parsers/test_serializer.py
+++ b/tests/parsers/test_serializer.py
@@ -1,3 +1,4 @@
+from visivo.models.selector import Selector
 from visivo.parsers.serializer import Serializer
 from tests.factories.model_factories import (
     DashboardFactory,
@@ -93,6 +94,7 @@ def test_Serializer_with_model_ref():
         == "model_name"
     )
 
+
 def test_Serializer_with_table_model_ref():
     model = SqlModelFactory(name="model_name")
     project = ProjectFactory(table_item=True, models=[model])
@@ -104,6 +106,22 @@ def test_Serializer_with_table_model_ref():
         project.dashboards[0].rows[0].items[0].table.traces[0].model.name
         == "model_name"
     )
+
+
+def test_Serializer_with_selector_model_ref():
+    selector = Selector(name="selector_name")
+    project = ProjectFactory(selectors=[selector])
+    chart = project.dashboards[0].rows[0].items[0].chart
+    chart.selector = "ref(selector_name)"
+    selector.options = [f"ref({chart.traces[0].name})"]
+    project = Serializer(project=project).dereference()
+    assert project.name == "project"
+    assert project.selectors == []
+    assert project.dashboards[0].rows[0].items[0].chart.selector.name == "selector_name"
+    assert (
+        project.dashboards[0].rows[0].items[0].chart.selector.options[0].name == "trace"
+    )
+
 
 def test_Serializer_with_refs_does_not_change_original():
     chart = ChartFactory(name="chart_name", traces=["ref(trace_name)"])

--- a/viewer/src/components/Dashboard.js
+++ b/viewer/src/components/Dashboard.js
@@ -21,10 +21,9 @@ const Dashboard = (props) => {
             return 256
         } else if (height === 'medium') {
             return 396
-        } else if (height === 'large') {
+        } else {
             return 512
         }
-        return 128
     }
 
     const getWidth = (row, item) => {

--- a/viewer/src/components/Dashboard.js
+++ b/viewer/src/components/Dashboard.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Chart from './items/Chart.js'
 import Table from './items/Table.js'
+import Selector from './items/Selector.js'
 import Markdown from 'react-markdown'
 import useDimensions from "react-cool-dimensions";
 import { throwError } from "../api/utils.js";
@@ -20,9 +21,10 @@ const Dashboard = (props) => {
             return 256
         } else if (height === 'medium') {
             return 396
-        } else {
+        } else if (height === 'large') {
             return 512
         }
+        return 128
     }
 
     const getWidth = (row, item) => {
@@ -60,6 +62,13 @@ const Dashboard = (props) => {
                 width={getWidth(row, item)}
                 height={getHeight(row.height)}
                 key={`dashboardRow${rowIndex}Item${itemIndex}`} />
+        } else if (item.selector) {
+            return <Selector
+                selector={item.selector}
+                project={props.project}
+                itemWidth={item.width}
+                key={`dashboardRow${rowIndex}Item${itemIndex}`} >
+            </Selector>
         } else if (item.markdown) {
             return <Markdown
                 className={`grow-${item.width} p-2 m-auto prose`}
@@ -70,9 +79,17 @@ const Dashboard = (props) => {
         return null
     }
 
+    const getHeightStyle = (row) => {
+        if (row.height !== "compact") {
+            return { height: getHeight(row.height) }
+        } else {
+            return null
+        }
+    }
+
     const renderRow = (row, rowIndex) => {
         return (
-            <div className={`flex ${isColumn ? 'flex-col' : 'flex-row'}`} style={isColumn ? {} : { height: getHeight(row.height) }} key={`dashboardRow${rowIndex}`}>
+            <div className={`flex ${isColumn ? 'flex-col' : 'flex-row'}`} style={isColumn ? {} : getHeightStyle(row)} key={`dashboardRow${rowIndex}`}>
                 {row.items.map((item, itemIndex) => renderComponent(item, row, itemIndex, rowIndex))}
             </div>
         )

--- a/viewer/src/components/items/Selector.js
+++ b/viewer/src/components/items/Selector.js
@@ -1,0 +1,34 @@
+import Loading from "../Loading";
+import React from "react";
+import CohortSelect from "./CohortSelect";
+import tw from "tailwind-styled-components"
+import { useTracesData } from "../../hooks/useTracesData";
+
+export const ChartContainer = tw.div`
+    relative
+`;
+
+const Selector = ({ selector, project, itemWidth }) => {
+    const traceNames = selector.options.map((trace) => trace.name)
+    const tracesData = useTracesData(project.id, traceNames)
+
+    if (!tracesData) {
+        return <Loading text={selector.name} width={itemWidth} />
+    }
+
+    return (
+        <div className={`grow-${itemWidth} p-2 m-auto flex`}>
+            <div className="m-auto justify-center">
+                <CohortSelect
+                    tracesData={tracesData}
+                    onChange={() => { }}
+                    selector={selector}
+                    parentName={selector.name}
+                    parentType="chart"
+                />
+            </div>
+        </div>
+    );
+}
+
+export default Selector;

--- a/viewer/src/components/items/Selector.test.js
+++ b/viewer/src/components/items/Selector.test.js
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Selector from './Selector';
+import * as useTracesData from '../../hooks/useTracesData';
+import { withProviders } from '../../utils/test-utils';
+
+let selector;
+
+beforeEach(() => {
+  selector = {
+    name: "selector",
+    type: "single",
+    parent_name: "selector",
+    options: [
+      { name: "traceName", columns: { x_data: "x" } }
+    ]
+  }
+});
+
+test('renders selector', async () => {
+  const traceData = {
+    "traceName": {
+      "cohortName": {
+        "columns.x_data": [
+          "value 1",
+          "value 2",
+        ]
+      }
+    }
+  };
+  jest.spyOn(useTracesData, 'useTracesData').mockImplementation((projectId, traceNames) => (traceData));
+
+  render(<Selector selector={selector} project={{ id: 1 }} itemWidth={1} />, { wrapper: withProviders });
+
+  await waitFor(() => {
+    expect(screen.getByText('cohortName')).toBeInTheDocument();
+  });
+});

--- a/visivo/models/base/selector_model.py
+++ b/visivo/models/base/selector_model.py
@@ -14,6 +14,10 @@ class SelectorModel(BaseModel):
     def set_parent_name(self):
         if BaseModel.is_obj(self.selector):
             self.selector.set_parent_name(self.name)
+            if len(self.selector.options) > 0:
+                raise ValueError(
+                    f"Selector '{self.selector.name}' can not have options set, they are set from the parent item."
+                )
         return self
 
     @model_validator(mode="before")

--- a/visivo/models/item.py
+++ b/visivo/models/item.py
@@ -1,3 +1,4 @@
+from visivo.models.selector import Selector
 from .base.base_model import BaseModel, REF_REGEX, generate_ref_field
 from .base.parent_model import ParentModel
 from pydantic import Field
@@ -22,6 +23,8 @@ class Item(BaseModel, ParentModel):
         table: ref(table-name)
       - width: 2
         chart: ref(chart-name)
+      - width: 1
+        chart: ref(selector-name)
     ```
     """
     def __init__(self, **kwargs):
@@ -44,19 +47,23 @@ class Item(BaseModel, ParentModel):
     table: Optional[generate_ref_field(Table)] = Field(
         None, description="A Table object defined inline or a ref() to a table"
     )
+    selector: Optional[generate_ref_field(Selector)] = Field(
+        None, description="A Selector object defined inline or a ref() to a selector"
+    )
 
     @model_validator(mode="before")
     @classmethod
     def validate_column_refs(cls, data: any):
-        markdown, chart, table = (
+        markdown, chart, table, selector = (
             data.get("markdown"),
             data.get("chart"),
             data.get("table"),
+            data.get("selector"),
         )
-        items_set = [i for i in [markdown, chart, table] if i is not None]
+        items_set = [i for i in [markdown, chart, table, selector] if i is not None]
         if len(items_set) > 1:
             raise ValueError(
-                'only one of the "markdown", "chart", or "table" properties should be set on an item'
+                'only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
             )
         return data
 
@@ -70,3 +77,5 @@ class Item(BaseModel, ParentModel):
             return self.table
         if self.chart is not None:
             return self.chart
+        if self.selector is not None:
+            return self.selector

--- a/visivo/models/item.py
+++ b/visivo/models/item.py
@@ -27,9 +27,10 @@ class Item(BaseModel, ParentModel):
         chart: ref(selector-name)
     ```
     """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._id = kwargs["id"] if "id" in kwargs else uuid.uuid4().hex 
+        self._id = kwargs["id"] if "id" in kwargs else uuid.uuid4().hex
 
     def id(self):
         return f"Item - {self._id}"
@@ -53,7 +54,7 @@ class Item(BaseModel, ParentModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_column_refs(cls, data: any):
+    def validate_unique_item_types(cls, data: any):
         markdown, chart, table, selector = (
             data.get("markdown"),
             data.get("chart"),

--- a/visivo/models/item.py
+++ b/visivo/models/item.py
@@ -24,7 +24,7 @@ class Item(BaseModel, ParentModel):
       - width: 2
         chart: ref(chart-name)
       - width: 1
-        chart: ref(selector-name)
+        selector: ref(selector-name)
     ```
     """
 

--- a/visivo/models/project.py
+++ b/visivo/models/project.py
@@ -33,6 +33,7 @@ class Project(NamedModel, ParentModel):
     traces: List[Trace] = []
     tables: List[Table] = []
     charts: List[Chart] = []
+    selectors: List[Selector] = []
     dashboards: List[Dashboard] = []
 
     def child_items(self):
@@ -43,6 +44,7 @@ class Project(NamedModel, ParentModel):
             + self.traces
             + self.tables
             + self.charts
+            + self.selectors
             + self.dashboards
         )
 

--- a/visivo/models/row.py
+++ b/visivo/models/row.py
@@ -7,6 +7,7 @@ from .item import Item
 
 
 class HeightEnum(str, Enum):
+    compact = "compact"
     small = "small"
     medium = "medium"
     large = "large"

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -40,6 +40,9 @@ class Serializer:
                     component.selector = ParentModel.all_descendants_of_type(
                         type=Selector, dag=dag, from_node=component
                     )[0]
+                    component.selector.options = ParentModel.all_descendants_of_type(
+                        type=Trace, dag=dag, from_node=item.selector
+                    )
                     for trace in component.traces:
                         trace.model = ParentModel.all_descendants_of_type(
                             type=Model, dag=dag, from_node=trace

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -52,6 +52,10 @@ class Serializer:
                             trace.model.models = ParentModel.all_descendants_of_type(
                                 type=Model, dag=dag, from_node=trace.model
                             )
+                if item.selector:
+                    item.selector.options = ParentModel.all_descendants_of_type(
+                        type=Trace, dag=dag, from_node=item.selector
+                    )
 
             dashboard.for_each_item(replace_item_ref)
 
@@ -60,4 +64,5 @@ class Serializer:
         project.tables = []
         project.models = []
         project.targets = []
+        project.selectors = []
         return project


### PR DESCRIPTION
Wrapped the `CohortSelect` model in a new `Selector` component to display them inline.

A bigger change in this is to allow "options" to be trace references.  This seems like an easy quick step toward having the more complex "meta" tagging we talked about.