### PR TITLE
feat: filter Insight property panel to chart-type-relevant essentials

### DIFF
--- a/viewer/e2e/stories/insight-property-filtering.spec.mjs
+++ b/viewer/e2e/stories/insight-property-filtering.spec.mjs
@@ -1,0 +1,138 @@
+/**
+ * Story: Insight & Layout Property Filtering
+ *
+ * Hides the scary "0 of 1366 properties" / "2 of 286 properties" by filtering
+ * the property panel to chart-type-relevant essentials. Default mode is
+ * "essentials"; users can opt in to the full schema with a toggle.
+ *
+ * Precondition: Sandbox running on :3017/:8017
+ *   bash scripts/sandbox.sh start
+ *
+ * The default Playwright baseURL is :3001; set PROPERTY_FILTER_E2E_BASE_URL
+ * to point to a different sandbox port, e.g.:
+ *   PROPERTY_FILTER_E2E_BASE_URL=http://localhost:3017
+ */
+
+import { test, expect } from '@playwright/test';
+import { loadExplorer } from '../helpers/explorer.mjs';
+
+if (process.env.PROPERTY_FILTER_E2E_BASE_URL) {
+  test.use({ baseURL: process.env.PROPERTY_FILTER_E2E_BASE_URL });
+}
+
+test.describe('Insight Property Filtering', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ context }) => {
+    // Reset cookies between tests. We cannot blanket-clear localStorage in an
+    // init script because addInitScript runs on every navigation, including
+    // page.reload() — which would defeat the persistence test below. Instead,
+    // each test that needs a clean slate does so explicitly.
+    await context.clearCookies();
+  });
+
+  test('defaults to essentials mode and shows a Show all toggle', async ({ page }) => {
+    await loadExplorer(page);
+
+    // Ensure default state — clear only the property-filter keys.
+    await page.evaluate(() => {
+      for (const k of Object.keys(window.localStorage)) {
+        if (k.startsWith('visivo_property_filter_mode_')) {
+          window.localStorage.removeItem(k);
+        }
+      }
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const insightSection = page.locator('[data-testid="insight-crud-section-insight"]');
+    await expect(insightSection).toBeVisible({ timeout: 10000 });
+
+    // The PropertyFilter should be visible inside the insight section.
+    const filter = insightSection.locator('[data-testid="property-filter"]').first();
+    await expect(filter).toBeVisible({ timeout: 10000 });
+    await expect(filter).toContainText(/essential propert/);
+
+    const toggle = insightSection.locator('[data-testid="property-filter-toggle"]').first();
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toContainText(/Show all/);
+
+    // Capture the "before" state visually.
+    await page.screenshot({
+      path: 'test-results/property-filtering-essentials.png',
+      fullPage: true,
+    });
+  });
+
+  test('toggling shows total properties count', async ({ page }) => {
+    await loadExplorer(page);
+
+    // Ensure default state — clear only the property-filter keys.
+    await page.evaluate(() => {
+      for (const k of Object.keys(window.localStorage)) {
+        if (k.startsWith('visivo_property_filter_mode_')) {
+          window.localStorage.removeItem(k);
+        }
+      }
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const insightSection = page.locator('[data-testid="insight-crud-section-insight"]');
+    await expect(insightSection).toBeVisible({ timeout: 10000 });
+
+    const filter = insightSection.locator('[data-testid="property-filter"]').first();
+    await expect(filter).toBeVisible({ timeout: 10000 });
+    await expect(filter).toContainText(/essential propert/);
+
+    const toggle = insightSection.locator('[data-testid="property-filter-toggle"]').first();
+    await toggle.click();
+
+    // After clicking, count flips to "total properties"
+    await expect(filter).toContainText(/total properties/, { timeout: 5000 });
+    await expect(toggle).toContainText(/Show essentials only/);
+
+    await page.screenshot({
+      path: 'test-results/property-filtering-all.png',
+      fullPage: true,
+    });
+  });
+
+  test('preserves last selected mode across reload (per chart type)', async ({ page }) => {
+    await loadExplorer(page);
+
+    // Start clean.
+    await page.evaluate(() => {
+      for (const k of Object.keys(window.localStorage)) {
+        if (k.startsWith('visivo_property_filter_mode_')) {
+          window.localStorage.removeItem(k);
+        }
+      }
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const insightSection = page.locator('[data-testid="insight-crud-section-insight"]');
+    await expect(insightSection).toBeVisible({ timeout: 10000 });
+
+    // Click toggle to switch to "all" mode
+    const toggle = insightSection.locator('[data-testid="property-filter-toggle"]').first();
+    await toggle.click();
+
+    const filter = insightSection.locator('[data-testid="property-filter"]').first();
+    await expect(filter).toContainText(/total properties/, { timeout: 5000 });
+
+    // Reload — mode should be preserved via localStorage
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const insightSectionAfter = page.locator('[data-testid="insight-crud-section-insight"]');
+    await expect(insightSectionAfter).toBeVisible({ timeout: 10000 });
+
+    const filterAfter = insightSectionAfter
+      .locator('[data-testid="property-filter"]')
+      .first();
+    await expect(filterAfter).toBeVisible({ timeout: 10000 });
+    await expect(filterAfter).toContainText(/total properties/, { timeout: 5000 });
+  });
+});

--- a/viewer/src/components/explorerNew/ChartCRUDSection.jsx
+++ b/viewer/src/components/explorerNew/ChartCRUDSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { PiCaretDown, PiCaretRight, PiPlus, PiX } from 'react-icons/pi';
 import { useDroppable } from '@dnd-kit/core';
 import EmbeddedPill from '../new-views/lineage/EmbeddedPill';
@@ -6,6 +6,30 @@ import useStore from '../../stores/store';
 import { selectInsightStatus } from '../../stores/explorerNewStore';
 import { getSchema } from '../../schemas/schemas';
 import { SchemaEditor } from '../new-views/common/SchemaEditor/SchemaEditor';
+import { flattenSchemaProperties } from '../new-views/common/SchemaEditor/utils/schemaUtils';
+import PropertyFilter from './PropertyFilter';
+import { getLayoutEssentials } from './chartTypeEssentials';
+
+const LAYOUT_FILTER_STORAGE_KEY = 'visivo_property_filter_mode_layout';
+
+const readLayoutFilterMode = () => {
+  if (typeof window === 'undefined' || !window.localStorage) return 'essentials';
+  try {
+    const stored = window.localStorage.getItem(LAYOUT_FILTER_STORAGE_KEY);
+    return stored === 'all' ? 'all' : 'essentials';
+  } catch (_e) {
+    return 'essentials';
+  }
+};
+
+const persistLayoutFilterMode = (mode) => {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(LAYOUT_FILTER_STORAGE_KEY, mode);
+  } catch (_e) {
+    // localStorage write failures are non-fatal
+  }
+};
 
 const InsightPillItem = ({ name, isActive, onRemove, onClick }) => {
   const status = useStore(selectInsightStatus(name));
@@ -40,7 +64,31 @@ const ChartCRUDSection = ({ isExpanded, onToggleExpand }) => {
   const [renameValue, setRenameValue] = useState('');
   const [renameError, setRenameError] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
+  const [layoutFilterMode, setLayoutFilterMode] = useState(() => readLayoutFilterMode());
   const skipNextCommitRef = useRef(false);
+
+  const handleLayoutFilterModeChange = useCallback((newMode) => {
+    setLayoutFilterMode(newMode);
+    persistLayoutFilterMode(newMode);
+  }, []);
+
+  const layoutEssentialPaths = useMemo(() => getLayoutEssentials(), []);
+
+  const allLayoutPropertyPaths = useMemo(() => {
+    if (!layoutSchema) return [];
+    const defs = layoutSchema.$defs || {};
+    return flattenSchemaProperties(layoutSchema, '', defs).map((p) => p.path);
+  }, [layoutSchema]);
+
+  const totalLayoutPropertyCount = allLayoutPropertyPaths.length;
+
+  const availableLayoutEssentialPaths = useMemo(() => {
+    if (!layoutSchema) return layoutEssentialPaths;
+    const allowed = new Set(allLayoutPropertyPaths);
+    return layoutEssentialPaths.filter((p) => allowed.has(p));
+  }, [layoutSchema, layoutEssentialPaths, allLayoutPropertyPaths]);
+
+  const essentialLayoutPropertyCount = availableLayoutEssentialPaths.length;
 
   // Keep the local editing value in sync with the chart name when we're not
   // actively typing, so switching charts updates the displayed text.
@@ -246,9 +294,17 @@ const ChartCRUDSection = ({ isExpanded, onToggleExpand }) => {
 
           {/* Layout Properties */}
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
-              Layout Properties
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-xs font-medium text-gray-600">Layout Properties</label>
+              {layoutSchema && (
+                <PropertyFilter
+                  totalCount={totalLayoutPropertyCount}
+                  essentialCount={essentialLayoutPropertyCount}
+                  mode={layoutFilterMode}
+                  onChange={handleLayoutFilterModeChange}
+                />
+              )}
+            </div>
             <SchemaEditor
               schema={layoutSchema}
               value={chartLayout}
@@ -256,6 +312,10 @@ const ChartCRUDSection = ({ isExpanded, onToggleExpand }) => {
               excludeProperties={[]}
               initiallyExpanded={Object.keys(chartLayout || {})}
               droppable={false}
+              filterToKeys={
+                layoutFilterMode === 'essentials' ? availableLayoutEssentialPaths : null
+              }
+              hidePropertyCount={true}
             />
           </div>
         </div>

--- a/viewer/src/components/explorerNew/ChartCRUDSection.test.jsx
+++ b/viewer/src/components/explorerNew/ChartCRUDSection.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DndContext } from '@dnd-kit/core';
 import ChartCRUDSection from './ChartCRUDSection';
@@ -44,9 +44,13 @@ jest.mock('../new-views/lineage/EmbeddedPill', () => {
 });
 
 jest.mock('../new-views/common/SchemaEditor/SchemaEditor', () => {
-  const MockSchemaEditor = ({ schema, value, onChange }) => {
+  const MockSchemaEditor = ({ schema, value, onChange, filterToKeys, hidePropertyCount }) => {
     return (
-      <div data-testid="chart-schema-editor">
+      <div
+        data-testid="chart-schema-editor"
+        data-filter-keys={filterToKeys ? JSON.stringify(filterToKeys) : 'null'}
+        data-hide-count={hidePropertyCount ? 'true' : 'false'}
+      >
         ChartSchemaEditor: {JSON.stringify(value)}
       </div>
     );
@@ -55,7 +59,32 @@ jest.mock('../new-views/common/SchemaEditor/SchemaEditor', () => {
 });
 
 jest.mock('../../schemas/schemas', () => ({
-  getSchema: jest.fn().mockResolvedValue({ properties: { title: {} } }),
+  getSchema: jest.fn().mockResolvedValue({
+    properties: {
+      title: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+      },
+      xaxis: {
+        type: 'object',
+        properties: {
+          title: { type: 'object', properties: { text: { type: 'string' } } },
+          type: { type: 'string' },
+        },
+      },
+      yaxis: {
+        type: 'object',
+        properties: {
+          title: { type: 'object', properties: { text: { type: 'string' } } },
+          type: { type: 'string' },
+        },
+      },
+      showlegend: { type: 'boolean' },
+      paper_bgcolor: { type: 'string' },
+      plot_bgcolor: { type: 'string' },
+      hovermode: { type: 'string' },
+    },
+  }),
 }));
 
 const defaultState = {
@@ -207,6 +236,62 @@ describe('ChartCRUDSection', () => {
       useStore.setState({ explorerChartInsightNames: [], explorerInsightStates: {} });
       renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
       expect(await screen.findByText(/drag from left nav/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('layout property filter', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('renders PropertyFilter once the layout schema loads', async () => {
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const filter = await screen.findByTestId('property-filter');
+      expect(filter).toBeInTheDocument();
+    });
+
+    it('defaults to "essentials" mode and passes layout essential paths to SchemaEditor', async () => {
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const editor = await screen.findByTestId('chart-schema-editor');
+      const filterKeys = JSON.parse(editor.getAttribute('data-filter-keys'));
+      expect(Array.isArray(filterKeys)).toBe(true);
+      expect(filterKeys).toContain('title.text');
+      expect(filterKeys).toContain('xaxis.title.text');
+      expect(filterKeys).toContain('showlegend');
+      // Layout essentials don't include hovermode, so it shouldn't appear here
+      expect(filterKeys).not.toContain('hovermode');
+    });
+
+    it('toggling the filter switches to "all" mode and clears filterToKeys', async () => {
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const toggle = await screen.findByTestId('property-filter-toggle');
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        const editor = screen.getByTestId('chart-schema-editor');
+        expect(editor.getAttribute('data-filter-keys')).toBe('null');
+      });
+    });
+
+    it('persists layout filter mode to localStorage', async () => {
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const toggle = await screen.findByTestId('property-filter-toggle');
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(window.localStorage.getItem('visivo_property_filter_mode_layout')).toBe('all');
+      });
+    });
+
+    it('reads persisted layout mode from localStorage on mount', async () => {
+      window.localStorage.setItem('visivo_property_filter_mode_layout', 'all');
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const filter = await screen.findByTestId('property-filter');
+      expect(filter).toHaveTextContent('total properties');
+    });
+
+    it('passes hidePropertyCount=true to layout SchemaEditor', async () => {
+      renderInDnd(<ChartCRUDSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      const editor = await screen.findByTestId('chart-schema-editor');
+      expect(editor.getAttribute('data-hide-count')).toBe('true');
     });
   });
 });

--- a/viewer/src/components/explorerNew/InsightCRUDSection.jsx
+++ b/viewer/src/components/explorerNew/InsightCRUDSection.jsx
@@ -8,6 +8,29 @@ import { getRequiredFields } from '../new-views/common/insightRequiredFields';
 import { SchemaEditor } from '../new-views/common/SchemaEditor/SchemaEditor';
 import { flattenSchemaProperties } from '../new-views/common/SchemaEditor/utils/schemaUtils';
 import RefTextArea from '../new-views/common/RefTextArea';
+import PropertyFilter from './PropertyFilter';
+import { getEssentialsForChartType } from './chartTypeEssentials';
+
+const PROPERTY_FILTER_STORAGE_PREFIX = 'visivo_property_filter_mode_';
+
+const readPersistedFilterMode = (insightType) => {
+  if (typeof window === 'undefined' || !window.localStorage) return 'essentials';
+  try {
+    const stored = window.localStorage.getItem(`${PROPERTY_FILTER_STORAGE_PREFIX}${insightType}`);
+    return stored === 'all' ? 'all' : 'essentials';
+  } catch (_e) {
+    return 'essentials';
+  }
+};
+
+const persistFilterMode = (insightType, mode) => {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(`${PROPERTY_FILTER_STORAGE_PREFIX}${insightType}`, mode);
+  } catch (_e) {
+    // localStorage write failures (quota, private mode) are non-fatal
+  }
+};
 
 const InteractionRow = ({ interaction, index, insightName, updateInsightInteraction, handleRemoveInteraction }) => {
   const { isOver, setNodeRef } = useDroppable({
@@ -98,6 +121,42 @@ const InsightCRUDSection = ({ insightName, isExpanded, onToggleExpand }) => {
   const type = insightState?.type || 'scatter';
   const props = insightState?.props || {};
   const interactions = insightState?.interactions || [];
+
+  const [filterMode, setFilterMode] = useState(() => readPersistedFilterMode(type));
+
+  // Resync filterMode when the chart type changes (e.g., user switches scatter -> bar).
+  // Each chart type has its own persisted preference.
+  useEffect(() => {
+    setFilterMode(readPersistedFilterMode(type));
+  }, [type]);
+
+  const handleFilterModeChange = useCallback(
+    (newMode) => {
+      setFilterMode(newMode);
+      persistFilterMode(type, newMode);
+    },
+    [type]
+  );
+
+  const essentialPaths = useMemo(() => getEssentialsForChartType(type), [type]);
+
+  const allPropertyPaths = useMemo(() => {
+    if (!schema) return [];
+    const defs = schema.$defs || {};
+    return flattenSchemaProperties(schema, '', defs)
+      .filter((p) => p.path !== 'type')
+      .map((p) => p.path);
+  }, [schema]);
+
+  const totalPropertyCount = allPropertyPaths.length;
+
+  const availableEssentialPaths = useMemo(() => {
+    if (!schema) return essentialPaths;
+    const allowed = new Set(allPropertyPaths);
+    return essentialPaths.filter((p) => allowed.has(p));
+  }, [schema, essentialPaths, allPropertyPaths]);
+
+  const essentialPropertyCount = availableEssentialPaths.length;
 
   useEffect(() => {
     let cancelled = false;
@@ -313,7 +372,17 @@ const InsightCRUDSection = ({ insightName, isExpanded, onToggleExpand }) => {
 
           {/* Properties (SchemaEditor) */}
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Properties</label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-xs font-medium text-gray-600">Properties</label>
+              {schema && (
+                <PropertyFilter
+                  totalCount={totalPropertyCount}
+                  essentialCount={essentialPropertyCount}
+                  mode={filterMode}
+                  onChange={handleFilterModeChange}
+                />
+              )}
+            </div>
             <SchemaEditor
               schema={schema}
               value={props}
@@ -321,6 +390,8 @@ const InsightCRUDSection = ({ insightName, isExpanded, onToggleExpand }) => {
               excludeProperties={['type']}
               initiallyExpanded={requiredFieldNames}
               droppable={true}
+              filterToKeys={filterMode === 'essentials' ? availableEssentialPaths : null}
+              hidePropertyCount={true}
             />
           </div>
 

--- a/viewer/src/components/explorerNew/InsightCRUDSection.test.jsx
+++ b/viewer/src/components/explorerNew/InsightCRUDSection.test.jsx
@@ -6,9 +6,14 @@ import InsightCRUDSection from './InsightCRUDSection';
 import useStore from '../../stores/store';
 
 jest.mock('../new-views/common/SchemaEditor/SchemaEditor', () => {
-  const MockSchemaEditor = ({ schema, value, onChange, droppable }) => {
+  const MockSchemaEditor = ({ schema, value, onChange, droppable, filterToKeys, hidePropertyCount }) => {
     return (
-      <div data-testid="schema-editor" data-droppable={droppable}>
+      <div
+        data-testid="schema-editor"
+        data-droppable={droppable}
+        data-filter-keys={filterToKeys ? JSON.stringify(filterToKeys) : 'null'}
+        data-hide-count={hidePropertyCount ? 'true' : 'false'}
+      >
         SchemaEditor: {JSON.stringify(value)}
       </div>
     );
@@ -22,7 +27,32 @@ jest.mock('../../schemas/schemas', () => ({
     { value: 'bar', label: 'Bar' },
     { value: 'pie', label: 'Pie' },
   ],
-  getSchema: jest.fn().mockResolvedValue({ properties: { x: {}, y: {} } }),
+  getSchema: jest.fn().mockResolvedValue({
+    properties: {
+      x: { type: 'array' },
+      y: { type: 'array' },
+      mode: { type: 'string' },
+      name: { type: 'string' },
+      hovertext: { type: 'string' },
+      hovertemplate: { type: 'string' },
+      marker: {
+        type: 'object',
+        properties: {
+          color: { type: 'string' },
+          size: { type: 'number' },
+          opacity: { type: 'number' },
+        },
+      },
+      line: {
+        type: 'object',
+        properties: {
+          color: { type: 'string' },
+          width: { type: 'number' },
+          shape: { type: 'string' },
+        },
+      },
+    },
+  }),
 }));
 
 jest.mock('../new-views/common/insightRequiredFields', () => ({
@@ -309,6 +339,105 @@ describe('InsightCRUDSection', () => {
     // the assertion in act() and lets the schema-fetch effect settle.
     await waitFor(() => {
       expect(screen.queryByTestId('insight-crud-section-nonexistent')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('property filter', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('renders PropertyFilter once schema loads', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const filter = await screen.findByTestId('property-filter');
+      expect(filter).toBeInTheDocument();
+    });
+
+    it('defaults to "essentials" mode and passes essential paths to SchemaEditor', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const editor = await screen.findByTestId('schema-editor');
+      const filterKeys = JSON.parse(editor.getAttribute('data-filter-keys'));
+      // For scatter type, essentials are intersected with the schema properties.
+      // The mocked schema includes x, y, mode, name, marker.color, marker.size, line.color, line.width
+      expect(Array.isArray(filterKeys)).toBe(true);
+      expect(filterKeys).toContain('x');
+      expect(filterKeys).toContain('y');
+      expect(filterKeys).toContain('marker.color');
+      expect(filterKeys).toContain('line.width');
+    });
+
+    it('passes null filterToKeys to SchemaEditor in "all" mode', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const toggle = await screen.findByTestId('property-filter-toggle');
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        const editor = screen.getByTestId('schema-editor');
+        expect(editor.getAttribute('data-filter-keys')).toBe('null');
+      });
+    });
+
+    it('toggles between modes when the toggle button is clicked', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const filter = await screen.findByTestId('property-filter');
+      expect(filter).toHaveTextContent('essential propert');
+      const toggle = screen.getByTestId('property-filter-toggle');
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(screen.getByTestId('property-filter')).toHaveTextContent('total properties');
+      });
+      fireEvent.click(screen.getByTestId('property-filter-toggle'));
+      await waitFor(() => {
+        expect(screen.getByTestId('property-filter')).toHaveTextContent('essential propert');
+      });
+    });
+
+    it('persists toggle choice to localStorage per chart type', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const toggle = await screen.findByTestId('property-filter-toggle');
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(window.localStorage.getItem('visivo_property_filter_mode_scatter')).toBe('all');
+      });
+    });
+
+    it('reads persisted mode from localStorage on mount', async () => {
+      window.localStorage.setItem('visivo_property_filter_mode_scatter', 'all');
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const filter = await screen.findByTestId('property-filter');
+      expect(filter).toHaveTextContent('total properties');
+    });
+
+    it('sets hidePropertyCount=true on the SchemaEditor', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const editor = await screen.findByTestId('schema-editor');
+      expect(editor.getAttribute('data-hide-count')).toBe('true');
+    });
+
+    it('shows essential count and total count in the filter summary', async () => {
+      render(
+        <InsightCRUDSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      const filter = await screen.findByTestId('property-filter');
+      // The mocked scatter schema has 8 essentials (x, y, mode, name, marker.color, marker.size, line.color, line.width)
+      expect(filter).toHaveTextContent('8');
+      const toggle = screen.getByTestId('property-filter-toggle');
+      // The toggle in essentials mode shows "Show all (N)" with the total count.
+      // Mocked schema flattens to: x, y, mode, name, hovertext, hovertemplate, marker.color, marker.size, marker.opacity, line.color, line.width, line.shape -> 12 total
+      expect(toggle).toHaveTextContent('Show all (12)');
     });
   });
 });

--- a/viewer/src/components/explorerNew/PropertyFilter.jsx
+++ b/viewer/src/components/explorerNew/PropertyFilter.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+/**
+ * PropertyFilter — toggle between essential and full property lists.
+ *
+ * Renders a count summary plus a button that toggles between
+ * `mode === 'essentials'` (showing the chart-type-specific shortlist) and
+ * `mode === 'all'` (showing the entire Plotly schema).
+ *
+ * @param {object} props
+ * @param {number} props.totalCount - Total properties available in schema
+ * @param {number} props.essentialCount - Number of essential properties
+ * @param {'essentials'|'all'} props.mode - Current filter mode
+ * @param {(mode: 'essentials'|'all') => void} props.onChange - Toggle callback
+ */
+export default function PropertyFilter({ totalCount, essentialCount, mode, onChange }) {
+  const handleToggle = () => {
+    onChange(mode === 'essentials' ? 'all' : 'essentials');
+  };
+
+  return (
+    <div
+      data-testid="property-filter"
+      className="flex items-center gap-2 text-xs"
+    >
+      <span className="text-gray-600">
+        {mode === 'essentials' ? (
+          <>
+            <strong>{essentialCount}</strong> essential propert
+            {essentialCount === 1 ? 'y' : 'ies'}
+          </>
+        ) : (
+          <>
+            <strong>{totalCount}</strong> total properties
+          </>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="text-purple-600 hover:text-purple-800 hover:underline transition-colors"
+        data-testid="property-filter-toggle"
+      >
+        {mode === 'essentials' ? `Show all (${totalCount})` : 'Show essentials only'}
+      </button>
+    </div>
+  );
+}

--- a/viewer/src/components/explorerNew/PropertyFilter.test.jsx
+++ b/viewer/src/components/explorerNew/PropertyFilter.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PropertyFilter from './PropertyFilter';
+
+describe('PropertyFilter', () => {
+  const defaults = {
+    totalCount: 286,
+    essentialCount: 8,
+    mode: 'essentials',
+    onChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders essential count when mode="essentials"', () => {
+    render(<PropertyFilter {...defaults} />);
+    expect(screen.getByTestId('property-filter')).toHaveTextContent('8');
+    expect(screen.getByTestId('property-filter')).toHaveTextContent('essential properties');
+  });
+
+  it('renders total count when mode="all"', () => {
+    render(<PropertyFilter {...defaults} mode="all" />);
+    expect(screen.getByTestId('property-filter')).toHaveTextContent('286');
+    expect(screen.getByTestId('property-filter')).toHaveTextContent('total properties');
+  });
+
+  it('uses singular "property" when essentialCount is 1', () => {
+    render(<PropertyFilter {...defaults} essentialCount={1} />);
+    const filter = screen.getByTestId('property-filter');
+    expect(filter).toHaveTextContent('1');
+    expect(filter).toHaveTextContent('essential property');
+    expect(filter.textContent).not.toContain('properties');
+  });
+
+  it('shows "Show all (N)" button text when in essentials mode', () => {
+    render(<PropertyFilter {...defaults} />);
+    const button = screen.getByTestId('property-filter-toggle');
+    expect(button).toHaveTextContent('Show all (286)');
+  });
+
+  it('shows "Show essentials only" button text when in all mode', () => {
+    render(<PropertyFilter {...defaults} mode="all" />);
+    const button = screen.getByTestId('property-filter-toggle');
+    expect(button).toHaveTextContent('Show essentials only');
+  });
+
+  it('calls onChange with "all" when toggling from essentials', () => {
+    const onChange = jest.fn();
+    render(<PropertyFilter {...defaults} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('property-filter-toggle'));
+    expect(onChange).toHaveBeenCalledWith('all');
+  });
+
+  it('calls onChange with "essentials" when toggling from all', () => {
+    const onChange = jest.fn();
+    render(<PropertyFilter {...defaults} mode="all" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('property-filter-toggle'));
+    expect(onChange).toHaveBeenCalledWith('essentials');
+  });
+});

--- a/viewer/src/components/explorerNew/chartTypeEssentials.js
+++ b/viewer/src/components/explorerNew/chartTypeEssentials.js
@@ -1,0 +1,65 @@
+/**
+ * Chart-type-specific essential property paths.
+ *
+ * For each chart type, lists the property paths most users want to set when
+ * configuring an Insight. These power the "Show essentials only / Show all"
+ * toggle in the Insight property panel so new users aren't overwhelmed by
+ * Plotly's full property surface (e.g., 286 props for scatter).
+ *
+ * Path format matches the SchemaEditor's flat dot-notation keys (e.g.,
+ * `marker.color`, `line.width`).
+ */
+export const CHART_TYPE_ESSENTIALS = {
+  scatter: ['x', 'y', 'mode', 'name', 'marker.color', 'marker.size', 'line.color', 'line.width'],
+  bar: ['x', 'y', 'name', 'marker.color', 'marker.line.color', 'marker.line.width', 'orientation'],
+  line: ['x', 'y', 'name', 'mode', 'line.color', 'line.width', 'line.shape'],
+  pie: ['labels', 'values', 'name', 'hole', 'marker.colors', 'textposition', 'textinfo'],
+  area: ['x', 'y', 'name', 'fill', 'fillcolor', 'line.color', 'mode'],
+  histogram: ['x', 'y', 'name', 'marker.color', 'nbinsx', 'nbinsy', 'orientation'],
+  box: ['x', 'y', 'name', 'marker.color', 'boxpoints', 'jitter'],
+  heatmap: ['x', 'y', 'z', 'name', 'colorscale', 'reversescale', 'showscale'],
+  table: ['header.values', 'cells.values', 'columnwidth'],
+  indicator: ['mode', 'value', 'title.text', 'gauge.axis.range', 'delta.reference'],
+};
+
+/**
+ * Layout essentials apply to ALL chart types — the most commonly tweaked
+ * properties on the chart-level (not insight-level) Layout panel.
+ */
+export const LAYOUT_ESSENTIALS = [
+  'title.text',
+  'xaxis.title.text',
+  'xaxis.type',
+  'yaxis.title.text',
+  'yaxis.type',
+  'showlegend',
+  'legend.orientation',
+  'paper_bgcolor',
+  'plot_bgcolor',
+  'margin.t',
+  'margin.b',
+  'margin.l',
+  'margin.r',
+];
+
+/**
+ * Fallback essential paths for chart types not explicitly listed above.
+ */
+const DEFAULT_ESSENTIALS = ['x', 'y', 'name'];
+
+/**
+ * Get the essential property paths for a given Insight chart type.
+ * @param {string} chartType - The chart type (e.g., 'scatter', 'bar')
+ * @returns {Array<string>} Array of dot-notation property paths
+ */
+export function getEssentialsForChartType(chartType) {
+  return CHART_TYPE_ESSENTIALS[chartType] || DEFAULT_ESSENTIALS;
+}
+
+/**
+ * Get the essential property paths for the Layout panel.
+ * @returns {Array<string>} Array of dot-notation property paths
+ */
+export function getLayoutEssentials() {
+  return LAYOUT_ESSENTIALS;
+}

--- a/viewer/src/components/explorerNew/chartTypeEssentials.test.js
+++ b/viewer/src/components/explorerNew/chartTypeEssentials.test.js
@@ -1,0 +1,104 @@
+import {
+  CHART_TYPE_ESSENTIALS,
+  LAYOUT_ESSENTIALS,
+  getEssentialsForChartType,
+  getLayoutEssentials,
+} from './chartTypeEssentials';
+
+describe('chartTypeEssentials', () => {
+  describe('CHART_TYPE_ESSENTIALS', () => {
+    it('covers at least the 10 most common chart types', () => {
+      const expectedTypes = [
+        'scatter',
+        'bar',
+        'line',
+        'pie',
+        'area',
+        'histogram',
+        'box',
+        'heatmap',
+        'table',
+        'indicator',
+      ];
+      for (const t of expectedTypes) {
+        expect(CHART_TYPE_ESSENTIALS).toHaveProperty(t);
+        expect(Array.isArray(CHART_TYPE_ESSENTIALS[t])).toBe(true);
+        expect(CHART_TYPE_ESSENTIALS[t].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('keeps each chart type at a reasonable length (under 20 essentials)', () => {
+      Object.entries(CHART_TYPE_ESSENTIALS).forEach(([type, paths]) => {
+        expect(paths.length).toBeLessThanOrEqual(20);
+        expect(paths.length).toBeGreaterThan(0);
+        // Each path should be a non-empty string
+        paths.forEach((p) => {
+          expect(typeof p).toBe('string');
+          expect(p.length).toBeGreaterThan(0);
+          // The label is just for the assertion message; we don't read it.
+          expect(p).not.toMatch(/\s/); // no whitespace in property paths
+          // suppress unused-var lint
+          void type;
+        });
+      });
+    });
+  });
+
+  describe('getEssentialsForChartType', () => {
+    it('returns the scatter shortlist for "scatter"', () => {
+      const result = getEssentialsForChartType('scatter');
+      expect(result).toEqual([
+        'x',
+        'y',
+        'mode',
+        'name',
+        'marker.color',
+        'marker.size',
+        'line.color',
+        'line.width',
+      ]);
+    });
+
+    it('returns the bar shortlist for "bar"', () => {
+      const result = getEssentialsForChartType('bar');
+      expect(result).toContain('x');
+      expect(result).toContain('y');
+      expect(result).toContain('marker.color');
+      expect(result).toContain('orientation');
+    });
+
+    it('returns the pie shortlist for "pie"', () => {
+      const result = getEssentialsForChartType('pie');
+      expect(result).toContain('labels');
+      expect(result).toContain('values');
+      expect(result).toContain('hole');
+    });
+
+    it('returns fallback ["x", "y", "name"] for an unknown chart type', () => {
+      expect(getEssentialsForChartType('unknown_type')).toEqual(['x', 'y', 'name']);
+    });
+
+    it('returns fallback for null/undefined chart type', () => {
+      expect(getEssentialsForChartType(undefined)).toEqual(['x', 'y', 'name']);
+      expect(getEssentialsForChartType(null)).toEqual(['x', 'y', 'name']);
+    });
+  });
+
+  describe('getLayoutEssentials', () => {
+    it('returns the layout shortlist', () => {
+      const result = getLayoutEssentials();
+      expect(result).toEqual(LAYOUT_ESSENTIALS);
+      expect(result).toContain('title.text');
+      expect(result).toContain('xaxis.title.text');
+      expect(result).toContain('yaxis.title.text');
+      expect(result).toContain('showlegend');
+      expect(result).toContain('paper_bgcolor');
+      expect(result).toContain('plot_bgcolor');
+    });
+
+    it('keeps the layout shortlist at a reasonable size (under 20)', () => {
+      expect(getLayoutEssentials().length).toBeLessThanOrEqual(20);
+      expect(getLayoutEssentials().length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/viewer/src/components/new-views/common/SchemaEditor/SchemaEditor.jsx
+++ b/viewer/src/components/new-views/common/SchemaEditor/SchemaEditor.jsx
@@ -19,6 +19,11 @@ import {
  * @param {Array<string>} props.initiallyExpanded - Properties to show by default
  * @param {boolean} props.disabled - Whether the editor is disabled
  * @param {boolean} props.droppable - Whether property rows support DnD drops
+ * @param {Array<string>|null} props.filterToKeys - When non-empty, restricts the
+ *   visible/pickable property list to these dot-notation paths. When null or
+ *   undefined, shows all properties (current behavior).
+ * @param {boolean} props.hidePropertyCount - When true, suppresses the built-in
+ *   "X of Y properties" summary (caller is rendering its own count UI).
  */
 export function SchemaEditor({
   schema,
@@ -28,6 +33,8 @@ export function SchemaEditor({
   initiallyExpanded = [],
   disabled = false,
   droppable = false,
+  filterToKeys = null,
+  hidePropertyCount = false,
 }) {
   const [addedProperties, setAddedProperties] = useState(() => new Set(initiallyExpanded));
   const [showPropertyPicker, setShowPropertyPicker] = useState(false);
@@ -37,8 +44,15 @@ export function SchemaEditor({
   const allProperties = useMemo(() => {
     if (!schema) return [];
     const flattened = flattenSchemaProperties(schema, '', defs);
-    return flattened.filter(prop => !excludeProperties.includes(prop.path.split('.')[0]));
-  }, [schema, defs, excludeProperties]);
+    const afterExcludes = flattened.filter(
+      prop => !excludeProperties.includes(prop.path.split('.')[0])
+    );
+    if (Array.isArray(filterToKeys) && filterToKeys.length > 0) {
+      const allowed = new Set(filterToKeys);
+      return afterExcludes.filter(prop => allowed.has(prop.path));
+    }
+    return afterExcludes;
+  }, [schema, defs, excludeProperties, filterToKeys]);
 
   const displayedProperties = useMemo(() => {
     return allProperties.filter(prop => addedProperties.has(prop.path));
@@ -145,9 +159,11 @@ export function SchemaEditor({
           {showPropertyPicker ? 'Hide Properties' : 'Add Properties'}
         </button>
 
-        <span className="ml-auto text-xs text-gray-500">
-          {displayedProperties.length} of {allProperties.length} properties
-        </span>
+        {!hidePropertyCount && (
+          <span className="ml-auto text-xs text-gray-500">
+            {displayedProperties.length} of {allProperties.length} properties
+          </span>
+        )}
       </div>
 
       {/* Property search/picker */}

--- a/viewer/src/components/new-views/common/SchemaEditor/SchemaEditor.test.jsx
+++ b/viewer/src/components/new-views/common/SchemaEditor/SchemaEditor.test.jsx
@@ -198,4 +198,54 @@ describe('SchemaEditor', () => {
     // onChange should be called
     expect(onChange).toHaveBeenCalled();
   });
+
+  describe('filterToKeys', () => {
+    it('restricts pickable properties to filterToKeys when provided', () => {
+      render(<SchemaEditor {...defaultProps} filterToKeys={['x', 'y']} />);
+
+      // Open picker
+      fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+      // x and y should be pickable
+      expect(screen.getByText('x')).toBeInTheDocument();
+      expect(screen.getByText('y')).toBeInTheDocument();
+      // mode and name should NOT be pickable (filtered out)
+      expect(screen.queryByText('mode')).not.toBeInTheDocument();
+      expect(screen.queryByText('name')).not.toBeInTheDocument();
+    });
+
+    it('shows the filtered count in the property summary', () => {
+      render(<SchemaEditor {...defaultProps} filterToKeys={['x', 'y']} />);
+      // The full schema has multiple properties; filter should restrict to 2
+      const counts = screen.getAllByText(/of 2 properties/);
+      expect(counts.length).toBeGreaterThan(0);
+    });
+
+    it('shows full schema when filterToKeys is null', () => {
+      render(<SchemaEditor {...defaultProps} filterToKeys={null} />);
+      fireEvent.click(screen.getByRole('button', { name: /add/i }));
+      expect(screen.getByText('mode')).toBeInTheDocument();
+      expect(screen.getByText('name')).toBeInTheDocument();
+    });
+
+    it('shows full schema when filterToKeys is an empty array', () => {
+      render(<SchemaEditor {...defaultProps} filterToKeys={[]} />);
+      fireEvent.click(screen.getByRole('button', { name: /add/i }));
+      expect(screen.getByText('mode')).toBeInTheDocument();
+    });
+  });
+
+  describe('hidePropertyCount', () => {
+    it('hides the built-in property count when hidePropertyCount=true', () => {
+      render(<SchemaEditor {...defaultProps} hidePropertyCount={true} />);
+      const propertyCountTexts = screen.queryAllByText(/of.*properties/);
+      expect(propertyCountTexts.length).toBe(0);
+    });
+
+    it('shows the built-in property count when hidePropertyCount=false (default)', () => {
+      render(<SchemaEditor {...defaultProps} />);
+      const propertyCountTexts = screen.getAllByText(/of.*properties/);
+      expect(propertyCountTexts.length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Demo

<!-- DROP VIDEO HERE: /tmp/visivo-pr-videos/7-property-filtering.mp4 -->

_Drop the demo video above. File is at `/tmp/visivo-pr-videos/7-property-filtering.mp4` on the maintainer's machine._

---

## Summary

Replaces the terrifying "0 of 1366 properties" / "2 of 286 properties" copy in the Insight + Layout panels with `"<N> essential properties — Show all (<total>)"`. Default filter shows the ~10-12 props most users want for the selected chart type; toggle reveals the full schema. Per-chart-type localStorage so user choice persists. Closes **Friction #14** from the dogfood walkthrough.

## What ships

- `chartTypeEssentials.js` — per-chart-type essential-properties list for the top 10 chart types (scatter, bar, line, pie, area, histogram, box, heatmap, table, indicator) plus a fallback for unknowns.
- `LAYOUT_ESSENTIALS` shortlist (title, axis titles, legend, margins).
- `PropertyFilter.jsx` — small toggle UI between `essentials` and `all` modes.
- `SchemaEditor.jsx` adds a `filterToKeys` allowlist prop (backwards-compatible no-op when not set) and `hidePropertyCount` prop.
- `InsightCRUDSection.jsx` and `ChartCRUDSection.jsx` wire the toggle + persist via `visivo_property_filter_mode_${chartType}` and `visivo_property_filter_mode_layout`.

## Test plan

- [x] Viewer unit + lint — 1456 / 1456 pass
- [x] Property-filter focused suite — 64/64
- [x] SchemaEditor regression — 257/257
- [x] Playwright e2e — `insight-property-filtering.spec.mjs` 3/3 pass on sandbox `:8017/:3017`
- [x] Python — 1679 pass, 0 failed (verified via follow-up agent on native arm64 venv)

## Demo

Video above shows: Insight panel renders "8 essential properties — Show all (286)" → click toggle → flips to "286 total properties — Show essentials only". Layout: "13 essential — Show all (1366)" → toggle → reload → preserved.

Worktree: `/tmp/visivo-wt-property-filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
