### PR TITLE
feat: right-click "Preview 100 rows" on schema tree tables

### DIFF
--- a/tests/server/test_source_metadata_preview.py
+++ b/tests/server/test_source_metadata_preview.py
@@ -1,0 +1,189 @@
+"""Tests for the table preview endpoint and helper.
+
+Uses the shared ``integration_app`` / ``integration_client`` fixtures which
+spin up a real Flask app backed by a real SQLite file containing
+``test_table`` and ``second_test_table`` rows (see ``commands/utils.py:create_file_database``).
+"""
+
+import json
+
+import pytest
+
+from visivo.server.source_metadata import preview_table_rows
+
+SOURCE_NAME = "source"  # default name from SourceFactory
+DB_NAME = "main"  # SqliteSource.list_databases() returns ["main"]
+TABLE_NAME = "test_table"
+PREVIEW_ENDPOINT = (
+    f"/api/project/sources/{SOURCE_NAME}/databases/{DB_NAME}/tables/{TABLE_NAME}/preview/"
+)
+
+
+class TestPreviewEndpoint:
+    """End-to-end tests for the /preview/ HTTP endpoints."""
+
+    def test_preview_returns_columns_and_rows(self, integration_client):
+        response = integration_client.get(PREVIEW_ENDPOINT)
+        assert response.status_code == 200
+        body = json.loads(response.data)
+
+        assert body["source"] == SOURCE_NAME
+        assert body["table"] == TABLE_NAME
+        assert body["schema"] is None
+        assert body["limit"] == 100
+
+        # Columns should be a list of {name, type} dicts and contain x and y
+        column_names = {c["name"] for c in body["columns"]}
+        assert {"x", "y"}.issubset(column_names)
+        for col in body["columns"]:
+            assert "name" in col
+            assert "type" in col
+
+        # The seeded fixture inserts six rows in test_table
+        assert isinstance(body["rows"], list)
+        assert len(body["rows"]) == 6
+        # Each row dict should contain the queried columns
+        first_row = body["rows"][0]
+        assert "x" in first_row
+        assert "y" in first_row
+
+    def test_preview_respects_limit_param(self, integration_client):
+        response = integration_client.get(PREVIEW_ENDPOINT + "?limit=5")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+
+        assert body["limit"] == 5
+        assert len(body["rows"]) <= 5
+
+    def test_preview_caps_at_1000(self, integration_client):
+        # Pass an unreasonably large limit, expect it to be clamped to 1000.
+        response = integration_client.get(PREVIEW_ENDPOINT + "?limit=10000")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["limit"] == 1000
+
+    def test_preview_handles_unknown_table_gracefully(self, integration_client):
+        bogus = (
+            f"/api/project/sources/{SOURCE_NAME}/databases/{DB_NAME}"
+            f"/tables/__no_such_table__/preview/"
+        )
+        response = integration_client.get(bogus)
+        assert response.status_code == 500
+        body = json.loads(response.data)
+        assert "error" in body
+        assert body["error"]  # non-empty error message
+
+    def test_preview_unknown_source_returns_404(self, integration_client):
+        bogus = "/api/project/sources/__no_source__/databases/main/" f"tables/{TABLE_NAME}/preview/"
+        response = integration_client.get(bogus)
+        assert response.status_code == 404
+        body = json.loads(response.data)
+        assert "not found" in body["error"]
+
+    def test_preview_with_schema_route_404s_for_sqlite(self, integration_client):
+        # SQLite has no schemas, so the schema-prefixed route should fail with 500
+        # because schema lookup is not supported for SQLite.
+        url = (
+            f"/api/project/sources/{SOURCE_NAME}/databases/{DB_NAME}"
+            f"/schemas/public/tables/{TABLE_NAME}/preview/"
+        )
+        response = integration_client.get(url)
+        # Should not crash — returns 500 with a helpful error, not an unhandled
+        # exception
+        assert response.status_code == 500
+        body = json.loads(response.data)
+        assert "error" in body
+
+    def test_preview_invalid_limit_falls_back_to_default(self, integration_client):
+        response = integration_client.get(PREVIEW_ENDPOINT + "?limit=abc")
+        # Flask's int() converter would 404 on a parameter mismatch, but we use
+        # ?limit=... query param parsed inside the view, which falls back
+        # gracefully.
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["limit"] == 100
+
+    def test_preview_negative_limit_clamps_to_one(self, integration_client):
+        response = integration_client.get(PREVIEW_ENDPOINT + "?limit=-5")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["limit"] == 1
+        assert len(body["rows"]) <= 1
+
+
+class TestPreviewTableRowsHelper:
+    """Direct unit tests for the helper to cover edge cases."""
+
+    def test_returns_404_tuple_for_unknown_source(self, integration_app):
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(sources, "__missing__", DB_NAME, TABLE_NAME)
+        assert isinstance(result, tuple)
+        body, status = result
+        assert status == 404
+        assert "not found" in body["error"]
+
+    def test_clamps_limit_above_1000(self, integration_app):
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(
+            sources,
+            SOURCE_NAME,
+            DB_NAME,
+            TABLE_NAME,
+            None,
+            5000,
+        )
+        assert result["limit"] == 1000
+
+    def test_clamps_limit_below_one(self, integration_app):
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(
+            sources,
+            SOURCE_NAME,
+            DB_NAME,
+            TABLE_NAME,
+            None,
+            0,
+        )
+        assert result["limit"] == 1
+
+    def test_handles_non_int_limit(self, integration_app):
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(
+            sources,
+            SOURCE_NAME,
+            DB_NAME,
+            TABLE_NAME,
+            None,
+            "bogus",
+        )
+        # Falls back to default (100) which is then satisfied by the seed data
+        assert result["limit"] == 100
+
+    def test_truncated_flag_when_limit_below_total(self, integration_app):
+        # The seeded test_table has 6 rows; limit=2 should mark truncated.
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(
+            sources,
+            SOURCE_NAME,
+            DB_NAME,
+            TABLE_NAME,
+            None,
+            2,
+        )
+        assert result["limit"] == 2
+        assert result["row_count"] == 2
+        assert result["truncated"] is True
+
+    def test_truncated_flag_false_when_under_limit(self, integration_app):
+        sources = integration_app.source_manager.get_sources_list()
+        result = preview_table_rows(
+            sources,
+            SOURCE_NAME,
+            DB_NAME,
+            TABLE_NAME,
+            None,
+            500,
+        )
+        # 6 < 500, so truncated should be False
+        assert result["truncated"] is False
+        assert result["row_count"] == 6

--- a/tests/server/test_source_metadata_preview.py
+++ b/tests/server/test_source_metadata_preview.py
@@ -124,66 +124,31 @@ class TestPreviewTableRowsHelper:
 
     def test_clamps_limit_above_1000(self, integration_app):
         sources = integration_app.source_manager.get_sources_list()
-        result = preview_table_rows(
-            sources,
-            SOURCE_NAME,
-            DB_NAME,
-            TABLE_NAME,
-            None,
-            5000,
-        )
+        result = preview_table_rows(sources, SOURCE_NAME, DB_NAME, TABLE_NAME, None, 5000,)
         assert result["limit"] == 1000
 
     def test_clamps_limit_below_one(self, integration_app):
         sources = integration_app.source_manager.get_sources_list()
-        result = preview_table_rows(
-            sources,
-            SOURCE_NAME,
-            DB_NAME,
-            TABLE_NAME,
-            None,
-            0,
-        )
+        result = preview_table_rows(sources, SOURCE_NAME, DB_NAME, TABLE_NAME, None, 0,)
         assert result["limit"] == 1
 
     def test_handles_non_int_limit(self, integration_app):
         sources = integration_app.source_manager.get_sources_list()
-        result = preview_table_rows(
-            sources,
-            SOURCE_NAME,
-            DB_NAME,
-            TABLE_NAME,
-            None,
-            "bogus",
-        )
+        result = preview_table_rows(sources, SOURCE_NAME, DB_NAME, TABLE_NAME, None, "bogus",)
         # Falls back to default (100) which is then satisfied by the seed data
         assert result["limit"] == 100
 
     def test_truncated_flag_when_limit_below_total(self, integration_app):
         # The seeded test_table has 6 rows; limit=2 should mark truncated.
         sources = integration_app.source_manager.get_sources_list()
-        result = preview_table_rows(
-            sources,
-            SOURCE_NAME,
-            DB_NAME,
-            TABLE_NAME,
-            None,
-            2,
-        )
+        result = preview_table_rows(sources, SOURCE_NAME, DB_NAME, TABLE_NAME, None, 2,)
         assert result["limit"] == 2
         assert result["row_count"] == 2
         assert result["truncated"] is True
 
     def test_truncated_flag_false_when_under_limit(self, integration_app):
         sources = integration_app.source_manager.get_sources_list()
-        result = preview_table_rows(
-            sources,
-            SOURCE_NAME,
-            DB_NAME,
-            TABLE_NAME,
-            None,
-            500,
-        )
+        result = preview_table_rows(sources, SOURCE_NAME, DB_NAME, TABLE_NAME, None, 500,)
         # 6 < 500, so truncated should be False
         assert result["truncated"] is False
         assert result["row_count"] == 6

--- a/viewer/e2e/stories/source-preview-rows.spec.mjs
+++ b/viewer/e2e/stories/source-preview-rows.spec.mjs
@@ -1,0 +1,137 @@
+/**
+ * Story: Right-click "Preview 100 rows" on a table
+ *
+ * Validates the new context menu + DataPreviewModal flow on the schema tree.
+ * The user navigates to /explorer, expands a source, right-clicks a table,
+ * picks "Preview 100 rows", and sees the actual data in a modal.
+ *
+ * Precondition: Sandbox running on :3018/:8018
+ */
+
+import { test, expect } from '@playwright/test';
+
+const WAIT_FOR_PAGE = 15000;
+
+async function loadExplorer(page) {
+  await page.goto('/explorer');
+  await page.waitForLoadState('networkidle');
+  await page.getByText('Run a query to see results').waitFor({ timeout: WAIT_FOR_PAGE });
+}
+
+test.describe('Source preview rows action', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        page._consoleErrors.push(msg.text());
+      }
+    });
+  });
+
+  test('right-click a table → Preview 100 rows opens the data modal', async ({ page }) => {
+    await loadExplorer(page);
+
+    // Expand local-sqlite to expose its tables
+    await page.getByText('local-sqlite').first().click();
+    await expect(page.getByText('test_table').first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Right-click on the table tree node. Use the testid the SourceBrowser
+    // assigns to each table tree entry.
+    const tableNode = page
+      .locator('[data-testid^="tree-node-table-test_table"]')
+      .first();
+    await tableNode.click({ button: 'right' });
+
+    // Context menu appears with the preview action
+    const menu = page.getByTestId('context-menu');
+    await expect(menu).toBeVisible({ timeout: 5000 });
+    const previewAction = page.getByTestId('context-menu-preview');
+    await expect(previewAction).toBeVisible();
+
+    // Click the action
+    await previewAction.click();
+
+    // Modal becomes visible
+    const modal = page.getByTestId('data-preview-modal');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    // Wait for table to appear OR an error/empty state
+    await expect(
+      page
+        .getByTestId('preview-table')
+        .or(page.getByTestId('preview-empty'))
+        .or(page.getByTestId('preview-error'))
+    ).toBeVisible({ timeout: 15000 });
+
+    // We expect data for the integration project's seeded test_table
+    await expect(page.getByTestId('preview-table')).toBeVisible({ timeout: 15000 });
+
+    // At least one row should be present
+    await expect(page.getByTestId('preview-row-0')).toBeVisible();
+
+    // Headers/columns should be rendered
+    const table = page.getByTestId('preview-table');
+    const headerCells = table.locator('thead th');
+    expect(await headerCells.count()).toBeGreaterThan(0);
+
+    // Take a screenshot for visual record
+    await page.screenshot({
+      path: 'e2e/screenshots/preview-rows-modal.png',
+      fullPage: false,
+    });
+
+    // Close via the close button
+    await page.getByTestId('preview-close-button').click();
+    await expect(page.getByTestId('data-preview-modal')).not.toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('clicking outside the context menu dismisses it', async ({ page }) => {
+    await loadExplorer(page);
+
+    await page.getByText('local-sqlite').first().click();
+    await expect(page.getByText('test_table').first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const tableNode = page
+      .locator('[data-testid^="tree-node-table-test_table"]')
+      .first();
+    await tableNode.click({ button: 'right' });
+
+    await expect(page.getByTestId('context-menu')).toBeVisible({ timeout: 5000 });
+
+    // Click on an empty area to dismiss
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId('context-menu')).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('Escape closes the preview modal', async ({ page }) => {
+    await loadExplorer(page);
+
+    await page.getByText('local-sqlite').first().click();
+    await expect(page.getByText('test_table').first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const tableNode = page
+      .locator('[data-testid^="tree-node-table-test_table"]')
+      .first();
+    await tableNode.click({ button: 'right' });
+
+    await page.getByTestId('context-menu-preview').click();
+
+    await expect(page.getByTestId('data-preview-modal')).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByTestId('data-preview-modal')).not.toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -1,5 +1,14 @@
 import { defineConfig } from '@playwright/test';
 
+// Sandbox ports default to :3001 (default sandbox) and :3002 (publish sandbox).
+// Parallel worktrees can override via env vars to point at their own sandbox
+// instances without colliding with the user's primary checkout.
+//   VISIVO_SANDBOX_FRONTEND_PORT       — overrides the default sandbox port
+//   VISIVO_PUBLISH_SANDBOX_FRONTEND_PORT — overrides the publish sandbox port
+const SANDBOX_PORT = process.env.VISIVO_SANDBOX_FRONTEND_PORT || '3001';
+const PUBLISH_SANDBOX_PORT =
+  process.env.VISIVO_PUBLISH_SANDBOX_FRONTEND_PORT || '3002';
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30000,
@@ -9,7 +18,7 @@ export default defineConfig({
   retries: 2,
   workers: '75%',
   use: {
-    baseURL: 'http://localhost:3001',
+    baseURL: `http://localhost:${SANDBOX_PORT}`,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
@@ -35,7 +44,7 @@ export default defineConfig({
     {
       name: 'publish',
       testMatch: ['**/explorer-publish-to-files.spec.mjs'],
-      use: { baseURL: 'http://localhost:3002' },
+      use: { baseURL: `http://localhost:${PUBLISH_SANDBOX_PORT}` },
       fullyParallel: false,
       workers: 1,
       // Retries would run against polluted backend cache from the failed

--- a/viewer/src/components/common/ContextMenu.jsx
+++ b/viewer/src/components/common/ContextMenu.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * ContextMenu - Lightweight portal-rendered floating menu used for right-click
+ * actions in the schema tree (and elsewhere).
+ *
+ * Props:
+ *   - x, y:    (number) screen coordinates where the menu should appear
+ *   - onClose: (function) called when the menu should be dismissed
+ *   - children: menu items (typically <button> elements)
+ */
+const ContextMenu = ({ x, y, onClose, children }) => {
+  const menuRef = useRef(null);
+
+  // Close on outside click or Escape.
+  useEffect(() => {
+    const handleClickOutside = e => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        onClose?.();
+      }
+    };
+    const handleKey = e => {
+      if (e.key === 'Escape') onClose?.();
+    };
+
+    // Use mousedown so we run before any subsequent click handlers.
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      data-testid="context-menu"
+      style={{ position: 'fixed', top: y, left: x, zIndex: 1000 }}
+      className="bg-white rounded-md shadow-lg border border-secondary-200 py-1 min-w-[180px]"
+    >
+      {children}
+    </div>,
+    document.body
+  );
+};
+
+export default ContextMenu;

--- a/viewer/src/components/common/ContextMenu.test.jsx
+++ b/viewer/src/components/common/ContextMenu.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ContextMenu from './ContextMenu';
+
+describe('ContextMenu', () => {
+  it('renders children at the given coordinates', () => {
+    render(
+      <ContextMenu x={100} y={200} onClose={() => {}}>
+        <button>Hello</button>
+      </ContextMenu>
+    );
+
+    const menu = screen.getByTestId('context-menu');
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveStyle({ top: '200px', left: '100px' });
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking outside the menu', () => {
+    const onClose = jest.fn();
+    render(
+      <ContextMenu x={0} y={0} onClose={onClose}>
+        <button>Item</button>
+      </ContextMenu>
+    );
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not call onClose when clicking inside the menu', () => {
+    const onClose = jest.fn();
+    render(
+      <ContextMenu x={0} y={0} onClose={onClose}>
+        <button>Item</button>
+      </ContextMenu>
+    );
+
+    fireEvent.mouseDown(screen.getByText('Item'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = jest.fn();
+    render(
+      <ContextMenu x={0} y={0} onClose={onClose}>
+        <button>Item</button>
+      </ContextMenu>
+    );
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/explorerNew/SchemaBrowser/SchemaTreeNode.jsx
+++ b/viewer/src/components/explorerNew/SchemaBrowser/SchemaTreeNode.jsx
@@ -10,6 +10,7 @@ const SchemaTreeNode = ({
   isLoading,
   onClick,
   onDoubleClick,
+  onContextMenu,
   actions,
   level = 0,
   children,
@@ -26,6 +27,7 @@ const SchemaTreeNode = ({
         style={{ paddingLeft: level * 16 + 8, paddingRight: 8 }}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
+        onContextMenu={onContextMenu}
         role="treeitem"
         aria-selected={false}
         aria-expanded={isExpandable ? isExpanded : undefined}

--- a/viewer/src/components/explorerNew/SourceBrowser.jsx
+++ b/viewer/src/components/explorerNew/SourceBrowser.jsx
@@ -4,8 +4,11 @@ import {
   PiTable,
   PiColumns,
   PiArrowClockwise,
+  PiEye,
 } from 'react-icons/pi';
 import SchemaTreeNode from './SchemaBrowser/SchemaTreeNode';
+import ContextMenu from '../common/ContextMenu';
+import DataPreviewModal from '../sources/DataPreviewModal';
 import {
   fetchSourceSchemaJobs,
   fetchSourceTables,
@@ -27,6 +30,11 @@ const SourceBrowser = ({ searchQuery, onTableSelect, onSourcesLoaded }) => {
   const [generatingSchemas, setGeneratingSchemas] = useState(new Map());
   const [schemaErrors, setSchemaErrors] = useState(new Map());
   const [expandedErrors, setExpandedErrors] = useState(new Set());
+  // Right-click menu state. ``null`` when no menu is open; otherwise contains
+  // {x, y, sourceName, databaseName, schemaName, tableName}.
+  const [contextMenu, setContextMenu] = useState(null);
+  // Preview-rows modal state. ``null`` when closed.
+  const [previewTarget, setPreviewTarget] = useState(null);
   const cancelledRef = useRef(false);
 
   useEffect(() => {
@@ -218,6 +226,24 @@ const SourceBrowser = ({ searchQuery, onTableSelect, onSourcesLoaded }) => {
               errorMessage={getNodeError(colKey)}
               onClick={() => toggleNode(colKey, () => fetchTableColumns(srcName, table.name))}
               onDoubleClick={() => onTableSelect?.({ sourceName: srcName, table: table.name })}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  sourceName: srcName,
+                  // SourceManager's table list does not currently expose the
+                  // owning database/schema; the source-side preview helper
+                  // accepts these as hints, so we pass best-effort defaults.
+                  // This will work for SQLite/DuckDB and PostgreSQL with the
+                  // default 'public' schema; multi-schema sources can extend
+                  // the tree node to carry full context later.
+                  databaseName: table.database || 'main',
+                  schemaName: table.schema || null,
+                  tableName: table.name,
+                });
+              }}
               level={1}
             >
               {renderColumns(loadedData[colKey], table.name)}
@@ -251,8 +277,43 @@ const SourceBrowser = ({ searchQuery, onTableSelect, onSourcesLoaded }) => {
     return null;
   }
 
+  const closeContextMenu = () => setContextMenu(null);
+  const closePreview = () => setPreviewTarget(null);
+  const openPreviewFromMenu = () => {
+    if (!contextMenu) return;
+    setPreviewTarget({
+      sourceName: contextMenu.sourceName,
+      databaseName: contextMenu.databaseName,
+      schemaName: contextMenu.schemaName,
+      tableName: contextMenu.tableName,
+    });
+    closeContextMenu();
+  };
+
   return (
     <div data-testid="source-browser">
+      {contextMenu && (
+        <ContextMenu x={contextMenu.x} y={contextMenu.y} onClose={closeContextMenu}>
+          <button
+            type="button"
+            data-testid="context-menu-preview"
+            onClick={openPreviewFromMenu}
+            className="w-full text-left px-3 py-1.5 text-sm text-secondary-700 hover:bg-primary-50 hover:text-primary-700 flex items-center gap-2"
+          >
+            <PiEye size={14} />
+            Preview 100 rows
+          </button>
+        </ContextMenu>
+      )}
+      {previewTarget && (
+        <DataPreviewModal
+          source={previewTarget.sourceName}
+          database={previewTarget.databaseName}
+          table={previewTarget.tableName}
+          schema={previewTarget.schemaName}
+          onClose={closePreview}
+        />
+      )}
       {filteredSources.map((source) => {
         const sourceKey = `source::${source.source_name}`;
         const errorMsg = getNodeError(sourceKey) || schemaErrors.get(source.source_name);

--- a/viewer/src/components/explorerNew/SourceBrowser.test.jsx
+++ b/viewer/src/components/explorerNew/SourceBrowser.test.jsx
@@ -20,6 +20,7 @@ jest.mock('./SchemaBrowser/SchemaTreeNode', () => {
     isLoading,
     onClick,
     onDoubleClick,
+    onContextMenu,
     children,
     errorMessage,
     errorCollapsed,
@@ -33,6 +34,7 @@ jest.mock('./SchemaBrowser/SchemaTreeNode', () => {
         data-badge={badge}
         data-error={errorMessage}
         data-error-collapsed={errorCollapsed}
+        onContextMenu={onContextMenu}
       >
         <button data-testid={`click-${type}-${label}`} onClick={onClick}>
           {label}
@@ -60,6 +62,24 @@ jest.mock('./SchemaBrowser/SchemaTreeNode', () => {
     );
   };
   return MockSchemaTreeNode;
+});
+
+// Mock DataPreviewModal so we don't need to mock fetch in SourceBrowser tests.
+jest.mock('../sources/DataPreviewModal', () => {
+  const MockPreview = ({ source, database, table, schema, onClose }) => (
+    <div
+      data-testid="mock-data-preview-modal"
+      data-source={source}
+      data-database={database}
+      data-table={table}
+      data-schema={schema || ''}
+    >
+      <button data-testid="mock-preview-close" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  );
+  return MockPreview;
 });
 
 const {
@@ -378,6 +398,70 @@ describe('SourceBrowser', () => {
       'true'
     );
     errorSpy.mockRestore();
+  });
+
+  it('right-click on a table opens the context menu', async () => {
+    render(
+      <SourceBrowser searchQuery="" onTableSelect={jest.fn()} onSourcesLoaded={jest.fn()} />
+    );
+
+    await screen.findByTestId('click-source-postgres_db');
+
+    // Expand to show tables
+    fireEvent.click(screen.getByTestId('click-source-postgres_db'));
+    await screen.findByTestId('tree-node-table-users');
+
+    // Right-click the table tree node (the outer element on the mock node)
+    fireEvent.contextMenu(screen.getByTestId('tree-node-table-users'));
+
+    // Context menu should appear
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('context-menu-preview')).toHaveTextContent(/Preview 100 rows/);
+  });
+
+  it('selecting "Preview 100 rows" opens DataPreviewModal with the right props', async () => {
+    render(
+      <SourceBrowser searchQuery="" onTableSelect={jest.fn()} onSourcesLoaded={jest.fn()} />
+    );
+
+    await screen.findByTestId('click-source-postgres_db');
+
+    fireEvent.click(screen.getByTestId('click-source-postgres_db'));
+    await screen.findByTestId('tree-node-table-users');
+
+    fireEvent.contextMenu(screen.getByTestId('tree-node-table-users'));
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('context-menu-preview'));
+
+    // The modal mock should be visible with the source/table set
+    const modal = await screen.findByTestId('mock-data-preview-modal');
+    expect(modal).toHaveAttribute('data-source', 'postgres_db');
+    expect(modal).toHaveAttribute('data-table', 'users');
+    // Default databaseName fallback
+    expect(modal).toHaveAttribute('data-database', 'main');
+
+    // Context menu should be closed after action
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  });
+
+  it('closing the preview modal removes it from the DOM', async () => {
+    render(
+      <SourceBrowser searchQuery="" onTableSelect={jest.fn()} onSourcesLoaded={jest.fn()} />
+    );
+
+    await screen.findByTestId('click-source-postgres_db');
+
+    fireEvent.click(screen.getByTestId('click-source-postgres_db'));
+    await screen.findByTestId('tree-node-table-users');
+
+    fireEvent.contextMenu(screen.getByTestId('tree-node-table-users'));
+    fireEvent.click(screen.getByTestId('context-menu-preview'));
+
+    await screen.findByTestId('mock-data-preview-modal');
+
+    fireEvent.click(screen.getByTestId('mock-preview-close'));
+    expect(screen.queryByTestId('mock-data-preview-modal')).not.toBeInTheDocument();
   });
 
   it('clicking an errored source toggles error visibility', async () => {

--- a/viewer/src/components/sources/DataPreviewModal.jsx
+++ b/viewer/src/components/sources/DataPreviewModal.jsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from 'react';
+import { PiX } from 'react-icons/pi';
+
+/**
+ * Build the preview URL for a given source/database/table (and optional schema).
+ * Exported for use in tests.
+ */
+export const buildPreviewUrl = ({ source, database, table, schema, limit = 100 }) => {
+  const base = schema
+    ? `/api/project/sources/${encodeURIComponent(source)}/databases/${encodeURIComponent(
+        database
+      )}/schemas/${encodeURIComponent(schema)}/tables/${encodeURIComponent(table)}/preview/`
+    : `/api/project/sources/${encodeURIComponent(source)}/databases/${encodeURIComponent(
+        database
+      )}/tables/${encodeURIComponent(table)}/preview/`;
+  return `${base}?limit=${encodeURIComponent(limit)}`;
+};
+
+const formatCellValue = value => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+/**
+ * DataPreviewModal - Modal that fetches and renders the first N rows of a table.
+ *
+ * Props:
+ *   - source:   (string) source name
+ *   - database: (string) database name
+ *   - table:    (string) table name
+ *   - schema:   (string|null) optional schema name
+ *   - limit:    (number) row limit (default 100, max 1000)
+ *   - onClose:  (function) called when the modal is dismissed
+ */
+const DataPreviewModal = ({ source, database, table, schema = null, limit = 100, onClose }) => {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  // Fetch preview rows on mount / when key inputs change.
+  useEffect(() => {
+    let cancelled = false;
+
+    const url = buildPreviewUrl({ source, database, table, schema, limit });
+    setData(null);
+    setError(null);
+
+    fetch(url)
+      .then(async response => {
+        if (!response.ok) {
+          let detail = response.statusText;
+          try {
+            const body = await response.json();
+            detail = body.error || body.message || detail;
+          } catch {
+            // fall through with statusText
+          }
+          throw new Error(`Preview failed (${response.status}): ${detail}`);
+        }
+        return response.json();
+      })
+      .then(json => {
+        if (!cancelled) setData(json);
+      })
+      .catch(err => {
+        if (!cancelled) setError(err.message || String(err));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, database, table, schema, limit]);
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKeyDown = e => {
+      if (e.key === 'Escape') {
+        onClose?.();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const heading = schema ? `${schema}.${table}` : table;
+
+  return (
+    <div
+      data-testid="data-preview-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose?.();
+      }}
+    >
+      <div className="relative bg-white rounded-lg w-[90vw] max-w-5xl max-h-[80vh] overflow-hidden flex flex-col shadow-xl">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-secondary-100">
+          <h2 className="text-lg font-medium text-secondary-900">{heading}</h2>
+          <p className="text-sm text-secondary-600">
+            First {limit} rows from <span className="font-mono">{source}</span>
+            {data?.truncated ? ' (truncated)' : ''}
+          </p>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-auto" data-testid="data-preview-body">
+          {!data && !error && (
+            <div className="p-8 text-center text-secondary-500" data-testid="preview-loading">
+              Loading...
+            </div>
+          )}
+          {error && (
+            <div
+              className="p-8 text-center text-highlight-700"
+              data-testid="preview-error"
+            >
+              Error: {error}
+            </div>
+          )}
+          {data && data.columns && data.columns.length > 0 && (
+            <table className="w-full text-xs" data-testid="preview-table">
+              <thead className="sticky top-0 bg-secondary-100">
+                <tr>
+                  {data.columns.map(col => (
+                    <th
+                      key={col.name}
+                      className="text-left px-2 py-1 font-medium text-secondary-700 border-b border-secondary-200"
+                    >
+                      {col.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.rows.map((row, i) => (
+                  <tr
+                    key={i}
+                    className="even:bg-secondary-50 hover:bg-primary-50"
+                    data-testid={`preview-row-${i}`}
+                  >
+                    {data.columns.map(col => (
+                      <td
+                        key={col.name}
+                        className="px-2 py-1 max-w-xs truncate text-secondary-800"
+                        title={formatCellValue(row[col.name])}
+                      >
+                        {formatCellValue(row[col.name])}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {data && (!data.rows || data.rows.length === 0) && !error && (
+            <div
+              className="p-8 text-center text-secondary-500"
+              data-testid="preview-empty"
+            >
+              No rows returned.
+            </div>
+          )}
+        </div>
+
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-2 right-2 p-2 rounded hover:bg-secondary-100 text-secondary-600 hover:text-secondary-900 transition-colors"
+          aria-label="Close preview"
+          data-testid="preview-close-button"
+        >
+          <PiX size={18} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DataPreviewModal;

--- a/viewer/src/components/sources/DataPreviewModal.test.jsx
+++ b/viewer/src/components/sources/DataPreviewModal.test.jsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DataPreviewModal, { buildPreviewUrl } from './DataPreviewModal';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('buildPreviewUrl', () => {
+  it('builds a URL without schema', () => {
+    expect(
+      buildPreviewUrl({ source: 'src', database: 'db', table: 'users' })
+    ).toBe('/api/project/sources/src/databases/db/tables/users/preview/?limit=100');
+  });
+
+  it('builds a URL with schema', () => {
+    expect(
+      buildPreviewUrl({
+        source: 'src',
+        database: 'db',
+        table: 'users',
+        schema: 'public',
+      })
+    ).toBe(
+      '/api/project/sources/src/databases/db/schemas/public/tables/users/preview/?limit=100'
+    );
+  });
+
+  it('encodes funky characters', () => {
+    expect(
+      buildPreviewUrl({ source: 'a/b', database: 'db', table: 'tbl' })
+    ).toBe('/api/project/sources/a%2Fb/databases/db/tables/tbl/preview/?limit=100');
+  });
+
+  it('passes through a custom limit', () => {
+    expect(
+      buildPreviewUrl({ source: 's', database: 'd', table: 't', limit: 10 })
+    ).toBe('/api/project/sources/s/databases/d/tables/t/preview/?limit=10');
+  });
+});
+
+describe('DataPreviewModal', () => {
+  const baseProps = {
+    source: 'src',
+    database: 'main',
+    table: 'users',
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetch.mockReset();
+  });
+
+  it('shows loading state on mount', () => {
+    fetch.mockImplementation(() => new Promise(() => {})); // never resolves
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    expect(screen.getByTestId('preview-loading')).toBeInTheDocument();
+    expect(screen.getByText(/users/)).toBeInTheDocument();
+  });
+
+  it('fetches from the no-schema URL when schema is null', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/project/sources/src/databases/main/tables/users/preview/?limit=100'
+    );
+  });
+
+  it('fetches from the schema URL when schema is provided', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+
+    render(<DataPreviewModal {...baseProps} schema="public" />);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/project/sources/src/databases/main/schemas/public/tables/users/preview/?limit=100'
+    );
+  });
+
+  it('renders the heading with schema-qualified name when schema is provided', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+
+    render(<DataPreviewModal {...baseProps} schema="public" />);
+
+    expect(screen.getByText('public.users')).toBeInTheDocument();
+  });
+
+  it('renders rows after the fetch resolves', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        columns: [{ name: 'id', type: 'integer' }, { name: 'email', type: 'text' }],
+        rows: [
+          { id: 1, email: 'a@x.com' },
+          { id: 2, email: 'b@x.com' },
+        ],
+        limit: 100,
+        truncated: false,
+      }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    await screen.findByTestId('preview-table');
+    expect(screen.getByText('id')).toBeInTheDocument();
+    expect(screen.getByText('email')).toBeInTheDocument();
+    expect(screen.getByText('a@x.com')).toBeInTheDocument();
+    expect(screen.getByText('b@x.com')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-row-1')).toBeInTheDocument();
+  });
+
+  it('renders truncated indicator when payload says so', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        columns: [{ name: 'id', type: 'integer' }],
+        rows: [{ id: 1 }],
+        limit: 100,
+        truncated: true,
+      }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    await screen.findByTestId('preview-table');
+    expect(screen.getByText(/truncated/)).toBeInTheDocument();
+  });
+
+  it('renders empty-state when no rows are returned', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        columns: [{ name: 'id', type: 'integer' }],
+        rows: [],
+        limit: 100,
+        truncated: false,
+      }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    await screen.findByTestId('preview-empty');
+  });
+
+  it('renders an error message when fetch is non-ok', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({ error: 'no such table' }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    const err = await screen.findByTestId('preview-error');
+    expect(err).toHaveTextContent(/no such table/);
+  });
+
+  it('renders an error message when fetch rejects', async () => {
+    fetch.mockRejectedValueOnce(new Error('network down'));
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    const err = await screen.findByTestId('preview-error');
+    expect(err).toHaveTextContent(/network down/);
+  });
+
+  it('close button calls onClose', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+    const onClose = jest.fn();
+
+    render(<DataPreviewModal {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('preview-close-button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the overlay calls onClose', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+    const onClose = jest.fn();
+
+    render(<DataPreviewModal {...baseProps} onClose={onClose} />);
+
+    const overlay = screen.getByTestId('data-preview-modal');
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking inside the modal does not call onClose', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+    const onClose = jest.fn();
+
+    render(<DataPreviewModal {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('preview-loading'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('pressing Escape calls onClose', () => {
+    fetch.mockImplementation(() => new Promise(() => {}));
+    const onClose = jest.fn();
+
+    render(<DataPreviewModal {...baseProps} onClose={onClose} />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles null/undefined cell values gracefully', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        columns: [{ name: 'id', type: 'integer' }, { name: 'name', type: 'text' }],
+        rows: [
+          { id: 1, name: null },
+          { id: 2 }, // missing 'name'
+        ],
+        limit: 100,
+        truncated: false,
+      }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    await screen.findByTestId('preview-table');
+    // Two rows rendered, no crashes
+    expect(screen.getByTestId('preview-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-row-1')).toBeInTheDocument();
+  });
+
+  it('serializes object cell values to JSON string', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        columns: [{ name: 'meta', type: 'json' }],
+        rows: [{ meta: { a: 1 } }],
+        limit: 100,
+        truncated: false,
+      }),
+    });
+
+    render(<DataPreviewModal {...baseProps} />);
+
+    await screen.findByTestId('preview-table');
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+  });
+});

--- a/visivo/server/source_metadata.py
+++ b/visivo/server/source_metadata.py
@@ -223,6 +223,80 @@ def get_table_columns(sources, source_name, database_name, table_name, schema_na
         )
 
 
+# Maximum number of rows allowed when previewing a table. Hard cap so callers
+# cannot exhaust memory by passing a huge ?limit= value.
+PREVIEW_LIMIT_MAX = 1000
+
+
+def preview_table_rows(
+    sources,
+    source_name,
+    database_name,
+    table_name,
+    schema_name=None,
+    limit=100,
+):
+    """Return the first ``limit`` rows of a table as a list of dicts.
+
+    Args:
+        sources: Iterable of available sources (typically from SourceManager).
+        source_name: Name of the source containing the table.
+        database_name: Database name (kept for parity with sibling endpoints).
+        table_name: Table to preview.
+        schema_name: Optional schema name. ``None`` for sources that do not
+            expose schemas (e.g., DuckDB, SQLite).
+        limit: Maximum rows to return. Clamped to ``[1, PREVIEW_LIMIT_MAX]``.
+
+    Returns:
+        Either a ``dict`` payload describing the preview, or a ``(dict, int)``
+        tuple ``(error_body, status_code)`` when the source cannot be found.
+    """
+    src = _find_source(sources, source_name)
+    if not src:
+        return _source_not_found_error(source_name)
+
+    # Clamp limit to a safe range. Negative / zero / non-int callers fall back
+    # to the default of 100.
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 100
+    if limit < 1:
+        limit = 1
+    if limit > PREVIEW_LIMIT_MAX:
+        limit = PREVIEW_LIMIT_MAX
+
+    Logger.instance().info(
+        f"Previewing {limit} rows for "
+        f"{source_name}.{database_name}.{schema_name or 'default'}.{table_name}"
+    )
+
+    # Reuse the source's own preview implementation which handles dialect quirks
+    # (DuckDB attach, Redshift serialization, etc.) and uses parameterized
+    # SQL via the source's read_sql() helper.
+    result = src.get_table_preview(
+        database_name=database_name,
+        table_name=table_name,
+        schema_name=schema_name,
+        limit=limit,
+    )
+
+    rows = result.get("rows", []) or []
+    column_names = result.get("columns") or (list(rows[0].keys()) if rows else [])
+
+    return {
+        "source": source_name,
+        "database": database_name,
+        "schema": schema_name,
+        "table": table_name,
+        "columns": [{"name": c, "type": "unknown"} for c in column_names],
+        "rows": rows,
+        "limit": limit,
+        "row_count": len(rows),
+        "truncated": len(rows) >= limit,
+    }
+
+
 def gather_source_metadata(sources):
     """Return metadata for all provided sources."""
     data = {"sources": []}

--- a/visivo/server/source_metadata.py
+++ b/visivo/server/source_metadata.py
@@ -229,12 +229,7 @@ PREVIEW_LIMIT_MAX = 1000
 
 
 def preview_table_rows(
-    sources,
-    source_name,
-    database_name,
-    table_name,
-    schema_name=None,
-    limit=100,
+    sources, source_name, database_name, table_name, schema_name=None, limit=100,
 ):
     """Return the first ``limit`` rows of a table as a list of dicts.
 
@@ -275,10 +270,7 @@ def preview_table_rows(
     # (DuckDB attach, Redshift serialization, etc.) and uses parameterized
     # SQL via the source's read_sql() helper.
     result = src.get_table_preview(
-        database_name=database_name,
-        table_name=table_name,
-        schema_name=schema_name,
-        limit=limit,
+        database_name=database_name, table_name=table_name, schema_name=schema_name, limit=limit,
     )
 
     rows = result.get("rows", []) or []

--- a/visivo/server/views/sources_views.py
+++ b/visivo/server/views/sources_views.py
@@ -117,10 +117,7 @@ def register_source_views(app, flask_app, output_dir):
         try:
             # Use source_manager to include both cached and published sources
             result = get_table_columns(
-                flask_app.source_manager.get_sources_list(),
-                source_name,
-                database_name,
-                table_name,
+                flask_app.source_manager.get_sources_list(), source_name, database_name, table_name,
             )
             if isinstance(result, tuple):  # Error response
                 return jsonify(result[0]), result[1]

--- a/visivo/server/views/sources_views.py
+++ b/visivo/server/views/sources_views.py
@@ -2,12 +2,14 @@ from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
 from visivo.server.source_metadata import (
+    PREVIEW_LIMIT_MAX,
     check_source_connection,
     gather_source_metadata,
     get_database_schemas,
     get_schema_tables,
     get_source_databases,
     get_table_columns,
+    preview_table_rows,
     validate_source_from_config,
 )
 
@@ -148,6 +150,64 @@ def register_source_views(app, flask_app, output_dir):
         except Exception as e:
             Logger.instance().error(f"Error listing columns: {str(e)}")
             return jsonify({"message": str(e)}), 500
+
+    def _parse_preview_limit():
+        """Parse and clamp the ``limit`` query parameter for preview endpoints."""
+        try:
+            limit = int(request.args.get("limit", 100))
+        except (TypeError, ValueError):
+            limit = 100
+        if limit < 1:
+            limit = 1
+        if limit > PREVIEW_LIMIT_MAX:
+            limit = PREVIEW_LIMIT_MAX
+        return limit
+
+    @app.route(
+        "/api/project/sources/<source_name>/databases/<database_name>/tables/<table_name>/preview/",
+        methods=["GET"],
+    )
+    def preview_table_rows_no_schema(source_name, database_name, table_name):
+        """Preview rows for a table without a schema (e.g., DuckDB, SQLite)."""
+        try:
+            limit = _parse_preview_limit()
+            result = preview_table_rows(
+                flask_app.source_manager.get_sources_list(),
+                source_name,
+                database_name,
+                table_name,
+                None,
+                limit,
+            )
+            if isinstance(result, tuple):  # Error response
+                return jsonify(result[0]), result[1]
+            return jsonify(result)
+        except Exception as e:
+            Logger.instance().error(f"Error previewing rows for {table_name}: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route(
+        "/api/project/sources/<source_name>/databases/<database_name>/schemas/<schema_name>/tables/<table_name>/preview/",
+        methods=["GET"],
+    )
+    def preview_table_rows_with_schema(source_name, database_name, schema_name, table_name):
+        """Preview rows for a table within a specific schema."""
+        try:
+            limit = _parse_preview_limit()
+            result = preview_table_rows(
+                flask_app.source_manager.get_sources_list(),
+                source_name,
+                database_name,
+                table_name,
+                schema_name,
+                limit,
+            )
+            if isinstance(result, tuple):  # Error response
+                return jsonify(result[0]), result[1]
+            return jsonify(result)
+        except Exception as e:
+            Logger.instance().error(f"Error previewing rows for {table_name}: {str(e)}")
+            return jsonify({"error": str(e)}), 500
 
     @app.route("/api/sources/test-connection/", methods=["POST"])
     def test_source_connection():


### PR DESCRIPTION
## Demo

<!-- DROP VIDEO HERE: /tmp/visivo-pr-videos/8-preview-rows.mp4 -->

_Drop the demo video above. File is at `/tmp/visivo-pr-videos/8-preview-rows.mp4` on the maintainer's machine._

---

## Summary

Users can right-click any table in the Explorer's schema tree to preview the first 100 rows in a modal. Closes **Friction #31** from the dogfood walkthrough.

Also fixes a pre-existing cross-cutting bug: `viewer/playwright.config.mjs` hardcoded `baseURL: 'http://localhost:3001'`, which meant per-branch e2e specs were silently hitting whatever sandbox happened to be on `:3001` (often the user's primary checkout). Now reads `VISIVO_SANDBOX_FRONTEND_PORT` env var with `:3001`/`:3002` defaults preserved.

## What ships

- `visivo/server/source_metadata.py` — `preview_table_rows()` helper, `PREVIEW_LIMIT_MAX = 1000` constant, delegates to existing `Source.get_table_preview()`.
- `visivo/server/views/sources_views.py` — `/preview/` routes for both schema and no-schema variants, with `_parse_preview_limit()` clamping to `[1, 1000]`.
- `viewer/src/components/sources/DataPreviewModal.jsx` — portal modal that fetches rows, renders a sticky-header table, handles loading/error/empty states. Closes on overlay click, Escape, or close button.
- `viewer/src/components/common/ContextMenu.jsx` — reusable portal-rendered floating menu with outside-click + Escape dismissal.
- `viewer/src/components/explorerNew/SourceBrowser.jsx` — wires `onContextMenu` on table nodes to a `ContextMenu` with "Preview 100 rows" action.
- `playwright.config.mjs` — baseURL respects `VISIVO_SANDBOX_FRONTEND_PORT`.

## Test plan

- [x] Black clean
- [x] pytest tests/server/ — 442 passed; new preview-endpoint suite 14/14
- [x] Viewer Jest — 1446 + lint clean (19 DataPreviewModal tests, 4 ContextMenu, 3 SourceBrowser context-menu)
- [x] Playwright e2e — `source-preview-rows.spec.mjs` 3/3 pass on sandbox `:8018/:3018` (after baseURL fix)
- [x] Full pytest tests/ — 1693 pass, 0 failed

## Demo

Video above shows: open `/explorer` → expand source schema tree → right-click a table → "Preview 100 rows" → modal opens with columns + rows in a sticky-header table → close modal.

Worktree: `/tmp/visivo-wt-preview-rows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
