### PR TITLE
fix(migrate): log per-file errors instead of silent skip (B03, B04)

### DIFF
--- a/tests/models/deprecations/test_name_format_deprecation.py
+++ b/tests/models/deprecations/test_name_format_deprecation.py
@@ -230,3 +230,77 @@ sources:
 
             # Should have 0 migrations because there's no project.visivo.yml
             assert len(migrations) == 0
+
+
+# ---------------------------------------------------------------------------
+# B03 / B04: silent-skip overhaul. Unreadable files must not stop the
+# cascade from processing other files in the same project, and the
+# previous bare ``except Exception: continue`` must be replaced with a
+# logged warning.
+# ---------------------------------------------------------------------------
+
+
+class TestNameFormatCascadeErrorHandling:
+    """B03/B04 regression coverage."""
+
+    def test_undecodable_file_does_not_block_other_files(self, tmp_path):
+        """A sibling file with non-UTF-8 bytes must not stop the cascade
+        from migrating other files. The new ``errors='replace'`` UTF-8
+        reader handles the bad bytes gracefully."""
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+
+        # Create a file with raw bytes that don't form valid UTF-8.
+        bad_path = tmp_path / "bad.visivo.yml"
+        with open(bad_path, "wb") as f:
+            f.write(b"# stray bytes: \xff\xfe\xfd\n")
+
+        # And a normal file with an invalid-format name to migrate.
+        good_path = tmp_path / "good.visivo.yml"
+        good_path.write_text("name: My Good Source\n")
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+
+        # The good file must produce at least one migration.
+        good_migrations = [m for m in migrations if str(good_path) in m.file_path]
+        assert good_migrations, (
+            "good.visivo.yml should still migrate even when a sibling file "
+            "has UTF-8-incompatible bytes"
+        )
+
+    def test_unreadable_file_logs_and_continues(self, tmp_path, monkeypatch):
+        """If the safe-reader hits a real OSError-like failure on one
+        file, that's logged via Logger and the pass continues with
+        every other file."""
+        from visivo.models.deprecations import name_format_deprecation as nfd
+
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        good_path = tmp_path / "good.visivo.yml"
+        good_path.write_text("name: My Good Source\n")
+        broken_path = tmp_path / "broken.visivo.yml"
+        broken_path.write_text("name: Should Not Migrate\n")
+
+        original_read = nfd._read_file_safe
+        warns = []
+
+        def patched_read(file_path):
+            if str(file_path).endswith("broken.visivo.yml"):
+                # Capture that the broken-file path was visited and
+                # signal a "skip" return like the real safe reader would.
+                warns.append(str(file_path))
+                return None
+            return original_read(file_path)
+
+        monkeypatch.setattr(nfd, "_read_file_safe", patched_read)
+
+        checker = nfd.NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+
+        # The patched reader was invoked for the broken file each time
+        # it appears in the file walk (3 passes in current code).
+        assert any(
+            p.endswith("broken.visivo.yml") for p in warns
+        ), "broken file should have been visited by the safe reader"
+        # And the good file should still produce a migration.
+        good_migrations = [m for m in migrations if str(good_path) in m.file_path]
+        assert good_migrations, "good file should migrate despite broken sibling"

--- a/visivo/models/deprecations/name_format_deprecation.py
+++ b/visivo/models/deprecations/name_format_deprecation.py
@@ -4,6 +4,7 @@ import os
 import re
 from typing import TYPE_CHECKING, List, Dict
 
+from visivo.logger.logger import Logger
 from visivo.models.deprecations.base_deprecation import (
     BaseDeprecationChecker,
     DeprecationWarning,
@@ -14,6 +15,33 @@ from visivo.utils import list_all_ymls_in_dir
 
 if TYPE_CHECKING:
     from visivo.models.project import Project
+
+
+def _read_file_safe(file_path) -> "str | None":
+    """Read a YAML file as UTF-8 with error replacement.
+
+    Returns the decoded content on success, or ``None`` if the read fails.
+    Logs a warning for any unexpected error so users can see WHICH file
+    was skipped during a migrate pass — the previous bare
+    ``except Exception: continue`` swallowed every error silently and
+    led to "migration looked complete but my refs aren't updated"
+    surprises (B03, B04).
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        Logger.instance().warn(
+            f"migrate: skipping {file_path} during name-format pass: "
+            f"{type(exc).__name__}: {exc}"
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 - log unexpected errors but keep going
+        Logger.instance().warn(
+            f"migrate: skipping {file_path} during name-format pass: "
+            f"{type(exc).__name__}: {exc}"
+        )
+        return None
 
 
 # Pattern to find name fields in YAML files
@@ -196,167 +224,155 @@ class NameFormatDeprecation(BaseDeprecationChecker):
 
         # First pass: collect all invalid names and their normalized versions
         for file_path in list_all_ymls_in_dir(working_dir):
-            try:
-                with open(file_path, "r") as f:
-                    content = f.read()
-
-                # Find unquoted name: value patterns
-                for match in NAME_FIELD_UNQUOTED_PATTERN.finditer(content):
-                    indent = match.group(1)
-                    list_prefix = match.group(2) or ""
-                    name_value = match.group(3).strip()
-
-                    if not is_valid_name(name_value):
-                        normalized = normalize_name(name_value)
-                        if normalized != name_value:
-                            name_renames[name_value] = normalized
-                            migrations.append(
-                                MigrationAction(
-                                    file_path=str(file_path),
-                                    old_text=match.group(0),
-                                    new_text=f"{indent}{list_prefix}name: {normalized}",
-                                    description=f"'{name_value}' -> '{normalized}'",
-                                )
-                            )
-
-                # Find quoted name: "value" or name: 'value' patterns
-                for match in NAME_FIELD_QUOTED_PATTERN.finditer(content):
-                    indent = match.group(1)
-                    list_prefix = match.group(2) or ""
-                    name_value = match.group(4)  # Group 3 is the quote char
-
-                    if not is_valid_name(name_value):
-                        normalized = normalize_name(name_value)
-                        if normalized != name_value:
-                            name_renames[name_value] = normalized
-                            migrations.append(
-                                MigrationAction(
-                                    file_path=str(file_path),
-                                    old_text=match.group(0),
-                                    new_text=f"{indent}{list_prefix}name: {normalized}",
-                                    description=f"'{name_value}' -> '{normalized}'",
-                                )
-                            )
-
-            except Exception:
-                # Skip files that can't be read
+            content = _read_file_safe(file_path)
+            if content is None:
                 continue
+
+            # Find unquoted name: value patterns
+            for match in NAME_FIELD_UNQUOTED_PATTERN.finditer(content):
+                indent = match.group(1)
+                list_prefix = match.group(2) or ""
+                name_value = match.group(3).strip()
+
+                if not is_valid_name(name_value):
+                    normalized = normalize_name(name_value)
+                    if normalized != name_value:
+                        name_renames[name_value] = normalized
+                        migrations.append(
+                            MigrationAction(
+                                file_path=str(file_path),
+                                old_text=match.group(0),
+                                new_text=f"{indent}{list_prefix}name: {normalized}",
+                                description=f"'{name_value}' -> '{normalized}'",
+                            )
+                        )
+
+            # Find quoted name: "value" or name: 'value' patterns
+            for match in NAME_FIELD_QUOTED_PATTERN.finditer(content):
+                indent = match.group(1)
+                list_prefix = match.group(2) or ""
+                name_value = match.group(4)  # Group 3 is the quote char
+
+                if not is_valid_name(name_value):
+                    normalized = normalize_name(name_value)
+                    if normalized != name_value:
+                        name_renames[name_value] = normalized
+                        migrations.append(
+                            MigrationAction(
+                                file_path=str(file_path),
+                                old_text=match.group(0),
+                                new_text=f"{indent}{list_prefix}name: {normalized}",
+                                description=f"'{name_value}' -> '{normalized}'",
+                            )
+                        )
 
         # Second pass: find all references to renamed items and update them
         # Also find any ref() calls with invalid names that weren't found as name: fields
         # (e.g., names defined in includes or external files)
         for file_path in list_all_ymls_in_dir(working_dir):
-            try:
-                with open(file_path, "r") as f:
-                    content = f.read()
+            content = _read_file_safe(file_path)
+            if content is None:
+                continue
 
-                # First handle known renames from name: fields
-                for old_name, new_name in name_renames.items():
-                    ref_pattern = build_ref_pattern(old_name)
-                    for match in ref_pattern.finditer(content):
-                        old_ref = match.group(0)
-                        # Convert to new refs syntax: ${refs.new_name}
-                        # Check if this ref has a property path
-                        new_ref = self._build_new_ref(old_ref, old_name, new_name)
+            # First handle known renames from name: fields
+            for old_name, new_name in name_renames.items():
+                ref_pattern = build_ref_pattern(old_name)
+                for match in ref_pattern.finditer(content):
+                    old_ref = match.group(0)
+                    # Convert to new refs syntax: ${refs.new_name}
+                    # Check if this ref has a property path
+                    new_ref = self._build_new_ref(old_ref, old_name, new_name)
+                    if new_ref and new_ref != old_ref:
+                        migrations.append(
+                            MigrationAction(
+                                file_path=str(file_path),
+                                old_text=old_ref,
+                                new_text=new_ref,
+                                description=f"ref '{old_name}' -> ref '{new_name}'",
+                            )
+                        )
+
+            # Also find any ref() calls with invalid names not in name_renames
+            # These might reference names defined in includes or external files
+            for match in REF_CALL_PATTERN.finditer(content):
+                ref_name = match.group("name").strip()
+                # Skip if already handled or if the name is valid
+                if ref_name in name_renames or is_valid_name(ref_name):
+                    continue
+
+                normalized = normalize_name(ref_name)
+                if normalized != ref_name:
+                    # Find the full ref pattern for this name
+                    ref_pattern = build_ref_pattern(ref_name)
+                    for ref_match in ref_pattern.finditer(content):
+                        old_ref = ref_match.group(0)
+                        new_ref = self._build_new_ref(old_ref, ref_name, normalized)
                         if new_ref and new_ref != old_ref:
                             migrations.append(
                                 MigrationAction(
                                     file_path=str(file_path),
                                     old_text=old_ref,
                                     new_text=new_ref,
-                                    description=f"ref '{old_name}' -> ref '{new_name}'",
+                                    description=f"ref '{ref_name}' -> ref '{normalized}'",
                                 )
                             )
-
-                # Also find any ref() calls with invalid names not in name_renames
-                # These might reference names defined in includes or external files
-                for match in REF_CALL_PATTERN.finditer(content):
-                    ref_name = match.group("name").strip()
-                    # Skip if already handled or if the name is valid
-                    if ref_name in name_renames or is_valid_name(ref_name):
-                        continue
-
-                    normalized = normalize_name(ref_name)
-                    if normalized != ref_name:
-                        # Find the full ref pattern for this name
-                        ref_pattern = build_ref_pattern(ref_name)
-                        for ref_match in ref_pattern.finditer(content):
-                            old_ref = ref_match.group(0)
-                            new_ref = self._build_new_ref(old_ref, ref_name, normalized)
-                            if new_ref and new_ref != old_ref:
-                                migrations.append(
-                                    MigrationAction(
-                                        file_path=str(file_path),
-                                        old_text=old_ref,
-                                        new_text=new_ref,
-                                        description=f"ref '{ref_name}' -> ref '{normalized}'",
-                                    )
-                                )
-                        # Add to name_renames to avoid duplicate processing
-                        name_renames[ref_name] = normalized
-
-            except Exception:
-                # Skip files that can't be read
-                continue
+                    # Add to name_renames to avoid duplicate processing
+                    name_renames[ref_name] = normalized
 
         # Third pass: update trace_name, insight_name, source_name, and alert_name fields
         # that reference renamed items
         for file_path in list_all_ymls_in_dir(working_dir):
-            try:
-                with open(file_path, "r") as f:
-                    content = f.read()
-
-                # Update trace_name fields
-                migrations.extend(
-                    self._migrate_reference_field(
-                        content,
-                        file_path,
-                        name_renames,
-                        "trace_name",
-                        TRACE_NAME_FIELD_UNQUOTED_PATTERN,
-                        TRACE_NAME_FIELD_QUOTED_PATTERN,
-                    )
-                )
-
-                # Update insight_name fields
-                migrations.extend(
-                    self._migrate_reference_field(
-                        content,
-                        file_path,
-                        name_renames,
-                        "insight_name",
-                        INSIGHT_NAME_FIELD_UNQUOTED_PATTERN,
-                        INSIGHT_NAME_FIELD_QUOTED_PATTERN,
-                    )
-                )
-
-                # Update source_name fields (used in defaults)
-                migrations.extend(
-                    self._migrate_reference_field(
-                        content,
-                        file_path,
-                        name_renames,
-                        "source_name",
-                        SOURCE_NAME_FIELD_UNQUOTED_PATTERN,
-                        SOURCE_NAME_FIELD_QUOTED_PATTERN,
-                    )
-                )
-
-                # Update alert_name fields (used in defaults)
-                migrations.extend(
-                    self._migrate_reference_field(
-                        content,
-                        file_path,
-                        name_renames,
-                        "alert_name",
-                        ALERT_NAME_FIELD_UNQUOTED_PATTERN,
-                        ALERT_NAME_FIELD_QUOTED_PATTERN,
-                    )
-                )
-
-            except Exception:
-                # Skip files that can't be read
+            content = _read_file_safe(file_path)
+            if content is None:
                 continue
+
+            # Update trace_name fields
+            migrations.extend(
+                self._migrate_reference_field(
+                    content,
+                    file_path,
+                    name_renames,
+                    "trace_name",
+                    TRACE_NAME_FIELD_UNQUOTED_PATTERN,
+                    TRACE_NAME_FIELD_QUOTED_PATTERN,
+                )
+            )
+
+            # Update insight_name fields
+            migrations.extend(
+                self._migrate_reference_field(
+                    content,
+                    file_path,
+                    name_renames,
+                    "insight_name",
+                    INSIGHT_NAME_FIELD_UNQUOTED_PATTERN,
+                    INSIGHT_NAME_FIELD_QUOTED_PATTERN,
+                )
+            )
+
+            # Update source_name fields (used in defaults)
+            migrations.extend(
+                self._migrate_reference_field(
+                    content,
+                    file_path,
+                    name_renames,
+                    "source_name",
+                    SOURCE_NAME_FIELD_UNQUOTED_PATTERN,
+                    SOURCE_NAME_FIELD_QUOTED_PATTERN,
+                )
+            )
+
+            # Update alert_name fields (used in defaults)
+            migrations.extend(
+                self._migrate_reference_field(
+                    content,
+                    file_path,
+                    name_renames,
+                    "alert_name",
+                    ALERT_NAME_FIELD_UNQUOTED_PATTERN,
+                    ALERT_NAME_FIELD_QUOTED_PATTERN,
+                )
+            )
 
         return migrations
 


### PR DESCRIPTION
## Summary
The name-format deprecation checker walked YAML files in three passes (collect renames, rewrite refs, rewrite \`trace_name\` / \`insight_name\` / \`source_name\` / \`alert_name\`). Each pass wrapped its file loop in:

\`\`\`python
except Exception:
    continue
\`\`\`

which silently swallowed every error — \`UnicodeDecodeError\`, \`OSError\`, even unexpected \`re.error\`. So a single problematic file would silently drop out of one or more passes, and the user would see "migration looked complete but my refs aren't updated".

This PR introduces a shared \`_read_file_safe\` helper that:

1. Opens with explicit \`encoding="utf-8", errors="replace"\` so a stray non-UTF-8 byte becomes U+FFFD instead of aborting.
2. Catches \`OSError\` / \`UnicodeDecodeError\` / unexpected \`Exception\`, logs a warning naming the file and the underlying error, then returns \`None\` for the caller to continue past it.

The three passes now use the helper and continue past any unreadable file with a **visible warning** instead of silently dropping it.

Diagnostic files:
- \`specs/plan/v1-final-bugfixes/B03-migrate-cascade-silent-skip.md\`
- \`specs/plan/v1-final-bugfixes/B04-migrate-name-whole-file-skip.md\`

## Test plan
- [x] \`poetry run pytest tests/models/deprecations/test_name_format_deprecation.py\` — 19 passing (2 new B03/B04 tests + 17 existing)
- [x] \`poetry run pytest tests/models/deprecations/\` — 55 passing (no regression)
- [x] \`poetry run black --check visivo/models/deprecations/name_format_deprecation.py\`

New tests cover:
- Sibling file with non-UTF-8 bytes does not block migration of other files
- Patched safe-reader path simulates a per-file failure → cascade continues; visited file is observed via spy

## Stacking
**Base branch: \`bugfix/b01-migrate-file-scope\`** (PR #379). This PR shares the file with PR #379 only at the import line / scanner-call sites; no logical conflict, but it's stacked here so PR #11 (B02 jinja guard) can stack on top of it.

After PR #379 merges, rebase this branch on \`main\` and update the base.

This is **PR #10 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)