### PR TITLE
fix: relax dependency constraints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3963,4 +3963,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = " >=3.10,<3.13"
-content-hash = "92beb07d5db707a1d8cc722e1df5f56139eac14c9ee503600ae98b8bc2eac17d"
+content-hash = "70df74dd660279dc1335977b79cced16be1d4e9d2a056820afa0ff5fdb791e08"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ write-schema-json = "visivo.generate_project_schema_json:write_schema_json"
 
 [tool.poetry.dependencies]
 python = " >=3.10,<3.13"
-pydantic = ">=2.9.0"
+pydantic = ">=2.9.0,<=2.9.2"
 requests = ">=2.28.2"
 Jinja2 = ">=3.1.2"
 PyYAML = ">=6.0"


### PR DESCRIPTION
This PR relaxes dependency constraints in `pyproject.toml` to use `>=` specifiers instead of `^` and `=`. 

The previously used constraints were too restrictive and made `visivo` incompatible with many projects. 

I understand that you probably want to keep some of the constraints more tight than the initial version of the PR (ex: do you want to keep `pandas < 2.0` like your original `^` constraint did?). Let's review them and make the necessary changes case-by-case. 