### PR TITLE
fix(migrate): scope list_all_ymls_in_dir to project files (B01)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,87 @@ def test_list_all_ymls_in_dir():
     assert all([file in yaml_list for file in expected_yaml_list])
 
 
+def _seed_project_tree(tmp_path, files):
+    """Helper for the scope tests: create files inside tmp_path."""
+    for relative in files:
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("name: foo\n")
+
+
+def test_list_all_ymls_in_dir_excludes_dot_dirs(tmp_path):
+    _seed_project_tree(
+        tmp_path,
+        [
+            "project.visivo.yml",
+            ".git/config.yml",
+            ".github/workflows/ci.yml",
+            ".rwx/ci.yml",
+            ".venv/lib/python3.12/site-packages/some_pkg/data.yml",
+            ".pytest_cache/v/cache/foo.yml",
+        ],
+    )
+    found = {str(p.relative_to(tmp_path)) for p in list_all_ymls_in_dir(tmp_path)}
+    assert found == {"project.visivo.yml"}
+
+
+def test_list_all_ymls_in_dir_excludes_node_modules(tmp_path):
+    _seed_project_tree(
+        tmp_path,
+        ["project.visivo.yml", "node_modules/some-pkg/config.yml"],
+    )
+    found = {str(p.relative_to(tmp_path)) for p in list_all_ymls_in_dir(tmp_path)}
+    assert found == {"project.visivo.yml"}
+
+
+def test_list_all_ymls_in_dir_excludes_dbt_packages(tmp_path):
+    _seed_project_tree(
+        tmp_path,
+        [
+            "project.visivo.yml",
+            "dbt_packages/dbt_utils/dbt_project.yml",
+            "dbt_packages/dbt_utils/models/foo.yml",
+        ],
+    )
+    found = {str(p.relative_to(tmp_path)) for p in list_all_ymls_in_dir(tmp_path)}
+    assert found == {"project.visivo.yml"}
+
+
+def test_list_all_ymls_in_dir_excludes_build_output(tmp_path):
+    _seed_project_tree(
+        tmp_path,
+        [
+            "project.visivo.yml",
+            "target/run/foo.yml",
+            "build/something.yml",
+            "dist/dist.yml",
+            "venv/lib/x.yml",
+            "__pycache__/cached.yml",
+        ],
+    )
+    found = {str(p.relative_to(tmp_path)) for p in list_all_ymls_in_dir(tmp_path)}
+    assert found == {"project.visivo.yml"}
+
+
+def test_list_all_ymls_in_dir_includes_nested_project_files(tmp_path):
+    _seed_project_tree(
+        tmp_path,
+        [
+            "project.visivo.yml",
+            "dashboards/sales.visivo.yml",
+            "models/orders/calls.yml",
+            "includes/shared.yaml",
+        ],
+    )
+    found = {str(p.relative_to(tmp_path)) for p in list_all_ymls_in_dir(tmp_path)}
+    assert found == {
+        "project.visivo.yml",
+        "dashboards/sales.visivo.yml",
+        "models/orders/calls.yml",
+        "includes/shared.yaml",
+    }
+
+
 def test_extract_value_from_function():
     function_string = "test(args)"
     argument = extract_value_from_function(function_string, "test")

--- a/visivo/utils.py
+++ b/visivo/utils.py
@@ -90,10 +90,37 @@ def yml_to_dict(relative_path):
         return dict(yaml_dict)
 
 
+# Directories that should never be scanned for project YAML.
+# Hidden dot-dirs (.git, .venv, .github, .rwx, .pytest_cache, ...) are excluded
+# by a separate startswith(".") check.
+_EXCLUDED_DIR_NAMES = {
+    "node_modules",
+    "dbt_packages",
+    "target",
+    "__pycache__",
+    "build",
+    "dist",
+    "venv",
+}
+
+
 def list_all_ymls_in_dir(path):
+    """List YAML files under `path`, excluding directories that should never
+    contain Visivo project files (hidden dot-dirs, vendored deps, build output).
+
+    The previous implementation used unconditional ``rglob`` which could rewrite
+    files in ``.venv/``, ``dbt_packages/``, ``.github/workflows/``, and other
+    locations that happen to contain ``.yml`` files but are not part of any
+    Visivo project. See ``specs/plan/v1-final-bugfixes/B01-migrate-scope-rglob.md``.
+    """
     dir_path = Path(path)
-    file_paths = list(dir_path.rglob("*.yml")) + list(dir_path.rglob("*.yaml"))
-    file_paths = [p for p in file_paths if os.path.isfile(p)]
+    file_paths = []
+    for root, dirs, filenames in os.walk(dir_path):
+        # Modify dirs in-place so os.walk doesn't descend into excluded dirs.
+        dirs[:] = [d for d in dirs if not d.startswith(".") and d not in _EXCLUDED_DIR_NAMES]
+        for filename in filenames:
+            if filename.endswith((".yml", ".yaml")):
+                file_paths.append(Path(root) / filename)
     return file_paths
 
 


### PR DESCRIPTION
## Summary
- Replace unconditional `rglob` in `list_all_ymls_in_dir` with an `os.walk` that filters hidden dot-dirs and known vendored/build directories.
- Previously, `visivo migrate --apply` from a repo root would rewrite YAML inside `.git/`, `.venv/`, `.github/workflows/`, `.rwx/`, `dbt_packages/`, `node_modules/`, etc. — corrupting CI workflows and vendored deps.

Excluded names: `node_modules`, `dbt_packages`, `target`, `__pycache__`, `build`, `dist`, `venv`, plus any directory whose name starts with `.`.

Diagnostic: `specs/plan/v1-final-bugfixes/B01-migrate-scope-rglob.md`.

## Test plan
- [x] `poetry run pytest tests/test_utils.py` (5 new scope tests, 17 passing)
- [x] `poetry run pytest tests/models/deprecations/ tests/commands/` (108 passing — no regression)
- [x] `poetry run black --check visivo/utils.py tests/test_utils.py`
- [ ] Reviewer: dry-run `visivo migrate` against a project with `.venv/` / `dbt_packages/` and confirm those files no longer appear in the migration plan.

## Notes
This is **PR #1 of 11** for the v1 final bugfix punch list (Empora migration). PR #10 (B03+B04 silent-skip overhaul) and PR #11 (B02 jinja guards) modify `name_format_deprecation.py` and rebase on this branch — please merge this first to unblock that chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)