### PR TITLE
fix(migrate): skip name normalization on Jinja-templated values (B02)

### DIFF
--- a/tests/models/deprecations/test_name_format_deprecation.py
+++ b/tests/models/deprecations/test_name_format_deprecation.py
@@ -304,3 +304,88 @@ class TestNameFormatCascadeErrorHandling:
         # And the good file should still produce a migration.
         good_migrations = [m for m in migrations if str(good_path) in m.file_path]
         assert good_migrations, "good file should migrate despite broken sibling"
+
+
+# ---------------------------------------------------------------------------
+# B02: Jinja-templated names must NOT be normalised. The migrator can't
+# pre-resolve `{{ period }}` so it would otherwise rewrite a templated name
+# into a literal string, producing duplicate-name compile errors when the
+# Jinja loop runs.
+# ---------------------------------------------------------------------------
+
+
+class TestNameFormatJinjaGuard:
+    """B02 regression coverage."""
+
+    def test_unquoted_name_with_jinja_expression_skipped(self, tmp_path):
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        path = tmp_path / "models.visivo.yml"
+        path.write_text(
+            "models:\n"
+            "  - name: inbound-call-treemap-past-{{ period }}-weeks\n"
+            "    sql: SELECT 1\n"
+        )
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+
+        # Migration would have produced something like
+        # `inbound-call-treemap-past-period-weeks` if not skipped.
+        for m in migrations:
+            assert "inbound-call-treemap-past-" not in m.new_text
+
+    def test_quoted_name_with_jinja_expression_skipped(self, tmp_path):
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        path = tmp_path / "models.visivo.yml"
+        path.write_text(
+            "models:\n" '  - name: "report-{{ period }}-summary"\n' "    sql: SELECT 1\n"
+        )
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+
+        for m in migrations:
+            assert "report-period-summary" not in m.new_text
+
+    def test_jinja_statement_block_also_skipped(self, tmp_path):
+        """`{% ... %}` statement blocks should also keep the name skipped."""
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        path = tmp_path / "models.visivo.yml"
+        path.write_text(
+            "models:\n"
+            "  - name: thing-{% if cond %}a{% else %}b{% endif %}\n"
+            "    sql: SELECT 1\n"
+        )
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+        for m in migrations:
+            assert "thing-a" not in m.new_text and "thing-b" not in m.new_text
+
+    def test_trace_name_with_jinja_skipped(self, tmp_path):
+        """`trace_name: foo-{{ x }}` (used in legacy column_defs) is also a
+        Jinja-templated reference and should not be normalised."""
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        path = tmp_path / "tables.visivo.yml"
+        path.write_text(
+            "tables:\n"
+            "  - name: t\n"
+            "    column_defs:\n"
+            "      - trace_name: my-trace-{{ period }}\n"
+        )
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+        for m in migrations:
+            assert "my-trace-period" not in m.new_text
+
+    def test_non_jinja_invalid_name_still_migrates(self, tmp_path):
+        """Sanity: a normal invalid-format name (no Jinja) is still migrated."""
+        (tmp_path / "project.visivo.yml").write_text("name: project\n")
+        path = tmp_path / "models.visivo.yml"
+        path.write_text("models:\n  - name: My Plain Model\n    sql: SELECT 1\n")
+
+        checker = NameFormatDeprecation()
+        migrations = checker.get_migrations_from_files(str(tmp_path))
+        plain = [m for m in migrations if "my-plain-model" in m.new_text]
+        assert plain, "non-Jinja invalid names should still migrate"

--- a/visivo/models/deprecations/name_format_deprecation.py
+++ b/visivo/models/deprecations/name_format_deprecation.py
@@ -44,6 +44,23 @@ def _read_file_safe(file_path) -> "str | None":
         return None
 
 
+# B02: detect Jinja control structures inside a name value. Names that
+# contain ``{{ ... }}`` or ``{% ... %}`` are dynamic — at runtime the
+# Jinja renderer replaces them with values that are not knowable at
+# migrate time. Normalising them as if they were literals turns
+# ``inbound-call-treemap-past-{{period}}-weeks`` into the literal
+# ``inbound-call-treemap-past-period-weeks``, which then collides three
+# times across a Jinja loop iteration and breaks compile.
+_JINJA_PRESENCE_PATTERN = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+
+
+def _has_jinja(value: str) -> bool:
+    """Return True if ``value`` contains a Jinja expression / statement."""
+    if not value:
+        return False
+    return _JINJA_PRESENCE_PATTERN.search(value) is not None
+
+
 # Pattern to find name fields in YAML files
 # Matches: name: value (unquoted) - value must start with non-quote/non-space char
 NAME_FIELD_UNQUOTED_PATTERN = re.compile(
@@ -174,7 +191,11 @@ class NameFormatDeprecation(BaseDeprecationChecker):
             # Check if this dict has a name field
             if "name" in data:
                 name_value = data["name"]
-                if isinstance(name_value, str) and not is_valid_name(name_value):
+                if (
+                    isinstance(name_value, str)
+                    and not is_valid_name(name_value)
+                    and not _has_jinja(name_value)
+                ):
                     warnings.append(self._create_warning(name_value, f"{path}.name"))
 
             # Recurse into all values
@@ -234,6 +255,11 @@ class NameFormatDeprecation(BaseDeprecationChecker):
                 list_prefix = match.group(2) or ""
                 name_value = match.group(3).strip()
 
+                # B02: skip names that contain Jinja — we can't normalise a
+                # template literally without breaking compile.
+                if _has_jinja(name_value):
+                    continue
+
                 if not is_valid_name(name_value):
                     normalized = normalize_name(name_value)
                     if normalized != name_value:
@@ -252,6 +278,10 @@ class NameFormatDeprecation(BaseDeprecationChecker):
                 indent = match.group(1)
                 list_prefix = match.group(2) or ""
                 name_value = match.group(4)  # Group 3 is the quote char
+
+                # B02: skip Jinja-containing values.
+                if _has_jinja(name_value):
+                    continue
 
                 if not is_valid_name(name_value):
                     normalized = normalize_name(name_value)
@@ -298,6 +328,11 @@ class NameFormatDeprecation(BaseDeprecationChecker):
                 ref_name = match.group("name").strip()
                 # Skip if already handled or if the name is valid
                 if ref_name in name_renames or is_valid_name(ref_name):
+                    continue
+
+                # B02: a Jinja-templated ref name has no fixed string identity
+                # at migrate time. Don't try to rename it.
+                if _has_jinja(ref_name):
                     continue
 
                 normalized = normalize_name(ref_name)
@@ -407,6 +442,10 @@ class NameFormatDeprecation(BaseDeprecationChecker):
             list_prefix = match.group(2) or ""
             ref_value = match.group(3).strip()
 
+            # B02: skip Jinja-templated reference values.
+            if _has_jinja(ref_value):
+                continue
+
             # Check if this references a renamed item
             if ref_value in name_renames:
                 new_value = name_renames[ref_value]
@@ -439,6 +478,10 @@ class NameFormatDeprecation(BaseDeprecationChecker):
             indent = match.group(1)
             list_prefix = match.group(2) or ""
             ref_value = match.group(4)  # Group 3 is the quote char
+
+            # B02: skip Jinja-templated reference values.
+            if _has_jinja(ref_value):
+                continue
 
             # Check if this references a renamed item
             if ref_value in name_renames:


### PR DESCRIPTION
## Summary
The name-format normalizer treated \`name: foo-{{ period }}-bar\` as a literal string, replaced the curly braces with hyphens, and produced \`foo-period-bar\`. When Jinja later expanded the loop, multiple iterations all collapsed to that same literal name, causing \`ambiguous_reference\` compile errors.

This PR adds a \`_has_jinja\` guard that detects \`{{ ... }}\` and \`{% ... %}\` inside a name value. When present, both the deprecation warning (check pass) and the rewrite migration (apply pass) are skipped — the name is dynamic and we can't know at migrate time what value it will resolve to.

The guard is applied at every site that drives a rename:
- \`_check_recursive\` (deprecation warnings)
- Both \`name:\` regex passes in \`get_migrations_from_files\` (unquoted + quoted)
- \`REF_CALL_PATTERN\` ref-name discovery
- \`_migrate_reference_field\` (\`trace_name\` / \`insight_name\` / \`source_name\` / \`alert_name\`)

Diagnostic: \`specs/plan/v1-final-bugfixes/B02-migrate-name-format-jinja.md\`

## Test plan
- [x] \`poetry run pytest tests/models/deprecations/test_name_format_deprecation.py\` — 24 passing (5 new B02 tests + 19 existing)
- [x] \`poetry run pytest tests/models/deprecations/\` — 60 passing (no regression)
- [x] \`poetry run black --check visivo/models/deprecations/name_format_deprecation.py\`

Tests cover:
- Unquoted name with \`{{ expression }}\` → not migrated
- Quoted name with \`{{ expression }}\` → not migrated
- \`{% ... %}\` statement blocks also trigger the skip
- \`trace_name: ...-{{ x }}\` (legacy column_defs) → not migrated
- Sanity: non-Jinja invalid names still migrate

## Stacking
**Base branch: \`bugfix/b03-b04-name-format-cascade\`** (PR #388). This PR shares \`name_format_deprecation.py\` with PR #388 only at the import line / new helper, but stacking keeps the diff clean.

After PR #388 merges, rebase this branch on \`main\` and update the base.

This is **PR #11 of 11** for the v1 final bugfix punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)