### PR TITLE
Fix read-only attach for duckdb sources

### DIFF
--- a/visivo/models/sources/duckdb_source.py
+++ b/visivo/models/sources/duckdb_source.py
@@ -55,7 +55,7 @@ class DuckdbSource(Source):
             if self.attach:
                 for attachment in self.attach:
                     connection.execute(
-                        f"ATTACH DATABASE '{attachment.source.database}' AS {attachment.schema_name}"
+                        f"ATTACH DATABASE '{attachment.source.database}' AS {attachment.schema_name} (READ_ONLY)"
                     )
 
             return connection


### PR DESCRIPTION
## Summary
- avoid DuckDB write-write conflicts by attaching dependencies in READ_ONLY mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68652571d4a883289a154e67f140e3da