### PR TITLE
fix(insight-props): strip internal keys + better error msg (B08)

### DIFF
--- a/tests/models/test_insight_props_validation.py
+++ b/tests/models/test_insight_props_validation.py
@@ -1,0 +1,91 @@
+"""Tests for InsightProps schema validation behavior (B08).
+
+Covers:
+- visivo-internal metadata (`file_path`, `path`) is stripped before
+  jsonschema validation, so it doesn't trigger spurious
+  "Additional properties are not allowed" errors.
+- The "additionalProperties" error message includes a sample of valid
+  Plotly props so authors can spot typos.
+"""
+
+import pytest
+
+from visivo.models.props.insight_props import InsightProps
+
+
+# ---------------------------------------------------------------------------
+# B08 part 1: file_path / path don't leak into validation
+# ---------------------------------------------------------------------------
+
+
+def test_file_path_does_not_break_validation():
+    """The parser may attach file_path to props for diagnostic context;
+    it must not cause schema validation to fail."""
+    # Construct via dict to mimic parser behavior assigning extras.
+    props = InsightProps(type="bar", file_path="some/path.visivo.yml")
+    assert props.type.value == "bar"
+
+
+def test_path_does_not_break_validation():
+    props = InsightProps(type="scatter", path="dashboards/foo.visivo.yml")
+    assert props.type.value == "scatter"
+
+
+# ---------------------------------------------------------------------------
+# B08 part 2: name (a Plotly-valid prop) actually validates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("trace_type", ["bar", "scatter", "histogram"])
+def test_name_prop_accepted(trace_type):
+    """`name` is a valid Plotly property at root for these trace types.
+    Setting it for legend labelling should not raise."""
+    props = InsightProps(type=trace_type, name="User Completed")
+    # Pydantic stores extras when extra='allow' on JsonSchemaBase
+    assert props.model_dump().get("name") == "User Completed"
+
+
+# ---------------------------------------------------------------------------
+# B08 part 3: invalid prop produces a helpful error
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_prop_message_lists_valid_props():
+    with pytest.raises(ValueError) as exc:
+        InsightProps(type="bar", garblegarble=42)
+    msg = str(exc.value)
+    # Either jsonschema_rs uses the modern phrase or the older one.
+    assert "Additional properties" in msg or "additionalProperties" in msg
+    # The message should include a list of valid property names.
+    assert "Valid Plotly properties" in msg
+    # Sanity-check: at least one well-known Plotly prop should appear in
+    # the suggestion list.
+    assert "name" in msg or "type" in msg
+
+
+def test_valid_props_unchanged_no_error():
+    """Sanity: a valid prop combination still validates cleanly."""
+    props = InsightProps(type="bar", name="x", marker={"color": "red"})
+    assert props.model_dump().get("name") == "x"
+    assert props.model_dump().get("marker") == {"color": "red"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: a realistic insight props block including file_path + extras
+# ---------------------------------------------------------------------------
+
+
+def test_realistic_props_with_file_path_and_user_extra():
+    """Mirror the actual parser output: file_path is set, plus a valid
+    user-supplied extra prop (`name`)."""
+    props = InsightProps(
+        type="bar",
+        name="User Completed",
+        file_path="dashboards/kpi.visivo.yml",
+    )
+    dumped = props.model_dump()
+    assert dumped["type"] == "bar"
+    assert dumped["name"] == "User Completed"
+    # file_path is preserved on the model (parser may need it later)
+    # even though it's stripped before schema validation.
+    assert dumped.get("file_path") == "dashboards/kpi.visivo.yml"

--- a/visivo/models/props/insight_props.py
+++ b/visivo/models/props/insight_props.py
@@ -11,6 +11,16 @@ from visivo.models.props.types import PropType
 from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
 
 
+#: Field names that the parser may attach to props during YAML loading
+#: but that are not valid Plotly trace properties. Strip them out of the
+#: dumped dict before running jsonschema validation, otherwise the
+#: schema's `additionalProperties: false` rejects them and produces a
+#: misleading error like "Additional properties are not allowed
+#: ('file_path' was unexpected)" when the user actually misspelled or
+#: added an unrelated prop. See B08.
+_VISIVO_INTERNAL_PROPS = {"file_path", "path"}
+
+
 class InsightProps(JsonSchemaBase):
 
     type: PropType = Field(..., description="Type of the trace")
@@ -35,6 +45,10 @@ class InsightProps(JsonSchemaBase):
 
         try:
             data_dict = self.model_dump()
+            # Drop visivo-internal metadata that the YAML parser may attach
+            # before handing the dict to the Plotly schema validator.
+            for key in _VISIVO_INTERNAL_PROPS:
+                data_dict.pop(key, None)
 
             validator.validate(data_dict)
 

--- a/visivo/models/props/json_schema_base.py
+++ b/visivo/models/props/json_schema_base.py
@@ -16,6 +16,21 @@ def get_message_from_error(error: ValidationError, schema: Dict[str, Any]) -> st
         message = "Value does not match any of the following schemas: \n" + "\n or \n".join(
             message_parts
         )
+    elif "Additional properties are not allowed" in message or (
+        "additionalProperties" in message and "not allowed" in message
+    ):
+        # B08: the default jsonschema_rs message names a single offending
+        # property (e.g. "'file_path' was unexpected"), which is misleading
+        # when the user added a different unknown prop and just happens to
+        # see whichever key got picked first. Append a list of valid props
+        # so authors can spot typos.
+        valid = sorted((schema.get("properties") or {}).keys())
+        if valid:
+            preview = ", ".join(valid[:25])
+            ellipsis = "..." if len(valid) > 25 else ""
+            message = (
+                f"{message}\n  Valid Plotly properties for this trace type: " f"{preview}{ellipsis}"
+            )
     return message
 
 


### PR DESCRIPTION
## Summary
Two related fixes for the \`InsightProps\` validation path:

1. **Strip visivo-internal metadata** (\`file_path\`, \`path\`) from the dumped dict before handing it to the jsonschema validator. The YAML parser may attach these for diagnostic context, but they're not Plotly trace properties — so the schema's \`additionalProperties: false\` rejected them and produced a misleading \`'file_path' was unexpected\` error when the user actually added an unrelated prop. With the strip, valid Plotly props like \`name\` (a legend label) now validate cleanly even when \`file_path\` is also set.

2. **Improve error message for unknown props.** When a truly unknown prop is rejected, append a list of the valid Plotly properties for that trace type to the error message. Authors spot typos faster than reading the raw jsonschema error.

Diagnostic: \`specs/plan/v1-final-bugfixes/B08-insight-props-name-rejected.md\`

## Test plan
- [x] \`poetry run pytest tests/models/test_insight_props_validation.py\` — 8 passing
- [x] \`poetry run pytest tests/models/test_insight_dependencies.py tests/models/test_insight_dynamic.py\` — 21 passing (no regression)
- [x] \`poetry run black --check visivo/models/props/\`

Tests cover:
- \`file_path\` and \`path\` extras don't break validation
- \`name\` (a Plotly-valid prop) accepted on bar / scatter / histogram
- Unknown props produce an error that lists valid Plotly properties

## Empora coordination
After merge, Empora can drop the \`interactions[].split: ?{'User Completed'}\` workaround for legend labels and use \`props.name: "User Completed"\` directly.

This is **PR #6 of 11** for the v1 final bugfix punch list. The B07 grammar PR (insight \`?{...}[slice]\` suffix) is intentionally deferred — it shares this file and is best landed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)