### PR TITLE
feat: surface compile errors in viewer banner instead of nuking project state

### DIFF
--- a/tests/commands/test_compile_phase_errors.py
+++ b/tests/commands/test_compile_phase_errors.py
@@ -1,0 +1,191 @@
+"""Tests for compile-phase error visibility (Branch 2: feat/compile-error-visibility).
+
+These tests cover three behaviors:
+1. ``error.json`` is written with a structured ``compile_failed`` payload when
+   YAML validation fails.
+2. ``project.json`` is preserved (not nuked) when compile fails — the viewer
+   keeps showing the last-known-good project.
+3. ``error.json`` is reset to ``{}`` on successful compile.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.factories.model_factories import ProjectFactory, CsvScriptModelFactory
+from tests.support.utils import temp_folder, temp_yml_file
+from visivo.commands.compile_phase import compile_phase
+from visivo.commands.utils import create_file_database
+from visivo.parsers.file_names import PROJECT_FILE_NAME
+from visivo.parsers.line_validation_error import LineValidationError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_invalid_project_yml(working_dir: str) -> Path:
+    """Write a project.visivo.yml whose Insight is missing ``props.type`` AND
+    has a stray ``model`` field at the top level — the two most common
+    new-user mistakes from the dogfood walkthrough."""
+    contents = (
+        "name: bad-project\n"
+        "sources:\n"
+        "  - name: src\n"
+        "    type: sqlite\n"
+        "    database: ':memory:'\n"
+        "models:\n"
+        "  - name: m\n"
+        "    sql: SELECT 1 AS x\n"
+        "    source: ${ref(src)}\n"
+        "insights:\n"
+        "  - name: bad-insight\n"
+        "    model: ${ref(m)}\n"
+        "    props:\n"
+        "      x: ?{ x }\n"
+    )
+    path = Path(working_dir) / PROJECT_FILE_NAME
+    path.write_text(contents)
+    return path
+
+
+def _compile_valid_project(working_dir: str, output_dir: str) -> None:
+    """Compile a known-valid project so target/project.json is populated."""
+    project = ProjectFactory()
+    project.sources = []
+    model = CsvScriptModelFactory(name="csv_model")
+    project.dashboards[0].rows[0].items[0].chart.traces[0].model = model
+    create_file_database(url=model.get_duckdb_source(output_dir).url(), output_dir=output_dir)
+
+    yml_path = temp_yml_file(
+        dict=json.loads(project.model_dump_json()),
+        name=PROJECT_FILE_NAME,
+        output_dir=working_dir,
+    )
+    assert yml_path.exists()
+
+    compile_phase(
+        default_source=None,
+        working_dir=working_dir,
+        output_dir=output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_compile_writes_structured_error_on_validation_failure():
+    output_dir = temp_folder()
+    working_dir = temp_folder()
+    os.makedirs(working_dir, exist_ok=True)
+
+    _write_invalid_project_yml(working_dir)
+
+    with pytest.raises(LineValidationError):
+        compile_phase(
+            default_source=None,
+            working_dir=working_dir,
+            output_dir=output_dir,
+        )
+
+    error_path = f"{output_dir}/error.json"
+    assert os.path.exists(error_path), "error.json should be written on compile failure"
+
+    with open(error_path) as fp:
+        payload = json.load(fp)
+
+    assert payload.get("compile_failed") is True
+    assert isinstance(payload.get("errors"), list)
+    assert len(payload["errors"]) >= 1
+    assert "summary" in payload
+    assert "validation errors" in payload["summary"].lower()
+    assert "compiled_at" in payload
+
+    # Each error entry should expose the structured Pydantic shape.
+    first = payload["errors"][0]
+    assert "loc" in first
+    assert "msg" in first
+    assert "type" in first
+    # ``loc`` should be a list of strings (json-serialisable path segments).
+    assert isinstance(first["loc"], list)
+    assert all(isinstance(part, str) for part in first["loc"])
+
+
+def test_compile_preserves_project_json_on_failure():
+    output_dir = temp_folder()
+    working_dir = temp_folder()
+    os.makedirs(working_dir, exist_ok=True)
+
+    # 1) First compile a valid project so project.json contains real data.
+    _compile_valid_project(working_dir=working_dir, output_dir=output_dir)
+    project_path = f"{output_dir}/project.json"
+    assert os.path.exists(project_path)
+    with open(project_path) as fp:
+        good_project_contents = fp.read()
+    assert len(good_project_contents) > 2  # not just "{}"
+
+    # 2) Now corrupt the working_dir's project.visivo.yml with an invalid Insight.
+    _write_invalid_project_yml(working_dir)
+
+    with pytest.raises(LineValidationError):
+        compile_phase(
+            default_source=None,
+            working_dir=working_dir,
+            output_dir=output_dir,
+        )
+
+    # 3) project.json must be UNCHANGED — last-known-good state preserved.
+    with open(project_path) as fp:
+        after_contents = fp.read()
+    assert after_contents == good_project_contents, (
+        "project.json was overwritten on compile failure; "
+        "this nukes the user's last-known-good project."
+    )
+
+
+def test_compile_writes_empty_error_on_success():
+    output_dir = temp_folder()
+    project = ProjectFactory()
+    project.sources = []
+    model = CsvScriptModelFactory(name="csv_script_model")
+    project.dashboards[0].rows[0].items[0].chart.traces[0].model = model
+    create_file_database(url=model.get_duckdb_source(output_dir).url(), output_dir=output_dir)
+
+    tmp = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
+    working_dir = os.path.dirname(tmp)
+
+    compile_phase(
+        default_source=None,
+        working_dir=working_dir,
+        output_dir=output_dir,
+    )
+
+    error_path = f"{output_dir}/error.json"
+    assert os.path.exists(error_path)
+    with open(error_path) as fp:
+        payload = json.load(fp)
+    assert payload == {}, "error.json should be emptied on successful compile"
+
+
+def test_compile_failure_creates_output_dir_if_missing():
+    """First-time compile of a brand-new project should still produce
+    ``error.json`` even if ``output_dir`` does not yet exist."""
+    output_dir = temp_folder()
+    # Deliberately do NOT create output_dir up front.
+    working_dir = temp_folder()
+    os.makedirs(working_dir, exist_ok=True)
+    _write_invalid_project_yml(working_dir)
+
+    with pytest.raises(LineValidationError):
+        compile_phase(
+            default_source=None,
+            working_dir=working_dir,
+            output_dir=output_dir,
+        )
+
+    assert os.path.exists(f"{output_dir}/error.json")

--- a/tests/models/test_insight_validators.py
+++ b/tests/models/test_insight_validators.py
@@ -1,0 +1,146 @@
+"""Tests for the friendlier Pydantic validators on Insight and Chart layout.
+
+These validators hand-curate the most common new-user mistakes with clear,
+actionable messages instead of Pydantic's default ``Extra inputs are not
+permitted`` / ``Validation error for layout`` errors.
+
+See visivo/models/insight.py and visivo/models/props/layout.py.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from visivo.models.chart import Chart
+from visivo.models.insight import Insight
+
+
+def _msgs(exc_info) -> str:
+    """Concatenate all error messages from a ValidationError for substring asserts."""
+    return "\n".join(err["msg"] for err in exc_info.value.errors())
+
+
+# ---------------------------------------------------------------------------
+# Insight: top-level fields that belong inside ``props`` (or aren't fields at all)
+# ---------------------------------------------------------------------------
+
+
+def test_insight_with_top_level_model_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            model="${ref(orders)}",
+            props={"type": "bar", "x": "?{ x }"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`model` is not a field on Insight" in text
+    assert "Reference your model from inside `props`" in text
+    assert "https://docs.visivo.io/" in text
+
+
+def test_insight_with_top_level_type_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            type="bar",
+            props={"type": "bar", "x": "?{ x }"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`type` belongs inside `props`" in text
+    assert "props.type: bar" in text
+
+
+def test_insight_with_top_level_x_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            x="?{ amount }",
+            props={"type": "bar"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`x` belongs inside `props`" in text
+
+
+def test_insight_with_top_level_filters_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            filters=["?{ x > 0 }"],
+            props={"type": "bar", "x": "?{ x }"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`filters`" in text
+    assert "`interactions`" in text
+    assert "filter" in text
+
+
+def test_insight_with_legacy_cohort_on_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            cohort_on="?{ region }",
+            props={"type": "bar", "x": "?{ x }"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`cohort_on`" in text
+    assert "`split`" in text
+
+
+def test_insight_missing_props_type_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Insight(
+            name="bad",
+            props={"x": "?{ x }"},
+        )
+
+    text = _msgs(exc_info)
+    assert "`props.type` is required" in text
+    assert "Available chart types" in text
+    # Spot-check a couple of common types appear in the hint.
+    assert "bar" in text
+    assert "scatter" in text
+
+
+def test_insight_with_valid_props_passes():
+    """Sanity: a correct Insight should still construct without raising."""
+    insight = Insight(name="good", props={"type": "bar", "x": "?{ x }"})
+    assert insight.name == "good"
+    assert insight.props.type.value == "bar"
+
+
+# ---------------------------------------------------------------------------
+# Chart layout: title-as-string is the most common new-user mistake
+# ---------------------------------------------------------------------------
+
+
+def test_chart_with_string_layout_title_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Chart(name="bad", layout={"title": "Plays by Month"})
+
+    text = _msgs(exc_info)
+    assert "`layout.title` must be an object" in text
+    assert '{text: "Plays by Month"}' in text
+
+
+def test_chart_with_string_xaxis_title_raises_friendly_error():
+    with pytest.raises(ValidationError) as exc_info:
+        Chart(
+            name="bad",
+            layout={
+                "title": {"text": "Chart"},
+                "xaxis": {"title": "Date"},
+            },
+        )
+
+    text = _msgs(exc_info)
+    assert "`layout.xaxis.title` must be an object" in text
+
+
+def test_chart_with_object_title_passes():
+    """Sanity: the documented form should still validate."""
+    chart = Chart(name="good", layout={"title": {"text": "Hello"}})
+    assert chart.layout.title["text"] == "Hello"

--- a/viewer/e2e/stories/compile-error-banner.spec.mjs
+++ b/viewer/e2e/stories/compile-error-banner.spec.mjs
@@ -1,0 +1,181 @@
+/**
+ * Story: Compile Error Banner (Branch 2: feat/compile-error-visibility)
+ *
+ * Validates that when target/error.json indicates a compile failure, the
+ * viewer renders a CompileErrorBanner at the top of the page above the
+ * dashboard, and that the dashboard below still renders the last-known-good
+ * project state.
+ *
+ * Approach: rather than corrupt the live project.visivo.yml (which would
+ * race with hot-reload), we directly write to the backend's
+ * `target/error.json`. The viewer's `loadError` route loader fetches this
+ * file via `/api/error/`, so the banner reflects whatever shape lives on
+ * disk. After the test we restore the file to `{}`.
+ *
+ * Precondition: Sandbox running on :3001/:8001 (or override-port via
+ * PLAYWRIGHT_BASE_URL when running on a custom branch port like :3012).
+ */
+
+import { test, expect } from '@playwright/test';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TARGET_ERROR_JSON = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'test-projects',
+  'integration',
+  'target',
+  'error.json'
+);
+
+// The shared playwright.config.mjs hardcodes baseURL to :3001. When this spec
+// is run against a per-branch sandbox (e.g. :3012), pass PLAYWRIGHT_BASE_URL
+// explicitly and we will resolve URLs through it instead.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
+
+const COMPILE_FAILED_PAYLOAD = {
+  compile_failed: true,
+  summary: '4 validation errors in Project',
+  errors: [
+    {
+      loc: ['insights', '0', 'props', 'type'],
+      msg: 'Field required',
+      type: 'missing',
+      file: '/abs/path/to/project.visivo.yml',
+      line: 22,
+    },
+    {
+      loc: ['insights', '0'],
+      msg: 'Value error, `model` is not a field on Insight. Reference your model from inside `props`.',
+      type: 'value_error',
+    },
+    {
+      loc: ['insights', '0'],
+      msg: 'Value error, `type` belongs inside `props`, e.g. `props.type: bar`.',
+      type: 'value_error',
+    },
+    {
+      loc: ['charts', '0', 'layout'],
+      msg: 'Value error, `layout.title` must be an object: `{text: "..."}`.',
+      type: 'value_error',
+    },
+  ],
+  compiled_at: '2026-04-29T17:30:00Z',
+};
+
+test.describe('Compile Error Banner', () => {
+  // Tests in this file all mutate target/error.json on disk. Running them in
+  // parallel would let one test's afterEach clobber another's setup, so we
+  // serialise within this describe block. (Other Playwright projects in
+  // sibling files still parallelise normally.)
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(60000);
+
+  let originalErrorContents = '{}';
+
+  test.beforeEach(async () => {
+    // Snapshot whatever lives in target/error.json so we can restore on teardown.
+    if (existsSync(TARGET_ERROR_JSON)) {
+      originalErrorContents = readFileSync(TARGET_ERROR_JSON, 'utf-8');
+    }
+  });
+
+  test.afterEach(async () => {
+    // Always restore the original error.json so this spec can't poison
+    // sibling tests in the same Playwright project.
+    writeFileSync(TARGET_ERROR_JSON, originalErrorContents);
+  });
+
+  test('Step 1: Banner is hidden on a healthy project', async ({ page }) => {
+    // Make sure error.json is empty (the success state).
+    writeFileSync(TARGET_ERROR_JSON, '{}');
+
+    await page.goto(`${BASE_URL}/`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('compile-error-banner')).not.toBeVisible();
+  });
+
+  test('Step 2: Banner appears at the top of the home page when compile fails', async ({
+    page,
+  }) => {
+    writeFileSync(TARGET_ERROR_JSON, JSON.stringify(COMPILE_FAILED_PAYLOAD));
+    // Verify the disk write took effect before we ask the backend.
+    const onDisk = readFileSync(TARGET_ERROR_JSON, 'utf-8');
+    expect(onDisk).toContain('compile_failed');
+
+    // Sanity check: confirm the backend exposes the new payload before we
+    // tell the browser to navigate. A plain page.goto can race with the
+    // filesystem write on slower CI hosts.
+    const apiResponse = await page.request.get(`${BASE_URL}/api/error/`);
+    const apiText = await apiResponse.text();
+    expect(apiText).toContain('compile_failed');
+
+    await page.goto(`${BASE_URL}/`);
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('compile-error-banner');
+    await expect(banner).toBeVisible({ timeout: 10000 });
+
+    // Banner must include the summary and the descriptive header.
+    await expect(
+      page.getByText('Project compile failed — last good state shown below')
+    ).toBeVisible();
+    await expect(page.getByText('4 validation errors in Project')).toBeVisible();
+
+    // First error path should render in <code> form.
+    await expect(page.getByText('insights.0.props.type')).toBeVisible();
+
+    // file:line hint should render as basename only.
+    await expect(page.getByText(/\(project\.visivo\.yml:22\)/)).toBeVisible();
+
+    // Visual snapshot for review.
+    await page.screenshot({
+      path: 'e2e/screenshots/compile-error-banner.png',
+      fullPage: false,
+    });
+  });
+
+  test('Step 3: Dashboard below the banner still renders (last-known-good preserved)', async ({
+    page,
+  }) => {
+    writeFileSync(TARGET_ERROR_JSON, JSON.stringify(COMPILE_FAILED_PAYLOAD));
+
+    await page.goto(`${BASE_URL}/`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('compile-error-banner')).toBeVisible();
+
+    // Home page navigation cards must still render below the banner — this
+    // proves the viewer didn't get into a dead-state when compile failed.
+    await expect(page.getByRole('heading', { name: 'Lineage', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Explorer', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Editor', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Project', exact: true })).toBeVisible();
+  });
+
+  test('Step 4: Banner truncates to 5 errors with overflow message', async ({ page }) => {
+    const manyErrors = {
+      ...COMPILE_FAILED_PAYLOAD,
+      summary: '7 validation errors in Project',
+      errors: Array.from({ length: 7 }, (_, i) => ({
+        loc: ['insights', String(i), 'props', 'type'],
+        msg: 'Field required',
+        type: 'missing',
+      })),
+    };
+    writeFileSync(TARGET_ERROR_JSON, JSON.stringify(manyErrors));
+
+    await page.goto(`${BASE_URL}/`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('compile-error-banner')).toBeVisible();
+    await expect(page.getByText(/and 2 more/)).toBeVisible();
+    await expect(page.getByText(/See terminal for full list/)).toBeVisible();
+  });
+});

--- a/viewer/src/components/Home.jsx
+++ b/viewer/src/components/Home.jsx
@@ -3,6 +3,7 @@ import Breadcrumbs from './common/Breadcrumbs';
 import ProjectHistory from './project/ProjectHistory';
 import { useLoaderData } from 'react-router-dom';
 import Error from './styled/Error';
+import CompileErrorBanner from './common/CompileErrorBanner';
 import TopNav from './common/TopNav';
 import { HiTemplate } from 'react-icons/hi';
 import { PiTreeStructure, PiMagnifyingGlass, PiPencil } from 'react-icons/pi';
@@ -122,6 +123,7 @@ const Home = () => {
           </div>
         )}
         {error && error.message && <Error>{error.message}</Error>}
+        <CompileErrorBanner />
         {isRoot ? renderNavigationCards() : <Outlet />}
       </div>
     </div>

--- a/viewer/src/components/common/CompileErrorBanner.jsx
+++ b/viewer/src/components/common/CompileErrorBanner.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useLoaderData } from 'react-router-dom';
+import { HiOutlineExclamationTriangle } from 'react-icons/hi2';
+
+const MAX_ERRORS_SHOWN = 5;
+
+/**
+ * Renders a banner at the top of the viewer when target/error.json indicates
+ * the latest compile failed. The banner explains that the dashboard below is
+ * the last-known-good state and lists up to the first 5 validation errors
+ * (file:line included when the YAML parser was able to resolve them).
+ *
+ * Returns null when there is no compile failure so it's safe to drop into any
+ * route element unconditionally.
+ */
+const CompileErrorBanner = () => {
+  // The route loader (`loadError`) hands us the parsed error.json. When the
+  // file is empty {} this contract still returns an object, just one without
+  // `compile_failed`.
+  const errorData = useLoaderData();
+
+  if (!errorData || !errorData.compile_failed) {
+    return null;
+  }
+
+  const errors = Array.isArray(errorData.errors) ? errorData.errors : [];
+  const visibleErrors = errors.slice(0, MAX_ERRORS_SHOWN);
+  const hiddenCount = errors.length - visibleErrors.length;
+
+  return (
+    <div
+      role="alert"
+      data-testid="compile-error-banner"
+      className="mx-4 my-3 rounded-lg border-l-4 border-highlight-500 bg-highlight-100 p-4 shadow-md"
+    >
+      <div className="flex items-start space-x-3">
+        <HiOutlineExclamationTriangle
+          className="mt-0.5 h-6 w-6 flex-shrink-0 text-highlight-600"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold text-highlight-900">
+            Project compile failed — last good state shown below
+          </h3>
+          {errorData.summary && (
+            <p className="mt-1 text-sm text-highlight-800">{errorData.summary}</p>
+          )}
+          {visibleErrors.length > 0 && (
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-highlight-800">
+              {visibleErrors.map((err, i) => (
+                <li key={i}>
+                  <code className="rounded bg-highlight-200 px-1 py-0.5 text-highlight-900">
+                    {Array.isArray(err.loc) ? err.loc.join('.') : ''}
+                  </code>
+                  : {(err.msg || '').replace(/^Value error,\s*/, '')}
+                  {err.file && err.line && (
+                    <span className="ml-1 text-highlight-700">
+                      ({err.file.split('/').pop()}:{err.line})
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          {hiddenCount > 0 && (
+            <p className="mt-2 text-sm text-highlight-700">
+              ... and {hiddenCount} more. See terminal for full list.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompileErrorBanner;

--- a/viewer/src/components/common/CompileErrorBanner.test.jsx
+++ b/viewer/src/components/common/CompileErrorBanner.test.jsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { futureFlags } from '../../router-config';
+import CompileErrorBanner from './CompileErrorBanner';
+
+const renderWithLoaderData = loaderData => {
+  const routes = [
+    {
+      path: '/',
+      element: <CompileErrorBanner />,
+      loader: () => loaderData,
+    },
+  ];
+  const router = createMemoryRouter(routes, {
+    initialEntries: ['/'],
+    initialIndex: 0,
+    future: futureFlags,
+  });
+  return render(<RouterProvider router={router} future={futureFlags} />);
+};
+
+describe('CompileErrorBanner', () => {
+  test('renders nothing when error.json is empty', async () => {
+    renderWithLoaderData({});
+
+    // Wait one tick so the router resolves the loader.
+    await waitFor(() => {
+      expect(screen.queryByTestId('compile-error-banner')).toBeNull();
+    });
+  });
+
+  test('renders nothing when compile_failed is false', async () => {
+    renderWithLoaderData({ compile_failed: false });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('compile-error-banner')).toBeNull();
+    });
+  });
+
+  test('renders banner when error.json has compile_failed', async () => {
+    renderWithLoaderData({
+      compile_failed: true,
+      summary: '4 validation errors in Project',
+      errors: [
+        { loc: ['insights', 0, 'props', 'type'], msg: 'Field required', type: 'missing' },
+      ],
+      compiled_at: '2026-04-29T17:30:00Z',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compile-error-banner')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('Project compile failed — last good state shown below')
+    ).toBeInTheDocument();
+    expect(screen.getByText('4 validation errors in Project')).toBeInTheDocument();
+    expect(screen.getByText('insights.0.props.type')).toBeInTheDocument();
+    // The "Field required" label should be in the same list item
+    expect(screen.getByText(/Field required/)).toBeInTheDocument();
+  });
+
+  test('truncates to 5 errors with "and N more"', async () => {
+    renderWithLoaderData({
+      compile_failed: true,
+      summary: '7 validation errors in Project',
+      errors: Array.from({ length: 7 }, (_, i) => ({
+        loc: ['insights', i, 'props', 'type'],
+        msg: 'Field required',
+        type: 'missing',
+      })),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compile-error-banner')).toBeInTheDocument();
+    });
+
+    // 5 visible items + 1 hidden-count line
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(5);
+
+    expect(screen.getByText(/and 2 more/)).toBeInTheDocument();
+    expect(screen.getByText(/See terminal for full list/)).toBeInTheDocument();
+  });
+
+  test('shows file:line when present', async () => {
+    renderWithLoaderData({
+      compile_failed: true,
+      summary: '1 validation errors in Project',
+      errors: [
+        {
+          loc: ['insights', 0, 'props', 'type'],
+          msg: 'Field required',
+          type: 'missing',
+          file: '/abs/path/to/project.visivo.yml',
+          line: 22,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compile-error-banner')).toBeInTheDocument();
+    });
+    // Only the basename should render to keep the banner readable.
+    expect(screen.getByText(/\(project\.visivo\.yml:22\)/)).toBeInTheDocument();
+  });
+
+  test('strips "Value error, " prefix from Pydantic messages', async () => {
+    renderWithLoaderData({
+      compile_failed: true,
+      summary: '1 validation errors in Project',
+      errors: [
+        {
+          loc: ['insights', 0],
+          msg: 'Value error, `model` is not a field on Insight.',
+          type: 'value_error',
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compile-error-banner')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/`model` is not a field on Insight\./)).toBeInTheDocument();
+    expect(screen.queryByText(/^Value error,/)).toBeNull();
+  });
+
+  test('renders nothing when loader returns null', async () => {
+    renderWithLoaderData(null);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('compile-error-banner')).toBeNull();
+    });
+  });
+});

--- a/visivo/commands/compile.py
+++ b/visivo/commands/compile.py
@@ -21,17 +21,25 @@ def compile(working_dir, output_dir, source, dbt_profile, dbt_target, no_depreca
     Parses the files in your working directory, extracting visivo configurations and then using those configurations to build the trace queries and a project.json file in your source directory. Queries are not run on compile, just written.
     """
     from visivo.logger.logger import Logger
+    from visivo.parsers.line_validation_error import LineValidationError
 
     Logger.instance().info("Compiling")
 
     from visivo.commands.compile_phase import compile_phase
 
-    compile_phase(
-        default_source=source,
-        working_dir=working_dir,
-        output_dir=output_dir,
-        dbt_profile=dbt_profile,
-        dbt_target=dbt_target,
-        no_deprecation_warnings=no_deprecation_warnings,
-    )
+    try:
+        compile_phase(
+            default_source=source,
+            working_dir=working_dir,
+            output_dir=output_dir,
+            dbt_profile=dbt_profile,
+            dbt_target=dbt_target,
+            no_deprecation_warnings=no_deprecation_warnings,
+        )
+    except LineValidationError:
+        # compile_phase has already written error.json and printed the
+        # ⚠ Compile failed summary. Surface a non-zero exit code via Click so
+        # CI runs and the user's terminal flag the failure cleanly.
+        raise click.ClickException("Compile failed. See errors above.")
+
     Logger.instance().success("Done")

--- a/visivo/commands/compile_phase.py
+++ b/visivo/commands/compile_phase.py
@@ -1,12 +1,15 @@
 from time import time
+from datetime import datetime, timezone
 
 compile_import_start = time()
 from visivo.logger.logger import Logger
 
 Logger.instance().debug("Compiling project...")
 import json
+import os
 
 from visivo.parsers.serializer import Serializer
+from visivo.parsers.line_validation_error import LineValidationError
 from visivo.commands.parse_project_phase import parse_project_phase
 
 import_duration = round(time() - compile_import_start, 2)
@@ -24,6 +27,81 @@ def _collect_compile_telemetry(project):
         pass
 
 
+def _serialize_validation_error(line_error: LineValidationError) -> dict:
+    """Convert a LineValidationError into the structured shape consumed by the
+    viewer's CompileErrorBanner.
+
+    The shape is:
+    {
+        "compile_failed": True,
+        "errors": [
+            {"loc": [...], "msg": "...", "type": "...", "file": "...", "line": N}
+        ],
+        "summary": "<N validation errors in <Title>>",
+        "compiled_at": "<iso8601 utc>"
+    }
+
+    The ``file`` and ``line`` fields are populated when YamlOrderedDict source
+    locations are available; otherwise they are omitted (never fabricated).
+    """
+    validation_error = line_error.validation_error
+    structured_errors = []
+
+    for err in validation_error.errors():
+        entry = {
+            "loc": [str(part) for part in err.get("loc", [])],
+            "msg": err.get("msg", ""),
+            "type": err.get("type", ""),
+        }
+        # Try to extract a file:line hint from the LineValidationError helper.
+        line_hint = line_error.get_line_message(err)
+        if line_hint:
+            # ``line_hint`` looks like " Location: /abs/path:LINE\n" — extract
+            # the final ":N" segment without resorting to a regex parse.
+            cleaned = line_hint.strip()
+            if cleaned.startswith("Location:"):
+                cleaned = cleaned[len("Location:") :].strip()
+            if ":" in cleaned:
+                file_part, _, line_part = cleaned.rpartition(":")
+                if file_part and line_part.isdigit():
+                    entry["file"] = file_part
+                    entry["line"] = int(line_part)
+        structured_errors.append(entry)
+
+    return {
+        "compile_failed": True,
+        "errors": structured_errors,
+        "summary": (
+            f"{validation_error.error_count()} validation errors " f"in {validation_error.title}"
+        ),
+        "compiled_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _print_compile_failure(error_payload: dict, project_file_path: str = None):
+    """Print a clear, terminal-friendly compile-failure summary.
+
+    Uses the existing logger system rather than ``print()`` so the output
+    integrates with spinners and CI mode.
+    """
+    log = Logger.instance()
+    summary = error_payload.get("summary", "Compile failed")
+    errors = error_payload.get("errors", [])
+    log.error(f"⚠ Compile failed ({len(errors)} errors). Last good state preserved.")
+    for err in errors:
+        loc = ".".join(err.get("loc", []))
+        msg = err.get("msg", "")
+        # Strip the "Value error, " prefix Pydantic emits for our model
+        # validators — it's noise for end users.
+        if msg.startswith("Value error, "):
+            msg = msg[len("Value error, ") :]
+        file_hint = err.get("file")
+        location_prefix = f"{file_hint}: " if file_hint else ""
+        line_hint = f" (line {err['line']})" if err.get("line") else ""
+        log.error(f"  → {location_prefix}{msg} at {loc}{line_hint}")
+    log.error(f"\nSummary: {summary}")
+
+
 def compile_phase(
     default_source: str,
     working_dir: str,
@@ -37,9 +115,26 @@ def compile_phase(
     parse_start = time()
     if project is None:
         Logger.instance().debug("    Running parse project phase...")
-        project = parse_project_phase(
-            working_dir, output_dir, default_source, dbt_profile, dbt_target
-        )
+        try:
+            project = parse_project_phase(
+                working_dir, output_dir, default_source, dbt_profile, dbt_target
+            )
+        except LineValidationError as line_error:
+            # Make sure the output directory exists so we always have a place
+            # to write error.json — even on first compile of a brand-new project.
+            os.makedirs(output_dir, exist_ok=True)
+
+            error_payload = _serialize_validation_error(line_error)
+            with open(f"{output_dir}/error.json", "w") as fp:
+                json.dump(error_payload, fp)
+
+            _print_compile_failure(error_payload)
+
+            # Re-raise so callers (CLI, hot-reload) can react. project.json is
+            # intentionally left untouched: the previous, last-known-good
+            # project remains in place for the viewer.
+            raise
+
         parse_duration = round(time() - parse_start, 2)
         Logger.instance().debug(f"Project parsing completed in {parse_duration}s")
     else:

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -1,6 +1,7 @@
 import webbrowser
 from visivo.commands.compile_phase import compile_phase
 from visivo.logger.logger import Logger
+from visivo.parsers.line_validation_error import LineValidationError
 
 from visivo.server.hot_reload_server import HotReloadServer
 from visivo.server.flask_app import FlaskApp
@@ -65,6 +66,14 @@ def serve_phase(
                 Logger.instance().info("View your project at: " + server_url)
             with open(f"{output_dir}/error.json", "w") as error_file:
                 error_file.write(json.dumps({}))
+        except LineValidationError:
+            # compile_phase already wrote a structured error.json and printed
+            # a clear "⚠ Compile failed" summary. Last-known-good project.json
+            # is preserved on disk for the viewer. The hot-reload loop must keep
+            # running so the user can fix the YAML and recover.
+            Logger.instance().info(
+                "View errors at " + server_url + " (banner will appear in the viewer)"
+            )
         except Exception as e:
             error_message = str(e)
             if os.environ.get("STACKTRACE"):

--- a/visivo/models/insight.py
+++ b/visivo/models/insight.py
@@ -1,5 +1,5 @@
-from typing import Optional, List, Set
-from pydantic import Field
+from typing import Optional, List, Set, Any
+from pydantic import Field, model_validator
 from visivo.models.base.project_dag import ProjectDag
 from visivo.models.interaction import InsightInteraction
 from visivo.models.props.insight_props import InsightProps
@@ -11,6 +11,47 @@ from visivo.query.insight.insight_query_info import InsightQueryInfo
 from visivo.models.dag import all_descendants_of_type
 from visivo.jobs.utils import get_source_for_model
 from visivo.logger.logger import Logger
+
+INSIGHT_DOCS_URL = "https://docs.visivo.io/reference/configuration/Insight/"
+
+# Common new-user mistakes: top-level fields that belong inside `props` (or aren't
+# Insight fields at all). We intercept these before Pydantic emits its generic
+# "Extra inputs are not permitted" error.
+_INSIGHT_TOP_LEVEL_MISPLACED_FIELDS = {
+    "model": (
+        "`model` is not a field on Insight. Reference your model from inside `props`, "
+        "e.g. `props.x: ?{ ${ref(my_model).column} }`. "
+        f"See {INSIGHT_DOCS_URL}."
+    ),
+    "type": ("`type` belongs inside `props`, e.g. `props.type: bar`. " f"See {INSIGHT_DOCS_URL}."),
+    "x": (
+        "`x` belongs inside `props`, e.g. `props.x: ?{ column_name }`. " f"See {INSIGHT_DOCS_URL}."
+    ),
+    "y": (
+        "`y` belongs inside `props`, e.g. `props.y: ?{ column_name }`. " f"See {INSIGHT_DOCS_URL}."
+    ),
+    "columns": (
+        "`columns` is not a field on Insight. Define your aggregations inline in "
+        "`props` query strings, e.g. `props.y: ?{ sum(amount) }`. "
+        f"See {INSIGHT_DOCS_URL}."
+    ),
+    "filters": (
+        "`filters` is not a top-level field on Insight. Use the `interactions` "
+        "list with a `filter` entry, e.g. "
+        "`interactions: [ {filter: ?{ amount > 0 }} ]`. "
+        f"See {INSIGHT_DOCS_URL}."
+    ),
+    "cohort_on": (
+        "`cohort_on` is from the legacy Trace API. Use `interactions` with a "
+        "`split` entry instead, e.g. `interactions: [ {split: ?{ region }} ]`. "
+        f"See {INSIGHT_DOCS_URL}."
+    ),
+}
+
+_AVAILABLE_PROP_TYPES = (
+    "bar, scatter, line, pie, area, indicator, heatmap, histogram, "
+    "box, violin, table, treemap, sunburst, waterfall, funnel"
+)
 
 
 class Insight(NamedModel, ParentModel):
@@ -88,6 +129,35 @@ class Insight(NamedModel, ParentModel):
         None,
         description="Leverage Inputs to create client-side interactions that will be applied to the insight data.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_misplaced_top_level_fields(cls, data: Any) -> Any:
+        """Catch the most common new-user mistakes before Pydantic's generic
+        ``extra='forbid'`` error fires.
+
+        Examples we hand-curate:
+        - ``model:`` at the top level (belongs inside ``props`` references)
+        - ``type:`` at the top level (belongs inside ``props.type``)
+        - Legacy Trace fields like ``columns``, ``filters``, ``cohort_on``
+        """
+        if not isinstance(data, dict):
+            return data
+
+        for field, message in _INSIGHT_TOP_LEVEL_MISPLACED_FIELDS.items():
+            if field in data:
+                raise ValueError(message)
+
+        # Augment the missing-props.type error with a list of valid types so users
+        # don't have to dig through docs to find a working value.
+        props = data.get("props")
+        if isinstance(props, dict) and "type" not in props:
+            raise ValueError(
+                f"`props.type` is required. Available chart types: "
+                f"{_AVAILABLE_PROP_TYPES}. See {INSIGHT_DOCS_URL}."
+            )
+
+        return data
 
     def child_items(self):
         """Return child items for DAG construction.

--- a/visivo/models/props/layout.py
+++ b/visivo/models/props/layout.py
@@ -5,8 +5,41 @@ from pydantic import model_validator
 from visivo.models.color_palette import ColorPalette
 from visivo.models.props.json_schema_base import JsonSchemaBase, get_message_from_error
 
+LAYOUT_DOCS_URL = "https://docs.visivo.io/reference/configuration/Chart/Layout/"
+
 
 class Layout(JsonSchemaBase):
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_title_shape(cls, data: dict) -> dict:
+        """Catch the common new-user mistake of writing ``title: "string"`` at the
+        top level or under any ``axis``/``yaxis``/``xaxis`` key, which Plotly
+        rejects with an opaque schema-validation message."""
+        if not isinstance(data, dict):
+            return data
+
+        title_value = data.get("title")
+        if isinstance(title_value, str):
+            raise ValueError(
+                f'`layout.title` must be an object: `{{text: "{title_value}"}}`. '
+                f'Got string `"{title_value}"`. See {LAYOUT_DOCS_URL}.'
+            )
+
+        # Same mistake is common under axis configs (xaxis.title, yaxis.title,
+        # yaxis2.title, etc.).
+        for key, value in data.items():
+            if key.endswith("axis") or key.startswith(("xaxis", "yaxis")):
+                if isinstance(value, dict):
+                    sub_title = value.get("title")
+                    if isinstance(sub_title, str):
+                        raise ValueError(
+                            f"`layout.{key}.title` must be an object: "
+                            f'`{{text: "{sub_title}"}}`. Got string '
+                            f'`"{sub_title}"`. See {LAYOUT_DOCS_URL}.'
+                        )
+
+        return data
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
## Demo

<!-- DROP VIDEO HERE: /tmp/visivo-pr-videos/2-compile-error-visibility.mp4 -->

_Drop the demo video above. File is at `/tmp/visivo-pr-videos/2-compile-error-visibility.mp4` on the maintainer's machine._

---

## Summary

When the YAML fails Pydantic validation during `visivo serve`, the user now sees:

1. A **structured `error.json`** with file:line locations and friendlier messages.
2. A **high-contrast banner** in every viewer route (`<CompileErrorBanner />`).
3. Their **last-known-good `project.json` preserved** — no more nuked-to-empty-arrays state.
4. A clear `⚠ Compile failed` message in the terminal during hot-reload.

Closes **Showstopper #5** from the dogfood walkthrough.

## What ships

- `compile_phase.py`: try/except around parse, structured error.json writer, terminal printer.
- `serve_phase.py`: hot-reload preserves last-known-good state instead of overwriting.
- `models/insight.py`: `model_validator(mode='before')` catches the most common new-user mistakes (`model:` at top level, `type:` outside `props`) with friendlier messages pointing at the right field.
- `models/props/layout.py`: catches `layout.title: "string"` (Plotly expects an object) and points the user at `layout.title.text`.
- `viewer/src/components/common/CompileErrorBanner.jsx`: new banner using existing `highlight-*` palette, truncates to 5 errors with "and N more."
- `Home.jsx`: wires the banner above `<Outlet />` so it renders on every route.

## Test plan

- [x] pytest tests/ — 1693 passed, 0 failed
- [x] Viewer Jest — 1427 / 114 suites + lint clean
- [x] Playwright e2e — `compile-error-banner.spec.mjs` 4/4 pass on sandbox `:8012/:3012` (banner hidden when healthy, visible with full content on failure, dashboard renders below banner, truncation works)
- [x] Black clean

## Demo

Video above shows: a YAML edit introducing a Pydantic error → terminal log → banner appears at top of viewer with structured per-error rows (file path, line number, friendly message) → dashboard below the banner continues to render last-known-good content.

Worktree: `/tmp/visivo-wt-error-visibility`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
