### PR TITLE
Visually cramped layout on dashboard

### DIFF
--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -97,11 +97,11 @@ const Dashboard = ({ project, dashboardName }) => {
         key={`row-${rowIndex}`}
         className={`dashboard-row w-full max-w-full ${isColumn ? 'flex' : 'grid justify-center'}`}
         style={{
-          margin: '0.1rem',
+          margin: '0.5rem',
           display: isColumn ? 'flex' : 'grid',
           flexDirection: isColumn ? 'column' : undefined,
           gridTemplateColumns: isColumn ? undefined : `repeat(${totalWidth}, 1fr)`,
-          gap: '0.1rem',
+          gap: '0.7rem',
           ...rowStyle,
         }}
       >


### PR DESCRIPTION
1. Added consistent horizontal and vertical spacing between rendered chart components.
2. Used gap and margin in the parent container to ensure clean spacing.