### PR TITLE
feat(viewer): Dashboards in Library Layout Items section (VIS-824)

### DIFF
--- a/viewer/e2e/stories/library-dashboards.spec.mjs
+++ b/viewer/e2e/stories/library-dashboards.spec.mjs
@@ -1,0 +1,81 @@
+/**
+ * Story: Dashboards in the Library Layout Items section (VIS-824)
+ *
+ * Validates that dashboards surface in the Library left rail under the
+ * Layout Items section (alongside Charts / Tables / Markdowns / Inputs) and
+ * that clicking a dashboard row scopes the middle pane to that dashboard —
+ * an independent dashboard navigation path from the Library that does not
+ * depend on the Project Editor or Workspace tabs.
+ *
+ * Precondition: Sandbox running on :3001/:8001
+ *   visivo serve --port 8001 (in test-projects/integration)
+ *   yarn start:sandbox (Vite on :3001 proxying to :8001)
+ *
+ * NOTE: Not run as part of this ticket — dev ports were occupied. Authored to
+ * lock down the flow for the next sandbox run.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Library — Dashboards in Layout Items (VIS-824)', () => {
+  test('Step 1: Workspace left rail shows the Layout Items section', async ({ page }) => {
+    await page.goto('/workspace');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('library-section-layout')).toBeVisible();
+    await expect(page.getByTestId('library-section-layout-header')).toContainText('Layout Items');
+  });
+
+  test('Step 2: Dashboards render as a Layout-Items subsection with a Dashboards chip', async ({
+    page,
+  }) => {
+    await page.goto('/workspace');
+    await page.waitForLoadState('networkidle');
+
+    // The per-type Dashboards subsection lives inside the Layout Items section.
+    await expect(page.getByTestId('library-subsection-dashboard')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('library-subsection-dashboard-header')).toContainText(
+      'Dashboards'
+    );
+
+    // The Layout Items filter chips include a "Dashboards" chip.
+    await expect(page.getByTestId('library-filter-chip-layout-dashboard')).toBeVisible();
+    await expect(page.getByTestId('library-filter-chip-layout-dashboard')).toContainText(
+      'Dashboards'
+    );
+  });
+
+  test('Step 3: Per-section search narrows to dashboards', async ({ page }) => {
+    await page.goto('/workspace');
+    await page.waitForLoadState('networkidle');
+
+    // Click the Dashboards filter chip — Charts / Tables / etc. subsections drop.
+    await page.getByTestId('library-filter-chip-layout-dashboard').click();
+    await expect(page.getByTestId('library-subsection-dashboard')).toBeVisible();
+    await expect(page.getByTestId('library-subsection-chart')).toHaveCount(0);
+  });
+
+  test('Step 4: Clicking a dashboard row scopes the middle pane to that dashboard', async ({
+    page,
+  }) => {
+    await page.goto('/workspace');
+    await page.waitForLoadState('networkidle');
+
+    // Grab the first dashboard row inside the dashboard subsection.
+    const dashboardRow = page
+      .getByTestId('library-subsection-dashboard-rows')
+      .locator('[data-testid^="library-row-dashboard-"]')
+      .first();
+    await expect(dashboardRow).toBeVisible({ timeout: 10000 });
+    await dashboardRow.click();
+
+    // The middle pane now scopes to the dashboard, exposing the Canvas +
+    // Lineage lenses for that dashboard.
+    await expect(page.getByTestId('workspace-middle-dashboard')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('workspace-subbar-dashboard')).toContainText('dashboard');
+
+    // The clicked row reflects the active selection.
+    await expect(dashboardRow).toHaveAttribute('data-selected', 'true');
+  });
+});

--- a/viewer/src/components/new-views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.test.jsx
@@ -55,6 +55,7 @@ const seedStore = (extra = {}) => {
       tables: [{ name: 'revenue_rows' }],
       markdowns: [{ name: 'project_notes' }],
       inputs: [{ name: 'date_range' }],
+      dashboards: [{ name: 'overview' }],
       // Data-layer collections.
       sources: [{ name: 'local-duck', type: 'duckdb' }],
       models: [{ name: 'monthly_revenue' }],
@@ -95,15 +96,15 @@ describe('Library', () => {
 
   test('section counts sum the per-type collections', () => {
     renderLibrary();
-    // Layout: 2 charts + 1 table + 1 markdown + 1 input = 5.
-    expect(screen.getByTestId('library-section-layout-count')).toHaveTextContent('(5)');
+    // Layout: 2 charts + 1 table + 1 markdown + 1 input + 1 dashboard = 6.
+    expect(screen.getByTestId('library-section-layout-count')).toHaveTextContent('(6)');
     // Data: 1 source + 1 model + 1 dimension + 1 metric + 1 relation + 1 insight = 6.
     expect(screen.getByTestId('library-section-data-count')).toHaveTextContent('(6)');
   });
 
-  test('renders the four Layout-Item subsections and the six Data-Layer subsections', () => {
+  test('renders the five Layout-Item subsections and the six Data-Layer subsections', () => {
     renderLibrary();
-    ['chart', 'table', 'markdown', 'input'].forEach(t => {
+    ['chart', 'table', 'markdown', 'input', 'dashboard'].forEach(t => {
       expect(screen.getByTestId(`library-subsection-${t}`)).toBeInTheDocument();
     });
     ['source', 'model', 'dimension', 'metric', 'relation', 'insight'].forEach(t => {
@@ -119,6 +120,8 @@ describe('Library', () => {
       'New Markdown'
     );
     expect(screen.getByTestId('library-subsection-input-create')).toHaveTextContent('New Input');
+    // Dashboards live in Layout Items but are not droppable — no inline create.
+    expect(screen.queryByTestId('library-subsection-dashboard-create')).not.toBeInTheDocument();
     // Data-layer subsections have no inline create button.
     ['source', 'model', 'dimension', 'metric', 'relation', 'insight'].forEach(t => {
       expect(screen.queryByTestId(`library-subsection-${t}-create`)).not.toBeInTheDocument();
@@ -163,6 +166,26 @@ describe('Library', () => {
       type: 'source',
       name: 'local-duck',
     });
+  });
+
+  test('clicking a dashboard row scopes the workspace to that dashboard (VIS-824)', () => {
+    const openWorkspaceTab = jest.fn();
+    seedStore({ openWorkspaceTab });
+    renderLibrary();
+    fireEvent.click(screen.getByTestId('library-row-dashboard-overview'));
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'dashboard:overview',
+      type: 'dashboard',
+      name: 'overview',
+    });
+  });
+
+  test('dashboard rows are not droppable drag sources (VIS-824)', () => {
+    renderLibrary();
+    fireEvent.mouseEnter(screen.getByTestId('library-row-dashboard-overview'));
+    expect(
+      screen.queryByTestId('library-row-dashboard-overview-drag-handle')
+    ).not.toBeInTheDocument();
   });
 
   test('"+ New Chart" calls the chart create-modal opener', () => {

--- a/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
@@ -37,12 +37,18 @@ import LibraryRowFlipPopover from './LibraryRowFlipPopover';
 // /editor, the lineage nodes, the explorer, and every edit form. The only
 // Library-specific knobs are which section a type belongs to (Layout vs.
 // Data) and the resulting droppable flag + visual accent.
-export const LAYOUT_TYPES = ['chart', 'table', 'markdown', 'input'];
+export const LAYOUT_TYPES = ['chart', 'table', 'markdown', 'input', 'dashboard'];
 export const DATA_TYPES = ['source', 'model', 'dimension', 'metric', 'relation', 'insight'];
+
+// Of the Layout-Items types, only these four are canvas-droppable drag sources
+// with an inline "+ New X" CTA. Dashboards live in the Layout Items section so
+// the Library offers a dashboard navigation path (VIS-824), but a dashboard is
+// not a canvas-droppable item — clicking it scopes the middle pane instead.
+export const DROPPABLE_TYPES = ['chart', 'table', 'markdown', 'input'];
 
 export const getTypeDef = type => {
   const cfg = getTypeByValue(type);
-  const droppable = LAYOUT_TYPES.includes(type);
+  const droppable = DROPPABLE_TYPES.includes(type);
   return {
     icon: cfg?.icon || getTypeIcon(type),
     label: cfg?.singularLabel || type,

--- a/viewer/src/components/new-views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRow.test.jsx
@@ -39,6 +39,11 @@ describe('LibraryRow', () => {
       expect(def.droppable).toBe(false);
       expect(def.accent).toBe('teal');
     });
+    // Dashboards (VIS-824) sit in the Layout Items section but are NOT
+    // canvas-droppable — clicking one scopes the middle pane instead.
+    const dashboardDef = getTypeDef('dashboard');
+    expect(dashboardDef).toBeTruthy();
+    expect(dashboardDef.droppable).toBe(false);
   });
 
   test('getTypeDef derives icon + label + plural from the canonical objectTypeConfigs', () => {

--- a/viewer/src/components/new-views/workspace/library/useLibraryData.js
+++ b/viewer/src/components/new-views/workspace/library/useLibraryData.js
@@ -8,8 +8,10 @@ import useStore from '../../../../stores/store';
  * collection from the zustand store and partitions them into the two
  * sections of the C-1 design:
  *
- *   - Layout Items — canvas-droppable types: Charts · Tables · Markdowns ·
- *                    Inputs.
+ *   - Layout Items — Charts · Tables · Markdowns · Inputs (canvas-droppable)
+ *                    plus Dashboards. Dashboards aren't dropped onto a canvas;
+ *                    clicking one scopes the middle pane to that dashboard
+ *                    (VIS-824).
  *   - Data Layer   — click-to-edit types: Sources · Models · Dimensions ·
  *                    Metrics · Relations · Insights.
  *
@@ -23,8 +25,9 @@ import useStore from '../../../../stores/store';
  *     layoutItems: {
  *       chart:    { id, type, name, status }[],
  *       table:    { id, type, name, status }[],
- *       markdown: { id, type, name, status }[],
- *       input:    { id, type, name, status }[],
+ *       markdown:  { id, type, name, status }[],
+ *       input:     { id, type, name, status }[],
+ *       dashboard: { id, type, name, status }[],
  *     },
  *     dataLayer: {
  *       source:    { id, type, name, status, subtype }[],
@@ -56,6 +59,7 @@ export function useLibraryData() {
   const tables = useStore(s => s.tables);
   const markdowns = useStore(s => s.markdowns);
   const inputs = useStore(s => s.inputs);
+  const dashboards = useStore(s => s.dashboards);
 
   // Data-layer collections.
   const sources = useStore(s => s.sources);
@@ -108,6 +112,7 @@ export function useLibraryData() {
         table: mapRows(tables, 'table'),
         markdown: mapRows(markdowns, 'markdown'),
         input: mapRows(inputs, 'input'),
+        dashboard: mapRows(dashboards, 'dashboard'),
       },
       dataLayer: {
         source: sourceRows,
@@ -123,6 +128,7 @@ export function useLibraryData() {
     tables,
     markdowns,
     inputs,
+    dashboards,
     sources,
     models,
     csvScriptModels,

--- a/viewer/src/components/new-views/workspace/library/useLibraryData.test.js
+++ b/viewer/src/components/new-views/workspace/library/useLibraryData.test.js
@@ -2,8 +2,9 @@
  * useLibraryData behaviour (VIS-769 / Track C C1).
  *
  * Verifies the hook partitions the project's collections into the C-1
- * design's two sections — Layout Items (chart · table · markdown · input)
- * and Data Layer (source · model · dimension · metric · relation · insight)
+ * design's two sections — Layout Items (chart · table · markdown · input ·
+ * dashboard) and Data Layer (source · model · dimension · metric · relation ·
+ * insight)
  * — with stable ids and `model` being the union of sql_model +
  * csv_script_model + local_merge_model.
  */
@@ -18,6 +19,7 @@ const resetStore = () => {
       tables: [],
       markdowns: [],
       inputs: [],
+      dashboards: [],
       sources: [],
       models: [],
       csvScriptModels: [],
@@ -39,6 +41,7 @@ describe('useLibraryData', () => {
     const { result } = renderHook(() => useLibraryData());
     expect(Object.keys(result.current.layoutItems).sort()).toEqual([
       'chart',
+      'dashboard',
       'input',
       'markdown',
       'table',
@@ -71,6 +74,22 @@ describe('useLibraryData', () => {
     ]);
     expect(result.current.layoutItems.markdown[0].type).toBe('markdown');
     expect(result.current.layoutItems.input[0].type).toBe('input');
+  });
+
+  test('maps dashboards into Layout-Item rows with stable ids (VIS-824)', () => {
+    act(() => {
+      useStore.setState({
+        dashboards: [
+          { name: 'overview', status: 'published' },
+          { name: 'sales', status: 'new' },
+        ],
+      });
+    });
+    const { result } = renderHook(() => useLibraryData());
+    expect(result.current.layoutItems.dashboard).toEqual([
+      { id: 'dashboard:overview', type: 'dashboard', name: 'overview', status: 'published' },
+      { id: 'dashboard:sales', type: 'dashboard', name: 'sales', status: 'new' },
+    ]);
   });
 
   test('maps the data-layer collections into typed rows', () => {
@@ -145,6 +164,7 @@ describe('useLibraryData', () => {
         tables: undefined,
         markdowns: undefined,
         inputs: undefined,
+        dashboards: undefined,
         sources: undefined,
         models: undefined,
         csvScriptModels: undefined,
@@ -158,6 +178,7 @@ describe('useLibraryData', () => {
     const { result } = renderHook(() => useLibraryData());
     expect(result.current.layoutItems.chart).toEqual([]);
     expect(result.current.layoutItems.table).toEqual([]);
+    expect(result.current.layoutItems.dashboard).toEqual([]);
     expect(result.current.dataLayer.model).toEqual([]);
     expect(result.current.dataLayer.insight).toEqual([]);
   });


### PR DESCRIPTION
## Summary
Adds Dashboards to the Library left rail under the **Layout Items** section (alongside Charts / Tables / Markdowns / Inputs), giving a dashboard navigation path from the Library that is independent of the Project Editor and Workspace tabs.

- `useLibraryData` now pulls the `dashboards` store slice into `layoutItems` (`mapRows(dashboards, 'dashboard')`), with stable `dashboard:<name>` ids and status passthrough.
- Dashboard rows render with the canonical dashboard icon + rose color from `objectTypeConfigs.js` (`getTypeIcon`/`getTypeColors('dashboard')`) — no hardcoded hex.
- Dashboards are **not** canvas-droppable: `DROPPABLE_TYPES` is split out of `LAYOUT_TYPES`, so dashboard rows appear in the section and the Layout Items filter chips (a "Dashboards" chip) and per-section search, but carry no drag handle and no "+ New" CTA.
- Clicking a dashboard row dispatches through the existing `openWorkspaceTab` path, setting `workspaceActiveTabId: 'dashboard:<name>'` and `workspaceActiveObject: { type: 'dashboard', name }`, so the middle pane scopes to that dashboard (Canvas + Lineage lenses via `workspace-middle-dashboard`). This matches exactly how the other Library rows dispatch selection.

## Test plan
- [x] `yarn test --watchAll=false --testPathPattern="library|Library"` — 1720 passing
- [x] `yarn lint` — 0 errors
- [x] New unit tests: `useLibraryData` (dashboards in Layout Items + no-crash), `Library` (subsection render, count, click→`openWorkspaceTab`, non-droppable, no create button), `LibraryRow` (`getTypeDef('dashboard').droppable === false`)
- [ ] `viewer/e2e/stories/library-dashboards.spec.mjs` authored but NOT run (dev ports occupied) — run against sandbox `:3001`

> Note: this revises the C-1 two-section model (Layout Items previously held only the four droppable types). Design sign-off pending.

Closes VIS-824