### PR TITLE
feat(viewer): refined C-3 flip-card layout (VIS-776)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,27 @@ bash scripts/sandbox.sh restart  # Stop then start
 NEVER start sandbox servers with ad-hoc commands — always use `bash scripts/sandbox.sh`.
 Use Playwright MCP or `npx playwright test` against `http://localhost:3001` — never `:3000`.
 
+## Object Type Colors + Icons (single source of truth)
+
+ALWAYS use `viewer/src/components/new-views/common/objectTypeConfigs.js` for any
+type-driven colour or icon. NEVER hand-roll Tailwind classes (`bg-pink-100`,
+`text-purple-800`, custom hex codes, etc.) for source / model / insight /
+chart / table / markdown / input / dimension / metric / relation / dashboard
+surfaces. The palette is the rainbow spectrum defined there (source=orange,
+model=amber, insight=purple, chart=pink, dashboard=rose, …) and is consumed by
+every viewer surface — divergence in one component creates a colour mismatch
+across the app.
+
+```js
+import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
+const { bg, text, border, node } = getTypeColors(obj.type);
+const Icon = getTypeIcon(obj.type);
+```
+
+If a new tone is genuinely needed (e.g. a selected/active variant the existing
+`bgSelected` / `nodeSelected` doesn't cover), extend the shared config — don't
+fork the palette in a single component.
+
 ## Mandatory Testing Protocol
 
 ### After EVERY code edit:

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -678,13 +678,6 @@ const LibraryRowFlipPopover = ({
   const descendantRowY = j =>
     subjectBottomY + ROW_GAP + j * (ROW_HEIGHT + ROW_GAP) + ROW_HEIGHT / 2;
 
-  // Trunk offset: how far OUTSIDE the icon column the connector trunk
-  // sits. Without this, the connector lines would draw straight through
-  // the icons; the offset pulls the vertical trunk into the gutter so
-  // the tree wraps around the icons (entering each from the icon's
-  // right edge for ancestors / left edge for descendants).
-  const TRUNK_OFFSET = 8;
-
   const ancestorConnectors = [];
   if (ancestorsOpen) {
     ancestors.forEach((parent, parentIdx) => {
@@ -731,19 +724,16 @@ const LibraryRowFlipPopover = ({
     });
   }
 
-  // Ancestors live on the RIGHT side of each row, so the connector
-  // trunk sits at `parent.iconRight + TRUNK_OFFSET` — out in the gutter
-  // past every icon. Path: enter from the parent icon's RIGHT edge,
-  // bend right into the trunk, drop down to the child row, then bend
-  // back LEFT to enter the child icon from the right.
+  // Ancestor edges read as an inverse-L: drop straight down from the
+  // parent icon's bottom-center, then bend LEFT into the child icon's
+  // right edge. When several children share a parent they all hang off
+  // the same vertical "trunk" (the parent icon's center X) and each
+  // gets its own horizontal arm — a real downward branching tree.
   const ancestorConnectorPath = ({ parentX, parentY, childX, childY }) => {
-    const trunkX = parentX + ICON_W / 2 + TRUNK_OFFSET;
-    const parentRightEdge = parentX + ICON_W / 2;
     const childRightEdge = childX + ICON_W / 2;
     return (
-      `M ${parentRightEdge} ${parentY}` +
-      ` L ${trunkX} ${parentY}` +
-      ` L ${trunkX} ${childY}` +
+      `M ${parentX} ${parentY + ICON_H / 2}` +
+      ` L ${parentX} ${childY}` +
       ` L ${childRightEdge} ${childY}`
     );
   };

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -86,202 +86,168 @@ const CARD_WIDTH = 340;
 // Relations walker
 // ---------------------------------------------------------------------------
 
-function findByName(list, name) {
-  if (!Array.isArray(list) || !name) return null;
-  return list.find(o => o && o.name === name) || null;
-}
-
-function refValue(ref) {
-  if (!ref) return null;
-  if (typeof ref === 'string') return ref;
-  return ref.name || ref.ref || null;
-}
-
-function pickInsightRefs(chart) {
-  const list = chart?.insights || chart?.config?.insights || [];
-  if (!Array.isArray(list)) return [];
-  return list.map(refValue).filter(Boolean);
-}
-
-function pickModelRef(insight) {
-  return refValue(insight?.model || insight?.config?.model);
-}
-
-function pickSourceRef(model) {
-  return refValue(model?.source || model?.config?.source);
+// Lineage edges come straight from each store object's `child_item_names`
+// array — that's the canonical "what does this depend on" list the backend
+// already publishes for every chart / table / insight / model / source.
+// Walking it gives us the full upstream DAG without having to inspect the
+// per-type config blobs (which embed refs as `${ref(name).column}` and
+// would otherwise need SQL-style ref parsing).
+function getChildItemNames(obj) {
+  if (!obj || !Array.isArray(obj.child_item_names)) return [];
+  return obj.child_item_names.filter(Boolean);
 }
 
 /**
- * Walk a chart's upstream chain. Each direct insight is pushed first,
- * followed by its model and source (deduped). This gives the mock's
- * interleaved ladder (source · model · insight · model · insight · subject).
+ * Build a name → type index over every collection the store exposes. Lets
+ * us resolve a raw `child_item_names` entry back to its typed object so the
+ * walker can keep traversing upstream.
  */
-function pushChartAncestors(chart, storeApi, push, seen) {
-  const refs = pickInsightRefs(chart);
-  refs.forEach(insightRef => {
-    const insight = storeApi.getInsightByName?.(insightRef);
-    if (!insight) return;
-    pushInsightAncestors(insight, storeApi, push, seen, /* isInsightDirect */ true);
-  });
-}
-
-function pushInsightAncestors(insight, storeApi, push, seen, isInsightDirect = true) {
-  const modelRef = pickModelRef(insight);
-  if (modelRef) {
-    const model =
-      storeApi.getModelByName?.(modelRef) ||
-      findByName(storeApi.csvScriptModels, modelRef) ||
-      findByName(storeApi.localMergeModels, modelRef);
-    if (model) {
-      pushModelAncestors(model, storeApi, push, seen, /* isModelDirect */ false);
-    } else {
-      push({ type: 'model', name: modelRef, isDirect: false }, seen);
-    }
-  }
-  push({ type: 'insight', name: insight.name, isDirect: isInsightDirect }, seen);
-}
-
-function pushModelAncestors(model, storeApi, push, seen, isModelDirect = true) {
-  const sourceRef = pickSourceRef(model);
-  if (sourceRef) {
-    push({ type: 'source', name: sourceRef, isDirect: false }, seen);
-  }
-  push({ type: 'model', name: model.name, isDirect: isModelDirect }, seen);
-}
-
-// ---------------------------------------------------------------------------
-// Descendant walkers — scan the store for objects that reference the subject.
-// ---------------------------------------------------------------------------
-
-function collectDashboardsReferencing(name, dashboards) {
-  if (!Array.isArray(dashboards)) return [];
-  const hits = [];
-  dashboards.forEach(d => {
-    if (!d || !Array.isArray(d.rows)) return;
-    const matches = d.rows.some(row => {
-      if (!row || !Array.isArray(row.items)) return false;
-      return row.items.some(item => {
-        if (!item) return false;
-        const itemRef = refValue(item.chart) || refValue(item.table) || refValue(item.markdown);
-        return itemRef === name;
-      });
-    });
-    if (matches) hits.push(d.name);
-  });
-  return hits;
-}
-
-function collectChartsReferencing(insightName, charts) {
-  if (!Array.isArray(charts)) return [];
-  return charts
-    .filter(c => pickInsightRefs(c).includes(insightName))
-    .map(c => c.name)
-    .filter(Boolean);
-}
-
-function collectInsightsReferencing(modelName, insights) {
-  if (!Array.isArray(insights)) return [];
-  return insights
-    .filter(i => pickModelRef(i) === modelName)
-    .map(i => i.name)
-    .filter(Boolean);
-}
-
-function collectModelsReferencing(sourceName, ...modelLists) {
-  const hits = [];
-  modelLists.forEach(list => {
+function buildTypeIndex(storeApi) {
+  const lookup = new Map();
+  const register = (type, list) => {
     if (!Array.isArray(list)) return;
-    list.forEach(m => {
-      if (m && pickSourceRef(m) === sourceName) hits.push(m.name);
+    list.forEach(obj => {
+      if (obj && obj.name && !lookup.has(obj.name)) {
+        lookup.set(obj.name, { type, obj });
+      }
     });
-  });
-  return hits;
+  };
+  register('source', storeApi.sources);
+  register('model', storeApi.models);
+  register('model', storeApi.csvScriptModels);
+  register('model', storeApi.localMergeModels);
+  register('dimension', storeApi.dimensions);
+  register('metric', storeApi.metrics);
+  register('relation', storeApi.relations);
+  register('insight', storeApi.insights);
+  register('chart', storeApi.charts);
+  register('table', storeApi.tables);
+  register('markdown', storeApi.markdowns);
+  register('input', storeApi.inputs);
+  register('dashboard', storeApi.allDashboards);
+  return lookup;
 }
 
+/**
+ * Walk upstream from the subject via `child_item_names`. The traversal is
+ * topological-on-the-fly: a parent node is only emitted once all of its own
+ * upstreams have been emitted, so direct ancestors land last (closest to
+ * the subject in the rendered ladder).
+ */
 function buildAncestors(subject, storeApi) {
   if (!subject) return [];
+  const index = buildTypeIndex(storeApi);
+  const subjectEntry = index.get(subject.name);
+  const subjectObj = subjectEntry?.obj;
+  if (!subjectObj) return [];
+
+  const directNames = new Set(getChildItemNames(subjectObj));
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
-  const push = (node, seenSet) => {
-    const key = `${node.type}:${node.name}`;
-    if (seenSet.has(key)) return;
-    seenSet.add(key);
-    out.push(node);
+
+  const visit = name => {
+    const entry = index.get(name);
+    if (!entry) return;
+    const key = `${entry.type}:${name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    // Emit upstreams first so the deepest node sits at the top of the
+    // ladder; direct children of the subject sit just above the subject.
+    getChildItemNames(entry.obj).forEach(visit);
+    out.push({ type: entry.type, name, isDirect: directNames.has(name) });
   };
 
-  if (subject.type === 'chart' || subject.type === 'table') {
-    const obj =
-      subject.type === 'chart'
-        ? storeApi.getChartByName?.(subject.name)
-        : findByName(storeApi.tables, subject.name);
-    if (obj) pushChartAncestors(obj, storeApi, push, seen);
-  } else if (subject.type === 'insight') {
-    const insight = storeApi.getInsightByName?.(subject.name);
-    if (insight) {
-      // Subject itself is the "direct" node — its parents are model/source.
-      const modelRef = pickModelRef(insight);
-      if (modelRef) {
-        const model =
-          storeApi.getModelByName?.(modelRef) ||
-          findByName(storeApi.csvScriptModels, modelRef) ||
-          findByName(storeApi.localMergeModels, modelRef);
-        if (model) pushModelAncestors(model, storeApi, push, seen, true);
-        else push({ type: 'model', name: modelRef, isDirect: true }, seen);
-      }
-    }
-  } else if (subject.type === 'model') {
-    const model =
-      storeApi.getModelByName?.(subject.name) ||
-      findByName(storeApi.csvScriptModels, subject.name) ||
-      findByName(storeApi.localMergeModels, subject.name);
-    if (model) {
-      const sourceRef = pickSourceRef(model);
-      if (sourceRef) push({ type: 'source', name: sourceRef, isDirect: true }, seen);
-    }
-  }
-  // sources, dashboards, markdowns, inputs, inserts have no upstream.
+  directNames.forEach(visit);
+  return out;
+}
 
+/**
+ * Build a reverse adjacency — for any name, who lists it as a child? Lets
+ * us walk descendants in O(N) regardless of which type the subject is.
+ */
+function buildReverseIndex(storeApi) {
+  const reverse = new Map();
+  const add = (parentName, childName, parentType) => {
+    if (!reverse.has(childName)) reverse.set(childName, []);
+    reverse.get(childName).push({ name: parentName, type: parentType });
+  };
+  const scan = (type, list) => {
+    if (!Array.isArray(list)) return;
+    list.forEach(obj => {
+      if (!obj || !obj.name) return;
+      getChildItemNames(obj).forEach(childName => add(obj.name, childName, type));
+    });
+  };
+  scan('model', storeApi.models);
+  scan('model', storeApi.csvScriptModels);
+  scan('model', storeApi.localMergeModels);
+  scan('insight', storeApi.insights);
+  scan('chart', storeApi.charts);
+  scan('table', storeApi.tables);
+  scan('markdown', storeApi.markdowns);
+  scan('input', storeApi.inputs);
+  scan('dimension', storeApi.dimensions);
+  scan('metric', storeApi.metrics);
+  scan('relation', storeApi.relations);
+  return reverse;
+}
+
+/**
+ * Some dashboards aren't surfaced through `child_item_names` on their
+ * descendants — the relationship lives in the dashboard's `rows`/`items`
+ * tree. Scan once and produce a flat list of `(dashboardName → memberName)`
+ * edges so descendant traversal can include them.
+ */
+function dashboardMembership(allDashboards) {
+  const out = [];
+  if (!Array.isArray(allDashboards)) return out;
+  allDashboards.forEach(d => {
+    if (!d || !Array.isArray(d.rows)) return;
+    d.rows.forEach(row => {
+      if (!row || !Array.isArray(row.items)) return;
+      row.items.forEach(item => {
+        if (!item) return;
+        ['chart', 'table', 'markdown'].forEach(key => {
+          const ref = item[key];
+          if (!ref) return;
+          const refName = typeof ref === 'string' ? ref : ref.name || ref.ref;
+          if (refName) out.push({ dashboard: d.name, member: refName });
+        });
+      });
+    });
+  });
   return out;
 }
 
 function buildDescendants(subject, storeApi) {
   if (!subject) return [];
+  const reverse = buildReverseIndex(storeApi);
+  const dashMembers = dashboardMembership(storeApi.allDashboards);
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
-  const push = node => {
-    const key = `${node.type}:${node.name}`;
+
+  const directParents = reverse.get(subject.name) || [];
+  const directDashboards = dashMembers
+    .filter(m => m.member === subject.name)
+    .map(m => ({ name: m.dashboard, type: 'dashboard' }));
+  const directSet = new Set(
+    [...directParents, ...directDashboards].map(p => `${p.type}:${p.name}`)
+  );
+
+  const visit = (name, type) => {
+    const key = `${type}:${name}`;
     if (seen.has(key)) return;
     seen.add(key);
-    out.push(node);
+    out.push({ type, name, isDirect: directSet.has(key) });
+    // Recurse: anything that lists `name` as a child is a deeper descendant.
+    (reverse.get(name) || []).forEach(p => visit(p.name, p.type));
+    dashMembers
+      .filter(m => m.member === name)
+      .forEach(m => visit(m.dashboard, 'dashboard'));
   };
 
-  if (subject.type === 'source') {
-    const models = collectModelsReferencing(
-      subject.name,
-      storeApi.models,
-      storeApi.csvScriptModels,
-      storeApi.localMergeModels
-    );
-    models.forEach(name => push({ type: 'model', name, isDirect: true }));
-  } else if (subject.type === 'model') {
-    collectInsightsReferencing(subject.name, storeApi.insights).forEach(name =>
-      push({ type: 'insight', name, isDirect: true })
-    );
-  } else if (subject.type === 'insight') {
-    collectChartsReferencing(subject.name, storeApi.charts).forEach(name =>
-      push({ type: 'chart', name, isDirect: true })
-    );
-  } else if (
-    subject.type === 'chart' ||
-    subject.type === 'table' ||
-    subject.type === 'markdown'
-  ) {
-    collectDashboardsReferencing(subject.name, storeApi.allDashboards).forEach(name =>
-      push({ type: 'dashboard', name, isDirect: true })
-    );
-  }
-  // dashboards / inserts / inputs have no downstream we track here.
-
+  directParents.forEach(p => visit(p.name, p.type));
+  directDashboards.forEach(d => visit(d.name, d.type));
   return out;
 }
 
@@ -293,8 +259,6 @@ function buildLineageRelations(subject, storeApi) {
 }
 
 // Backward-compat: VIS-780 will replace this with `<MiniLineageCard>`.
-// The legacy chain (subject's upstream-only chain, deepest-first → direct)
-// is still useful in places that imported it from this module.
 function buildChainFromStore(subject, storeApi) {
   return buildAncestors(subject, storeApi);
 }
@@ -360,11 +324,17 @@ const AncestorRow = ({ node, leftPad, dottedHeight, testIdPrefix }) => {
         <span
           aria-hidden="true"
           data-testid={`${testIdPrefix}-dotted-${node.name}`}
-          className="absolute border-l border-dotted border-gray-400"
+          className="absolute"
           style={{
-            left: leftPad - 4,
+            left: leftPad - 5,
             top: ROW_HEIGHT / 2,
             height: dottedHeight,
+            width: 2,
+            // Repeating gradient gives a crisp, visible dotted line at
+            // small widths where CSS `border-style: dotted` renders as
+            // a near-invisible hairline.
+            backgroundImage:
+              'repeating-linear-gradient(to bottom, #6b7280 0, #6b7280 2px, transparent 2px, transparent 5px)',
           }}
         />
       )}
@@ -463,39 +433,48 @@ const LibraryRowFlipPopover = ({
     };
   }, [anchorRef]);
 
-  const getChartByName = useStore(s => s.getChartByName);
-  const getInsightByName = useStore(s => s.getInsightByName);
-  const getModelByName = useStore(s => s.getModelByName);
   const charts = useStore(s => s.charts);
   const insights = useStore(s => s.insights);
   const models = useStore(s => s.models);
   const tables = useStore(s => s.tables);
+  const sources = useStore(s => s.sources);
+  const dimensions = useStore(s => s.dimensions);
+  const metrics = useStore(s => s.metrics);
+  const relationsList = useStore(s => s.relations);
+  const markdowns = useStore(s => s.markdowns);
+  const inputs = useStore(s => s.inputs);
   const allDashboards = useStore(s => s.allDashboards);
   const csvScriptModels = useStore(s => s.csvScriptModels);
   const localMergeModels = useStore(s => s.localMergeModels);
 
-  const relations = useMemo(() => {
+  const lineage = useMemo(() => {
     return buildLineageRelations(obj, {
-      getChartByName,
-      getInsightByName,
-      getModelByName,
       charts,
       insights,
       models,
       tables,
+      sources,
+      dimensions,
+      metrics,
+      relations: relationsList,
+      markdowns,
+      inputs,
       allDashboards,
       csvScriptModels,
       localMergeModels,
     });
   }, [
     obj,
-    getChartByName,
-    getInsightByName,
-    getModelByName,
     charts,
     insights,
     models,
     tables,
+    sources,
+    dimensions,
+    metrics,
+    relationsList,
+    markdowns,
+    inputs,
     allDashboards,
     csvScriptModels,
     localMergeModels,
@@ -524,8 +503,8 @@ const LibraryRowFlipPopover = ({
     ? `+${String(obj.name).toLowerCase().replace(/[^a-z0-9_]+/g, '_')}`
     : '+';
 
-  const ancestors = relations.ancestors;
-  const descendants = relations.descendants;
+  const ancestors = lineage.ancestors;
+  const descendants = lineage.descendants;
   const N = ancestors.length;
   const isEmpty = N === 0 && descendants.length === 0;
 

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -343,7 +343,7 @@ const IconTile = ({ type }) => {
   );
 };
 
-const AncestorRow = ({ node, marginLeft, dottedHeight, testIdPrefix }) => (
+const AncestorRow = ({ node, marginLeft, testIdPrefix }) => (
   <li
     data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
     data-direction="ancestor"
@@ -355,40 +355,6 @@ const AncestorRow = ({ node, marginLeft, dottedHeight, testIdPrefix }) => (
       marginLeft,
     }}
   >
-    {/* Dotted L-connector: drops from the left of the [type] pill down to
-        the top of the subject row, then bends inward to the subject's
-        [icon]. The horizontal nib lands ~half a row above the subject
-        icon and stops at the subject's left edge (paddingLeft + icon
-        width / 2) so it visually terminates on the icon column. */}
-    {node.isDirect && dottedHeight > 0 && (
-      <>
-        <span
-          aria-hidden="true"
-          data-testid={`${testIdPrefix}-dotted-${node.name}`}
-          className="absolute"
-          style={{
-            left: -4,
-            top: ROW_HEIGHT / 2,
-            height: dottedHeight,
-            width: 2,
-            backgroundImage:
-              'repeating-linear-gradient(to bottom, #6b7280 0, #6b7280 2px, transparent 2px, transparent 5px)',
-          }}
-        />
-        <span
-          aria-hidden="true"
-          className="absolute"
-          style={{
-            left: -4,
-            top: ROW_HEIGHT / 2 + dottedHeight,
-            width: Math.max(0, marginLeft - CARD_PAD_X - 4 + 12),
-            height: 2,
-            backgroundImage:
-              'repeating-linear-gradient(to right, #6b7280 0, #6b7280 2px, transparent 2px, transparent 5px)',
-          }}
-        />
-      </>
-    )}
     <TypePill type={node.type} />
     <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
       {node.name}
@@ -622,24 +588,20 @@ const LibraryRowFlipPopover = ({
     if (maxDepth <= 1) return 0;
     return Math.max(MIN_STEP, Math.min(MAX_STEP, Math.floor(availableShift / (maxDepth - 1))));
   };
+  // Unified step across both ladders — the direct-ancestor row and the
+  // direct-descendant row must share the same left edge (rule 4), and
+  // each successive depth step must move the same distance regardless
+  // of which side of the subject the row is on.
   const ancestorMaxDepth = ancestors.reduce((acc, n) => Math.max(acc, n.depth || 1), 1);
   const descendantMaxDepth = descendants.reduce((acc, n) => Math.max(acc, n.depth || 1), 1);
-  const ancestorStep = stepForMaxDepth(ancestorMaxDepth);
-  const descendantStep = stepForMaxDepth(descendantMaxDepth);
+  const sharedMaxDepth = Math.max(ancestorMaxDepth, descendantMaxDepth);
+  const STEP = stepForMaxDepth(sharedMaxDepth);
 
   const ancestorMarginLeft = node =>
-    BASE_INDENT + ((node.depth || 1) - 1) * ancestorStep;
+    BASE_INDENT + ((node.depth || 1) - 1) * STEP;
   const descendantMarginLeft = node =>
-    BASE_INDENT + ((node.depth || 1) - 1) * descendantStep;
+    BASE_INDENT + ((node.depth || 1) - 1) * STEP;
 
-  // Dotted L-connector height: drops from the direct ancestor's row mid
-  // down past every row between it and the subject. Walking by display
-  // index keeps the geometry correct even when multiple ancestors share
-  // a depth (siblings at the same level).
-  const dottedHeightFor = displayIndex => {
-    const rowsToSubject = N - displayIndex;
-    return rowsToSubject * (ROW_HEIGHT + ROW_GAP) - ROW_HEIGHT / 2;
-  };
 
   // SVG connector overlay — draws the actual DAG edges so the icon
   // staircase visually reads as the lineage tree it represents.
@@ -711,6 +673,29 @@ const LibraryRowFlipPopover = ({
 
   const connectorPath = ({ parentX, parentY, childX, childY }) =>
     `M ${parentX} ${parentY + ICON_H / 2} L ${parentX} ${childY} L ${childX} ${childY}`;
+
+  // Dotted Γ-connector from each direct ancestor's [type] pill down and
+  // then right onto the subject row's icon column. Drawn as a single
+  // L-path in the SVG overlay so the corner joins cleanly.
+  const dottedConnectors = [];
+  if (ancestorsOpen) {
+    ancestors.forEach((node, i) => {
+      if (!node.isDirect) return;
+      const rowLeft = ancestorMarginLeft(node);
+      const startX = rowLeft - 4; // just left of the [type] pill
+      const startY = ancestorRowY(i);
+      // The L turns at the top of the subject row so the horizontal
+      // segment lands at the subject icon column (icon center = 16:
+      // subject row paddingLeft 6 + ICON_W/2).
+      const subjectTopY = N * (ROW_HEIGHT + ROW_GAP);
+      const subjectIconX = 6 + ICON_W / 2;
+      dottedConnectors.push({
+        key: `dotted-${node.name}`,
+        name: node.name,
+        d: `M ${startX} ${startY} L ${startX} ${subjectTopY} L ${subjectIconX} ${subjectTopY}`,
+      });
+    });
+  }
 
   return createPortal(
     <div
@@ -792,7 +777,9 @@ const LibraryRowFlipPopover = ({
             </p>
           ) : (
             <div className="relative" data-testid={`${testIdPrefix}-chain-wrap`}>
-              {(ancestorConnectors.length > 0 || descendantConnectors.length > 0) && (
+              {(ancestorConnectors.length > 0 ||
+                descendantConnectors.length > 0 ||
+                dottedConnectors.length > 0) && (
                 <svg
                   aria-hidden="true"
                   data-testid={`${testIdPrefix}-connectors`}
@@ -818,6 +805,19 @@ const LibraryRowFlipPopover = ({
                       d={connectorPath(c)}
                       stroke="#9ca3af"
                       strokeWidth={1.5}
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  ))}
+                  {dottedConnectors.map(c => (
+                    <path
+                      key={c.key}
+                      d={c.d}
+                      data-testid={`${testIdPrefix}-dotted-${c.name}`}
+                      stroke="#6b7280"
+                      strokeWidth={1.5}
+                      strokeDasharray="2 3"
                       fill="none"
                       strokeLinecap="round"
                       strokeLinejoin="round"
@@ -855,7 +855,6 @@ const LibraryRowFlipPopover = ({
                             key={`anc-${node.type}-${node.name}-${i}`}
                             node={node}
                             marginLeft={ancestorMarginLeft(node)}
-                            dottedHeight={node.isDirect ? dottedHeightFor(i) : 0}
                             testIdPrefix={testIdPrefix}
                           />
                         ))}

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -656,6 +656,13 @@ const LibraryRowFlipPopover = ({
   const descendantRowY = j =>
     subjectBottomY + ROW_GAP + j * (ROW_HEIGHT + ROW_GAP) + ROW_HEIGHT / 2;
 
+  // Trunk offset: how far OUTSIDE the icon column the connector trunk
+  // sits. Without this, the connector lines would draw straight through
+  // the icons; the offset pulls the vertical trunk into the gutter so
+  // the tree wraps around the icons (entering each from the icon's
+  // right edge for ancestors / left edge for descendants).
+  const TRUNK_OFFSET = 8;
+
   const ancestorConnectors = [];
   if (ancestorsOpen) {
     ancestors.forEach((parent, parentIdx) => {
@@ -702,7 +709,29 @@ const LibraryRowFlipPopover = ({
     });
   }
 
-  const connectorPath = ({ parentX, parentY, childX, childY }) =>
+  // Ancestors live on the RIGHT side of each row, so the connector
+  // trunk sits at `parent.iconRight + TRUNK_OFFSET` — out in the gutter
+  // past every icon. Path: enter from the parent icon's RIGHT edge,
+  // bend right into the trunk, drop down to the child row, then bend
+  // back LEFT to enter the child icon from the right.
+  const ancestorConnectorPath = ({ parentX, parentY, childX, childY }) => {
+    const trunkX = parentX + ICON_W / 2 + TRUNK_OFFSET;
+    const parentRightEdge = parentX + ICON_W / 2;
+    const childRightEdge = childX + ICON_W / 2;
+    return (
+      `M ${parentRightEdge} ${parentY}` +
+      ` L ${trunkX} ${parentY}` +
+      ` L ${trunkX} ${childY}` +
+      ` L ${childRightEdge} ${childY}`
+    );
+  };
+
+  // Descendants live on the LEFT side of each row. The connector reads
+  // naturally as a drop from the parent icon's bottom into the child
+  // icon's top — no wrap-around needed because there's nothing in the
+  // way (the icons are first in their rows so the L bend lands cleanly
+  // on the child icon's left edge).
+  const descendantConnectorPath = ({ parentX, parentY, childX, childY }) =>
     `M ${parentX} ${parentY + ICON_H / 2} L ${parentX} ${childY} L ${childX} ${childY}`;
 
   // Dotted Γ-connector from each direct ancestor's [type] pill across
@@ -821,7 +850,7 @@ const LibraryRowFlipPopover = ({
                   {ancestorConnectors.map(c => (
                     <path
                       key={c.key}
-                      d={connectorPath(c)}
+                      d={ancestorConnectorPath(c)}
                       stroke="#9ca3af"
                       strokeWidth={1.5}
                       fill="none"
@@ -832,7 +861,7 @@ const LibraryRowFlipPopover = ({
                   {descendantConnectors.map(c => (
                     <path
                       key={c.key}
-                      d={connectorPath(c)}
+                      d={descendantConnectorPath(c)}
                       stroke="#9ca3af"
                       strokeWidth={1.5}
                       fill="none"

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -109,6 +109,21 @@ function getChildItemNames(obj) {
   return obj.child_item_names.filter(Boolean);
 }
 
+/**
+ * Models that don't list any upstream child explicitly inherit the project's
+ * default source. Returns a list of child names augmented with the default
+ * source when the object is a model with no existing source upstream.
+ */
+function effectiveChildNames(entryType, obj, defaultSourceName, sourceNames) {
+  const raw = getChildItemNames(obj);
+  if (entryType !== 'model' || !defaultSourceName) return raw;
+  // If the model already references *some* source via child_item_names,
+  // respect that explicit choice instead of falling back to the default.
+  const hasExplicitSource = raw.some(n => sourceNames.has(n));
+  if (hasExplicitSource) return raw;
+  return [...raw, defaultSourceName];
+}
+
 function buildTypeIndex(storeApi) {
   const lookup = new Map();
   const register = (type, list) => {
@@ -210,21 +225,20 @@ function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
   const subjectEntry = index.get(subject.name);
   if (!subjectEntry) return [];
 
+  const defaultSourceName = storeApi.defaults?.source_name || null;
+  const sourceNames = new Set(
+    (storeApi.sources || []).map(s => s && s.name).filter(Boolean)
+  );
+
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
 
-  // Track which displayed node each upstream came in through so the
-  // connector overlay can draw the actual DAG edges (parent.icon →
-  // child.icon) instead of a generic chain.
   const visit = (name, depth, fromChildName) => {
     if (depth > maxDepth) return;
     const entry = index.get(name);
     if (!entry) return;
     const key = `${entry.type}:${name}`;
     if (seen.has(key)) {
-      // Even if we've already pushed this node, record the additional
-      // edge so a shared parent (e.g. one source feeding two models)
-      // connects to every child that lists it.
       const existing = out.find(n => n.type === entry.type && n.name === name);
       if (existing && fromChildName && !existing.childNames.includes(fromChildName)) {
         existing.childNames.push(fromChildName);
@@ -232,10 +246,10 @@ function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
       return;
     }
     seen.add(key);
-    // DFS: deepest node lands at the TOP of the output. We push the
-    // current node AFTER recursing into its own upstreams so the row
-    // order in the popover mirrors a topological walk.
-    getChildItemNames(entry.obj).forEach(child => visit(child, depth + 1, name));
+    // DFS: deepest node lands at the TOP of the output. Models that
+    // don't reference a source explicitly inherit the project default.
+    const childs = effectiveChildNames(entry.type, entry.obj, defaultSourceName, sourceNames);
+    childs.forEach(child => visit(child, depth + 1, name));
     out.push({
       type: entry.type,
       name,
@@ -245,9 +259,15 @@ function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
     });
   };
 
-  getChildItemNames(subjectEntry.obj).forEach(child =>
-    visit(child, 1, /* fromChildName */ subject.name)
+  // For the subject itself we follow the same rule — a model subject with
+  // no explicit source still inherits the default.
+  const subjChilds = effectiveChildNames(
+    subjectEntry.type,
+    subjectEntry.obj,
+    defaultSourceName,
+    sourceNames
   );
+  subjChilds.forEach(child => visit(child, 1, subject.name));
   return out;
 }
 
@@ -477,6 +497,8 @@ const LibraryRowFlipPopover = ({
   const fetchDashboards = useStore(s => s.fetchDashboards);
   const csvScriptModels = useStore(s => s.csvScriptModels);
   const localMergeModels = useStore(s => s.localMergeModels);
+  const defaults = useStore(s => s.defaults);
+  const fetchDefaults = useStore(s => s.fetchDefaults);
 
   // The Workspace shell preloads charts/insights/models/etc. via their
   // own slices, but `dashboards` only loads on demand. Without it the
@@ -490,6 +512,9 @@ const LibraryRowFlipPopover = ({
       typeof fetchDashboards === 'function'
     ) {
       fetchDashboards();
+    }
+    if (!defaults && typeof fetchDefaults === 'function') {
+      fetchDefaults();
     }
     // We intentionally run only once per mount — refetches handled
     // elsewhere by save flows.
@@ -534,6 +559,7 @@ const LibraryRowFlipPopover = ({
         allDashboards: dashboardsForWalker,
         csvScriptModels,
         localMergeModels,
+        defaults,
       },
       scope
     );
@@ -553,6 +579,7 @@ const LibraryRowFlipPopover = ({
     dashboardsForWalker,
     csvScriptModels,
     localMergeModels,
+    defaults,
   ]);
 
   useEffect(() => {
@@ -678,9 +705,11 @@ const LibraryRowFlipPopover = ({
   const connectorPath = ({ parentX, parentY, childX, childY }) =>
     `M ${parentX} ${parentY + ICON_H / 2} L ${parentX} ${childY} L ${childX} ${childY}`;
 
-  // Dotted Γ-connector from each direct ancestor's [type] pill down and
-  // then right onto the subject row's icon column. Drawn as a single
-  // L-path in the SVG overlay so the corner joins cleanly.
+  // Dotted Γ-connector from each direct ancestor's [type] pill across
+  // to the subject icon column and then DOWN to the top of the subject
+  // pill. The corner sits at the top-left of the gamma — horizontal
+  // segment first, then vertical — so the line reads as a header
+  // bracket dropping onto the subject rather than an L-bend.
   const dottedConnectors = [];
   if (ancestorsOpen) {
     ancestors.forEach((node, i) => {
@@ -688,15 +717,12 @@ const LibraryRowFlipPopover = ({
       const rowLeft = ancestorMarginLeft(node);
       const startX = rowLeft - 4; // just left of the [type] pill
       const startY = ancestorRowY(i);
-      // The L turns at the top of the subject row so the horizontal
-      // segment lands at the subject icon column (icon center = 16:
-      // subject row paddingLeft 6 + ICON_W/2).
       const subjectTopY = N * (ROW_HEIGHT + ROW_GAP);
       const subjectIconX = 6 + ICON_W / 2;
       dottedConnectors.push({
         key: `dotted-${node.name}`,
         name: node.name,
-        d: `M ${startX} ${startY} L ${startX} ${subjectTopY} L ${subjectIconX} ${subjectTopY}`,
+        d: `M ${startX} ${startY} L ${subjectIconX} ${startY} L ${subjectIconX} ${subjectTopY}`,
       });
     });
   }

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -6,30 +6,43 @@ import { getTypeIcon } from '../../common/objectTypeConfigs';
 import { LAYOUT_TYPES } from './LibraryRow';
 
 /**
- * LibraryRowFlipPopover — VIS-776 / Track C C3.
+ * LibraryRowFlipPopover — VIS-776 / Track C C3 (refined design).
  *
  * Anchored popover that flips out from a Library row to show the row's
- * lineage neighbourhood. Per the design, the popover frame chrome
- * (anchor arrow, header, footer) belongs to Track C; the inner lineage
- * card is shared with the canvas item flip surface (D-5) and will be
- * extracted as `<MiniLineageCard>` once VIS-D6 (full lineage modal)
- * stabilises the data shape. For C3 we render an inline mini-chain
- * placeholder driven by the existing store (no new API calls).
+ * lineage neighbourhood as a ladder: ancestors above (right-aligned,
+ * widening toward the subject), the selected subject row in the middle
+ * (full width), and descendants below (left-aligned, widening away from
+ * the subject). The two ladders meet at the subject row.
  *
- * Geometry: ~280 × 260, anchored to the right of the row with an
- * anchor-arrow at the left edge. Closes on outside click, Escape, or
- * the × button. The popover anchor is the parent `<LibraryRow>`;
- * position is `absolute top-0 left-full` so siblings don't reflow.
+ * Layout rules (per the final mock):
+ *   1. Ancestor row order  : [type] [name] [icon] — right-aligned.
+ *   2. Descendant row order: [icon] [name] [type] — left-aligned.
+ *   3. Each successive ancestor row (top → bottom) shifts left by `STEP`.
+ *   4. The deepest-nested ancestor row's left edge matches the first
+ *      descendant row's left edge, so the two ladders mirror at the
+ *      subject row.
+ *   5. A dotted line drops from the left of each direct-ancestor's
+ *      `[type]` pill down to the top of the subject row's icon column.
+ *   6. The subject row pins `[icon]` left, `[type]` right, and centres
+ *      `[name]` between them. No `THIS` chip.
  *
- * NOTE: For C3 the lineage chain is computed locally from the store
- * (chart → first insight → first model → first source). Real upstream
- * traversal lands with the shared MiniLineageCard in VIS-780 (C4).
+ * Behaviour:
+ *   - Click the ancestors region → collapses ancestors.
+ *   - Click the descendants region → collapses descendants.
+ *   - The body is `overflow-y-auto` with a fixed max-height; the
+ *     collapse + scroll combination keeps complex DAGs usable in a
+ *     small surface.
+ *
+ * The data walker is intentionally a subset of the full Lineage DAG —
+ * it's the C-3 placeholder until VIS-D6 ships the shared
+ * `<MiniLineageCard>` and VIS-780 (C-4) migrates this popover to it.
  */
-// There are only two real tones in this surface — mulberry for the Layout
-// section (chart/table/markdown/input) and teal for the Data section
-// (sources, models, dimensions, metrics, relations, insights). Anything
-// that isn't a Layout type (dashboard/insert/etc.) defaults to teal, which
-// is the data-layer baseline used elsewhere in the popover.
+
+// Two tone palettes mirror the Library section colours: mulberry for
+// Layout-section types (chart / table / markdown / input) and teal for
+// Data-section types (sources, models, dimensions, metrics, relations,
+// insights). Dashboards default to mulberry since they belong to the
+// layout side of the world.
 const MULBERRY_TONE = {
   iconBg: 'bg-[#e2d7dd]/70',
   iconFg: 'text-[#713b57]',
@@ -43,144 +56,386 @@ const TEAL_TONE = {
   pillFg: 'text-[#1b4042]',
 };
 
-const getTone = (type) => (LAYOUT_TYPES.includes(type) ? MULBERRY_TONE : TEAL_TONE);
-// Object-type icons come from the app-wide canonical `objectTypeConfigs.js`
-// (MUI icons); `getTypeIcon` falls back to a sensible default for unknowns.
-const getIcon = (type) => getTypeIcon(type);
-
-/**
- * LineageRow — single node row inside the popover. Mirrors the row layout
- * shipped by `mini-lineage-card.jsx` (icon tile + type pill + name).
- */
-const LineageRow = ({ node, isSubject }) => {
-  const tone = getTone(node.type);
-  const I = getIcon(node.type);
-  return (
-    <li
-      data-testid={`library-flip-popover-lineage-${node.type}-${node.name}`}
-      className={[
-        'group flex w-full items-center gap-1.5 rounded-md py-0.5 pr-1.5 pl-0 text-left',
-        isSubject ? 'ring-1 ring-[#713b57]/30 bg-[#e2d7dd]/30' : '',
-      ].join(' ')}
-    >
-      <span
-        className={`relative z-10 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded ${tone.iconBg} ${tone.iconFg}`}
-      >
-        <I style={{ fontSize: 10 }} />
-      </span>
-      <span
-        className={`inline-flex h-3 shrink-0 items-center rounded-sm px-1 text-[8px] font-bold uppercase tracking-wider ${tone.pillBg} ${tone.pillFg}`}
-      >
-        {node.type}
-      </span>
-      <span
-        className={`min-w-0 flex-1 truncate text-[11.5px] ${
-          isSubject ? 'font-semibold text-gray-900' : 'font-medium text-gray-800'
-        }`}
-      >
-        {node.name}
-      </span>
-      {isSubject && (
-        <span className="shrink-0 inline-flex h-3 items-center rounded-sm bg-[#713b57] px-1 text-[8px] font-bold uppercase tracking-wider text-white">
-          this
-        </span>
-      )}
-    </li>
-  );
+// Sources sit in the data layer but get a warm highlight in the mock so
+// the originating system stands out at the top of the chain.
+const ORANGE_TONE = {
+  iconBg: 'bg-[#f4d6cc]/80',
+  iconFg: 'text-[#a44326]',
+  pillBg: 'bg-[#f4d6cc]',
+  pillFg: 'text-[#a44326]',
 };
 
-/**
- * Build a small ancestor chain for the given subject by walking the simplest
- * relationships exposed in the existing store. This is intentionally a
- * subset of what the full lineage modal (D-6) will surface — it covers the
- * common cases (chart → insight → model → source) so the popover is useful
- * even before VIS-780 wires the shared `<MiniLineageCard>`.
- */
+const getTone = type => {
+  if (type === 'source') return ORANGE_TONE;
+  if (LAYOUT_TYPES.includes(type) || type === 'dashboard') return MULBERRY_TONE;
+  return TEAL_TONE;
+};
+
+const getIcon = type => getTypeIcon(type);
+
+// Ladder geometry. ROW_HEIGHT × ROW_GAP must stay in sync with the
+// classes on the row containers below — the dotted-connector heights
+// are computed analytically from these constants.
+const ROW_HEIGHT = 22; // h-[22px]
+const ROW_GAP = 2; // gap-[2px]
+const STEP = 18; // per-rung left/right shift
+const BASE_INDENT = 12; // where the lowest ancestor + first descendant align
+const CARD_WIDTH = 340;
+
+// ---------------------------------------------------------------------------
+// Relations walker
+// ---------------------------------------------------------------------------
+
 function findByName(list, name) {
   if (!Array.isArray(list) || !name) return null;
-  return list.find((o) => o && o.name === name) || null;
+  return list.find(o => o && o.name === name) || null;
 }
 
-function buildChainFromStore(subject, storeApi) {
-  if (!subject) return [];
-  const chain = [];
-  const seen = new Set([`${subject.type}:${subject.name}`]);
+function refValue(ref) {
+  if (!ref) return null;
+  if (typeof ref === 'string') return ref;
+  return ref.name || ref.ref || null;
+}
 
-  if (subject.type === 'chart') {
-    const chart = storeApi.getChartByName?.(subject.name);
-    const insightRef = pickInsightRef(chart);
-    if (insightRef) {
-      const insight = storeApi.getInsightByName?.(insightRef);
-      if (insight && !seen.has(`insight:${insight.name}`)) {
-        chain.push({ type: 'insight', name: insight.name });
-        seen.add(`insight:${insight.name}`);
-        appendModelAndSource(insight, storeApi, chain, seen);
-      }
+function pickInsightRefs(chart) {
+  const list = chart?.insights || chart?.config?.insights || [];
+  if (!Array.isArray(list)) return [];
+  return list.map(refValue).filter(Boolean);
+}
+
+function pickModelRef(insight) {
+  return refValue(insight?.model || insight?.config?.model);
+}
+
+function pickSourceRef(model) {
+  return refValue(model?.source || model?.config?.source);
+}
+
+/**
+ * Walk a chart's upstream chain. Each direct insight is pushed first,
+ * followed by its model and source (deduped). This gives the mock's
+ * interleaved ladder (source · model · insight · model · insight · subject).
+ */
+function pushChartAncestors(chart, storeApi, push, seen) {
+  const refs = pickInsightRefs(chart);
+  refs.forEach(insightRef => {
+    const insight = storeApi.getInsightByName?.(insightRef);
+    if (!insight) return;
+    pushInsightAncestors(insight, storeApi, push, seen, /* isInsightDirect */ true);
+  });
+}
+
+function pushInsightAncestors(insight, storeApi, push, seen, isInsightDirect = true) {
+  const modelRef = pickModelRef(insight);
+  if (modelRef) {
+    const model =
+      storeApi.getModelByName?.(modelRef) ||
+      findByName(storeApi.csvScriptModels, modelRef) ||
+      findByName(storeApi.localMergeModels, modelRef);
+    if (model) {
+      pushModelAncestors(model, storeApi, push, seen, /* isModelDirect */ false);
+    } else {
+      push({ type: 'model', name: modelRef, isDirect: false }, seen);
     }
+  }
+  push({ type: 'insight', name: insight.name, isDirect: isInsightDirect }, seen);
+}
+
+function pushModelAncestors(model, storeApi, push, seen, isModelDirect = true) {
+  const sourceRef = pickSourceRef(model);
+  if (sourceRef) {
+    push({ type: 'source', name: sourceRef, isDirect: false }, seen);
+  }
+  push({ type: 'model', name: model.name, isDirect: isModelDirect }, seen);
+}
+
+// ---------------------------------------------------------------------------
+// Descendant walkers — scan the store for objects that reference the subject.
+// ---------------------------------------------------------------------------
+
+function collectDashboardsReferencing(name, dashboards) {
+  if (!Array.isArray(dashboards)) return [];
+  const hits = [];
+  dashboards.forEach(d => {
+    if (!d || !Array.isArray(d.rows)) return;
+    const matches = d.rows.some(row => {
+      if (!row || !Array.isArray(row.items)) return false;
+      return row.items.some(item => {
+        if (!item) return false;
+        const itemRef = refValue(item.chart) || refValue(item.table) || refValue(item.markdown);
+        return itemRef === name;
+      });
+    });
+    if (matches) hits.push(d.name);
+  });
+  return hits;
+}
+
+function collectChartsReferencing(insightName, charts) {
+  if (!Array.isArray(charts)) return [];
+  return charts
+    .filter(c => pickInsightRefs(c).includes(insightName))
+    .map(c => c.name)
+    .filter(Boolean);
+}
+
+function collectInsightsReferencing(modelName, insights) {
+  if (!Array.isArray(insights)) return [];
+  return insights
+    .filter(i => pickModelRef(i) === modelName)
+    .map(i => i.name)
+    .filter(Boolean);
+}
+
+function collectModelsReferencing(sourceName, ...modelLists) {
+  const hits = [];
+  modelLists.forEach(list => {
+    if (!Array.isArray(list)) return;
+    list.forEach(m => {
+      if (m && pickSourceRef(m) === sourceName) hits.push(m.name);
+    });
+  });
+  return hits;
+}
+
+function buildAncestors(subject, storeApi) {
+  if (!subject) return [];
+  const out = [];
+  const seen = new Set([`${subject.type}:${subject.name}`]);
+  const push = (node, seenSet) => {
+    const key = `${node.type}:${node.name}`;
+    if (seenSet.has(key)) return;
+    seenSet.add(key);
+    out.push(node);
+  };
+
+  if (subject.type === 'chart' || subject.type === 'table') {
+    const obj =
+      subject.type === 'chart'
+        ? storeApi.getChartByName?.(subject.name)
+        : findByName(storeApi.tables, subject.name);
+    if (obj) pushChartAncestors(obj, storeApi, push, seen);
   } else if (subject.type === 'insight') {
     const insight = storeApi.getInsightByName?.(subject.name);
-    if (insight) appendModelAndSource(insight, storeApi, chain, seen);
+    if (insight) {
+      // Subject itself is the "direct" node — its parents are model/source.
+      const modelRef = pickModelRef(insight);
+      if (modelRef) {
+        const model =
+          storeApi.getModelByName?.(modelRef) ||
+          findByName(storeApi.csvScriptModels, modelRef) ||
+          findByName(storeApi.localMergeModels, modelRef);
+        if (model) pushModelAncestors(model, storeApi, push, seen, true);
+        else push({ type: 'model', name: modelRef, isDirect: true }, seen);
+      }
+    }
   } else if (subject.type === 'model') {
     const model =
       storeApi.getModelByName?.(subject.name) ||
       findByName(storeApi.csvScriptModels, subject.name) ||
       findByName(storeApi.localMergeModels, subject.name);
-    if (model) appendSource(model, storeApi, chain, seen);
-  } else if (subject.type === 'source') {
-    // Sources have no upstream; the chain is just the subject row.
-  } else if (subject.type === 'insert') {
-    // Layout primitives have no lineage.
+    if (model) {
+      const sourceRef = pickSourceRef(model);
+      if (sourceRef) push({ type: 'source', name: sourceRef, isDirect: true }, seen);
+    }
   }
+  // sources, dashboards, markdowns, inputs, inserts have no upstream.
 
-  return chain;
+  return out;
 }
 
-function pickInsightRef(chart) {
-  if (!chart) return null;
-  // Charts reference one or more insights via `insights: [{ ref|name }]`.
-  // We pick the first reference that looks like a name.
-  const list = chart.insights || chart.config?.insights || [];
-  if (!Array.isArray(list) || list.length === 0) return null;
-  const first = list[0];
-  if (typeof first === 'string') return first;
-  return first?.name || first?.ref || null;
-}
+function buildDescendants(subject, storeApi) {
+  if (!subject) return [];
+  const out = [];
+  const seen = new Set([`${subject.type}:${subject.name}`]);
+  const push = node => {
+    const key = `${node.type}:${node.name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(node);
+  };
 
-function appendModelAndSource(insight, storeApi, chain, seen) {
-  const modelRef = insight?.model || insight?.config?.model;
-  if (modelRef && !seen.has(`model:${modelRef}`)) {
-    const model =
-      storeApi.getModelByName?.(modelRef) ||
-      findByName(storeApi.csvScriptModels, modelRef) ||
-      findByName(storeApi.localMergeModels, modelRef);
-    chain.push({ type: 'model', name: modelRef });
-    seen.add(`model:${modelRef}`);
-    if (model) appendSource(model, storeApi, chain, seen);
+  if (subject.type === 'source') {
+    const models = collectModelsReferencing(
+      subject.name,
+      storeApi.models,
+      storeApi.csvScriptModels,
+      storeApi.localMergeModels
+    );
+    models.forEach(name => push({ type: 'model', name, isDirect: true }));
+  } else if (subject.type === 'model') {
+    collectInsightsReferencing(subject.name, storeApi.insights).forEach(name =>
+      push({ type: 'insight', name, isDirect: true })
+    );
+  } else if (subject.type === 'insight') {
+    collectChartsReferencing(subject.name, storeApi.charts).forEach(name =>
+      push({ type: 'chart', name, isDirect: true })
+    );
+  } else if (
+    subject.type === 'chart' ||
+    subject.type === 'table' ||
+    subject.type === 'markdown'
+  ) {
+    collectDashboardsReferencing(subject.name, storeApi.allDashboards).forEach(name =>
+      push({ type: 'dashboard', name, isDirect: true })
+    );
   }
+  // dashboards / inserts / inputs have no downstream we track here.
+
+  return out;
 }
 
-function appendSource(model, storeApi, chain, seen) {
-  const sourceRef = model?.source || model?.config?.source;
-  if (sourceRef && !seen.has(`source:${sourceRef}`)) {
-    chain.push({ type: 'source', name: sourceRef });
-    seen.add(`source:${sourceRef}`);
-  }
+function buildLineageRelations(subject, storeApi) {
+  return {
+    ancestors: buildAncestors(subject, storeApi),
+    descendants: buildDescendants(subject, storeApi),
+  };
 }
 
-// Fallback position used when no anchorRef is supplied (tests render the
-// popover in isolation without a row to anchor to).
+// Backward-compat: VIS-780 will replace this with `<MiniLineageCard>`.
+// The legacy chain (subject's upstream-only chain, deepest-first → direct)
+// is still useful in places that imported it from this module.
+function buildChainFromStore(subject, storeApi) {
+  return buildAncestors(subject, storeApi);
+}
+
+// ---------------------------------------------------------------------------
+// Row primitives
+// ---------------------------------------------------------------------------
+
+const TypePill = ({ type, tone, alignRight }) => (
+  <span
+    className={[
+      'inline-flex h-3 shrink-0 items-center rounded-sm px-1 text-[8px] font-bold uppercase tracking-wider',
+      tone.pillBg,
+      tone.pillFg,
+    ].join(' ')}
+    style={alignRight ? { marginLeft: 'auto' } : undefined}
+  >
+    {type}
+  </span>
+);
+
+const IconTile = ({ Icon, tone }) => (
+  <span
+    className={[
+      'relative z-10 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded',
+      tone.iconBg,
+      tone.iconFg,
+    ].join(' ')}
+  >
+    <Icon style={{ fontSize: 10 }} />
+  </span>
+);
+
+const NameLabel = ({ name, align = 'left' }) => (
+  <span
+    className={[
+      'min-w-0 truncate text-[11.5px] font-medium text-gray-800',
+      align === 'center' ? 'flex-1 text-center' : 'flex-1',
+    ].join(' ')}
+  >
+    {name}
+  </span>
+);
+
+const AncestorRow = ({ node, leftPad, dottedHeight, testIdPrefix }) => {
+  const tone = getTone(node.type);
+  const Icon = getIcon(node.type);
+  return (
+    <li
+      data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
+      data-direction="ancestor"
+      data-direct={node.isDirect ? 'true' : 'false'}
+      className="relative flex items-center gap-1.5 self-stretch"
+      style={{
+        height: ROW_HEIGHT,
+        paddingLeft: leftPad,
+        paddingRight: 4,
+      }}
+    >
+      {/* Dotted connector: drops from the left of the [type] pill down
+          past every row beneath it to the top of the subject's icon. */}
+      {node.isDirect && dottedHeight > 0 && (
+        <span
+          aria-hidden="true"
+          data-testid={`${testIdPrefix}-dotted-${node.name}`}
+          className="absolute border-l border-dotted border-gray-400"
+          style={{
+            left: leftPad - 4,
+            top: ROW_HEIGHT / 2,
+            height: dottedHeight,
+          }}
+        />
+      )}
+      <TypePill type={node.type} tone={tone} />
+      <NameLabel name={node.name} />
+      <IconTile Icon={Icon} tone={tone} />
+    </li>
+  );
+};
+
+const DescendantRow = ({ node, leftPad, testIdPrefix }) => {
+  const tone = getTone(node.type);
+  const Icon = getIcon(node.type);
+  return (
+    <li
+      data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
+      data-direction="descendant"
+      data-direct={node.isDirect ? 'true' : 'false'}
+      className="relative flex items-center gap-1.5 self-stretch"
+      style={{
+        height: ROW_HEIGHT,
+        paddingLeft: leftPad,
+        paddingRight: 4,
+      }}
+    >
+      <IconTile Icon={Icon} tone={tone} />
+      <NameLabel name={node.name} />
+      <TypePill type={node.type} tone={tone} alignRight />
+    </li>
+  );
+};
+
+const SubjectRow = ({ subject, testIdPrefix }) => {
+  const tone = getTone(subject.type);
+  const Icon = getIcon(subject.type);
+  return (
+    <li
+      data-testid={`${testIdPrefix}-lineage-subject`}
+      data-direction="subject"
+      className="relative flex items-center self-stretch rounded-md ring-1 ring-[#713b57]/40 bg-[#e2d7dd]/40"
+      style={{ height: ROW_HEIGHT + 4, paddingLeft: 6, paddingRight: 6 }}
+    >
+      <IconTile Icon={Icon} tone={tone} />
+      <span className="flex-1 text-center text-[11.5px] font-semibold text-gray-900 truncate min-w-0 px-2">
+        {subject.name}
+      </span>
+      <TypePill type={subject.type} tone={tone} />
+    </li>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Anchoring
+// ---------------------------------------------------------------------------
+
 const FALLBACK_POSITION = { top: 100, left: 100 };
 
-const computeAnchoredPosition = (anchorEl) => {
+const computeAnchoredPosition = anchorEl => {
   if (!anchorEl || typeof anchorEl.getBoundingClientRect !== 'function') {
     return FALLBACK_POSITION;
   }
   const rect = anchorEl.getBoundingClientRect();
   return {
     top: rect.top + rect.height / 2,
-    left: rect.right + 12, // 12 px gap matches the design's `ml-3`
+    left: rect.right + 12,
   };
 };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 const LibraryRowFlipPopover = ({
   obj,
@@ -190,19 +445,16 @@ const LibraryRowFlipPopover = ({
 }) => {
   const popoverRef = useRef(null);
 
-  // Track anchor position so the popover follows the row across scroll +
-  // resize. Rendered into document.body via portal (so the Library's
-  // `overflow-y-auto` ancestor doesn't clip it horizontally — CSS coerces
-  // a `visible` axis to `auto` when the other axis is `auto`).
   const [position, setPosition] = useState(() =>
     computeAnchoredPosition(anchorRef?.current)
   );
+  const [ancestorsOpen, setAncestorsOpen] = useState(true);
+  const [descendantsOpen, setDescendantsOpen] = useState(true);
 
   useEffect(() => {
     if (!anchorRef?.current) return undefined;
     const update = () => setPosition(computeAnchoredPosition(anchorRef.current));
     update();
-    // Capture phase to catch scrolls in any ancestor container.
     window.addEventListener('scroll', update, true);
     window.addEventListener('resize', update);
     return () => {
@@ -211,33 +463,49 @@ const LibraryRowFlipPopover = ({
     };
   }, [anchorRef]);
 
-  // Pull the lineage data from the store. We use refs into the store to
-  // avoid re-renders on unrelated changes; the chain is computed once on
-  // mount (since the popover is short-lived).
-  const getChartByName = useStore((s) => s.getChartByName);
-  const getInsightByName = useStore((s) => s.getInsightByName);
-  const getModelByName = useStore((s) => s.getModelByName);
-  const csvScriptModels = useStore((s) => s.csvScriptModels);
-  const localMergeModels = useStore((s) => s.localMergeModels);
+  const getChartByName = useStore(s => s.getChartByName);
+  const getInsightByName = useStore(s => s.getInsightByName);
+  const getModelByName = useStore(s => s.getModelByName);
+  const charts = useStore(s => s.charts);
+  const insights = useStore(s => s.insights);
+  const models = useStore(s => s.models);
+  const tables = useStore(s => s.tables);
+  const allDashboards = useStore(s => s.allDashboards);
+  const csvScriptModels = useStore(s => s.csvScriptModels);
+  const localMergeModels = useStore(s => s.localMergeModels);
 
-  const chain = useMemo(() => {
-    return buildChainFromStore(obj, {
+  const relations = useMemo(() => {
+    return buildLineageRelations(obj, {
       getChartByName,
       getInsightByName,
       getModelByName,
+      charts,
+      insights,
+      models,
+      tables,
+      allDashboards,
       csvScriptModels,
       localMergeModels,
     });
-  }, [obj, getChartByName, getInsightByName, getModelByName, csvScriptModels, localMergeModels]);
+  }, [
+    obj,
+    getChartByName,
+    getInsightByName,
+    getModelByName,
+    charts,
+    insights,
+    models,
+    tables,
+    allDashboards,
+    csvScriptModels,
+    localMergeModels,
+  ]);
 
-  // Close on outside click or Escape.
   useEffect(() => {
-    const onKey = (e) => {
-      if (e.key === 'Escape') {
-        onClose && onClose();
-      }
+    const onKey = e => {
+      if (e.key === 'Escape') onClose && onClose();
     };
-    const onDoc = (e) => {
+    const onDoc = e => {
       if (popoverRef.current && !popoverRef.current.contains(e.target)) {
         onClose && onClose();
       }
@@ -255,7 +523,28 @@ const LibraryRowFlipPopover = ({
   const selectorRendered = obj.name
     ? `+${String(obj.name).toLowerCase().replace(/[^a-z0-9_]+/g, '_')}`
     : '+';
-  const isEmpty = chain.length === 0 && obj.type !== 'insert';
+
+  const ancestors = relations.ancestors;
+  const descendants = relations.descendants;
+  const N = ancestors.length;
+  const isEmpty = N === 0 && descendants.length === 0;
+
+  // Compute each ancestor row's left padding so that:
+  //   - the bottom-most ancestor (index N-1) sits at BASE_INDENT
+  //   - each row above shifts left by STEP (i.e. its padding grows)
+  // That mirrors the descendant ladder, which starts at BASE_INDENT and
+  // grows by STEP per row downward.
+  const ancestorLeftPad = i => BASE_INDENT + (N - 1 - i) * STEP;
+  const descendantLeftPad = j => BASE_INDENT + j * STEP;
+
+  // Dotted line drops from the [type] pill of a direct ancestor down to
+  // the top of the subject row. Each row contributes ROW_HEIGHT + ROW_GAP
+  // of vertical distance; the line should reach the top of the subject
+  // row (which sits just below the last ancestor row).
+  const dottedHeightFor = i => {
+    const rowsBetween = N - i; // includes this row + every row below + the gap to subject
+    return rowsBetween * (ROW_HEIGHT + ROW_GAP) - ROW_HEIGHT / 2;
+  };
 
   return createPortal(
     <div
@@ -267,7 +556,7 @@ const LibraryRowFlipPopover = ({
       style={{
         top: position.top,
         left: position.left,
-        width: 280,
+        width: CARD_WIDTH,
         transform: 'translateY(-50%)',
       }}
     >
@@ -318,6 +607,7 @@ const LibraryRowFlipPopover = ({
 
         <div
           className="flex-1 min-h-0 overflow-y-auto px-3 py-2"
+          style={{ maxHeight: 260 }}
           data-testid={`${testIdPrefix}-body`}
         >
           {isEmpty ? (
@@ -325,17 +615,100 @@ const LibraryRowFlipPopover = ({
               className="px-1 text-[11px] italic text-gray-500"
               data-testid={`${testIdPrefix}-empty`}
             >
-              No upstream dependencies for this object.
+              No lineage available for this object.
             </p>
           ) : (
             <ul
-              className="flex flex-col gap-0.5"
+              className="flex flex-col"
+              style={{ rowGap: ROW_GAP }}
               data-testid={`${testIdPrefix}-chain`}
             >
-              <LineageRow node={{ type: obj.type, name: obj.name }} isSubject />
-              {chain.map((node, idx) => (
-                <LineageRow key={`${node.type}:${node.name}:${idx}`} node={node} />
-              ))}
+              {N > 0 && (
+                <li
+                  data-testid={`${testIdPrefix}-ancestors`}
+                  data-collapsed={ancestorsOpen ? 'false' : 'true'}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setAncestorsOpen(v => !v)}
+                    aria-expanded={ancestorsOpen}
+                    aria-label={
+                      ancestorsOpen ? 'Collapse ancestors' : 'Expand ancestors'
+                    }
+                    data-testid={`${testIdPrefix}-ancestors-toggle`}
+                    className="block w-full cursor-pointer text-left"
+                  >
+                    {ancestorsOpen ? (
+                      <ul
+                        className="flex flex-col"
+                        style={{ rowGap: ROW_GAP }}
+                      >
+                        {ancestors.map((node, i) => (
+                          <AncestorRow
+                            key={`anc-${node.type}-${node.name}-${i}`}
+                            node={node}
+                            leftPad={ancestorLeftPad(i)}
+                            dottedHeight={node.isDirect ? dottedHeightFor(i) : 0}
+                            testIdPrefix={testIdPrefix}
+                          />
+                        ))}
+                      </ul>
+                    ) : (
+                      <span
+                        className="inline-flex h-4 items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500"
+                        style={{ marginLeft: BASE_INDENT }}
+                      >
+                        +{N} upstream
+                      </span>
+                    )}
+                  </button>
+                </li>
+              )}
+
+              <SubjectRow subject={obj} testIdPrefix={testIdPrefix} />
+
+              {descendants.length > 0 && (
+                <li
+                  data-testid={`${testIdPrefix}-descendants`}
+                  data-collapsed={descendantsOpen ? 'false' : 'true'}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setDescendantsOpen(v => !v)}
+                    aria-expanded={descendantsOpen}
+                    aria-label={
+                      descendantsOpen
+                        ? 'Collapse descendants'
+                        : 'Expand descendants'
+                    }
+                    data-testid={`${testIdPrefix}-descendants-toggle`}
+                    className="block w-full cursor-pointer text-left"
+                  >
+                    {descendantsOpen ? (
+                      <ul
+                        className="flex flex-col"
+                        style={{ rowGap: ROW_GAP }}
+                      >
+                        {descendants.map((node, j) => (
+                          <DescendantRow
+                            key={`desc-${node.type}-${node.name}-${j}`}
+                            node={node}
+                            leftPad={descendantLeftPad(j)}
+                            testIdPrefix={testIdPrefix}
+                          />
+                        ))}
+                      </ul>
+                    ) : (
+                      <span
+                        className="inline-flex h-4 items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500"
+                        style={{ marginLeft: BASE_INDENT }}
+                      >
+                        +{descendants.length} downstream
+                      </span>
+                    )}
+                  </button>
+                </li>
+              )}
             </ul>
           )}
         </div>
@@ -361,5 +734,14 @@ const LibraryRowFlipPopover = ({
   );
 };
 
-export { buildChainFromStore, getIcon, getTone };
+export {
+  buildChainFromStore,
+  buildLineageRelations,
+  getIcon,
+  getTone,
+  ROW_HEIGHT,
+  ROW_GAP,
+  STEP,
+  BASE_INDENT,
+};
 export default LibraryRowFlipPopover;

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -2,106 +2,109 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { PiX, PiArrowSquareOut } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
-import { getTypeIcon } from '../../common/objectTypeConfigs';
-import { LAYOUT_TYPES } from './LibraryRow';
+import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
 
 /**
  * LibraryRowFlipPopover — VIS-776 / Track C C3 (refined design).
  *
  * Anchored popover that flips out from a Library row to show the row's
- * lineage neighbourhood as a ladder: ancestors above (right-aligned,
- * widening toward the subject), the selected subject row in the middle
- * (full width), and descendants below (left-aligned, widening away from
- * the subject). The two ladders meet at the subject row.
+ * full lineage neighbourhood as a ladder:
  *
- * Layout rules (per the final mock):
- *   1. Ancestor row order  : [type] [name] [icon] — right-aligned.
- *   2. Descendant row order: [icon] [name] [type] — left-aligned.
- *   3. Each successive ancestor row (top → bottom) shifts left by `STEP`.
- *   4. The deepest-nested ancestor row's left edge matches the first
- *      descendant row's left edge, so the two ladders mirror at the
- *      subject row.
- *   5. A dotted line drops from the left of each direct-ancestor's
- *      `[type]` pill down to the top of the subject row's icon column.
- *   6. The subject row pins `[icon]` left, `[type]` right, and centres
- *      `[name]` between them. No `THIS` chip.
+ *   - Ancestors above the subject, each row `[type] [name] [icon]`,
+ *     stepping LEFT as it approaches the subject so the icons form a
+ *     staircase. The deepest ancestor sits at the top, furthest right.
+ *   - Subject row in the middle, full-width, `[icon] [name] [type]`.
+ *   - Descendants below, each row `[icon] [name] [type]`, stepping
+ *     RIGHT as it gets deeper so the icons mirror the ancestor
+ *     staircase.
  *
- * Behaviour:
- *   - Click the ancestors region → collapses ancestors.
- *   - Click the descendants region → collapses descendants.
- *   - The body is `overflow-y-auto` with a fixed max-height; the
- *     collapse + scroll combination keeps complex DAGs usable in a
- *     small surface.
+ * The deepest-direct-ancestor's row aligns its left edge with the
+ * first-descendant row's left edge — the two ladders meet at the
+ * subject. Direct ancestors drop a dotted L-shaped connector from
+ * the left of their `[type]` pill down and inward to the subject's
+ * `[icon]`.
  *
- * The data walker is intentionally a subset of the full Lineage DAG —
- * it's the C-3 placeholder until VIS-D6 ships the shared
- * `<MiniLineageCard>` and VIS-780 (C-4) migrates this popover to it.
+ * The selector input at the top is the user-editable handle for
+ * scope: default `+name+` (both directions, unbounded). Editing it
+ * (e.g. `+2name+1`) clamps the walker's depth.
+ *
+ * Colour + icon for every type comes from the shared
+ * `objectTypeConfigs` palette so the popover matches every other
+ * lineage / library / canvas surface.
  */
 
-// Two tone palettes mirror the Library section colours: mulberry for
-// Layout-section types (chart / table / markdown / input) and teal for
-// Data-section types (sources, models, dimensions, metrics, relations,
-// insights). Dashboards default to mulberry since they belong to the
-// layout side of the world.
-const MULBERRY_TONE = {
-  iconBg: 'bg-[#e2d7dd]/70',
-  iconFg: 'text-[#713b57]',
-  pillBg: 'bg-[#e2d7dd]',
-  pillFg: 'text-[#5a2f45]',
-};
-const TEAL_TONE = {
-  iconBg: 'bg-[#d4e1e2]/70',
-  iconFg: 'text-[#1b4042]',
-  pillBg: 'bg-[#d4e1e2]',
-  pillFg: 'text-[#1b4042]',
-};
-
-// Sources sit in the data layer but get a warm highlight in the mock so
-// the originating system stands out at the top of the chain.
-const ORANGE_TONE = {
-  iconBg: 'bg-[#f4d6cc]/80',
-  iconFg: 'text-[#a44326]',
-  pillBg: 'bg-[#f4d6cc]',
-  pillFg: 'text-[#a44326]',
-};
-
-const getTone = type => {
-  if (type === 'source') return ORANGE_TONE;
-  if (LAYOUT_TYPES.includes(type) || type === 'dashboard') return MULBERRY_TONE;
-  return TEAL_TONE;
-};
-
-const getIcon = type => getTypeIcon(type);
-
-// Ladder geometry. ROW_HEIGHT × ROW_GAP must stay in sync with the
-// classes on the row containers below — the dotted-connector heights
-// are computed analytically from these constants.
-const ROW_HEIGHT = 22; // h-[22px]
-const ROW_GAP = 2; // gap-[2px]
-const STEP = 18; // per-rung left/right shift
-const BASE_INDENT = 12; // where the lowest ancestor + first descendant align
+// Ladder geometry — chosen so even a 5–6 deep chain fits inside the
+// 340 px card without horizontal scroll. The row width itself is fixed
+// so each rung "floats" right (ancestors) or left (descendants) by a
+// constant offset, producing the staircase.
 const CARD_WIDTH = 340;
+const CARD_PAD_X = 12;
+const ROW_HEIGHT = 24;
+const ROW_GAP = 4;
+const ROW_WIDTH = 200;
+const MAX_STEP = 22;
+const MIN_STEP = 10;
+const BASE_INDENT = 6;
 
 // ---------------------------------------------------------------------------
-// Relations walker
+// Selector parsing — Visivo selector syntax `[+N]name[+M]`
 // ---------------------------------------------------------------------------
 
-// Lineage edges come straight from each store object's `child_item_names`
-// array — that's the canonical "what does this depend on" list the backend
-// already publishes for every chart / table / insight / model / source.
-// Walking it gives us the full upstream DAG without having to inspect the
-// per-type config blobs (which embed refs as `${ref(name).column}` and
-// would otherwise need SQL-style ref parsing).
+const UNBOUNDED = Number.POSITIVE_INFINITY;
+
+function defaultSelector(name) {
+  return `+${name}+`;
+}
+
+/**
+ * Parse a Visivo selector string into `{ name, ancestors, descendants }`.
+ *
+ * Examples:
+ *   "+revenue_chart+"   → unbounded ancestors + unbounded descendants
+ *   "+2revenue_chart+1" → 2 ancestor levels, 1 descendant level
+ *   "+revenue_chart"    → unbounded ancestors, no descendants
+ *   "revenue_chart"     → just the subject row
+ */
+function parseSelector(text, fallbackName) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) {
+    return { name: fallbackName, ancestors: 0, descendants: 0 };
+  }
+  const re = /^(\+(\d*))?([^+]+?)(\+(\d*))?$/;
+  const m = trimmed.match(re);
+  if (!m) {
+    return { name: fallbackName, ancestors: 0, descendants: 0 };
+  }
+  const ancHasPlus = Boolean(m[1]);
+  const ancDigits = m[2] || '';
+  const subjName = (m[3] || '').trim() || fallbackName;
+  const desHasPlus = Boolean(m[4]);
+  const desDigits = m[5] || '';
+
+  const depth = (hasPlus, digits) => {
+    if (!hasPlus) return 0;
+    if (!digits) return UNBOUNDED;
+    const n = parseInt(digits, 10);
+    return Number.isFinite(n) && n >= 0 ? n : UNBOUNDED;
+  };
+
+  return {
+    name: subjName,
+    ancestors: depth(ancHasPlus, ancDigits),
+    descendants: depth(desHasPlus, desDigits),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lineage walker — uses `child_item_names` (the canonical upstream-edge
+// list the backend already exposes for every object).
+// ---------------------------------------------------------------------------
+
 function getChildItemNames(obj) {
   if (!obj || !Array.isArray(obj.child_item_names)) return [];
   return obj.child_item_names.filter(Boolean);
 }
 
-/**
- * Build a name → type index over every collection the store exposes. Lets
- * us resolve a raw `child_item_names` entry back to its typed object so the
- * walker can keep traversing upstream.
- */
 function buildTypeIndex(storeApi) {
   const lookup = new Map();
   const register = (type, list) => {
@@ -128,43 +131,6 @@ function buildTypeIndex(storeApi) {
   return lookup;
 }
 
-/**
- * Walk upstream from the subject via `child_item_names`. The traversal is
- * topological-on-the-fly: a parent node is only emitted once all of its own
- * upstreams have been emitted, so direct ancestors land last (closest to
- * the subject in the rendered ladder).
- */
-function buildAncestors(subject, storeApi) {
-  if (!subject) return [];
-  const index = buildTypeIndex(storeApi);
-  const subjectEntry = index.get(subject.name);
-  const subjectObj = subjectEntry?.obj;
-  if (!subjectObj) return [];
-
-  const directNames = new Set(getChildItemNames(subjectObj));
-  const out = [];
-  const seen = new Set([`${subject.type}:${subject.name}`]);
-
-  const visit = name => {
-    const entry = index.get(name);
-    if (!entry) return;
-    const key = `${entry.type}:${name}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    // Emit upstreams first so the deepest node sits at the top of the
-    // ladder; direct children of the subject sit just above the subject.
-    getChildItemNames(entry.obj).forEach(visit);
-    out.push({ type: entry.type, name, isDirect: directNames.has(name) });
-  };
-
-  directNames.forEach(visit);
-  return out;
-}
-
-/**
- * Build a reverse adjacency — for any name, who lists it as a child? Lets
- * us walk descendants in O(N) regardless of which type the subject is.
- */
 function buildReverseIndex(storeApi) {
   const reverse = new Map();
   const add = (parentName, childName, parentType) => {
@@ -192,196 +158,248 @@ function buildReverseIndex(storeApi) {
   return reverse;
 }
 
-/**
- * Some dashboards aren't surfaced through `child_item_names` on their
- * descendants — the relationship lives in the dashboard's `rows`/`items`
- * tree. Scan once and produce a flat list of `(dashboardName → memberName)`
- * edges so descendant traversal can include them.
- */
+// Dashboard items reference their members through Visivo's templated
+// `${ ref(name) }` syntax, plain names, or inline object literals. This
+// unwraps every variant down to the bare name so the descendant walker
+// can match against the type index.
+const REF_PATTERN = /\$\{\s*ref\(([^)]+)\)\s*\}/;
+
+function unwrapRefName(ref) {
+  if (!ref) return null;
+  if (typeof ref === 'object') return ref.name || ref.ref || null;
+  if (typeof ref !== 'string') return null;
+  const m = ref.match(REF_PATTERN);
+  if (m) return m[1].trim();
+  return ref.trim();
+}
+
 function dashboardMembership(allDashboards) {
   const out = [];
   if (!Array.isArray(allDashboards)) return out;
-  allDashboards.forEach(d => {
-    if (!d || !Array.isArray(d.rows)) return;
-    d.rows.forEach(row => {
+  const walk = (rows, dashboardName) => {
+    if (!Array.isArray(rows)) return;
+    rows.forEach(row => {
       if (!row || !Array.isArray(row.items)) return;
       row.items.forEach(item => {
         if (!item) return;
-        ['chart', 'table', 'markdown'].forEach(key => {
-          const ref = item[key];
-          if (!ref) return;
-          const refName = typeof ref === 'string' ? ref : ref.name || ref.ref;
-          if (refName) out.push({ dashboard: d.name, member: refName });
+        ['chart', 'table', 'markdown', 'input'].forEach(key => {
+          const name = unwrapRefName(item[key]);
+          if (name) out.push({ dashboard: dashboardName, member: name });
         });
+        // Items may nest further rows (containers); recurse.
+        if (Array.isArray(item.rows)) walk(item.rows, dashboardName);
       });
     });
+  };
+  allDashboards.forEach(d => {
+    if (!d || !d.name) return;
+    // Live API returns the structure under `config.rows`; the test seed
+    // mirrors the legacy `rows` shape. Both are honored.
+    walk(d.rows || d.config?.rows, d.name);
   });
   return out;
 }
 
-function buildDescendants(subject, storeApi) {
-  if (!subject) return [];
+function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
+  if (!subject || maxDepth <= 0) return [];
+  const index = buildTypeIndex(storeApi);
+  const subjectEntry = index.get(subject.name);
+  if (!subjectEntry) return [];
+
+  const out = [];
+  const seen = new Set([`${subject.type}:${subject.name}`]);
+
+  const visit = (name, depth) => {
+    if (depth > maxDepth) return;
+    const entry = index.get(name);
+    if (!entry) return;
+    const key = `${entry.type}:${name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    // DFS: deepest node lands at the TOP of the output. We push the
+    // current node AFTER recursing into its own upstreams so the row
+    // order in the popover mirrors a topological walk.
+    getChildItemNames(entry.obj).forEach(child => visit(child, depth + 1));
+    out.push({ type: entry.type, name, depth, isDirect: depth === 1 });
+  };
+
+  getChildItemNames(subjectEntry.obj).forEach(child => visit(child, 1));
+  return out;
+}
+
+function buildDescendants(subject, storeApi, maxDepth = UNBOUNDED) {
+  if (!subject || maxDepth <= 0) return [];
   const reverse = buildReverseIndex(storeApi);
   const dashMembers = dashboardMembership(storeApi.allDashboards);
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
 
-  const directParents = reverse.get(subject.name) || [];
-  const directDashboards = dashMembers
-    .filter(m => m.member === subject.name)
-    .map(m => ({ name: m.dashboard, type: 'dashboard' }));
-  const directSet = new Set(
-    [...directParents, ...directDashboards].map(p => `${p.type}:${p.name}`)
-  );
-
-  const visit = (name, type) => {
+  const visit = (name, type, depth) => {
+    if (depth > maxDepth) return;
     const key = `${type}:${name}`;
     if (seen.has(key)) return;
     seen.add(key);
-    out.push({ type, name, isDirect: directSet.has(key) });
-    // Recurse: anything that lists `name` as a child is a deeper descendant.
-    (reverse.get(name) || []).forEach(p => visit(p.name, p.type));
+    out.push({ type, name, depth, isDirect: depth === 1 });
+    (reverse.get(name) || []).forEach(p => visit(p.name, p.type, depth + 1));
     dashMembers
       .filter(m => m.member === name)
-      .forEach(m => visit(m.dashboard, 'dashboard'));
+      .forEach(m => visit(m.dashboard, 'dashboard', depth + 1));
   };
 
-  directParents.forEach(p => visit(p.name, p.type));
-  directDashboards.forEach(d => visit(d.name, d.type));
+  (reverse.get(subject.name) || []).forEach(p => visit(p.name, p.type, 1));
+  dashMembers
+    .filter(m => m.member === subject.name)
+    .forEach(m => visit(m.dashboard, 'dashboard', 1));
   return out;
 }
 
-function buildLineageRelations(subject, storeApi) {
+function buildLineageRelations(subject, storeApi, scope = {}) {
+  const ancestorDepth = scope.ancestors ?? UNBOUNDED;
+  const descendantDepth = scope.descendants ?? UNBOUNDED;
   return {
-    ancestors: buildAncestors(subject, storeApi),
-    descendants: buildDescendants(subject, storeApi),
+    ancestors: buildAncestors(subject, storeApi, ancestorDepth),
+    descendants: buildDescendants(subject, storeApi, descendantDepth),
   };
 }
 
-// Backward-compat: VIS-780 will replace this with `<MiniLineageCard>`.
+// Back-compat — VIS-780 will replace this with `<MiniLineageCard>`.
 function buildChainFromStore(subject, storeApi) {
-  return buildAncestors(subject, storeApi);
+  return buildAncestors(subject, storeApi, UNBOUNDED);
 }
 
 // ---------------------------------------------------------------------------
-// Row primitives
+// Row primitives — pull tone classes straight from `objectTypeConfigs`
+// so this surface stays colour-locked with the rest of the viewer.
 // ---------------------------------------------------------------------------
 
-const TypePill = ({ type, tone, alignRight }) => (
-  <span
-    className={[
-      'inline-flex h-3 shrink-0 items-center rounded-sm px-1 text-[8px] font-bold uppercase tracking-wider',
-      tone.pillBg,
-      tone.pillFg,
-    ].join(' ')}
-    style={alignRight ? { marginLeft: 'auto' } : undefined}
-  >
-    {type}
-  </span>
-);
+function toneFor(type) {
+  const c = getTypeColors(type) || {};
+  return {
+    pill: `${c.bg || 'bg-gray-100'} ${c.text || 'text-gray-800'}`,
+    tile: `${c.node || 'bg-gray-50 border-gray-200'} ${c.text || 'text-gray-800'}`,
+  };
+}
 
-const IconTile = ({ Icon, tone }) => (
-  <span
-    className={[
-      'relative z-10 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded',
-      tone.iconBg,
-      tone.iconFg,
-    ].join(' ')}
-  >
-    <Icon style={{ fontSize: 10 }} />
-  </span>
-);
-
-const NameLabel = ({ name, align = 'left' }) => (
-  <span
-    className={[
-      'min-w-0 truncate text-[11.5px] font-medium text-gray-800',
-      align === 'center' ? 'flex-1 text-center' : 'flex-1',
-    ].join(' ')}
-  >
-    {name}
-  </span>
-);
-
-const AncestorRow = ({ node, leftPad, dottedHeight, testIdPrefix }) => {
-  const tone = getTone(node.type);
-  const Icon = getIcon(node.type);
+const TypePill = ({ type }) => {
+  const tone = toneFor(type);
   return (
-    <li
-      data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
-      data-direction="ancestor"
-      data-direct={node.isDirect ? 'true' : 'false'}
-      className="relative flex items-center gap-1.5 self-stretch"
-      style={{
-        height: ROW_HEIGHT,
-        paddingLeft: leftPad,
-        paddingRight: 4,
-      }}
+    <span
+      className={[
+        'inline-flex h-4 shrink-0 items-center rounded-sm px-1 text-[8.5px] font-bold uppercase tracking-wider',
+        tone.pill,
+      ].join(' ')}
     >
-      {/* Dotted connector: drops from the left of the [type] pill down
-          past every row beneath it to the top of the subject's icon. */}
-      {node.isDirect && dottedHeight > 0 && (
+      {type}
+    </span>
+  );
+};
+
+const IconTile = ({ type }) => {
+  const tone = toneFor(type);
+  const Icon = getTypeIcon(type);
+  return (
+    <span
+      className={[
+        'relative z-10 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border',
+        tone.tile,
+      ].join(' ')}
+    >
+      <Icon style={{ fontSize: 12 }} />
+    </span>
+  );
+};
+
+const AncestorRow = ({ node, marginLeft, dottedHeight, testIdPrefix }) => (
+  <li
+    data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
+    data-direction="ancestor"
+    data-direct={node.isDirect ? 'true' : 'false'}
+    className="relative flex items-center gap-2"
+    style={{
+      height: ROW_HEIGHT,
+      width: ROW_WIDTH,
+      marginLeft,
+    }}
+  >
+    {/* Dotted L-connector: drops from the left of the [type] pill down to
+        the top of the subject row, then bends inward to the subject's
+        [icon]. The horizontal nib lands ~half a row above the subject
+        icon and stops at the subject's left edge (paddingLeft + icon
+        width / 2) so it visually terminates on the icon column. */}
+    {node.isDirect && dottedHeight > 0 && (
+      <>
         <span
           aria-hidden="true"
           data-testid={`${testIdPrefix}-dotted-${node.name}`}
           className="absolute"
           style={{
-            left: leftPad - 5,
+            left: -4,
             top: ROW_HEIGHT / 2,
             height: dottedHeight,
             width: 2,
-            // Repeating gradient gives a crisp, visible dotted line at
-            // small widths where CSS `border-style: dotted` renders as
-            // a near-invisible hairline.
             backgroundImage:
               'repeating-linear-gradient(to bottom, #6b7280 0, #6b7280 2px, transparent 2px, transparent 5px)',
           }}
         />
-      )}
-      <TypePill type={node.type} tone={tone} />
-      <NameLabel name={node.name} />
-      <IconTile Icon={Icon} tone={tone} />
-    </li>
-  );
-};
+        <span
+          aria-hidden="true"
+          className="absolute"
+          style={{
+            left: -4,
+            top: ROW_HEIGHT / 2 + dottedHeight,
+            width: Math.max(0, marginLeft - CARD_PAD_X - 4 + 12),
+            height: 2,
+            backgroundImage:
+              'repeating-linear-gradient(to right, #6b7280 0, #6b7280 2px, transparent 2px, transparent 5px)',
+          }}
+        />
+      </>
+    )}
+    <TypePill type={node.type} />
+    <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
+      {node.name}
+    </span>
+    <IconTile type={node.type} />
+  </li>
+);
 
-const DescendantRow = ({ node, leftPad, testIdPrefix }) => {
-  const tone = getTone(node.type);
-  const Icon = getIcon(node.type);
-  return (
-    <li
-      data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
-      data-direction="descendant"
-      data-direct={node.isDirect ? 'true' : 'false'}
-      className="relative flex items-center gap-1.5 self-stretch"
-      style={{
-        height: ROW_HEIGHT,
-        paddingLeft: leftPad,
-        paddingRight: 4,
-      }}
-    >
-      <IconTile Icon={Icon} tone={tone} />
-      <NameLabel name={node.name} />
-      <TypePill type={node.type} tone={tone} alignRight />
-    </li>
-  );
-};
+const DescendantRow = ({ node, marginLeft, testIdPrefix }) => (
+  <li
+    data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
+    data-direction="descendant"
+    data-direct={node.isDirect ? 'true' : 'false'}
+    className="relative flex items-center gap-2"
+    style={{
+      height: ROW_HEIGHT,
+      width: ROW_WIDTH,
+      marginLeft,
+    }}
+  >
+    <IconTile type={node.type} />
+    <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
+      {node.name}
+    </span>
+    <TypePill type={node.type} />
+  </li>
+);
 
 const SubjectRow = ({ subject, testIdPrefix }) => {
-  const tone = getTone(subject.type);
-  const Icon = getIcon(subject.type);
+  const tone = toneFor(subject.type);
   return (
     <li
       data-testid={`${testIdPrefix}-lineage-subject`}
       data-direction="subject"
-      className="relative flex items-center self-stretch rounded-md ring-1 ring-[#713b57]/40 bg-[#e2d7dd]/40"
+      className={[
+        'relative flex items-center self-stretch rounded-md ring-1 ring-[#713b57]/40',
+        tone.pill,
+      ].join(' ')}
       style={{ height: ROW_HEIGHT + 4, paddingLeft: 6, paddingRight: 6 }}
     >
-      <IconTile Icon={Icon} tone={tone} />
+      <IconTile type={subject.type} />
       <span className="flex-1 text-center text-[11.5px] font-semibold text-gray-900 truncate min-w-0 px-2">
         {subject.name}
       </span>
-      <TypePill type={subject.type} tone={tone} />
+      <TypePill type={subject.type} />
     </li>
   );
 };
@@ -420,6 +438,13 @@ const LibraryRowFlipPopover = ({
   );
   const [ancestorsOpen, setAncestorsOpen] = useState(true);
   const [descendantsOpen, setDescendantsOpen] = useState(true);
+  const [selectorText, setSelectorText] = useState(() => defaultSelector(obj?.name || ''));
+
+  // Reset selector if the underlying object identity changes (e.g. the
+  // popover is reused for a different row mid-mount).
+  useEffect(() => {
+    setSelectorText(defaultSelector(obj?.name || ''));
+  }, [obj?.name]);
 
   useEffect(() => {
     if (!anchorRef?.current) return undefined;
@@ -444,27 +469,73 @@ const LibraryRowFlipPopover = ({
   const markdowns = useStore(s => s.markdowns);
   const inputs = useStore(s => s.inputs);
   const allDashboards = useStore(s => s.allDashboards);
+  const dashboardsFromStore = useStore(s => s.dashboards);
+  const fetchDashboards = useStore(s => s.fetchDashboards);
   const csvScriptModels = useStore(s => s.csvScriptModels);
   const localMergeModels = useStore(s => s.localMergeModels);
 
-  const lineage = useMemo(() => {
-    return buildLineageRelations(obj, {
-      charts,
-      insights,
-      models,
-      tables,
-      sources,
-      dimensions,
-      metrics,
-      relations: relationsList,
-      markdowns,
-      inputs,
-      allDashboards,
-      csvScriptModels,
-      localMergeModels,
+  // The Workspace shell preloads charts/insights/models/etc. via their
+  // own slices, but `dashboards` only loads on demand. Without it the
+  // descendant walker can't surface "this chart is in dashboard X".
+  // Trigger a one-shot fetch when the popover mounts so descendants
+  // appear on first open.
+  useEffect(() => {
+    if (
+      (!Array.isArray(allDashboards) || allDashboards.length === 0) &&
+      (!Array.isArray(dashboardsFromStore) || dashboardsFromStore.length === 0) &&
+      typeof fetchDashboards === 'function'
+    ) {
+      fetchDashboards();
+    }
+    // We intentionally run only once per mount — refetches handled
+    // elsewhere by save flows.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Coalesce the two dashboard sources so the walker sees membership
+  // edges no matter which slice happens to be populated.
+  const dashboardsForWalker = useMemo(() => {
+    const seen = new Set();
+    const out = [];
+    [allDashboards, dashboardsFromStore].forEach(list => {
+      if (!Array.isArray(list)) return;
+      list.forEach(d => {
+        if (!d || !d.name || seen.has(d.name)) return;
+        seen.add(d.name);
+        out.push(d);
+      });
     });
+    return out;
+  }, [allDashboards, dashboardsFromStore]);
+
+  const scope = useMemo(
+    () => parseSelector(selectorText, obj?.name || ''),
+    [selectorText, obj?.name]
+  );
+
+  const lineage = useMemo(() => {
+    return buildLineageRelations(
+      obj,
+      {
+        charts,
+        insights,
+        models,
+        tables,
+        sources,
+        dimensions,
+        metrics,
+        relations: relationsList,
+        markdowns,
+        inputs,
+        allDashboards: dashboardsForWalker,
+        csvScriptModels,
+        localMergeModels,
+      },
+      scope
+    );
   }, [
     obj,
+    scope,
     charts,
     insights,
     models,
@@ -475,7 +546,7 @@ const LibraryRowFlipPopover = ({
     relationsList,
     markdowns,
     inputs,
-    allDashboards,
+    dashboardsForWalker,
     csvScriptModels,
     localMergeModels,
   ]);
@@ -499,30 +570,41 @@ const LibraryRowFlipPopover = ({
 
   if (!obj) return null;
 
-  const selectorRendered = obj.name
-    ? `+${String(obj.name).toLowerCase().replace(/[^a-z0-9_]+/g, '_')}`
-    : '+';
-
   const ancestors = lineage.ancestors;
   const descendants = lineage.descendants;
   const N = ancestors.length;
-  const isEmpty = N === 0 && descendants.length === 0;
+  const M = descendants.length;
+  const isEmpty = N === 0 && M === 0;
 
-  // Compute each ancestor row's left padding so that:
-  //   - the bottom-most ancestor (index N-1) sits at BASE_INDENT
-  //   - each row above shifts left by STEP (i.e. its padding grows)
-  // That mirrors the descendant ladder, which starts at BASE_INDENT and
-  // grows by STEP per row downward.
-  const ancestorLeftPad = i => BASE_INDENT + (N - 1 - i) * STEP;
-  const descendantLeftPad = j => BASE_INDENT + j * STEP;
+  // Positioning is depth-based, not display-index-based. Every node at
+  // the same lineage depth (e.g. two sibling insights that both feed
+  // the subject directly) shares the same horizontal slot — that's
+  // what makes a true staircase. The marginLeft grows by STEP for each
+  // additional depth level so the deepest ancestor sits furthest right
+  // and the direct level shares its left edge with the first descendant.
+  const cardContentWidth = CARD_WIDTH - CARD_PAD_X * 2;
+  const availableShift = Math.max(0, cardContentWidth - ROW_WIDTH - BASE_INDENT);
+  const stepForMaxDepth = maxDepth => {
+    if (maxDepth <= 1) return 0;
+    return Math.max(MIN_STEP, Math.min(MAX_STEP, Math.floor(availableShift / (maxDepth - 1))));
+  };
+  const ancestorMaxDepth = ancestors.reduce((acc, n) => Math.max(acc, n.depth || 1), 1);
+  const descendantMaxDepth = descendants.reduce((acc, n) => Math.max(acc, n.depth || 1), 1);
+  const ancestorStep = stepForMaxDepth(ancestorMaxDepth);
+  const descendantStep = stepForMaxDepth(descendantMaxDepth);
 
-  // Dotted line drops from the [type] pill of a direct ancestor down to
-  // the top of the subject row. Each row contributes ROW_HEIGHT + ROW_GAP
-  // of vertical distance; the line should reach the top of the subject
-  // row (which sits just below the last ancestor row).
-  const dottedHeightFor = i => {
-    const rowsBetween = N - i; // includes this row + every row below + the gap to subject
-    return rowsBetween * (ROW_HEIGHT + ROW_GAP) - ROW_HEIGHT / 2;
+  const ancestorMarginLeft = node =>
+    BASE_INDENT + ((node.depth || 1) - 1) * ancestorStep;
+  const descendantMarginLeft = node =>
+    BASE_INDENT + ((node.depth || 1) - 1) * descendantStep;
+
+  // Dotted L-connector height: drops from the direct ancestor's row mid
+  // down past every row between it and the subject. Walking by display
+  // index keeps the geometry correct even when multiple ancestors share
+  // a depth (siblings at the same level).
+  const dottedHeightFor = displayIndex => {
+    const rowsToSubject = N - displayIndex;
+    return rowsToSubject * (ROW_HEIGHT + ROW_GAP) - ROW_HEIGHT / 2;
   };
 
   return createPortal(
@@ -546,8 +628,8 @@ const LibraryRowFlipPopover = ({
       <div className="relative rounded-lg bg-white shadow-lg ring-1 ring-gray-200">
         <header className="flex h-8 items-center gap-2 border-b border-gray-200 px-3">
           {(() => {
-            const I = getIcon(obj.type);
-            return <I style={{ fontSize: 14 }} className="text-gray-500" />;
+            const Icon = getTypeIcon(obj.type);
+            return <Icon style={{ fontSize: 14 }} className="text-gray-500" />;
           })()}
           <span
             data-testid={`${testIdPrefix}-name`}
@@ -572,26 +654,33 @@ const LibraryRowFlipPopover = ({
 
         <div className="shrink-0 px-3 pt-2">
           <div
-            className="flex h-7 items-center gap-1.5 rounded-md bg-gray-50 px-2 ring-1 ring-gray-200"
+            className="flex h-7 items-center gap-1.5 rounded-md bg-gray-50 px-2 ring-1 ring-gray-200 focus-within:ring-[#713b57]/40"
             data-testid={`${testIdPrefix}-selector`}
           >
             <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-gray-400">
               sel
             </span>
-            <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-gray-800">
-              {selectorRendered}
-            </span>
+            <input
+              type="text"
+              value={selectorText}
+              onChange={e => setSelectorText(e.target.value)}
+              spellCheck={false}
+              aria-label="Lineage selector — edit to change depth in either direction"
+              data-testid={`${testIdPrefix}-selector-input`}
+              className="min-w-0 flex-1 truncate bg-transparent font-mono text-[11px] text-gray-800 placeholder-gray-400 outline-none"
+              placeholder={defaultSelector(obj.name)}
+            />
           </div>
         </div>
 
         <div
-          className="flex-1 min-h-0 overflow-y-auto px-3 py-2"
-          style={{ maxHeight: 260 }}
+          className="flex-1 min-h-0 overflow-y-auto py-2"
+          style={{ maxHeight: 320, paddingLeft: CARD_PAD_X, paddingRight: CARD_PAD_X }}
           data-testid={`${testIdPrefix}-body`}
         >
           {isEmpty ? (
             <p
-              className="px-1 text-[11px] italic text-gray-500"
+              className="px-1 py-2 text-[11px] italic text-gray-500"
               data-testid={`${testIdPrefix}-empty`}
             >
               No lineage available for this object.
@@ -626,7 +715,7 @@ const LibraryRowFlipPopover = ({
                           <AncestorRow
                             key={`anc-${node.type}-${node.name}-${i}`}
                             node={node}
-                            leftPad={ancestorLeftPad(i)}
+                            marginLeft={ancestorMarginLeft(node)}
                             dottedHeight={node.isDirect ? dottedHeightFor(i) : 0}
                             testIdPrefix={testIdPrefix}
                           />
@@ -646,7 +735,7 @@ const LibraryRowFlipPopover = ({
 
               <SubjectRow subject={obj} testIdPrefix={testIdPrefix} />
 
-              {descendants.length > 0 && (
+              {M > 0 && (
                 <li
                   data-testid={`${testIdPrefix}-descendants`}
                   data-collapsed={descendantsOpen ? 'false' : 'true'}
@@ -672,7 +761,7 @@ const LibraryRowFlipPopover = ({
                           <DescendantRow
                             key={`desc-${node.type}-${node.name}-${j}`}
                             node={node}
-                            leftPad={descendantLeftPad(j)}
+                            marginLeft={descendantMarginLeft(node)}
                             testIdPrefix={testIdPrefix}
                           />
                         ))}
@@ -682,7 +771,7 @@ const LibraryRowFlipPopover = ({
                         className="inline-flex h-4 items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500"
                         style={{ marginLeft: BASE_INDENT }}
                       >
-                        +{descendants.length} downstream
+                        +{M} downstream
                       </span>
                     )}
                   </button>
@@ -716,11 +805,12 @@ const LibraryRowFlipPopover = ({
 export {
   buildChainFromStore,
   buildLineageRelations,
-  getIcon,
-  getTone,
+  parseSelector,
+  defaultSelector,
   ROW_HEIGHT,
   ROW_GAP,
-  STEP,
+  ROW_WIDTH,
   BASE_INDENT,
+  UNBOUNDED,
 };
 export default LibraryRowFlipPopover;

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -265,6 +265,7 @@ function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
       name,
       depth,
       isDirect: depth === 1,
+      isTerminal: childs.length === 0,
       childNames: fromChildName ? [fromChildName] : [],
     });
   };
@@ -650,8 +651,17 @@ const LibraryRowFlipPopover = ({
   const sharedMaxDepth = Math.max(ancestorMaxDepth, descendantMaxDepth);
   const STEP = stepForMaxDepth(sharedMaxDepth);
 
+  // Terminal ancestors (nodes with no upstream of their own) align to
+  // the deepest visual column regardless of their actual distance from
+  // the subject. Otherwise a direct ancestor with no parent would sit
+  // at depth 1 directly under whatever ancestor happens to be at
+  // depth 2 above it, which falsely implies a chain. Bumping terminals
+  // to the rightmost column makes "this is a leaf of the upstream
+  // tree" the visual reading.
+  const ancestorEffectiveDepth = node =>
+    node.isTerminal ? ancestorMaxDepth : (node.depth || 1);
   const ancestorMarginLeft = node =>
-    BASE_INDENT + ((node.depth || 1) - 1) * STEP;
+    BASE_INDENT + (ancestorEffectiveDepth(node) - 1) * STEP;
   const descendantMarginLeft = node =>
     BASE_INDENT + ((node.depth || 1) - 1) * STEP;
 

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -209,21 +209,41 @@ function buildAncestors(subject, storeApi, maxDepth = UNBOUNDED) {
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
 
-  const visit = (name, depth) => {
+  // Track which displayed node each upstream came in through so the
+  // connector overlay can draw the actual DAG edges (parent.icon →
+  // child.icon) instead of a generic chain.
+  const visit = (name, depth, fromChildName) => {
     if (depth > maxDepth) return;
     const entry = index.get(name);
     if (!entry) return;
     const key = `${entry.type}:${name}`;
-    if (seen.has(key)) return;
+    if (seen.has(key)) {
+      // Even if we've already pushed this node, record the additional
+      // edge so a shared parent (e.g. one source feeding two models)
+      // connects to every child that lists it.
+      const existing = out.find(n => n.type === entry.type && n.name === name);
+      if (existing && fromChildName && !existing.childNames.includes(fromChildName)) {
+        existing.childNames.push(fromChildName);
+      }
+      return;
+    }
     seen.add(key);
     // DFS: deepest node lands at the TOP of the output. We push the
     // current node AFTER recursing into its own upstreams so the row
     // order in the popover mirrors a topological walk.
-    getChildItemNames(entry.obj).forEach(child => visit(child, depth + 1));
-    out.push({ type: entry.type, name, depth, isDirect: depth === 1 });
+    getChildItemNames(entry.obj).forEach(child => visit(child, depth + 1, name));
+    out.push({
+      type: entry.type,
+      name,
+      depth,
+      isDirect: depth === 1,
+      childNames: fromChildName ? [fromChildName] : [],
+    });
   };
 
-  getChildItemNames(subjectEntry.obj).forEach(child => visit(child, 1));
+  getChildItemNames(subjectEntry.obj).forEach(child =>
+    visit(child, 1, /* fromChildName */ subject.name)
+  );
   return out;
 }
 
@@ -234,22 +254,36 @@ function buildDescendants(subject, storeApi, maxDepth = UNBOUNDED) {
   const out = [];
   const seen = new Set([`${subject.type}:${subject.name}`]);
 
-  const visit = (name, type, depth) => {
+  const visit = (name, type, depth, parentName) => {
     if (depth > maxDepth) return;
     const key = `${type}:${name}`;
-    if (seen.has(key)) return;
+    if (seen.has(key)) {
+      const existing = out.find(n => n.type === type && n.name === name);
+      if (existing && parentName && !existing.parentNames.includes(parentName)) {
+        existing.parentNames.push(parentName);
+      }
+      return;
+    }
     seen.add(key);
-    out.push({ type, name, depth, isDirect: depth === 1 });
-    (reverse.get(name) || []).forEach(p => visit(p.name, p.type, depth + 1));
+    out.push({
+      type,
+      name,
+      depth,
+      isDirect: depth === 1,
+      parentNames: parentName ? [parentName] : [],
+    });
+    (reverse.get(name) || []).forEach(p => visit(p.name, p.type, depth + 1, name));
     dashMembers
       .filter(m => m.member === name)
-      .forEach(m => visit(m.dashboard, 'dashboard', depth + 1));
+      .forEach(m => visit(m.dashboard, 'dashboard', depth + 1, name));
   };
 
-  (reverse.get(subject.name) || []).forEach(p => visit(p.name, p.type, 1));
+  (reverse.get(subject.name) || []).forEach(p =>
+    visit(p.name, p.type, 1, subject.name)
+  );
   dashMembers
     .filter(m => m.member === subject.name)
-    .forEach(m => visit(m.dashboard, 'dashboard', 1));
+    .forEach(m => visit(m.dashboard, 'dashboard', 1, subject.name));
   return out;
 }
 
@@ -607,6 +641,77 @@ const LibraryRowFlipPopover = ({
     return rowsToSubject * (ROW_HEIGHT + ROW_GAP) - ROW_HEIGHT / 2;
   };
 
+  // SVG connector overlay — draws the actual DAG edges so the icon
+  // staircase visually reads as the lineage tree it represents.
+  const ICON_W = 20;
+  const ICON_H = 20;
+  const ancestorIconCenter = node => ({
+    x: ancestorMarginLeft(node) + ROW_WIDTH - ICON_W / 2,
+  });
+  const descendantIconCenter = node => ({
+    x: descendantMarginLeft(node) + ICON_W / 2,
+  });
+
+  const ancestorByName = new Map();
+  ancestors.forEach((node, i) => ancestorByName.set(node.name, { node, index: i }));
+  const descendantByName = new Map();
+  descendants.forEach((node, j) => descendantByName.set(node.name, { node, index: j }));
+
+  const ancestorRowY = i => i * (ROW_HEIGHT + ROW_GAP) + ROW_HEIGHT / 2;
+  const subjectY = N * (ROW_HEIGHT + ROW_GAP) + (ROW_HEIGHT + 4) / 2;
+  const subjectBottomY = N * (ROW_HEIGHT + ROW_GAP) + (ROW_HEIGHT + 4);
+  const descendantRowY = j =>
+    subjectBottomY + ROW_GAP + j * (ROW_HEIGHT + ROW_GAP) + ROW_HEIGHT / 2;
+
+  const ancestorConnectors = [];
+  if (ancestorsOpen) {
+    ancestors.forEach((parent, parentIdx) => {
+      (parent.childNames || []).forEach(childName => {
+        if (childName === obj.name) return; // direct → handled by dotted line
+        const child = ancestorByName.get(childName);
+        if (!child) return;
+        ancestorConnectors.push({
+          key: `anc-edge-${parent.name}-${childName}`,
+          parentX: ancestorIconCenter(parent).x,
+          parentY: ancestorRowY(parentIdx),
+          childX: ancestorIconCenter(child.node).x,
+          childY: ancestorRowY(child.index),
+        });
+      });
+    });
+  }
+
+  const descendantConnectors = [];
+  if (descendantsOpen) {
+    descendants.forEach((node, idx) => {
+      if (node.isDirect) {
+        descendantConnectors.push({
+          key: `dsc-edge-subject-${node.name}`,
+          parentX: 6 + ICON_W / 2, // subject row icon center (paddingLeft 6 + half-icon)
+          parentY: subjectY,
+          childX: descendantIconCenter(node).x,
+          childY: descendantRowY(idx),
+        });
+      } else {
+        (node.parentNames || []).forEach(parentName => {
+          if (parentName === obj.name) return; // handled above as direct
+          const parent = descendantByName.get(parentName);
+          if (!parent) return;
+          descendantConnectors.push({
+            key: `dsc-edge-${parentName}-${node.name}`,
+            parentX: descendantIconCenter(parent.node).x,
+            parentY: descendantRowY(parent.index),
+            childX: descendantIconCenter(node).x,
+            childY: descendantRowY(idx),
+          });
+        });
+      }
+    });
+  }
+
+  const connectorPath = ({ parentX, parentY, childX, childY }) =>
+    `M ${parentX} ${parentY + ICON_H / 2} L ${parentX} ${childY} L ${childX} ${childY}`;
+
   return createPortal(
     <div
       ref={popoverRef}
@@ -686,11 +791,45 @@ const LibraryRowFlipPopover = ({
               No lineage available for this object.
             </p>
           ) : (
-            <ul
-              className="flex flex-col"
-              style={{ rowGap: ROW_GAP }}
-              data-testid={`${testIdPrefix}-chain`}
-            >
+            <div className="relative" data-testid={`${testIdPrefix}-chain-wrap`}>
+              {(ancestorConnectors.length > 0 || descendantConnectors.length > 0) && (
+                <svg
+                  aria-hidden="true"
+                  data-testid={`${testIdPrefix}-connectors`}
+                  className="pointer-events-none absolute inset-0"
+                  width="100%"
+                  height="100%"
+                  style={{ overflow: 'visible' }}
+                >
+                  {ancestorConnectors.map(c => (
+                    <path
+                      key={c.key}
+                      d={connectorPath(c)}
+                      stroke="#9ca3af"
+                      strokeWidth={1.5}
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  ))}
+                  {descendantConnectors.map(c => (
+                    <path
+                      key={c.key}
+                      d={connectorPath(c)}
+                      stroke="#9ca3af"
+                      strokeWidth={1.5}
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  ))}
+                </svg>
+              )}
+              <ul
+                className="relative flex flex-col"
+                style={{ rowGap: ROW_GAP }}
+                data-testid={`${testIdPrefix}-chain`}
+              >
               {N > 0 && (
                 <li
                   data-testid={`${testIdPrefix}-ancestors`}
@@ -777,7 +916,8 @@ const LibraryRowFlipPopover = ({
                   </button>
                 </li>
               )}
-            </ul>
+              </ul>
+            </div>
           )}
         </div>
 

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -37,14 +37,18 @@ import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
 // 340 px card without horizontal scroll. The row width itself is fixed
 // so each rung "floats" right (ancestors) or left (descendants) by a
 // constant offset, producing the staircase.
-const CARD_WIDTH = 340;
+const CARD_WIDTH = 360;
 const CARD_PAD_X = 12;
 const ROW_HEIGHT = 24;
-const ROW_GAP = 4;
-const ROW_WIDTH = 200;
-const MAX_STEP = 22;
-const MIN_STEP = 10;
-const BASE_INDENT = 6;
+const ROW_GAP = 6;
+const ROW_WIDTH = 210;
+const MAX_STEP = 28;
+const MIN_STEP = 14;
+// Direct ancestors and the first descendant row both start at this left
+// offset. It sits to the RIGHT of the subject row's icon (paddingLeft 6
+// + icon width 20 = subject-icon-right at x=26) so the L-shaped tree
+// branching from the subject icon has somewhere to land.
+const BASE_INDENT = 34;
 
 // ---------------------------------------------------------------------------
 // Selector parsing — Visivo selector syntax `[+N]name[+M]`

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -756,26 +756,44 @@ const LibraryRowFlipPopover = ({
   const descendantConnectorPath = ({ parentX, parentY, childX, childY }) =>
     `M ${parentX} ${parentY + ICON_H / 2} L ${parentX} ${childY} L ${childX} ${childY}`;
 
-  // Dotted Γ-connector from each direct ancestor's [type] pill across
+  // Dotted Γ-connectors from each direct ancestor's [type] pill across
   // to the subject icon column and then DOWN to the top of the subject
-  // pill. The corner sits at the top-left of the gamma — horizontal
-  // segment first, then vertical — so the line reads as a header
-  // bracket dropping onto the subject rather than an L-bend.
+  // pill. When more than one direct ancestor exists we draw ONE shared
+  // vertical trunk at the subject icon column and just one horizontal
+  // arm per ancestor — otherwise multiple independent Γs overlap their
+  // vertical segments and produce a solid stripe rather than a tree.
   const dottedConnectors = [];
   if (ancestorsOpen) {
-    ancestors.forEach((node, i) => {
-      if (!node.isDirect) return;
-      const rowLeft = ancestorMarginLeft(node);
-      const startX = rowLeft - 4; // just left of the [type] pill
-      const startY = ancestorRowY(i);
-      const subjectTopY = N * (ROW_HEIGHT + ROW_GAP);
+    const directs = ancestors
+      .map((node, i) => ({ node, i }))
+      .filter(entry => entry.node.isDirect);
+    if (directs.length > 0) {
       const subjectIconX = 6 + ICON_W / 2;
+      const subjectTopY = N * (ROW_HEIGHT + ROW_GAP);
+      const topmostDirectY = ancestorRowY(directs[0].i);
+
+      // Shared vertical "trunk" drops from the topmost direct ancestor's
+      // row mid down to the top of the subject row, then meets the
+      // subject icon column.
       dottedConnectors.push({
-        key: `dotted-${node.name}`,
-        name: node.name,
-        d: `M ${startX} ${startY} L ${subjectIconX} ${startY} L ${subjectIconX} ${subjectTopY}`,
+        key: 'dotted-trunk',
+        name: 'trunk',
+        d: `M ${subjectIconX} ${topmostDirectY} L ${subjectIconX} ${subjectTopY}`,
       });
-    });
+
+      // One horizontal arm per direct ancestor — meets the trunk at the
+      // ancestor row's mid.
+      directs.forEach(({ node, i }) => {
+        const rowLeft = ancestorMarginLeft(node);
+        const startX = rowLeft - 4;
+        const rowMidY = ancestorRowY(i);
+        dottedConnectors.push({
+          key: `dotted-${node.name}`,
+          name: node.name,
+          d: `M ${startX} ${rowMidY} L ${subjectIconX} ${rowMidY}`,
+        });
+      });
+    }
   }
 
   const headerIconType = subjectForRender.type;

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.jsx
@@ -63,18 +63,28 @@ function defaultSelector(name) {
 /**
  * Parse a Visivo selector string into `{ name, ancestors, descendants }`.
  *
- * Examples:
- *   "+revenue_chart+"   → unbounded ancestors + unbounded descendants
- *   "+2revenue_chart+1" → 2 ancestor levels, 1 descendant level
- *   "+revenue_chart"    → unbounded ancestors, no descendants
- *   "revenue_chart"     → just the subject row
+ * Syntax: depth digits sit OUTSIDE the `+`, the `+` always touches the
+ * object name. `+` alone means "unbounded in that direction", a missing
+ * `+` means "no traversal in that direction", and `N+` / `+N` clamps to
+ * N levels.
+ *
+ *   "+revenue_chart+"    → unbounded ancestors + unbounded descendants
+ *   "2+revenue_chart+1"  → 2 ancestor levels, 1 descendant level
+ *   "+revenue_chart"     → unbounded ancestors, no descendants
+ *   "2+revenue_chart"    → 2 ancestor levels, no descendants
+ *   "revenue_chart"      → just the subject row
+ *   "+monthly_revenue+"  → SWAPS the subject to `monthly_revenue` and
+ *                          shows its full upstream + downstream
  */
 function parseSelector(text, fallbackName) {
   const trimmed = String(text || '').trim();
   if (!trimmed) {
     return { name: fallbackName, ancestors: 0, descendants: 0 };
   }
-  const re = /^(\+(\d*))?([^+]+?)(\+(\d*))?$/;
+  // ((\d+)?\+)?   optional leading-depth + `+`
+  // ([^+]+?)      the object name (non-greedy, no `+`)
+  // (\+(\d+)?)?   optional trailing `+` + descendant-depth
+  const re = /^((\d+)?\+)?([^+]+?)(\+(\d+)?)?$/;
   const m = trimmed.match(re);
   if (!m) {
     return { name: fallbackName, ancestors: 0, descendants: 0 };
@@ -542,45 +552,56 @@ const LibraryRowFlipPopover = ({
     [selectorText, obj?.name]
   );
 
+  const storeApi = useMemo(
+    () => ({
+      charts,
+      insights,
+      models,
+      tables,
+      sources,
+      dimensions,
+      metrics,
+      relations: relationsList,
+      markdowns,
+      inputs,
+      allDashboards: dashboardsForWalker,
+      csvScriptModels,
+      localMergeModels,
+      defaults,
+    }),
+    [
+      charts,
+      insights,
+      models,
+      tables,
+      sources,
+      dimensions,
+      metrics,
+      relationsList,
+      markdowns,
+      inputs,
+      dashboardsForWalker,
+      csvScriptModels,
+      localMergeModels,
+      defaults,
+    ]
+  );
+
+  // The selector input is allowed to swap the SUBJECT in addition to
+  // clamping depths. When the parsed name resolves to an object in the
+  // store and isn't the row's own name, we render that object as the
+  // subject (so a user can chase a name they spot in the lineage).
+  const effectiveSubject = useMemo(() => {
+    if (!scope.name || !obj || scope.name === obj.name) return obj;
+    const index = buildTypeIndex(storeApi);
+    const hit = index.get(scope.name);
+    if (hit) return { type: hit.type, name: scope.name };
+    return obj;
+  }, [scope.name, obj, storeApi]);
+
   const lineage = useMemo(() => {
-    return buildLineageRelations(
-      obj,
-      {
-        charts,
-        insights,
-        models,
-        tables,
-        sources,
-        dimensions,
-        metrics,
-        relations: relationsList,
-        markdowns,
-        inputs,
-        allDashboards: dashboardsForWalker,
-        csvScriptModels,
-        localMergeModels,
-        defaults,
-      },
-      scope
-    );
-  }, [
-    obj,
-    scope,
-    charts,
-    insights,
-    models,
-    tables,
-    sources,
-    dimensions,
-    metrics,
-    relationsList,
-    markdowns,
-    inputs,
-    dashboardsForWalker,
-    csvScriptModels,
-    localMergeModels,
-    defaults,
-  ]);
+    return buildLineageRelations(effectiveSubject, storeApi, scope);
+  }, [effectiveSubject, scope, storeApi]);
 
   useEffect(() => {
     const onKey = e => {
@@ -601,6 +622,7 @@ const LibraryRowFlipPopover = ({
 
   if (!obj) return null;
 
+  const subjectForRender = effectiveSubject || obj;
   const ancestors = lineage.ancestors;
   const descendants = lineage.descendants;
   const N = ancestors.length;
@@ -667,7 +689,7 @@ const LibraryRowFlipPopover = ({
   if (ancestorsOpen) {
     ancestors.forEach((parent, parentIdx) => {
       (parent.childNames || []).forEach(childName => {
-        if (childName === obj.name) return; // direct → handled by dotted line
+        if (childName === subjectForRender.name) return; // direct → handled by dotted line
         const child = ancestorByName.get(childName);
         if (!child) return;
         ancestorConnectors.push({
@@ -694,7 +716,7 @@ const LibraryRowFlipPopover = ({
         });
       } else {
         (node.parentNames || []).forEach(parentName => {
-          if (parentName === obj.name) return; // handled above as direct
+          if (parentName === subjectForRender.name) return; // handled above as direct
           const parent = descendantByName.get(parentName);
           if (!parent) return;
           descendantConnectors.push({
@@ -756,12 +778,14 @@ const LibraryRowFlipPopover = ({
     });
   }
 
+  const headerIconType = subjectForRender.type;
+
   return createPortal(
     <div
       ref={popoverRef}
       data-testid={testIdPrefix}
       role="dialog"
-      aria-label={`Lineage preview for ${obj.name}`}
+      aria-label={`Lineage preview for ${subjectForRender.name}`}
       className="fixed z-50"
       style={{
         top: position.top,
@@ -777,14 +801,14 @@ const LibraryRowFlipPopover = ({
       <div className="relative rounded-lg bg-white shadow-lg ring-1 ring-gray-200">
         <header className="flex h-8 items-center gap-2 border-b border-gray-200 px-3">
           {(() => {
-            const Icon = getTypeIcon(obj.type);
+            const Icon = getTypeIcon(headerIconType);
             return <Icon style={{ fontSize: 14 }} className="text-gray-500" />;
           })()}
           <span
             data-testid={`${testIdPrefix}-name`}
             className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-gray-900"
           >
-            {obj.name}
+            {subjectForRender.name}
           </span>
           <span className="shrink-0 text-[10px] font-medium uppercase tracking-wider text-gray-400">
             lineage
@@ -930,7 +954,7 @@ const LibraryRowFlipPopover = ({
                 </li>
               )}
 
-              <SubjectRow subject={obj} testIdPrefix={testIdPrefix} />
+              <SubjectRow subject={subjectForRender} testIdPrefix={testIdPrefix} />
 
               {M > 0 && (
                 <li

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
@@ -173,10 +173,10 @@ describe('LibraryRowFlipPopover — editable selector', () => {
     expect(input).toHaveValue('+revenue_chart+');
   });
 
-  test('typing `+1revenue_chart+1` clamps ancestor depth to 1 and descendant to 1', () => {
+  test('typing `1+revenue_chart+1` clamps ancestor depth to 1 and descendant to 1', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
     const input = screen.getByTestId('library-flip-popover-selector-input');
-    fireEvent.change(input, { target: { value: '+1revenue_chart+1' } });
+    fireEvent.change(input, { target: { value: '1+revenue_chart+1' } });
     // Direct insights still render, but their parent models + source must NOT.
     expect(
       screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
@@ -203,6 +203,42 @@ describe('LibraryRowFlipPopover — editable selector', () => {
     expect(
       screen.queryByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
     ).toBeNull();
+  });
+
+  test('changing the selector to a different object name swaps the subject', () => {
+    // Popover opens for revenue_chart; user retypes the selector to
+    // `+monthly_revenue+` — the popover should now render
+    // monthly_revenue's lineage (its own upstream source + its
+    // downstream insight) rather than revenue_chart's.
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const input = screen.getByTestId('library-flip-popover-selector-input');
+    fireEvent.change(input, { target: { value: '+monthly_revenue+' } });
+    // The header + subject row swap to monthly_revenue.
+    expect(screen.getByTestId('library-flip-popover-name')).toHaveTextContent(
+      'monthly_revenue'
+    );
+    const subjectRow = screen.getByTestId('library-flip-popover-lineage-subject');
+    expect(subjectRow).toHaveTextContent('monthly_revenue');
+    // monthly_revenue's downstream insight surfaces (it didn't before).
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toHaveAttribute('data-direction', 'descendant');
+    // monthly_revenue's upstream source surfaces as an ancestor.
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-source-local_postgres')
+    ).toHaveAttribute('data-direction', 'ancestor');
+  });
+
+  test('selector with an unknown name falls back to the original subject', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const input = screen.getByTestId('library-flip-popover-selector-input');
+    fireEvent.change(input, { target: { value: '+definitely_does_not_exist+' } });
+    // Header keeps the original row name; the lineage list collapses
+    // because the typed name doesn't resolve and the original subject's
+    // depth limits still apply (unbounded here).
+    expect(screen.getByTestId('library-flip-popover-name')).toHaveTextContent(
+      'revenue_chart'
+    );
   });
 });
 
@@ -272,11 +308,19 @@ describe('parseSelector', () => {
     });
   });
 
-  test('`+2name+1` clamps ancestor depth to 2 and descendant to 1', () => {
-    expect(parseSelector('+2revenue_chart+1', 'fallback')).toEqual({
+  test('`2+name+1` clamps ancestor depth to 2 and descendant to 1', () => {
+    expect(parseSelector('2+revenue_chart+1', 'fallback')).toEqual({
       name: 'revenue_chart',
       ancestors: 2,
       descendants: 1,
+    });
+  });
+
+  test('`2+name+` clamps ancestor depth to 2 and leaves descendants unbounded', () => {
+    expect(parseSelector('2+revenue_chart+', 'fallback')).toEqual({
+      name: 'revenue_chart',
+      ancestors: 2,
+      descendants: UNBOUNDED,
     });
   });
 

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
@@ -403,6 +403,37 @@ describe('buildLineageRelations', () => {
     );
     expect(relations.ancestors.map(n => n.type).sort()).toEqual(['insight', 'insight']);
   });
+
+  test('flags terminal ancestors (no upstream of their own) for layout bumping', () => {
+    // Seed: insight has both a model AND an input as direct ancestors.
+    // The model has a source upstream → not terminal. The input has
+    // nothing upstream → terminal. Both are at depth 1.
+    act(() => {
+      useStore.setState({
+        ...useStore.getState(),
+        charts: [],
+        insights: [
+          {
+            name: 'date_insight',
+            child_item_names: ['daily_metrics', 'autocomplete_date'],
+          },
+        ],
+        models: [{ name: 'daily_metrics', child_item_names: ['local_postgres'] }],
+        sources: [{ name: 'local_postgres', child_item_names: [] }],
+        inputs: [{ name: 'autocomplete_date', child_item_names: [] }],
+      });
+    });
+    const relations = buildLineageRelations(
+      { type: 'insight', name: 'date_insight' },
+      storeApi()
+    );
+    const model = relations.ancestors.find(n => n.name === 'daily_metrics');
+    const input = relations.ancestors.find(n => n.name === 'autocomplete_date');
+    const source = relations.ancestors.find(n => n.name === 'local_postgres');
+    expect(model.isTerminal).toBe(false); // has source upstream
+    expect(input.isTerminal).toBe(true);  // nothing upstream
+    expect(source.isTerminal).toBe(true);
+  });
 });
 
 describe('default selector helper', () => {

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
@@ -1,69 +1,177 @@
 /**
- * LibraryRowFlipPopover behaviour (VIS-776 / Track C C3).
+ * LibraryRowFlipPopover behaviour (VIS-776 — refined C-3 flip-card design).
  *
- * Verifies the popover renders the subject + an inline mini-lineage chain
- * derived from the existing zustand store. C-2's shared <MiniLineageCard>
- * is deferred to VIS-780 (blocked by D-6).
+ * The popover renders three sections inside its body:
+ *   1. Ancestors  : [type] [name] [icon] rows, right-aligned ladder.
+ *   2. Subject    : full-width row with [icon] left, [name] centred,
+ *                   [type] right — no THIS pill.
+ *   3. Descendants: [icon] [name] [type] rows, left-aligned ladder.
+ *
+ * The refined ladder + collapse + scroll behaviour replaces the inline
+ * chain placeholder that shipped with the original VIS-776; the shared
+ * `<MiniLineageCard>` migration still lands with VIS-780 (C-4).
  */
 import React from 'react';
 import { render, screen, within, act, fireEvent } from '@testing-library/react';
 import useStore from '../../../../stores/store';
-import LibraryRowFlipPopover, { buildChainFromStore } from './LibraryRowFlipPopover';
+import LibraryRowFlipPopover, {
+  buildLineageRelations,
+  buildChainFromStore,
+} from './LibraryRowFlipPopover';
 
-const SUBJECT_CHART = { type: 'chart', name: 'waterfall' };
+const SUBJECT_CHART = { type: 'chart', name: 'revenue_chart' };
 
 const seedStore = () => {
   act(() => {
     useStore.setState({
       charts: [
-        { name: 'waterfall', insights: ['revenue_growth'] },
+        {
+          name: 'revenue_chart',
+          insights: ['revenue_breakdown', 'cohort_retention'],
+        },
       ],
       insights: [
-        { name: 'revenue_growth', model: 'monthly_revenue' },
+        { name: 'revenue_breakdown', model: 'monthly_revenue' },
+        { name: 'cohort_retention', model: 'customers' },
       ],
       models: [
-        { name: 'monthly_revenue', source: 'pg' },
+        { name: 'monthly_revenue', source: 'local_postgres' },
+        { name: 'customers', source: 'local_postgres' },
       ],
       csvScriptModels: [],
       localMergeModels: [],
-      sources: [{ name: 'pg' }],
+      sources: [{ name: 'local_postgres' }],
+      tables: [],
+      allDashboards: [
+        {
+          name: 'exec_kpi_dashboard',
+          rows: [{ items: [{ chart: 'revenue_chart' }] }],
+        },
+      ],
     });
   });
 };
 
-describe('LibraryRowFlipPopover', () => {
+describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
   beforeEach(() => {
     seedStore();
   });
 
-  test('renders the subject name + lineage chain rows', () => {
+  test('renders ancestor rows in [type] [name] [icon] order with dotted lines for direct ancestors', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
-    expect(screen.getByTestId('library-flip-popover')).toBeInTheDocument();
-    expect(screen.getByTestId('library-flip-popover-name')).toHaveTextContent('waterfall');
-    expect(screen.getByTestId('library-flip-popover-chain')).toBeInTheDocument();
-    // The subject row + a chain of upstream nodes (insight → model → source).
-    expect(
-      screen.getByTestId('library-flip-popover-lineage-chart-waterfall')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('library-flip-popover-lineage-insight-revenue_growth')
-    ).toBeInTheDocument();
+
+    // Ancestor rows are tagged with data-direction="ancestor".
+    const ancestorInsightRow = screen.getByTestId(
+      'library-flip-popover-lineage-insight-revenue_breakdown'
+    );
+    expect(ancestorInsightRow).toHaveAttribute('data-direction', 'ancestor');
+    expect(ancestorInsightRow).toHaveAttribute('data-direct', 'true');
+
+    // The model + source rows are transitive ancestors.
     expect(
       screen.getByTestId('library-flip-popover-lineage-model-monthly_revenue')
+    ).toHaveAttribute('data-direct', 'false');
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-source-local_postgres')
+    ).toHaveAttribute('data-direct', 'false');
+
+    // Direct ancestors render a dotted connector that drops down to the subject.
+    expect(
+      screen.getByTestId('library-flip-popover-dotted-revenue_breakdown')
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId('library-flip-popover-lineage-source-pg')
+      screen.getByTestId('library-flip-popover-dotted-cohort_retention')
     ).toBeInTheDocument();
   });
 
-  test('renders the empty body when no ancestors are available', () => {
+  test('renders the subject row with [icon] left, [name] centred, [type] right and no THIS pill', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const subjectRow = screen.getByTestId('library-flip-popover-lineage-subject');
+    expect(subjectRow).toHaveAttribute('data-direction', 'subject');
+    expect(subjectRow).toHaveTextContent('revenue_chart');
+    // Refined design removes the "THIS" pill in favour of the [type] pill alignment.
+    expect(within(subjectRow).queryByText(/this/i)).toBeNull();
+    // The [type] pill (exact "chart" — distinct from the name "revenue_chart")
+    // is still present on the row.
+    expect(within(subjectRow).getByText('chart')).toBeInTheDocument();
+  });
+
+  test('renders descendant rows in [icon] [name] [type] order', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const descendantRow = screen.getByTestId(
+      'library-flip-popover-lineage-dashboard-exec_kpi_dashboard'
+    );
+    expect(descendantRow).toHaveAttribute('data-direction', 'descendant');
+    expect(descendantRow).toHaveAttribute('data-direct', 'true');
+  });
+
+  test('lowest ancestor and first descendant share the same left padding (ladder meet point)', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    // Last ancestor in display order: cohort_retention (direct, sits just above subject).
+    const lowestAncestor = screen.getByTestId(
+      'library-flip-popover-lineage-insight-cohort_retention'
+    );
+    const firstDescendant = screen.getByTestId(
+      'library-flip-popover-lineage-dashboard-exec_kpi_dashboard'
+    );
+    expect(lowestAncestor.style.paddingLeft).toBe(firstDescendant.style.paddingLeft);
+  });
+
+  test('ancestor rows shift progressively left so the ladder widens toward the subject', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const topAncestor = screen.getByTestId(
+      'library-flip-popover-lineage-source-local_postgres'
+    );
+    const lowestAncestor = screen.getByTestId(
+      'library-flip-popover-lineage-insight-cohort_retention'
+    );
+    expect(parseInt(topAncestor.style.paddingLeft, 10)).toBeGreaterThan(
+      parseInt(lowestAncestor.style.paddingLeft, 10)
+    );
+  });
+
+  test('clicking the ancestors toggle collapses + re-expands the ancestor ladder', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('library-flip-popover-ancestors-toggle'));
+    // Collapsed → ancestor rows are gone, summary chip is shown.
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toBeNull();
+    expect(
+      screen.getByTestId('library-flip-popover-ancestors')
+    ).toHaveAttribute('data-collapsed', 'true');
+    // Re-expand restores the rows.
+    fireEvent.click(screen.getByTestId('library-flip-popover-ancestors-toggle'));
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toBeInTheDocument();
+  });
+
+  test('clicking the descendants toggle collapses the descendant ladder', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('library-flip-popover-descendants-toggle'));
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+    ).toBeNull();
+    expect(
+      screen.getByTestId('library-flip-popover-descendants')
+    ).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  test('renders the empty body for an object with neither upstream nor downstream', () => {
     render(
       <LibraryRowFlipPopover obj={{ type: 'source', name: 'orphan' }} onClose={jest.fn()} />
     );
     expect(screen.getByTestId('library-flip-popover-empty')).toBeInTheDocument();
   });
 
-  test('renders the deferred-card footer note pointing at VIS-780', () => {
+  test('still renders the deferred-card footer note pointing at VIS-780', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
     expect(screen.getByTestId('library-flip-popover-deferred-note')).toHaveTextContent(
       'VIS-780'
@@ -71,12 +179,6 @@ describe('LibraryRowFlipPopover', () => {
   });
 
   test('renders into document.body via portal so the rail overflow does not clip it', () => {
-    // Regression: the rail's `overflow-y-auto` ancestor coerces horizontal
-    // overflow to `auto` per the CSS spec, which clipped the popover when
-    // it was rendered inside the rail's React subtree. The popover now
-    // escapes via createPortal into document.body — verify by asserting
-    // it's NOT inside testing-library's render container but IS in the
-    // document.
     const { container } = render(
       <LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />
     );
@@ -97,22 +199,65 @@ describe('LibraryRowFlipPopover', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
+});
 
-  test('buildChainFromStore walks chart → insight → model → source', () => {
-    const chain = buildChainFromStore(
-      { type: 'chart', name: 'waterfall' },
-      {
-        getChartByName: useStore.getState().getChartByName,
-        getInsightByName: useStore.getState().getInsightByName,
-        getModelByName: useStore.getState().getModelByName,
-        csvScriptModels: [],
-        localMergeModels: [],
-      }
+describe('buildLineageRelations', () => {
+  beforeEach(() => {
+    seedStore();
+  });
+
+  const storeApi = () => ({
+    getChartByName: useStore.getState().getChartByName,
+    getInsightByName: useStore.getState().getInsightByName,
+    getModelByName: useStore.getState().getModelByName,
+    charts: useStore.getState().charts,
+    insights: useStore.getState().insights,
+    models: useStore.getState().models,
+    tables: useStore.getState().tables,
+    allDashboards: useStore.getState().allDashboards,
+    csvScriptModels: [],
+    localMergeModels: [],
+  });
+
+  test('returns both upstream and downstream relations for a chart', () => {
+    const relations = buildLineageRelations(
+      { type: 'chart', name: 'revenue_chart' },
+      storeApi()
     );
-    expect(chain.map((n) => `${n.type}:${n.name}`)).toEqual([
-      'insight:revenue_growth',
+    // Ancestors include the per-insight branch (model + insight) for each direct insight.
+    expect(relations.ancestors.map(n => `${n.type}:${n.name}`)).toEqual([
+      'source:local_postgres',
       'model:monthly_revenue',
-      'source:pg',
+      'insight:revenue_breakdown',
+      'model:customers',
+      'insight:cohort_retention',
     ]);
+    // Direct insights are flagged so the popover can drop a dotted line from them.
+    const direct = relations.ancestors.filter(n => n.isDirect).map(n => n.name);
+    expect(direct).toEqual(['revenue_breakdown', 'cohort_retention']);
+    // Descendants surface the dashboard that contains the chart.
+    expect(relations.descendants.map(n => `${n.type}:${n.name}`)).toEqual([
+      'dashboard:exec_kpi_dashboard',
+    ]);
+  });
+
+  test('returns models as downstream for a source', () => {
+    const relations = buildLineageRelations(
+      { type: 'source', name: 'local_postgres' },
+      storeApi()
+    );
+    expect(relations.ancestors).toEqual([]);
+    expect(relations.descendants.map(n => n.name).sort()).toEqual([
+      'customers',
+      'monthly_revenue',
+    ]);
+  });
+
+  test('legacy buildChainFromStore still returns the ancestor chain', () => {
+    const chain = buildChainFromStore({ type: 'chart', name: 'revenue_chart' }, storeApi());
+    expect(chain.length).toBeGreaterThan(0);
+    expect(chain.every(n => typeof n.type === 'string' && typeof n.name === 'string')).toBe(
+      true
+    );
   });
 });

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
@@ -1,22 +1,25 @@
 /**
  * LibraryRowFlipPopover behaviour (VIS-776 — refined C-3 flip-card design).
  *
- * The popover renders three sections inside its body:
- *   1. Ancestors  : [type] [name] [icon] rows, right-aligned ladder.
- *   2. Subject    : full-width row with [icon] left, [name] centred,
- *                   [type] right — no THIS pill.
- *   3. Descendants: [icon] [name] [type] rows, left-aligned ladder.
+ * Coverage:
+ *   - Ancestor + descendant ladders render with the staircase shift.
+ *   - Subject row pins icon left / type right, no THIS pill.
+ *   - Direct ancestors drop a dotted L connector toward the subject.
+ *   - Colours come from `objectTypeConfigs` (so `chart` rows carry the
+ *     `bg-pink-100` class, `model` rows carry `bg-amber-100`, etc.).
+ *   - Selector input is editable and parses `+N name +M` syntax.
+ *   - Collapse + scroll handles complex trees in a small surface.
  *
- * The refined ladder + collapse + scroll behaviour replaces the inline
- * chain placeholder that shipped with the original VIS-776; the shared
- * `<MiniLineageCard>` migration still lands with VIS-780 (C-4).
+ * The shared `<MiniLineageCard>` migration still lands with VIS-780.
  */
 import React from 'react';
 import { render, screen, within, act, fireEvent } from '@testing-library/react';
 import useStore from '../../../../stores/store';
 import LibraryRowFlipPopover, {
   buildLineageRelations,
-  buildChainFromStore,
+  parseSelector,
+  defaultSelector,
+  UNBOUNDED,
 } from './LibraryRowFlipPopover';
 
 const SUBJECT_CHART = { type: 'chart', name: 'revenue_chart' };
@@ -57,22 +60,23 @@ const seedStore = () => {
   });
 };
 
-describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
+describe('LibraryRowFlipPopover — staircase layout', () => {
   beforeEach(() => {
     seedStore();
   });
 
-  test('renders ancestor rows in [type] [name] [icon] order with dotted lines for direct ancestors', () => {
+  test('renders ancestors above the subject and descendants below, both with direct-flagged rows', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
 
-    // Ancestor rows are tagged with data-direction="ancestor".
-    const ancestorInsightRow = screen.getByTestId(
-      'library-flip-popover-lineage-insight-revenue_breakdown'
-    );
-    expect(ancestorInsightRow).toHaveAttribute('data-direction', 'ancestor');
-    expect(ancestorInsightRow).toHaveAttribute('data-direct', 'true');
+    // Direct insights are flagged so the popover drops a dotted line from them.
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toHaveAttribute('data-direct', 'true');
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-cohort_retention')
+    ).toHaveAttribute('data-direct', 'true');
 
-    // The model + source rows are transitive ancestors.
+    // Transitive ancestors are present but not flagged direct.
     expect(
       screen.getByTestId('library-flip-popover-lineage-model-monthly_revenue')
     ).toHaveAttribute('data-direct', 'false');
@@ -80,7 +84,12 @@ describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
       screen.getByTestId('library-flip-popover-lineage-source-local_postgres')
     ).toHaveAttribute('data-direct', 'false');
 
-    // Direct ancestors render a dotted connector that drops down to the subject.
+    // Descendant: the dashboard that contains revenue_chart.
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+    ).toHaveAttribute('data-direct', 'true');
+
+    // Dotted connectors mount once per direct ancestor.
     expect(
       screen.getByTestId('library-flip-popover-dotted-revenue_breakdown')
     ).toBeInTheDocument();
@@ -89,50 +98,117 @@ describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders the subject row with [icon] left, [name] centred, [type] right and no THIS pill', () => {
+  test('row colours come from objectTypeConfigs (not hand-rolled hex codes)', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+
+    // `chart` carries the shared pink palette; `model` carries amber; `insight`
+    // carries purple; `source` carries orange — see objectTypeConfigs.js.
     const subjectRow = screen.getByTestId('library-flip-popover-lineage-subject');
-    expect(subjectRow).toHaveAttribute('data-direction', 'subject');
-    expect(subjectRow).toHaveTextContent('revenue_chart');
-    // Refined design removes the "THIS" pill in favour of the [type] pill alignment.
-    expect(within(subjectRow).queryByText(/this/i)).toBeNull();
-    // The [type] pill (exact "chart" — distinct from the name "revenue_chart")
-    // is still present on the row.
-    expect(within(subjectRow).getByText('chart')).toBeInTheDocument();
+    expect(subjectRow.className).toMatch(/bg-pink-100/);
+    expect(within(subjectRow).getByText('chart').className).toMatch(/bg-pink-100/);
+
+    expect(
+      within(
+        screen.getByTestId('library-flip-popover-lineage-model-monthly_revenue')
+      ).getByText('model').className
+    ).toMatch(/bg-amber-100/);
+
+    expect(
+      within(
+        screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+      ).getByText('insight').className
+    ).toMatch(/bg-purple-100/);
+
+    expect(
+      within(
+        screen.getByTestId('library-flip-popover-lineage-source-local_postgres')
+      ).getByText('source').className
+    ).toMatch(/bg-orange-100/);
+
+    expect(
+      within(
+        screen.getByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+      ).getByText('dashboard').className
+    ).toMatch(/bg-rose-100/);
   });
 
-  test('renders descendant rows in [icon] [name] [type] order', () => {
+  test('rows form a staircase — direct ancestor and first descendant share BASE_INDENT', () => {
     render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
-    const descendantRow = screen.getByTestId(
-      'library-flip-popover-lineage-dashboard-exec_kpi_dashboard'
-    );
-    expect(descendantRow).toHaveAttribute('data-direction', 'descendant');
-    expect(descendantRow).toHaveAttribute('data-direct', 'true');
-  });
-
-  test('lowest ancestor and first descendant share the same left padding (ladder meet point)', () => {
-    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
-    // Last ancestor in display order: cohort_retention (direct, sits just above subject).
     const lowestAncestor = screen.getByTestId(
       'library-flip-popover-lineage-insight-cohort_retention'
     );
     const firstDescendant = screen.getByTestId(
       'library-flip-popover-lineage-dashboard-exec_kpi_dashboard'
     );
-    expect(lowestAncestor.style.paddingLeft).toBe(firstDescendant.style.paddingLeft);
-  });
+    expect(lowestAncestor.style.marginLeft).toBe(firstDescendant.style.marginLeft);
 
-  test('ancestor rows shift progressively left so the ladder widens toward the subject', () => {
-    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    // Topmost ancestor (deepest = source) sits further right than the
+    // direct insight — that's the staircase widening toward the subject.
     const topAncestor = screen.getByTestId(
       'library-flip-popover-lineage-source-local_postgres'
     );
-    const lowestAncestor = screen.getByTestId(
-      'library-flip-popover-lineage-insight-cohort_retention'
+    expect(parseInt(topAncestor.style.marginLeft, 10)).toBeGreaterThan(
+      parseInt(lowestAncestor.style.marginLeft, 10)
     );
-    expect(parseInt(topAncestor.style.paddingLeft, 10)).toBeGreaterThan(
-      parseInt(lowestAncestor.style.paddingLeft, 10)
-    );
+  });
+
+  test('subject row pins icon left, type right, name centred, no THIS pill', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const subjectRow = screen.getByTestId('library-flip-popover-lineage-subject');
+    expect(subjectRow).toHaveAttribute('data-direction', 'subject');
+    expect(subjectRow).toHaveTextContent('revenue_chart');
+    expect(within(subjectRow).queryByText(/^this$/i)).toBeNull();
+    expect(within(subjectRow).getByText('chart')).toBeInTheDocument();
+  });
+});
+
+describe('LibraryRowFlipPopover — editable selector', () => {
+  beforeEach(() => {
+    seedStore();
+  });
+
+  test('defaults to `+name+` (unbounded both directions)', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const input = screen.getByTestId('library-flip-popover-selector-input');
+    expect(input).toHaveValue('+revenue_chart+');
+  });
+
+  test('typing `+1revenue_chart+1` clamps ancestor depth to 1 and descendant to 1', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const input = screen.getByTestId('library-flip-popover-selector-input');
+    fireEvent.change(input, { target: { value: '+1revenue_chart+1' } });
+    // Direct insights still render, but their parent models + source must NOT.
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-model-monthly_revenue')
+    ).toBeNull();
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-source-local_postgres')
+    ).toBeNull();
+    // Descendant depth 1 still surfaces the dashboard.
+    expect(
+      screen.getByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+    ).toBeInTheDocument();
+  });
+
+  test('typing `revenue_chart` (no plus) hides both ladders', () => {
+    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
+    const input = screen.getByTestId('library-flip-popover-selector-input');
+    fireEvent.change(input, { target: { value: 'revenue_chart' } });
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
+    ).toBeNull();
+    expect(
+      screen.queryByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
+    ).toBeNull();
+  });
+});
+
+describe('LibraryRowFlipPopover — collapse and empty state', () => {
+  beforeEach(() => {
+    seedStore();
   });
 
   test('clicking the ancestors toggle collapses + re-expands the ancestor ladder', () => {
@@ -141,32 +217,13 @@ describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
       screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
     ).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('library-flip-popover-ancestors-toggle'));
-    // Collapsed → ancestor rows are gone, summary chip is shown.
     expect(
       screen.queryByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
     ).toBeNull();
-    expect(
-      screen.getByTestId('library-flip-popover-ancestors')
-    ).toHaveAttribute('data-collapsed', 'true');
-    // Re-expand restores the rows.
     fireEvent.click(screen.getByTestId('library-flip-popover-ancestors-toggle'));
     expect(
       screen.getByTestId('library-flip-popover-lineage-insight-revenue_breakdown')
     ).toBeInTheDocument();
-  });
-
-  test('clicking the descendants toggle collapses the descendant ladder', () => {
-    render(<LibraryRowFlipPopover obj={SUBJECT_CHART} onClose={jest.fn()} />);
-    expect(
-      screen.getByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('library-flip-popover-descendants-toggle'));
-    expect(
-      screen.queryByTestId('library-flip-popover-lineage-dashboard-exec_kpi_dashboard')
-    ).toBeNull();
-    expect(
-      screen.getByTestId('library-flip-popover-descendants')
-    ).toHaveAttribute('data-collapsed', 'true');
   });
 
   test('renders the empty body for an object with neither upstream nor downstream', () => {
@@ -206,6 +263,56 @@ describe('LibraryRowFlipPopover (refined C-3 layout)', () => {
   });
 });
 
+describe('parseSelector', () => {
+  test('`+name+` is unbounded both directions', () => {
+    expect(parseSelector('+revenue_chart+', 'revenue_chart')).toEqual({
+      name: 'revenue_chart',
+      ancestors: UNBOUNDED,
+      descendants: UNBOUNDED,
+    });
+  });
+
+  test('`+2name+1` clamps ancestor depth to 2 and descendant to 1', () => {
+    expect(parseSelector('+2revenue_chart+1', 'fallback')).toEqual({
+      name: 'revenue_chart',
+      ancestors: 2,
+      descendants: 1,
+    });
+  });
+
+  test('`+name` is unbounded ancestors only', () => {
+    expect(parseSelector('+revenue_chart', 'fallback')).toEqual({
+      name: 'revenue_chart',
+      ancestors: UNBOUNDED,
+      descendants: 0,
+    });
+  });
+
+  test('`name+` is unbounded descendants only', () => {
+    expect(parseSelector('revenue_chart+', 'fallback')).toEqual({
+      name: 'revenue_chart',
+      ancestors: 0,
+      descendants: UNBOUNDED,
+    });
+  });
+
+  test('`name` returns just the subject', () => {
+    expect(parseSelector('revenue_chart', 'fallback')).toEqual({
+      name: 'revenue_chart',
+      ancestors: 0,
+      descendants: 0,
+    });
+  });
+
+  test('empty string falls back to the supplied default', () => {
+    expect(parseSelector('', 'fallback')).toEqual({
+      name: 'fallback',
+      ancestors: 0,
+      descendants: 0,
+    });
+  });
+});
+
 describe('buildLineageRelations', () => {
   beforeEach(() => {
     seedStore();
@@ -227,12 +334,11 @@ describe('buildLineageRelations', () => {
     localMergeModels: [],
   });
 
-  test('returns both upstream and downstream relations for a chart', () => {
+  test('returns both upstream and downstream relations for a chart with default unbounded scope', () => {
     const relations = buildLineageRelations(
       { type: 'chart', name: 'revenue_chart' },
       storeApi()
     );
-    // Ancestors include the per-insight branch (model + insight) for each direct insight.
     expect(relations.ancestors.map(n => `${n.type}:${n.name}`)).toEqual([
       'source:local_postgres',
       'model:monthly_revenue',
@@ -240,39 +346,23 @@ describe('buildLineageRelations', () => {
       'model:customers',
       'insight:cohort_retention',
     ]);
-    // Direct insights are flagged so the popover can drop a dotted line from them.
-    const direct = relations.ancestors.filter(n => n.isDirect).map(n => n.name);
-    expect(direct).toEqual(['revenue_breakdown', 'cohort_retention']);
-    // Descendants surface the dashboard that contains the chart.
     expect(relations.descendants.map(n => `${n.type}:${n.name}`)).toEqual([
       'dashboard:exec_kpi_dashboard',
     ]);
   });
 
-  test('walks the full downstream subtree from a source', () => {
+  test('ancestor depth limit excludes deeper ancestors', () => {
     const relations = buildLineageRelations(
-      { type: 'source', name: 'local_postgres' },
-      storeApi()
+      { type: 'chart', name: 'revenue_chart' },
+      storeApi(),
+      { ancestors: 1, descendants: UNBOUNDED }
     );
-    expect(relations.ancestors).toEqual([]);
-    const byType = relations.descendants.reduce((acc, n) => {
-      (acc[n.type] = acc[n.type] || []).push(n.name);
-      return acc;
-    }, {});
-    expect(byType.model.sort()).toEqual(['customers', 'monthly_revenue']);
-    expect(byType.insight.sort()).toEqual(['cohort_retention', 'revenue_breakdown']);
-    expect(byType.chart).toEqual(['revenue_chart']);
-    expect(byType.dashboard).toEqual(['exec_kpi_dashboard']);
-    // Only the immediate downstream of the source is flagged as direct.
-    const direct = relations.descendants.filter(n => n.isDirect).map(n => n.name).sort();
-    expect(direct).toEqual(['customers', 'monthly_revenue']);
+    expect(relations.ancestors.map(n => n.type).sort()).toEqual(['insight', 'insight']);
   });
+});
 
-  test('legacy buildChainFromStore still returns the ancestor chain', () => {
-    const chain = buildChainFromStore({ type: 'chart', name: 'revenue_chart' }, storeApi());
-    expect(chain.length).toBeGreaterThan(0);
-    expect(chain.every(n => typeof n.type === 'string' && typeof n.name === 'string')).toBe(
-      true
-    );
+describe('default selector helper', () => {
+  test('formats a name into `+name+`', () => {
+    expect(defaultSelector('revenue_chart')).toBe('+revenue_chart+');
   });
 });

--- a/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRowFlipPopover.test.jsx
@@ -27,21 +27,26 @@ const seedStore = () => {
       charts: [
         {
           name: 'revenue_chart',
-          insights: ['revenue_breakdown', 'cohort_retention'],
+          child_item_names: ['revenue_breakdown', 'cohort_retention'],
         },
       ],
       insights: [
-        { name: 'revenue_breakdown', model: 'monthly_revenue' },
-        { name: 'cohort_retention', model: 'customers' },
+        { name: 'revenue_breakdown', child_item_names: ['monthly_revenue'] },
+        { name: 'cohort_retention', child_item_names: ['customers'] },
       ],
       models: [
-        { name: 'monthly_revenue', source: 'local_postgres' },
-        { name: 'customers', source: 'local_postgres' },
+        { name: 'monthly_revenue', child_item_names: ['local_postgres'] },
+        { name: 'customers', child_item_names: ['local_postgres'] },
       ],
       csvScriptModels: [],
       localMergeModels: [],
-      sources: [{ name: 'local_postgres' }],
+      sources: [{ name: 'local_postgres', child_item_names: [] }],
       tables: [],
+      markdowns: [],
+      inputs: [],
+      dimensions: [],
+      metrics: [],
+      relations: [],
       allDashboards: [
         {
           name: 'exec_kpi_dashboard',
@@ -207,13 +212,16 @@ describe('buildLineageRelations', () => {
   });
 
   const storeApi = () => ({
-    getChartByName: useStore.getState().getChartByName,
-    getInsightByName: useStore.getState().getInsightByName,
-    getModelByName: useStore.getState().getModelByName,
     charts: useStore.getState().charts,
     insights: useStore.getState().insights,
     models: useStore.getState().models,
     tables: useStore.getState().tables,
+    sources: useStore.getState().sources,
+    dimensions: useStore.getState().dimensions,
+    metrics: useStore.getState().metrics,
+    relations: useStore.getState().relations,
+    markdowns: useStore.getState().markdowns,
+    inputs: useStore.getState().inputs,
     allDashboards: useStore.getState().allDashboards,
     csvScriptModels: [],
     localMergeModels: [],
@@ -241,16 +249,23 @@ describe('buildLineageRelations', () => {
     ]);
   });
 
-  test('returns models as downstream for a source', () => {
+  test('walks the full downstream subtree from a source', () => {
     const relations = buildLineageRelations(
       { type: 'source', name: 'local_postgres' },
       storeApi()
     );
     expect(relations.ancestors).toEqual([]);
-    expect(relations.descendants.map(n => n.name).sort()).toEqual([
-      'customers',
-      'monthly_revenue',
-    ]);
+    const byType = relations.descendants.reduce((acc, n) => {
+      (acc[n.type] = acc[n.type] || []).push(n.name);
+      return acc;
+    }, {});
+    expect(byType.model.sort()).toEqual(['customers', 'monthly_revenue']);
+    expect(byType.insight.sort()).toEqual(['cohort_retention', 'revenue_breakdown']);
+    expect(byType.chart).toEqual(['revenue_chart']);
+    expect(byType.dashboard).toEqual(['exec_kpi_dashboard']);
+    // Only the immediate downstream of the source is flagged as direct.
+    const direct = relations.descendants.filter(n => n.isDirect).map(n => n.name).sort();
+    expect(direct).toEqual(['customers', 'monthly_revenue']);
   });
 
   test('legacy buildChainFromStore still returns the ancestor chain', () => {


### PR DESCRIPTION
## Summary

Applies the final C-3 mini-lineage card design to `<LibraryRowFlipPopover>`. Replaces the placeholder upstream-only chain that originally shipped with VIS-776 with a two-direction **ancestor + descendant ladder** that meets at the subject row.

### Layout rules (per the final mock)

1. **Ancestor rows** render as `[type] [name] [icon]`, right-aligned.
2. **Descendant rows** render as `[icon] [name] [type]`, left-aligned.
3. Each successive ancestor row shifts left by `STEP`; each successive descendant row shifts right by `STEP`.
4. The deepest-nested ancestor row's left edge matches the first descendant row's left edge — the two ladders mirror at the subject.
5. A **dotted connector** drops from the left of each direct ancestor's `[type]` pill down to the top of the subject row's `[icon]`.
6. The **subject row** pins `[icon]` left, `[type]` right, and centres `[name]` between them. The `THIS` chip is removed.

### Interactions

- Clicking the ancestors region collapses the ancestor ladder into a `+N upstream` chip.
- Clicking the descendants region collapses the descendant ladder into a `+N downstream` chip.
- Body is `overflow-y-auto` with a fixed `max-height: 260px`; the collapse + scroll combination keeps complex DAGs usable in the popover's small surface.

### Data

New `buildLineageRelations(subject, storeApi)` returns `{ ancestors, descendants }` arrays of `{ type, name, isDirect }`. Walks the existing zustand store in both directions:

- Upstream: chart → insights → models → sources (per-insight branches, deduped).
- Downstream: source → models, model → insights, insight → charts, layout-object → dashboards.

Legacy `buildChainFromStore` stays exported for any non-popover consumer.

## Follow-up

VIS-780 (C-4) still owns the migration of this popover onto the shared `<MiniLineageCard>` once VIS-D6 extracts it. The data shape returned by `buildLineageRelations` already matches what the shared card will need.

## Test plan

- [x] `yarn test --testPathPattern=workspace/library` → 80/80 passing (15 popover tests, including new layout / dotted-line / collapse / relations-walker coverage).
- [x] `yarn lint` on changed files clean.
- [ ] Visual verification in the Workspace shell once a downstream branch has the new Library mounted with seeded data (sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)