### PR TITLE
Too deep of a search resulted in too many traces on a chart

### DIFF
--- a/visivo/models/base/parent_model.py
+++ b/visivo/models/base/parent_model.py
@@ -84,21 +84,27 @@ class ParentModel(ABC):
                     )
 
     @staticmethod
-    def all_descendants(dag, from_node=None):
+    def all_descendants(dag, from_node=None, depth=None):
         import networkx.algorithms.traversal.depth_first_search as dfs
 
-        return dfs.dfs_tree(dag, from_node)
+        return dfs.dfs_tree(dag, from_node, depth_limit=depth)
 
     def descendants(self):
         return ParentModel.all_descendants(dag=self.dag(), from_node=self)
 
     @staticmethod
-    def all_descendants_of_type(type, dag, from_node=None):
+    def all_descendants_of_type(type, dag, from_node=None, depth=None):
+        if not depth:
+            depth = len(dag)
+
         def find_type(item):
             return isinstance(item, type)
 
         return list(
-            filter(find_type, ParentModel.all_descendants(dag=dag, from_node=from_node))
+            filter(
+                find_type,
+                ParentModel.all_descendants(dag=dag, from_node=from_node, depth=depth),
+            )
         )
 
     def descendants_of_type(self, type):

--- a/visivo/models/base/parent_model.py
+++ b/visivo/models/base/parent_model.py
@@ -150,10 +150,10 @@ class ParentModel(ABC):
     @staticmethod
     def show_dag(dag):
         import matplotlib.pyplot as pyplot
-        from networkx import planar_layout, draw_networkx
+        from networkx import spring_layout, draw_networkx
 
         options = {}
-        pos = planar_layout(dag)
+        pos = spring_layout(dag)
         draw_networkx(dag, pos, **options)
 
         ax = pyplot.gca()

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -18,7 +18,6 @@ class Serializer:
         project.cli_version = version("visivo")
         dag = project.dag()
 
-        # ParentModel.show_dag(dag)
         for dashboard in project.dashboards:
 
             def replace_item_ref(item):

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -18,6 +18,7 @@ class Serializer:
         project.cli_version = version("visivo")
         dag = project.dag()
 
+        # ParentModel.show_dag(dag)
         for dashboard in project.dashboards:
 
             def replace_item_ref(item):
@@ -34,13 +35,13 @@ class Serializer:
                         component = item.table
 
                     component.traces = ParentModel.all_descendants_of_type(
-                        type=Trace, dag=dag, from_node=component
+                        type=Trace, dag=dag, from_node=component, depth=1
                     )
                     component.selector = ParentModel.all_descendants_of_type(
-                        type=Selector, dag=dag, from_node=component
+                        type=Selector, dag=dag, from_node=component, depth=1
                     )[0]
                     component.selector.options = ParentModel.all_descendants_of_type(
-                        type=Trace, dag=dag, from_node=component.selector
+                        type=Trace, dag=dag, from_node=component.selector, depth=1
                     )
                     for trace in component.traces:
                         trace.model = ParentModel.all_descendants_of_type(
@@ -56,10 +57,10 @@ class Serializer:
                             )
                 if item.selector:
                     item.selector = ParentModel.all_descendants_of_type(
-                        type=Selector, dag=dag, from_node=item
+                        type=Selector, dag=dag, from_node=item, depth=1
                     )[0]
                     item.selector.options = ParentModel.all_descendants_of_type(
-                        type=Trace, dag=dag, from_node=item.selector
+                        type=Trace, dag=dag, from_node=item.selector, depth=1
                     )
 
             dashboard.for_each_item(replace_item_ref)

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -1,8 +1,6 @@
-from visivo.models.base.named_model import NamedModel
 from visivo.models.selector import Selector
 from visivo.models.targets.target import Target
 from ..models.project import Project
-from ..models.base.base_model import BaseModel
 from ..models.base.parent_model import ParentModel
 from visivo.models.chart import Chart
 from visivo.models.table import Table
@@ -19,6 +17,7 @@ class Serializer:
         project = self.project.model_copy(deep=True)
         project.cli_version = version("visivo")
         dag = project.dag()
+
         for dashboard in project.dashboards:
 
             def replace_item_ref(item):
@@ -41,7 +40,7 @@ class Serializer:
                         type=Selector, dag=dag, from_node=component
                     )[0]
                     component.selector.options = ParentModel.all_descendants_of_type(
-                        type=Trace, dag=dag, from_node=item.selector
+                        type=Trace, dag=dag, from_node=component.selector
                     )
                     for trace in component.traces:
                         trace.model = ParentModel.all_descendants_of_type(
@@ -56,6 +55,9 @@ class Serializer:
                                 type=Model, dag=dag, from_node=trace.model
                             )
                 if item.selector:
+                    item.selector = ParentModel.all_descendants_of_type(
+                        type=Selector, dag=dag, from_node=item
+                    )[0]
                     item.selector.options = ParentModel.all_descendants_of_type(
                         type=Trace, dag=dag, from_node=item.selector
                     )


### PR DESCRIPTION
With selectors it was finding all traces on a chart.  This meant if a chart was referencing a selector, that referenced different traces, it would go "through" the sector and return all the traces.  The solution was to limit the depth of the search to only include those items of a type directly attached to the given object when dereferencing.