### PR TITLE
fix(rwx): stop deploy_dashboard run from failing on PR close

### DIFF
--- a/.rwx/deploy_dashboard.yml
+++ b/.rwx/deploy_dashboard.yml
@@ -7,7 +7,7 @@ on:
         pr-num: ${{ event.github.pull_request.pull_request.number }}
         head-ref: ${{ event.git.branch	}}
         deploy: ${{ event.github.pull_request.pull_request.merged == false && event.github.pull_request.pull_request.state == 'open' }}
-        archive: ${{ event.github.pull_request.pull_request.merged == true && event.github.pull_request.pull_request.state == 'closed' }}
+        archive: ${{ event.github.pull_request.pull_request.state == 'closed' }}
 
 base:
   image: ubuntu:22.04
@@ -31,11 +31,13 @@ tasks:
     call: github/install-cli 1.0.5
 
   - key: install-visivo
+    if: ${{ init.deploy }}
     use: [python]
     run: pip install git+https://github.com/visivo-io/visivo.git@${{ init.head-ref }}
     filter: [visivo]
 
   - key: install-visivo-for-archive
+    if: ${{ init.archive }}
     use: [python]
     run: pip install git+https://github.com/visivo-io/visivo.git@main
     filter: [visivo]


### PR DESCRIPTION
## Problem

`.rwx/deploy_dashboard.yml` fails when a PR is closed. Example failing run: https://cloud.rwx.com/mint/visivo/runs/7b5002af68fd4398a5e28b992ae6ce18

The failed task is `install-visivo`, with these logs:

```
pip install git+https://github.com/visivo-io/visivo.git@bugfix/b09-sqlglot-preserve-quoted-case
  WARNING: Did not find branch or tag 'bugfix/b09-sqlglot-preserve-quoted-case', assuming revision or ref.
  error: pathspec 'bugfix/b09-sqlglot-preserve-quoted-case' did not match any file(s) known to git
Task finished with exit code 1
```

**Root cause:** the `install-visivo` task installs Visivo from the **PR head branch** (`pip install git+...@${{ init.head-ref }}`) but had no `if:` guard, so it ran on *every* event including `closed`. When a PR is merged its head branch is deleted, so the pip install fails with `did not match any file(s) known to git` and fails the whole run.

PR #331 previously added a separate `install-visivo-for-archive` task (installs from `main`) and pointed `archive-ci-stage` at it, but never gated `install-visivo` itself — so that task kept running and failing on close. This completes that fix.

## Changes

- **Gate `install-visivo` behind `init.deploy`** — it only feeds `run-visivo` and `deploy-ci-stage`, both already gated by `deploy`. It no longer runs (and fails) on `closed` events.
- **Gate `install-visivo-for-archive` behind `init.archive`** — it only feeds `archive-ci-stage`; no reason to run it on deploy events.
- **Broaden the `archive` condition to any closed PR** (merged or not), so stages from PRs closed *without* merging also get cleaned up instead of being orphaned. Safe even for a PR closed before it ever deployed: `visivo archive` exits cleanly (exit 0) when the named stage does not exist (`visivo/commands/archive_phase.py`).

## Behavior after fix

| Event | `deploy` | `archive` | Tasks that run |
|---|---|---|---|
| opened / reopened / synchronize | true | false | `install-visivo`, `run-visivo`, `deploy-ci-stage` |
| closed (merged or unmerged) | false | true | `install-visivo-for-archive`, `archive-ci-stage` |

`sanitize-stage-name` still works on `closed` because `event.git.branch` remains in the payload even after branch deletion.

## Testing

CI-config only — no Python/JS code changed. RWX workflows can't run locally; verified by inspecting the failing run logs via the RWX MCP and tracing each event type by hand. Real verification happens on the next PR open + close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)