### PR TITLE
fix(build): collect-all jsonschema_rs + pin python in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
       - name: Setup Poetry
         uses: Gr1N/setup-poetry@v9
 
@@ -48,14 +53,14 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
         run: |
-          cd viewer 
-          yarn install --network-timeout 600000 && yarn deploy 
+          cd viewer
+          yarn install --network-timeout 600000 && yarn deploy
           cd ..
           poetry install
           poetry run write-schema-json
           poetry run copy-install-script
           poetry version ${{ inputs.version }}
-          ls 
+          ls
           echo "VISIVO_VERSION = \"${{ inputs.version }}\"" > ${{ matrix.version_file }}
 
       - name: Build Artifact
@@ -82,6 +87,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
 
       - name: Setup Poetry
         uses: Gr1N/setup-poetry@v9

--- a/.rwx/test_visivo.yml
+++ b/.rwx/test_visivo.yml
@@ -183,6 +183,41 @@ tasks:
       DEBUG: true
     filter: [test-projects/integration]
 
+  - key: binary-init-smoke
+    # Runs the PyInstaller bundle (dist/visivo/visivo) end-to-end against
+    # `visivo init` in an empty directory — the exact path that crashed
+    # in v2.0.2 with `cannot import name 'EmailOptions' from
+    # 'jsonschema_rs.jsonschema_rs'`. Other binary tests in this file only
+    # exercise `visivo run`, which lazy-loads a different import graph and
+    # missed the bundling regression.
+    use: visivo-install
+    run: |
+      BIN="$PWD/dist/visivo/visivo"
+      test -x "$BIN" || (echo "binary not found at $BIN" && exit 1)
+      SMOKE_DIR=$(mktemp -d)
+
+      # --bare: exercise the full model import graph without binding a port.
+      (cd "$SMOKE_DIR" && "$BIN" init --bare)
+      test -f "$SMOKE_DIR/project.visivo.yml" || (echo "project.visivo.yml not written" && exit 1)
+
+      # Full serve path: confirm Flask boots and the onboarding page responds.
+      SERVE_DIR=$(mktemp -d)
+      (cd "$SERVE_DIR" && "$BIN" init --headless --port 8765) &
+      SERVE_PID=$!
+      trap 'kill $SERVE_PID 2>/dev/null || true' EXIT
+      for i in $(seq 1 30); do
+        if curl -fsS "http://localhost:8765/" >/dev/null 2>&1; then
+          echo "onboarding page is up after ${i}s"
+          break
+        fi
+        sleep 1
+      done
+      curl -fsS "http://localhost:8765/" >/dev/null \
+        || (echo "init+serve never responded on :8765" && exit 1)
+    env:
+      STACKTRACE: true
+    filter: [dist]
+
   - key: postgres-packages
     run: |
       sudo apt-get update

--- a/.rwx/test_visivo.yml
+++ b/.rwx/test_visivo.yml
@@ -190,30 +190,36 @@ tasks:
     # 'jsonschema_rs.jsonschema_rs'`. Other binary tests in this file only
     # exercise `visivo run`, which lazy-loads a different import graph and
     # missed the bundling regression.
+    #
+    # The auto-launched dev server is a foreground, never-exiting process, so
+    # it runs as a Mint background-process (which Mint tears down). Inlining it
+    # in `run` with `&` orphaned the PyInstaller child and hung the task to the
+    # 10-minute timeout.
     use: visivo-install
+    background-processes:
+      - key: init-serve
+        # `init --headless` scaffolds a fresh project in an empty dir and then
+        # boots `visivo serve`. A broken bundle crashes here on import, so the
+        # ready-check never passes and the task fails fast (instead of hanging).
+        run: |
+          BIN="$(pwd)/dist/visivo/visivo"
+          SERVE_DIR=$(mktemp -d)
+          cd "$SERVE_DIR"
+          "$BIN" init --headless --port 8765
+        ready-check: curl -fsS http://localhost:8765/ >/dev/null
     run: |
       BIN="$PWD/dist/visivo/visivo"
       test -x "$BIN" || (echo "binary not found at $BIN" && exit 1)
-      SMOKE_DIR=$(mktemp -d)
 
       # --bare: exercise the full model import graph without binding a port.
+      SMOKE_DIR=$(mktemp -d)
       (cd "$SMOKE_DIR" && "$BIN" init --bare)
       test -f "$SMOKE_DIR/project.visivo.yml" || (echo "project.visivo.yml not written" && exit 1)
 
-      # Full serve path: confirm Flask boots and the onboarding page responds.
-      SERVE_DIR=$(mktemp -d)
-      (cd "$SERVE_DIR" && "$BIN" init --headless --port 8765) &
-      SERVE_PID=$!
-      trap 'kill $SERVE_PID 2>/dev/null || true' EXIT
-      for i in $(seq 1 30); do
-        if curl -fsS "http://localhost:8765/" >/dev/null 2>&1; then
-          echo "onboarding page is up after ${i}s"
-          break
-        fi
-        sleep 1
-      done
-      curl -fsS "http://localhost:8765/" >/dev/null \
-        || (echo "init+serve never responded on :8765" && exit 1)
+      # The init-serve background process passed its ready-check (Flask booted
+      # and served the onboarding page); assert it once more explicitly.
+      curl -fsS http://localhost:8765/ >/dev/null \
+        || (echo "init+serve not reachable on :8765" && exit 1)
     env:
       STACKTRACE: true
     filter: [dist]

--- a/tests/test_jsonschema_rs_imports.py
+++ b/tests/test_jsonschema_rs_imports.py
@@ -1,0 +1,24 @@
+"""Guards against jsonschema_rs version drift inside a packaged bundle.
+
+The v2.0.2 release shipped a PyInstaller bundle that merged three different
+jsonschema_rs `.so` files into `_internal/jsonschema_rs/`. Python 3.13 picked
+the oldest one (which predated `EmailOptions`), but the bundled `__init__.py`
+came from the newer 0.46.4 wheel and tried to import it — crashing every
+`visivo init` on first run.
+
+A unit-level guard can't catch a bundling regression on its own (the RWX
+`binary-init-smoke` task does that against `dist/visivo/visivo`), but pinning
+the import surface here means a future jsonschema_rs upgrade that drops a
+symbol visivo relies on fails fast in `pytest` instead of in the customer's
+terminal.
+"""
+
+
+def test_jsonschema_rs_exports_used_by_visivo():
+    from jsonschema_rs import ValidationError, validator_for  # noqa: F401
+    from jsonschema_rs import meta  # noqa: F401
+
+
+def test_jsonschema_rs_email_options_present():
+    # The exact symbol whose absence shipped broken in v2.0.2.
+    from jsonschema_rs import EmailOptions  # noqa: F401

--- a/visivo/build.py
+++ b/visivo/build.py
@@ -29,6 +29,16 @@ def build():
         "sqlglot",
         "--collect-submodules",
         "snowflake.connector",
+        # pyo3 abi3 wheels: collect-all forces PyInstaller to take the .so and
+        # .py from a single matched install. Without this it can merge stale
+        # .so files from other site-packages on the build runner — see v2.0.2
+        # where `visivo init` crashed with `cannot import name 'EmailOptions'
+        # from 'jsonschema_rs.jsonschema_rs'` because three different versions
+        # of the .so ended up in _internal/jsonschema_rs/.
+        "--collect-all",
+        "jsonschema_rs",
+        "--collect-all",
+        "pydantic_core",
         "-n",
         "visivo",
         "--add-data",


### PR DESCRIPTION
## Summary

`visivo init` crashes on a fresh v2.0.2 install in an empty dir with:

```
ImportError: cannot import name 'EmailOptions' from 'jsonschema_rs.jsonschema_rs'
(/Users/.../.visivo/bin/_internal/jsonschema_rs/jsonschema_rs.cpython-313-darwin.so)
```

This is the first command a new user runs after `curl https://visivo.sh | bash`, so the install flow is fully broken on darwin-arm64. Confirmed root cause: the bundled `_internal/jsonschema_rs/` directory contains **three** `.so` files (`abi3.so` from May, `cpython-312-darwin.so` from Sep, `cpython-313-darwin.so` from April) merged from different installs on the GitHub Actions build runner. Python 3.13 picks the April `cpython-313-darwin.so` which predates `EmailOptions`, while the bundled `__init__.py` is from jsonschema-rs 0.46.4 and imports it.

- **`visivo/build.py`** — `--collect-all jsonschema_rs` and `--collect-all pydantic_core` so PyInstaller takes the `.so` and `.py` from a single matched install. The other `--collect-submodules` entries are kept as-is.
- **`.github/workflows/release.yml`** — added `actions/setup-python@v5` pinned via `.python-version` (3.12.10) to both jobs. Was using runner-default which silently drifted to 3.13 on macos-latest, contributing to the wrong-`.so` selection.
- **`.rwx/test_visivo.yml`** — new `binary-init-smoke` task runs `dist/visivo/visivo init --bare` in a tmp dir (the exact crashed code path), then `--headless --port 8765` + `curl` to verify the Flask serve responds. Existing binary tests only exercise `visivo run`, which lazy-loads a different import graph and missed this.
- **`tests/test_jsonschema_rs_imports.py`** (new) — unit-level guard pinning every jsonschema_rs symbol visivo currently uses.

## Test plan

- [x] `poetry run pytest tests/test_jsonschema_rs_imports.py -xvs` — passes locally
- [x] `poetry run black --target-version py312 visivo/build.py tests/test_jsonschema_rs_imports.py` — clean
- [x] YAML lint on both edited workflow files — clean
- [ ] CI: new `binary-init-smoke` task validates the fix against the freshly built `dist/visivo/visivo`
- [ ] Post-merge: run **Release** workflow with version=2.0.3, dryrun=false
- [ ] Post-release: curl + visivo init in clean dir — should print "Done" with no traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)