### PR TITLE
Add iframe support to viewer UI

### DIFF
--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -136,11 +136,13 @@ dashboards:
         items:
           - width: 5
             chart: ${ref(simple_chart)}
+            - width: 2
+              markdown: |
+                # Here is the first
+                1. Numbered
+                1. List
           - width: 2
-            markdown: |
-              # Here is the first
-              1. Numbered
-              1. List
+            iframe: https://example.com
 ```
 
 ### Set up a Source & store secrets safely
@@ -224,11 +226,11 @@ charts:
 ```
 
 ### Create a Dashboard
-Dashboards house `charts`, `tables` and `markdown`. They help you set up a highly flexible grid so that you can put all of your information exactly where you need it. 
+Dashboards house `charts`, `tables`, `markdown` and `iframes`. They help you set up a highly flexible grid so that you can put all of your information exactly where you need it.
 
 You can structure the grid by specifying rows that house many items. Items have a particular width that is evaluated relative to the other item widths in the row. So if for example you had 3 items in a row with widths of 5, 2 and 3. The first item would take up 50% of the row, the second 20% and the third 30%. 
 ```
-Dashboard --> row --> item --> chart/table/markdown
+Dashboard --> row --> item --> chart/table/markdown/iframe
                  |        |
                  |         --> width
                   --> height 
@@ -242,11 +244,13 @@ dashboards:
         items:
           - width: 5
             chart: ${ref(simple_chart)}
+            - width: 2
+              markdown: |
+                # Here is the first
+                1. Numbered
+                1. List
           - width: 2
-            markdown: |
-              # Here is the first
-              1. Numbered
-              1. List
+            iframe: https://example.com
 ```
 
 ### Set up Alerts - Optional

--- a/tests/models/test_item.py
+++ b/tests/models/test_item.py
@@ -17,7 +17,7 @@ def test_Item_both_chart_and_markdown():
     error = exc_info.value.errors()[0]
     assert (
         error["msg"]
-        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
+        == 'Value error, only one of the "markdown", "chart", "table", "selector", or "iframe" properties should be set on an item'
     )
     assert error["type"] == "value_error"
 
@@ -38,7 +38,7 @@ def test_Item_both_chart_and_table():
     error = exc_info.value.errors()[0]
     assert (
         error["msg"]
-        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
+        == 'Value error, only one of the "markdown", "chart", "table", "selector", or "iframe" properties should be set on an item'
     )
     assert error["type"] == "value_error"
 
@@ -50,8 +50,34 @@ def test_Item_both_chart_and_selector():
     error = exc_info.value.errors()[0]
     assert (
         error["msg"]
-        == 'Value error, only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
+        == 'Value error, only one of the "markdown", "chart", "table", "selector", or "iframe" properties should be set on an item'
     )
+    assert error["type"] == "value_error"
+
+
+def test_Item_iframe_simple():
+    item = Item(iframe="https://example.com")
+    assert item.iframe == "https://example.com"
+
+
+def test_Item_iframe_and_chart():
+    with pytest.raises(ValidationError) as exc_info:
+        Item(chart="ref(chart)", iframe="https://example.com")
+
+    error = exc_info.value.errors()[0]
+    assert (
+        error["msg"]
+        == 'Value error, only one of the "markdown", "chart", "table", "selector", or "iframe" properties should be set on an item'
+    )
+    assert error["type"] == "value_error"
+
+
+def test_Item_iframe_and_align():
+    with pytest.raises(ValidationError) as exc_info:
+        Item(iframe="https://example.com", align="right")
+
+    error = exc_info.value.errors()[0]
+    assert "property can only be set when" in error["msg"]
     assert error["type"] == "value_error"
 
 

--- a/viewer/src/components/items/Iframe.jsx
+++ b/viewer/src/components/items/Iframe.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { ItemContainer } from './ItemContainer';
+import MenuContainer from './MenuContainer';
+import Menu from './Menu';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faShareAlt } from '@fortawesome/free-solid-svg-icons';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+
+const Iframe = ({ url, height }) => {
+  const [hovering, setHovering] = useState(false);
+  const { toolTip, copyText, resetToolTip } = useCopyToClipboard();
+
+  return (
+    <ItemContainer
+      onMouseOver={() => setHovering(true)}
+      onMouseOut={() => setHovering(false)}
+    >
+      <MenuContainer>
+        <Menu
+          hovering={hovering}
+          withDropDown={false}
+          buttonChildren={<FontAwesomeIcon icon={faShareAlt} />}
+          buttonProps={{
+            style: {
+              cursor: 'pointer',
+              visibility: hovering ? 'visible' : 'hidden',
+            },
+            onClick: () => {
+              const shareUrl = new URL(window.location.href);
+              shareUrl.searchParams.set('element_id', window.scrollY);
+              copyText(shareUrl.toString());
+            },
+            onMouseLeave: resetToolTip,
+          }}
+          showToolTip
+          toolTip={toolTip}
+        ></Menu>
+      </MenuContainer>
+      <iframe
+        src={url}
+        title={url}
+        width="100%"
+        height={height}
+        frameBorder="0"
+        className="w-full"
+      ></iframe>
+    </ItemContainer>
+  );
+};
+
+export default Iframe;

--- a/viewer/src/components/items/Iframe.test.jsx
+++ b/viewer/src/components/items/Iframe.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Iframe from './Iframe';
+
+test('renders iframe with provided url', () => {
+  render(<Iframe url="https://example.com" height={300} />);
+  const iframe = screen.getByTitle('https://example.com');
+  expect(iframe).toBeInTheDocument();
+  expect(iframe).toHaveAttribute('src', 'https://example.com');
+});

--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -6,6 +6,7 @@ import { throwError } from '../../api/utils';
 import { useSearchParams } from 'react-router-dom';
 import { getSelectorByOptionName } from '../../models/Project';
 import Markdown from '../items/Markdown';
+import Iframe from '../items/Iframe';
 
 const Dashboard = ({ project, dashboardName }) => {
   const [searchParams] = useSearchParams();
@@ -105,7 +106,7 @@ const Dashboard = ({ project, dashboardName }) => {
       >
         {visibleItems.map((item, itemIndex) => (
           <div
-            key={`item-${rowIndex}-${itemIndex}-${item.chart?.path || item.table?.path || item.selector?.path}`}
+            key={`item-${rowIndex}-${itemIndex}-${item.chart?.path || item.table?.path || item.selector?.path || item.iframe}`}
             className={isColumn ? 'w-full max-w-full' : ''}
             style={{
               gridColumn: isColumn ? undefined : `span ${item.width || 1}`,
@@ -156,6 +157,14 @@ const Dashboard = ({ project, dashboardName }) => {
           itemWidth={item.width}
           key={`dashboardRow${rowIndex}Item${itemIndex}`}
         ></Selector>
+      );
+    } else if (item.iframe) {
+      return (
+        <Iframe
+          key={`dashboardRow${rowIndex}Item${itemIndex}`}
+          url={item.iframe}
+          height={getHeight(row.height)}
+        />
       );
     } else if (item.markdown) {
       return (

--- a/visivo/models/item.py
+++ b/visivo/models/item.py
@@ -11,7 +11,7 @@ from pydantic import model_validator
 
 class Item(NamedModel, ParentModel):
     """
-    The Item houses a single chart, table, selector or markdown object.
+    The Item houses a single chart, table, selector, markdown or iframe object.
 
     It also informs the width that the chart, table or markdown should occupy within a row. Widths are evaluated for each item in a row relative to all of the other items in the row.
 
@@ -139,20 +139,22 @@ class Item(NamedModel, ParentModel):
     selector: Optional[generate_ref_field(Selector)] = Field(
         None, description="A Selector object defined inline or a ref() to a selector"
     )
+    iframe: Optional[str] = Field(None, description="URL to embed as an iframe.")
 
     @model_validator(mode="before")
     @classmethod
     def validate_unique_item_types(cls, data: any):
-        markdown, chart, table, selector = (
+        markdown, chart, table, selector, iframe = (
             data.get("markdown"),
             data.get("chart"),
             data.get("table"),
             data.get("selector"),
+            data.get("iframe"),
         )
-        items_set = [i for i in [markdown, chart, table, selector] if i is not None]
+        items_set = [i for i in [markdown, chart, table, selector, iframe] if i is not None]
         if len(items_set) > 1:
             raise ValueError(
-                'only one of the "markdown", "chart", "table", or "selector" properties should be set on an item'
+                'only one of the "markdown", "chart", "table", "selector", or "iframe" properties should be set on an item'
             )
         return data
 


### PR DESCRIPTION
## Summary
- add Item Iframe component for dashboard rendering
- update Dashboard view to display iframe items
- document iframe usage in quickstart

## Testing
- `yarn test`
- `poetry run pytest -q` *(fails: duckdb download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688237cc39c4832883810aebe4bf95e4