### PR TITLE
Move ordering to trace names

### DIFF
--- a/viewer/src/hooks/useTracesData.js
+++ b/viewer/src/hooks/useTracesData.js
@@ -21,7 +21,11 @@ export const useTracesData = (projectId, traceNames) => {
     useEffect(() => {
         const waitForData = async () => {
             const fetchedTracesData = await fetchTracesData(traces);
-            setTraceData(filterObject(fetchedTracesData, memoizedTraceNames));
+            const orderedTracesData = memoizedTraceNames.reduce((orderedJson, traceName) => {
+                orderedJson[traceName] = fetchedTracesData[traceName];
+                return orderedJson;
+            }, {});
+            setTraceData(filterObject(orderedTracesData, memoizedTraceNames));
         };
         if (traces) {
             waitForData();

--- a/viewer/src/hooks/useTracesData.test.js
+++ b/viewer/src/hooks/useTracesData.test.js
@@ -1,23 +1,46 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { useTracesData } from "./useTracesData";
 import { withProviders } from "../utils/test-utils";
+import { QueryProvider } from "../contexts/QueryContext";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as fetchTracesData from "../queries/tracesData";
 
 describe("useTraceDate", () => {
-    test("should return null when no traces", () => {
-        const { result } = renderHook(() => useTracesData(), { wrapper: withProviders })
-        expect(result.current).toBe(null);
-    });
-
-    test("should return trace data", async () => {
-        const { result } = renderHook(() => useTracesData(), {
-            wrapper: withProviders,
-            initialProps: {
-                traces: [{ name: "trace" }]
-            }
-        })
+    test("should return empty object when no traces", async () => {
+        const { result } = renderHook(() => useTracesData("projectId", []), { wrapper: withProviders })
 
         await waitFor(() => {
             expect(result.current).toStrictEqual({});
+        });
+    });
+
+    test("should return trace data", async () => {
+        const fetchTracesQuery = (projectId, name) => ({
+            queryKey: ['trace', projectId, name],
+            queryFn: () => [{ "name": "traceName" }],
+        })
+        const queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                },
+            },
+        })
+
+        jest.spyOn(fetchTracesData, 'fetchTracesData').mockImplementation((projectId, traceNames) => ({ traceName: { data: "data" } }));
+        const { result } = renderHook(() => useTracesData("projectId", ["traceName"]), {
+            wrapper: ({ children }) => {
+                return (
+                    <QueryProvider value={{ fetchTracesQuery }}>
+                        <QueryClientProvider client={queryClient}>
+                            {children}
+                        </QueryClientProvider>
+                    </QueryProvider>
+                )
+            }
+        })
+        await waitFor(() => {
+            expect(result.current).toStrictEqual({ traceName: { data: "data" } });
         });
     });
 })

--- a/viewer/src/queries/tracesData.js
+++ b/viewer/src/queries/tracesData.js
@@ -11,9 +11,5 @@ export const fetchTracesData = async (traces) => {
             returnJson[trace.name] = traceJson;
         })
     )
-
-    return traces.reduce((orderedJson, trace) => {
-        orderedJson[trace.name] = returnJson[trace.name];
-        return orderedJson;
-    }, {});
+    return returnJson;
 }

--- a/viewer/src/utils/test-utils.js
+++ b/viewer/src/utils/test-utils.js
@@ -10,10 +10,10 @@ export const TestComponent = () => {
     return <div>TEST COMPONENT</div>
 }
 
-export const withProviders = ({ children, initialPath = '/' }) => {
+export const withProviders = ({ children, initialPath = '/', traces = [] }) => {
     const fetchTracesQuery = (projectId, name) => ({
         queryKey: ['trace', projectId, name],
-        queryFn: () => [],
+        queryFn: () => traces,
     })
 
     const queryClient = new QueryClient({


### PR DESCRIPTION
Move the ordering of traces one level higher to have the trace names available.