### PR TITLE
test: integration fixture + Playwright story for nested layouts (VIS-750)

### DIFF
--- a/test-projects/integration/nested_layouts.visivo.yml
+++ b/test-projects/integration/nested_layouts.visivo.yml
@@ -1,0 +1,118 @@
+# Integration fixture for VIS-750 — exercises every layout shape unlocked by
+# Item.rows (VIS-747 + VIS-748). Reuses charts/inputs already defined in the
+# integration project so the file stays self-contained and dependency-free.
+#
+# The dashboard renders only when both:
+#   - Backend Item.rows field is present (VIS-747)
+#   - Frontend renderer recurses through item.rows (VIS-748)
+#
+# Layout sections, in render order:
+#   1. Uneven vertical stack — big chart left, three small charts stacked right
+#   2. 2x2 KPI cluster + sidebar chart
+#   3. Sidebar — left column inputs, right column content rows
+#   4. Deep nesting — 3 levels, smallest leaf is a chart
+dashboards:
+  - name: nested-layouts-dashboard
+    level: 1
+    tags:
+      - "layout"
+      - "nested"
+    description: |
+      Exercises every layout shape unlocked by `Item.rows` (VIS-747 + VIS-748):
+      uneven vertical stack, 2x2 cluster, sidebar, and deep nesting.
+    rows:
+      # Section 1: Uneven vertical stack — big chart on left, three stacked small charts on right
+      - height: compact
+        items:
+          - markdown:
+              content: "## Section 1 — Uneven Vertical Stack"
+
+      - height: large
+        items:
+          - width: 2
+            chart: ${ref(simple-scatter-chart)}
+          - width: 1
+            rows:
+              - height: small
+                items:
+                  - chart: ${ref(indicator_chart)}
+              - height: small
+                items:
+                  - chart: ${ref(toggle-mode-chart)}
+              - height: small
+                items:
+                  - chart: ${ref(range-slider-chart)}
+
+      # Section 2: 2x2 KPI cluster + sidebar chart on the right
+      - height: compact
+        items:
+          - markdown:
+              content: "## Section 2 — 2x2 Cluster + Sidebar Chart"
+
+      - height: medium
+        items:
+          - width: 1
+            rows:
+              - height: small
+                items:
+                  - width: 1
+                    chart: ${ref(indicator_chart)}
+                  - width: 1
+                    chart: ${ref(toggle-mode-chart)}
+              - height: small
+                items:
+                  - width: 1
+                    chart: ${ref(range-slider-chart)}
+                  - width: 1
+                    chart: ${ref(autocomplete-date-chart)}
+          - width: 2
+            chart: ${ref(simple-scatter-chart)}
+
+      # Section 3: Sidebar — left column inputs stacked, right column content rows
+      - height: compact
+        items:
+          - markdown:
+              content: "## Section 3 — Sidebar Layout"
+
+      - height: large
+        items:
+          - width: 1
+            rows:
+              - height: compact
+                items:
+                  - input: ${ref(split_threshold)}
+              - height: compact
+                items:
+                  - input: ${ref(sort_direction)}
+              - height: compact
+                items:
+                  - input: ${ref(show_markers)}
+          - width: 3
+            rows:
+              - height: medium
+                items:
+                  - chart: ${ref(simple-scatter-chart)}
+              - height: medium
+                items:
+                  - chart: ${ref(toggle-mode-chart)}
+
+      # Section 4: Deep nesting — 3 levels — exercises recursion past depth 1
+      - height: compact
+        items:
+          - markdown:
+              content: "## Section 4 — Deep Nesting (3 levels)"
+
+      - height: large
+        items:
+          - width: 1
+            rows:
+              - height: medium
+                items:
+                  - width: 1
+                    rows:
+                      - height: small
+                        items:
+                          - chart: ${ref(slider-day-chart)}
+              - height: medium
+                items:
+                  - chart: ${ref(week-selector-chart)}

--- a/test-projects/integration/project.visivo.yml
+++ b/test-projects/integration/project.visivo.yml
@@ -3,6 +3,7 @@ name: project
 includes:
   - path: models.visivo.yml
   - path: insights.visivo.yml
+  - path: nested_layouts.visivo.yml
   - path: visivo-io/example-include.git@main
 
 defaults:

--- a/tests/integration/test_nested_layouts_fixture.py
+++ b/tests/integration/test_nested_layouts_fixture.py
@@ -1,0 +1,154 @@
+"""Backend integration test for VIS-750 — confirms the nested-layouts fixture
+in test-projects/integration parses end-to-end and that its Item.rows recursion
+matches the documented sample shape."""
+
+import os
+import pytest
+
+from visivo.commands.compile_phase import compile_phase
+
+INTEGRATION_PROJECT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "test-projects", "integration")
+)
+
+
+@pytest.fixture
+def compiled_project():
+    """Compile the integration project and return the resulting Project object."""
+    output_dir = os.path.join(INTEGRATION_PROJECT_DIR, "target")
+    cwd_before = os.getcwd()
+    os.chdir(INTEGRATION_PROJECT_DIR)
+    try:
+        project = compile_phase(
+            default_source=None,
+            working_dir=INTEGRATION_PROJECT_DIR,
+            output_dir=output_dir,
+        )
+        return project
+    finally:
+        os.chdir(cwd_before)
+
+
+def test_integration_project_includes_nested_layouts_dashboard(compiled_project):
+    """The fixture's dashboard exists and has the expected name."""
+    names = [d.name for d in compiled_project.dashboards if hasattr(d, "name")]
+    assert "nested-layouts-dashboard" in names
+
+
+def get_nested_dashboard(project):
+    return next(d for d in project.dashboards if d.name == "nested-layouts-dashboard")
+
+
+def test_section_1_uneven_vertical_stack_shape(compiled_project):
+    """Row 1 (index 1, after the section header in row 0): a leaf chart with
+    width=2 alongside a row-container of three sub-rows."""
+    dashboard = get_nested_dashboard(compiled_project)
+    row = dashboard.rows[1]
+    assert row.height.value == "large"
+    assert len(row.items) == 2
+
+    leaf, container = row.items
+    assert leaf.width == 2
+    assert leaf.chart is not None
+    assert leaf.rows is None
+
+    assert container.width == 1
+    assert container.chart is None
+    assert container.rows is not None
+    assert len(container.rows) == 3
+    for sub in container.rows:
+        assert sub.height.value == "small"
+        assert len(sub.items) == 1
+        assert sub.items[0].chart is not None
+
+
+def test_section_2_2x2_cluster_with_sidebar_shape(compiled_project):
+    """Row 3: a 1-wide row-container holding 2 sub-rows of 2 items each, plus a
+    2-wide leaf chart on the right."""
+    dashboard = get_nested_dashboard(compiled_project)
+    row = dashboard.rows[3]
+    assert row.height.value == "medium"
+    assert len(row.items) == 2
+
+    cluster, side = row.items
+    assert cluster.rows is not None
+    assert len(cluster.rows) == 2
+    for sub in cluster.rows:
+        assert len(sub.items) == 2
+        for item in sub.items:
+            assert item.chart is not None
+
+    assert side.chart is not None
+    assert side.width == 2
+
+
+def test_section_3_sidebar_layout_shape(compiled_project):
+    """Row 5: a 1-wide column of inputs alongside a 3-wide column of content rows."""
+    dashboard = get_nested_dashboard(compiled_project)
+    row = dashboard.rows[5]
+    left, right = row.items
+    # Left column: three input rows.
+    assert left.rows is not None
+    assert len(left.rows) == 3
+    for sub in left.rows:
+        assert len(sub.items) == 1
+        assert sub.items[0].input is not None
+
+    # Right column: two content rows, each with one chart.
+    assert right.rows is not None
+    assert len(right.rows) == 2
+    for sub in right.rows:
+        assert len(sub.items) == 1
+        assert sub.items[0].chart is not None
+
+
+def test_section_4_three_levels_deep(compiled_project):
+    """Row 7: a 1-wide row-container whose first sub-row is itself a row-container
+    that contains another sub-row with a chart leaf — verifies the recursive
+    primitive supports at least 3 levels of nesting."""
+    dashboard = get_nested_dashboard(compiled_project)
+    row = dashboard.rows[7]
+    assert len(row.items) == 1
+
+    level_1 = row.items[0]
+    assert level_1.rows is not None and len(level_1.rows) == 2
+
+    # The first sub-row's only item is itself a row-container.
+    nested_item = level_1.rows[0].items[0]
+    assert nested_item.rows is not None
+    assert len(nested_item.rows) == 1
+
+    # Level-3 leaf: a chart.
+    deepest = nested_item.rows[0].items[0]
+    assert deepest.chart is not None
+    assert deepest.rows is None
+
+
+def test_existing_dashboards_unchanged(compiled_project):
+    """The new fixture should not change the existing dashboards' shapes."""
+    names = sorted(d.name for d in compiled_project.dashboards if hasattr(d, "name"))
+    # Existing four + the new fixture.
+    assert "insights-dashboard" in names
+    assert "new-tables-dashboard" in names
+    assert "table-dashboard" in names
+    assert "simple-dashboard" in names
+    assert len(names) >= 5
+
+
+def test_no_existing_item_uses_rows_field(compiled_project):
+    """Every existing top-level dashboard's items are leaves — confirms that
+    the nested fixture is the only consumer of Item.rows in the integration
+    project (and therefore the only thing exercising the new code path)."""
+    for dashboard in compiled_project.dashboards:
+        if dashboard.name == "nested-layouts-dashboard":
+            continue
+        if not hasattr(dashboard, "rows"):
+            # External dashboards have no rows.
+            continue
+        for row in dashboard.rows:
+            for item in row.items:
+                assert item.rows is None, (
+                    f"Existing dashboard '{dashboard.name}' has an Item.rows usage; "
+                    "either back-port the fixture's structure intentionally or "
+                    "update this test."
+                )

--- a/tests/models/test_insight_props_validation.py
+++ b/tests/models/test_insight_props_validation.py
@@ -12,7 +12,6 @@ import pytest
 
 from visivo.models.props.insight_props import InsightProps
 
-
 # ---------------------------------------------------------------------------
 # B08 part 1: file_path / path don't leak into validation
 # ---------------------------------------------------------------------------

--- a/viewer/e2e/stories/nested-layouts.spec.mjs
+++ b/viewer/e2e/stories/nested-layouts.spec.mjs
@@ -1,0 +1,153 @@
+/**
+ * Story: Nested Layouts (VIS-750)
+ *
+ * Validates that the recursive Item.rows primitive (VIS-747 backend, VIS-748
+ * renderer) renders end-to-end against the integration project's
+ * nested-layouts-dashboard fixture.
+ *
+ * The fixture exercises four canonical layout shapes that the legacy flat
+ * Row.items model cannot express:
+ *   1. Uneven vertical stack — one big chart left, three small charts right
+ *   2. 2x2 KPI cluster + sidebar chart
+ *   3. Sidebar layout — input column + content rows
+ *   4. Deep nesting — three levels deep
+ *
+ * Precondition: Sandbox running on :3001/:8001 with the integration project.
+ *   bash scripts/sandbox.sh start
+ */
+
+import { test, expect } from '@playwright/test';
+
+const DASHBOARD_PATH = '/project/nested-layouts-dashboard';
+
+test.describe('Nested Layouts', () => {
+  test('Step 1: Dashboard route loads without runtime errors', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    const networkErrors = [];
+    page.on('response', response => {
+      if (response.status() >= 400 && response.url().includes('/api/')) {
+        networkErrors.push(`${response.status()} ${response.url()}`);
+      }
+    });
+
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // Filter common noise that has nothing to do with our test.
+    const realErrors = consoleErrors.filter(
+      e =>
+        !e.includes('favicon') &&
+        !e.includes('DevTools') &&
+        !e.includes('react-cool') &&
+        !e.includes('compile') /* the integration project ships with intentional compile errors in unrelated dashboards */,
+    );
+    expect(realErrors).toEqual([]);
+    expect(networkErrors).toEqual([]);
+
+    // Dashboard root element should be on the page.
+    await expect(
+      page.locator('[data-testid="dashboard_nested-layouts-dashboard"]'),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('Step 2: All four section headers render in order', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // The four `## Section N — ...` markdown headers exist as h2 elements.
+    const headers = page.locator('h2');
+    await expect(headers.nth(0)).toContainText('Section 1');
+    await expect(headers.nth(1)).toContainText('Section 2');
+    await expect(headers.nth(2)).toContainText('Section 3');
+    await expect(headers.nth(3)).toContainText('Section 4');
+  });
+
+  test('Step 3: Row-container items render the dashboard-nested-rows wrapper', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // The fixture has 5 rows that contain row-container items
+    // (rows 1, 3, 5 each with at least one container; row 7 has one).
+    // We don't pin the exact count — just assert there's at least one wrapper
+    // per section to verify the recursive renderer is firing.
+    const wrappers = page.locator('[data-testid="dashboard-nested-rows"]');
+    await expect(wrappers.first()).toBeVisible({ timeout: 10000 });
+    expect(await wrappers.count()).toBeGreaterThanOrEqual(4);
+  });
+
+  test('Step 4: Sub-rows inside each row-container have the dashboard-nested-subrow testid', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // Section 1 alone has 3 sub-rows (the three small charts on the right);
+    // total across the fixture is 13 sub-rows including deep nesting.
+    // Pin just the lower bound so this test stays robust against fixture growth.
+    const subRows = page.locator('[data-testid="dashboard-nested-subrow"]');
+    await expect(subRows.first()).toBeVisible({ timeout: 10000 });
+    expect(await subRows.count()).toBeGreaterThanOrEqual(13);
+  });
+
+  test('Step 5: Charts inside nested rows render Plotly content', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // The nested charts share types with the rest of the project; if the
+    // recursive renderer skipped them they would be missing. Plotly mounts
+    // a `.js-plotly-plot` div per chart — count and assert >= 5 (the fixture
+    // has more than that across the 4 sections, lower bound is conservative).
+    const plotlyCharts = page.locator('.js-plotly-plot');
+    await expect(plotlyCharts.first()).toBeVisible({ timeout: 20000 });
+    expect(await plotlyCharts.count()).toBeGreaterThanOrEqual(5);
+  });
+
+  test('Step 6: Sub-row weights produce different rendered heights when heights differ', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // Section 1 has a row-container with three [small, small, small] sub-rows.
+    // Their flex values should be equal (weight=2 each), and consequently their
+    // rendered heights should be approximately equal. We pick the first
+    // dashboard-nested-rows wrapper (Section 1) and assert all its direct
+    // sub-row children share the same flex value string.
+    const firstWrapper = page.locator('[data-testid="dashboard-nested-rows"]').first();
+    const subRowsInSection1 = firstWrapper.locator(':scope > [data-testid="dashboard-nested-subrow"]');
+    const count = await subRowsInSection1.count();
+    expect(count).toBe(3);
+
+    const flexValues = await subRowsInSection1.evaluateAll(els => els.map(el => el.style.flex));
+    expect(flexValues[0]).toBeTruthy();
+    expect(flexValues[1]).toBe(flexValues[0]);
+    expect(flexValues[2]).toBe(flexValues[0]);
+  });
+
+  test('Step 7: Sidebar inputs in section 3 render', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // Section 3 has three input widgets (split_threshold dropdown, sort_direction
+    // tabs, show_markers toggle) stacked in a column container. Their wrapper
+    // elements should be visible somewhere on the page.
+    // Inputs render as Flowbite Select / Tabs / Toggle components.
+    // We assert at least one input control surface (form/select/role=tablist/
+    // checkbox) is present; the framework controls vary by display type.
+    const interactiveCount = await page
+      .locator('select, [role="tablist"], [role="checkbox"], [role="radiogroup"], button[role="tab"]')
+      .count();
+    expect(interactiveCount).toBeGreaterThan(0);
+  });
+
+  test('Step 8: Visual snapshot of the nested-layouts dashboard', async ({ page }) => {
+    await page.goto(DASHBOARD_PATH);
+    await page.waitForLoadState('networkidle');
+    // Plotly charts can take a beat to settle.
+    await page.waitForTimeout(2000);
+
+    await page.screenshot({
+      path: 'e2e/screenshots/nested-layouts.png',
+      fullPage: true,
+    });
+  });
+});

--- a/visivo/models/props/insight_props.py
+++ b/visivo/models/props/insight_props.py
@@ -10,7 +10,6 @@ from visivo.models.props.json_schema_base import JsonSchemaBase, get_message_fro
 from visivo.models.props.types import PropType
 from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
 
-
 #: Field names that the parser may attach to props during YAML loading
 #: but that are not valid Plotly trace properties. Strip them out of the
 #: dumped dict before running jsonschema validation, otherwise the


### PR DESCRIPTION
## Summary

Integration-test layer for the `Item.rows` primitive (VIS-747 + VIS-748). Stacked on PR #408; merge order is #408 then this.

## What changed

### Fixture: `test-projects/integration/nested_layouts.visivo.yml`
New `nested-layouts-dashboard` covering 4 patterns:
- Uneven vertical stack (big chart + 3 stacked small)
- 2×2 KPI cluster + sidebar chart
- Sidebar (input column + content rows)
- 3-level deep nesting

Reuses existing project objects; wired into `project.visivo.yml` includes.

### Backend test: `tests/integration/test_nested_layouts_fixture.py`
7 tests that compile_phase the project and assert the parsed structure for each section + a guardrail confirming no other dashboard uses `Item.rows`.

### Playwright story: `viewer/e2e/stories/nested-layouts.spec.mjs`
8 tests covering: load without errors, section headers, `dashboard-nested-rows`/`dashboard-nested-subrow` presence, Plotly content in nested charts, equal-weight sub-rows, sidebar inputs, full-page screenshot.

## Test plan

- [x] `pytest tests/integration/test_nested_layouts_fixture.py` → 7 passed.
- [x] `pytest tests/models/ tests/parsers/ tests/integration/test_nested_layouts_fixture.py` → 444 passed, 0 regressions.
- [x] `compile_phase` on integration project → 5 dashboards, all clean.
- [x] `npx playwright test --list nested-layouts.spec.mjs` → 8 tests collected.
- [ ] Reviewer: `bash scripts/sandbox.sh start && cd viewer && npx playwright test e2e/stories/nested-layouts.spec.mjs` against clean sandbox.

## Linked Linear

- VIS-750: integration fixture + Playwright story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)