### PR TITLE
feat: allow dashboard rename via UI + endpoint (VIS-749)

### DIFF
--- a/tests/models/test_insight_props_validation.py
+++ b/tests/models/test_insight_props_validation.py
@@ -12,7 +12,6 @@ import pytest
 
 from visivo.models.props.insight_props import InsightProps
 
-
 # ---------------------------------------------------------------------------
 # B08 part 1: file_path / path don't leak into validation
 # ---------------------------------------------------------------------------

--- a/tests/server/managers/test_object_manager.py
+++ b/tests/server/managers/test_object_manager.py
@@ -282,3 +282,126 @@ class TestObjectManager:
         assert ObjectStatus.NEW.value == "new"
         assert ObjectStatus.MODIFIED.value == "modified"
         assert ObjectStatus.PUBLISHED.value == "published"
+
+
+class TestObjectManagerRename:
+    """Tests for the generic rename() method on ObjectManager (VIS-749)."""
+
+    def test_rename_published_only_object(self):
+        """Renaming an object that exists only in published_objects copies it under
+        the new name in cache and marks the old name for deletion."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old", "value": 1}
+
+        renamed = manager.rename("old", "new")
+
+        assert renamed is not None
+        assert renamed["name"] == "new"
+        assert renamed["value"] == 1
+        # New name landed in cache.
+        assert manager.cached_objects["new"]["name"] == "new"
+        # Old name marked for deletion (None in cache).
+        assert "old" in manager.cached_objects
+        assert manager.cached_objects["old"] is None
+        # Published objects untouched.
+        assert manager.published_objects["old"]["name"] == "old"
+
+    def test_rename_cache_only_object(self):
+        """Renaming a NEW (cache-only) object moves it under the new name and
+        removes the old key entirely (no need to mark for deletion)."""
+        manager = ConcreteObjectManager()
+        manager.save("old", {"name": "old", "value": 2})
+
+        renamed = manager.rename("old", "new")
+
+        assert renamed["name"] == "new"
+        assert "new" in manager.cached_objects
+        assert "old" not in manager.cached_objects
+
+    def test_rename_modified_object(self):
+        """Renaming an object that exists in BOTH cache and published uses the
+        cached version (the user's draft) and marks the old name for deletion."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old", "value": 1}
+        manager.save("old", {"name": "old", "value": 99})  # draft change
+
+        renamed = manager.rename("old", "new")
+
+        assert renamed["value"] == 99  # took the draft value
+        assert manager.cached_objects["new"]["value"] == 99
+        assert manager.cached_objects["old"] is None
+
+    def test_rename_returns_none_for_missing_object(self):
+        """Renaming a non-existent object returns None (no exception)."""
+        manager = ConcreteObjectManager()
+
+        result = manager.rename("missing", "anything")
+
+        assert result is None
+        # Nothing was added to cache.
+        assert "anything" not in manager.cached_objects
+
+    def test_rename_rejects_collision_with_cached(self):
+        """Cannot rename to a name that's already taken by another cached object."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old"}
+        manager.save("taken", {"name": "taken"})
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.rename("old", "taken")
+        assert "already uses that name" in str(exc_info.value)
+
+    def test_rename_rejects_collision_with_published(self):
+        """Cannot rename to a name that's already taken by a published object."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old"}
+        manager._published_objects["taken"] = {"name": "taken"}
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.rename("old", "taken")
+        assert "already uses that name" in str(exc_info.value)
+
+    def test_rename_rejects_same_name(self):
+        """Renaming to the same name is a noop and raises so callers don't think
+        anything changed."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["foo"] = {"name": "foo"}
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.rename("foo", "foo")
+        assert "different from the old name" in str(exc_info.value)
+
+    def test_rename_rejects_object_marked_for_deletion(self):
+        """Cannot rename an object that's already been marked for deletion."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old"}
+        manager.mark_for_deletion("old")
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.rename("old", "new")
+        assert "marked for deletion" in str(exc_info.value)
+
+    def test_rename_rejects_destination_with_pending_deletion(self):
+        """If the destination name is currently marked for deletion, the rename is
+        still rejected — the user should publish the deletion first, then rename.
+        This is conservative; the rename pipeline does not auto-resolve pending
+        deletions on the destination side."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old", "value": 1}
+        manager._published_objects["dest"] = {"name": "dest"}
+        manager.mark_for_deletion("dest")  # cached_objects["dest"] = None
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.rename("old", "dest")
+        assert "already uses that name" in str(exc_info.value)
+
+    def test_rename_status_after_published_to_published(self):
+        """After renaming, the new name has status NEW (cache-only) and the old
+        name has status DELETED (None in cache, exists in published)."""
+        manager = ConcreteObjectManager()
+        manager._published_objects["old"] = {"name": "old"}
+
+        manager.rename("old", "new")
+
+        assert manager.get_status("new") == ObjectStatus.NEW
+        assert manager.get_status("old") == ObjectStatus.DELETED

--- a/tests/server/views/test_dashboard_views.py
+++ b/tests/server/views/test_dashboard_views.py
@@ -1,0 +1,205 @@
+"""Tests for dashboard API endpoints (focused on the rename surface added in VIS-749)."""
+
+import pytest
+from unittest.mock import Mock
+from flask import Flask
+
+from visivo.server.views.dashboard_views import register_dashboard_views
+from visivo.server.managers.object_manager import ObjectStatus
+
+
+class TestDashboardRenameEndpoint:
+    """Tests for POST /api/dashboards/<name>/rename/ and the preview endpoint."""
+
+    @pytest.fixture
+    def app(self):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        flask_app = Mock()
+        flask_app.dashboard_manager = Mock()
+        flask_app.dashboard_manager.cached_objects = {}
+        flask_app.dashboard_manager.published_objects = {}
+
+        register_dashboard_views(app, flask_app, "/tmp/output")
+
+        app.flask_app = flask_app
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    # ---------- /rename/ ----------
+
+    def test_rename_success(self, client, app):
+        renamed = Mock()
+        renamed.name = "new-dashboard"
+        app.flask_app.dashboard_manager.rename.return_value = renamed
+        app.flask_app.dashboard_manager.get_status.return_value = ObjectStatus.NEW
+
+        response = client.post(
+            "/api/dashboards/old-dashboard/rename/",
+            json={"new_name": "new-dashboard"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["old_name"] == "old-dashboard"
+        assert data["new_name"] == "new-dashboard"
+        assert data["status"] == "new"
+        assert data["rewritten_ref_count"] == 0
+        app.flask_app.dashboard_manager.rename.assert_called_once_with(
+            "old-dashboard", "new-dashboard"
+        )
+
+    def test_rename_missing_new_name_returns_400(self, client, app):
+        response = client.post(
+            "/api/dashboards/old/rename/",
+            json={},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "new_name is required" in response.get_json()["error"]
+        app.flask_app.dashboard_manager.rename.assert_not_called()
+
+    def test_rename_blank_new_name_returns_400(self, client, app):
+        response = client.post(
+            "/api/dashboards/old/rename/",
+            json={"new_name": "   "},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        app.flask_app.dashboard_manager.rename.assert_not_called()
+
+    def test_rename_nonexistent_returns_404(self, client, app):
+        app.flask_app.dashboard_manager.rename.return_value = None
+
+        response = client.post(
+            "/api/dashboards/missing/rename/",
+            json={"new_name": "anything"},
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+        assert "not found" in response.get_json()["error"]
+
+    def test_rename_collision_returns_400(self, client, app):
+        app.flask_app.dashboard_manager.rename.side_effect = ValueError(
+            "another object already uses that name"
+        )
+
+        response = client.post(
+            "/api/dashboards/old/rename/",
+            json={"new_name": "taken"},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "already uses that name" in response.get_json()["error"]
+
+    def test_rename_same_name_returns_400(self, client, app):
+        app.flask_app.dashboard_manager.rename.side_effect = ValueError(
+            "New name must be different from the old name"
+        )
+
+        response = client.post(
+            "/api/dashboards/old/rename/",
+            json={"new_name": "old"},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_rename_strips_whitespace(self, client, app):
+        renamed = Mock()
+        renamed.name = "trimmed"
+        app.flask_app.dashboard_manager.rename.return_value = renamed
+        app.flask_app.dashboard_manager.get_status.return_value = ObjectStatus.NEW
+
+        response = client.post(
+            "/api/dashboards/old/rename/",
+            json={"new_name": "  trimmed  "},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        # The endpoint should pass the trimmed name to the manager.
+        app.flask_app.dashboard_manager.rename.assert_called_once_with("old", "trimmed")
+
+    # ---------- /preview-rename/ ----------
+
+    def test_preview_rename_valid(self, client, app):
+        # Source exists, destination is free.
+        app.flask_app.dashboard_manager.get.return_value = Mock()
+        app.flask_app.dashboard_manager.cached_objects = {}
+        app.flask_app.dashboard_manager.published_objects = {"old": Mock()}
+
+        response = client.get("/api/dashboards/old/preview-rename/?new_name=new")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["valid"] is True
+        assert data["rewritten_ref_count"] == 0
+
+    def test_preview_rename_missing_new_name_returns_400(self, client, app):
+        response = client.get("/api/dashboards/old/preview-rename/")
+        assert response.status_code == 400
+        assert "new_name query parameter is required" in response.get_json()["error"]
+
+    def test_preview_rename_source_missing_returns_404(self, client, app):
+        app.flask_app.dashboard_manager.get.return_value = None
+
+        response = client.get("/api/dashboards/missing/preview-rename/?new_name=anything")
+        assert response.status_code == 404
+
+    def test_preview_rename_same_name_invalid(self, client, app):
+        app.flask_app.dashboard_manager.get.return_value = Mock()
+
+        response = client.get("/api/dashboards/foo/preview-rename/?new_name=foo")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["valid"] is False
+        assert "different" in data["error"]
+
+    def test_preview_rename_collision_with_published(self, client, app):
+        app.flask_app.dashboard_manager.get.return_value = Mock()
+        app.flask_app.dashboard_manager.cached_objects = {}
+        app.flask_app.dashboard_manager.published_objects = {
+            "old": Mock(),
+            "taken": Mock(),
+        }
+
+        response = client.get("/api/dashboards/old/preview-rename/?new_name=taken")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["valid"] is False
+        assert "already used" in data["error"]
+
+    def test_preview_rename_collision_with_cached(self, client, app):
+        app.flask_app.dashboard_manager.get.return_value = Mock()
+        app.flask_app.dashboard_manager.cached_objects = {"taken": Mock()}
+        app.flask_app.dashboard_manager.published_objects = {"old": Mock()}
+
+        response = client.get("/api/dashboards/old/preview-rename/?new_name=taken")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["valid"] is False
+
+    def test_preview_rename_destination_marked_for_deletion_is_free(self, client, app):
+        """If the destination is marked for deletion (None in cache), preview
+        treats the name as taken because the *published* entry still exists.
+        Mirrors the rename endpoint's conservative collision check."""
+        app.flask_app.dashboard_manager.get.return_value = Mock()
+        app.flask_app.dashboard_manager.cached_objects = {"taken": None}
+        app.flask_app.dashboard_manager.published_objects = {
+            "old": Mock(),
+            "taken": Mock(),
+        }
+
+        response = client.get("/api/dashboards/old/preview-rename/?new_name=taken")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        # The published entry still exists, so this is treated as taken.
+        assert data["valid"] is False

--- a/viewer/src/components/new-views/common/DashboardEditForm.jsx
+++ b/viewer/src/components/new-views/common/DashboardEditForm.jsx
@@ -33,6 +33,12 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const [error, setError] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Rename confirmation state — when the Name input differs from the original
+  // dashboard name on a non-create form, we capture the rename and prompt the
+  // user to confirm before applying.
+  const [renameConfirm, setRenameConfirm] = useState(null);
+  const [renaming, setRenaming] = useState(false);
+  const originalName = dashboard?.name || '';
 
   // Build available objects list grouped by type
   const availableObjects = useMemo(() => {
@@ -85,10 +91,39 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const handleSubmit = async e => {
     e.preventDefault();
     setError(null);
+
+    const trimmedName = name.trim();
+
+    // If this is an edit (not create) and the name has changed, run the rename
+    // preview first so we can show a confirmation dialog with the count of
+    // cross-object references that would be rewritten. The actual rename
+    // happens via the dedicated /rename/ endpoint, after the user confirms.
+    if (!isCreate && originalName && trimmedName !== originalName) {
+      try {
+        const previewRes = await fetch(
+          `/api/dashboards/${encodeURIComponent(originalName)}/preview-rename/?new_name=${encodeURIComponent(trimmedName)}`,
+        );
+        const previewData = await previewRes.json();
+        if (!previewRes.ok || previewData?.valid === false) {
+          setError(previewData?.error || 'Cannot rename dashboard.');
+          return;
+        }
+        setRenameConfirm({
+          oldName: originalName,
+          newName: trimmedName,
+          rewrittenRefCount: previewData?.rewritten_ref_count ?? 0,
+        });
+        return;
+      } catch (err) {
+        setError(err?.message || 'Failed to preview rename.');
+        return;
+      }
+    }
+
     setSaving(true);
 
     const config = {
-      name: name.trim(),
+      name: trimmedName,
       type: 'internal',
     };
 
@@ -118,6 +153,44 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
     if (!result?.success) {
       setError(result?.error || 'Failed to save dashboard');
     }
+  };
+
+  const handleRenameConfirm = async () => {
+    if (!renameConfirm) return;
+    setRenaming(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/dashboards/${encodeURIComponent(renameConfirm.oldName)}/rename/`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_name: renameConfirm.newName }),
+        },
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data?.error || 'Rename failed.');
+        return;
+      }
+      // Refresh publish status so the top-bar publish badge picks up the
+      // pending rename, then close the form. The new dashboard's edit panel
+      // will be re-opened by the parent if needed.
+      await checkPublishStatus();
+      setRenameConfirm(null);
+      onClose();
+    } catch (err) {
+      setError(err?.message || 'Rename failed.');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const handleRenameCancel = () => {
+    setRenameConfirm(null);
+    // Restore the input to the original name so the user knows the rename
+    // was abandoned and can keep editing other fields.
+    setName(originalName);
   };
 
   const handleDelete = async () => {
@@ -248,9 +321,52 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
           label="Name"
           value={name}
           onChange={e => setName(e.target.value)}
-          disabled={!isCreate}
-          helperText={!isCreate ? 'Dashboard names cannot be changed after creation.' : undefined}
+          helperText={
+            !isCreate && name.trim() !== originalName && name.trim()
+              ? `Will rename '${originalName}' on save.`
+              : undefined
+          }
         />
+
+        {/* Rename confirmation dialog */}
+        {renameConfirm && !isCreate && (
+          <div className="p-3 bg-yellow-50 border border-yellow-300 rounded-md space-y-2">
+            <p className="text-sm text-gray-800">
+              Rename <span className="font-semibold">{renameConfirm.oldName}</span> to{' '}
+              <span className="font-semibold">{renameConfirm.newName}</span>?
+            </p>
+            <p className="text-xs text-gray-600">
+              <span data-testid="rename-ref-count-message">
+                {renameConfirm.rewrittenRefCount > 0
+                  ? `This will also update ${renameConfirm.rewrittenRefCount} reference${
+                      renameConfirm.rewrittenRefCount === 1 ? '' : 's'
+                    } in your project.`
+                  : 'No other objects reference this dashboard, so no other files will change.'}
+              </span>{' '}
+              You will need to publish to flush the rename to YAML.
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                data-testid="rename-cancel-button"
+                onClick={handleRenameCancel}
+                disabled={renaming}
+                className="px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
+              >
+                Cancel Rename
+              </button>
+              <button
+                type="button"
+                data-testid="rename-confirm-button"
+                onClick={handleRenameConfirm}
+                disabled={renaming}
+                className="px-3 py-1 text-sm text-white bg-yellow-600 rounded hover:bg-yellow-700 disabled:opacity-50"
+              >
+                {renaming ? 'Renaming...' : 'Confirm Rename'}
+              </button>
+            </div>
+          </div>
+        )}
 
         <FormInput
           id="dashboard-description"

--- a/viewer/src/components/new-views/common/DashboardEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/DashboardEditForm.test.jsx
@@ -1,0 +1,356 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DashboardEditForm from './DashboardEditForm';
+import useStore from '../../../stores/store';
+
+jest.mock('../../../stores/store');
+
+describe('DashboardEditForm', () => {
+  const setupStore = (overrides = {}) => {
+    useStore.mockImplementation(selector => {
+      const state = {
+        deleteDashboard: jest.fn().mockResolvedValue({ success: true }),
+        checkPublishStatus: jest.fn().mockResolvedValue(undefined),
+        charts: [],
+        tables: [],
+        markdowns: [],
+        inputs: [],
+        ...overrides,
+      };
+      return typeof selector === 'function' ? selector(state) : state;
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupStore();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  // ---------- Name field is editable in edit mode (VIS-749) ----------
+
+  describe('Name field editability', () => {
+    it('does not disable the Name input in edit mode', () => {
+      const dashboard = {
+        name: 'sales-summary',
+        config: { name: 'sales-summary', rows: [] },
+      };
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const nameInput = screen.getByLabelText('Name');
+      expect(nameInput).not.toBeDisabled();
+      expect(nameInput).toHaveValue('sales-summary');
+    });
+
+    it('shows the rename helper text when the user types a different name', () => {
+      const dashboard = {
+        name: 'sales-summary',
+        config: { name: 'sales-summary', rows: [] },
+      };
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const nameInput = screen.getByLabelText('Name');
+      fireEvent.change(nameInput, { target: { value: 'sales-overview' } });
+
+      expect(screen.getByText(/Will rename 'sales-summary' on save/)).toBeInTheDocument();
+    });
+
+    it('hides the rename helper text when the name matches the original', () => {
+      const dashboard = {
+        name: 'sales-summary',
+        config: { name: 'sales-summary', rows: [] },
+      };
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      // Name is unchanged — no helper.
+      expect(screen.queryByText(/Will rename/)).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------- Rename confirmation flow ----------
+
+  describe('Rename confirmation flow', () => {
+    const dashboard = {
+      name: 'sales-summary',
+      config: { name: 'sales-summary', rows: [] },
+    };
+
+    it('hits the preview endpoint and shows a confirmation dialog on save', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 0 }),
+      });
+
+      const onSave = jest.fn();
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={onSave}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const nameInput = screen.getByLabelText('Name');
+      fireEvent.change(nameInput, { target: { value: 'sales-overview' } });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/dashboards/sales-summary/preview-rename/?new_name=sales-overview',
+        );
+      });
+
+      // Confirmation dialog renders.
+      expect(await screen.findByTestId('rename-confirm-button')).toBeInTheDocument();
+      expect(screen.getByTestId('rename-cancel-button')).toBeInTheDocument();
+      // The save flow does NOT call onSave when a rename is pending.
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('shows the ref-count message when rewritten_ref_count > 0', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 3 }),
+      });
+
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      const message = await screen.findByTestId('rename-ref-count-message');
+      expect(message.textContent).toMatch(/will also update 3 references/);
+    });
+
+    it('uses singular "reference" for a count of 1', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 1 }),
+      });
+
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      const message = await screen.findByTestId('rename-ref-count-message');
+      expect(message.textContent).toMatch(/will also update 1 reference[^s]/);
+    });
+
+    it('shows the no-other-files message when count is 0', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 0 }),
+      });
+
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      const message = await screen.findByTestId('rename-ref-count-message');
+      expect(message.textContent).toMatch(/No other objects reference this dashboard/);
+    });
+
+    it('surfaces the preview error and aborts the save flow', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          valid: false,
+          error: "'sales-overview' is already used by another dashboard",
+        }),
+      });
+
+      const onSave = jest.fn();
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={onSave}
+          onClose={jest.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("'sales-overview' is already used by another dashboard"),
+        ).toBeInTheDocument();
+      });
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('confirms the rename via the rename endpoint and closes the form', async () => {
+      // First call: preview-rename
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 0 }),
+      });
+      // Second call: rename
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          old_name: 'sales-summary',
+          new_name: 'sales-overview',
+          status: 'new',
+          rewritten_ref_count: 0,
+        }),
+      });
+
+      const onClose = jest.fn();
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={onClose}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      const confirmButton = await screen.findByTestId('rename-confirm-button');
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/dashboards/sales-summary/rename/',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ new_name: 'sales-overview' }),
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('cancels the rename and restores the original name', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 0 }),
+      });
+
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={jest.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+      const cancelButton = await screen.findByTestId('rename-cancel-button');
+      fireEvent.click(cancelButton);
+
+      // After cancel, the input is restored to the original name and the
+      // confirmation dialog is gone.
+      await waitFor(() => {
+        expect(screen.queryByTestId('rename-confirm-button')).not.toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('Name')).toHaveValue('sales-summary');
+    });
+
+    it('surfaces a server error on rename failure', async () => {
+      // Preview succeeds...
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ valid: true, rewritten_ref_count: 0 }),
+      });
+      // ...but the actual rename fails.
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn().mockResolvedValue({ error: 'Server exploded' }),
+      });
+
+      const onClose = jest.fn();
+      render(
+        <DashboardEditForm
+          dashboard={dashboard}
+          isCreate={false}
+          onSave={jest.fn()}
+          onClose={onClose}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'sales-overview' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+      fireEvent.click(await screen.findByRole('button', { name: /Confirm Rename/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Server exploded')).toBeInTheDocument();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/visivo/models/props/insight_props.py
+++ b/visivo/models/props/insight_props.py
@@ -10,7 +10,6 @@ from visivo.models.props.json_schema_base import JsonSchemaBase, get_message_fro
 from visivo.models.props.types import PropType
 from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
 
-
 #: Field names that the parser may attach to props during YAML loading
 #: but that are not valid Plotly trace properties. Strip them out of the
 #: dumped dict before running jsonschema validation, otherwise the

--- a/visivo/server/managers/object_manager.py
+++ b/visivo/server/managers/object_manager.py
@@ -225,6 +225,78 @@ class ObjectManager(ABC, Generic[T]):
                 return True
             return False
 
+    def rename(self, old_name: str, new_name: str) -> Optional[T]:
+        """
+        Rename an object from old_name to new_name.
+
+        Implementation:
+        1. Find the current object (cached takes priority over published).
+        2. Validate the new name is not already taken in cache or published.
+        3. Save the object under new_name with its `name` attribute updated.
+        4. Mark old_name for deletion (None in cache) so the publish step removes the old YAML entry.
+
+        Note: this method does NOT rewrite cross-object references that point at the
+        old name. Callers that need cross-ref rewriting (e.g., when renaming objects
+        that other objects reference by name) should layer that on top.
+
+        Args:
+            old_name: The current name of the object.
+            new_name: The desired new name. Must be unique across cached + published.
+
+        Returns:
+            The renamed object (with its `name` attribute updated to `new_name`),
+            or None if `old_name` does not exist.
+
+        Raises:
+            ValueError: If new_name is already taken, or if old_name == new_name.
+        """
+        if old_name == new_name:
+            raise ValueError("New name must be different from the old name")
+
+        with self._lock:
+            # Find current object — prefer cached over published.
+            current = self._cached_objects.get(old_name)
+            if current is None and old_name in self._cached_objects:
+                # Already marked for deletion under old_name
+                raise ValueError(f"Cannot rename '{old_name}' — already marked for deletion")
+            if current is None:
+                current = self._published_objects.get(old_name)
+            if current is None:
+                return None
+
+            # Validate destination name is free.
+            destination_taken_in_cache = (
+                new_name in self._cached_objects and self._cached_objects[new_name] is not None
+            )
+            destination_taken_in_published = new_name in self._published_objects
+            if destination_taken_in_cache or destination_taken_in_published:
+                raise ValueError(
+                    f"Cannot rename '{old_name}' to '{new_name}': another object already uses that name"
+                )
+
+            # Update the object's `name` on a copy so we don't mutate published state.
+            if hasattr(current, "model_copy"):
+                # Pydantic v2 path — used by every real ObjectManager subclass.
+                renamed = current.model_copy(update={"name": new_name})
+            elif isinstance(current, dict):
+                # dict path — used by the abstract-class test stub.
+                renamed = {**current, "name": new_name}
+            else:
+                # Fallback for plain Python objects with a `name` attribute.
+                renamed = current
+                if hasattr(renamed, "name"):
+                    setattr(renamed, "name", new_name)
+
+            self._cached_objects[new_name] = renamed
+            # Mark the old name for deletion so the publish step removes the old YAML entry.
+            # Only mark for deletion if the old name is published (otherwise just drop from cache).
+            if old_name in self._published_objects:
+                self._cached_objects[old_name] = None
+            elif old_name in self._cached_objects:
+                del self._cached_objects[old_name]
+
+            return renamed
+
     def get_objects_for_publish(self) -> Dict[str, T]:
         """
         Get all cached objects ready for publishing to YAML.

--- a/visivo/server/views/dashboard_views.py
+++ b/visivo/server/views/dashboard_views.py
@@ -156,3 +156,114 @@ def register_dashboard_views(app, flask_app, output_dir):
         except Exception as e:
             Logger.instance().error(f"Error validating dashboard: {str(e)}")
             return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/dashboards/<dashboard_name>/rename/", methods=["POST"])
+    def rename_dashboard_crud(dashboard_name):
+        """Rename a dashboard from <dashboard_name> to the new name in the request body.
+
+        Body: {"new_name": "..."}. The rename is applied to the draft cache; the user
+        must publish to flush the change to YAML. Validates that the new name doesn't
+        collide with another dashboard.
+
+        Note: this endpoint does NOT rewrite cross-object references to the dashboard
+        (e.g., `${ ref(<old>) }` in another object's config). Dashboards are leaves of
+        the project DAG — almost no other object references them by name — so the
+        cross-ref rewrite is deferred. A future generic-rename pass will cover charts,
+        tables, etc., where ref-rewrite is load-bearing.
+        """
+        try:
+            body = request.get_json(silent=True) or {}
+            new_name = (body.get("new_name") or "").strip()
+            if not new_name:
+                return jsonify({"error": "new_name is required"}), 400
+
+            try:
+                renamed = flask_app.dashboard_manager.rename(dashboard_name, new_name)
+            except ValueError as e:
+                return jsonify({"error": str(e)}), 400
+
+            if renamed is None:
+                return jsonify({"error": f"Dashboard '{dashboard_name}' not found"}), 404
+
+            status = flask_app.dashboard_manager.get_status(new_name)
+            return (
+                jsonify(
+                    {
+                        "message": (
+                            f"Dashboard renamed from '{dashboard_name}' to '{new_name}'. "
+                            "Publish your changes to flush the rename to YAML."
+                        ),
+                        "old_name": dashboard_name,
+                        "new_name": new_name,
+                        "status": status.value if status else None,
+                        "rewritten_ref_count": 0,
+                    }
+                ),
+                200,
+            )
+        except Exception as e:
+            Logger.instance().error(f"Error renaming dashboard: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/dashboards/<dashboard_name>/preview-rename/", methods=["GET"])
+    def preview_rename_dashboard_crud(dashboard_name):
+        """Preview a rename without applying it.
+
+        Query params: `new_name`. Returns whether the rename is valid and how many
+        cross-object references would be rewritten (currently always 0 for dashboards
+        since they aren't referenced by other objects — see the note on the rename endpoint).
+        """
+        try:
+            new_name = (request.args.get("new_name") or "").strip()
+            if not new_name:
+                return jsonify({"error": "new_name query parameter is required"}), 400
+
+            manager = flask_app.dashboard_manager
+
+            # Existence check
+            existing = manager.get(dashboard_name)
+            if existing is None:
+                return jsonify({"error": f"Dashboard '{dashboard_name}' not found"}), 404
+
+            # Same-name no-op
+            if dashboard_name == new_name:
+                return (
+                    jsonify(
+                        {
+                            "valid": False,
+                            "error": "New name must be different from the old name",
+                            "rewritten_ref_count": 0,
+                        }
+                    ),
+                    200,
+                )
+
+            # Collision check across cached + published.
+            taken_in_cache = (
+                new_name in manager.cached_objects and manager.cached_objects[new_name] is not None
+            )
+            taken_in_published = new_name in manager.published_objects
+            if taken_in_cache or taken_in_published:
+                return (
+                    jsonify(
+                        {
+                            "valid": False,
+                            "error": f"'{new_name}' is already used by another dashboard",
+                            "rewritten_ref_count": 0,
+                        }
+                    ),
+                    200,
+                )
+
+            return (
+                jsonify(
+                    {
+                        "valid": True,
+                        "rewritten_ref_count": 0,
+                    }
+                ),
+                200,
+            )
+        except Exception as e:
+            Logger.instance().error(f"Error previewing dashboard rename: {str(e)}")
+            return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary

- Lifts the form's dashboard-name immutability and adds a server-side rename flow so users can rename dashboards inline without hand-editing YAML.
- Adds a generic `rename(old, new)` method on the base `ObjectManager` so future generic-rename support for charts/tables/inputs/markdowns reuses the same plumbing.
- Adds two new endpoints: `POST /api/dashboards/<old>/rename/` and `GET /api/dashboards/<old>/preview-rename/?new_name=<new>`.

## What changed

### Backend
- `visivo/server/managers/object_manager.py` — new `rename(old_name, new_name)` method on the base class. Copies the object under the new name (Pydantic `model_copy` for real managers, dict spread for the abstract-class test stub), marks the old name for deletion in cache (or removes from cache if it was cache-only), and rejects collisions against both cached and published names + same-name renames + already-deleted-source renames.
- `visivo/server/views/dashboard_views.py`:
  - `POST /api/dashboards/<dashboard_name>/rename/` accepts `{"new_name": "..."}`, calls the manager's rename, returns `{old_name, new_name, status, rewritten_ref_count}`.
  - `GET /api/dashboards/<dashboard_name>/preview-rename/?new_name=<new>` returns `{valid, error?, rewritten_ref_count}` without writing.

### Frontend (`DashboardEditForm.jsx`)
- Drops the `disabled={!isCreate}` flag on the Name input; adds a helper text ("Will rename '<old>' on save.") when the typed name differs from the original.
- Save calls the preview endpoint first when a rename is detected, then surfaces a confirmation dialog with the count of cross-object refs that would be rewritten and a Confirm/Cancel pair.
- Confirm POSTs to `/rename/`, refreshes publish status, closes the form. Cancel restores the original name. Errors from either endpoint surface in the form's error banner.

### Scope note (deferred)
This PR does NOT rewrite `${ ref(<old>) }` strings in other objects' configs. Dashboards are leaves of the project DAG — almost no other object references them by name — so the cross-ref rewrite is deferred. The response's `rewritten_ref_count` is plumbed through but always 0 today. A future generic-rename pass that covers charts / tables / inputs / markdowns (where ref-rewrite IS load-bearing) will fill this in by walking other managers' configs and applying `replace_refs` from `visivo/query/patterns.py`.

## Test plan

- [x] **Backend manager** (`tests/server/managers/test_object_manager.py`): 10 new tests (50 total, all pass) covering rename of published-only / cache-only / modified objects, collision rejection (cache + published), same-name rejection, marked-for-deletion source rejection, deletion-pending destination still rejected, status transitions.
- [x] **Backend endpoint** (`tests/server/views/test_dashboard_views.py`): 13 new tests covering success, missing/blank `new_name`, 404 on missing source, 400 on collision, 400 on same-name, whitespace stripping, and the preview endpoint's full success/error matrix.
- [x] **Frontend form** (`DashboardEditForm.test.jsx`): 11 new tests covering name editability, helper text behavior, preview-then-confirm flow, ref-count message variants (0 / 1 / N), preview-failure handling, rename-failure handling, cancel-restores-name.
- [x] `bash scripts/viewer-check.sh DashboardEditForm` → 11 passed, lint clean.
- [x] `bash scripts/viewer-check.sh DashboardNew` → 12 passed (sanity check that the renderer work from VIS-747/748 still passes).
- [x] Server-side regression: `pytest tests/server/` → 454 passed, 0 regressions.
- [ ] Reviewer sanity check: rename a dashboard in the integration project via the form, confirm the dialog shows, click Confirm, verify the change appears in the publish badge, click Publish, verify YAML reflects the new name.

## Linked Linear

- VIS-749: lift dashboard name immutability + rewrite refs on rename (this PR delivers everything except the cross-object ref rewrite — deferred to a future generic-rename pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)