### PR TITLE
fix(viewer): tables fill item divs and scroll horizontally (B15)

### DIFF
--- a/viewer/src/components/common/DataTable.jsx
+++ b/viewer/src/components/common/DataTable.jsx
@@ -133,7 +133,7 @@ const DataTable = ({
   if (isLoading) {
     return (
       <div
-        className="flex flex-col items-center justify-center h-full border border-secondary-200 rounded overflow-hidden bg-white"
+        className="flex flex-col items-center justify-center h-full w-full max-w-full border border-secondary-200 rounded overflow-hidden bg-white"
         style={{ height }}
       >
         <PiSpinner className="animate-spin text-secondary-400 mb-2" size={24} />
@@ -146,7 +146,7 @@ const DataTable = ({
   if (!columns.length || !rows.length) {
     return (
       <div
-        className="flex flex-col items-center justify-center h-full border border-secondary-200 rounded overflow-hidden bg-white"
+        className="flex flex-col items-center justify-center h-full w-full max-w-full border border-secondary-200 rounded overflow-hidden bg-white"
         style={{ height }}
       >
         <span className="text-sm text-secondary-400">No data available</span>
@@ -160,8 +160,12 @@ const DataTable = ({
   const totalWidth = leafHeaderGroup?.headers.reduce((sum, h) => sum + h.getSize(), 0) ?? 0;
 
   return (
+    // w-full max-w-full: fill the parent item div without overflowing it.
+    // Combined with the inner overflow-auto, wide tables now scroll
+    // horizontally inside this container instead of being clipped by the
+    // parent item div's overflow:hidden. See B15.
     <div
-      className="flex flex-col border border-secondary-200 rounded overflow-hidden bg-white"
+      className="flex flex-col w-full max-w-full border border-secondary-200 rounded overflow-hidden bg-white"
       style={{ height }}
     >
       {/* Query progress indicator */}

--- a/viewer/src/components/common/DataTable.test.jsx
+++ b/viewer/src/components/common/DataTable.test.jsx
@@ -146,4 +146,34 @@ describe('DataTable', () => {
       expect(cb).toBeChecked();
     });
   });
+
+  // B15: the root must fill its parent item div in both directions and not
+  // exceed it. Combined with the inner overflow-auto this gives wide tables
+  // a horizontal scrollbar inside the card and prevents narrow-content
+  // tables from shrinking to less than the slot width.
+  describe('B15 sizing', () => {
+    it('root has w-full and max-w-full classes (data state)', () => {
+      const { container } = render(<DataTable {...defaultProps} />);
+      // eslint-disable-next-line testing-library/no-node-access
+      const root = container.firstChild;
+      expect(root.className).toMatch(/\bw-full\b/);
+      expect(root.className).toMatch(/\bmax-w-full\b/);
+    });
+
+    it('root has w-full and max-w-full classes (loading state)', () => {
+      const { container } = render(<DataTable {...defaultProps} isLoading={true} />);
+      // eslint-disable-next-line testing-library/no-node-access
+      const root = container.firstChild;
+      expect(root.className).toMatch(/\bw-full\b/);
+      expect(root.className).toMatch(/\bmax-w-full\b/);
+    });
+
+    it('root has w-full and max-w-full classes (empty state)', () => {
+      const { container } = render(<DataTable {...defaultProps} rows={[]} />);
+      // eslint-disable-next-line testing-library/no-node-access
+      const root = container.firstChild;
+      expect(root.className).toMatch(/\bw-full\b/);
+      expect(root.className).toMatch(/\bmax-w-full\b/);
+    });
+  });
 });

--- a/viewer/src/components/items/ItemContainer.js
+++ b/viewer/src/components/items/ItemContainer.js
@@ -1,7 +1,14 @@
 import tw from 'tailwind-styled-components';
 
+// w-full / h-full ensure the container fills its parent dashboard item div
+// rather than sizing to the natural width of inner content. Without these,
+// 2.0 tables shrink to content (leaving empty gutters in narrow slots) or
+// overflow horizontally with no scrollbar in wide slots. See B15 in
+// specs/plan/v1-final-bugfixes/.
 export const ItemContainer = tw.div`
     relative
+    w-full
+    h-full
     rounded-2xl
     shadow-lg           // Adds a subtle shadow for the "pop out" effect
     transition          // Enables smooth transition

--- a/viewer/src/components/items/ItemContainer.test.jsx
+++ b/viewer/src/components/items/ItemContainer.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ItemContainer } from './ItemContainer';
+
+// B15: ItemContainer must fill its parent item div so 2.0 widgets
+// (notably the new table) don't shrink to content or overflow without a
+// scrollbar. The fix is `w-full h-full` in the tw template literal.
+describe('ItemContainer (B15 sizing)', () => {
+  it('renders with w-full and h-full classes', () => {
+    const { container } = render(
+      <ItemContainer>
+        <div>child</div>
+      </ItemContainer>
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    const root = container.firstChild;
+    expect(root.className).toMatch(/\bw-full\b/);
+    expect(root.className).toMatch(/\bh-full\b/);
+  });
+
+  it('still has the visual-style classes from before', () => {
+    const { container } = render(
+      <ItemContainer>
+        <div>child</div>
+      </ItemContainer>
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    const root = container.firstChild;
+    expect(root.className).toMatch(/\brounded-2xl\b/);
+    expect(root.className).toMatch(/\bshadow-lg\b/);
+    expect(root.className).toMatch(/\boverflow-hidden\b/);
+  });
+
+  it('renders children', () => {
+    render(
+      <ItemContainer>
+        <div>hello world</div>
+      </ItemContainer>
+    );
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
The 2.0 \`columns:\`-style table widget had two related sizing problems:

- **A) Wide tables overflow the viewport with no horizontal scrollbar.** Columns clipped on left and right edges, unreachable. Affects every dashboard table with more columns than fit in its slot.
- **B) Tables in narrow item slots shrink to content width**, leaving an empty gutter inside the item div.

Both stem from the absence of \`w-full max-w-full\` on the table chrome:

- **\`ItemContainer\`** (styled wrapper for every dashboard widget) only set rounded/shadow/border classes. Add \`w-full h-full\` so the wrapper always matches the parent item slot.
- **\`DataTable\`**'s root div (data, loading, and empty branches) only set height. Add \`w-full max-w-full\` so the table sizes to the slot. The existing inner \`overflow-auto\` element then provides the horizontal scrollbar for wide tables instead of being clipped by ItemContainer's \`overflow-hidden\`.

Diagnostic: \`specs/plan/v1-final-bugfixes/B15-table-widget-overflow-and-shrink.md\`

## Test plan
- [x] \`yarn test --testPathPattern=ItemContainer|DataTable.test\` — 22 passing (6 new)
- [x] \`yarn lint\` — clean
- [ ] Reviewer (Playwright MCP / manual): wide-and-narrow table dashboard at 1280px viewport — verify horizontal scrollbar inside wide table card, narrow table fills its slot.

Tests cover:
- \`ItemContainer\` has \`w-full h-full\`, retains existing visual classes
- \`DataTable\` root has \`w-full max-w-full\` in data, loading, and empty states

## Empora coordination
After merge, Empora can remove the "accepting the regression" note on the table widget for the KPI dashboard.

This is **PR #5 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)