### PR TITLE
feat: visivo init opens browser to onboarding wizard

### DIFF
--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -14,7 +14,7 @@ def test_init_with_project_dir():
     project_dir = os.path.join(tmp, "my-test-project")
     os.makedirs(project_dir, exist_ok=True)
 
-    response = runner.invoke(init, args=["--project-dir", project_dir])
+    response = runner.invoke(init, args=["--project-dir", project_dir, "--bare"])
 
     assert response.exit_code == 0, f"Command failed with output: {response.output}"
     assert "Done" in response.output
@@ -23,7 +23,9 @@ def test_init_with_project_dir():
     # Check that project name matches the directory name
     project_content = Path(f"{project_dir}/project.visivo.yml").read_text()
     assert "name: my-test-project" in project_content
-    assert "sources: []" in project_content
+    # Scaffold places `sources:` followed by commented examples, not `sources: []`
+    assert "sources:" in project_content
+    assert "# A Source is where your data lives" in project_content
 
 
 @patch("visivo.commands.init_phase.load_example_project")
@@ -37,7 +39,8 @@ def test_init_with_example_value(mock_load_example):
     mock_load_example.return_value = f"{project_dir}/project.visivo.yml"
 
     response = runner.invoke(
-        init, args=["--project-dir", project_dir, "--example", "github-releases"]
+        init,
+        args=["--project-dir", project_dir, "--example", "github-releases", "--bare"],
     )
 
     assert response.exit_code == 0, f"Command failed with output: {response.output}"
@@ -56,14 +59,17 @@ def test_init_basic_creates_simple_project():
     tmp = temp_folder()
     os.makedirs(f"{tmp}", exist_ok=True)
 
-    response = runner.invoke(init, args=["--project-dir", tmp])
+    response = runner.invoke(init, args=["--project-dir", tmp, "--bare"])
 
     assert response.exit_code == 0, f"Command failed with output: {response.output}"
     assert "Done" in response.output
     assert os.path.exists(f"{tmp}/project.visivo.yml")
 
-    # Check that basic project structure is created
+    # Check that basic project structure is created (scaffolded YAML)
     project_content = Path(f"{tmp}/project.visivo.yml").read_text()
     project_name = os.path.basename(tmp)
     assert f"name: {project_name}" in project_content
-    assert "sources: []" in project_content
+    assert "sources:" in project_content
+    assert "models:" in project_content
+    assert "insights:" in project_content
+    assert "dashboards:" in project_content

--- a/tests/commands/test_init_phase.py
+++ b/tests/commands/test_init_phase.py
@@ -1,0 +1,126 @@
+"""Tests for `visivo.commands.init_phase` scaffolding output."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from visivo.commands.init_phase import (
+    ENV_EXAMPLE_CONTENT,
+    GITIGNORE_CONTENT,
+    SCAFFOLD_TEMPLATE,
+    init_phase,
+)
+from visivo.models.project import Project
+from tests.support.utils import temp_folder
+
+
+def test_basic_init_writes_scaffolded_yaml():
+    """init_phase() writes a scaffolded YAML that Pydantic accepts."""
+    tmp = temp_folder()
+    project_dir = os.path.join(tmp, "my-scaffold-project")
+    os.makedirs(project_dir, exist_ok=True)
+
+    init_phase(project_dir)
+
+    yml_path = Path(project_dir) / "project.visivo.yml"
+    assert yml_path.exists()
+
+    content = yml_path.read_text()
+    # Comment markers (the user-facing copy) must be present.
+    assert "# A Source is where your data lives" in content
+    assert "# A Model is a SQL query saved against a Source." in content
+    assert "# An Insight is a chart configured against a Model." in content
+    assert "# A Dashboard arranges Insights into a layout." in content
+    # name should match directory basename
+    assert "name: my-scaffold-project" in content
+
+    # The 2.0 vocabulary check — must not mention legacy concepts.
+    assert "Trace" not in content
+    assert "Selector" not in content
+
+    # Pydantic must accept it (missing optional arrays default to [])
+    data = yaml.safe_load(content)
+    project = Project.model_validate(data)
+    assert project.name == "my-scaffold-project"
+    assert project.sources == []
+    assert project.models == []
+    assert project.insights == []
+    assert project.dashboards == []
+
+
+def test_basic_init_writes_gitignore():
+    """init_phase() creates a .gitignore with the expected entries."""
+    tmp = temp_folder()
+    project_dir = os.path.join(tmp, "ignore-project")
+    os.makedirs(project_dir, exist_ok=True)
+
+    init_phase(project_dir)
+
+    gitignore_path = Path(project_dir) / ".gitignore"
+    assert gitignore_path.exists()
+    content = gitignore_path.read_text()
+    assert "target/" in content
+    assert ".visivo/" in content
+    assert ".env" in content
+    assert "*.duckdb" in content
+    assert ".DS_Store" in content
+
+
+def test_basic_init_writes_env_example():
+    """init_phase() creates a .env.example with the placeholder comment."""
+    tmp = temp_folder()
+    project_dir = os.path.join(tmp, "env-project")
+    os.makedirs(project_dir, exist_ok=True)
+
+    init_phase(project_dir)
+
+    env_example_path = Path(project_dir) / ".env.example"
+    assert env_example_path.exists()
+    content = env_example_path.read_text()
+    assert "Put data-source secrets here" in content
+
+
+def test_init_does_not_overwrite_existing_files():
+    """init_phase() must not overwrite an existing .gitignore or .env.example."""
+    tmp = temp_folder()
+    project_dir = os.path.join(tmp, "preserve-project")
+    os.makedirs(project_dir, exist_ok=True)
+
+    custom_gitignore = "# my custom gitignore\nnode_modules/\n"
+    custom_env_example = "# my custom env example\nFOO=bar\n"
+
+    Path(project_dir, ".gitignore").write_text(custom_gitignore)
+    Path(project_dir, ".env.example").write_text(custom_env_example)
+
+    init_phase(project_dir)
+
+    assert Path(project_dir, ".gitignore").read_text() == custom_gitignore
+    assert Path(project_dir, ".env.example").read_text() == custom_env_example
+
+
+@patch("visivo.commands.init_phase.load_example_project")
+def test_example_init_still_works(mock_load_example):
+    """init_phase(example_type=...) delegates to load_example_project."""
+    tmp = temp_folder()
+    project_dir = os.path.join(tmp, "example-project")
+    os.makedirs(project_dir, exist_ok=True)
+
+    mock_load_example.return_value = os.path.join(project_dir, "project.visivo.yml")
+
+    result = init_phase(project_dir, example_type="github-releases")
+
+    mock_load_example.assert_called_once_with(
+        "example-project",
+        "github-releases",
+        project_dir,
+    )
+    assert result == os.path.join(project_dir, "project.visivo.yml")
+
+
+def test_scaffold_template_constants_are_strings():
+    """Sanity: exported constants are non-empty strings."""
+    assert isinstance(SCAFFOLD_TEMPLATE, str) and len(SCAFFOLD_TEMPLATE) > 0
+    assert isinstance(GITIGNORE_CONTENT, str) and "target/" in GITIGNORE_CONTENT
+    assert isinstance(ENV_EXAMPLE_CONTENT, str) and ENV_EXAMPLE_CONTENT.startswith("#")

--- a/viewer/e2e/stories/init-launches-onboarding.spec.mjs
+++ b/viewer/e2e/stories/init-launches-onboarding.spec.mjs
@@ -1,0 +1,66 @@
+/**
+ * Story: visivo init launches the in-browser onboarding wizard.
+ *
+ * The full happy path is:
+ *   1. user runs `visivo init`
+ *   2. CLI writes the scaffolded project files
+ *   3. CLI continues into `visivo serve` and opens the browser at
+ *      `http://localhost:8000/?onboarding=1`
+ *   4. The viewer redirects from `/` -> `/onboarding` and renders the
+ *      onboarding flow (OnboardingFlow / Welcome screen).
+ *
+ * For E2E we don't actually run `visivo init` (heavy + slow). Instead we hit
+ * the running sandbox at the equivalent URL and verify the routing lands on
+ * the Onboarding screen.
+ *
+ * Precondition: Sandbox running on a known port. Override with
+ * `PLAYWRIGHT_BASE_URL=http://localhost:3001`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
+
+// Mirrors the KEY constant in viewer/src/components/onboarding/onboardingState.js
+const ONBOARDING_STATE_KEY = 'visivo.onboarding.v1';
+
+test.describe('visivo init launches onboarding', () => {
+  test.setTimeout(60000);
+
+  test('Step 1: ?onboarding=1 redirects to /onboarding', async ({ page }) => {
+    await page.goto(`${BASE_URL}/?onboarding=1`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/onboarding/);
+  });
+
+  test('Step 2: Onboarding flow renders the welcome screen', async ({ page }) => {
+    await page.goto(`${BASE_URL}/?onboarding=1`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('onboarding-frame')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: /Welcome to Visivo/i })).toBeVisible();
+    await expect(page.getByTestId('onb-welcome-skip')).toBeVisible();
+
+    await page.screenshot({
+      path: 'e2e/screenshots/init-launches-onboarding.png',
+      fullPage: true,
+    });
+  });
+
+  test('Step 3: completed onboarding suppresses the redirect', async ({ page }) => {
+    // Pre-set the completion flag on / first, then verify the redirect is suppressed.
+    await page.goto(`${BASE_URL}/`);
+    await page.evaluate(key => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ completed_at: new Date().toISOString() })
+      );
+    }, ONBOARDING_STATE_KEY);
+
+    await page.goto(`${BASE_URL}/?onboarding=1`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).not.toHaveURL(/\/onboarding/);
+  });
+});

--- a/viewer/src/components/Home.jsx
+++ b/viewer/src/components/Home.jsx
@@ -13,6 +13,7 @@ import PublishModal from './publish/PublishModal';
 import OnboardingChecklist from './onboarding/OnboardingChecklist';
 import OnboardingCoach from './onboarding/OnboardingCoach';
 import ProjectVisitTracker from './onboarding/ProjectVisitTracker';
+import { hasCompletedOnboarding } from './onboarding/onboardingState';
 import { useState, useEffect } from 'react';
 
 const Home = () => {
@@ -23,6 +24,7 @@ const Home = () => {
   const [isDeployOpen, setIsDeployOpen] = useState(false);
 
   const isNewProject = useStore(state => state.isNewProject);
+  const isOnboardingRequested = useStore(state => state.isOnboardingRequested);
   const hasUnpublishedChanges = useStore(state => state.hasUnpublishedChanges);
   const checkPublishStatus = useStore(state => state.checkPublishStatus);
   const openPublishModal = useStore(state => state.openPublishModal);
@@ -40,7 +42,8 @@ const Home = () => {
     );
   }
 
-  if (isNewProject && isRoot) return <Navigate to="/onboarding" />;
+  if ((isNewProject || isOnboardingRequested) && isRoot && !hasCompletedOnboarding())
+    return <Navigate to="/onboarding" replace />;
 
   const renderNavigationCards = () => (
     <div className="container mx-auto px-4 py-12">

--- a/viewer/src/components/Home.test.jsx
+++ b/viewer/src/components/Home.test.jsx
@@ -16,37 +16,66 @@ const loadError = () => {
   return { message: 'Error Message' };
 };
 
-const routes = [
-  {
-    path: '/',
-    element: <Home />,
-    loader: loadError,
-  },
-];
+const buildRouter = () =>
+  createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <Home />,
+        loader: loadError,
+      },
+      {
+        path: '/onboarding',
+        element: <div data-testid="onboarding-route">Onboarding here</div>,
+      },
+    ],
+    {
+      initialEntries: ['/'],
+      initialIndex: 0,
+      future: futureFlags,
+    }
+  );
 
-const router = createMemoryRouter(routes, {
-  initialEntries: ['/'],
-  initialIndex: 0,
-  future: futureFlags,
-});
-
-test('renders error message', async () => {
+const renderWithStore = storeState => {
   useStore.mockImplementation(cb =>
     cb({
       isNewProject: false,
+      isOnboardingRequested: false,
       hasUnpublishedChanges: false,
       checkPublishStatus: jest.fn(),
       openPublishModal: jest.fn(),
+      ...storeState,
     })
   );
 
-  render(
+  return render(
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} future={futureFlags} />
+      <RouterProvider router={buildRouter()} future={futureFlags} />
     </QueryClientProvider>
   );
+};
+
+test('renders error message', async () => {
+  renderWithStore({ isNewProject: false, isOnboardingRequested: false });
 
   await waitFor(() => {
     expect(screen.getByText('Error Message')).toBeInTheDocument();
+  });
+});
+
+test('redirects to /onboarding when isOnboardingRequested is true', async () => {
+  renderWithStore({ isNewProject: false, isOnboardingRequested: true });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('onboarding-route')).toBeInTheDocument();
+  });
+});
+
+test('does not redirect when isOnboardingRequested is false', async () => {
+  renderWithStore({ isNewProject: false, isOnboardingRequested: false });
+
+  // Should NOT navigate to onboarding; the home page renders instead.
+  await waitFor(() => {
+    expect(screen.queryByTestId('onboarding-route')).not.toBeInTheDocument();
   });
 });

--- a/viewer/src/stores/commonStore.js
+++ b/viewer/src/stores/commonStore.js
@@ -1,5 +1,25 @@
 import { fetchProject } from '../api/project';
 import { fetchProjectFilePath } from '../api/projectFilePath';
+import { hasCompletedOnboarding } from '../components/onboarding/onboardingState';
+
+// `visivo init` opens the viewer at `?onboarding=1` to explicitly request
+// the onboarding flow. This is needed because the new-project heuristic
+// (name === 'Quickstart Visivo') does not match an init-scaffolded project,
+// which is named after its directory. Completion is tracked solely through
+// onboardingState (localStorage) so there is one source of truth.
+const isOnboardingRequestedInUrl = () => {
+  try {
+    if (typeof window === 'undefined' || !window.location) return false;
+    const params = new URLSearchParams(window.location.search);
+    return params.get('onboarding') === '1';
+  } catch (e) {
+    return false;
+  }
+};
+
+const computeIsOnboardingRequested = () => {
+  return isOnboardingRequestedInUrl() && !hasCompletedOnboarding();
+};
 
 const createCommonSlice = (set, get) => {
   const evaluateIsNewProject = () => {
@@ -13,6 +33,7 @@ const createCommonSlice = (set, get) => {
     project: null,
     projectFilePath: null,
     isNewProject: undefined,
+    isOnboardingRequested: computeIsOnboardingRequested(),
     scrollPositions: {},
     previewDrawerWidth: 500, // Default preview drawer width
     setScrollPosition: (dashName, pos) => {
@@ -20,7 +41,7 @@ const createCommonSlice = (set, get) => {
         scrollPositions: { ...state.scrollPositions, [dashName]: pos },
       }));
     },
-    setPreviewDrawerWidth: (width) => {
+    setPreviewDrawerWidth: width => {
       set({ previewDrawerWidth: width });
     },
     setProject: project => {

--- a/viewer/src/stores/commonStore.test.js
+++ b/viewer/src/stores/commonStore.test.js
@@ -1,0 +1,59 @@
+/**
+ * Tests for the URL-param-driven onboarding routing in commonStore.
+ *
+ * The store's `isOnboardingRequested` flag is derived at module init from
+ * (a) the `onboarding=1` URL param and (b) whether onboarding has already
+ * been completed (the onboardingState localStorage contract). Because the
+ * flag is captured when the store module is first imported, each test resets
+ * globals and re-imports the store via jest.isolateModules.
+ */
+
+// Mirrors the KEY constant in components/onboarding/onboardingState.js
+const ONBOARDING_STATE_KEY = 'visivo.onboarding.v1';
+
+const setLocation = (search = '', pathname = '/') => {
+  delete window.location;
+  window.location = {
+    href: `http://localhost${pathname}${search}`,
+    pathname,
+    search,
+    hash: '',
+  };
+};
+
+const loadStore = () => {
+  let useStore;
+  jest.isolateModules(() => {
+    useStore = require('./store').default;
+  });
+  return useStore;
+};
+
+describe('commonStore - onboarding URL routing', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    setLocation('', '/');
+  });
+
+  test('isOnboardingRequested true when ?onboarding=1 and onboarding not completed', () => {
+    setLocation('?onboarding=1', '/');
+
+    expect(loadStore().getState().isOnboardingRequested).toBe(true);
+  });
+
+  test('isOnboardingRequested false when onboarding already completed', () => {
+    setLocation('?onboarding=1', '/');
+    window.localStorage.setItem(
+      ONBOARDING_STATE_KEY,
+      JSON.stringify({ completed_at: new Date().toISOString() })
+    );
+
+    expect(loadStore().getState().isOnboardingRequested).toBe(false);
+  });
+
+  test('isOnboardingRequested false when URL has no onboarding param', () => {
+    setLocation('', '/');
+
+    expect(loadStore().getState().isOnboardingRequested).toBe(false);
+  });
+});

--- a/visivo/commands/init.py
+++ b/visivo/commands/init.py
@@ -1,3 +1,4 @@
+import os
 import click
 from visivo.commands.options import project_dir
 from visivo.models.example_type import ExampleTypeEnum
@@ -11,12 +12,41 @@ from visivo.models.example_type import ExampleTypeEnum
     help="Load an example project from GitHub",
     default=None,
 )
-def init(project_dir, example):
+@click.option(
+    "--bare",
+    is_flag=True,
+    default=False,
+    help="Only write the project files; do not auto-launch the dev server.",
+)
+@click.option(
+    "--headless",
+    is_flag=True,
+    default=False,
+    help="Do not open the browser when the dev server starts.",
+)
+@click.option(
+    "--no-onboarding",
+    is_flag=True,
+    default=False,
+    help="When auto-launching the dev server, do not append ?onboarding=1 to the URL.",
+)
+@click.option(
+    "-p",
+    "--port",
+    help="What port to serve on when auto-launching the dev server",
+    default=8000,
+)
+def init(project_dir, example, bare, headless, no_onboarding, port):
     """
     Initialize a new Visivo project.
 
-    By default, creates a simple project.visivo.yml file with a project name.
-    Use --example to load an example project from GitHub.
+    By default, creates a scaffolded project.visivo.yml file with commented examples
+    and continues into `visivo serve` to open the in-browser onboarding wizard.
+
+    Use --example to load an example project from GitHub instead of the scaffold.
+    Use --bare to skip auto-launching the dev server.
+    Use --headless to skip opening the browser.
+    Use --no-onboarding to skip the ?onboarding=1 query param when launching the browser.
     """
     from visivo.logger.logger import Logger
 
@@ -24,6 +54,47 @@ def init(project_dir, example):
 
     from visivo.commands.init_phase import init_phase
 
-    init_phase(project_dir, example)
+    project_file_path = init_phase(project_dir, example)
 
     Logger.instance().success("Done")
+
+    if bare:
+        return
+
+    # Auto-launch the dev server pointed at the freshly-initialized project.
+    final_project_dir = project_dir or "."
+    from visivo.commands.serve_phase import serve_phase
+    from visivo.commands.parse_project_phase import parse_project_phase
+
+    output_dir = os.path.join(os.path.abspath(final_project_dir), "target")
+    server_url = f"http://localhost:{port}"
+
+    project = parse_project_phase(
+        working_dir=os.path.abspath(final_project_dir),
+        output_dir=output_dir,
+        default_source=None,
+        dbt_profile=None,
+        dbt_target=None,
+    )
+
+    server, on_change, on_ready = serve_phase(
+        output_dir=output_dir,
+        working_dir=os.path.abspath(final_project_dir),
+        default_source=None,
+        dag_filter=None,
+        threads=None,
+        skip_compile=False,
+        project=project,
+        server_url=server_url,
+        new=not headless,
+        onboarding=not no_onboarding,
+        no_deprecation_warnings=False,
+    )
+
+    Logger.instance().info(f"Server running at {server_url}")
+    server.serve(
+        host="0.0.0.0",
+        port=port,
+        on_change_callback=on_change,
+        on_server_ready=on_ready,
+    )

--- a/visivo/commands/init_phase.py
+++ b/visivo/commands/init_phase.py
@@ -46,19 +46,97 @@ def get_env_content_for_example_type(example_type: str) -> str:
             return "# Add any required environment variables here"
 
 
+SCAFFOLD_TEMPLATE = """\
+# Visivo project file. Edit this directly or use `visivo serve` to author in the browser.
+name: {project_name}
+
+sources:
+  # A Source is where your data lives - a database or file.
+  # Uncomment and edit, or use the in-browser wizard.
+  #
+  # - name: my_db
+  #   type: sqlite
+  #   database: /path/to/file.db
+
+models:
+  # A Model is a SQL query saved against a Source.
+  #
+  # - name: monthly_revenue
+  #   source: ${{ref(my_db)}}
+  #   sql: |
+  #     SELECT date_trunc('month', order_date) AS month,
+  #            SUM(amount) AS revenue
+  #     FROM orders
+  #     GROUP BY 1
+
+insights:
+  # An Insight is a chart configured against a Model.
+  #
+  # - name: revenue_by_month
+  #   props:
+  #     type: bar
+  #     x: ?{{ ${{ref(monthly_revenue).month}} }}
+  #     y: ?{{ ${{ref(monthly_revenue).revenue}} }}
+
+dashboards:
+  # A Dashboard arranges Insights into a layout.
+  #
+  # - name: my_dashboard
+  #   rows:
+  #     - height: medium
+  #       items:
+  #         - width: 1
+  #           insight: ${{ref(revenue_by_month)}}
+"""
+
+GITIGNORE_CONTENT = """\
+target/
+.visivo/
+.env
+*.duckdb
+.DS_Store
+"""
+
+ENV_EXAMPLE_CONTENT = """\
+# Put data-source secrets here. Reference in YAML as ${ env_var('NAME') }.
+"""
+
+
+def _write_if_missing(path: str, content: str) -> bool:
+    """Write file at path with given content only if path does not exist.
+
+    Returns True if file was written, False if it already existed.
+    """
+    if os.path.exists(path):
+        return False
+    with open(path, "w") as fp:
+        fp.write(content)
+    return True
+
+
 def create_basic_project(project_name: str, project_dir: str = "."):
     """Create a basic empty project with just name and structure."""
     Logger.instance().success(f"Initializing project '{project_name}' in {project_dir}")
 
-    # Create basic project structure
-    project = Project(name=project_name)
+    # Ensure project_dir exists
+    os.makedirs(project_dir, exist_ok=True)
 
-    # Write project file
+    # Write project file with scaffolded YAML (commented examples)
     project_file_path = os.path.join(project_dir, "project.visivo.yml")
     with open(project_file_path, "w") as fp:
-        fp.write(yaml.dump(json.loads(project.model_dump_json(exclude_none=True)), sort_keys=False))
+        fp.write(SCAFFOLD_TEMPLATE.format(project_name=project_name))
 
     Logger.instance().success(f"Created project file: {project_file_path}")
+
+    # Write sibling files (only if they don't already exist)
+    gitignore_path = os.path.join(project_dir, ".gitignore")
+    if _write_if_missing(gitignore_path, GITIGNORE_CONTENT):
+        Logger.instance().success(f"Created .gitignore: {gitignore_path}")
+
+    env_example_path = os.path.join(project_dir, ".env.example")
+    if _write_if_missing(env_example_path, ENV_EXAMPLE_CONTENT):
+        Logger.instance().success(f"Created .env.example: {env_example_path}")
+
     return project_file_path
 
 

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -20,6 +20,7 @@ def serve_phase(
     project,
     server_url,
     new=False,
+    onboarding=False,
     no_deprecation_warnings=False,
 ):
 
@@ -98,7 +99,8 @@ def serve_phase(
                 Logger.instance().info("View your project at: " + server_url)
                 try:
                     if new:
-                        webbrowser.open(server_url, new=0, autoraise=True)
+                        open_url = f"{server_url}/?onboarding=1" if onboarding else server_url
+                        webbrowser.open(open_url, new=0, autoraise=True)
                 except Exception as e:
                     error_message = str(e)
                     if os.environ.get("STACKTRACE"):

--- a/visivo/models/project.py
+++ b/visivo/models/project.py
@@ -264,6 +264,40 @@ class Project(NamedModel, ParentModel):
         return validator.validate(self)
 
     @model_validator(mode="before")
+    def coerce_null_list_fields(cls, values):
+        """Coerce null/None values for list fields to empty lists.
+
+        This lets users write a YAML where a list-typed key has only comments
+        beneath it (which YAML parses as None) without tripping Pydantic's
+        list validation. Used by the scaffold produced by `visivo init`.
+        """
+        if not isinstance(values, dict):
+            return values
+        list_field_names = [
+            "includes",
+            "destinations",
+            "alerts",
+            "sources",
+            "targets",
+            "models",
+            "traces",
+            "insights",
+            "markdowns",
+            "tables",
+            "charts",
+            "selectors",
+            "inputs",
+            "dashboards",
+            "metrics",
+            "relations",
+            "dimensions",
+        ]
+        for name in list_field_names:
+            if name in values and values[name] is None:
+                values[name] = []
+        return values
+
+    @model_validator(mode="before")
     def set_path_on_named_models(cls, values):
         def set_path_recursively(obj, path=""):
             if isinstance(obj, dict):


### PR DESCRIPTION
## Demo

<!-- DROP VIDEO HERE: /tmp/visivo-pr-videos/1-init-launches-wizard.mp4 -->

_Drop the demo video above. File is at `/tmp/visivo-pr-videos/1-init-launches-wizard.mp4` on the maintainer's machine._

---

## Summary

Makes `visivo init` the new-user front door: writes a scaffolded YAML, then auto-launches `visivo serve` and opens the browser at `?onboarding=1`. URL-param-driven onboarding routing replaces the brittle `name === 'Quickstart Visivo'` check, so `init` no longer accidentally defeats onboarding.

From the dogfood walkthrough (`specs/local-cli-onboarding-plan/01-dogfood-walkthrough.md`), this closes **Showstopper #1** and partial **Showstopper #4** (better init scaffolding).

## What ships

- New flags on `visivo init`: `--bare` (write YAML and exit), `--headless` (no browser), `--no-onboarding` (server starts but no `?onboarding=1` param).
- `init_phase.py` now writes a scaffolded YAML with commented-out Source / Model / Insight / Dashboard examples instead of 19 empty arrays.
- Auto-creates `.gitignore` and `.env.example` only if missing.
- `viewer/src/stores/commonStore.js` derives `isOnboardingRequested` from URL param + localStorage; `markOnboardingCompleted()` clears the param so the wizard doesn't reappear.
- `Onboarding.jsx` adds a "Skip onboarding" button.

## Test plan

- [x] pytest tests/ — 1685 passed, 0 failed (after rebuilding venv on native arm64 poetry)
- [x] Viewer Jest — 1429 / 114 suites + lint clean
- [x] Playwright e2e — `init-launches-onboarding.spec.mjs` 3/3 pass on sandbox `:8011/:3011`
- [x] Black clean on changed Python

## Demo

Video above shows: navigating to `http://localhost:3011/?onboarding=1` → URL routes to `/onboarding`, the wizard renders, the "Skip onboarding" button is visible, clicking it preserves the `markOnboardingCompleted` flag.

Worktree: `/tmp/visivo-wt-init-wizard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
