### PR TITLE
Change ref syntax from ${ref(name)} to ${name} dot syntax

### DIFF
--- a/tests/commands/test_dbt_phase.py
+++ b/tests/commands/test_dbt_phase.py
@@ -82,7 +82,7 @@ def test_dbt_with_defaults():
     with open(f"{output_dir}/dbt.yml", "r") as file:
         dbt_content = yaml.safe_load(file)
         SnowflakeSource(**dbt_content["sources"][0])
-        assert dbt_content["models"][0]["source"] == "ref(profile_name_target_name)"
+        assert dbt_content["models"][0]["source"] == "${profile_name_target_name}"
 
 
 def test_dbt_with_set_profile_and_target():
@@ -101,7 +101,7 @@ def test_dbt_with_set_profile_and_target():
     assert os.path.exists(f"{output_dir}/dbt.yml")
     with open(f"{output_dir}/dbt.yml", "r") as file:
         dbt_content = yaml.safe_load(file)
-        assert dbt_content["models"][0]["source"] == "ref(profile_name_target_name)"
+        assert dbt_content["models"][0]["source"] == "${profile_name_target_name}"
 
 
 def test_dbt_with_missing_profile():

--- a/tests/integration/test_input_interaction_pipeline.py
+++ b/tests/integration/test_input_interaction_pipeline.py
@@ -102,8 +102,8 @@ class TestInputInteractionPipeline:
         insight_children = insight.child_items()
 
         # ASSERT - Insight depends on input (accessor syntax still creates ref dependency)
-        assert "ref(filter_value)" in insight_children, "Insight doesn't depend on input"
-        assert "ref(data)" in insight_children, "Insight doesn't depend on model"
+        assert "${filter_value}" in insight_children, "Insight doesn't depend on input"
+        assert "${data}" in insight_children, "Insight doesn't depend on model"
 
         # Verify input job function exists
         from visivo.jobs.dag_runner import input_job

--- a/tests/models/base/test_context_string.py
+++ b/tests/models/base/test_context_string.py
@@ -14,6 +14,14 @@ def test_ContextString_is_context_string():
     assert not ContextString.is_context_string("{ ref(Name) }")
 
 
+def test_ContextString_is_context_string_dot_syntax():
+    """Test that new dot syntax is recognized as context string."""
+    assert ContextString.is_context_string("${orders}")
+    assert ContextString.is_context_string("${my-model}")
+    assert ContextString.is_context_string("${orders.id}")
+    assert ContextString.is_context_string(ContextString("${orders}"))
+
+
 def test_ContextString_ref_name():
     context_string = ContextString("")
     assert context_string.get_reference() == None
@@ -32,6 +40,18 @@ def test_ContextString_ref_name():
 
     context_string = ContextString("${ref(Name)}.property[1]")
     assert context_string.get_reference() == "Name"
+
+
+def test_ContextString_ref_name_dot_syntax():
+    """Test getting reference from new dot syntax."""
+    context_string = ContextString("${orders}")
+    assert context_string.get_reference() == "orders"
+
+    context_string = ContextString("${my-model}")
+    assert context_string.get_reference() == "my-model"
+
+    context_string = ContextString("${orders.id}")
+    assert context_string.get_reference() == "orders"
 
 
 def test_ContextString_get_path():
@@ -73,8 +93,21 @@ def test_ContextString_get_ref_props_path():
     context_string = ContextString("Regular string without ref")
     assert context_string.get_ref_props_path() == None
 
+    # ${project.name} is an inline path, not a dot-syntax ref
     context_string = ContextString("${ project.name }")
     assert context_string.get_ref_props_path() == None
+
+
+def test_ContextString_get_ref_props_path_dot_syntax():
+    """Test getting props path from new dot syntax."""
+    context_string = ContextString("${orders}")
+    assert context_string.get_ref_props_path() == ""
+
+    context_string = ContextString("${orders.id}")
+    assert context_string.get_ref_props_path() == ".id"
+
+    context_string = ContextString("${orders.nested.field}")
+    assert context_string.get_ref_props_path() == ".nested.field"
 
 
 def test_ContextString_as_field():
@@ -83,6 +116,12 @@ def test_ContextString_as_field():
 
     with pytest.raises(ValueError):
         MockStringModel(**{"ref": "{ ref(Name) }"})
+
+
+def test_ContextString_as_field_dot_syntax():
+    """Test using new dot syntax in a Pydantic field."""
+    test_string_model = MockStringModel(**{"ref": "${orders}"})
+    assert test_string_model.ref.get_reference() == "orders"
 
 
 def test_ContextString_hash():

--- a/tests/models/base/test_eval_string.py
+++ b/tests/models/base/test_eval_string.py
@@ -24,6 +24,7 @@ def test_EvalString_get_references():
     eval_string = EvalString(">{ ${ref(Name1)} == ${ref(Name1)} }")
     assert eval_string.get_references() == ["Name1", "Name1"]
 
+    # ${project.name} is an inline path, not a named ref
     eval_string = EvalString(">{ ${ref(Name)} == ${project.name} }")
     assert eval_string.get_references() == ["Name"]
 

--- a/tests/models/deprecations/test_ref_syntax_deprecation.py
+++ b/tests/models/deprecations/test_ref_syntax_deprecation.py
@@ -61,7 +61,7 @@ class TestRefSyntaxDeprecation:
         assert "ref(source)" in warnings[0].message
         assert warnings[0].feature == "Raw ref() syntax"
         assert warnings[0].removal_version == "2.0.0"
-        assert "${ref(source)}" in warnings[0].migration
+        assert "${source}" in warnings[0].migration
 
     def test_warns_on_multiple_bare_refs(self):
         """Test that multiple bare refs each trigger a warning."""

--- a/tests/models/test_input.py
+++ b/tests/models/test_input.py
@@ -76,7 +76,7 @@ class TestSingleSelectInput:
         children = input_obj.child_items()
 
         assert len(children) == 1
-        assert "products" in children
+        assert "${products}" in children
 
     def test_child_items_empty_for_static_options(self):
         data = {
@@ -188,8 +188,8 @@ class TestMultiSelectInput:
         children = input_obj.child_items()
 
         assert len(children) == 2
-        assert "products" in children
-        assert "orders" in children
+        assert "${products}" in children
+        assert "${orders}" in children
 
     def test_child_items_empty_for_static_range(self):
         data = {

--- a/tests/models/test_input.py
+++ b/tests/models/test_input.py
@@ -76,7 +76,7 @@ class TestSingleSelectInput:
         children = input_obj.child_items()
 
         assert len(children) == 1
-        assert "ref(products)" in children
+        assert "products" in children
 
     def test_child_items_empty_for_static_options(self):
         data = {
@@ -188,8 +188,8 @@ class TestMultiSelectInput:
         children = input_obj.child_items()
 
         assert len(children) == 2
-        assert "ref(products)" in children
-        assert "ref(orders)" in children
+        assert "products" in children
+        assert "orders" in children
 
     def test_child_items_empty_for_static_range(self):
         data = {

--- a/tests/models/test_insight_dependencies.py
+++ b/tests/models/test_insight_dependencies.py
@@ -42,8 +42,12 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert input_obj.name in children, f"Expected {input_obj.name} in children, got: {children}"
-        assert model.name in children, f"Expected {model.name} in children, got: {children}"
+        assert (
+            f"${{{input_obj.name}}}" in children
+        ), f"Expected ${{{input_obj.name}}} in children, got: {children}"
+        assert (
+            f"${{{model.name}}}" in children
+        ), f"Expected ${{{model.name}}} in children, got: {children}"
 
     def test_child_items_includes_model_references(self):
         """Verify model refs from props still work."""
@@ -64,7 +68,9 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert model.name in children, f"Expected {model.name} in children, got: {children}"
+        assert (
+            f"${{{model.name}}}" in children
+        ), f"Expected ${{{model.name}}} in children, got: {children}"
 
     def test_child_items_handles_multiple_inputs(self):
         """Verify multiple input refs all detected."""
@@ -94,9 +100,15 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert input1.name in children, f"Expected {input1.name} in children, got: {children}"
-        assert input2.name in children, f"Expected {input2.name} in children, got: {children}"
-        assert model.name in children, f"Expected {model.name} in children, got: {children}"
+        assert (
+            f"${{{input1.name}}}" in children
+        ), f"Expected ${{{input1.name}}} in children, got: {children}"
+        assert (
+            f"${{{input2.name}}}" in children
+        ), f"Expected ${{{input2.name}}} in children, got: {children}"
+        assert (
+            f"${{{model.name}}}" in children
+        ), f"Expected ${{{model.name}}} in children, got: {children}"
 
     def test_child_items_mixed_inputs_and_models(self):
         """Verify mixed refs (inputs + models)."""
@@ -126,9 +138,9 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert model1.name in children
-        assert model2.name in children
-        assert input_obj.name in children
+        assert f"${{{model1.name}}}" in children
+        assert f"${{{model2.name}}}" in children
+        assert f"${{{input_obj.name}}}" in children
 
     def test_child_items_no_inputs_unchanged(self):
         """Verify behavior without inputs unchanged."""
@@ -149,7 +161,7 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert model.name in children
+        assert f"${{{model.name}}}" in children
         # Should only have the model ref
         assert len(children) == 1
 
@@ -184,10 +196,10 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert input_filter.name in children
-        assert input_split.name in children
-        assert input_sort.name in children
-        assert model.name in children
+        assert f"${{{input_filter.name}}}" in children
+        assert f"${{{input_split.name}}}" in children
+        assert f"${{{input_sort.name}}}" in children
+        assert f"${{{model.name}}}" in children
 
 
 class TestInsightPropsInputRefs:

--- a/tests/models/test_insight_dependencies.py
+++ b/tests/models/test_insight_dependencies.py
@@ -42,10 +42,8 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert (
-            f"ref({input_obj.name})" in children
-        ), f"Expected ref(threshold) in children, got: {children}"
-        assert f"ref({model.name})" in children, f"Expected ref(data) in children, got: {children}"
+        assert input_obj.name in children, f"Expected {input_obj.name} in children, got: {children}"
+        assert model.name in children, f"Expected {model.name} in children, got: {children}"
 
     def test_child_items_includes_model_references(self):
         """Verify model refs from props still work."""
@@ -66,9 +64,7 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert (
-            f"ref({model.name})" in children
-        ), f"Expected ref(orders) in children, got: {children}"
+        assert model.name in children, f"Expected {model.name} in children, got: {children}"
 
     def test_child_items_handles_multiple_inputs(self):
         """Verify multiple input refs all detected."""
@@ -98,13 +94,9 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert (
-            f"ref({input1.name})" in children
-        ), f"Expected ref(min_value) in children, got: {children}"
-        assert (
-            f"ref({input2.name})" in children
-        ), f"Expected ref(max_value) in children, got: {children}"
-        assert f"ref({model.name})" in children, f"Expected ref(data) in children, got: {children}"
+        assert input1.name in children, f"Expected {input1.name} in children, got: {children}"
+        assert input2.name in children, f"Expected {input2.name} in children, got: {children}"
+        assert model.name in children, f"Expected {model.name} in children, got: {children}"
 
     def test_child_items_mixed_inputs_and_models(self):
         """Verify mixed refs (inputs + models)."""
@@ -134,9 +126,9 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert f"ref({model1.name})" in children
-        assert f"ref({model2.name})" in children
-        assert f"ref({input_obj.name})" in children
+        assert model1.name in children
+        assert model2.name in children
+        assert input_obj.name in children
 
     def test_child_items_no_inputs_unchanged(self):
         """Verify behavior without inputs unchanged."""
@@ -157,9 +149,9 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert f"ref({model.name})" in children
-        # Should not have any input refs - only the model ref
-        assert len([c for c in children if "ref(" in c]) == 1
+        assert model.name in children
+        # Should only have the model ref
+        assert len(children) == 1
 
     def test_child_items_from_filter_split_sort(self):
         """Verify refs extracted from all interaction types."""
@@ -192,10 +184,10 @@ class TestInsightChildItems:
         children = insight.child_items()
 
         # ASSERT
-        assert f"ref({input_filter.name})" in children
-        assert f"ref({input_split.name})" in children
-        assert f"ref({input_sort.name})" in children
-        assert f"ref({model.name})" in children
+        assert input_filter.name in children
+        assert input_split.name in children
+        assert input_sort.name in children
+        assert model.name in children
 
 
 class TestInsightPropsInputRefs:

--- a/tests/models/test_project_dag.py
+++ b/tests/models/test_project_dag.py
@@ -198,7 +198,7 @@ def test_ambiguous_ref_Project_dag():
         Project(**project.model_dump())
 
     assert (
-        'The reference "${ref(chart_name)}" on item "item" points to multiple objects. Check for the duplicated name '
+        'The reference "${chart_name}" on item "item" points to multiple objects. Check for the duplicated name '
         in str(exc_info.value)
     )
 

--- a/tests/models/test_semantic_layer_dag.py
+++ b/tests/models/test_semantic_layer_dag.py
@@ -40,7 +40,7 @@ def test_nested_metric_references_parent_model():
 
     # Verify child_items returns ref to parent
     children = nested_metric.child_items()
-    assert children == ["ref(orders)"]
+    assert children == ["orders"]
 
     # Verify edge exists from metric to model in DAG (nested metric depends on parent model)
     assert dag.has_edge(nested_metric, model)
@@ -76,7 +76,7 @@ def test_nested_dimension_references_parent_model():
 
     # Verify child_items returns ref to parent
     children = nested_dimension.child_items()
-    assert children == ["ref(orders)"]
+    assert children == ["orders"]
 
     # Verify edge exists from dimension to model in DAG (nested dimension depends on parent model)
     assert dag.has_edge(nested_dimension, model)
@@ -115,7 +115,7 @@ def test_standalone_metric_extracts_model_references():
 
     # Verify child_items extracts model reference
     children = standalone_metric.child_items()
-    assert set(children) == {"ref(orders)"}
+    assert set(children) == {"orders"}
 
     # Verify edge exists from metric to model (metric depends on model)
     assert dag.has_edge(standalone_metric, orders_model)
@@ -157,7 +157,7 @@ def test_standalone_dimension_extracts_model_references():
 
     # Verify child_items extracts model reference
     children = standalone_dimension.child_items()
-    assert children == ["ref(orders)"]
+    assert children == ["orders"]
 
     # Verify edge exists from dimension to model (dimension depends on model)
     assert dag.has_edge(standalone_dimension, orders_model)
@@ -198,7 +198,7 @@ def test_relation_extracts_model_references():
 
     # Verify child_items extracts both model references
     children = relation.child_items()
-    assert set(children) == {"ref(orders)", "ref(users)"}
+    assert set(children) == {"orders", "users"}
 
     # Verify edges exist from relation to both models (relation depends on both models)
     assert dag.has_edge(relation, orders_model)
@@ -295,7 +295,7 @@ def test_mixed_nested_and_standalone_metrics():
 
     # Verify standalone metric references the model
     standalone_children = standalone_metric.child_items()
-    assert set(standalone_children) == {"ref(orders)"}
+    assert set(standalone_children) == {"orders"}
 
     # Verify edges (nested metrics depend on their parent model)
     assert dag.has_edge(orders_model.metrics[0], orders_model)

--- a/tests/models/test_semantic_layer_dag.py
+++ b/tests/models/test_semantic_layer_dag.py
@@ -40,7 +40,7 @@ def test_nested_metric_references_parent_model():
 
     # Verify child_items returns ref to parent
     children = nested_metric.child_items()
-    assert children == ["orders"]
+    assert children == ["${orders}"]
 
     # Verify edge exists from metric to model in DAG (nested metric depends on parent model)
     assert dag.has_edge(nested_metric, model)
@@ -76,7 +76,7 @@ def test_nested_dimension_references_parent_model():
 
     # Verify child_items returns ref to parent
     children = nested_dimension.child_items()
-    assert children == ["orders"]
+    assert children == ["${orders}"]
 
     # Verify edge exists from dimension to model in DAG (nested dimension depends on parent model)
     assert dag.has_edge(nested_dimension, model)
@@ -115,7 +115,7 @@ def test_standalone_metric_extracts_model_references():
 
     # Verify child_items extracts model reference
     children = standalone_metric.child_items()
-    assert set(children) == {"orders"}
+    assert set(children) == {"${orders}"}
 
     # Verify edge exists from metric to model (metric depends on model)
     assert dag.has_edge(standalone_metric, orders_model)
@@ -157,7 +157,7 @@ def test_standalone_dimension_extracts_model_references():
 
     # Verify child_items extracts model reference
     children = standalone_dimension.child_items()
-    assert children == ["orders"]
+    assert children == ["${orders}"]
 
     # Verify edge exists from dimension to model (dimension depends on model)
     assert dag.has_edge(standalone_dimension, orders_model)
@@ -198,7 +198,7 @@ def test_relation_extracts_model_references():
 
     # Verify child_items extracts both model references
     children = relation.child_items()
-    assert set(children) == {"orders", "users"}
+    assert set(children) == {"${orders}", "${users}"}
 
     # Verify edges exist from relation to both models (relation depends on both models)
     assert dag.has_edge(relation, orders_model)
@@ -295,7 +295,7 @@ def test_mixed_nested_and_standalone_metrics():
 
     # Verify standalone metric references the model
     standalone_children = standalone_metric.child_items()
-    assert set(standalone_children) == {"orders"}
+    assert set(standalone_children) == {"${orders}"}
 
     # Verify edges (nested metrics depend on their parent model)
     assert dag.has_edge(orders_model.metrics[0], orders_model)

--- a/tests/query/insight/test_insight_query_builder_with_inputs.py
+++ b/tests/query/insight/test_insight_query_builder_with_inputs.py
@@ -185,8 +185,8 @@ class TestReplaceInputPlaceholdersForParsing:
         assert "/* __VISIVO_INPUT:color.value__ */" in result_sql
         assert replacements == {"threshold.value": "100", "color.value": "'red'"}
 
-    def test_raises_error_for_undefined_input(self):
-        """Test that ValueError is raised for undefined input placeholder."""
+    def test_skips_undefined_input_refs(self):
+        """Test that undefined input placeholders are silently skipped (could be model refs)."""
         source = SourceFactory()
         orders_model = SqlModel(
             name="orders",
@@ -211,10 +211,12 @@ class TestReplaceInputPlaceholdersForParsing:
         dag = project.dag()
 
         sql = "amount > ${ref(undefined_input).value}"
-        with pytest.raises(ValueError) as exc_info:
-            replace_input_placeholders_for_parsing(sql, dag=dag, insight=insight)
-        assert "undefined_input" in str(exc_info.value)
-        assert "undefined input" in str(exc_info.value)
+        result_sql, replacements = replace_input_placeholders_for_parsing(
+            sql, dag=dag, insight=insight
+        )
+        # Undefined input refs are left unchanged (might be model refs with dot syntax)
+        assert "${ref(undefined_input).value}" in result_sql
+        assert len(replacements) == 0
 
 
 class TestRestoreInputPlaceholders:

--- a/tests/query/resolvers/test_field_resolver_with_inputs.py
+++ b/tests/query/resolvers/test_field_resolver_with_inputs.py
@@ -13,12 +13,8 @@ from tests.factories.model_factories import SourceFactory
 class TestFieldResolverWithInputs:
     """Tests for FieldResolver handling of input references."""
 
-    def test_field_resolver_crashes_on_unsanitized_input_ref(self):
-        """Document that FieldResolver crashes when given unsanitized input reference.
-
-        This test documents the expected behavior - FieldResolver should crash on
-        unsanitized input refs because they have no parents in the DAG.
-        """
+    def test_field_resolver_skips_input_refs(self):
+        """FieldResolver should skip input references and leave them unchanged."""
         source = SourceFactory()
         orders_model = SqlModel(
             name="orders",
@@ -45,10 +41,9 @@ class TestFieldResolverWithInputs:
             native_dialect="duckdb",
         )
 
-        # This will crash with IndexError because FieldResolver tries to get parent
-        # of Input node, but Inputs have no parents in the DAG
-        with pytest.raises(IndexError):
-            field_resolver.resolve(expression="${ref(threshold)}")
+        # Input refs should be returned unchanged (not resolved as model refs)
+        result = field_resolver.resolve(expression="${ref(threshold)}")
+        assert "${ref(threshold)}" in result
 
     def test_field_resolver_ignores_sanitized_input_placeholder(self):
         """Test that FieldResolver passes through sanitized input placeholders unchanged."""

--- a/tests/query/test_patterns.py
+++ b/tests/query/test_patterns.py
@@ -2,7 +2,7 @@
 Tests for visivo.query.patterns module.
 
 This module tests all the regex patterns and utility functions used for
-parsing ${ref(...)} patterns in the Visivo query system.
+parsing ${ref(...)} and ${name} patterns in the Visivo query system.
 """
 
 import pytest
@@ -13,6 +13,7 @@ from visivo.query.patterns import (
     PROPERTY_PATH_PATTERN,
     CONTEXT_STRING_REF_PATTERN,
     CONTEXT_STRING_REF_PATTERN_COMPILED,
+    DOT_SYNTAX_NAME_PATTERN,
     get_model_name_from_match,
     extract_ref_components,
     extract_ref_names,
@@ -24,155 +25,189 @@ from visivo.query.patterns import (
 
 
 class TestREFRegex:
-    """Test the REF_PROPERTY_PATTERN pattern for simple ref() validation."""
+    """Test the REF_PROPERTY_PATTERN pattern for simple ref() and bare name validation."""
 
     def test_simple_ref(self):
-        """Test matching simple unquoted ref patterns."""
         assert re.match(REF_PROPERTY_PATTERN, "ref(orders)")
         assert re.match(REF_PROPERTY_PATTERN, "ref(users)")
         assert re.match(REF_PROPERTY_PATTERN, "ref(model_name)")
 
+    def test_bare_name(self):
+        """Test matching bare name patterns (new dot syntax)."""
+        assert re.match(REF_PROPERTY_PATTERN, "orders")
+        assert re.match(REF_PROPERTY_PATTERN, "my-model")
+        assert re.match(REF_PROPERTY_PATTERN, "model_name")
+        assert re.match(REF_PROPERTY_PATTERN, "3d-scatter")
+
     def test_ref_with_spaces_in_name(self):
-        """Test matching ref patterns with spaces in model names."""
         assert re.match(REF_PROPERTY_PATTERN, "ref(Fibonacci Waterfall)")
         assert re.match(REF_PROPERTY_PATTERN, "ref(My Model Name)")
 
     def test_ref_with_quotes(self):
-        """Test matching ref patterns with quoted model names."""
         assert re.match(REF_PROPERTY_PATTERN, "ref('my-model')")
         assert re.match(REF_PROPERTY_PATTERN, 'ref("my-model")')
         assert re.match(REF_PROPERTY_PATTERN, "ref('model with spaces')")
 
     def test_ref_with_special_chars(self):
-        """Test matching ref patterns with hyphens and underscores."""
         assert re.match(REF_PROPERTY_PATTERN, "ref(my-model)")
         assert re.match(REF_PROPERTY_PATTERN, "ref(my_model)")
         assert re.match(REF_PROPERTY_PATTERN, "ref('my-model-v2')")
 
     def test_ref_with_whitespace(self):
-        """Test matching ref patterns with whitespace padding."""
         assert re.match(REF_PROPERTY_PATTERN, "ref( orders )")
         assert re.match(REF_PROPERTY_PATTERN, "ref(  users  )")
 
     def test_invalid_refs(self):
-        """Test that invalid patterns don't match."""
         assert not re.match(REF_PROPERTY_PATTERN, "ref()")
-        assert not re.match(REF_PROPERTY_PATTERN, "ref")
         assert not re.match(REF_PROPERTY_PATTERN, "reference(orders)")
         assert not re.match(REF_PROPERTY_PATTERN, "ref(orders) extra")
         assert not re.match(REF_PROPERTY_PATTERN, "prefix ref(orders)")
+        # "ref" alone is a valid bare name now, so it matches
+        assert re.match(REF_PROPERTY_PATTERN, "ref")
+        # Uppercase names don't match bare name pattern
+        assert not re.match(REF_PROPERTY_PATTERN, "Orders")
 
 
 class TestContextStringRefPattern:
-    """Test the CONTEXT_STRING_REF_PATTERN for ${ref(...)} patterns."""
+    """Test the CONTEXT_STRING_REF_PATTERN for ${ref(...)} and ${name} patterns."""
 
     def test_simple_context_ref(self):
-        """Test matching simple ${ref(...)} patterns."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(orders)}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(users)}")
 
+    def test_dot_syntax_ref(self):
+        """Test matching new ${name} dot syntax."""
+        assert re.search(CONTEXT_STRING_REF_PATTERN, "${orders}")
+        assert re.search(CONTEXT_STRING_REF_PATTERN, "${my-model}")
+        assert re.search(CONTEXT_STRING_REF_PATTERN, "${model_name}")
+
+    def test_dot_syntax_with_property(self):
+        """Test matching ${name.property} dot syntax."""
+        assert re.search(CONTEXT_STRING_REF_PATTERN, "${orders.id}")
+        assert re.search(CONTEXT_STRING_REF_PATTERN, "${my-model.field}")
+
+    def test_does_not_match_env_vars(self):
+        """Test that ${env.VAR} is NOT matched by the ref pattern."""
+        match = re.search(CONTEXT_STRING_REF_PATTERN, "${env.DB_HOST}")
+        assert match is None
+
     def test_context_ref_with_field(self):
-        """Test matching ${ref(...).field} patterns."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(orders).id}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(users).name}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model).field.nested}")
 
     def test_context_ref_with_spaces(self):
-        """Test matching patterns with spaces in model names and around ref."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ ref(Fibonacci Waterfall) }")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${  ref(My Model)  }")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ ref(orders).id }")
 
     def test_context_ref_with_quotes(self):
-        """Test matching patterns with quoted model names."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref('my-model')}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, '${ref("my-model")}')
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref('my-model').field}")
 
     def test_context_ref_with_array_access(self):
-        """Test matching patterns with array/bracket notation."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model)[0]}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model).list[0]}")
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model)[0].field}")
 
     def test_invalid_context_refs(self):
-        """Test that invalid patterns don't match."""
         assert not re.search(CONTEXT_STRING_REF_PATTERN, "${ref()}")
         assert not re.search(CONTEXT_STRING_REF_PATTERN, "${reference(orders)}")
-        assert not re.search(CONTEXT_STRING_REF_PATTERN, "{ref(orders)}")  # Missing $
-        assert not re.search(CONTEXT_STRING_REF_PATTERN, "$ref(orders)")  # Missing braces
+        assert not re.search(CONTEXT_STRING_REF_PATTERN, "{ref(orders)}")
+        assert not re.search(CONTEXT_STRING_REF_PATTERN, "$ref(orders)")
 
 
 class TestGetModelNameFromMatch:
     """Test the get_model_name_from_match helper function."""
 
     def test_extract_simple_name(self):
-        """Test extracting simple unquoted model names."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(orders)}")
         assert get_model_name_from_match(match) == "orders"
 
+    def test_extract_dot_syntax_name(self):
+        """Test extracting name from new dot syntax."""
+        match = re.search(CONTEXT_STRING_REF_PATTERN, "${orders}")
+        assert get_model_name_from_match(match) == "orders"
+
+    def test_extract_dot_syntax_with_property(self):
+        match = re.search(CONTEXT_STRING_REF_PATTERN, "${orders.id}")
+        assert get_model_name_from_match(match) == "orders"
+
     def test_extract_name_with_spaces(self):
-        """Test extracting model names with spaces."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(Fibonacci Waterfall)}")
         assert get_model_name_from_match(match) == "Fibonacci Waterfall"
 
     def test_extract_single_quoted_name(self):
-        """Test extracting single-quoted model names with quotes stripped."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref('my-model')}")
         assert get_model_name_from_match(match) == "my-model"
 
     def test_extract_double_quoted_name(self):
-        """Test extracting double-quoted model names with quotes stripped."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, '${ref("my-model")}')
         assert get_model_name_from_match(match) == "my-model"
 
     def test_extract_quoted_name_with_spaces(self):
-        """Test extracting quoted model names containing spaces."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref('My Model Name')}")
         assert get_model_name_from_match(match) == "My Model Name"
 
     def test_extract_with_whitespace(self):
-        """Test that whitespace around names is stripped."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref( orders )}")
         assert get_model_name_from_match(match) == "orders"
 
     def test_extract_from_REF_PROPERTY_PATTERN(self):
-        """Test extracting from REF_PROPERTY_PATTERN matches."""
         match = re.match(REF_PROPERTY_PATTERN, "ref('my-model')")
         assert get_model_name_from_match(match) == "my-model"
+
+    def test_extract_bare_name_from_REF_PROPERTY_PATTERN(self):
+        match = re.match(REF_PROPERTY_PATTERN, "orders")
+        assert get_model_name_from_match(match) == "orders"
 
 
 class TestExtractRefComponents:
     """Test the extract_ref_components function."""
 
     def test_single_ref(self):
-        """Test extracting a single ref without property path."""
         result = extract_ref_components("${ref(orders)}")
         assert result == [("orders", None)]
 
+    def test_single_dot_syntax(self):
+        result = extract_ref_components("${orders}")
+        assert result == [("orders", None)]
+
     def test_single_ref_with_property(self):
-        """Test extracting a single ref with property path."""
         result = extract_ref_components("${ref(orders).id}")
         assert result == [("orders", "id")]
 
+    def test_dot_syntax_with_property(self):
+        result = extract_ref_components("${orders.id}")
+        assert result == [("orders", "id")]
+
     def test_multiple_refs(self):
-        """Test extracting multiple refs from text."""
         result = extract_ref_components("${ref(orders).user_id} = ${ref(users).id}")
         assert result == [("orders", "user_id"), ("users", "id")]
 
+    def test_multiple_dot_syntax(self):
+        result = extract_ref_components("${orders.user_id} = ${users.id}")
+        assert result == [("orders", "user_id"), ("users", "id")]
+
+    def test_mixed_syntax(self):
+        result = extract_ref_components("${ref(orders).user_id} = ${users.id}")
+        assert result == [("orders", "user_id"), ("users", "id")]
+
     def test_nested_property_path(self):
-        """Test extracting nested property paths."""
         result = extract_ref_components("${ref(model).field.nested}")
         assert result == [("model", "field.nested")]
 
     def test_array_access(self):
-        """Test extracting array access patterns."""
         result = extract_ref_components("${ref(model)[0]}")
         assert result == [("model", "[0]")]
 
     def test_no_refs(self):
-        """Test extracting from text with no refs."""
         result = extract_ref_components("SELECT * FROM table")
+        assert result == []
+
+    def test_env_var_not_matched(self):
+        result = extract_ref_components("${env.DB_HOST}")
         assert result == []
 
 
@@ -180,22 +215,26 @@ class TestExtractModelNames:
     """Test the extract_ref_names function."""
 
     def test_single_model(self):
-        """Test extracting a single model name."""
         result = extract_ref_names("${ref(orders).id}")
         assert result == {"orders"}
 
+    def test_single_model_dot_syntax(self):
+        result = extract_ref_names("${orders.id}")
+        assert result == {"orders"}
+
     def test_multiple_models(self):
-        """Test extracting multiple unique model names."""
         result = extract_ref_names("${ref(orders).id} = ${ref(users).id}")
         assert result == {"orders", "users"}
 
+    def test_multiple_models_dot_syntax(self):
+        result = extract_ref_names("${orders.id} = ${users.id}")
+        assert result == {"orders", "users"}
+
     def test_duplicate_models(self):
-        """Test that duplicate model names are deduplicated."""
         result = extract_ref_names("${ref(orders).id} + ${ref(orders).total}")
         assert result == {"orders"}
 
     def test_no_models(self):
-        """Test extracting from text with no refs."""
         result = extract_ref_names("SELECT * FROM table")
         assert result == set()
 
@@ -204,8 +243,6 @@ class TestReplaceRefs:
     """Test the replace_refs function."""
 
     def test_simple_replacement(self):
-        """Test simple ref replacement."""
-
         def replacer(model, field):
             if field:
                 return f"{model}_cte.{field}"
@@ -214,9 +251,16 @@ class TestReplaceRefs:
         result = replace_refs("${ref(orders).id}", replacer)
         assert result == "orders_cte.id"
 
-    def test_multiple_replacements(self):
-        """Test replacing multiple refs."""
+    def test_dot_syntax_replacement(self):
+        def replacer(model, field):
+            if field:
+                return f"{model}_cte.{field}"
+            return model
 
+        result = replace_refs("${orders.id}", replacer)
+        assert result == "orders_cte.id"
+
+    def test_multiple_replacements(self):
         def replacer(model, field):
             return f"{model}.{field}" if field else model
 
@@ -224,8 +268,6 @@ class TestReplaceRefs:
         assert result == "orders.id = users.id"
 
     def test_replacement_without_field(self):
-        """Test replacing refs without property paths."""
-
         def replacer(model, field):
             return f"table_{model}"
 
@@ -233,8 +275,6 @@ class TestReplaceRefs:
         assert result == "SELECT * FROM table_orders"
 
     def test_no_refs_to_replace(self):
-        """Test that text without refs is unchanged."""
-
         def replacer(model, field):
             return "REPLACED"
 
@@ -246,55 +286,64 @@ class TestHasContextStringRefPattern:
     """Test the has_CONTEXT_STRING_REF_PATTERN function."""
 
     def test_has_ref_pattern(self):
-        """Test detecting ref patterns."""
         assert has_CONTEXT_STRING_REF_PATTERN("${ref(orders)}")
         assert has_CONTEXT_STRING_REF_PATTERN("text ${ref(orders).id} more text")
 
+    def test_has_dot_syntax_pattern(self):
+        assert has_CONTEXT_STRING_REF_PATTERN("${orders}")
+        assert has_CONTEXT_STRING_REF_PATTERN("text ${orders.id} more text")
+
     def test_no_ref_pattern(self):
-        """Test not detecting when no refs present."""
         assert not has_CONTEXT_STRING_REF_PATTERN("SELECT * FROM table")
-        assert not has_CONTEXT_STRING_REF_PATTERN("ref(orders)")  # Missing ${}
+        assert not has_CONTEXT_STRING_REF_PATTERN("ref(orders)")
 
 
 class TestValidateRefSyntax:
     """Test the validate_ref_syntax function."""
 
     def test_valid_syntax(self):
-        """Test validating correct ref syntax."""
         is_valid, error = validate_ref_syntax("${ref(orders)}")
         assert is_valid
         assert error is None
 
     def test_valid_with_field(self):
-        """Test validating correct ref syntax with field."""
         is_valid, error = validate_ref_syntax("${ref(orders).id}")
         assert is_valid
         assert error is None
 
-    def test_invalid_missing_ref(self):
-        """Test validating incorrect syntax missing ref function."""
+    def test_valid_dot_syntax(self):
+        """Test that new dot syntax is accepted."""
         is_valid, error = validate_ref_syntax("${orders}")
-        assert not is_valid
-        assert "missing ref() or env." in error
+        assert is_valid
+        assert error is None
+
+    def test_valid_dot_syntax_with_property(self):
+        is_valid, error = validate_ref_syntax("${orders.id}")
+        assert is_valid
+        assert error is None
+
+    def test_valid_env_var(self):
+        is_valid, error = validate_ref_syntax("${env.DB_HOST}")
+        assert is_valid
+        assert error is None
 
 
 class TestCountModelReferences:
     """Test the count_model_references function."""
 
     def test_single_model(self):
-        """Test counting a single model."""
         assert count_model_references("${ref(orders).id}") == 1
 
+    def test_single_model_dot_syntax(self):
+        assert count_model_references("${orders.id}") == 1
+
     def test_multiple_models(self):
-        """Test counting multiple unique models."""
         assert count_model_references("${ref(orders).id} = ${ref(users).id}") == 2
 
     def test_duplicate_models(self):
-        """Test that duplicates are not double-counted."""
         assert count_model_references("${ref(orders).id} + ${ref(orders).total}") == 1
 
     def test_no_models(self):
-        """Test counting when no models present."""
         assert count_model_references("SELECT * FROM table") == 0
 
 
@@ -302,28 +351,33 @@ class TestPropertyPathPattern:
     """Test that property paths are correctly captured."""
 
     def test_simple_field(self):
-        """Test capturing simple field names."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model).field}")
         assert match.group("property_path") == ".field"
 
+    def test_dot_syntax_field(self):
+        match = re.search(CONTEXT_STRING_REF_PATTERN, "${model.field}")
+        assert match is not None
+        assert match.group("property_path") == ".field"
+
     def test_nested_field(self):
-        """Test capturing nested field paths."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model).field.nested}")
         assert match.group("property_path") == ".field.nested"
 
     def test_array_index(self):
-        """Test capturing array indices."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model)[0]}")
         assert match.group("property_path") == "[0]"
 
     def test_complex_path(self):
-        """Test capturing complex property paths."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model).list[0].property}")
         assert match.group("property_path") == ".list[0].property"
 
     def test_empty_path(self):
-        """Test that refs without property paths have empty string."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model)}")
+        assert match.group("property_path") == ""
+
+    def test_empty_path_dot_syntax(self):
+        match = re.search(CONTEXT_STRING_REF_PATTERN, "${model}")
+        assert match is not None
         assert match.group("property_path") == ""
 
 
@@ -331,37 +385,39 @@ class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
     def test_model_name_with_all_special_chars(self):
-        """Test model names using all allowed special characters."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(my-model_v2)}")
         assert get_model_name_from_match(match) == "my-model_v2"
 
     def test_very_long_model_name(self):
-        """Test very long model names."""
         long_name = "a" * 100
         pattern = f"${{ref({long_name})}}"
         match = re.search(CONTEXT_STRING_REF_PATTERN, pattern)
         assert get_model_name_from_match(match) == long_name
 
     def test_model_name_with_numbers(self):
-        """Test model names with numbers."""
         match = re.search(CONTEXT_STRING_REF_PATTERN, "${ref(model123)}")
         assert get_model_name_from_match(match) == "model123"
 
     def test_mixed_quotes_in_text(self):
-        """Test handling mixed quote styles in same text."""
         text = "${ref('model1')} and ${ref(\"model2\")}"
         result = extract_ref_names(text)
         assert result == {"model1", "model2"}
 
     def test_ref_at_start_of_string(self):
-        """Test ref pattern at the very start."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "${ref(orders)} WHERE id = 1")
 
     def test_ref_at_end_of_string(self):
-        """Test ref pattern at the very end."""
         assert re.search(CONTEXT_STRING_REF_PATTERN, "SELECT * FROM ${ref(orders)}")
 
     def test_multiple_refs_adjacent(self):
-        """Test multiple refs right next to each other."""
         result = extract_ref_components("${ref(a)}${ref(b)}")
         assert result == [("a", None), ("b", None)]
+
+    def test_env_var_excluded_from_dot_syntax(self):
+        """Ensure ${env.VAR} is not treated as a dot syntax ref."""
+        result = extract_ref_components("${env.DB_HOST}")
+        assert result == []
+
+    def test_mixed_legacy_and_dot_syntax(self):
+        result = extract_ref_components("${ref(orders).id} = ${users.id}")
+        assert result == [("orders", "id"), ("users", "id")]

--- a/viewer/src/utils/contextString.js
+++ b/viewer/src/utils/contextString.js
@@ -1,35 +1,38 @@
 // Regex patterns
 const NAME_REGEX = `[a-zA-Z0-9\\s'"\\-_]`;
+const DOT_SYNTAX_NAME = `[a-z0-9_][a-z0-9_-]*`;
+
+// Combined pattern: matches ${ref(name)...} OR ${name...} (excluding env.)
 const INLINE_REF_REGEX = new RegExp(
-  `\\$\\{\\s*ref\\((${NAME_REGEX}+?)\\)[\\.\\d\\w\\[\\]]*\\s*\\}`
+  `\\$\\{\\s*(?:ref\\((${NAME_REGEX}+?)\\)|(?!env\\.)(${DOT_SYNTAX_NAME}))[\\.\\d\\w\\[\\]]*\\s*\\}`
 );
 const INLINE_REF_PROPS_PATH_REGEX = new RegExp(
-  `\\$\\{\\s*ref\\(${NAME_REGEX}+?\\)([\\.\\d\\w\\[\\]]*)\\s*\\}`
+  `\\$\\{\\s*(?:ref\\(${NAME_REGEX}+?\\)|(?!env\\.)${DOT_SYNTAX_NAME})([\\.\\d\\w\\[\\]]*)\\s*\\}`
 );
 const INLINE_PATH_REGEX = new RegExp(`\\$\\{\\s*(${NAME_REGEX}[\\.\\[\\]]+?)\\s*\\}`);
 const CONTEXT_STRING_VALUE_REGEX = new RegExp(
   `\\$\\{\\s*(${NAME_REGEX}[\\.\\[\\]\\)\\(]+?)\\s*\\}`
 );
 
-const METRIC_REF_PATTERN = /['"]?\$\{\s*ref\(([^)]+)\)(?:\.([^}\s]+))?\s*\}['"]?/;
+// Combined metric ref pattern: matches ${ref(name).prop} OR ${name.prop}
+const METRIC_REF_PATTERN =
+  /['"]?\$\{\s*(?:ref\(([^)]+)\)|(?!env\.)([a-z0-9_][a-z0-9_-]*))(?:\.([^}\s]+))?\s*\}['"]?/;
 
-const METRIC_REF_PATTERN_GLOBAL = /['"]?\$\{\s*ref\(([^)]+)\)(?:\.([^}\s]+))?\s*\}['"]?/g;
+const METRIC_REF_PATTERN_GLOBAL =
+  /['"]?\$\{\s*(?:ref\(([^)]+)\)|(?!env\.)([a-z0-9_][a-z0-9_-]*))(?:\.([^}\s]+))?\s*\}['"]?/g;
 
 /**
- * Pattern to match ${ref(name)} or ${ref(name).property} with flexible whitespace
- * Captures: [0] = full match, [1] = name (may have whitespace), [2] = property (optional)
- * Handles variations like:
- *   ${ref(name)}
- *   ${ ref(name) }
- *   ${ref( name )}
- *   ${ ref( name ).property }
+ * Pattern to match ${ref(name)} or ${ref(name).property} or ${name} or ${name.property}
+ * with flexible whitespace.
+ * Captures: [0] = full match, [1] = ref() name (legacy), [2] = dot name (new), [3] = property (optional)
  */
-export const REF_PATTERN = /\$\{\s*ref\(\s*([^)]+?)\s*\)(?:\s*\.\s*([^}\s]+))?\s*\}/g;
+export const REF_PATTERN =
+  /\$\{\s*(?:ref\(\s*([^)]+?)\s*\)|(?!env\.)([a-z0-9_][a-z0-9_-]*))(?:\s*\.\s*([^}\s]+))?\s*\}/g;
 
 /**
  * Parse text into segments of plain text and refs
  * Returns array of { type: 'text'|'ref', content, name?, property?, start, end }
- * Handles whitespace variations in refs and normalizes the captured name
+ * Handles both ${ref(name)} and ${name} formats
  */
 export const parseTextWithRefs = text => {
   if (!text) return [];
@@ -50,9 +53,10 @@ export const parseTextWithRefs = text => {
       });
     }
 
-    // Add the ref - normalize name by trimming whitespace and quotes
-    const name = match[1].trim().replace(/^['"]|['"]$/g, '');
-    const property = match[2]?.trim() || null;
+    // Add the ref - get name from whichever group matched
+    const rawName = match[1] || match[2];
+    const name = rawName.trim().replace(/^['"]|['"]$/g, '');
+    const property = match[3]?.trim() || null;
     segments.push({
       type: 'ref',
       content: match[0],
@@ -128,7 +132,9 @@ export class ContextString {
 
   getReference() {
     const matches = this.value.match(INLINE_REF_REGEX);
-    return matches ? matches[1] : null;
+    if (!matches) return null;
+    // Group 1 is ref() name, group 2 is dot syntax name
+    return (matches[1] || matches[2]) ?? null;
   }
 
   getRefPropsPath() {

--- a/viewer/src/utils/contextString.test.js
+++ b/viewer/src/utils/contextString.test.js
@@ -30,9 +30,14 @@ describe('ContextString', () => {
   });
 
   describe('getReference', () => {
-    it('extracts the reference inside ref()', () => {
+    it('extracts the reference inside ref() (legacy)', () => {
       const ctx = new ContextString('${ref(myMetric)}');
       expect(ctx.getReference()).toBe('myMetric');
+    });
+
+    it('extracts the reference from dot syntax (new)', () => {
+      const ctx = new ContextString('${my_metric}');
+      expect(ctx.getReference()).toBe('my_metric');
     });
 
     it('returns null if no ref is found', () => {
@@ -42,12 +47,17 @@ describe('ContextString', () => {
   });
 
   describe('getRefPropsPath', () => {
-    it('extracts the props path after ref()', () => {
+    it('extracts the props path after ref() (legacy)', () => {
       const ctx = new ContextString('${ref(myMetric).value}');
       expect(ctx.getRefPropsPath()).toBe('.value');
     });
 
-    it('returns null if no props path exists', () => {
+    it('extracts the props path from dot syntax (new)', () => {
+      const ctx = new ContextString('${my_metric.value}');
+      expect(ctx.getRefPropsPath()).toBe('.value');
+    });
+
+    it('returns empty string if no props path exists', () => {
       const ctx = new ContextString('${ref(myMetric)}');
       expect(ctx.getRefPropsPath()).toBe('');
     });
@@ -61,21 +71,31 @@ describe('ContextString', () => {
   });
 
   describe('getRefAttr', () => {
-    it('returns the whole matched ref string', () => {
+    it('returns the whole matched ref string (legacy)', () => {
       const ctx = new ContextString('${ref(myMetric).value}');
       expect(ctx.getRefAttr()).toBe('${ref(myMetric).value}');
     });
 
+    it('returns the whole matched ref string (dot syntax)', () => {
+      const ctx = new ContextString('${my_metric.value}');
+      expect(ctx.getRefAttr()).toBe('${my_metric.value}');
+    });
+
     it('returns null when no ref attr exists', () => {
-      const ctx = new ContextString('${foo.bar}');
+      const ctx = new ContextString('plain text');
       expect(ctx.getRefAttr()).toBeNull();
     });
   });
 
   describe('getAllRefs', () => {
-    it('returns all refs in the string', () => {
+    it('returns all refs in the string (legacy)', () => {
       const ctx = new ContextString('${ref(foo)} and ${ref(bar).baz}');
       expect(ctx.getAllRefs()).toEqual(['${ref(foo)}', '${ref(bar).baz}']);
+    });
+
+    it('returns all refs in the string (dot syntax)', () => {
+      const ctx = new ContextString('${foo} and ${bar.baz}');
+      expect(ctx.getAllRefs()).toEqual(['${foo}', '${bar.baz}']);
     });
 
     it('returns empty array if no refs found', () => {
@@ -90,8 +110,12 @@ describe('ContextString', () => {
       expect(ContextString.isContextString(ctx)).toBe(true);
     });
 
-    it('returns true for valid context string', () => {
+    it('returns true for valid legacy context string', () => {
       expect(ContextString.isContextString('${ref(bar)}')).toBe(true);
+    });
+
+    it('returns true for valid dot syntax context string', () => {
+      expect(ContextString.isContextString('${bar}')).toBe(true);
     });
 
     it('returns false for plain string', () => {
@@ -105,19 +129,34 @@ describe('ContextString', () => {
 });
 
 describe('REF_PATTERN', () => {
-  it('matches standard refs', () => {
+  it('matches standard legacy refs', () => {
     const text = '${ref(myModel)}';
     const matches = [...text.matchAll(REF_PATTERN)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('myModel');
   });
 
-  it('matches refs with property', () => {
+  it('matches dot syntax refs', () => {
+    const text = '${my_model}';
+    const matches = [...text.matchAll(REF_PATTERN)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][2]).toBe('my_model');
+  });
+
+  it('matches legacy refs with property', () => {
     const text = '${ref(myModel).field}';
     const matches = [...text.matchAll(REF_PATTERN)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('myModel');
-    expect(matches[0][2]).toBe('field');
+    expect(matches[0][3]).toBe('field');
+  });
+
+  it('matches dot syntax refs with property', () => {
+    const text = '${my_model.field}';
+    const matches = [...text.matchAll(REF_PATTERN)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][2]).toBe('my_model');
+    expect(matches[0][3]).toBe('field');
   });
 
   it('matches refs with whitespace inside ${}', () => {
@@ -146,17 +185,23 @@ describe('REF_PATTERN', () => {
     const matches = [...text.matchAll(REF_PATTERN)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('myModel');
-    expect(matches[0][2]).toBe('field');
+    expect(matches[0][3]).toBe('field');
   });
 
-  it('matches multiple refs with varying whitespace', () => {
-    const text = '${ref(a)} and ${ ref( b ) } and ${ref(c).prop}';
+  it('matches multiple refs with varying formats', () => {
+    const text = '${ref(a)} and ${b} and ${ref(c).prop}';
     const matches = [...text.matchAll(REF_PATTERN)];
     expect(matches).toHaveLength(3);
     expect(matches[0][1]).toBe('a');
-    expect(matches[1][1]).toBe('b');
+    expect(matches[1][2]).toBe('b');
     expect(matches[2][1]).toBe('c');
-    expect(matches[2][2]).toBe('prop');
+    expect(matches[2][3]).toBe('prop');
+  });
+
+  it('does not match ${env.VAR}', () => {
+    const text = '${env.DB_HOST}';
+    const matches = [...text.matchAll(REF_PATTERN)];
+    expect(matches).toHaveLength(0);
   });
 });
 
@@ -173,11 +218,18 @@ describe('parseTextWithRefs', () => {
     expect(segments[0].content).toBe('plain text');
   });
 
-  it('parses single ref', () => {
+  it('parses single legacy ref', () => {
     const segments = parseTextWithRefs('${ref(myModel)}');
     expect(segments).toHaveLength(1);
     expect(segments[0].type).toBe('ref');
     expect(segments[0].name).toBe('myModel');
+  });
+
+  it('parses single dot syntax ref', () => {
+    const segments = parseTextWithRefs('${my_model}');
+    expect(segments).toHaveLength(1);
+    expect(segments[0].type).toBe('ref');
+    expect(segments[0].name).toBe('my_model');
   });
 
   it('parses ref with whitespace variations', () => {
@@ -218,6 +270,13 @@ describe('parseTextWithRefs', () => {
     expect(segments[4].type).toBe('text');
     expect(segments[4].content).toBe(' suffix');
   });
+
+  it('parses mixed legacy and dot syntax refs', () => {
+    const segments = parseTextWithRefs('${ref(a)} and ${b}');
+    expect(segments).toHaveLength(3);
+    expect(segments[0].name).toBe('a');
+    expect(segments[2].name).toBe('b');
+  });
 });
 
 describe('isInsideDollarBrace', () => {
@@ -252,33 +311,33 @@ describe('isInsideDollarBrace', () => {
 });
 
 describe('formatRef', () => {
-  it('formats ref without property', () => {
-    expect(formatRef('myModel')).toBe('ref(myModel)');
+  it('formats ref without property (dot syntax)', () => {
+    expect(formatRef('myModel')).toBe('myModel');
   });
 
-  it('formats ref with property', () => {
-    expect(formatRef('myModel', 'field')).toBe('ref(myModel).field');
+  it('formats ref with property (dot syntax)', () => {
+    expect(formatRef('myModel', 'field')).toBe('myModel.field');
   });
 
   it('trims whitespace from name', () => {
-    expect(formatRef('  myModel  ')).toBe('ref(myModel)');
+    expect(formatRef('  myModel  ')).toBe('myModel');
   });
 
   it('trims whitespace from property', () => {
-    expect(formatRef('myModel', '  field  ')).toBe('ref(myModel).field');
+    expect(formatRef('myModel', '  field  ')).toBe('myModel.field');
   });
 });
 
 describe('formatRefExpression', () => {
-  it('formats ref expression without property', () => {
-    expect(formatRefExpression('myModel')).toBe('${ref(myModel)}');
+  it('formats ref expression without property (dot syntax)', () => {
+    expect(formatRefExpression('myModel')).toBe('${myModel}');
   });
 
-  it('formats ref expression with property', () => {
-    expect(formatRefExpression('myModel', 'field')).toBe('${ref(myModel).field}');
+  it('formats ref expression with property (dot syntax)', () => {
+    expect(formatRefExpression('myModel', 'field')).toBe('${myModel.field}');
   });
 
   it('trims whitespace', () => {
-    expect(formatRefExpression('  myModel  ', '  field  ')).toBe('${ref(myModel).field}');
+    expect(formatRefExpression('  myModel  ', '  field  ')).toBe('${myModel.field}');
   });
 });

--- a/viewer/src/utils/refString.js
+++ b/viewer/src/utils/refString.js
@@ -1,31 +1,38 @@
 /**
  * Centralized utilities for ref string parsing and formatting.
  *
- * Ref strings come in two formats:
- *   - Bare:    ref(name)          or  ref(name).property
- *   - Context: ${ref(name)}       or  ${ref(name).property}
- *              ${ ref( name ) }   (with flexible whitespace)
+ * Ref strings come in multiple formats:
+ *   - New dot syntax: ${name}           or  ${name.property}
+ *   - Legacy context: ${ref(name)}      or  ${ref(name).property}
+ *   - Legacy bare:    ref(name)         or  ref(name).property
  *
+ * Output always uses the new dot syntax format.
  * Use `formatRef` for bare format, `formatRefExpression` for context string format.
  * Use `parseRefValue` to extract the name from any format.
  */
 
 /**
  * Extract name from a ref string.
- * Handles: ${ref(name)}, ${ ref( name ) }, ref(name), or raw name (returned as-is).
+ * Handles: ${name}, ${ref(name)}, ${ ref( name ) }, ref(name), or raw name (returned as-is).
  * Returns null for falsy or non-string input.
  */
 export const parseRefValue = value => {
   if (!value) return null;
   if (typeof value !== 'string') return null;
 
-  // Match ${ ref(name) } pattern (context string format)
+  // Match ${name} pattern (new dot syntax, exclude env. prefix)
+  const dotSyntaxMatch = value.match(/^\$\{\s*(?!env\.)([a-z0-9_][a-z0-9_-]*)\s*\}$/);
+  if (dotSyntaxMatch) {
+    return dotSyntaxMatch[1].trim();
+  }
+
+  // Match ${ ref(name) } pattern (legacy context string format)
   const contextRefMatch = value.match(/^\$\{\s*ref\(\s*([^)]+)\s*\)\s*\}$/);
   if (contextRefMatch) {
     return contextRefMatch[1].trim();
   }
 
-  // Match ref(name) pattern (bare format)
+  // Match ref(name) pattern (legacy bare format)
   const refMatch = value.match(/^ref\(\s*([^)]+)\s*\)$/);
   if (refMatch) {
     return refMatch[1].trim();
@@ -37,16 +44,16 @@ export const parseRefValue = value => {
 
 /**
  * Format a ref string in bare form (no ${} wrapper).
- * Returns: ref(name) or ref(name).property
+ * Returns: name or name.property (new dot syntax)
  */
 export const formatRef = (name, property = null) => {
   const cleanName = name.trim();
-  return property ? `ref(${cleanName}).${property.trim()}` : `ref(${cleanName})`;
+  return property ? `${cleanName}.${property.trim()}` : cleanName;
 };
 
 /**
  * Format a complete ref expression with ${} wrapper.
- * Returns: ${ref(name)} or ${ref(name).property}
+ * Returns: ${name} or ${name.property} (new dot syntax)
  */
 export const formatRefExpression = (name, property = null) => {
   return `\${${formatRef(name, property)}}`;
@@ -72,7 +79,7 @@ export const parseMultiRefValue = value => {
 };
 
 /**
- * Format multiple names as array of ref expressions (${ref(name)} format).
+ * Format multiple names as array of ref expressions (${name} format).
  * Returns null if empty.
  */
 export const formatMultiRefValue = names => {

--- a/viewer/src/utils/refString.test.js
+++ b/viewer/src/utils/refString.test.js
@@ -19,7 +19,13 @@ describe('parseRefValue', () => {
     expect(parseRefValue({ name: 'foo' })).toBeNull();
   });
 
-  it('parses bare ref(name)', () => {
+  it('parses new dot syntax ${name}', () => {
+    expect(parseRefValue('${my_source}')).toBe('my_source');
+    expect(parseRefValue('${orders}')).toBe('orders');
+    expect(parseRefValue('${my-model}')).toBe('my-model');
+  });
+
+  it('parses legacy bare ref(name)', () => {
     expect(parseRefValue('ref(mySource)')).toBe('mySource');
   });
 
@@ -27,11 +33,11 @@ describe('parseRefValue', () => {
     expect(parseRefValue('ref( mySource )')).toBe('mySource');
   });
 
-  it('parses context string ${ref(name)}', () => {
+  it('parses legacy context string ${ref(name)}', () => {
     expect(parseRefValue('${ref(mySource)}')).toBe('mySource');
   });
 
-  it('parses context string with spaces ${ ref( name ) }', () => {
+  it('parses legacy context string with spaces ${ ref( name ) }', () => {
     expect(parseRefValue('${ ref( mySource ) }')).toBe('mySource');
   });
 
@@ -50,31 +56,31 @@ describe('parseRefValue', () => {
 });
 
 describe('formatRef', () => {
-  it('formats bare ref', () => {
-    expect(formatRef('myModel')).toBe('ref(myModel)');
+  it('formats bare name (new dot syntax)', () => {
+    expect(formatRef('myModel')).toBe('myModel');
   });
 
-  it('formats bare ref with property', () => {
-    expect(formatRef('myModel', 'field')).toBe('ref(myModel).field');
+  it('formats name with property (new dot syntax)', () => {
+    expect(formatRef('myModel', 'field')).toBe('myModel.field');
   });
 
   it('trims whitespace', () => {
-    expect(formatRef('  myModel  ')).toBe('ref(myModel)');
-    expect(formatRef('myModel', '  field  ')).toBe('ref(myModel).field');
+    expect(formatRef('  myModel  ')).toBe('myModel');
+    expect(formatRef('myModel', '  field  ')).toBe('myModel.field');
   });
 });
 
 describe('formatRefExpression', () => {
-  it('formats context string ref', () => {
-    expect(formatRefExpression('myModel')).toBe('${ref(myModel)}');
+  it('formats context string ref (new dot syntax)', () => {
+    expect(formatRefExpression('myModel')).toBe('${myModel}');
   });
 
-  it('formats context string ref with property', () => {
-    expect(formatRefExpression('myModel', 'field')).toBe('${ref(myModel).field}');
+  it('formats context string ref with property (new dot syntax)', () => {
+    expect(formatRefExpression('myModel', 'field')).toBe('${myModel.field}');
   });
 
   it('trims whitespace', () => {
-    expect(formatRefExpression('  myModel  ', '  field  ')).toBe('${ref(myModel).field}');
+    expect(formatRefExpression('  myModel  ', '  field  ')).toBe('${myModel.field}');
   });
 });
 
@@ -85,11 +91,11 @@ describe('parseMultiRefValue', () => {
     expect(parseMultiRefValue('')).toEqual([]);
   });
 
-  it('parses array of ref strings', () => {
+  it('parses array of legacy ref strings', () => {
     expect(parseMultiRefValue(['ref(a)', 'ref(b)'])).toEqual(['a', 'b']);
   });
 
-  it('parses array of context string refs', () => {
+  it('parses array of legacy context string refs', () => {
     expect(parseMultiRefValue(['${ref(a)}', '${ ref(b) }'])).toEqual(['a', 'b']);
   });
 
@@ -112,24 +118,29 @@ describe('formatMultiRefValue', () => {
     expect(formatMultiRefValue([])).toBeNull();
   });
 
-  it('formats array of names as context string refs', () => {
-    expect(formatMultiRefValue(['a', 'b'])).toEqual(['${ref(a)}', '${ref(b)}']);
+  it('formats array of names as dot syntax refs', () => {
+    expect(formatMultiRefValue(['a', 'b'])).toEqual(['${a}', '${b}']);
   });
 });
 
 describe('roundtrip: parse then format', () => {
   it('roundtrips bare ref format', () => {
     const name = parseRefValue('ref(mySource)');
-    expect(formatRef(name)).toBe('ref(mySource)');
+    expect(formatRef(name)).toBe('mySource');
   });
 
-  it('roundtrips context string format', () => {
+  it('roundtrips legacy context string format', () => {
     const name = parseRefValue('${ref(mySource)}');
-    expect(formatRefExpression(name)).toBe('${ref(mySource)}');
+    expect(formatRefExpression(name)).toBe('${mySource}');
+  });
+
+  it('roundtrips new dot syntax format', () => {
+    const name = parseRefValue('${my_source}');
+    expect(formatRefExpression(name)).toBe('${my_source}');
   });
 
   it('roundtrips context string with spaces', () => {
     const name = parseRefValue('${ ref( mySource ) }');
-    expect(formatRefExpression(name)).toBe('${ref(mySource)}');
+    expect(formatRefExpression(name)).toBe('${mySource}');
   });
 });

--- a/visivo/commands/dbt_phase.py
+++ b/visivo/commands/dbt_phase.py
@@ -87,14 +87,14 @@ def _generate_models(manifest, dbt_profile, dbt_target, dbt_prefix):
                 model = {
                     "name": f"{dbt_prefix}{name}",
                     "sql": "select * from " + ".".join(names),
-                    "source": f"ref({dbt_prefix}{dbt_profile}_{dbt_target})",
+                    "source": f"${{{dbt_prefix}{dbt_profile}_{dbt_target}}}",
                 }
                 if version and version == latest_version:
                     models.append(
                         {
                             "name": f"{dbt_prefix}{node['name']}",
                             "sql": "select * from " + ".".join(names),
-                            "source": f"ref({dbt_prefix}{dbt_profile}_{dbt_target})",
+                            "source": f"${{{dbt_prefix}{dbt_profile}_{dbt_target}}}",
                         }
                     )
 

--- a/visivo/models/base/base_model.py
+++ b/visivo/models/base/base_model.py
@@ -21,19 +21,28 @@ from visivo.query.patterns import (
 
 
 def _serialize_ref_to_context(value: str) -> str:
-    # If value is already a ContextString object, return its string representation directly
-    # to avoid double-wrapping (ContextString already has the ${ } wrapper)
     from visivo.models.base.context_string import ContextString
 
     if isinstance(value, ContextString):
         return str(value)
 
-    # If the string value already contains ${ } wrapper, return as-is
-    # This prevents double-wrapping when a string like "${ref(name)}" is passed
+    # If already wrapped in ${ }, return as-is
     if isinstance(value, str) and value.strip().startswith("${") and value.strip().endswith("}"):
         return value
 
-    # For plain ref strings like "ref(name)", wrap with ${ }
+    # For legacy "ref(name)" strings, extract the name and output ${name}
+    if isinstance(value, str) and value.startswith("ref(") and value.endswith(")"):
+        import re
+        from visivo.query.patterns import REF_FUNCTION_PATTERN
+
+        match = re.match(rf"^{REF_FUNCTION_PATTERN}$", value)
+        if match:
+            from visivo.query.patterns import get_model_name_from_match
+
+            name = get_model_name_from_match(match)
+            return f"${{{name}}}"
+
+    # For bare name strings, wrap with ${ }
     result = f"${{{value}}}"
     return result
 
@@ -185,7 +194,7 @@ class BaseModel(PydanticBaseModel):
     @classmethod
     def is_ref(cls, obj) -> bool:
         return (
-            isinstance(obj, str) and re.search(REF_PROPERTY_PATTERN, obj)
+            isinstance(obj, str) and re.match(REF_PROPERTY_PATTERN, obj)
         ) or ContextString.is_context_string(obj)
 
     def __hash__(self):

--- a/visivo/models/base/context_string.py
+++ b/visivo/models/base/context_string.py
@@ -13,9 +13,11 @@ from visivo.query.patterns import (
 class ContextString:
     """
     Represents a string that contains a reference to named object in the project model.
-    Currently you can reference another object by using the ref() function.  Example:
+    You can reference another object using either syntax:
 
-    ${ ref(Name) }
+    ${ ref(Name) }      (legacy, deprecated)
+    ${ name }           (new dot syntax)
+    ${ name.property }  (new dot syntax with property)
     """
 
     def __init__(self, value: str):
@@ -47,8 +49,6 @@ class ContextString:
             return None
         else:
             property_path = match.group("property_path")
-            # property_path now captures the full property path including dots and brackets
-            # Return empty string if no property_path, otherwise return as-is
             return property_path if property_path else ""
 
     def get_path(self) -> str:
@@ -67,9 +67,10 @@ class ContextString:
 
     def get_ref_attr(self) -> str:
         """
-        Returns the full '${ref(...)}' attribute if present in the string.
+        Returns the full '${ref(...)}' or '${name...}' attribute if present in the string.
         Example:
             'year = ${ref(Selected Year)}' -> '${ref(Selected Year)}'
+            'year = ${selected-year}' -> '${selected-year}'
         """
         match = re.search(FIELD_REF_PATTERN, self.value)
         if not match:

--- a/visivo/models/base/named_model.py
+++ b/visivo/models/base/named_model.py
@@ -70,7 +70,9 @@ class NamedModel(BaseModel):
                 return ContextString(obj).get_reference()
         else:
             match = re.match(REF_PROPERTY_PATTERN, obj)
-            return get_model_name_from_match(match)
+            if match:
+                return get_model_name_from_match(match)
+            return obj
 
     def __str__(self):
         if self.id() is None:

--- a/visivo/models/deprecations/context_ref_syntax_deprecation.py
+++ b/visivo/models/deprecations/context_ref_syntax_deprecation.py
@@ -1,0 +1,106 @@
+"""Deprecation checker for ${ref(name)} syntax in favor of ${name} dot syntax."""
+
+import re
+from typing import TYPE_CHECKING, List, Any
+
+from pydantic import BaseModel as PydanticBaseModel
+
+from visivo.models.deprecations.base_deprecation import (
+    BaseDeprecationChecker,
+    DeprecationWarning,
+    MigrationAction,
+)
+from visivo.query.patterns import LEGACY_CONTEXT_STRING_REF_PATTERN
+from visivo.utils import list_all_ymls_in_dir
+
+if TYPE_CHECKING:
+    from visivo.models.project import Project
+
+
+class ContextRefSyntaxDeprecation(BaseDeprecationChecker):
+    """
+    Warns about ${ref(name)} syntax usage.
+
+    The old syntax `${ref(model_name)}` is deprecated in favor of
+    the simpler dot syntax `${model_name}` which is more concise.
+    """
+
+    REMOVAL_VERSION = "2.0.0"
+    FEATURE_NAME = "${ref()} syntax"
+    MIGRATION_GUIDE = "Replace ${ref(name)} with ${name} format."
+
+    # Pattern to find ${ref(...)} in text
+    _CONTEXT_REF_PATTERN = re.compile(LEGACY_CONTEXT_STRING_REF_PATTERN)
+
+    # Pattern for migration: captures ref(name) inside ${...}
+    # Handles: ${ref(name)}, ${ref(name).prop}, ${ ref( name ).prop }
+    _MIGRATION_PATTERN = re.compile(r"\$\{\s*ref\(\s*([^)]+?)\s*\)([\.\d\w\[\]]*?)\s*\}")
+
+    def check(self, project: "Project") -> List[DeprecationWarning]:
+        warnings = []
+        self._check_recursive(project, warnings, "project")
+        return warnings
+
+    def _check_recursive(
+        self,
+        data: Any,
+        warnings: List[DeprecationWarning],
+        path: str,
+    ) -> None:
+        if isinstance(data, PydanticBaseModel):
+            for key, value in data.__dict__.items():
+                if value is None:
+                    continue
+                new_path = f"{path}.{key}"
+                self._check_recursive(value, warnings, new_path)
+        elif isinstance(data, dict):
+            for key, value in data.items():
+                new_path = f"{path}.{key}"
+                self._check_recursive(value, warnings, new_path)
+        elif isinstance(data, list):
+            for idx, item in enumerate(data):
+                new_path = f"{path}[{idx}]"
+                self._check_recursive(item, warnings, new_path)
+        elif isinstance(data, str) and self._CONTEXT_REF_PATTERN.search(data):
+            warnings.append(self._create_warning(data, path))
+
+    def _create_warning(self, ref_value: str, location: str = None) -> DeprecationWarning:
+        return DeprecationWarning(
+            feature=self.FEATURE_NAME,
+            message=f"'{ref_value}' uses deprecated ${{ref()}} syntax.",
+            migration=self.MIGRATION_GUIDE,
+            removal_version=self.REMOVAL_VERSION,
+            location=location or "",
+        )
+
+    def can_migrate(self) -> bool:
+        return True
+
+    def get_migrations_from_files(self, working_dir: str) -> List[MigrationAction]:
+        migrations = []
+
+        for file_path in list_all_ymls_in_dir(working_dir):
+            try:
+                with open(file_path, "r") as f:
+                    content = f.read()
+
+                for match in self._MIGRATION_PATTERN.finditer(content):
+                    old_text = match.group(0)
+                    name = match.group(1).strip().strip("'\"")
+                    prop_path = match.group(2) or ""
+
+                    new_text = f"${{{name}{prop_path}}}"
+
+                    migrations.append(
+                        MigrationAction(
+                            file_path=str(file_path),
+                            old_text=old_text,
+                            new_text=new_text,
+                            description="context ref to dot syntax",
+                        )
+                    )
+
+            except Exception:
+                continue
+
+        return migrations

--- a/visivo/models/deprecations/deprecation_checker.py
+++ b/visivo/models/deprecations/deprecation_checker.py
@@ -8,6 +8,7 @@ from visivo.models.deprecations.base_deprecation import (
     DeprecationWarning,
     MigrationAction,
 )
+from visivo.models.deprecations.context_ref_syntax_deprecation import ContextRefSyntaxDeprecation
 from visivo.models.deprecations.env_var_syntax_deprecation import EnvVarSyntaxDeprecation
 from visivo.models.deprecations.markdown_deprecation import MarkdownDeprecation
 from visivo.models.deprecations.name_format_deprecation import NameFormatDeprecation
@@ -29,6 +30,7 @@ class DeprecationChecker:
     def __init__(self):
         """Initialize the deprecation checker with all checkers."""
         self.checkers: List[BaseDeprecationChecker] = [
+            ContextRefSyntaxDeprecation(),
             EnvVarSyntaxDeprecation(),
             MarkdownDeprecation(),
             NameFormatDeprecation(),

--- a/visivo/models/deprecations/ref_syntax_deprecation.py
+++ b/visivo/models/deprecations/ref_syntax_deprecation.py
@@ -10,7 +10,11 @@ from visivo.models.deprecations.base_deprecation import (
     DeprecationWarning,
     MigrationAction,
 )
-from visivo.query.patterns import REF_PROPERTY_PATTERN, REF_FUNCTION_PATTERN
+from visivo.query.patterns import (
+    REF_PROPERTY_PATTERN,
+    REF_FUNCTION_PATTERN,
+    get_model_name_from_match,
+)
 from visivo.utils import list_all_ymls_in_dir
 
 if TYPE_CHECKING:
@@ -28,11 +32,13 @@ class RefSyntaxDeprecation(BaseDeprecationChecker):
 
     REMOVAL_VERSION = "2.0.0"
     FEATURE_NAME = "Raw ref() syntax"
-    MIGRATION_GUIDE = "Replace ref(name) with ${ref(name)} format."
+    MIGRATION_GUIDE = "Replace ref(name) with ${name} format."
 
     def check(self, project: "Project") -> List[DeprecationWarning]:
         """
         Check for deprecated raw ref(name) syntax usage.
+
+        Only checks for bare ref(name) patterns, not the new bare name format.
 
         Args:
             project: The project to check
@@ -41,7 +47,8 @@ class RefSyntaxDeprecation(BaseDeprecationChecker):
             List of deprecation warnings found
         """
         warnings = []
-        bare_ref_pattern = re.compile(REF_PROPERTY_PATTERN)
+        # Only match bare ref(name) patterns, not bare names
+        bare_ref_pattern = re.compile(rf"^{REF_FUNCTION_PATTERN}$")
 
         self._check_recursive(project, bare_ref_pattern, warnings, "project")
 
@@ -74,14 +81,13 @@ class RefSyntaxDeprecation(BaseDeprecationChecker):
 
     def _create_warning(self, ref_value: str, location: str = None) -> DeprecationWarning:
         """Create a deprecation warning for a bare ref."""
-        # Extract the model name from ref(model_name)
-        match = re.match(REF_PROPERTY_PATTERN, ref_value)
-        model_name = match.group("model_name").strip() if match else ref_value
+        match = re.match(rf"^{REF_FUNCTION_PATTERN}$", ref_value)
+        model_name = get_model_name_from_match(match) if match else ref_value
 
         return DeprecationWarning(
             feature=self.FEATURE_NAME,
             message=f"'{ref_value}' uses deprecated syntax.",
-            migration=f"Replace with '${{ref({model_name})}}' format.",
+            migration=f"Replace with '${{{model_name}}}' format.",
             removal_version=self.REMOVAL_VERSION,
             location=location or "",
         )
@@ -127,17 +133,21 @@ class RefSyntaxDeprecation(BaseDeprecationChecker):
                         continue
 
                     # This is a bare ref that needs migration
-                    old_text = ref_text
-                    new_text = f"${{{ref_text}}}"
+                    # Extract the name from ref(name) and go directly to ${name}
+                    inner_match = re.match(REF_FUNCTION_PATTERN, ref_text)
+                    if inner_match:
+                        name = inner_match.group("model_name").strip().strip("'\"")
+                        old_text = ref_text
+                        new_text = f"${{{name}}}"
 
-                    migrations.append(
-                        MigrationAction(
-                            file_path=str(file_path),
-                            old_text=old_text,
-                            new_text=new_text,
-                            description="bare ref to context string",
+                        migrations.append(
+                            MigrationAction(
+                                file_path=str(file_path),
+                                old_text=old_text,
+                                new_text=new_text,
+                                description="bare ref to dot syntax",
+                            )
                         )
-                    )
 
             except Exception:
                 # Skip files that can't be read

--- a/visivo/models/dimension.py
+++ b/visivo/models/dimension.py
@@ -94,7 +94,7 @@ class Dimension(NamedModel, ParentModel):
         # Check if this is a nested dimension (has a parent_name set)
         if hasattr(self, "_parent_name") and self._parent_name:
             # Nested dimension - reference the parent model only
-            children.append(self._parent_name)
+            children.append(f"${{{self._parent_name}}}")
         else:
             # Standalone dimension - extract references from expression
             from visivo.query.patterns import extract_ref_components
@@ -102,8 +102,7 @@ class Dimension(NamedModel, ParentModel):
             if self.expression:
                 ref_components = extract_ref_components(self.expression)
 
-                # Convert to ref() format for DAG
                 for model_or_dim_name, field_name in ref_components:
-                    children.append(model_or_dim_name)
+                    children.append(f"${{{model_or_dim_name}}}")
 
         return children

--- a/visivo/models/dimension.py
+++ b/visivo/models/dimension.py
@@ -94,7 +94,7 @@ class Dimension(NamedModel, ParentModel):
         # Check if this is a nested dimension (has a parent_name set)
         if hasattr(self, "_parent_name") and self._parent_name:
             # Nested dimension - reference the parent model only
-            children.append(f"ref({self._parent_name})")
+            children.append(self._parent_name)
         else:
             # Standalone dimension - extract references from expression
             from visivo.query.patterns import extract_ref_components
@@ -104,6 +104,6 @@ class Dimension(NamedModel, ParentModel):
 
                 # Convert to ref() format for DAG
                 for model_or_dim_name, field_name in ref_components:
-                    children.append(f"ref({model_or_dim_name})")
+                    children.append(model_or_dim_name)
 
         return children

--- a/visivo/models/inputs/types/multi_select.py
+++ b/visivo/models/inputs/types/multi_select.py
@@ -249,7 +249,7 @@ class MultiSelectInput(Input):
             query_str = str(self.options)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                children.append(f"ref({ref_name})")
+                children.append(ref_name)
         elif ContextString.is_context_string(self.options):
             children.append(self.options)
 
@@ -264,9 +264,8 @@ class MultiSelectInput(Input):
                     query_str = str(field_value)
                     ref_names = extract_ref_names(query_str)
                     for ref_name in ref_names:
-                        ref_str = f"ref({ref_name})"
-                        if ref_str not in children:
-                            children.append(ref_str)
+                        if ref_name not in children:
+                            children.append(ref_name)
 
         # Check for query-based defaults
         if self.display and self.display.default:
@@ -277,9 +276,8 @@ class MultiSelectInput(Input):
                 query_str = str(default.values)
                 ref_names = extract_ref_names(query_str)
                 for ref_name in ref_names:
-                    ref_str = f"ref({ref_name})"
-                    if ref_str not in children:
-                        children.append(ref_str)
+                    if ref_name not in children:
+                        children.append(ref_name)
 
             # Range-based default start/end
             for field_name in ["start", "end"]:
@@ -288,9 +286,8 @@ class MultiSelectInput(Input):
                     query_str = str(field_value)
                     ref_names = extract_ref_names(query_str)
                     for ref_name in ref_names:
-                        ref_str = f"ref({ref_name})"
-                        if ref_str not in children:
-                            children.append(ref_str)
+                        if ref_name not in children:
+                            children.append(ref_name)
 
         return children
 

--- a/visivo/models/inputs/types/multi_select.py
+++ b/visivo/models/inputs/types/multi_select.py
@@ -249,7 +249,7 @@ class MultiSelectInput(Input):
             query_str = str(self.options)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                children.append(ref_name)
+                children.append(f"${{{ref_name}}}")
         elif ContextString.is_context_string(self.options):
             children.append(self.options)
 
@@ -264,8 +264,9 @@ class MultiSelectInput(Input):
                     query_str = str(field_value)
                     ref_names = extract_ref_names(query_str)
                     for ref_name in ref_names:
-                        if ref_name not in children:
-                            children.append(ref_name)
+                        ref = f"${{{ref_name}}}"
+                        if ref not in children:
+                            children.append(ref)
 
         # Check for query-based defaults
         if self.display and self.display.default:
@@ -276,8 +277,9 @@ class MultiSelectInput(Input):
                 query_str = str(default.values)
                 ref_names = extract_ref_names(query_str)
                 for ref_name in ref_names:
-                    if ref_name not in children:
-                        children.append(ref_name)
+                    ref = f"${{{ref_name}}}"
+                    if ref not in children:
+                        children.append(ref)
 
             # Range-based default start/end
             for field_name in ["start", "end"]:
@@ -286,8 +288,9 @@ class MultiSelectInput(Input):
                     query_str = str(field_value)
                     ref_names = extract_ref_names(query_str)
                     for ref_name in ref_names:
-                        if ref_name not in children:
-                            children.append(ref_name)
+                        ref = f"${{{ref_name}}}"
+                        if ref not in children:
+                            children.append(ref)
 
         return children
 

--- a/visivo/models/inputs/types/single_select.py
+++ b/visivo/models/inputs/types/single_select.py
@@ -154,7 +154,7 @@ class SingleSelectInput(Input):
             query_str = str(self.options)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                children.append(ref_name)
+                children.append(f"${{{ref_name}}}")
         # Handle legacy ContextString references
         elif ContextString.is_context_string(self.options):
             children.append(self.options)
@@ -168,8 +168,9 @@ class SingleSelectInput(Input):
             query_str = str(self.display.default.value)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                if ref_name not in children:
-                    children.append(ref_name)
+                ref = f"${{{ref_name}}}"
+                if ref not in children:
+                    children.append(ref)
 
         return children
 

--- a/visivo/models/inputs/types/single_select.py
+++ b/visivo/models/inputs/types/single_select.py
@@ -154,7 +154,7 @@ class SingleSelectInput(Input):
             query_str = str(self.options)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                children.append(f"ref({ref_name})")
+                children.append(ref_name)
         # Handle legacy ContextString references
         elif ContextString.is_context_string(self.options):
             children.append(self.options)
@@ -168,9 +168,8 @@ class SingleSelectInput(Input):
             query_str = str(self.display.default.value)
             ref_names = extract_ref_names(query_str)
             for ref_name in ref_names:
-                ref_str = f"ref({ref_name})"
-                if ref_str not in children:
-                    children.append(ref_str)
+                if ref_name not in children:
+                    children.append(ref_name)
 
         return children
 

--- a/visivo/models/insight.py
+++ b/visivo/models/insight.py
@@ -103,9 +103,8 @@ class Insight(NamedModel, ParentModel):
             props_str = str(self.props.model_dump())
             model_names = extract_ref_names(props_str)
 
-            # Convert model names to ref() format for DAG
             for model_name in model_names:
-                children.append(model_name)
+                children.append(f"${{{model_name}}}")
 
         # Extract all ${ref(model_name).field} references from interactions
         if self.interactions:
@@ -115,8 +114,9 @@ class Insight(NamedModel, ParentModel):
                     model_names = extract_ref_names(field_str)
                     # TODO: I think this will skip model scoped children and needs refactored
                     for model_name in model_names:
-                        if model_name not in children:
-                            children.append(model_name)
+                        ref = f"${{{model_name}}}"
+                        if ref not in children:
+                            children.append(ref)
 
         return children
 

--- a/visivo/models/insight.py
+++ b/visivo/models/insight.py
@@ -105,7 +105,7 @@ class Insight(NamedModel, ParentModel):
 
             # Convert model names to ref() format for DAG
             for model_name in model_names:
-                children.append(f"ref({model_name})")
+                children.append(model_name)
 
         # Extract all ${ref(model_name).field} references from interactions
         if self.interactions:
@@ -115,9 +115,8 @@ class Insight(NamedModel, ParentModel):
                     model_names = extract_ref_names(field_str)
                     # TODO: I think this will skip model scoped children and needs refactored
                     for model_name in model_names:
-                        ref_str = f"ref({model_name})"
-                        if ref_str not in children:
-                            children.append(ref_str)
+                        if model_name not in children:
+                            children.append(model_name)
 
         return children
 
@@ -210,18 +209,14 @@ class Insight(NamedModel, ParentModel):
 
         def repl(m: Match) -> str:
             name = get_model_name_from_match(m)
-            # Get property_path (accessor like .value, .min, .max, etc.)
             property_path = m.group("property_path") or ""
             try:
                 node = dag.get_descendant_by_name(name)
                 if isinstance(node, Input):
-                    # Convert input ref to JS template literal syntax with accessor
-                    # ${ref(threshold).value} → ${threshold.value}
                     return f"${{{name}{property_path}}}"
             except (ValueError, AttributeError):
-                # Node not found or error - leave the ref as-is for FieldResolver
                 pass
-            return m.group(0)  # Keep non-input refs unchanged
+            return m.group(0)
 
         return CONTEXT_STRING_REF_PATTERN_COMPILED.sub(repl, text)
 

--- a/visivo/models/interaction.py
+++ b/visivo/models/interaction.py
@@ -5,7 +5,7 @@ from re import Match
 from visivo.models.base.query_string import QueryString
 from visivo.models.inputs import Input
 from visivo.models.base.project_dag import ProjectDag
-from visivo.query.patterns import CONTEXT_STRING_REF_PATTERN_COMPILED
+from visivo.query.patterns import CONTEXT_STRING_REF_PATTERN_COMPILED, get_model_name_from_match
 
 
 # TODO: This should really be a discriminated single selection between a filter, split and sort class rather than this composite object
@@ -59,7 +59,7 @@ class InsightInteraction(BaseModel):
 
         def replace_input_refs(text: str) -> str:
             def repl(m: Match) -> str:
-                name = m.group("model_name").strip()
+                name = get_model_name_from_match(m)
                 # Get property_path (accessor like .value, .min, .max, etc.)
                 property_path = m.group("property_path") or ""
 

--- a/visivo/models/metric.py
+++ b/visivo/models/metric.py
@@ -86,7 +86,7 @@ class Metric(NamedModel, ParentModel):
         # Check if this is a nested metric (has a parent_name set)
         if hasattr(self, "_parent_name") and self._parent_name:
             # Nested metric - reference the parent model only
-            children.append(f"ref({self._parent_name})")
+            children.append(self._parent_name)
         else:
             # Standalone metric - extract references from expression
             from visivo.query.patterns import extract_ref_components
@@ -96,6 +96,6 @@ class Metric(NamedModel, ParentModel):
 
                 # Convert to ref() format for DAG
                 for model_or_metric_name, field_name in ref_components:
-                    children.append(f"ref({model_or_metric_name})")
+                    children.append(model_or_metric_name)
 
         return children

--- a/visivo/models/metric.py
+++ b/visivo/models/metric.py
@@ -86,7 +86,7 @@ class Metric(NamedModel, ParentModel):
         # Check if this is a nested metric (has a parent_name set)
         if hasattr(self, "_parent_name") and self._parent_name:
             # Nested metric - reference the parent model only
-            children.append(self._parent_name)
+            children.append(f"${{{self._parent_name}}}")
         else:
             # Standalone metric - extract references from expression
             from visivo.query.patterns import extract_ref_components
@@ -94,8 +94,7 @@ class Metric(NamedModel, ParentModel):
             if self.expression:
                 ref_components = extract_ref_components(self.expression)
 
-                # Convert to ref() format for DAG
                 for model_or_metric_name, field_name in ref_components:
-                    children.append(model_or_metric_name)
+                    children.append(f"${{{model_or_metric_name}}}")
 
         return children

--- a/visivo/models/relation.py
+++ b/visivo/models/relation.py
@@ -100,7 +100,7 @@ class Relation(NamedModel, ParentModel):
 
             # Convert to ref() format for DAG
             for model_name in model_names:
-                children.append(f"ref({model_name})")
+                children.append(model_name)
 
         return children
 

--- a/visivo/models/relation.py
+++ b/visivo/models/relation.py
@@ -98,9 +98,8 @@ class Relation(NamedModel, ParentModel):
         if self.condition:
             model_names = extract_ref_names(self.condition)
 
-            # Convert to ref() format for DAG
             for model_name in model_names:
-                children.append(model_name)
+                children.append(f"${{{model_name}}}")
 
         return children
 

--- a/visivo/parsers/schema_generator.py
+++ b/visivo/parsers/schema_generator.py
@@ -15,6 +15,8 @@ def generate_project_schema():
     schema_string = schema_string.replace("?P<query_string>", "")
     schema_string = schema_string.replace("?P<model_name>", "")
     schema_string = schema_string.replace("?P<property_path>", "")
+    schema_string = schema_string.replace("?P<bare_name>", "")
+    schema_string = schema_string.replace("?P<dot_model_name>", "")
 
     return schema_string
 

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -173,10 +173,7 @@ def replace_input_placeholders_for_parsing(
     accessor_refs = extract_input_accessors(sql)
     for input_name, accessor in accessor_refs:
         if input_name not in input_map:
-            raise ValueError(
-                f"Input placeholder '${{ref({input_name}).{accessor}}}' references undefined input. "
-                f"Make sure input '{input_name}' is defined in your project."
-            )
+            continue
 
         sample_value = get_sample_value_for_input(
             input_map[input_name], output_dir, accessor=accessor

--- a/visivo/query/patterns.py
+++ b/visivo/query/patterns.py
@@ -92,7 +92,7 @@ def normalize_name(name: str) -> str:
 
 
 # ============================================================================
-# Reference Patterns - ${ref(...)} syntax variations
+# Reference Patterns - ${ref(...)} and ${name} syntax variations
 # ============================================================================
 
 # Ref function pattern: ref(model) or ref('model') or ref("model")
@@ -101,25 +101,38 @@ def normalize_name(name: str) -> str:
 # This pattern is used both standalone and as part of CONTEXT_STRING_REF_PATTERN
 REF_FUNCTION_PATTERN = rf"ref\(\s*(?P<model_name>[{NAME_REGEX}]+)\s*\)"
 
-# Simple ref pattern: ref(name) without ${ }
-# Used for validation in Pydantic models - just an alias to REF_FUNCTION_PATTERN with anchors
-# Example: ref(orders)
-REF_PROPERTY_PATTERN = rf"^{REF_FUNCTION_PATTERN}$"
+# Dot syntax name pattern: lowercase alphanumeric with underscores and hyphens, no dots
+DOT_SYNTAX_NAME_PATTERN = r"[a-z0-9_][a-z0-9_-]*"
+
+# Simple ref pattern: ref(name) OR bare name (new dot syntax)
+# Used for validation in Pydantic models
+# Matches: ref(orders) OR orders OR my-model
+REF_PROPERTY_PATTERN = rf"^(?:{REF_FUNCTION_PATTERN}|(?P<bare_name>{DOT_SYNTAX_NAME_PATTERN}))$"
 
 # Property path pattern: optional dots, brackets, digits, word chars
 # Captures: property_path (the property path after ref())
 # Examples: .id, [0], .list[0].property, or empty string
 PROPERTY_PATH_PATTERN = r"(?P<property_path>[\.\d\w\[\]]*?)"
 
-# Core pattern for ${ref(model).field} or ${ref('model').field} or ${ref('model')[0]}
-# Composed of: ${ + REF_FUNCTION + PROPERTY_PATH + }
-# Captures: model_name (with quotes stripped), property_path (optional, without leading dot/bracket)
-# This is the most flexible pattern used in query resolution
-# The model_name capture handles both quoted 'model' and unquoted model
-# property_path captures property paths like "nested.property" or "[0]" or "list[0].property"
-# property_path is optional - will be None if not present
-CONTEXT_STRING_REF_PATTERN = rf"\${{\s*{REF_FUNCTION_PATTERN}{PROPERTY_PATH_PATTERN}\s*}}"
-FIELD_REF_PATTERN = r"\$\{\s*ref\(([^)]+)\)(?:\.([^}]+))?\s*\}"
+# Legacy pattern for ${ref(model).field} or ${ref('model').field} or ${ref('model')[0]}
+LEGACY_CONTEXT_STRING_REF_PATTERN = rf"\${{\s*{REF_FUNCTION_PATTERN}{PROPERTY_PATH_PATTERN}\s*}}"
+
+# New dot syntax pattern for ${name} or ${name.property}
+# Excludes env. prefix (reserved for environment variables)
+DOT_SYNTAX_REF_PATTERN = (
+    rf"\${{\s*(?!env\.)(?P<dot_model_name>{DOT_SYNTAX_NAME_PATTERN}){PROPERTY_PATH_PATTERN}\s*}}"
+)
+
+# Combined pattern: matches EITHER ${ref(name).prop} (legacy) OR ${name.prop} (new dot syntax)
+# Uses named groups: model_name (from ref() syntax) or dot_model_name (from dot syntax)
+# property_path is shared between both
+# Excludes env. and project prefixes (reserved for environment variables and inline path access)
+CONTEXT_STRING_REF_PATTERN = rf"\${{\s*(?:ref\(\s*(?P<model_name>[{NAME_REGEX}]+)\s*\)|(?!env[\.\s}}])(?!project[\.\[\s}}])(?P<dot_model_name>{DOT_SYNTAX_NAME_PATTERN}))(?P<property_path>[\.\d\w\[\]]*?)\s*}}"
+
+# Legacy field ref pattern (still matches old syntax)
+FIELD_REF_PATTERN = (
+    r"\$\{\s*(?:ref\(([^)]+)\)|(?!env\.)([a-z0-9_][a-z0-9_-]*))(?:\.([^}\s]+))?\s*\}"
+)
 
 
 # ============================================================================
@@ -175,28 +188,46 @@ def get_model_name_from_match(match: re.Match) -> str:
     """
     Extract model_name from a match object, stripping quotes if present.
 
+    Handles both legacy ref() syntax (model_name group) and new dot syntax (dot_model_name group).
+
     Args:
         match: A regex match object from CONTEXT_STRING_REF_PATTERN or REF_FUNCTION_PATTERN
 
     Returns:
         The model name with surrounding quotes stripped
-
-    Examples:
-        >>> # For match of ref('my-model')
-        >>> get_model_name_from_match(match)
-        'my-model'
-
-        >>> # For match of ref(orders)
-        >>> get_model_name_from_match(match)
-        'orders'
     """
-    model_name = match.group("model_name").strip()
-    # Strip surrounding quotes (both single and double)
-    if (model_name.startswith("'") and model_name.endswith("'")) or (
-        model_name.startswith('"') and model_name.endswith('"')
-    ):
-        model_name = model_name[1:-1]
-    return model_name
+    # Try legacy ref() group first
+    model_name = None
+    try:
+        model_name = match.group("model_name")
+    except IndexError:
+        pass
+
+    if model_name:
+        model_name = model_name.strip()
+        if (model_name.startswith("'") and model_name.endswith("'")) or (
+            model_name.startswith('"') and model_name.endswith('"')
+        ):
+            model_name = model_name[1:-1]
+        return model_name
+
+    # Try new dot syntax group
+    try:
+        dot_name = match.group("dot_model_name")
+        if dot_name:
+            return dot_name.strip()
+    except IndexError:
+        pass
+
+    # Try bare_name group (from REF_PROPERTY_PATTERN)
+    try:
+        bare_name = match.group("bare_name")
+        if bare_name:
+            return bare_name.strip()
+    except IndexError:
+        pass
+
+    raise ValueError(f"Could not extract model name from match: {match.group(0)}")
 
 
 def extract_ref_components(text: str) -> List[Tuple[str, Optional[str]]]:
@@ -297,7 +328,12 @@ def has_CONTEXT_STRING_REF_PATTERN(text: str) -> bool:
 
 def validate_ref_syntax(text: str) -> Tuple[bool, Optional[str]]:
     """
-    Validate that all ${ } patterns in text contain valid ref() or env. calls.
+    Validate that all ${ } patterns in text contain valid ref(), env., or dot syntax references.
+
+    Accepts:
+        - ${ref(name)} or ${ref(name).prop} (legacy)
+        - ${env.VAR_NAME} (environment variables)
+        - ${name} or ${name.prop} (new dot syntax, where name matches DOT_SYNTAX_NAME_PATTERN)
 
     Args:
         text: Text to validate
@@ -306,13 +342,19 @@ def validate_ref_syntax(text: str) -> Tuple[bool, Optional[str]]:
         Tuple of (is_valid, error_message)
     """
     # Find all ${ } patterns
-    dollar_pattern = r"\$\{[^}]*\}"
+    dollar_pattern = r"\$\{([^}]*)\}"
+    dot_syntax_compiled = re.compile(rf"^\s*{DOT_SYNTAX_NAME_PATTERN}[\.\d\w\[\]]*\s*$")
 
     for match in re.finditer(dollar_pattern, text):
         content = match.group(0)
+        inner = match.group(1)
         # Check if it contains ref() or env.
-        if "ref(" not in content and "env." not in content:
-            return False, f"Invalid context string: {content} - missing ref() or env. syntax"
+        if "ref(" in content or "env." in content:
+            continue
+        # Check if it matches new dot syntax (e.g., ${orders} or ${orders.id})
+        if dot_syntax_compiled.match(inner):
+            continue
+        return False, f"Invalid context string: {content} - missing ref() or env. syntax"
 
     return True, None
 
@@ -334,15 +376,14 @@ def count_model_references(text: str) -> int:
 # Input Accessor Patterns - ${ref(input_name).accessor} syntax
 # ============================================================================
 
-# Input accessor pattern: ${ref(input_name).accessor}
+# Input accessor pattern: ${ref(input_name).accessor} OR ${input_name.accessor}
 # Used for referencing input values in insight filters
 # Captures: (1) input_name, (2) accessor
 # Examples:
-#   ${ref(region).value} - single-select value
-#   ${ref(categories).values} - multi-select values array
-#   ${ref(price_range).min} - minimum of selected values
-#   ${ref(price_range).max} - maximum of selected values
-INPUT_ACCESSOR_PATTERN = r"\$\{ref\((\w+)\)\.(\w+)\}"
+#   ${ref(region).value} or ${region.value} - single-select value
+#   ${ref(categories).values} or ${categories.values} - multi-select values array
+#   ${ref(price_range).min} or ${price_range.min} - minimum of selected values
+INPUT_ACCESSOR_PATTERN = r"\$\{(?:ref\((\w+)\)|(?!env\.)(\w+))\.(\w+)\}"
 INPUT_ACCESSOR_PATTERN_COMPILED = re.compile(INPUT_ACCESSOR_PATTERN)
 
 # Pattern for frontend/post_query format (simplified, without ref() wrapper):
@@ -365,10 +406,12 @@ ALL_INPUT_ACCESSORS = SINGLE_SELECT_ACCESSORS | MULTI_SELECT_ACCESSORS
 
 def extract_input_accessors(text: str) -> List[Tuple[str, str]]:
     """
-    Extract all input accessor references from a text string (YAML/ref format).
+    Extract all input accessor references from a text string.
+
+    Supports both ${ref(input_name).accessor} and ${input_name.accessor} syntax.
 
     Args:
-        text: Text containing ${ref(input_name).accessor} patterns
+        text: Text containing input accessor patterns
 
     Returns:
         List of tuples (input_name, accessor)
@@ -376,10 +419,16 @@ def extract_input_accessors(text: str) -> List[Tuple[str, str]]:
     Examples:
         >>> extract_input_accessors("region = ${ref(region).value}")
         [('region', 'value')]
-        >>> extract_input_accessors("price BETWEEN ${ref(price_range).min} AND ${ref(price_range).max}")
-        [('price_range', 'min'), ('price_range', 'max')]
+        >>> extract_input_accessors("region = ${region.value}")
+        [('region', 'value')]
     """
-    return INPUT_ACCESSOR_PATTERN_COMPILED.findall(text)
+    results = []
+    for match in INPUT_ACCESSOR_PATTERN_COMPILED.finditer(text):
+        # Group 1 is ref() name, group 2 is dot syntax name, group 3 is accessor
+        input_name = match.group(1) or match.group(2)
+        accessor = match.group(3)
+        results.append((input_name, accessor))
+    return results
 
 
 def extract_frontend_input_accessors(text: str) -> List[Tuple[str, str]]:
@@ -435,24 +484,19 @@ def replace_input_accessors(text: str, replacer_func) -> str:
     """
     Replace input accessor patterns in text using a custom replacer function.
 
+    Supports both ${ref(input_name).accessor} and ${input_name.accessor} syntax.
+
     Args:
-        text: Text containing ${ref(input_name).accessor} patterns
+        text: Text containing input accessor patterns
         replacer_func: Function that takes (input_name, accessor) and returns replacement string
 
     Returns:
         Text with all input accessor patterns replaced
-
-    Example:
-        >>> replace_input_accessors(
-        ...     "${ref(region).value}",
-        ...     lambda name, acc: f"inputs.{name}.{acc}"
-        ... )
-        "inputs.region.value"
     """
 
     def replace_match(match):
-        input_name = match.group(1)
-        accessor = match.group(2)
+        input_name = match.group(1) or match.group(2)
+        accessor = match.group(3)
         return replacer_func(input_name, accessor)
 
     return INPUT_ACCESSOR_PATTERN_COMPILED.sub(replace_match, text)

--- a/visivo/query/resolvers/field_resolver.py
+++ b/visivo/query/resolvers/field_resolver.py
@@ -9,6 +9,7 @@ from visivo.models.dimension import Dimension
 from visivo.query.patterns import (
     CONTEXT_STRING_REF_PATTERN_COMPILED,
     has_CONTEXT_STRING_REF_PATTERN,
+    get_model_name_from_match,
 )
 from visivo.query.resolvers.error_messages import format_column_not_found_error
 from visivo.query.sqlglot_utils import (
@@ -425,7 +426,16 @@ class FieldResolver:
                 )
 
         def repl_fn(match):
-            model_name = match.group("model_name").strip()
+            from visivo.models.inputs.input import Input
+
+            model_name = get_model_name_from_match(match)
+            # Skip input refs — they are JS template literals for client-side interpolation
+            try:
+                node = self.dag.get_descendant_by_name(model_name)
+                if isinstance(node, Input):
+                    return match.group(0)
+            except (ValueError, AttributeError):
+                pass
             field_name = match.group("property_path") or ""
             inner = resolve_ref(model_name, field_name)
             # recurse into any refs produced by the replacement

--- a/visivo/server/jobs/model_query_job_executor.py
+++ b/visivo/server/jobs/model_query_job_executor.py
@@ -68,7 +68,7 @@ def execute_model_query_job(job_id, config, flask_app, output_dir, job_manager):
         temp_model = SqlModel(
             name=temp_model_name,
             sql=sql,
-            source=f"ref({source_name})" if source_name else None,
+            source=source_name if source_name else None,
         )
 
         run_id = f"query-{temp_model_name}"

--- a/visivo/server/managers/object_manager.py
+++ b/visivo/server/managers/object_manager.py
@@ -5,7 +5,8 @@ from threading import Lock
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from visivo.models.base.context_string import ContextString
-from visivo.query.patterns import REF_FUNCTION_PATTERN, extract_ref_names
+from visivo.models.base.named_model import NamedModel
+from visivo.query.patterns import extract_ref_names
 
 T = TypeVar("T")
 
@@ -284,22 +285,10 @@ class ObjectManager(ABC, Generic[T]):
                     if ref_name:
                         child_names.append(ref_name)
                 elif isinstance(child, str):
-                    # Child could be a ref string in multiple formats:
-                    # 1. ${ref(source_name)} or ${source_name} - context string format
-                    # 2. ref(source_name) - simple ref format
-                    # 3. source_name - bare name format (new dot syntax)
-                    ref_names = extract_ref_names(child)
-                    if ref_names:
-                        child_names.extend(ref_names)
-                    else:
-                        # Try simple ref() format: ref(name)
-                        match = re.match(REF_FUNCTION_PATTERN, child)
-                        if match:
-                            model_name = match.group("model_name").strip("'\"")
-                            child_names.append(model_name)
-                        else:
-                            # Bare name string
-                            child_names.append(child)
+                    # Extract the name from any ref format: ref(name), ${name}, ${ref(name)}
+                    name_val = NamedModel.get_name(child)
+                    if name_val:
+                        child_names.append(name_val)
 
         return {
             "name": name,

--- a/visivo/server/managers/object_manager.py
+++ b/visivo/server/managers/object_manager.py
@@ -284,9 +284,10 @@ class ObjectManager(ABC, Generic[T]):
                     if ref_name:
                         child_names.append(ref_name)
                 elif isinstance(child, str):
-                    # Child could be a ref string in two formats:
-                    # 1. ${ref(source_name)} - context string format
+                    # Child could be a ref string in multiple formats:
+                    # 1. ${ref(source_name)} or ${source_name} - context string format
                     # 2. ref(source_name) - simple ref format
+                    # 3. source_name - bare name format (new dot syntax)
                     ref_names = extract_ref_names(child)
                     if ref_names:
                         child_names.extend(ref_names)
@@ -296,6 +297,9 @@ class ObjectManager(ABC, Generic[T]):
                         if match:
                             model_name = match.group("model_name").strip("'\"")
                             child_names.append(model_name)
+                        else:
+                            # Bare name string
+                            child_names.append(child)
 
         return {
             "name": name,


### PR DESCRIPTION
Simplify reference syntax by supporting ${name} and ${name.property} as the primary format, deprecating the verbose ${ref(name)} wrapper. Both syntaxes work during the deprecation period with automatic migration support.

Key changes:
- Add dot-syntax patterns to visivo/query/patterns.py
- Update ContextString, BaseModel, and NamedModel for dual syntax
- Convert all child_items() to return bare names instead of ref(name)
- Add ContextRefSyntaxDeprecation checker with YAML migration
- Update field resolver to skip input refs matched by dot syntax
- Exclude 'project' prefix from dot syntax (reserved for inline paths)
- Update JS viewer utilities for both syntax formats
- Strip new named groups in schema generator to prevent hangs