### PR TITLE
fix(server): /api/files/ falls back to alpha_hash(stem) lookup (B16)

### DIFF
--- a/tests/server/views/test_file_views.py
+++ b/tests/server/views/test_file_views.py
@@ -1,0 +1,174 @@
+"""Tests for /api/files/<hash>/<run_id>/ — covers the B16 hash-of-stem fallback.
+
+B16: post-1.0.82 the parquet writer started naming files with the model's
+clean name (e.g. `metrics_table.parquet`) instead of `<alpha_hash>.parquet`.
+The frontend still computes `alpha_hash(model_name)` client-side, so every
+table data fetch hits a 404 unless the route falls back to scanning the dir
+and matching by `alpha_hash(stem)`.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+from flask import Flask
+
+from visivo.models.base.named_model import alpha_hash
+from visivo.server.views.file_views import register_file_views
+
+
+# Smallest possible parquet payload: real PAR1 magic bytes + footer. We don't
+# care about the parquet contents in these tests — only that send_file streams
+# the file we expect — so a stub byte string with the magic header is fine for
+# asserting "the right file was served."
+def _write_stub_parquet(path, payload=b"PAR1stub-payload-PAR1"):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(payload)
+
+
+@pytest.fixture
+def output_dir():
+    tmp = tempfile.mkdtemp()
+    yield tmp
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture
+def client(output_dir):
+    app = Flask(__name__)
+    register_file_views(app, output_dir)
+    return app.test_client()
+
+
+def _put_parquet(output_dir, run_id, stem, payload=b"PAR1content"):
+    path = os.path.join(output_dir, run_id, "files", f"{stem}.parquet")
+    _write_stub_parquet(path, payload)
+    return path
+
+
+# ---------- B16 regression: clean-name parquet served by alpha_hash(stem) ----------
+
+
+def test_clean_named_parquet_served_via_alpha_hash_route(client, output_dir):
+    """The bug: parquet on disk is `tiny_metrics.parquet`, frontend asks for
+    `/api/files/<alpha_hash('tiny_metrics')>/main/`. Route must resolve."""
+    model_name = "tiny_metrics"
+    payload = b"PAR1tiny_metrics_payload"
+    _put_parquet(output_dir, "main", model_name, payload=payload)
+
+    response = client.get(f"/api/files/{alpha_hash(model_name)}/main/")
+
+    assert response.status_code == 200
+    assert response.data == payload
+
+
+def test_clean_named_parquet_with_hyphens_and_dots(client, output_dir):
+    """Model names with hyphens and dots (legal stem chars) still resolve."""
+    model_name = "current-deal-status-by-open-month"
+    _put_parquet(output_dir, "main", model_name)
+
+    response = client.get(f"/api/files/{alpha_hash(model_name)}/main/")
+
+    assert response.status_code == 200
+    assert response.data.startswith(b"PAR1")
+
+
+def test_legacy_hash_named_parquet_still_served(client, output_dir):
+    """Pre-1.0.82 layout: parquet on disk is `<hash>.parquet`. Direct match
+    must still win over the fallback so existing target/ dirs keep working
+    when a project upgrades without `rm -rf target/`."""
+    model_name = "legacy_model"
+    name_hash = alpha_hash(model_name)
+    payload = b"PAR1legacy_hash_named"
+    _put_parquet(output_dir, "main", name_hash, payload=payload)
+
+    response = client.get(f"/api/files/{name_hash}/main/")
+
+    assert response.status_code == 200
+    assert response.data == payload
+
+
+def test_mixed_hash_and_clean_names_in_same_run(client, output_dir):
+    """A target/ dir with both legacy hash-named and new clean-named parquets
+    serves both correctly through the same route."""
+    legacy_model = "legacy_model"
+    new_model = "new_model"
+    legacy_payload = b"PAR1legacy"
+    new_payload = b"PAR1clean"
+
+    _put_parquet(output_dir, "main", alpha_hash(legacy_model), payload=legacy_payload)
+    _put_parquet(output_dir, "main", new_model, payload=new_payload)
+
+    legacy_resp = client.get(f"/api/files/{alpha_hash(legacy_model)}/main/")
+    new_resp = client.get(f"/api/files/{alpha_hash(new_model)}/main/")
+
+    assert legacy_resp.status_code == 200
+    assert legacy_resp.data == legacy_payload
+    assert new_resp.status_code == 200
+    assert new_resp.data == new_payload
+
+
+def test_404_when_no_parquet_for_hash(client, output_dir):
+    """Hash that doesn't correspond to anything on disk still 404s."""
+    _put_parquet(output_dir, "main", "real_model")
+    bogus_hash = alpha_hash("does_not_exist")
+
+    response = client.get(f"/api/files/{bogus_hash}/main/")
+
+    assert response.status_code == 404
+
+
+def test_404_when_run_dir_missing(client, output_dir):
+    """A run_id that doesn't exist yet 404s cleanly (no listdir error)."""
+    response = client.get(f"/api/files/{alpha_hash('anything')}/run-that-doesnt-exist/")
+
+    assert response.status_code == 404
+
+
+def test_default_route_serves_main_run(client, output_dir):
+    """The shorthand `/api/files/<hash>/` route uses run_id=main."""
+    _put_parquet(output_dir, "main", "default_model", payload=b"PAR1default")
+
+    response = client.get(f"/api/files/{alpha_hash('default_model')}/")
+
+    assert response.status_code == 200
+    assert response.data == b"PAR1default"
+
+
+# ---------- Cache freshness: a parquet written after the first request is
+# picked up on the next request without a server restart ----------
+
+
+def test_cache_refreshes_on_miss_when_new_parquet_appears(client, output_dir):
+    """First request 404s (no file). After we write the parquet, the next
+    request must succeed — the cache rebuilds on miss."""
+    model_name = "appears_later"
+    name_hash = alpha_hash(model_name)
+
+    first = client.get(f"/api/files/{name_hash}/main/")
+    assert first.status_code == 404
+
+    _put_parquet(output_dir, "main", model_name, payload=b"PAR1now-here")
+
+    second = client.get(f"/api/files/{name_hash}/main/")
+    assert second.status_code == 200
+    assert second.data == b"PAR1now-here"
+
+
+def test_cache_keyed_per_run_id(client, output_dir):
+    """Parquets in different runs don't bleed into each other's lookups."""
+    model_name = "shared_name"
+    name_hash = alpha_hash(model_name)
+
+    _put_parquet(output_dir, "run-a", model_name, payload=b"PAR1from-a")
+    _put_parquet(output_dir, "run-b", model_name, payload=b"PAR1from-b")
+
+    a = client.get(f"/api/files/{name_hash}/run-a/")
+    b = client.get(f"/api/files/{name_hash}/run-b/")
+
+    assert a.status_code == 200
+    assert a.data == b"PAR1from-a"
+    assert b.status_code == 200
+    assert b.data == b"PAR1from-b"

--- a/visivo/server/views/file_views.py
+++ b/visivo/server/views/file_views.py
@@ -1,17 +1,60 @@
 import os
+import threading
 from flask import jsonify, send_file
 from visivo.logger.logger import Logger
+from visivo.models.base.named_model import alpha_hash
 
 
 def register_file_views(app, output_dir):
+    # Per-run cache: {run_id: {hash: parquet_filename}}. Lazy-built on first
+    # request for a run; refreshed on a cache-miss before returning 404 so a
+    # freshly-written parquet is served without restarting the server.
+    _cache = {}
+    _lock = threading.Lock()
+
+    def _files_dir(run_id):
+        return os.path.join(output_dir, run_id, "files")
+
+    def _build_cache(run_id):
+        mapping = {}
+        files_dir = _files_dir(run_id)
+        if os.path.isdir(files_dir):
+            for entry in os.listdir(files_dir):
+                if entry.endswith(".parquet"):
+                    stem = entry[: -len(".parquet")]
+                    mapping[alpha_hash(stem)] = entry
+        return mapping
+
+    def _resolve_filename(hash_value, run_id):
+        with _lock:
+            mapping = _cache.get(run_id)
+            if mapping is None or hash_value not in mapping:
+                mapping = _build_cache(run_id)
+                _cache[run_id] = mapping
+            return mapping.get(hash_value)
+
     @app.route("/api/files/<hash>/<run_id>/")
     def serve_file_data_by_hash_with_run(hash, run_id):
-        """API endpoint to serve data file by hash from a specific run"""
+        """Serve a parquet by hash, with a fallback that hashes on-disk stems.
+
+        Resolution order:
+          1. Direct match: ``<run_id>/files/<hash>.parquet`` (legacy path used
+             pre-1.0.82 when parquets were written with hash filenames).
+          2. Hash-of-stem fallback: scan the run's files dir, return the
+             parquet whose stem hashes to ``<hash>``. This is the post-1.0.82
+             path — parquets are written under their clean model name while
+             the frontend still requests ``alpha_hash(model_name)``.
+        """
         try:
             data_file = os.path.join(output_dir, run_id, "files", f"{hash}.parquet")
-
             if os.path.exists(data_file):
                 return send_file(data_file)
+
+            filename = _resolve_filename(hash, run_id)
+            if filename:
+                resolved = os.path.join(output_dir, run_id, "files", filename)
+                if os.path.exists(resolved):
+                    return send_file(resolved)
 
             return (
                 jsonify({"message": f"Data file not found for hash: {hash} in run: {run_id}"}),


### PR DESCRIPTION
## Summary
- Patch `serve_file_data_by_hash_with_run` in `visivo/server/views/file_views.py` so a 404 from the direct `<hash>.parquet` match triggers a fallback scan that serves the parquet whose stem hashes to the requested hash.
- Mapping is cached per-`run_id` with a thread lock; cache refreshes on miss so newly-written parquets are picked up without restarting the server.
- 9 new tests in `tests/server/views/test_file_views.py`.

## Bug
Every dashboard table built with the 2.0 `${ref(model).column} as Header` syntax 404'd its data fetch:
\`\`\`
404 GET /api/files/<32-char-alpha-hash>/main/
\`\`\`

Three components disagreed on filename convention post-1.0.82:
| Component | Behavior |
|---|---|
| Parquet writer (`jobs/parquet_io.py`) | Writes `<output_dir>/<run_id>/files/<clean_name>.parquet` |
| Insight URL builder (`insight_jobs_views.py`) | Reads filename from disk → embeds clean name in URL ✓ |
| Table data URL (viewer JS) | Computes `alpha_hash(model_name)` → asks for `<hash>.parquet` ✗ |
| Flask route (`file_views.py`) | Exact-match only on `<hash>.parquet` → 404 ✗ |

The route was correct before 1.0.82 (matched the writer's hash filenames). The 1.0.82 commit that switched the writer to clean names didn't update the table path on either the frontend or the route handler.

## Fix approach
Backend-only fallback (Option A from the spec). When `<hash>.parquet` doesn't exist, the route scans the run's files dir and matches by `alpha_hash(stem) == hash`. This:

- Lands as a one-file change on the request path (low blast radius).
- Is fully backwards-compatible — legacy hash-named parquets still serve via the direct lookup.
- Unblocks every consumer immediately without requiring a viewer rebuild.

The longer-term Option B (move table data URLs to clean-stem on the frontend, matching insights) can ship in a follow-up. The route fallback is cheap insurance against future divergence either way.

## Cache behavior
- Per-`run_id` `{hash → filename}` mapping built lazily on first request for that run.
- Refreshed on miss so a freshly-written parquet is picked up immediately.
- Thread-locked because Flask serves concurrently.
- O(1) amortized after warm-up; an O(N) scan over `files/` only runs on the first request and on cache-misses.

## Affected versions
- **Broken:** 1.0.82, 2.0.0
- **Working:** 1.0.81 and earlier (hash-named parquets — direct match wins)

## Test plan
- [x] `poetry run pytest tests/server/views/test_file_views.py` — 9/9 pass.
- [x] Full suite: `poetry run pytest tests/` — 1555 passed.
- [x] Black clean.
- [ ] Manual smoke: spin up an empora-dbt-style project with `${ref(model).column} as Header` tables, drop the local `.venv` patch, confirm tables render rows.
- [ ] Backwards-compat smoke: a project on 1.0.81 → 2.0.x upgrade with mixed hash and clean-name parquets in `target/` (e.g. user did `visivo run` on 1.0.81 then upgraded without `rm -rf target/`) still serves both via the route fallback. (Covered by `test_mixed_hash_and_clean_names_in_same_run`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)