### PR TITLE
extract server shutdown

### DIFF
--- a/tests/tokens/test_server.py
+++ b/tests/tokens/test_server.py
@@ -25,11 +25,13 @@ def test_authorize_device_callback_no_token(client):
     assert data["error"] == "Token not provided"
 
 
+@patch("visivo.tokens.server.threading.Thread")
 @patch("visivo.tokens.server.validate_and_store_token")  # bottom patch
 @patch("visivo.tokens.server.Logger.instance")  # top patch
 def test_authorize_device_callback_with_token(
     mock_logger_class,
     mock_validate,
+    mock_thread,
     client,
 ):
     """
@@ -53,3 +55,7 @@ def test_authorize_device_callback_with_token(
 
     response_data = response.data.decode("utf-8")
     assert "Authorization Successful" in response_data
+
+    mock_thread.assert_called_once()
+    thread_instance = mock_thread.return_value
+    thread_instance.start.assert_called_once()


### PR DESCRIPTION
# Flask Server - Premature Shutdown Fix

## Ticket 
TBC

## What
* Fix to shutdown the flask server 1s after the response is sent and not to assume that the shut down process would take longer than sending the response. Server shutdown function extracted onto a new thread.

## Why
* The server was shutting down before the html was sent

## Acceptance
* Ensure that the token success html response gets shown and then a redirect to the profile page occurs