### PR TITLE
fix(snowflake): support ${env.X} on account/warehouse/role/timezone/protocol (B05)

### DIFF
--- a/tests/models/sources/test_snowflake_source.py
+++ b/tests/models/sources/test_snowflake_source.py
@@ -292,3 +292,111 @@ class TestSnowflakeSourceGetSchema:
         # Verify metadata
         assert schema["metadata"]["default_schema"] == "EDW"
         assert schema["metadata"]["total_tables"] == 3
+
+
+class TestSnowflakeSourceEnvVarFields:
+    """Regression coverage for B05.
+
+    account/warehouse/role/timezone/protocol used to be typed Optional[str], so
+    ${env.X} references were stored verbatim and never resolved. This made
+    `visivo migrate`'s `{{ env_var('X') }}` -> ${env.X} rewrite produce a
+    broken connection.
+    """
+
+    @pytest.mark.parametrize(
+        "field_name,env_var",
+        [
+            ("account", "${env.SNOWFLAKE_ACCOUNT}"),
+            ("warehouse", "${env.SNOWFLAKE_WAREHOUSE}"),
+            ("role", "${env.SNOWFLAKE_ROLE}"),
+            ("timezone", "${env.SNOWFLAKE_TIMEZONE}"),
+            ("protocol", "${env.SNOWFLAKE_PROTOCOL}"),
+        ],
+    )
+    def test_field_accepts_env_var_template(self, field_name, env_var):
+        from visivo.models.base.env_var_string import EnvVarString
+
+        kwargs = {
+            "name": "snow",
+            "type": "snowflake",
+            "database": "DEV",
+            field_name: env_var,
+        }
+        source = SnowflakeSource(**kwargs)
+        value = getattr(source, field_name)
+        assert isinstance(
+            value, EnvVarString
+        ), f"{field_name} should parse as EnvVarString, got {type(value).__name__}"
+
+    @pytest.mark.parametrize(
+        "field_name,getter_name,env_name,resolved",
+        [
+            ("account", "get_account", "TEST_SNOW_ACCOUNT", "abc.us-east-1.aws"),
+            ("warehouse", "get_warehouse", "TEST_SNOW_WAREHOUSE", "MY_WH"),
+            ("role", "get_role", "TEST_SNOW_ROLE", "ANALYST"),
+            ("timezone", "get_timezone", "TEST_SNOW_TIMEZONE", "America/New_York"),
+            ("protocol", "get_protocol", "TEST_SNOW_PROTOCOL", "https"),
+        ],
+    )
+    def test_getter_resolves_env_var(
+        self, monkeypatch, field_name, getter_name, env_name, resolved
+    ):
+        monkeypatch.setenv(env_name, resolved)
+        kwargs = {
+            "name": "snow",
+            "type": "snowflake",
+            "database": "DEV",
+            field_name: f"${{env.{env_name}}}",
+        }
+        source = SnowflakeSource(**kwargs)
+        assert getattr(source, getter_name)() == resolved
+
+    def test_plain_string_account_still_works(self):
+        source = SnowflakeSource(
+            name="snow",
+            type="snowflake",
+            database="DEV",
+            account="ab12345.us-west-1.aws",
+        )
+        assert source.account == "ab12345.us-west-1.aws"
+        assert source.get_account() == "ab12345.us-west-1.aws"
+
+    def test_none_field_returns_none_from_getter(self):
+        source = SnowflakeSource(name="snow", type="snowflake", database="DEV")
+        assert source.get_account() is None
+        assert source.get_warehouse() is None
+        assert source.get_role() is None
+        assert source.get_timezone() is None
+        assert source.get_protocol() is None
+
+    def test_url_resolves_env_var_account(self, monkeypatch):
+        monkeypatch.setenv("URL_ACCOUNT", "abc.us-east-1.aws")
+        source = SnowflakeSource(
+            name="snow",
+            type="snowflake",
+            database="DEV",
+            account="${env.URL_ACCOUNT}",
+            username="alice",
+            password="pw",
+        )
+        url_str = str(source.url())
+        assert "abc.us-east-1.aws" in url_str
+        assert "${env." not in url_str
+
+    def test_url_resolves_env_var_warehouse_and_role(self, monkeypatch):
+        monkeypatch.setenv("WH", "MY_WH")
+        monkeypatch.setenv("RL", "MY_ROLE")
+        source = SnowflakeSource(
+            name="snow",
+            type="snowflake",
+            database="DEV",
+            account="ab1.us-east-1.aws",
+            username="u",
+            password="p",
+            warehouse="${env.WH}",
+            role="${env.RL}",
+        )
+        url_str = str(source.url())
+        assert "warehouse=MY_WH" in url_str
+        assert "role=MY_ROLE" in url_str
+        assert "${env." not in url_str

--- a/visivo/models/sources/snowflake_source.py
+++ b/visivo/models/sources/snowflake_source.py
@@ -49,19 +49,19 @@ class SnowflakeSource(ServerSource, SqlalchemySource):
     Note: Recommended environment variable use is covered in the [sources overview.](/topics/sources/)
     """
 
-    account: Optional[str] = Field(
+    account: Optional[StringOrEnvVar] = Field(
         None,
         description="The snowflake account url. Here's how you find this: [snowflake docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier).",
     )
-    warehouse: Optional[str] = Field(
+    warehouse: Optional[StringOrEnvVar] = Field(
         None,
         description="The compute warehouse that you want queries from your Visivo project to leverage.",
     )
-    role: Optional[str] = Field(
+    role: Optional[StringOrEnvVar] = Field(
         None,
         description="The access role that you want to use when running queries.",
     )
-    timezone: Optional[str] = Field(
+    timezone: Optional[StringOrEnvVar] = Field(
         None,
         description="The timezone that you want to use by default when running queries.",
     )
@@ -80,10 +80,30 @@ class SnowflakeSource(ServerSource, SqlalchemySource):
         8, description="The pool size that is used for this connection."
     )
 
-    protocol: Optional[str] = Field(
+    protocol: Optional[StringOrEnvVar] = Field(
         None,
         description="The protocol to use for the connection.",
     )
+
+    def get_account(self) -> Optional[str]:
+        """Get the resolved account value (handles ${env.X} references)."""
+        return self._resolve_field(self.account)
+
+    def get_warehouse(self) -> Optional[str]:
+        """Get the resolved warehouse value (handles ${env.X} references)."""
+        return self._resolve_field(self.warehouse)
+
+    def get_role(self) -> Optional[str]:
+        """Get the resolved role value (handles ${env.X} references)."""
+        return self._resolve_field(self.role)
+
+    def get_timezone(self) -> Optional[str]:
+        """Get the resolved timezone value (handles ${env.X} references)."""
+        return self._resolve_field(self.timezone)
+
+    def get_protocol(self) -> Optional[str]:
+        """Get the resolved protocol value (handles ${env.X} references)."""
+        return self._resolve_field(self.protocol)
 
     def get_private_key_path(self) -> Optional[str]:
         """Get the resolved private key path value."""
@@ -130,27 +150,31 @@ class SnowflakeSource(ServerSource, SqlalchemySource):
 
         url_attributes = {
             "user": self.get_username(),
-            "account": self.account,
+            "account": self.get_account(),
         }
 
         if not self.get_private_key_path():
             url_attributes["password"] = self.get_password()
 
         # Optional attributes where if its not set the default value is used
-        if self.timezone:
-            url_attributes["timezone"] = self.timezone
-        if self.warehouse:
-            url_attributes["warehouse"] = self.warehouse
-        if self.role:
-            url_attributes["role"] = self.role
+        timezone = self.get_timezone()
+        if timezone:
+            url_attributes["timezone"] = timezone
+        warehouse = self.get_warehouse()
+        if warehouse:
+            url_attributes["warehouse"] = warehouse
+        role = self.get_role()
+        if role:
+            url_attributes["role"] = role
 
         host = self.get_host()
         if host:
             url_attributes["host"] = host
         if self.port:
             url_attributes["port"] = self.port
-        if self.protocol:
-            url_attributes["protocol"] = self.protocol
+        protocol = self.get_protocol()
+        if protocol:
+            url_attributes["protocol"] = protocol
 
         database = self.get_database()
         if database:


### PR DESCRIPTION
## Summary
Five fields on `SnowflakeSource` (`account`, `warehouse`, `role`, `timezone`, `protocol`) were typed `Optional[str]`, so `${env.X}` references were stored verbatim and never resolved at connect time. After `visivo migrate` rewrote `{{ env_var('X') }}` -> `${env.X}`, Snowflake projects would fail to connect.

This PR:
- Changes those five fields to `Optional[StringOrEnvVar]` so they participate in the env-var-aware discriminator that already powers `username`, `password`, `private_key_path`, etc.
- Adds `get_account()`, `get_warehouse()`, `get_role()`, `get_timezone()`, `get_protocol()` resolver methods.
- Routes `url()` through the new resolvers.

Plain-string values continue to work unchanged — drop-in compatible.

Diagnostic: `specs/plan/v1-final-bugfixes/B05-snowflake-source-env-var-typing.md`

## Test plan
- [x] `poetry run pytest tests/models/sources/test_snowflake_source.py` — 24 passing (15 new)
- [x] `poetry run pytest tests/models/sources/` — 82 passing, no regressions
- [x] `poetry run black --check visivo/models/sources/snowflake_source.py`

Test cases cover:
- Each field accepts `${env.X}` and parses as `EnvVarString`
- `get_*()` getters resolve env vars at call time
- Plain string values still work
- `url()` interpolates resolved values; literal `${env.` does not appear in the URL
- `None` returns `None` from getters

## Notes
**Audit follow-up:** `RedshiftSource.cluster_identifier` and `RedshiftSource.region` have the same `Optional[str]` shape — they're listed in IAM auth docs as user-configurable, so the same migrate-induced bug could surface there. Out of scope for this PR; tracking as a follow-up if anyone hits it.

This is **PR #2 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)