### PR TITLE
fix(migrate): preserve column_defs blocks with cell-level styling (B06)

### DIFF
--- a/tests/models/deprecations/test_table_deprecation.py
+++ b/tests/models/deprecations/test_table_deprecation.py
@@ -60,3 +60,125 @@ tables:
             assert len(migrations) > 0
             column_def_migrations = [m for m in migrations if "column_defs" in m.old_text]
             assert len(column_def_migrations) > 0
+
+    # ---------------------------------------------------------------------
+    # B06: column_defs that carry cell-level styling MUST NOT be deleted
+    # automatically — auto-deletion drops user-visible markdown / justify /
+    # align / header_name flags that have no equivalent in the 2.0 widget.
+    # ---------------------------------------------------------------------
+
+    def test_column_defs_with_markdown_flag_not_deleted(self):
+        """Per-cell `markdown: True` (used for <a> link rendering) cannot
+        be expressed in a SQL alias. Don't auto-delete the block."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = os.path.join(tmpdir, "test.yml")
+            with open(yaml_path, "w") as f:
+                f.write(
+                    """
+tables:
+  - name: deals-table
+    data: ref(deal-rows)
+    column_defs:
+      - trace_name: deal-trace
+        columns:
+          - key: "deal_link"
+            markdown: True
+          - key: "deal_name"
+"""
+                )
+
+            checker = TableDeprecation()
+            migrations = checker.get_migrations_from_files(tmpdir)
+
+            column_def_migrations = [m for m in migrations if "column_defs" in m.old_text]
+            assert column_def_migrations == [], (
+                "column_defs containing markdown: True must not be auto-deleted; "
+                "user must migrate manually"
+            )
+
+    def test_column_defs_with_justify_flag_not_deleted(self):
+        """`justify` is a per-column alignment hint with no SQL-alias equivalent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = os.path.join(tmpdir, "test.yml")
+            with open(yaml_path, "w") as f:
+                f.write(
+                    """
+tables:
+  - name: t
+    data: ref(rows)
+    column_defs:
+      - trace_name: t1
+        columns:
+          - key: "col1"
+            justify: center
+"""
+                )
+            checker = TableDeprecation()
+            migrations = checker.get_migrations_from_files(tmpdir)
+            assert [m for m in migrations if "column_defs" in m.old_text] == []
+
+    def test_column_defs_with_align_flag_not_deleted(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = os.path.join(tmpdir, "test.yml")
+            with open(yaml_path, "w") as f:
+                f.write(
+                    """
+tables:
+  - name: t
+    data: ref(rows)
+    column_defs:
+      - trace_name: t1
+        columns:
+          - key: "col1"
+            align: right
+"""
+                )
+            checker = TableDeprecation()
+            migrations = checker.get_migrations_from_files(tmpdir)
+            assert [m for m in migrations if "column_defs" in m.old_text] == []
+
+    def test_column_defs_with_header_name_not_deleted(self):
+        """`header_name` overrides the column header text. The 2.0 widget
+        derives headers from SQL aliases, so a header_name override is
+        only safe to delete if the user simultaneously aliases the column
+        — we can't determine that automatically. Punt to manual review."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = os.path.join(tmpdir, "test.yml")
+            with open(yaml_path, "w") as f:
+                f.write(
+                    """
+tables:
+  - name: t
+    data: ref(rows)
+    column_defs:
+      - trace_name: t1
+        columns:
+          - key: "col1"
+            header_name: "Custom Display Name"
+"""
+                )
+            checker = TableDeprecation()
+            migrations = checker.get_migrations_from_files(tmpdir)
+            assert [m for m in migrations if "column_defs" in m.old_text] == []
+
+    def test_column_defs_without_cell_flags_still_deleted(self):
+        """Sanity: a column_defs block that uses only `key` (which the 2.0
+        widget can recover from auto-generation) is still auto-deleted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = os.path.join(tmpdir, "test.yml")
+            with open(yaml_path, "w") as f:
+                f.write(
+                    """
+tables:
+  - name: t
+    data: ref(rows)
+    column_defs:
+      - trace_name: t1
+        columns:
+          - key: "col1"
+          - key: "col2"
+"""
+                )
+            checker = TableDeprecation()
+            migrations = checker.get_migrations_from_files(tmpdir)
+            assert any("column_defs" in m.old_text for m in migrations)

--- a/visivo/models/deprecations/table_deprecation.py
+++ b/visivo/models/deprecations/table_deprecation.py
@@ -170,6 +170,17 @@ class TableDeprecation(BaseDeprecationChecker):
 
         return None
 
+    # Cell-level flags inside ``column_defs`` that have no automatic
+    # equivalent in the 2.0 table widget. If any of these are present we
+    # must NOT delete the block — doing so silently drops user-visible
+    # styling (e.g. ``markdown: True`` for link rendering, ``justify`` /
+    # ``align`` per-column alignment, custom ``header_name`` overrides
+    # that aren't expressible as SQL aliases). See B06.
+    _PRESERVE_CELL_FLAGS_RE = re.compile(
+        r"^\s+(markdown|justify|align|header_name)\s*:\s*\S",
+        re.MULTILINE,
+    )
+
     def _create_remove_column_defs_migration(
         self, content: str, table_name: str
     ) -> MigrationAction:
@@ -204,6 +215,13 @@ class TableDeprecation(BaseDeprecationChecker):
 
         old_lines = lines[column_defs_start : column_defs_end + 1]
         old_text = "\n".join(old_lines)
+
+        # B06: refuse to auto-delete blocks that carry cell-level styling
+        # the 2.0 widget can't auto-recover. Surface as a deprecation
+        # warning instead so the user can address the migration manually.
+        if self._PRESERVE_CELL_FLAGS_RE.search(old_text):
+            return None
+
         new_text = ""
 
         return MigrationAction(


### PR DESCRIPTION
## Summary
The migrate command's table deprecation pass deleted entire \`column_defs\` blocks, silently dropping per-cell styling that has no equivalent in the 2.0 table widget:

- \`markdown: True\` (renders \`<a>\` tags / inline HTML in cells)
- \`justify\` / \`align\` (per-column alignment)
- \`header_name\` (custom column-header text — only safe to delete if the user also aliases the column in SQL, which we can't determine automatically)

Auto-deleting these blocks silently lost user-visible styling. Refuse to auto-delete when any of these flags appear in the block; the deprecation warning then guides the user to migrate manually.

\`column_defs\` blocks that only use \`key:\` (which the 2.0 widget can auto-recover from query data) continue to be auto-deleted.

Diagnostic: \`specs/plan/v1-final-bugfixes/B06-migrate-column-defs-loses-markdown-flag.md\`

## Test plan
- [x] \`poetry run pytest tests/models/deprecations/test_table_deprecation.py\` — 8 passing (5 new B06 tests + existing 3)
- [x] \`poetry run pytest tests/models/deprecations/\` — 58 passing (no regression)
- [x] \`poetry run black --check visivo/models/deprecations/table_deprecation.py\`

Tests cover:
- \`markdown: True\` block not auto-deleted
- \`justify\` block not auto-deleted
- \`align\` block not auto-deleted
- \`header_name\` block not auto-deleted
- Plain \`key:\`-only block still auto-deleted (regression check)

## Empora coordination
After merge, the \`deal-calls.visivo.yml:calls-missing-deal-associations\` table (and similar link-rendering tables) will surface as a deprecation warning rather than being silently mangled. Empora handles each manually as part of Phase 7.

## Future work
A 2.0 per-column directive that preserves \`markdown:\` rendering exists as a feature ask but is intentionally out of scope for this PR (it's a feature, not a bug fix).

This is **PR #8 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)