### PR TITLE
fix(jobs): robust parquet-write helper for null-heavy and decimal columns (B12, B14)

### DIFF
--- a/tests/jobs/test_parquet_io.py
+++ b/tests/jobs/test_parquet_io.py
@@ -1,0 +1,158 @@
+"""Tests for visivo.jobs.parquet_io.write_dicts_to_parquet.
+
+Covers regressions B12 (null-heavy schema inference) and B14 (decimal128
+serialization).
+
+Diagnostic files:
+    specs/plan/v1-final-bugfixes/B12-polars-infer-schema-length.md
+    specs/plan/v1-final-bugfixes/B14-arrow-decimal128-object-serialization.md
+"""
+
+from datetime import datetime, date
+from decimal import Decimal
+
+import polars as pl
+import pytest
+
+from visivo.jobs.parquet_io import write_dicts_to_parquet
+
+
+# ---------------------------------------------------------------------------
+# B14: Decimal columns are cast to Float64 before parquet write
+# ---------------------------------------------------------------------------
+
+
+def test_single_decimal_column_cast_to_float64(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [{"v": Decimal("0.714646")}, {"v": Decimal("1.5")}]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.schema["v"] == pl.Float64
+    values = df["v"].to_list()
+    assert values[0] == pytest.approx(0.714646)
+    assert values[1] == pytest.approx(1.5)
+
+
+def test_multiple_decimal_columns_cast(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [
+        {"a": Decimal("1.1"), "b": Decimal("2.2"), "c": Decimal("3.3")},
+        {"a": Decimal("4.4"), "b": Decimal("5.5"), "c": Decimal("6.6")},
+    ]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    for col in ("a", "b", "c"):
+        assert df.schema[col] == pl.Float64
+
+
+def test_precision_within_float64_limits(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    # 9 significant digits — well within Float64's ~15
+    data = [{"v": Decimal("1234567.89")}]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df["v"].to_list()[0] == pytest.approx(1234567.89, rel=1e-9)
+
+
+def test_non_decimal_columns_unchanged(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [
+        {"name": "alice", "age": 30, "active": True},
+        {"name": "bob", "age": 25, "active": False},
+    ]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.schema["name"] == pl.String
+    assert df.schema["age"] == pl.Int64
+    assert df.schema["active"] == pl.Boolean
+
+
+def test_mixed_decimal_and_non_decimal(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [
+        {"label": "x", "value": Decimal("0.5"), "count": 10},
+        {"label": "y", "value": Decimal("0.25"), "count": 20},
+    ]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.schema["label"] == pl.String
+    assert df.schema["value"] == pl.Float64
+    assert df.schema["count"] == pl.Int64
+
+
+# ---------------------------------------------------------------------------
+# B12: null-heavy columns must be inferred from full dataset, not first 100 rows
+# ---------------------------------------------------------------------------
+
+
+def test_null_heavy_column_handled(tmp_path):
+    """
+    Reproduces B12: a column whose first 200 rows are NULL and only later
+    rows have data with a non-trivial type. With infer_schema_length=100
+    (polars default) this raises ComputeError. With None it succeeds.
+    """
+    parquet_path = tmp_path / "out.parquet"
+    data = [{"sparse_col": None, "stable": i} for i in range(200)]
+    data.extend([{"sparse_col": f"value-{i}", "stable": 200 + i} for i in range(50)])
+    # No exception expected.
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.height == 250
+    assert df["sparse_col"].null_count() == 200
+
+
+def test_null_heavy_datetime_column(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [{"event_time": None} for _ in range(150)]
+    data.append({"event_time": datetime(2026, 4, 25, 12, 0, 0)})
+
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.height == 151
+    # The single non-null value should round-trip as a datetime.
+    assert df["event_time"][-1] == datetime(2026, 4, 25, 12, 0, 0)
+
+
+def test_null_heavy_date_column(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [{"d": None} for _ in range(150)]
+    data.append({"d": date(2026, 4, 25)})
+
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.height == 151
+    assert df["d"][-1] == date(2026, 4, 25)
+
+
+# ---------------------------------------------------------------------------
+# Integration: data round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_empty_dict_list_writes_empty_parquet(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    # Empty list should still produce a parquet (with zero rows).
+    write_dicts_to_parquet([], str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.height == 0
+
+
+def test_single_row_round_trip(tmp_path):
+    parquet_path = tmp_path / "out.parquet"
+    data = [{"a": 1, "b": "two", "c": Decimal("3.14")}]
+    write_dicts_to_parquet(data, str(parquet_path))
+
+    df = pl.read_parquet(parquet_path)
+    assert df.height == 1
+    assert df["a"][0] == 1
+    assert df["b"][0] == "two"
+    assert df["c"][0] == pytest.approx(3.14)

--- a/visivo/jobs/parquet_io.py
+++ b/visivo/jobs/parquet_io.py
@@ -1,0 +1,55 @@
+"""Shared parquet-write helper for model and insight jobs.
+
+This module exists to give both ``run_model_data_job.py`` and
+``run_insight_job.py`` a single, robust implementation for writing
+list-of-dicts data to parquet. Two latent issues drove the extraction:
+
+* **B12** — ``pl.DataFrame(data)`` with the polars default
+  ``infer_schema_length=100`` produces wrong dtypes for null-heavy or
+  rare-type columns (UUID varchar / TIMESTAMP_TZ / ARRAY / DATE columns
+  whose first 100 values are NULL). When the first non-null value
+  arrives, polars raises ``ComputeError`` and the whole model build
+  aborts. We pass ``infer_schema_length=None`` to scan all rows.
+* **B14** — Decimal columns become ``Decimal128`` in the parquet, which
+  the viewer's Arrow.js renderer serializes as
+  ``{0: low, 1: mid, 2: high, 3: sign}`` instead of a number. Plotly
+  receives an object and renders garbage. We cast Decimal columns to
+  Float64 before writing, which is acceptable lossy conversion for the
+  visualization path (Float64 has ~15 significant digits, more than any
+  realistic dashboard metric needs).
+
+Diagnostic files:
+``specs/plan/v1-final-bugfixes/B12-polars-infer-schema-length.md``
+``specs/plan/v1-final-bugfixes/B14-arrow-decimal128-object-serialization.md``
+"""
+
+from typing import List
+
+import polars as pl
+
+
+def write_dicts_to_parquet(data: List[dict], path: str) -> None:
+    """Write a list-of-dicts to parquet at ``path``.
+
+    The implementation is robust to two issues that affected the prior
+    naive ``pl.DataFrame(data).write_parquet(path)``:
+
+    1. Null-heavy columns (B12): ``infer_schema_length=None`` scans all
+       rows so polars can pick the right dtype even when the first 100
+       rows of a column are NULL.
+    2. Decimal columns (B14): every ``pl.Decimal`` column is cast to
+       ``Float64`` before write so the viewer's Arrow.js layer
+       deserialises it as a JS Number rather than a 128-bit object.
+
+    Args:
+        data: list of row dicts (typically the output of
+            ``Source.read_sql``).
+        path: absolute or relative path to the destination parquet file.
+    """
+    df = pl.DataFrame(data, infer_schema_length=None)
+
+    decimal_cols = [name for name, dtype in df.schema.items() if isinstance(dtype, pl.Decimal)]
+    if decimal_cols:
+        df = df.with_columns([pl.col(c).cast(pl.Float64) for c in decimal_cols])
+
+    df.write_parquet(path)

--- a/visivo/jobs/run_insight_job.py
+++ b/visivo/jobs/run_insight_job.py
@@ -65,14 +65,13 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
         insights_directory = f"{run_output_dir}/insights"
 
         if insight_query_info.pre_query:
-            import polars as pl
+            from visivo.jobs.parquet_io import write_dicts_to_parquet
 
             data = source.read_sql(insight_query_info.pre_query)
             os.makedirs(files_directory, exist_ok=True)
             # Use name_hash for file naming within the run directory
             parquet_path = f"{files_directory}/{insight.name_hash()}.parquet"
-            df = pl.DataFrame(data)
-            df.write_parquet(parquet_path)
+            write_dicts_to_parquet(data, parquet_path)
             files = [{"name_hash": insight.name_hash(), "signed_data_file_url": parquet_path}]
         else:
             models = insight.get_all_dependent_models(dag=dag)

--- a/visivo/jobs/run_model_data_job.py
+++ b/visivo/jobs/run_model_data_job.py
@@ -9,10 +9,10 @@ Used by:
 
 import os
 from time import time
-import polars as pl
 
 from visivo.models.sources.source import Source
 from visivo.constants import DEFAULT_RUN_ID
+from visivo.jobs.parquet_io import write_dicts_to_parquet
 
 
 def write_parquet_from_data(
@@ -35,7 +35,7 @@ def write_parquet_from_data(
     files_directory = f"{output_dir}/{run_id}/files"
     os.makedirs(files_directory, exist_ok=True)
     parquet_path = f"{files_directory}/{name_hash}.parquet"
-    pl.DataFrame(data).write_parquet(parquet_path)
+    write_dicts_to_parquet(data, parquet_path)
     return parquet_path
 
 


### PR DESCRIPTION
## Summary
Extract a shared \`visivo.jobs.parquet_io.write_dicts_to_parquet\` helper used by both \`run_model_data_job.py\` and \`run_insight_job.py\`. The helper addresses two latent issues with the prior \`pl.DataFrame(data).write_parquet(path)\`:

- **B12 (null-heavy columns)** — polars' default \`infer_schema_length=100\` picks a Null dtype when the first 100 sampled rows of a column are NULL, then crashes with \`ComputeError\` on the first non-null value. Pass \`infer_schema_length=None\` so polars scans every row.
- **B14 (Decimal columns)** — Decimal columns become decimal128 in parquet, which Arrow.js in the viewer serialises as \`{0: low, 1: mid, 2: high, 3: sign}\` instead of a number — Plotly then renders garbage. Cast every \`pl.Decimal\` column to \`pl.Float64\` before writing. Lossy by design (Float64 has ~15 significant digits, more than realistic dashboard metrics need).

Diagnostic files:
- \`specs/plan/v1-final-bugfixes/B12-polars-infer-schema-length.md\`
- \`specs/plan/v1-final-bugfixes/B14-arrow-decimal128-object-serialization.md\`

## Test plan
- [x] \`poetry run pytest tests/jobs/test_parquet_io.py\` — 10 new tests passing
- [x] \`poetry run pytest tests/jobs/\` — 48 passing (no regression)
- [x] \`poetry run black --check visivo/jobs/ tests/jobs/\`

Tests cover:
- Single & multi Decimal columns cast to Float64
- Precision preserved within Float64 limits
- Non-decimal columns unchanged (string, int, bool)
- Null-heavy string column (200 nulls then 50 strings) — would crash with old infer_schema_length=100
- Null-heavy datetime / date columns (rare polars-default failure mode)
- Empty input list and single-row round trip

## Empora coordination
Once merged, Empora can remove the in-tree patches they applied to \`.venv/\` for both \`run_model_data_job.py\` and \`run_insight_job.py\`.

This is **PR #3 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)