### PR TITLE
feat: SQL templates and drag-table-to-seed in empty Explorer editor

### DIFF
--- a/viewer/e2e/stories/explorer-sql-templates.spec.mjs
+++ b/viewer/e2e/stories/explorer-sql-templates.spec.mjs
@@ -1,0 +1,117 @@
+/**
+ * Story: Explorer SQL Templates
+ *
+ * Validates the empty-editor experience: when a source is selected but the
+ * editor is empty, an actionable card with starter SQL templates is shown.
+ * Also validates that picking a template populates the editor.
+ *
+ * Precondition: Sandbox running on the configured frontend port.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// Allow overriding the frontend port via env var so this spec can target an
+// isolated sandbox (e.g. :3016) without colliding with the default :3001
+// sandbox used by the rest of the suite.
+const FRONTEND_PORT = process.env.VISIVO_SANDBOX_FRONTEND_PORT || '3001';
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${FRONTEND_PORT}`;
+test.use({ baseURL: BASE_URL });
+
+const WAIT_FOR_PAGE = 15000;
+
+async function loadExplorer(page) {
+  await page.goto('/explorer');
+  await page.waitForLoadState('networkidle');
+  // Either the empty-editor overlay or the regular empty results message can
+  // appear depending on whether there's an auto-loaded model with SQL.
+  await Promise.race([
+    page.locator('[data-testid="empty-editor-overlay"]').first().waitFor({ timeout: WAIT_FOR_PAGE }),
+    page.getByText('Run a query to see results').waitFor({ timeout: WAIT_FOR_PAGE }),
+  ]);
+}
+
+async function openFreshModelTab(page) {
+  // Add a new model tab — it auto-selects the project default source
+  // and starts with an empty editor, so the overlay should be visible.
+  await page.getByRole('button', { name: 'Add model' }).click();
+  // Wait for editor to render
+  await page.locator('.view-lines').first().waitFor({ timeout: 10000 });
+}
+
+test.describe('Explorer SQL Templates', () => {
+  test.setTimeout(60000);
+
+  test('Step 1: empty-editor overlay shows on a fresh model tab', async ({ page }) => {
+    await loadExplorer(page);
+    await openFreshModelTab(page);
+
+    // The empty-editor card should be visible because the editor is empty
+    // and a default source is auto-selected.
+    await expect(page.locator('[data-testid="empty-editor-overlay"]')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText('Start a query to see results')).toBeVisible();
+    await expect(page.getByTestId('sql-template-menu-trigger')).toBeVisible();
+  });
+
+  test('Step 2: clicking the template menu opens it with all six templates', async ({
+    page,
+  }) => {
+    await loadExplorer(page);
+    await openFreshModelTab(page);
+
+    await page.getByTestId('sql-template-menu-trigger').click();
+
+    await expect(page.getByTestId('sql-template-menu-list')).toBeVisible();
+    await expect(page.getByTestId('sql-template-select-all')).toBeVisible();
+    await expect(page.getByTestId('sql-template-count-by-category')).toBeVisible();
+    await expect(page.getByTestId('sql-template-sum-by-month')).toBeVisible();
+    await expect(page.getByTestId('sql-template-top-n')).toBeVisible();
+    await expect(page.getByTestId('sql-template-join-two')).toBeVisible();
+    await expect(page.getByTestId('sql-template-distinct-values')).toBeVisible();
+  });
+
+  test('Step 3: picking the "Show all rows" template populates the editor', async ({
+    page,
+  }) => {
+    await loadExplorer(page);
+    await openFreshModelTab(page);
+
+    // Open menu and pick the SELECT * starter
+    await page.getByTestId('sql-template-menu-trigger').click();
+    await page.getByTestId('sql-template-select-all').click();
+
+    // Editor should now contain the template's SELECT * pattern. The editor
+    // is Monaco — its content renders within `.view-lines`.
+    const editorContent = page.locator('.view-lines').first();
+    await expect(editorContent).toContainText('SELECT *', { timeout: 5000 });
+    await expect(editorContent).toContainText('LIMIT 100');
+
+    // Take a screenshot for visual verification
+    await page.screenshot({
+      path: 'e2e/.artifacts/explorer-sql-templates-after-pick.png',
+      fullPage: true,
+    });
+  });
+
+  test('Step 4: empty-editor card is hidden once SQL is present', async ({ page }) => {
+    await loadExplorer(page);
+    await openFreshModelTab(page);
+
+    // Start in the empty state
+    await expect(page.locator('[data-testid="empty-editor-overlay"]')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Pick a template — that populates the editor
+    await page.getByTestId('sql-template-menu-trigger').click();
+    await page.getByTestId('sql-template-select-all').click();
+
+    // The empty-editor overlay should disappear; the regular "Run a query" hint
+    // takes over (since we have SQL but no result yet).
+    await expect(page.locator('[data-testid="empty-editor-overlay"]')).not.toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByTestId('empty-results')).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/viewer/src/components/explorerNew/CenterPanel.jsx
+++ b/viewer/src/components/explorerNew/CenterPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback, useRef, useState, useEffect } from 'react';
 import { PiCaretUp, PiCaretDown, PiCode, PiChartBar } from 'react-icons/pi';
 import SQLEditor from './SQLEditor';
+import SQLTemplateMenu from './SQLTemplateMenu';
 import DataTable from '../common/DataTable';
 import ColumnProfilePanel from './ColumnProfilePanel';
 import ExplorerChartPreview from './ExplorerChartPreview';
@@ -12,6 +13,7 @@ import ModelTabBar from './ModelTabBar';
 import VerticalDivider from '../common/VerticalDivider';
 import Divider from '../common/Divider';
 import useStore from '../../stores/store';
+import { useSourceSchema } from '../../hooks/useSourceSchema';
 import {
   selectActiveModelSql,
   selectActiveModelSourceName,
@@ -51,9 +53,18 @@ const CenterPanel = () => {
   // Initialize DuckDB integration for computed columns
   useExplorerDuckDB();
 
+  // Schema for the active source (used to suggest a sample table in templates)
+  const { tables: schemaTables } = useSourceSchema(sourceName);
+  const firstTableInScope = useMemo(() => {
+    if (!schemaTables || schemaTables.length === 0) return null;
+    const first = schemaTables[0];
+    return first?.table_name || first?.name || null;
+  }, [schemaTables]);
+
   const containerRef = useRef(null);
   const topRowRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(800);
+  const [isDragOverEditor, setIsDragOverEditor] = useState(false);
 
   // Observe container width for responsive behavior
   useEffect(() => {
@@ -201,8 +212,46 @@ const CenterPanel = () => {
     </button>
   );
 
+  const handleEditorDragOver = useCallback((e) => {
+    if (e.dataTransfer.types.includes('application/x-visivo-table')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setIsDragOverEditor(true);
+    }
+  }, []);
+
+  const handleEditorDragLeave = useCallback((e) => {
+    // Only clear when leaving the section, not transitioning between children
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+    setIsDragOverEditor(false);
+  }, []);
+
+  const handleEditorDrop = useCallback(
+    (e) => {
+      const data = e.dataTransfer.getData('application/x-visivo-table');
+      setIsDragOverEditor(false);
+      if (!data) return;
+      e.preventDefault();
+      try {
+        const { tableName } = JSON.parse(data);
+        if (tableName) {
+          setSql(`SELECT *\nFROM ${tableName}\nLIMIT 1000;`);
+        }
+      } catch {
+        // Ignore malformed payload
+      }
+    },
+    [setSql]
+  );
+
   const renderEditorSection = () => (
-    <div className="flex flex-col h-full overflow-hidden" data-testid="editor-section">
+    <div
+      className="flex flex-col h-full overflow-hidden relative"
+      data-testid="editor-section"
+      onDragOver={handleEditorDragOver}
+      onDragLeave={handleEditorDragLeave}
+      onDrop={handleEditorDrop}
+    >
       {!isEditorCollapsed ? (
         <div className="flex-1 min-h-0">
           <SQLEditor
@@ -220,6 +269,16 @@ const CenterPanel = () => {
         <div className="flex items-center justify-between px-3 py-1.5 bg-secondary-50 border-b border-secondary-100 flex-shrink-0">
           {sourceSelector}
           {editorToggleButton}
+        </div>
+      )}
+      {isDragOverEditor && (
+        <div
+          className="absolute inset-0 pointer-events-none flex items-center justify-center bg-primary-500/10 border-2 border-dashed border-primary-500 rounded"
+          data-testid="editor-drop-overlay"
+        >
+          <div className="bg-white rounded-md shadow-md px-4 py-2 text-sm font-medium text-primary-700">
+            Drop to seed SELECT * query
+          </div>
         </div>
       )}
     </div>
@@ -338,6 +397,34 @@ const CenterPanel = () => {
                 data-testid="query-error"
               >
                 {queryError}
+              </div>
+            </div>
+          ) : !sourceName ? (
+            <div className="flex items-center justify-center h-full w-full">
+              <span className="text-sm text-secondary-400" data-testid="empty-results">
+                No source selected — set a source on your model or select one to run queries
+              </span>
+            </div>
+          ) : !sql || sql.trim() === '' ? (
+            <div
+              className="flex items-center justify-center h-full w-full p-6"
+              data-testid="empty-editor-overlay"
+            >
+              <div className="bg-white rounded-lg shadow-md border border-secondary-200 p-6 max-w-md w-full text-center">
+                <h3 className="text-base font-medium text-secondary-900 mb-2">
+                  Start a query to see results
+                </h3>
+                <p className="text-sm text-secondary-600 mb-4">
+                  Drag a table from the left panel, pick a SQL template, or type your own query
+                  in the editor above.
+                </p>
+                <div className="flex flex-col gap-2">
+                  <SQLTemplateMenu
+                    onPick={(templateSql) => setSql(templateSql)}
+                    currentTable={firstTableInScope}
+                    label="Use a SQL template"
+                  />
+                </div>
               </div>
             </div>
           ) : (

--- a/viewer/src/components/explorerNew/CenterPanel.test.jsx
+++ b/viewer/src/components/explorerNew/CenterPanel.test.jsx
@@ -111,6 +111,25 @@ jest.mock('../../hooks/useExplorerDuckDB', () => ({
   default: () => {},
 }));
 
+// Mock useSourceSchema (CenterPanel uses it to suggest a sample table for templates)
+jest.mock('../../hooks/useSourceSchema', () => ({
+  __esModule: true,
+  useSourceSchema: () => ({
+    tables: [{ name: 'sample_table' }],
+    tableColumns: {},
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+  default: () => ({
+    tables: [{ name: 'sample_table' }],
+    tableColumns: {},
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
 // Mock DataSectionToolbar — reads from store internally, no props from CenterPanel
 jest.mock('./DataSectionToolbar', () => {
   return function MockDataSectionToolbar() {
@@ -387,6 +406,195 @@ describe('CenterPanel', () => {
       render(<CenterPanel />);
 
       expect(screen.queryByTestId('data-section-toolbar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Empty-editor overlay (SQL templates)', () => {
+    it('renders the empty-editor overlay when source is set and editor is empty', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      expect(screen.getByTestId('empty-editor-overlay')).toBeInTheDocument();
+      expect(screen.getByText('Start a query to see results')).toBeInTheDocument();
+      expect(screen.getByTestId('sql-template-menu-trigger')).toBeInTheDocument();
+    });
+
+    it('treats whitespace-only SQL as empty and shows the overlay', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '   \n  ', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      expect(screen.getByTestId('empty-editor-overlay')).toBeInTheDocument();
+    });
+
+    it('hides the overlay and shows "Run a query" when editor has content', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      expect(screen.queryByTestId('empty-editor-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+      expect(screen.getByText('Run a query to see results')).toBeInTheDocument();
+    });
+
+    it('does not show overlay or template menu when no source is selected', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '', sourceName: null }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      expect(screen.queryByTestId('empty-editor-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('empty-results')).toHaveTextContent(
+        /No source selected/i
+      );
+    });
+
+    it('does not show overlay when query result exists', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({
+            sql: '',
+            sourceName: 'test_source',
+            queryResult: {
+              columns: ['id'],
+              rows: [{ id: 1 }],
+              row_count: 1,
+            },
+          }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      expect(screen.queryByTestId('empty-editor-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+
+    it('picking a template via menu populates the editor SQL', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      // Open the template menu
+      fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+      // Pick the "select-all" template
+      fireEvent.click(screen.getByTestId('sql-template-select-all'));
+
+      const newSql = useStore.getState().explorerModelStates.test_model.sql;
+      expect(newSql).toContain('SELECT *');
+      expect(newSql).toContain('LIMIT 100');
+    });
+  });
+
+  describe('Drag table to seed editor', () => {
+    it('drop with valid table payload sets editor SQL to a SELECT *', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      const editorSection = screen.getByTestId('editor-section');
+      const dataTransfer = {
+        types: ['application/x-visivo-table'],
+        getData: jest.fn(() =>
+          JSON.stringify({ tableName: 'main.songs', sourceName: 'test_source' })
+        ),
+        dropEffect: '',
+      };
+
+      fireEvent.dragOver(editorSection, { dataTransfer });
+      fireEvent.drop(editorSection, { dataTransfer });
+
+      const newSql = useStore.getState().explorerModelStates.test_model.sql;
+      expect(newSql).toContain('SELECT *');
+      expect(newSql).toContain('FROM main.songs');
+      expect(newSql).toContain('LIMIT 1000');
+    });
+
+    it('shows the drop overlay while dragging a table over the editor', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: '', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      const editorSection = screen.getByTestId('editor-section');
+      const dataTransfer = {
+        types: ['application/x-visivo-table'],
+        getData: jest.fn(),
+        dropEffect: '',
+      };
+
+      fireEvent.dragOver(editorSection, { dataTransfer });
+
+      expect(screen.getByTestId('editor-drop-overlay')).toBeInTheDocument();
+      expect(screen.getByText('Drop to seed SELECT * query')).toBeInTheDocument();
+    });
+
+    it('drop without a table payload does not change SQL', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      const editorSection = screen.getByTestId('editor-section');
+      const dataTransfer = {
+        types: ['text/plain'],
+        getData: jest.fn(() => ''),
+        dropEffect: '',
+      };
+
+      fireEvent.drop(editorSection, { dataTransfer });
+
+      expect(useStore.getState().explorerModelStates.test_model.sql).toBe('SELECT 1');
+    });
+
+    it('drop with malformed payload does not throw', () => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+        },
+      });
+
+      render(<CenterPanel />);
+
+      const editorSection = screen.getByTestId('editor-section');
+      const dataTransfer = {
+        types: ['application/x-visivo-table'],
+        getData: jest.fn(() => 'not-json'),
+        dropEffect: '',
+      };
+
+      expect(() => fireEvent.drop(editorSection, { dataTransfer })).not.toThrow();
+      expect(useStore.getState().explorerModelStates.test_model.sql).toBe('SELECT 1');
     });
   });
 });

--- a/viewer/src/components/explorerNew/SQLTemplateMenu.jsx
+++ b/viewer/src/components/explorerNew/SQLTemplateMenu.jsx
@@ -1,0 +1,136 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { PiCaretDown, PiCode } from 'react-icons/pi';
+
+/**
+ * Starter SQL templates offered to new users when the editor is empty.
+ * Each template's `sql` is a function that takes an optional table name and
+ * returns a SQL string. When `table` is not provided, the placeholder
+ * `your_table` is used so users can clearly see where to substitute names.
+ */
+export const SQL_TEMPLATES = [
+  {
+    id: 'select-all',
+    label: 'Show all rows from a table',
+    description: 'SELECT * with a LIMIT — good for exploring',
+    sql: (table) => `SELECT *\nFROM ${table || 'your_table'}\nLIMIT 100;`,
+  },
+  {
+    id: 'count-by-category',
+    label: 'Count rows by category',
+    description: 'COUNT and GROUP BY — counts per group',
+    sql: (table) =>
+      `SELECT category_column, COUNT(*) AS row_count\nFROM ${table || 'your_table'}\nGROUP BY category_column\nORDER BY row_count DESC;`,
+  },
+  {
+    id: 'sum-by-month',
+    label: 'Aggregate by month',
+    description: 'Sum a numeric column grouped by month',
+    sql: (table) =>
+      `SELECT date_trunc('month', date_column) AS month,\n       SUM(amount_column) AS total\nFROM ${table || 'your_table'}\nGROUP BY 1\nORDER BY 1;`,
+  },
+  {
+    id: 'top-n',
+    label: 'Top 10 by a metric',
+    description: 'Sorted, limited result set',
+    sql: (table) =>
+      `SELECT name, value\nFROM ${table || 'your_table'}\nORDER BY value DESC\nLIMIT 10;`,
+  },
+  {
+    id: 'join-two',
+    label: 'Join two tables',
+    description: 'INNER JOIN pattern',
+    sql: () =>
+      `SELECT a.id, a.name, b.value\nFROM table_a a\nJOIN table_b b ON b.a_id = a.id\nLIMIT 100;`,
+  },
+  {
+    id: 'distinct-values',
+    label: 'List distinct values',
+    description: 'Unique values from a column',
+    sql: (table) =>
+      `SELECT DISTINCT category_column\nFROM ${table || 'your_table'}\nORDER BY 1;`,
+  },
+];
+
+/**
+ * SQLTemplateMenu - Dropdown picker for starter SQL queries.
+ *
+ * Props:
+ * - onPick: (sqlString) => void  — called with the rendered SQL when a template is selected
+ * - currentTable: string | null  — optional table name to substitute into templates
+ * - label: string                — visible button label (default: "Use a SQL template")
+ */
+const SQLTemplateMenu = ({ onPick, currentTable, label = 'Use a SQL template' }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const handlePick = (template) => {
+    onPick?.(template.sql(currentTable));
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative w-full" ref={dropdownRef} data-testid="sql-template-menu">
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        className={`
+          w-full flex items-center justify-between gap-2
+          px-3 py-2 rounded-md border text-sm font-medium
+          transition-colors
+          ${
+            isOpen
+              ? 'border-primary-500 ring-1 ring-primary-500 bg-primary-50 text-primary-700'
+              : 'border-secondary-300 hover:border-primary-400 bg-white text-secondary-700'
+          }
+        `}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        data-testid="sql-template-menu-trigger"
+      >
+        <span className="flex items-center gap-2">
+          <PiCode size={14} className="text-primary" />
+          {label}
+        </span>
+        <PiCaretDown
+          size={12}
+          className={`text-secondary-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute top-full left-0 right-0 mt-1 bg-white rounded-md shadow-lg border border-secondary-200 z-50 py-1 max-h-80 overflow-y-auto"
+          role="menu"
+          data-testid="sql-template-menu-list"
+        >
+          {SQL_TEMPLATES.map((template) => (
+            <button
+              key={template.id}
+              type="button"
+              onClick={() => handlePick(template)}
+              className="w-full text-left px-3 py-2 hover:bg-primary-50 transition-colors flex flex-col gap-0.5"
+              role="menuitem"
+              data-testid={`sql-template-${template.id}`}
+            >
+              <span className="text-sm font-medium text-secondary-800">{template.label}</span>
+              <span className="text-xs text-secondary-500">{template.description}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SQLTemplateMenu;

--- a/viewer/src/components/explorerNew/SQLTemplateMenu.test.jsx
+++ b/viewer/src/components/explorerNew/SQLTemplateMenu.test.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SQLTemplateMenu, { SQL_TEMPLATES } from './SQLTemplateMenu';
+
+describe('SQLTemplateMenu', () => {
+  it('renders the trigger button with default label', () => {
+    render(<SQLTemplateMenu onPick={jest.fn()} />);
+    expect(screen.getByTestId('sql-template-menu-trigger')).toHaveTextContent(
+      'Use a SQL template'
+    );
+  });
+
+  it('renders the trigger button with custom label', () => {
+    render(<SQLTemplateMenu onPick={jest.fn()} label="Pick a starter" />);
+    expect(screen.getByTestId('sql-template-menu-trigger')).toHaveTextContent('Pick a starter');
+  });
+
+  it('does not show the menu list until the trigger is clicked', () => {
+    render(<SQLTemplateMenu onPick={jest.fn()} />);
+    expect(screen.queryByTestId('sql-template-menu-list')).not.toBeInTheDocument();
+  });
+
+  it('opens the menu on click and renders all template labels', () => {
+    render(<SQLTemplateMenu onPick={jest.fn()} />);
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+
+    expect(screen.getByTestId('sql-template-menu-list')).toBeInTheDocument();
+    SQL_TEMPLATES.forEach((template) => {
+      expect(screen.getByText(template.label)).toBeInTheDocument();
+      expect(screen.getByText(template.description)).toBeInTheDocument();
+    });
+  });
+
+  it('toggles the menu closed on second trigger click', () => {
+    render(<SQLTemplateMenu onPick={jest.fn()} />);
+    const trigger = screen.getByTestId('sql-template-menu-trigger');
+
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('sql-template-menu-list')).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId('sql-template-menu-list')).not.toBeInTheDocument();
+  });
+
+  it('calls onPick with rendered SQL when a template is selected', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} currentTable="songs" />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    fireEvent.click(screen.getByTestId('sql-template-select-all'));
+
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith('SELECT *\nFROM songs\nLIMIT 100;');
+  });
+
+  it('substitutes the current table for the count-by-category template', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} currentTable="orders" />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    fireEvent.click(screen.getByTestId('sql-template-count-by-category'));
+
+    expect(onPick).toHaveBeenCalledWith(expect.stringContaining('FROM orders'));
+    expect(onPick).toHaveBeenCalledWith(expect.stringContaining('GROUP BY category_column'));
+  });
+
+  it('falls back to your_table when currentTable is not provided', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    fireEvent.click(screen.getByTestId('sql-template-select-all'));
+
+    expect(onPick).toHaveBeenCalledWith('SELECT *\nFROM your_table\nLIMIT 100;');
+  });
+
+  it('falls back to your_table when currentTable is null', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} currentTable={null} />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    fireEvent.click(screen.getByTestId('sql-template-distinct-values'));
+
+    expect(onPick).toHaveBeenCalledWith(expect.stringContaining('FROM your_table'));
+  });
+
+  it('the join-two template ignores currentTable (it is a 2-table example)', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} currentTable="ignored" />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    fireEvent.click(screen.getByTestId('sql-template-join-two'));
+
+    const arg = onPick.mock.calls[0][0];
+    expect(arg).toContain('FROM table_a a');
+    expect(arg).toContain('JOIN table_b b');
+    expect(arg).not.toContain('ignored');
+  });
+
+  it('closes the menu after a template is picked', () => {
+    const onPick = jest.fn();
+    render(<SQLTemplateMenu onPick={onPick} />);
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    expect(screen.getByTestId('sql-template-menu-list')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('sql-template-top-n'));
+    expect(screen.queryByTestId('sql-template-menu-list')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on outside click', () => {
+    const onPick = jest.fn();
+    render(
+      <div>
+        <SQLTemplateMenu onPick={onPick} />
+        <button data-testid="outside">Outside</button>
+      </div>
+    );
+
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    expect(screen.getByTestId('sql-template-menu-list')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByTestId('sql-template-menu-list')).not.toBeInTheDocument();
+  });
+
+  it('does not throw when onPick is not provided', () => {
+    render(<SQLTemplateMenu />);
+    fireEvent.click(screen.getByTestId('sql-template-menu-trigger'));
+    expect(() =>
+      fireEvent.click(screen.getByTestId('sql-template-select-all'))
+    ).not.toThrow();
+  });
+
+  it('exposes SQL_TEMPLATES with all six templates', () => {
+    expect(SQL_TEMPLATES).toHaveLength(6);
+    expect(SQL_TEMPLATES.map((t) => t.id)).toEqual([
+      'select-all',
+      'count-by-category',
+      'sum-by-month',
+      'top-n',
+      'join-two',
+      'distinct-values',
+    ]);
+  });
+});

--- a/viewer/src/components/explorerNew/SchemaBrowser/SchemaTreeNode.jsx
+++ b/viewer/src/components/explorerNew/SchemaBrowser/SchemaTreeNode.jsx
@@ -16,6 +16,9 @@ const SchemaTreeNode = ({
   statusIcon,
   errorMessage,
   errorCollapsed = false,
+  draggable = false,
+  onDragStart,
+  onDragEnd,
 }) => {
   const isExpandable = type !== 'column';
 
@@ -31,6 +34,9 @@ const SchemaTreeNode = ({
         aria-expanded={isExpandable ? isExpanded : undefined}
         data-testid={`tree-node-${type}-${label}`}
         title={errorMessage || undefined}
+        draggable={draggable || undefined}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
       >
         <span className="w-4 h-4 flex items-center justify-center flex-shrink-0 mr-1">
           {isLoading ? (

--- a/viewer/src/components/explorerNew/SourceBrowser.jsx
+++ b/viewer/src/components/explorerNew/SourceBrowser.jsx
@@ -207,6 +207,17 @@ const SourceBrowser = ({ searchQuery, onTableSelect, onSourcesLoaded }) => {
         })
         .map((table) => {
           const colKey = `${sourceKey}::table::${table.name}`;
+          const handleDragStart = (e) => {
+            try {
+              e.dataTransfer.setData(
+                'application/x-visivo-table',
+                JSON.stringify({ tableName: table.name, sourceName: srcName })
+              );
+              e.dataTransfer.effectAllowed = 'copy';
+            } catch {
+              // older browsers / jsdom may throw — ignore
+            }
+          };
           return (
             <SchemaTreeNode
               key={colKey}
@@ -218,6 +229,8 @@ const SourceBrowser = ({ searchQuery, onTableSelect, onSourcesLoaded }) => {
               errorMessage={getNodeError(colKey)}
               onClick={() => toggleNode(colKey, () => fetchTableColumns(srcName, table.name))}
               onDoubleClick={() => onTableSelect?.({ sourceName: srcName, table: table.name })}
+              draggable
+              onDragStart={handleDragStart}
               level={1}
             >
               {renderColumns(loadedData[colKey], table.name)}

--- a/viewer/src/components/explorerNew/SourceBrowser.test.jsx
+++ b/viewer/src/components/explorerNew/SourceBrowser.test.jsx
@@ -24,6 +24,8 @@ jest.mock('./SchemaBrowser/SchemaTreeNode', () => {
     errorMessage,
     errorCollapsed,
     actions,
+    draggable,
+    onDragStart,
   }) => {
     return (
       <div
@@ -33,8 +35,14 @@ jest.mock('./SchemaBrowser/SchemaTreeNode', () => {
         data-badge={badge}
         data-error={errorMessage}
         data-error-collapsed={errorCollapsed}
+        data-draggable={draggable ? 'true' : undefined}
       >
-        <button data-testid={`click-${type}-${label}`} onClick={onClick}>
+        <button
+          data-testid={`click-${type}-${label}`}
+          onClick={onClick}
+          draggable={draggable || undefined}
+          onDragStart={onDragStart}
+        >
           {label}
         </button>
         {onDoubleClick && (
@@ -378,6 +386,58 @@ describe('SourceBrowser', () => {
       'true'
     );
     errorSpy.mockRestore();
+  });
+
+  it('table nodes are draggable and emit a visivo-table payload on drag start', async () => {
+    render(
+      <SourceBrowser searchQuery="" onTableSelect={jest.fn()} onSourcesLoaded={jest.fn()} />
+    );
+
+    await screen.findByTestId('click-source-postgres_db');
+
+    // Expand postgres_db so its tables render
+    fireEvent.click(screen.getByTestId('click-source-postgres_db'));
+
+    await screen.findByTestId('tree-node-table-users');
+
+    // Table nodes should be marked draggable
+    expect(screen.getByTestId('tree-node-table-users')).toHaveAttribute(
+      'data-draggable',
+      'true'
+    );
+
+    // Simulate drag start and verify the payload written to dataTransfer
+    const setData = jest.fn();
+    const dataTransfer = {
+      setData,
+      get effectAllowed() {
+        return this._effectAllowed;
+      },
+      set effectAllowed(value) {
+        this._effectAllowed = value;
+      },
+    };
+
+    fireEvent.dragStart(screen.getByTestId('click-table-users'), { dataTransfer });
+
+    expect(setData).toHaveBeenCalledWith(
+      'application/x-visivo-table',
+      JSON.stringify({ tableName: 'users', sourceName: 'postgres_db' })
+    );
+    expect(dataTransfer._effectAllowed).toBe('copy');
+  });
+
+  it('source and column nodes are not draggable', async () => {
+    render(
+      <SourceBrowser searchQuery="" onTableSelect={jest.fn()} onSourcesLoaded={jest.fn()} />
+    );
+
+    await screen.findByTestId('tree-node-source-postgres_db');
+
+    // Source nodes should not be draggable
+    expect(
+      screen.getByTestId('tree-node-source-postgres_db')
+    ).not.toHaveAttribute('data-draggable');
   });
 
   it('clicking an errored source toggles error visibility', async () => {


### PR DESCRIPTION
## Demo

<!-- DROP VIDEO HERE: /tmp/visivo-pr-videos/6-explorer-sql-templates.mp4 -->

_Drop the demo video above. File is at `/tmp/visivo-pr-videos/6-explorer-sql-templates.mp4` on the maintainer's machine._

---

## Summary

Replaces the empty SQL editor's "Run a query to see results" wall-of-void with an actionable card offering 6 SQL templates and a drag-table-to-seed affordance. Closes **Friction #33** from the dogfood walkthrough.

## What ships

- New `SQLTemplateMenu.jsx` with 6 starter queries: SELECT * with LIMIT, COUNT by category, sum-by-month aggregate, top-10 by metric, JOIN two tables, DISTINCT values.
- `CenterPanel.jsx` shows the template card overlay only when source IS selected and editor IS empty (other empty-state copy preserved for the "no source" and "no results yet" cases).
- `SourceBrowser.jsx` table nodes now `draggable`. Drop on the editor area seeds `SELECT *\nFROM <table>\nLIMIT 1000;` with a primary-bordered "Drop to seed SELECT * query" overlay during drag.
- New `application/x-visivo-table` mime payload carries `tableName` and `sourceName`.
- `SchemaTreeNode.jsx` accepts opt-in `draggable`/`onDragStart`/`onDragEnd` props.

## Test plan

- [x] Python pytest — 1679 passed, 0 failed (verified via follow-up agent)
- [x] Viewer Jest — 1446 / 114 suites + lint clean (439 explorerNew tests pass)
- [x] Playwright e2e — `explorer-sql-templates.spec.mjs` 4/4 pass on sandbox `:8016/:3016`

## Demo

Video above shows: open `/explorer` with a model tab → empty editor shows the new card → click "Use a SQL template" → pick "Show all rows from a table" → editor populated. Then drag a table from the left tree → drop on editor → SELECT * seeded.

Worktree: `/tmp/visivo-wt-sql-templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
