### PR TITLE
Filter Cohort zIndex on tables fix

### DIFF
--- a/viewer/src/components/select/NameSelect.jsx
+++ b/viewer/src/components/select/NameSelect.jsx
@@ -142,6 +142,7 @@ const NameSelect = ({
       {showLabel && <label htmlFor={`selector${name}`}>Selector</label>}
       {visible && (
         <Select
+          styles={{ menu: provided => ({ ...provided, zIndex: 9999 })}}
           data-testid="selector"
           name="selector"
           inputId={`selector${name}`}


### PR DESCRIPTION
Filter Cohort is now fully visible and accessible when used on tables.