### PR TITLE
Add empty error

### DIFF
--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -27,6 +27,7 @@ def test_dist():
     assert "Created dist folder" in response.output
     assert response.exit_code == 0
     assert os.path.exists(f"dist/data/trace/data.json")
+    assert os.path.exists(f"dist/data/error.json")
     assert os.path.exists(f"dist/data/project.json")
     with open("dist/data/project.json") as project_json:
         assert '"created_at"' in project_json.read()

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -31,6 +31,8 @@ def dist_phase(output_dir, working_dir, dist_dir, default_source, name_filter, t
                 }
             )
         )
+    with open(f"{dist_dir}/data/error.json", "w") as f:
+        f.write(json.dumps({}))
 
     trace_dirs = glob(f"{output_dir}/*/", recursive=True)
     for trace_dir in trace_dirs:


### PR DESCRIPTION
The dist didn't have a response for the error.  This is fine for now, but if we have other ones for static sites we should think about doing it differently.