### PR TITLE
feat(viewer): Workspace shell matching B-1 delivered design (VIS-775)

### DIFF
--- a/viewer/src/LocalRouter.jsx
+++ b/viewer/src/LocalRouter.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, createBrowserRouter, createRoutesFromElements } from 'react-router-dom';
+import { Navigate, Route, createBrowserRouter, createRoutesFromElements, useParams } from 'react-router-dom';
 import { futureFlags } from './router-config';
 import { loadProject } from './loaders/project';
 import { loadError } from './loaders/error';
@@ -8,11 +8,17 @@ import ProjectContainer from './components/project/ProjectContainer';
 import BreadcrumbLink from './components/common/BreadcrumbLink';
 import ErrorPage from './components/common/ErrorPage';
 import Onboarding from './components/onboarding/Onboarding';
-import LineageNew from './components/new-views/lineage/LineageNew';
-import EditorNew from './components/new-views/editor/EditorNew';
 import ProjectNew from './components/new-views/project/ProjectNew'; // Container component
 import ExplorerNewPage from './components/explorerNew/ExplorerNewPage';
+import Workspace from './components/new-views/workspace/Workspace';
 import { createURLConfig, setGlobalURLConfig } from './contexts/URLContext';
+
+// VIS-772: /editor/<type>/<name> redirects into Workspace with the edit selector encoded
+// as a query param. Wrapping <Navigate /> so we can pull params out of the URL.
+const EditorTypeNameRedirect = () => {
+  const { type, name } = useParams();
+  return <Navigate to={`/workspace?edit=${type}:${name}`} replace />;
+};
 
 // Set global URL config early for router loaders
 export const localURLConfig = createURLConfig({ environment: 'server' });
@@ -35,22 +41,47 @@ const LocalRouter = createBrowserRouter(
         loader={loadError}
         handle={{ crumb: () => <a href="/">Home</a> }}
       >
+        {/* VIS-772 Track B B1: /lineage and /editor become redirects into Workspace.
+            See specs/dashboard-building/04-open-questions.md Q19 — these routes
+            forever redirect into /workspace. */}
         <Route
-          id="lineage"
+          id="lineage-redirect"
           path="/lineage"
-          element={<LineageNew />}
+          element={<Navigate to="/workspace?view=lineage" replace />}
+        />
+        <Route
+          id="editor-redirect"
+          path="/editor"
+          element={<Navigate to="/workspace?view=project" replace />}
+        />
+        <Route
+          id="editor-typed-redirect"
+          path="/editor/:type/:name"
+          element={<EditorTypeNameRedirect />}
+        />
+        {/* VIS-772 Track B B1: Workspace shell mounts here. The placeholder Workspace
+            component ships with B1; VIS-775 (B2) builds out the full shell per the
+            B-1 design at design/cofounder-mockups/. */}
+        <Route
+          id="workspace"
+          path="/workspace"
+          element={<Workspace />}
           loader={loadProject}
           handle={{
-            crumb: () => <BreadcrumbLink to="/lineage">Lineage</BreadcrumbLink>,
+            crumb: () => <BreadcrumbLink to="/workspace">Workspace</BreadcrumbLink>,
           }}
         />
         <Route
-          id="editor"
-          path="/editor"
-          element={<EditorNew />}
+          id="workspace-dashboard"
+          path="/workspace/dashboard/:dashboardName"
+          element={<Workspace />}
           loader={loadProject}
           handle={{
-            crumb: () => <BreadcrumbLink to="/editor">Editor</BreadcrumbLink>,
+            crumb: match => (
+              <BreadcrumbLink to={`/workspace/dashboard/${match.params.dashboardName}`}>
+                {match.params.dashboardName}
+              </BreadcrumbLink>
+            ),
           }}
         />
         <Route

--- a/viewer/src/LocalRouter.test.jsx
+++ b/viewer/src/LocalRouter.test.jsx
@@ -1,8 +1,117 @@
-import { render } from '@testing-library/react';
-import { RouterProvider } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  RouterProvider,
+  Route,
+  Navigate,
+  createMemoryRouter,
+  createRoutesFromElements,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
 import LocalRouter from './LocalRouter';
 import { futureFlags } from './router-config';
 
+// Smoke test: the production router boots without crashing.
 test('renders Visivo local router', () => {
   render(<RouterProvider router={LocalRouter} future={futureFlags} />);
+});
+
+// ---------- VIS-772 (Track B B1): Workspace routes + redirects ----------
+//
+// We can't use the production router (LocalRouter from createBrowserRouter) to
+// assert specific routing behavior without spinning up jsdom history. Instead we
+// build a small memory router with the same route shapes and assert behavior on
+// the fragments under test.
+
+describe('VIS-772 Workspace routes + redirects', () => {
+  // Probe component used to surface the current URL + matched params in the rendered DOM.
+  const RouteProbe = ({ label }) => {
+    const location = useLocation();
+    const params = useParams();
+    return (
+      <div>
+        <p data-testid={`probe-${label}-pathname`}>{location.pathname}</p>
+        <p data-testid={`probe-${label}-search`}>{location.search}</p>
+        <p data-testid={`probe-${label}-dashboard`}>{params.dashboardName ?? '(none)'}</p>
+      </div>
+    );
+  };
+
+  const TypedRedirect = () => {
+    const { type, name } = useParams();
+    return <Navigate to={`/workspace?edit=${type}:${name}`} replace />;
+  };
+
+  const makeRouter = initialEntry =>
+    createMemoryRouter(
+      createRoutesFromElements(
+        <>
+          <Route path="/lineage" element={<Navigate to="/workspace?view=lineage" replace />} />
+          <Route path="/editor" element={<Navigate to="/workspace?view=project" replace />} />
+          <Route path="/editor/:type/:name" element={<TypedRedirect />} />
+          <Route path="/workspace" element={<RouteProbe label="workspace" />} />
+          <Route
+            path="/workspace/dashboard/:dashboardName"
+            element={<RouteProbe label="workspace" />}
+          />
+          <Route path="/project" element={<RouteProbe label="project" />} />
+          <Route path="/project/:dashboardName?" element={<RouteProbe label="project" />} />
+        </>
+      ),
+      { initialEntries: [initialEntry], future: futureFlags }
+    );
+
+  const renderAt = entry => render(<RouterProvider router={makeRouter(entry)} future={futureFlags} />);
+
+  test('mounts Workspace at /workspace (unscoped)', async () => {
+    renderAt('/workspace');
+    expect(await screen.findByTestId('probe-workspace-pathname')).toHaveTextContent('/workspace');
+    expect(screen.getByTestId('probe-workspace-dashboard')).toHaveTextContent('(none)');
+  });
+
+  test('mounts Workspace at /workspace/dashboard/<name>', async () => {
+    renderAt('/workspace/dashboard/simple-dashboard');
+    expect(await screen.findByTestId('probe-workspace-pathname')).toHaveTextContent(
+      '/workspace/dashboard/simple-dashboard'
+    );
+    expect(screen.getByTestId('probe-workspace-dashboard')).toHaveTextContent('simple-dashboard');
+  });
+
+  test('redirects /editor → /workspace?view=project', async () => {
+    renderAt('/editor');
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-workspace-pathname')).toHaveTextContent('/workspace');
+    });
+    expect(screen.getByTestId('probe-workspace-search')).toHaveTextContent('?view=project');
+  });
+
+  test('redirects /editor/<type>/<name> → /workspace?edit=<type>:<name>', async () => {
+    renderAt('/editor/chart/revenue_chart');
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-workspace-pathname')).toHaveTextContent('/workspace');
+    });
+    expect(screen.getByTestId('probe-workspace-search')).toHaveTextContent(
+      '?edit=chart:revenue_chart'
+    );
+  });
+
+  test('redirects /lineage → /workspace?view=lineage', async () => {
+    renderAt('/lineage');
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-workspace-pathname')).toHaveTextContent('/workspace');
+    });
+    expect(screen.getByTestId('probe-workspace-search')).toHaveTextContent('?view=lineage');
+  });
+
+  test('preserves /project route (Q18)', async () => {
+    renderAt('/project');
+    expect(await screen.findByTestId('probe-project-pathname')).toHaveTextContent('/project');
+  });
+
+  test('preserves /project/<name> route (Q18)', async () => {
+    renderAt('/project/simple-dashboard');
+    expect(await screen.findByTestId('probe-project-dashboard')).toHaveTextContent(
+      'simple-dashboard'
+    );
+  });
 });

--- a/viewer/src/components/new-views/workspace/DragHandle.jsx
+++ b/viewer/src/components/new-views/workspace/DragHandle.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * DragHandle — rail-resize gutter visual.
+ *
+ * 4 px hot zone (the outer `w-1` band), 1 px gray line in the middle,
+ * mulberry on hover/active. When `active` is true a navy width tooltip
+ * surfaces the current width (used by the s5 artboard "rail resize, drag
+ * active" state).
+ *
+ * Phase 0 ships the visual only — actual pointer-drag resize behaviour is
+ * deferred. Hooking up the resize is straightforward (pointermove diffing
+ * against `onDragWidthChange`) and lands when the rails grow editable
+ * content that needs the user-controllable width.
+ */
+const DragHandle = ({
+  side = 'left',
+  active = false,
+  widthLabel = null,
+  onPointerDown,
+  testId = 'workspace-drag-handle',
+}) => {
+  const base =
+    'group relative h-full w-1 shrink-0 cursor-col-resize select-none';
+  const tone = active
+    ? 'bg-[#713b57]/30'
+    : 'bg-transparent hover:bg-[#713b57]/15';
+  const lineBase =
+    'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2';
+  const lineTone = active
+    ? 'bg-[#713b57]'
+    : 'bg-gray-200 group-hover:bg-[#713b57]';
+
+  return (
+    <div
+      data-testid={`${testId}-${side}`}
+      role="separator"
+      aria-orientation="vertical"
+      onPointerDown={onPointerDown}
+      className={`${base} ${tone}`}
+    >
+      <div className={`${lineBase} ${lineTone}`} />
+      {active && widthLabel && (
+        <div
+          className={[
+            'pointer-events-none absolute top-1/2 z-10 -translate-y-1/2 whitespace-nowrap rounded-md bg-[#191d33] px-2 py-1 text-[11px] font-medium text-white shadow-md',
+            side === 'left' ? 'left-3' : 'right-3',
+          ].join(' ')}
+        >
+          {widthLabel}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DragHandle;

--- a/viewer/src/components/new-views/workspace/LeftRail.jsx
+++ b/viewer/src/components/new-views/workspace/LeftRail.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import {
+  PiMagnifyingGlass,
+  PiPlus,
+  PiChartBar,
+  PiLightbulb,
+  PiCube,
+  PiDatabase,
+  PiCaretDown,
+  PiSidebar,
+} from 'react-icons/pi';
+
+/**
+ * LeftRail — project-wide Library navigator (VIS-775 / Track B B2).
+ *
+ * Phase 0 ships the **shell** only: section headers (Insert · Charts ·
+ * Insights · Models · Sources) and a search-input placeholder. The actual
+ * Library content (per-section item lists, drag sources, scope chips
+ * `[All] [Used here] [Compatible]`) ships in VIS-C1 (Track C).
+ *
+ * The rail anchors full-height (top bar to bottom of viewport). When
+ * collapsed it becomes a 48-px icon strip with the same vocabulary so the
+ * user can quickly re-expand or jump to a specific section.
+ */
+
+const SECTIONS = [
+  { key: 'insert', label: 'Insert', icon: PiPlus, hint: 'layout primitives' },
+  { key: 'charts', label: 'Charts', icon: PiChartBar },
+  { key: 'insights', label: 'Insights', icon: PiLightbulb },
+  { key: 'models', label: 'Models', icon: PiCube },
+  { key: 'sources', label: 'Sources', icon: PiDatabase },
+];
+
+const SectionHeader = ({ section }) => (
+  <button
+    type="button"
+    className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-[11px] font-semibold uppercase tracking-wider text-gray-500 hover:bg-gray-50"
+    data-testid={`workspace-left-rail-section-${section.key}`}
+  >
+    <PiCaretDown aria-hidden="true" className="h-3 w-3 -rotate-90 transition-transform" />
+    {section.label}
+    {section.hint && (
+      <span className="ml-auto pr-1 font-normal normal-case tracking-normal text-gray-400">
+        {section.hint}
+      </span>
+    )}
+  </button>
+);
+
+const LeftRailExpanded = ({ onCollapse }) => {
+  return (
+    <aside
+      data-testid="workspace-left-rail"
+      data-collapsed="false"
+      className="flex h-full flex-col border-r border-gray-200 bg-white"
+    >
+      <div className="flex h-10 shrink-0 items-center justify-between border-b border-gray-200 px-3">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] font-semibold text-gray-900">Library</span>
+          <span className="text-[11px] text-gray-400">· project</span>
+        </div>
+        <button
+          type="button"
+          onClick={onCollapse}
+          className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          title="Collapse left rail"
+          aria-label="Collapse left rail"
+          data-testid="workspace-left-rail-collapse"
+        >
+          <PiSidebar className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1.5 border-b border-gray-200 px-3 py-2">
+        <div className="flex h-8 items-center gap-2 rounded-md bg-gray-100 px-2 text-[12px] text-gray-500">
+          <PiMagnifyingGlass aria-hidden="true" className="h-3.5 w-3.5" />
+          Search library…
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-1.5 py-2 text-[13px] text-gray-800">
+        {SECTIONS.map((section) => (
+          <div key={section.key} className="mb-1">
+            <SectionHeader section={section} />
+          </div>
+        ))}
+
+        <div
+          data-testid="workspace-left-rail-placeholder"
+          className="mt-4 rounded-md border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-[12px] text-gray-500"
+        >
+          Library coming soon (VIS-C1)
+        </div>
+      </div>
+
+      <div className="shrink-0 border-t border-gray-200 px-3 py-2 text-[11px] text-gray-400">
+        Drag any item onto the canvas or onto the Edit panel.
+      </div>
+    </aside>
+  );
+};
+
+const LeftRailCollapsed = ({ onExpand }) => {
+  return (
+    <aside
+      data-testid="workspace-left-rail"
+      data-collapsed="true"
+      className="flex h-full w-12 flex-col items-center border-r border-gray-200 bg-white"
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex h-10 w-12 shrink-0 items-center justify-center border-b border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900"
+        title="Expand left rail"
+        aria-label="Expand left rail"
+        data-testid="workspace-left-rail-expand"
+      >
+        <PiSidebar className="h-4 w-4" />
+      </button>
+      <div className="flex flex-1 flex-col items-center gap-1 py-2">
+        <button
+          type="button"
+          title="Search"
+          aria-label="Search"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+        >
+          <PiMagnifyingGlass className="h-[18px] w-[18px]" />
+        </button>
+        {SECTIONS.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            title={label}
+            aria-label={label}
+            data-testid={`workspace-left-rail-collapsed-${key}`}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          >
+            <Icon className="h-[18px] w-[18px]" />
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+};
+
+const LeftRail = ({ collapsed = false, onToggleCollapsed }) => {
+  return collapsed ? (
+    <LeftRailCollapsed onExpand={onToggleCollapsed} />
+  ) : (
+    <LeftRailExpanded onCollapse={onToggleCollapsed} />
+  );
+};
+
+export default LeftRail;

--- a/viewer/src/components/new-views/workspace/MiddlePane.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.jsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import SubBar, { PreviewLensPicker } from './SubBar';
+import DashboardNew from '../project/DashboardNew';
+
+/**
+ * MiddlePane — dispatches on `activeObject.type` (VIS-775 / Track B B2).
+ *
+ *   project    → ProjectEditorPlaceholder (Track M ships the polished surface)
+ *   dashboard  → DashboardNew (existing renderer) when scoped, placeholder
+ *                otherwise
+ *   chart      → PerObjectPreviewPlaceholder (Track N)
+ *   model      → PerObjectPreviewPlaceholder (Track N) — lineage fallback in n2
+ *   _          → UnknownObjectPlaceholder
+ *
+ * Each variant renders the `<SubBar>` above its viewport so the lens picker
+ * stays close to the surface it switches the view of (per the chat
+ * transcript in `design/cofounder-mockups/chats/chat1.md`).
+ */
+
+const Placeholder = ({ title, body, testId }) => (
+  <div
+    data-testid={testId}
+    className="flex flex-1 items-center justify-center bg-gray-50 p-12"
+  >
+    <div className="max-w-[440px] rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+      <h2 className="text-[16px] font-semibold text-gray-900">{title}</h2>
+      {body && (
+        <p className="mx-auto mt-1.5 max-w-[320px] text-[13px] leading-relaxed text-gray-500">
+          {body}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const ProjectPane = ({ activeObject }) => {
+  const projectName = activeObject?.name || 'project';
+  return (
+    <section
+      data-testid="workspace-middle-project"
+      className="flex h-full w-full flex-col bg-gray-50"
+    >
+      <SubBar
+        testId="workspace-subbar-project"
+        left={
+          <div className="flex items-center gap-2 text-[12px]">
+            <span className="font-semibold text-gray-900">{projectName}</span>
+            <span className="text-gray-400">·</span>
+            <span className="text-gray-500">project</span>
+          </div>
+        }
+      />
+      <Placeholder
+        testId="workspace-middle-project-placeholder"
+        title="Project Editor coming soon (Track M)"
+        body="The unscoped Workspace surface ships in Wave 2 as VIS-M1 — health row, level groups, and recent edits."
+      />
+    </section>
+  );
+};
+
+const DashboardPane = ({ activeObject, lens, onLensChange, projectId }) => {
+  const name = activeObject?.name;
+  return (
+    <section
+      data-testid="workspace-middle-dashboard"
+      className="flex h-full w-full flex-col bg-gray-50"
+    >
+      <SubBar
+        testId="workspace-subbar-dashboard"
+        left={
+          <div className="flex items-center gap-2 text-[12px]">
+            <span className="font-semibold text-gray-900">{name}</span>
+            <span className="text-gray-400">·</span>
+            <span className="text-gray-500">dashboard</span>
+          </div>
+        }
+        right={
+          <PreviewLensPicker
+            value={lens}
+            onChange={onLensChange}
+            previewLabel="Canvas"
+          />
+        }
+      />
+      {lens === 'lineage' ? (
+        <Placeholder
+          testId="workspace-middle-dashboard-lineage"
+          title="Lineage view coming soon (Track E)"
+          body={`Showing the +${name || ''} neighbourhood in the DAG.`}
+        />
+      ) : name && projectId ? (
+        <div
+          data-testid="workspace-middle-dashboard-canvas"
+          className="flex-1 overflow-auto"
+        >
+          <DashboardNew projectId={projectId} dashboardName={name} />
+        </div>
+      ) : (
+        <Placeholder
+          testId="workspace-middle-dashboard-placeholder"
+          title="No dashboard scoped"
+          body="Open a dashboard from the Library to start editing."
+        />
+      )}
+    </section>
+  );
+};
+
+const PerObjectPane = ({ activeObject, lens, onLensChange, fallbackToLineage = false }) => {
+  const name = activeObject?.name || '(unnamed)';
+  const type = activeObject?.type || 'object';
+  const lensEffective = fallbackToLineage ? 'lineage' : lens;
+  return (
+    <section
+      data-testid={`workspace-middle-${type}`}
+      className="flex h-full w-full flex-col bg-gray-50"
+    >
+      <SubBar
+        testId={`workspace-subbar-${type}`}
+        left={
+          <div className="flex items-center gap-2 text-[12px]">
+            <span className="font-semibold text-gray-900">{name}</span>
+            <span className="text-gray-400">·</span>
+            <span className="text-gray-500">{type}</span>
+            {fallbackToLineage && (
+              <>
+                <span className="text-gray-400">·</span>
+                <span className="text-[11px] font-medium text-amber-700">
+                  No preview yet — showing lineage
+                </span>
+              </>
+            )}
+          </div>
+        }
+        right={
+          <PreviewLensPicker
+            value={lensEffective}
+            onChange={onLensChange}
+            previewLabel="Preview"
+            previewDisabled={fallbackToLineage}
+          />
+        }
+      />
+      <Placeholder
+        testId={`workspace-middle-${type}-placeholder`}
+        title="Per-object preview coming soon (Track N)"
+        body={`Custom previews for ${type}s ship in Phase 4. Phase 0 falls back to the lineage view for object types without a renderer.`}
+      />
+    </section>
+  );
+};
+
+const MiddlePane = ({
+  activeObject = null,
+  lens = 'preview',
+  onLensChange,
+  projectId = null,
+}) => {
+  const obj = activeObject || { type: 'project', name: 'project' };
+
+  if (obj.type === 'project') {
+    return <ProjectPane activeObject={obj} />;
+  }
+  if (obj.type === 'dashboard') {
+    return (
+      <DashboardPane
+        activeObject={obj}
+        lens={lens}
+        onLensChange={onLensChange}
+        projectId={projectId}
+      />
+    );
+  }
+  if (obj.type === 'chart') {
+    return (
+      <PerObjectPane
+        activeObject={obj}
+        lens={lens}
+        onLensChange={onLensChange}
+      />
+    );
+  }
+  if (obj.type === 'model') {
+    // Lineage fallback — no chart-preview component yet.
+    return (
+      <PerObjectPane
+        activeObject={obj}
+        lens={lens}
+        onLensChange={onLensChange}
+        fallbackToLineage
+      />
+    );
+  }
+  // Unknown — still mount the sub-bar so the shell visual is consistent.
+  return (
+    <PerObjectPane
+      activeObject={obj}
+      lens={lens}
+      onLensChange={onLensChange}
+    />
+  );
+};
+
+export default MiddlePane;

--- a/viewer/src/components/new-views/workspace/RightRail.jsx
+++ b/viewer/src/components/new-views/workspace/RightRail.jsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import {
+  PiList,
+  PiPencil,
+  PiClockCounterClockwise,
+  PiSidebar,
+} from 'react-icons/pi';
+
+/**
+ * RightRail — Outline / Edit / History tab host (VIS-775 / Track B B2).
+ *
+ * Three tabs (mulberry underline indicator on the active one):
+ *   - **Outline** — compact tree of the active object (project for the
+ *     unscoped surface, dashboard structure for a scoped dashboard, etc.).
+ *     Real tree ships in VIS-F3.
+ *   - **Edit** — selection-driven property editor. Real form ships in
+ *     VIS-G1 (and the per-object forms in Track G).
+ *   - **History** — deferred to v1.x. The slot exists so the visual is
+ *     present and the right-rail tab bar's three-way symmetry holds.
+ *
+ * The active object's `name` is surfaced in the Edit-tab placeholder so the
+ * shell visibly reacts to tab/selection changes during Phase 0.
+ */
+
+const TABS = [
+  { key: 'outline', label: 'Outline', icon: PiList },
+  { key: 'edit', label: 'Edit', icon: PiPencil },
+  { key: 'history', label: 'History', icon: PiClockCounterClockwise },
+];
+
+const TabBtn = ({ tab, active, onClick }) => {
+  const Icon = tab.icon;
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      data-testid={`workspace-right-rail-tab-${tab.key}`}
+      data-active={active ? 'true' : 'false'}
+      className={[
+        'relative inline-flex h-full items-center gap-1.5 px-2.5 text-[13px] font-medium transition-colors',
+        active ? 'text-gray-900' : 'text-gray-500 hover:text-gray-900',
+      ].join(' ')}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {tab.label}
+      {active && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-x-1 -bottom-px h-0.5 rounded-full bg-primary"
+        />
+      )}
+    </button>
+  );
+};
+
+const RightRailBody = ({ activeTab, activeObject }) => {
+  if (activeTab === 'outline') {
+    return (
+      <div
+        data-testid="workspace-right-rail-outline"
+        className="flex flex-1 items-start justify-center px-6 py-8 text-center"
+      >
+        <div className="text-gray-500">
+          <PiList aria-hidden="true" className="mx-auto mb-2 h-5 w-5 text-gray-400" />
+          <p className="text-[12px] leading-relaxed">
+            Outline tree coming soon (VIS-F3)
+          </p>
+        </div>
+      </div>
+    );
+  }
+  if (activeTab === 'edit') {
+    return (
+      <div
+        data-testid="workspace-right-rail-edit"
+        className="flex flex-1 items-start justify-center px-6 py-8 text-center"
+      >
+        <div className="text-gray-500">
+          <PiPencil aria-hidden="true" className="mx-auto mb-2 h-5 w-5 text-gray-400" />
+          <p className="text-[12px] leading-relaxed">
+            Edit form coming soon (VIS-G1)
+            {activeObject && (
+              <>
+                {' '}
+                — selected:{' '}
+                <span
+                  className="font-medium text-gray-700"
+                  data-testid="workspace-right-rail-edit-active-name"
+                >
+                  {activeObject.name}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+    );
+  }
+  // history
+  return (
+    <div
+      data-testid="workspace-right-rail-history"
+      className="flex flex-1 items-start justify-center px-6 py-8 text-center"
+    >
+      <div className="text-gray-500">
+        <PiClockCounterClockwise
+          aria-hidden="true"
+          className="mx-auto mb-2 h-5 w-5 text-gray-400"
+        />
+        <p className="text-[12px] leading-relaxed">Coming in v1.x</p>
+      </div>
+    </div>
+  );
+};
+
+const RightRailExpanded = ({
+  activeTab,
+  onSelectTab,
+  onCollapse,
+  activeObject,
+}) => {
+  return (
+    <aside
+      data-testid="workspace-right-rail"
+      data-collapsed="false"
+      className="flex h-full flex-col border-l border-gray-200 bg-white"
+    >
+      <div className="flex h-10 shrink-0 items-center justify-between border-b border-gray-200 pl-2 pr-3">
+        <div role="tablist" aria-label="Right rail" className="flex h-full items-center gap-1">
+          {TABS.map((tab) => (
+            <TabBtn
+              key={tab.key}
+              tab={tab}
+              active={activeTab === tab.key}
+              onClick={() => onSelectTab && onSelectTab(tab.key)}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onCollapse}
+          title="Collapse right rail"
+          aria-label="Collapse right rail"
+          data-testid="workspace-right-rail-collapse"
+          className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+        >
+          <PiSidebar className="h-4 w-4 -scale-x-100" />
+        </button>
+      </div>
+      <RightRailBody activeTab={activeTab} activeObject={activeObject} />
+    </aside>
+  );
+};
+
+const RightRailCollapsed = ({ activeTab, onExpand }) => {
+  return (
+    <aside
+      data-testid="workspace-right-rail"
+      data-collapsed="true"
+      className="flex h-full w-12 flex-col items-center border-l border-gray-200 bg-white"
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        title="Expand right rail"
+        aria-label="Expand right rail"
+        data-testid="workspace-right-rail-expand"
+        className="flex h-10 w-12 shrink-0 items-center justify-center border-b border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900"
+      >
+        <PiSidebar className="h-4 w-4 -scale-x-100" />
+      </button>
+      <div className="flex flex-1 flex-col items-center gap-1 py-2">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const active = tab.key === activeTab;
+          return (
+            <button
+              type="button"
+              key={tab.key}
+              title={tab.label}
+              aria-label={tab.label}
+              data-testid={`workspace-right-rail-collapsed-${tab.key}`}
+              className={[
+                'inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors',
+                active
+                  ? 'bg-[#e2d7dd] text-[#5a2f45]'
+                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-900',
+              ].join(' ')}
+            >
+              <Icon className="h-[18px] w-[18px]" />
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+};
+
+const RightRail = ({
+  collapsed = false,
+  activeTab = 'edit',
+  onSelectTab,
+  onToggleCollapsed,
+  activeObject = null,
+}) => {
+  return collapsed ? (
+    <RightRailCollapsed activeTab={activeTab} onExpand={onToggleCollapsed} />
+  ) : (
+    <RightRailExpanded
+      activeTab={activeTab}
+      onSelectTab={onSelectTab}
+      onCollapse={onToggleCollapsed}
+      activeObject={activeObject}
+    />
+  );
+};
+
+export default RightRail;

--- a/viewer/src/components/new-views/workspace/Segmented.jsx
+++ b/viewer/src/components/new-views/workspace/Segmented.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+/**
+ * Segmented — design-system primitive for the sub-bar lens picker and any
+ * other two-/three-state toggle that benefits from a pill-on-track look.
+ *
+ * Two tones (per the delivered B-1 design system notes in
+ * `design/cofounder-mockups/`):
+ *   - `light` (default) — white pill on a tinted gray track. Used by the
+ *     `<SubBar>` `[Canvas | Lineage]` toggle.
+ *   - `dark` — white pill on navy. Reserved for any future on-dark surface.
+ *
+ * Each option: `{ value, label, icon?, disabled?, title? }`. The selected
+ * `value` is matched against `value` on the parent prop. `disabled` items
+ * render muted and are non-interactive — used for the "lineage fallback"
+ * pattern where Preview is disabled because the object type has no preview
+ * component yet (per the n2 artboard).
+ */
+const Segmented = ({
+  value,
+  onChange,
+  options = [],
+  tone = 'light',
+  size = 'sm',
+  ariaLabel,
+  testId,
+}) => {
+  const heightCls = size === 'sm' ? 'h-7' : 'h-8';
+  const trackCls =
+    tone === 'dark'
+      ? 'bg-white/10 ring-white/15'
+      : 'bg-gray-100 ring-gray-200';
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={`inline-flex ${heightCls} items-center gap-0.5 rounded-md p-0.5 ring-1 ${trackCls}`}
+    >
+      {options.map((opt) => {
+        const isActive = opt.value === value;
+        const isDisabled = !!opt.disabled;
+        const baseActive =
+          tone === 'dark'
+            ? 'bg-white text-[#191d33] shadow-sm'
+            : 'bg-white text-[#191d33] shadow-sm ring-1 ring-gray-200';
+        const baseInactive =
+          tone === 'dark'
+            ? 'text-white/70 hover:text-white hover:bg-white/10'
+            : 'text-gray-500 hover:text-gray-900 hover:bg-white/60';
+        const baseDisabled = 'cursor-not-allowed text-gray-300';
+        const cls = isDisabled ? baseDisabled : isActive ? baseActive : baseInactive;
+        const Icon = opt.icon || null;
+        return (
+          <button
+            type="button"
+            key={opt.value}
+            role="tab"
+            aria-selected={isActive}
+            aria-disabled={isDisabled || undefined}
+            disabled={isDisabled}
+            title={opt.title}
+            onClick={() => !isDisabled && onChange && onChange(opt.value)}
+            className={`inline-flex h-full items-center gap-1.5 rounded-[5px] px-2.5 text-[12px] font-medium transition-colors ${cls}`}
+            data-testid={
+              testId && opt.value ? `${testId}-option-${opt.value}` : undefined
+            }
+          >
+            {Icon && <Icon className="h-3.5 w-3.5" />}
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Segmented;

--- a/viewer/src/components/new-views/workspace/SubBar.jsx
+++ b/viewer/src/components/new-views/workspace/SubBar.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { PiSquaresFour, PiTreeStructure } from 'react-icons/pi';
+import Segmented from './Segmented';
+
+/**
+ * SubBar — h-9 white bar above the middle-pane viewport.
+ *
+ * Per the delivered B-1 design (`design/cofounder-mockups/`), every preview
+ * surface shares this pattern: `<name> · <metadata>` on the LEFT, view
+ * switcher on the RIGHT. Single visual idiom across dashboards, charts,
+ * insights, models, and tables — adding a new object type means adding a
+ * new MiddlePane variant that reuses `<SubBar>` (Track N).
+ */
+export const SubBar = ({ left, right, testId = 'workspace-subbar' }) => {
+  return (
+    <div
+      data-testid={testId}
+      className="flex h-9 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-3"
+    >
+      <div className="min-w-0 flex-1 truncate">{left}</div>
+      <div className="shrink-0">{right}</div>
+    </div>
+  );
+};
+
+/**
+ * PreviewLensPicker — the `[Canvas | Lineage]` / `[Preview | Lineage]`
+ * segmented lives in the sub-bar, NOT in the top bar. View switcher
+ * belongs next to the thing it's switching the view of (per the chat
+ * transcript in `design/cofounder-mockups/chats/chat1.md`).
+ *
+ * `previewLabel` lets non-dashboard objects say "Preview" instead of
+ * "Canvas". `previewDisabled` is the lineage-fallback case — object types
+ * that don't have a preview component yet (e.g. Phase 0 models) stay parked
+ * on Lineage and Preview reads as muted.
+ */
+export const PreviewLensPicker = ({
+  value,
+  onChange,
+  previewLabel = 'Preview',
+  previewDisabled = false,
+  testId = 'workspace-lens-picker',
+}) => {
+  return (
+    <Segmented
+      ariaLabel="View"
+      tone="light"
+      value={value}
+      onChange={onChange}
+      testId={testId}
+      options={[
+        {
+          value: 'preview',
+          label: previewLabel,
+          icon: PiSquaresFour,
+          disabled: previewDisabled,
+          title: previewDisabled
+            ? 'No preview available yet — showing lineage'
+            : undefined,
+        },
+        {
+          value: 'lineage',
+          label: 'Lineage',
+          icon: PiTreeStructure,
+        },
+      ]}
+    />
+  );
+};
+
+export default SubBar;

--- a/viewer/src/components/new-views/workspace/TabStrip.jsx
+++ b/viewer/src/components/new-views/workspace/TabStrip.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { PiX, PiPlus } from 'react-icons/pi';
+import { getKind } from './objKind';
+
+/**
+ * WorkspaceTab — a single tab in the strip.
+ *
+ * Per the delivered B-1 design:
+ *   - type icon (from OBJ_KIND) + name + dirty dot + close (×).
+ *   - Active tab: white background, dark text, mulberry bottom underline.
+ *   - Inactive tab: gray track, lighter text; hover lifts to white.
+ *   - Close button: always visible when active or dirty (so the user can
+ *     dismiss the dirty dot); fades in on hover otherwise.
+ *
+ * Project is just another tab with the cube icon — no special chrome.
+ */
+const WorkspaceTab = ({ tab, active, onSelect, onClose }) => {
+  const kind = getKind(tab.type);
+  const TypeIcon = kind.icon;
+  return (
+    <div
+      role="tab"
+      aria-selected={active}
+      data-testid={`workspace-tab-${tab.id}`}
+      data-active={active ? 'true' : 'false'}
+      className={[
+        'group/tab relative flex h-9 min-w-0 max-w-[220px] shrink-0 items-center gap-1.5 border-r border-gray-200 px-3 text-[12.5px] transition-colors',
+        active
+          ? 'bg-white text-gray-900 font-medium'
+          : 'bg-gray-50 text-gray-600 hover:bg-white/70 hover:text-gray-900',
+      ].join(' ')}
+    >
+      <button
+        type="button"
+        onClick={() => onSelect && onSelect(tab.id)}
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        title={tab.name}
+        data-testid={`workspace-tab-select-${tab.id}`}
+      >
+        <TypeIcon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+        <span className="truncate">{tab.name}</span>
+        {tab.dirty && (
+          <span
+            title="Unsaved changes"
+            data-testid={`workspace-tab-dirty-${tab.id}`}
+            className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+          />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose && onClose(tab.id);
+        }}
+        title="Close tab"
+        aria-label={`Close ${tab.name}`}
+        data-testid={`workspace-tab-close-${tab.id}`}
+        className={[
+          'ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-gray-400 transition-opacity',
+          active || tab.dirty
+            ? 'opacity-100 hover:bg-gray-200 hover:text-gray-900'
+            : 'opacity-0 group-hover/tab:opacity-100 hover:bg-gray-200 hover:text-gray-900',
+        ].join(' ')}
+      >
+        <PiX className="h-3 w-3" />
+      </button>
+      {active && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-x-1 -bottom-px h-0.5 rounded-full bg-primary"
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * TabStrip — h-9 white bar between the top bar and the middle/right area.
+ *
+ * Sits OVER the middle + right rail only — the left rail anchors full-height.
+ * This visually signals that tabs scope the active-object area (middle +
+ * right rail), not the project-wide Library.
+ *
+ * Phase 0 supports: open project tab on mount, click-to-switch, close.
+ * Drag-to-reorder ships in VIS-O3.
+ */
+const TabStrip = ({
+  tabs = [],
+  activeId,
+  onSelect,
+  onClose,
+  onNewTab,
+}) => {
+  if (!tabs || tabs.length === 0) return null;
+  return (
+    <div
+      data-testid="workspace-tab-strip"
+      role="tablist"
+      aria-label="Workspace tabs"
+      className="relative flex h-9 shrink-0 items-stretch border-b border-gray-200 bg-gray-50"
+    >
+      <div className="flex flex-1 items-stretch overflow-x-auto">
+        {tabs.map((tab) => (
+          <WorkspaceTab
+            key={tab.id}
+            tab={tab}
+            active={tab.id === activeId}
+            onSelect={onSelect}
+            onClose={onClose}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={onNewTab}
+          title="New tab"
+          aria-label="New tab"
+          data-testid="workspace-tab-new"
+          className="ml-1 inline-flex h-9 w-9 shrink-0 items-center justify-center text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+        >
+          <PiPlus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TabStrip;

--- a/viewer/src/components/new-views/workspace/TabStrip.test.jsx
+++ b/viewer/src/components/new-views/workspace/TabStrip.test.jsx
@@ -1,0 +1,89 @@
+/**
+ * TabStrip behaviour (VIS-775 / Track B B2).
+ *
+ * Pure-presentational tests against the strip. The smart tab state
+ * (workspace store hydration, URL sync) is covered in Workspace.test.jsx.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TabStrip from './TabStrip';
+
+const sampleTabs = [
+  { id: 'project:analytics-platform', type: 'project', name: 'analytics-platform' },
+  {
+    id: 'dashboard:simple-dashboard',
+    type: 'dashboard',
+    name: 'simple-dashboard',
+    dirty: true,
+  },
+  { id: 'chart:revenue_chart', type: 'chart', name: 'revenue_chart' },
+];
+
+describe('TabStrip', () => {
+  test('renders nothing when there are no tabs', () => {
+    const { container } = render(<TabStrip tabs={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders one tab per descriptor with the right active state', () => {
+    render(
+      <TabStrip tabs={sampleTabs} activeId="dashboard:simple-dashboard" />
+    );
+    expect(
+      screen.getByTestId('workspace-tab-project:analytics-platform')
+    ).toHaveAttribute('data-active', 'false');
+    expect(
+      screen.getByTestId('workspace-tab-dashboard:simple-dashboard')
+    ).toHaveAttribute('data-active', 'true');
+    expect(
+      screen.getByTestId('workspace-tab-chart:revenue_chart')
+    ).toHaveAttribute('data-active', 'false');
+  });
+
+  test('renders the dirty dot on tabs marked dirty', () => {
+    render(<TabStrip tabs={sampleTabs} activeId={null} />);
+    expect(
+      screen.getByTestId('workspace-tab-dirty-dashboard:simple-dashboard')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('workspace-tab-dirty-project:analytics-platform')
+    ).not.toBeInTheDocument();
+  });
+
+  test('clicking the tab body calls onSelect with the tab id', () => {
+    const onSelect = jest.fn();
+    render(
+      <TabStrip tabs={sampleTabs} activeId={null} onSelect={onSelect} />
+    );
+    fireEvent.click(
+      screen.getByTestId('workspace-tab-select-chart:revenue_chart')
+    );
+    expect(onSelect).toHaveBeenCalledWith('chart:revenue_chart');
+  });
+
+  test('clicking the close button calls onClose without bubbling to select', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <TabStrip
+        tabs={sampleTabs}
+        activeId={null}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(
+      screen.getByTestId('workspace-tab-close-dashboard:simple-dashboard')
+    );
+    expect(onClose).toHaveBeenCalledWith('dashboard:simple-dashboard');
+    // stopPropagation in the close handler prevents the underlying select fire.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test('clicking the + button calls onNewTab', () => {
+    const onNewTab = jest.fn();
+    render(<TabStrip tabs={sampleTabs} activeId={null} onNewTab={onNewTab} />);
+    fireEvent.click(screen.getByTestId('workspace-tab-new'));
+    expect(onNewTab).toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/new-views/workspace/TopBar.jsx
+++ b/viewer/src/components/new-views/workspace/TopBar.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { SiSlack } from 'react-icons/si';
+import { MdMenuBook } from 'react-icons/md';
+import { FaUserCircle } from 'react-icons/fa';
+import { HiOutlineCloudUpload } from 'react-icons/hi';
+import { PiCaretRight } from 'react-icons/pi';
+import logo from '../../../images/logo.png';
+
+/**
+ * TopBar — h-12 navy top bar for the Workspace shell (VIS-775 / Track B B2).
+ *
+ * Per the delivered B-1 design (`design/cofounder-mockups/`):
+ *   LEFT  — brand mark + breadcrumb (`Workspace › <projectName>`).
+ *   RIGHT — `Publish · N` (visible only when `dirty > 0 && canBuild`) →
+ *           `Deploy` → utility icons (Slack, Docs, Account).
+ *
+ * No mode toggle, no lens picker, no save-state pill. The Publish button's
+ * presence IS the save state (saved ⇒ no Publish; unsaved ⇒ `Publish · N`).
+ * The route split (`/workspace` = editing, `/project` = consumer) is the
+ * mode toggle.
+ */
+const IconButton = ({ children, title, href, onClick, testId }) => {
+  const cls =
+    'inline-flex h-8 w-8 items-center justify-center rounded-md text-white/80 transition-colors hover:bg-white/10 hover:text-white';
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={title}
+        aria-label={title}
+        data-testid={testId}
+        className={cls}
+      >
+        {children}
+      </a>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      data-testid={testId}
+      className={cls}
+    >
+      {children}
+    </button>
+  );
+};
+
+const TopBar = ({
+  projectName,
+  canBuild = true,
+  dirty = 0,
+  onPublishClick,
+  onDeployClick,
+}) => {
+  return (
+    <header
+      data-testid="workspace-top-bar"
+      className="flex h-12 shrink-0 items-center gap-3 border-b border-white/10 bg-dark px-3 text-white"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <img
+          src={logo}
+          alt="Visivo"
+          className="h-7 w-7 rounded-md"
+          data-testid="workspace-top-bar-logo"
+        />
+        <nav
+          aria-label="Workspace breadcrumb"
+          className="flex min-w-0 shrink items-center gap-1.5 text-[13px]"
+        >
+          <span className="text-white/55">Workspace</span>
+          <PiCaretRight
+            aria-hidden="true"
+            className="h-3.5 w-3.5 shrink-0 text-white/30"
+          />
+          <span
+            className="truncate font-medium text-white"
+            data-testid="workspace-top-bar-project-name"
+          >
+            {projectName}
+          </span>
+        </nav>
+      </div>
+
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        {dirty > 0 && canBuild && (
+          <button
+            type="button"
+            onClick={onPublishClick}
+            data-testid="workspace-top-bar-publish"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[13px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600"
+          >
+            Publish
+            <span className="rounded-sm bg-white/20 px-1.5 py-px text-[11px] font-bold tabular-nums">
+              {dirty}
+            </span>
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDeployClick}
+          data-testid="workspace-top-bar-deploy"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[13px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600"
+        >
+          Deploy
+          <HiOutlineCloudUpload className="h-4 w-4" />
+        </button>
+        <span className="mx-1 h-5 w-px bg-white/15" />
+        <IconButton
+          title="Join the Community"
+          href="https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ"
+          testId="workspace-top-bar-slack"
+        >
+          <SiSlack className="h-[18px] w-[18px]" />
+        </IconButton>
+        <IconButton
+          title="Documentation"
+          href="https://docs.visivo.io"
+          testId="workspace-top-bar-docs"
+        >
+          <MdMenuBook className="h-[18px] w-[18px]" />
+        </IconButton>
+        <IconButton title="Account" testId="workspace-top-bar-account">
+          <FaUserCircle className="h-5 w-5" />
+        </IconButton>
+      </div>
+    </header>
+  );
+};
+
+export default TopBar;

--- a/viewer/src/components/new-views/workspace/Workspace.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+/**
+ * Workspace — placeholder shell mounted by `/workspace` and `/workspace/dashboard/<name>`.
+ *
+ * VIS-772 (Track B B1) only adds the routes + redirects from `/editor` and `/lineage`.
+ * The actual shell (top bar, tab strip, three rails, sub-bar, middle pane variants per
+ * the delivered B-1 design) ships in VIS-775 (Track B B2). This stub exists so the new
+ * routes have something to mount and so redirects land on a real component instead of
+ * 404ing.
+ *
+ * See `specs/dashboard-building/implementation/design/cofounder-mockups/` for the
+ * delivered B-1 design that B2 will implement against.
+ */
+const Workspace = () => {
+  const { dashboardName } = useParams();
+  const [searchParams] = useSearchParams();
+  const view = searchParams.get('view');
+  const edit = searchParams.get('edit');
+
+  return (
+    <div
+      data-testid="workspace-shell-stub"
+      className="flex h-full w-full items-center justify-center bg-gray-50 text-gray-600"
+    >
+      <div className="max-w-md text-center">
+        <h1 className="text-xl font-medium text-gray-900">Workspace</h1>
+        <p className="mt-2 text-sm">
+          Workspace shell coming soon (VIS-775). This route + redirect plumbing ships in VIS-772.
+        </p>
+        <dl className="mt-4 inline-block rounded-md border border-gray-200 bg-white px-4 py-2 text-left text-xs text-gray-500">
+          <div className="flex gap-2">
+            <dt className="font-medium text-gray-700">dashboardName:</dt>
+            <dd data-testid="workspace-scope-dashboard">{dashboardName ?? '(unscoped)'}</dd>
+          </div>
+          {view && (
+            <div className="flex gap-2">
+              <dt className="font-medium text-gray-700">?view=</dt>
+              <dd data-testid="workspace-query-view">{view}</dd>
+            </div>
+          )}
+          {edit && (
+            <div className="flex gap-2">
+              <dt className="font-medium text-gray-700">?edit=</dt>
+              <dd data-testid="workspace-query-edit">{edit}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    </div>
+  );
+};
+
+export default Workspace;

--- a/viewer/src/components/new-views/workspace/Workspace.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.jsx
@@ -1,53 +1,181 @@
-import React from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import React, { useEffect, useMemo, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import useStore from '../../../stores/store';
+import WorkspaceShell from './WorkspaceShell';
+import { emitWorkspaceEvent } from './telemetry';
+import { useWorkspaceScope } from './useWorkspaceScope';
 
 /**
- * Workspace — placeholder shell mounted by `/workspace` and `/workspace/dashboard/<name>`.
+ * Workspace — smart container for the `/workspace` and
+ * `/workspace/dashboard/:dashboardName` routes (VIS-775 / Track B B2).
  *
- * VIS-772 (Track B B1) only adds the routes + redirects from `/editor` and `/lineage`.
- * The actual shell (top bar, tab strip, three rails, sub-bar, middle pane variants per
- * the delivered B-1 design) ships in VIS-775 (Track B B2). This stub exists so the new
- * routes have something to mount and so redirects land on a real component instead of
- * 404ing.
+ * Responsibilities:
+ *   1. Hydrate the project tab on mount (project is a first-class tab —
+ *      per the delivered B-1 design, opening `/workspace` should always
+ *      show a project tab).
+ *   2. When the URL is dashboard-scoped (`/workspace/dashboard/<name>`),
+ *      open a dashboard tab for that name and focus it.
+ *   3. Subscribe to workspace store state and pass it into
+ *      `<WorkspaceShell>`.
+ *   4. Fire the `workspace_mode_entered` telemetry event on mount (with the
+ *      scoped dashboard name, or `null` for unscoped).
  *
- * See `specs/dashboard-building/implementation/design/cofounder-mockups/` for the
- * delivered B-1 design that B2 will implement against.
+ * Most of the visual work lives in `<WorkspaceShell>` (presentational) and
+ * its sub-components. Splitting smart/dumb keeps the shell trivially
+ * snapshot-testable.
  */
 const Workspace = () => {
   const { dashboardName } = useParams();
-  const [searchParams] = useSearchParams();
-  const view = searchParams.get('view');
-  const edit = searchParams.get('edit');
 
+  // Project data ---------------------------------------------------------
+  const project = useStore((s) => s.project);
+  const hasUnpublishedChanges = useStore((s) => s.hasUnpublishedChanges);
+  const checkPublishStatus = useStore((s) => s.checkPublishStatus);
+  const openPublishModal = useStore((s) => s.openPublishModal);
+
+  // Workspace store ------------------------------------------------------
+  const tabs = useStore((s) => s.workspaceTabs);
+  const activeTabId = useStore((s) => s.workspaceActiveTabId);
+  const leftCollapsed = useStore((s) => s.workspaceLeftCollapsed);
+  const rightCollapsed = useStore((s) => s.workspaceRightCollapsed);
+  const rightTab = useStore((s) => s.workspaceRightTab);
+  const lens = useStore((s) => s.workspaceLens);
+  const leftWidth = useStore((s) => s.workspaceLeftWidth);
+  const rightWidth = useStore((s) => s.workspaceRightWidth);
+  const resizing = useStore((s) => s.workspaceResizing);
+
+  const openWorkspaceTab = useStore((s) => s.openWorkspaceTab);
+  const switchWorkspaceTab = useStore((s) => s.switchWorkspaceTab);
+  const closeWorkspaceTab = useStore((s) => s.closeWorkspaceTab);
+  const toggleLeftCollapsed = useStore(
+    (s) => s.toggleWorkspaceLeftCollapsed
+  );
+  const toggleRightCollapsed = useStore(
+    (s) => s.toggleWorkspaceRightCollapsed
+  );
+  const setRightTab = useStore((s) => s.setWorkspaceRightTab);
+  const setLens = useStore((s) => s.setWorkspaceLens);
+
+  const scope = useWorkspaceScope();
+
+  // Project display name — fall back to a friendly stub when the project
+  // loader hasn't completed (tests don't always hydrate it).
+  const projectName = useMemo(() => {
+    return (
+      project?.project_json?.name ||
+      project?.name ||
+      'project'
+    );
+  }, [project]);
+
+  // Hydrate tabs from URL on mount + when route changes ------------------
+  useEffect(() => {
+    // Always make sure the project tab exists.
+    openWorkspaceTab({
+      id: `project:${projectName}`,
+      type: 'project',
+      name: projectName,
+    });
+    if (dashboardName) {
+      openWorkspaceTab({
+        id: `dashboard:${dashboardName}`,
+        type: 'dashboard',
+        name: dashboardName,
+      });
+    }
+    // We re-run when projectName / dashboardName change so navigation
+    // between scoped/unscoped surfaces keeps tabs in sync. openWorkspaceTab
+    // is a stable Zustand action reference.
+  }, [projectName, dashboardName, openWorkspaceTab]);
+
+  // Check publish status so the Publish · N button has accurate count.
+  useEffect(() => {
+    if (typeof checkPublishStatus === 'function') {
+      checkPublishStatus();
+    }
+  }, [checkPublishStatus]);
+
+  // Telemetry ------------------------------------------------------------
+  useEffect(() => {
+    emitWorkspaceEvent('workspace_mode_entered', {
+      dashboardName: dashboardName || null,
+      scope: scope.scope,
+    });
+    // Only fire on mount / scope change — not every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dashboardName]);
+
+  // Derive active object from active tab. If the tab is gone but the URL
+  // is scoped, fall back to a synthesised dashboard descriptor (avoids a
+  // flash of "project" content right before the tab hydrates).
+  const activeObject = useMemo(() => {
+    const tab = (tabs || []).find((t) => t.id === activeTabId);
+    if (tab) return { type: tab.type, name: tab.name };
+    if (dashboardName) return { type: 'dashboard', name: dashboardName };
+    return { type: 'project', name: projectName };
+  }, [tabs, activeTabId, dashboardName, projectName]);
+
+  // Wire actions -------------------------------------------------------
+  const handleSelectTab = useCallback(
+    (id) => switchWorkspaceTab(id),
+    [switchWorkspaceTab]
+  );
+  const handleCloseTab = useCallback(
+    (id) => closeWorkspaceTab(id),
+    [closeWorkspaceTab]
+  );
+  const handleNewTab = useCallback(() => {
+    // Defer real "open in new tab" semantics to VIS-O2; the button is a
+    // visual affordance for now. Focus the project tab as a sane default.
+    openWorkspaceTab({
+      id: `project:${projectName}`,
+      type: 'project',
+      name: projectName,
+    });
+  }, [openWorkspaceTab, projectName]);
+
+  const dirty = hasUnpublishedChanges ? 1 : 0;
+
+  // The shell is full-viewport. Home wraps every route in a `pt-12`
+  // container to reserve space for its fixed `<TopNav>`. The Workspace
+  // shell renders its own TopBar (per the delivered B-1 design), so we
+  // anchor the shell to `top-0 bottom-0` to occupy the full viewport
+  // height and visually replace the outer nav. Subsequent work will lift
+  // the conditional out of Home itself; for Phase 0 this overlay is the
+  // cleanest path that doesn't touch the existing route container.
   return (
     <div
-      data-testid="workspace-shell-stub"
-      className="flex h-full w-full items-center justify-center bg-gray-50 text-gray-600"
+      className="fixed inset-0 z-40 bg-white"
+      data-testid="workspace-route-root"
     >
-      <div className="max-w-md text-center">
-        <h1 className="text-xl font-medium text-gray-900">Workspace</h1>
-        <p className="mt-2 text-sm">
-          Workspace shell coming soon (VIS-775). This route + redirect plumbing ships in VIS-772.
-        </p>
-        <dl className="mt-4 inline-block rounded-md border border-gray-200 bg-white px-4 py-2 text-left text-xs text-gray-500">
-          <div className="flex gap-2">
-            <dt className="font-medium text-gray-700">dashboardName:</dt>
-            <dd data-testid="workspace-scope-dashboard">{dashboardName ?? '(unscoped)'}</dd>
-          </div>
-          {view && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-700">?view=</dt>
-              <dd data-testid="workspace-query-view">{view}</dd>
-            </div>
-          )}
-          {edit && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-700">?edit=</dt>
-              <dd data-testid="workspace-query-edit">{edit}</dd>
-            </div>
-          )}
-        </dl>
-      </div>
+      <WorkspaceShell
+        projectName={projectName}
+        canBuild={true}
+        dirty={dirty}
+        onPublishClick={openPublishModal}
+        onDeployClick={() => {
+          // Phase 0 stub — full deploy modal lives in Home.jsx today. Track O
+          // / Track G will wire the deploy CTA from the Workspace TopBar.
+        }}
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onSelectTab={handleSelectTab}
+        onCloseTab={handleCloseTab}
+        onNewTab={handleNewTab}
+        activeObject={activeObject}
+        lens={lens}
+        onLensChange={setLens}
+        projectId={project?.id || null}
+        leftCollapsed={leftCollapsed}
+        rightCollapsed={rightCollapsed}
+        onToggleLeftCollapsed={toggleLeftCollapsed}
+        onToggleRightCollapsed={toggleRightCollapsed}
+        rightTab={rightTab}
+        onSelectRightTab={setRightTab}
+        leftWidth={leftWidth}
+        rightWidth={rightWidth}
+        resizing={resizing}
+      />
     </div>
   );
 };

--- a/viewer/src/components/new-views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.test.jsx
@@ -1,0 +1,193 @@
+/**
+ * Workspace shell mount tests (VIS-775 / Track B B2).
+ *
+ * Verifies the smart Workspace container renders the shell at both
+ * /workspace (unscoped) and /workspace/dashboard/:dashboardName (scoped),
+ * hydrates the project tab, opens a dashboard tab when scoped, fires the
+ * workspace_mode_entered telemetry event on mount, and dispatches the
+ * middle pane based on the active object type.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import {
+  createMemoryRouter,
+  Route,
+  createRoutesFromElements,
+  RouterProvider,
+} from 'react-router-dom';
+import { futureFlags } from '../../../router-config';
+import Workspace from './Workspace';
+import useStore from '../../../stores/store';
+import { setWorkspaceTelemetryListener } from './telemetry';
+
+// DashboardNew has heavy dependencies (insights data, plotly, etc.) — stub
+// it out so the Workspace shell render stays focused on shell behaviour.
+jest.mock('../project/DashboardNew', () => ({
+  __esModule: true,
+  default: ({ projectId, dashboardName }) => (
+    <div data-testid="dashboard-new-stub">
+      DashboardNew {projectId}:{dashboardName}
+    </div>
+  ),
+}));
+
+const resetWorkspaceStore = () => {
+  act(() => {
+    useStore.setState({
+      workspaceTabs: [],
+      workspaceActiveTabId: null,
+      workspaceLeftCollapsed: false,
+      workspaceRightCollapsed: false,
+      workspaceRightTab: 'edit',
+      workspaceLens: 'preview',
+      hasUnpublishedChanges: false,
+      // Stub project that the loader normally hydrates.
+      project: {
+        id: 'p1',
+        project_json: { name: 'analytics-platform' },
+      },
+      // Stub a no-op checkPublishStatus / openPublishModal so the
+      // Workspace mount effect doesn't throw.
+      checkPublishStatus: jest.fn(),
+      openPublishModal: jest.fn(),
+    });
+  });
+};
+
+const renderAt = (entry) => {
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <>
+        <Route path="/workspace" element={<Workspace />} />
+        <Route
+          path="/workspace/dashboard/:dashboardName"
+          element={<Workspace />}
+        />
+      </>
+    ),
+    { initialEntries: [entry], future: futureFlags }
+  );
+  return render(<RouterProvider router={router} future={futureFlags} />);
+};
+
+describe('VIS-775 Workspace shell', () => {
+  beforeEach(() => {
+    resetWorkspaceStore();
+  });
+
+  test('mounts the shell at /workspace (unscoped) with the project tab as default', () => {
+    renderAt('/workspace');
+    expect(screen.getByTestId('workspace-shell')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-top-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-top-bar-project-name')).toHaveTextContent(
+      'analytics-platform'
+    );
+    // Project tab is hydrated on mount.
+    expect(
+      screen.getByTestId('workspace-tab-project:analytics-platform')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('workspace-tab-project:analytics-platform')
+    ).toHaveAttribute('data-active', 'true');
+    // Middle pane shows the Project Editor placeholder.
+    expect(screen.getByTestId('workspace-middle-project')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('workspace-middle-project-placeholder')
+    ).toBeInTheDocument();
+  });
+
+  test('mounts the shell at /workspace/dashboard/<name> and focuses the dashboard tab', () => {
+    renderAt('/workspace/dashboard/simple-dashboard');
+    expect(screen.getByTestId('workspace-shell')).toBeInTheDocument();
+    // Both tabs exist — project (hydrated) + dashboard (URL-scoped).
+    expect(
+      screen.getByTestId('workspace-tab-project:analytics-platform')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('workspace-tab-dashboard:simple-dashboard')
+    ).toBeInTheDocument();
+    // Dashboard tab is the active one (URL drives focus).
+    expect(
+      screen.getByTestId('workspace-tab-dashboard:simple-dashboard')
+    ).toHaveAttribute('data-active', 'true');
+    // Middle pane dispatches to the dashboard variant.
+    expect(screen.getByTestId('workspace-middle-dashboard')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-middle-dashboard-canvas')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-new-stub')).toHaveTextContent(
+      'DashboardNew p1:simple-dashboard'
+    );
+  });
+
+  test('renders all three rails and the drag handles', () => {
+    renderAt('/workspace');
+    expect(screen.getByTestId('workspace-left-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-right-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-drag-handle-left')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-drag-handle-right')).toBeInTheDocument();
+    // Library placeholder is visible (real content lands in VIS-C1).
+    expect(
+      screen.getByTestId('workspace-left-rail-placeholder')
+    ).toHaveTextContent('Library coming soon (VIS-C1)');
+    // Right rail defaults to Edit tab.
+    expect(screen.getByTestId('workspace-right-rail-edit')).toBeInTheDocument();
+  });
+
+  test('right rail Edit tab surfaces the active object name', () => {
+    renderAt('/workspace/dashboard/simple-dashboard');
+    expect(
+      screen.getByTestId('workspace-right-rail-edit-active-name')
+    ).toHaveTextContent('simple-dashboard');
+  });
+
+  test('Publish · N button only renders when dirty > 0', () => {
+    // Clean state.
+    renderAt('/workspace');
+    expect(
+      screen.queryByTestId('workspace-top-bar-publish')
+    ).not.toBeInTheDocument();
+    // Mark dirty.
+    act(() => {
+      useStore.setState({ hasUnpublishedChanges: true });
+    });
+    expect(screen.getByTestId('workspace-top-bar-publish')).toHaveTextContent(
+      'Publish'
+    );
+    expect(screen.getByTestId('workspace-top-bar-publish')).toHaveTextContent('1');
+  });
+
+  test('fires workspace_mode_entered telemetry on mount with dashboard scope', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener((evt) =>
+      events.push(evt)
+    );
+    try {
+      renderAt('/workspace/dashboard/simple-dashboard');
+      const entered = events.filter(
+        (e) => e.eventName === 'workspace_mode_entered'
+      );
+      expect(entered).toHaveLength(1);
+      expect(entered[0].payload.dashboardName).toBe('simple-dashboard');
+      expect(entered[0].payload.scope).toBe('dashboard');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  test('fires workspace_mode_entered telemetry with null dashboardName when unscoped', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener((evt) =>
+      events.push(evt)
+    );
+    try {
+      renderAt('/workspace');
+      const entered = events.filter(
+        (e) => e.eventName === 'workspace_mode_entered'
+      );
+      expect(entered).toHaveLength(1);
+      expect(entered[0].payload.dashboardName).toBeNull();
+      expect(entered[0].payload.scope).toBe('root');
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import TopBar from './TopBar';
+import TabStrip from './TabStrip';
+import LeftRail from './LeftRail';
+import RightRail from './RightRail';
+import MiddlePane from './MiddlePane';
+import DragHandle from './DragHandle';
+
+/**
+ * WorkspaceShell — VIS-775 (Track B B2).
+ *
+ * Pure presentational shell — all state arrives as props. The smart
+ * `<Workspace>` container reads from the workspace store and URL, wires
+ * actions, and passes them down. Splitting smart/dumb makes the shell
+ * trivially renderable in Storybook / tests without spinning up the store.
+ *
+ * Layout (matches the delivered B-1 design's bands + columns):
+ *
+ *   ┌──────────── TopBar (h-12 navy, full width) ────────────┐
+ *   ├────────────┬──────────────────────────────────────────┤
+ *   │            │ TabStrip (h-9 white, scoped to active obj)│
+ *   │ LeftRail   ├──────────────────────────┬───────────────┤
+ *   │ (full-h)   │ MiddlePane               │ RightRail     │
+ *   │            │ (sub-bar + variant body) │ (Outline/Edit/│
+ *   │            │                          │  History)     │
+ *   └────────────┴──────────────────────────┴───────────────┘
+ *
+ * Key insight: the **left rail anchors full-height** (from the TopBar to
+ * the bottom). The **tab strip's width matches what it scopes** — middle +
+ * right rail only, NOT the Library — making it visually obvious that tabs
+ * control the editor surface, not the project navigator.
+ */
+const WorkspaceShell = ({
+  // Top bar -----------------------------------------------------------------
+  projectName,
+  canBuild = true,
+  dirty = 0,
+  onPublishClick,
+  onDeployClick,
+
+  // Tabs --------------------------------------------------------------------
+  tabs = [],
+  activeTabId = null,
+  onSelectTab,
+  onCloseTab,
+  onNewTab,
+
+  // Middle pane -------------------------------------------------------------
+  activeObject = null,
+  lens = 'preview',
+  onLensChange,
+  projectId = null,
+
+  // Rails -------------------------------------------------------------------
+  leftCollapsed = false,
+  rightCollapsed = false,
+  onToggleLeftCollapsed,
+  onToggleRightCollapsed,
+  rightTab = 'edit',
+  onSelectRightTab,
+  leftWidth = 320,
+  rightWidth = 360,
+  resizing = null,
+
+  // Slot escape hatch for tests that need to peek at internals -------------
+  testId = 'workspace-shell',
+}) => {
+  return (
+    <div
+      data-testid={testId}
+      className="flex h-full w-full flex-col overflow-hidden bg-white antialiased"
+      style={{
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      }}
+    >
+      <TopBar
+        projectName={projectName}
+        canBuild={canBuild}
+        dirty={dirty}
+        onPublishClick={onPublishClick}
+        onDeployClick={onDeployClick}
+      />
+      <div className="flex min-h-0 flex-1">
+        {/* Left rail — project-wide, full-height anchor. */}
+        <div
+          style={{ width: leftCollapsed ? 48 : leftWidth }}
+          className="shrink-0"
+          data-testid="workspace-left-rail-container"
+        >
+          <LeftRail
+            collapsed={leftCollapsed}
+            onToggleCollapsed={onToggleLeftCollapsed}
+          />
+        </div>
+        <DragHandle
+          side="left"
+          active={resizing === 'left'}
+          widthLabel={resizing === 'left' ? `${leftWidth}px` : null}
+        />
+        {/* Tab + middle/right column. The tab strip's width matches exactly
+            what the tabs scope (the active-object area). */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <TabStrip
+            tabs={tabs}
+            activeId={activeTabId}
+            onSelect={onSelectTab}
+            onClose={onCloseTab}
+            onNewTab={onNewTab}
+          />
+          <div className="flex min-h-0 flex-1">
+            <main
+              className="flex min-w-0 flex-1 flex-col"
+              data-testid="workspace-middle-container"
+            >
+              <MiddlePane
+                activeObject={activeObject}
+                lens={lens}
+                onLensChange={onLensChange}
+                projectId={projectId}
+              />
+            </main>
+            <DragHandle
+              side="right"
+              active={resizing === 'right'}
+              widthLabel={resizing === 'right' ? `${rightWidth}px` : null}
+            />
+            <div
+              style={{ width: rightCollapsed ? 48 : rightWidth }}
+              className="shrink-0"
+              data-testid="workspace-right-rail-container"
+            >
+              <RightRail
+                collapsed={rightCollapsed}
+                onToggleCollapsed={onToggleRightCollapsed}
+                activeTab={rightTab}
+                onSelectTab={onSelectRightTab}
+                activeObject={activeObject}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceShell;

--- a/viewer/src/components/new-views/workspace/objKind.js
+++ b/viewer/src/components/new-views/workspace/objKind.js
@@ -1,0 +1,93 @@
+/**
+ * OBJ_KIND — single source of truth for object icon + tone.
+ *
+ * Used by the Workspace shell's `<TabStrip>`, the right-rail kind chip, and
+ * (eventually) lineage nodes and Library row icons. Per the delivered B-1
+ * design (`design/cofounder-mockups/`), Phase 0 supports six keys:
+ * `project | dashboard | chart | insight | model | source`. Track N (Phase 4)
+ * extends the map to all object types — when adding a new type, add it here
+ * so every surface stays visually consistent.
+ *
+ * `tone` is a Tailwind background + text pair tuned for the rail chip / tab
+ * background; matches the cofounder palette (mulberry for chrome, blue for
+ * dashboards, teal for data layer).
+ */
+import {
+  PiCube,
+  PiSquaresFour,
+  PiChartBar,
+  PiLightbulb,
+  PiDatabase,
+} from 'react-icons/pi';
+
+export const OBJ_KIND = {
+  project: {
+    icon: PiCube,
+    label: 'Project',
+    tone: {
+      bg: 'bg-[#d4e1e2]',
+      fg: 'text-[#1b4042]',
+      chipBg: 'bg-[#d4e1e2]/60',
+      chipFg: 'text-[#1b4042]',
+      chipRing: 'ring-[#1b4042]/15',
+    },
+  },
+  dashboard: {
+    icon: PiSquaresFour,
+    label: 'Dashboard',
+    tone: {
+      bg: 'bg-[#e6edf8]',
+      fg: 'text-[#1e3a5f]',
+      chipBg: 'bg-[#e6edf8]/60',
+      chipFg: 'text-[#1e3a5f]',
+      chipRing: 'ring-[#1e3a5f]/15',
+    },
+  },
+  chart: {
+    icon: PiChartBar,
+    label: 'Chart',
+    tone: {
+      bg: 'bg-[#e2d7dd]',
+      fg: 'text-[#5a2f45]',
+      chipBg: 'bg-[#e2d7dd]/60',
+      chipFg: 'text-[#5a2f45]',
+      chipRing: 'ring-[#5a2f45]/15',
+    },
+  },
+  insight: {
+    icon: PiLightbulb,
+    label: 'Insight',
+    tone: {
+      bg: 'bg-[#d4e1e2]',
+      fg: 'text-[#1b4042]',
+      chipBg: 'bg-[#d4e1e2]/60',
+      chipFg: 'text-[#1b4042]',
+      chipRing: 'ring-[#1b4042]/15',
+    },
+  },
+  model: {
+    icon: PiCube,
+    label: 'Model',
+    tone: {
+      bg: 'bg-[#d4e1e2]',
+      fg: 'text-[#1b4042]',
+      chipBg: 'bg-[#d4e1e2]/60',
+      chipFg: 'text-[#1b4042]',
+      chipRing: 'ring-[#1b4042]/15',
+    },
+  },
+  source: {
+    icon: PiDatabase,
+    label: 'Source',
+    tone: {
+      bg: 'bg-[#d4e1e2]',
+      fg: 'text-[#1b4042]',
+      chipBg: 'bg-[#d4e1e2]/60',
+      chipFg: 'text-[#1b4042]',
+      chipRing: 'ring-[#1b4042]/15',
+    },
+  },
+};
+
+/** Safe lookup — falls back to the dashboard tone for unknown types. */
+export const getKind = (type) => OBJ_KIND[type] || OBJ_KIND.dashboard;

--- a/viewer/src/components/new-views/workspace/telemetry.js
+++ b/viewer/src/components/new-views/workspace/telemetry.js
@@ -1,0 +1,59 @@
+/**
+ * Workspace telemetry stub (VIS-775 / Track B B2).
+ *
+ * The viewer has no frontend telemetry framework yet — server-side telemetry
+ * lives in `visivo/telemetry/` (Flask middleware + PostHog client). When the
+ * frontend gets its own analytics sink (PostHog browser SDK or similar), wire
+ * `emitWorkspaceEvent` to forward to it.
+ *
+ * The spec for VIS-775 (`specs/dashboard-building/implementation/01-tracks-and-phasing.md`
+ * Track B B2) requires firing `workspace_mode_entered` on shell mount with the
+ * scoped dashboard name (or `null` for unscoped). We log the event to the
+ * console in dev so the shape is visible during local testing, and we expose
+ * a hook so tests can spy on emissions without coupling to a sink.
+ *
+ * TODO(VIS-?): replace with real telemetry call once the viewer adopts a
+ * browser-side analytics module. Keep the function signature stable so
+ * call-sites don't need to change.
+ */
+
+let listener = null;
+
+/**
+ * Fire a workspace telemetry event.
+ *
+ * @param {string} eventName — canonical event name (e.g. `workspace_mode_entered`).
+ * @param {object} [payload] — JSON-serialisable properties for the event.
+ */
+export function emitWorkspaceEvent(eventName, payload = {}) {
+  if (!eventName) return;
+  const event = { eventName, payload, ts: Date.now() };
+  // In tests `listener` is set by `setWorkspaceTelemetryListener` to capture
+  // emissions without going through a console.
+  if (listener) {
+    try {
+      listener(event);
+    } catch {
+      // Swallow listener errors so a faulty subscriber can't break the shell.
+    }
+    return;
+  }
+  // Dev visibility only — keep silent in CI/test to avoid the
+  // setupTests.js "unexpected console call" guard.
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.debug(`[workspace-telemetry] ${eventName}`, payload);
+  }
+}
+
+/**
+ * Subscribe to workspace telemetry events. Returns an unsubscribe function.
+ * Intended for tests; production code should send events through a real
+ * analytics sink once one exists.
+ */
+export function setWorkspaceTelemetryListener(fn) {
+  listener = fn;
+  return () => {
+    if (listener === fn) listener = null;
+  };
+}

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.js
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.js
@@ -1,0 +1,101 @@
+import { useMemo } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import useStore from '../../../stores/store';
+
+/**
+ * useWorkspaceScope — VIS-775 (Track B B2).
+ *
+ * Single source of truth for what the Workspace is currently focused on. The
+ * scope is derived from URL state (route params + query string) and the
+ * workspace store (active tab). Consumers: Library left rail (filters items
+ * by scope), MiddlePane (decides which preview to mount), right rail
+ * (drives Outline + Edit content), telemetry (events tag the active scope).
+ *
+ * Returns:
+ *
+ *   {
+ *     scope:           'root' | 'dashboard' | 'item' | 'level' | 'project',
+ *     selector:        string,           // Lineage-selector form ('*', '+name', etc.)
+ *     dashboardName:   string | null,    // current dashboard, if any
+ *     selectedItem:    { type, name }|null  // active object the right rail is bound to
+ *   }
+ *
+ * Scope semantics, in order of precedence:
+ *
+ *   1. `:dashboardName` URL param → `dashboard` scope.
+ *   2. `?edit=<type>:<name>` query (Q19 redirect target) → `item` scope.
+ *   3. Active workspace tab whose type is not `project` → matches tab's
+ *      scope. Tabs are how multi-object editing is plumbed; the URL still
+ *      shows `/workspace` for non-dashboard objects in Phase 0.
+ *   4. Otherwise `root` (the unscoped Project Editor surface). The project
+ *      tab is the implicit selected item — Edit form binds to the project.
+ *
+ * NB: this hook does not subscribe to URL changes itself — it relies on
+ * `useParams` / `useSearchParams` (which do). Selector strings follow the
+ * Visivo lineage-selector grammar (`+name` = ancestors + descendants).
+ */
+export function useWorkspaceScope() {
+  const { dashboardName } = useParams();
+  const [searchParams] = useSearchParams();
+
+  // Tab state — used as a tertiary source after the URL (the URL is canonical
+  // for dashboards; tabs are for object selection in Phase 0).
+  const tabs = useStore((s) => s.workspaceTabs);
+  const activeTabId = useStore((s) => s.workspaceActiveTabId);
+
+  // Active tab object (memoised so consumers can rely on referential
+  // stability across renders that don't actually change scope).
+  const activeTab = useMemo(
+    () => (tabs || []).find((t) => t.id === activeTabId) || null,
+    [tabs, activeTabId]
+  );
+
+  return useMemo(() => {
+    // Dashboard scope — URL is canonical.
+    if (dashboardName) {
+      return {
+        scope: 'dashboard',
+        selector: `+${dashboardName}`,
+        dashboardName,
+        selectedItem: { type: 'dashboard', name: dashboardName },
+      };
+    }
+
+    // `?edit=<type>:<name>` — used by /editor/<type>/<name> redirect path.
+    const editParam = searchParams.get('edit');
+    if (editParam && editParam.includes(':')) {
+      const [type, ...rest] = editParam.split(':');
+      const name = rest.join(':');
+      if (type && name) {
+        return {
+          scope: 'item',
+          selector: `+${name}`,
+          dashboardName: null,
+          selectedItem: { type, name },
+        };
+      }
+    }
+
+    // Active workspace tab (non-project) — scopes by tab.
+    if (activeTab && activeTab.type !== 'project') {
+      return {
+        scope: activeTab.type === 'dashboard' ? 'dashboard' : 'item',
+        selector: `+${activeTab.name}`,
+        dashboardName: activeTab.type === 'dashboard' ? activeTab.name : null,
+        selectedItem: { type: activeTab.type, name: activeTab.name },
+      };
+    }
+
+    // Unscoped — Project Editor surface. Selected item is the project
+    // itself (so the right-rail Edit form binds to project chrome).
+    const projectName = activeTab && activeTab.type === 'project' ? activeTab.name : null;
+    return {
+      scope: 'root',
+      selector: '*',
+      dashboardName: null,
+      selectedItem: projectName ? { type: 'project', name: projectName } : null,
+    };
+  }, [dashboardName, searchParams, activeTab]);
+}
+
+export default useWorkspaceScope;

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
@@ -1,0 +1,181 @@
+/**
+ * useWorkspaceScope() shape contract (VIS-775 / Track B B2).
+ *
+ * The hook is the single source of truth for what the Workspace is focused
+ * on — every downstream consumer (Library, MiddlePane, right rail,
+ * telemetry) reads from it. These tests pin the expected shapes for each
+ * entry point so the hook can't silently regress.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import {
+  createMemoryRouter,
+  Route,
+  createRoutesFromElements,
+  RouterProvider,
+} from 'react-router-dom';
+import { futureFlags } from '../../../router-config';
+import useStore from '../../../stores/store';
+import useWorkspaceScope from './useWorkspaceScope';
+
+const Probe = () => {
+  const scope = useWorkspaceScope();
+  return (
+    <div>
+      <span data-testid="probe-scope">{scope.scope}</span>
+      <span data-testid="probe-selector">{scope.selector}</span>
+      <span data-testid="probe-dashboard">
+        {scope.dashboardName === null ? 'null' : scope.dashboardName}
+      </span>
+      <span data-testid="probe-selected-type">
+        {scope.selectedItem ? scope.selectedItem.type : 'null'}
+      </span>
+      <span data-testid="probe-selected-name">
+        {scope.selectedItem ? scope.selectedItem.name : 'null'}
+      </span>
+    </div>
+  );
+};
+
+const resetWorkspaceStore = () => {
+  act(() => {
+    useStore.setState({
+      workspaceTabs: [],
+      workspaceActiveTabId: null,
+    });
+  });
+};
+
+const renderAt = (entry) => {
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <>
+        <Route path="/workspace" element={<Probe />} />
+        <Route path="/workspace/dashboard/:dashboardName" element={<Probe />} />
+      </>
+    ),
+    { initialEntries: [entry], future: futureFlags }
+  );
+  return render(<RouterProvider router={router} future={futureFlags} />);
+};
+
+describe('useWorkspaceScope', () => {
+  beforeEach(() => {
+    resetWorkspaceStore();
+  });
+
+  test('returns root scope at /workspace with no tabs', () => {
+    renderAt('/workspace');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('root');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent('*');
+    expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('null');
+    expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('null');
+  });
+
+  test('returns root scope with project selectedItem when project tab is active', () => {
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          {
+            id: 'project:analytics-platform',
+            type: 'project',
+            name: 'analytics-platform',
+            dirty: false,
+          },
+        ],
+        workspaceActiveTabId: 'project:analytics-platform',
+      });
+    });
+    renderAt('/workspace');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('root');
+    expect(screen.getByTestId('probe-selected-type')).toHaveTextContent(
+      'project'
+    );
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
+      'analytics-platform'
+    );
+  });
+
+  test('returns dashboard scope when URL is /workspace/dashboard/<name>', () => {
+    renderAt('/workspace/dashboard/simple-dashboard');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
+      '+simple-dashboard'
+    );
+    expect(screen.getByTestId('probe-dashboard')).toHaveTextContent(
+      'simple-dashboard'
+    );
+    expect(screen.getByTestId('probe-selected-type')).toHaveTextContent(
+      'dashboard'
+    );
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
+      'simple-dashboard'
+    );
+  });
+
+  test('returns item scope when ?edit=<type>:<name> is present', () => {
+    renderAt('/workspace?edit=chart:revenue_chart');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('item');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
+      '+revenue_chart'
+    );
+    expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('null');
+    expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('chart');
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
+      'revenue_chart'
+    );
+  });
+
+  test('reflects the active non-project tab when no URL scope', () => {
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          {
+            id: 'project:analytics-platform',
+            type: 'project',
+            name: 'analytics-platform',
+            dirty: false,
+          },
+          {
+            id: 'model:monthly_revenue',
+            type: 'model',
+            name: 'monthly_revenue',
+            dirty: false,
+          },
+        ],
+        workspaceActiveTabId: 'model:monthly_revenue',
+      });
+    });
+    renderAt('/workspace');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('item');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
+      '+monthly_revenue'
+    );
+    expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('model');
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
+      'monthly_revenue'
+    );
+  });
+
+  test('URL dashboard scope takes precedence over an active tab', () => {
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          {
+            id: 'model:monthly_revenue',
+            type: 'model',
+            name: 'monthly_revenue',
+            dirty: false,
+          },
+        ],
+        workspaceActiveTabId: 'model:monthly_revenue',
+      });
+    });
+    renderAt('/workspace/dashboard/simple-dashboard');
+    // URL wins.
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
+      'simple-dashboard'
+    );
+  });
+});

--- a/viewer/src/stores/store.js
+++ b/viewer/src/stores/store.js
@@ -22,6 +22,7 @@ import createCsvScriptModelSlice from './csvScriptModelStore';
 import createLocalMergeModelSlice from './localMergeModelStore';
 import createExplorerNewSlice from './explorerNewStore';
 import createModelJobsSlice from './modelJobsStore';
+import createWorkspaceSlice from './workspaceStore';
 
 // Re-export ObjectStatus for convenience
 export { ObjectStatus };
@@ -48,6 +49,7 @@ const useStore = create(
     ...createLocalMergeModelSlice(...a),
     ...createExplorerNewSlice(...a),
     ...createModelJobsSlice(...a),
+    ...createWorkspaceSlice(...a),
     ...persist(createCommonSlice, {
       name: 'common-storage',
       partialize: state => ({ scrollPositions: state.scrollPositions }),

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -1,0 +1,157 @@
+/**
+ * Workspace Store Slice (VIS-775 / Track B B2)
+ *
+ * Tab + active-object state for the Workspace shell. The Workspace shell is
+ * always editing — `/workspace` and `/project` are separate routes, not a
+ * mode toggle. State held here:
+ *
+ *   - `workspaceTabs`        — ordered array of tab descriptors.
+ *   - `workspaceActiveTabId` — id of the currently active tab (drives the
+ *                              middle pane + right rail content).
+ *   - `workspaceLeftCollapsed` / `workspaceRightCollapsed` — rail collapse.
+ *   - `workspaceRightTab`    — which right-rail tab is active.
+ *   - `workspaceLens`        — sub-bar lens for the active object.
+ *
+ * Each tab descriptor: `{ id, type, name, dirty }` where:
+ *   - `id`    — stable per-tab string identifier (e.g. `project:<projectName>`
+ *               or `dashboard:simple-dashboard`).
+ *   - `type`  — one of `OBJ_KIND` keys (`project | dashboard | chart |
+ *               insight | model | source`).
+ *   - `name`  — display name (also the underlying object name for non-project
+ *               types).
+ *   - `dirty` — boolean indicating unsaved edits (the mulberry dot in the
+ *               tab strip). Phase 0 leaves this manually toggled — Track H
+ *               (auto-save) and VIS-O3 (dirty confirmation) wire it up.
+ *
+ * Per the delivered B-1 design (`design/cofounder-mockups/`), the **project is
+ * a first-class tab**: opening `/workspace` adds a project tab if one doesn't
+ * exist yet, and the project tab is what users see by default. Multi-tab,
+ * drag-reorder, right-click-open-in-new-tab semantics ship in VIS-O1 / O2 /
+ * O3 — this slice only carries the state the shell needs in Phase 0.
+ */
+
+const createWorkspaceSlice = (set, get) => ({
+  // Tabs --------------------------------------------------------------------
+  workspaceTabs: [],
+  workspaceActiveTabId: null,
+
+  // Rails -------------------------------------------------------------------
+  workspaceLeftCollapsed: false,
+  workspaceRightCollapsed: false,
+  workspaceRightTab: 'edit', // 'outline' | 'edit' | 'history'
+
+  // Lens (sub-bar segmented) ------------------------------------------------
+  workspaceLens: 'preview', // 'preview' | 'lineage'
+
+  // Resize state (Phase 0 visual stub; actual resizing comes later) --------
+  workspaceLeftWidth: 320,
+  workspaceRightWidth: 360,
+  workspaceResizing: null, // 'left' | 'right' | null
+
+  // ------------------------------------------------------------------------
+  // Tab actions
+  // ------------------------------------------------------------------------
+
+  /**
+   * Open a tab (or focus it if already open). Returns the focused tab id.
+   *
+   * `tab` shape: `{ id?, type, name, dirty? }`. `id` defaults to
+   * `<type>:<name>` so opening the same object twice focuses the existing tab.
+   */
+  openWorkspaceTab: (tab) => {
+    if (!tab || !tab.type || !tab.name) return null;
+    const id = tab.id || `${tab.type}:${tab.name}`;
+    const state = get();
+    const existing = state.workspaceTabs.find((t) => t.id === id);
+    if (existing) {
+      set({ workspaceActiveTabId: id });
+      return id;
+    }
+    const next = {
+      id,
+      type: tab.type,
+      name: tab.name,
+      dirty: !!tab.dirty,
+    };
+    set({
+      workspaceTabs: [...state.workspaceTabs, next],
+      workspaceActiveTabId: id,
+    });
+    return id;
+  },
+
+  /** Focus a tab by id without opening anything new. No-op if id unknown. */
+  switchWorkspaceTab: (tabId) => {
+    const state = get();
+    if (!state.workspaceTabs.some((t) => t.id === tabId)) return;
+    set({ workspaceActiveTabId: tabId });
+  },
+
+  /**
+   * Close a tab. If the closed tab was active, focus shifts to the
+   * preceding tab (or `null` if no tabs remain). Dirty-confirmation
+   * semantics (VIS-O3) are deferred — callers handle their own guard.
+   */
+  closeWorkspaceTab: (tabId) => {
+    const state = get();
+    const idx = state.workspaceTabs.findIndex((t) => t.id === tabId);
+    if (idx === -1) return;
+    const remaining = state.workspaceTabs.filter((t) => t.id !== tabId);
+    let activeId = state.workspaceActiveTabId;
+    if (activeId === tabId) {
+      if (remaining.length === 0) activeId = null;
+      else activeId = remaining[Math.max(0, idx - 1)].id;
+    }
+    set({
+      workspaceTabs: remaining,
+      workspaceActiveTabId: activeId,
+    });
+  },
+
+  /** Mark a tab dirty/clean — drives the mulberry dot in the tab strip. */
+  setWorkspaceTabDirty: (tabId, dirty) => {
+    const state = get();
+    set({
+      workspaceTabs: state.workspaceTabs.map((t) =>
+        t.id === tabId ? { ...t, dirty: !!dirty } : t
+      ),
+    });
+  },
+
+  // ------------------------------------------------------------------------
+  // Rail / lens actions
+  // ------------------------------------------------------------------------
+
+  toggleWorkspaceLeftCollapsed: () => {
+    set((s) => ({ workspaceLeftCollapsed: !s.workspaceLeftCollapsed }));
+  },
+
+  toggleWorkspaceRightCollapsed: () => {
+    set((s) => ({ workspaceRightCollapsed: !s.workspaceRightCollapsed }));
+  },
+
+  setWorkspaceRightTab: (tab) => {
+    if (!['outline', 'edit', 'history'].includes(tab)) return;
+    set({ workspaceRightTab: tab });
+  },
+
+  setWorkspaceLens: (lens) => {
+    if (!['preview', 'lineage'].includes(lens)) return;
+    set({ workspaceLens: lens });
+  },
+
+  /**
+   * Replace the entire tab set in one shot. Used by the Workspace shell on
+   * mount to hydrate a project tab from the loaded project. Avoids the
+   * double-render of openWorkspaceTab when the caller knows exactly what the
+   * tab strip should look like.
+   */
+  hydrateWorkspaceTabs: (tabs, activeTabId) => {
+    set({
+      workspaceTabs: tabs || [],
+      workspaceActiveTabId: activeTabId || (tabs && tabs[0] ? tabs[0].id : null),
+    });
+  },
+});
+
+export default createWorkspaceSlice;

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -1,0 +1,159 @@
+/**
+ * Workspace store slice — tab management (VIS-775 / Track B B2).
+ *
+ * The slice is consumed by the Workspace shell to drive tab state. These
+ * tests pin the open/switch/close + dirty-flag behaviour so VIS-O1's
+ * subsequent multi-tab work has a stable contract to build on.
+ */
+import { act } from '@testing-library/react';
+import useStore from './store';
+
+const reset = () => {
+  act(() => {
+    useStore.setState({
+      workspaceTabs: [],
+      workspaceActiveTabId: null,
+      workspaceLeftCollapsed: false,
+      workspaceRightCollapsed: false,
+      workspaceRightTab: 'edit',
+      workspaceLens: 'preview',
+    });
+  });
+};
+
+describe('workspace store slice', () => {
+  beforeEach(reset);
+
+  test('openWorkspaceTab adds a new tab and focuses it', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({
+        type: 'dashboard',
+        name: 'simple-dashboard',
+      });
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(1);
+    expect(s.workspaceTabs[0].id).toBe('dashboard:simple-dashboard');
+    expect(s.workspaceActiveTabId).toBe('dashboard:simple-dashboard');
+  });
+
+  test('openWorkspaceTab re-focuses an existing tab without duplicating it', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({
+        type: 'dashboard',
+        name: 'simple-dashboard',
+      });
+      useStore.getState().openWorkspaceTab({
+        type: 'chart',
+        name: 'revenue_chart',
+      });
+      useStore.getState().openWorkspaceTab({
+        type: 'dashboard',
+        name: 'simple-dashboard',
+      });
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(2);
+    expect(s.workspaceActiveTabId).toBe('dashboard:simple-dashboard');
+  });
+
+  test('switchWorkspaceTab focuses an existing tab; no-op for unknown ids', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd2' });
+      useStore.getState().switchWorkspaceTab('dashboard:d1');
+    });
+    expect(useStore.getState().workspaceActiveTabId).toBe('dashboard:d1');
+
+    act(() => {
+      useStore.getState().switchWorkspaceTab('dashboard:does-not-exist');
+    });
+    // unchanged
+    expect(useStore.getState().workspaceActiveTabId).toBe('dashboard:d1');
+  });
+
+  test('closeWorkspaceTab removes the tab and reassigns focus when the active tab closes', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd2' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd3' });
+      // d3 is now active.
+      useStore.getState().closeWorkspaceTab('dashboard:d3');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs.map((t) => t.id)).toEqual([
+      'dashboard:d1',
+      'dashboard:d2',
+    ]);
+    // Focus shifts left to d2.
+    expect(s.workspaceActiveTabId).toBe('dashboard:d2');
+  });
+
+  test('closeWorkspaceTab leaves focus alone when closing a non-active tab', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd2' });
+      useStore.getState().switchWorkspaceTab('dashboard:d1');
+      useStore.getState().closeWorkspaceTab('dashboard:d2');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs.map((t) => t.id)).toEqual(['dashboard:d1']);
+    expect(s.workspaceActiveTabId).toBe('dashboard:d1');
+  });
+
+  test('closing the last tab clears the active id', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().closeWorkspaceTab('dashboard:d1');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(0);
+    expect(s.workspaceActiveTabId).toBeNull();
+  });
+
+  test('setWorkspaceTabDirty toggles the dirty flag without touching others', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd2' });
+      useStore.getState().setWorkspaceTabDirty('dashboard:d2', true);
+    });
+    const tabs = useStore.getState().workspaceTabs;
+    expect(tabs.find((t) => t.id === 'dashboard:d1').dirty).toBe(false);
+    expect(tabs.find((t) => t.id === 'dashboard:d2').dirty).toBe(true);
+  });
+
+  test('rail collapse toggles flip independently', () => {
+    act(() => {
+      useStore.getState().toggleWorkspaceLeftCollapsed();
+    });
+    expect(useStore.getState().workspaceLeftCollapsed).toBe(true);
+    expect(useStore.getState().workspaceRightCollapsed).toBe(false);
+    act(() => {
+      useStore.getState().toggleWorkspaceRightCollapsed();
+    });
+    expect(useStore.getState().workspaceRightCollapsed).toBe(true);
+  });
+
+  test('setWorkspaceRightTab only accepts known tab keys', () => {
+    act(() => {
+      useStore.getState().setWorkspaceRightTab('outline');
+    });
+    expect(useStore.getState().workspaceRightTab).toBe('outline');
+    act(() => {
+      useStore.getState().setWorkspaceRightTab('not-a-tab');
+    });
+    // unchanged
+    expect(useStore.getState().workspaceRightTab).toBe('outline');
+  });
+
+  test('setWorkspaceLens only accepts preview | lineage', () => {
+    act(() => {
+      useStore.getState().setWorkspaceLens('lineage');
+    });
+    expect(useStore.getState().workspaceLens).toBe('lineage');
+    act(() => {
+      useStore.getState().setWorkspaceLens('garbage');
+    });
+    expect(useStore.getState().workspaceLens).toBe('lineage');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the VIS-772 placeholder stub with the full Workspace shell composition matching the **delivered B-1 design** at \`specs/dashboard-building/implementation/design/cofounder-mockups/\`.

This is **VIS-775 (Track B B2)** — the second of two sub-issues under the Track B project. Phase 0 work. Frontend-only.

**Note on the original ticket text:** Linear's stored description for VIS-775 still references the *pre-revision* brief (\`[View] [Build]\` mode toggle, \`[Project|Lineage|Outline]\` lens picker, B-2 Project Overview pane). The delivered B-1 design replaced all of those. This implementation matches the **revised** spec in \`01-phase-0-workspace-shell.md\` and \`01-tracks-and-phasing.md\` Track B B2, not the original ticket text.

## What ships

**Layout** (matches the delivered B-1 design — 15 artboards):
- Top bar (h-12 navy): brand + breadcrumb (\`Workspace › <projectName>\`); right cluster \`Publish · N\` (when dirty) + \`Deploy\` + utility icons. No mode toggle, no lens picker, no save-state pill.
- Tab strip (h-9 white) BETWEEN top bar and middle/right area (NOT spanning the left rail). Per-tab type icon + name + dirty dot + close. Active tab has mulberry underline. "+" new-tab button at end. **Project is a first-class tab.**
- Left rail: full-height anchor (top bar to bottom). Library section headers as placeholders ("Library coming soon — VIS-C1"). Collapsed-rail icon strip.
- Middle pane: dispatches on \`activeObject.type\` (project / dashboard / chart / model). Sub-bar with lens picker (\`[Canvas | Lineage]\` for dashboards, \`[Preview | Lineage]\` for non-dashboard, Preview muted when no preview exists yet — the n2 model lineage-fallback artboard).
- Right rail: three-tab bar (Outline · Edit · History) with mulberry underline. Tab body placeholders.
- Drag handles between rails (4-px hot zone, 1-px gray line, mulberry on hover).

**State:**
- \`useWorkspaceScope()\` hook → \`{ scope, selector, dashboardName, selectedItem }\` per spec.
- Zustand \`workspaceStore.js\` slice: tabs, activeTabId, rail collapse, right-rail tab, lens.

**Telemetry:**
- \`workspace_mode_entered\` event stub fires on mount (with scoped dashboard name or \`null\`).

## New files

\`viewer/src/components/new-views/workspace/\`:
- \`Workspace.jsx\` (smart container — replaces the VIS-772 stub)
- \`WorkspaceShell.jsx\` (presentational shell)
- \`TopBar.jsx\`, \`TabStrip.jsx\`, \`LeftRail.jsx\`, \`RightRail.jsx\`, \`MiddlePane.jsx\`, \`SubBar.jsx\`, \`Segmented.jsx\`, \`DragHandle.jsx\`
- \`objKind.js\` (OBJ_KIND map)
- \`useWorkspaceScope.js\` (hook)
- \`telemetry.js\` (stub + test listener)

\`viewer/src/stores/workspaceStore.js\` (Zustand slice, registered in store.js).

**29 new tests:**
- \`workspaceStore.test.js\` — 10 tests (tab actions, focus shift on close, dirty toggle, rail collapse)
- \`TabStrip.test.jsx\` — 6 tests
- \`useWorkspaceScope.test.jsx\` — 6 tests
- \`Workspace.test.jsx\` — 7 tests

## Test plan

- [x] \`cd viewer && yarn test --watchAll=false\` — 1574/1574 pass (29 new + all existing)
- [x] \`cd viewer && yarn lint\` — clean
- [x] VIS-772's \`LocalRouter\` tests still pass (8/8)

## Deferred (per spec, not in scope for B2)

- Drag-to-reorder tabs → VIS-O3
- Right-click \"Open in new tab\" → VIS-O2
- Actual Library content → VIS-C1
- Actual right-rail forms → VIS-G1 / VIS-F3
- Pointer-drag rail resize → visual stub only here
- Auto-save / dirty confirmation → Track H

## Stacking note

This branch was based on top of \`b1-vis-772-workspace-routes\` so the route stub is replaced cleanly. **Recommend merging VIS-772 first**, then this PR.

## Visual stacking caveat

Home renders a fixed \`<TopNav>\` and wraps \`<Outlet/>\` in \`pt-12\`. The new Workspace anchors to \`fixed inset-0 z-40\` to overlay Home's nav so the user sees only the new workspace TopBar. Flagged in a comment as the cleanest Phase 0 path until the route container is refactored.

## Linked

- Linear: [VIS-775](https://linear.app/visivo/issue/VIS-775) (Track B project)
- Targets: \`feature/dashboard-building-v1\`
- Stacks on: VIS-772 (this branch was based on \`b1-vis-772-workspace-routes\`)
- Unblocks: every subsequent frontend track (C, D, E, F, G, H, I, M, N, O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)