### PR TITLE
fix(install): wipe ~/.visivo/bin before extracting to clear stale files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,8 +154,16 @@ main() {
 
   # Create directories
   mkdir -p "$VISIVO_DIR"
+
+  # Wipe any previously-installed binary before extracting. `unzip -o` only
+  # overwrites files that exist in the new archive; it never removes files
+  # that were dropped between releases. A stale, version-specific extension
+  # (e.g. jsonschema_rs.cpython-312-darwin.so left over from an older build
+  # that now ships only as abi3) would otherwise shadow the new one and crash
+  # `visivo` on import. Removing the dir guarantees a clean install on upgrade.
+  rm -rf "$VISIVO_BIN_DIR"
   mkdir -p "$VISIVO_BIN_DIR"
-  
+
   # Download and extract
   curl -# -L "$DOWNLOAD_URL" -o "$VISIVO_DIR/visivo.zip"
 

--- a/mkdocs/assets/install.sh
+++ b/mkdocs/assets/install.sh
@@ -154,8 +154,16 @@ main() {
 
   # Create directories
   mkdir -p "$VISIVO_DIR"
+
+  # Wipe any previously-installed binary before extracting. `unzip -o` only
+  # overwrites files that exist in the new archive; it never removes files
+  # that were dropped between releases. A stale, version-specific extension
+  # (e.g. jsonschema_rs.cpython-312-darwin.so left over from an older build
+  # that now ships only as abi3) would otherwise shadow the new one and crash
+  # `visivo` on import. Removing the dir guarantees a clean install on upgrade.
+  rm -rf "$VISIVO_BIN_DIR"
   mkdir -p "$VISIVO_BIN_DIR"
-  
+
   # Download and extract
   curl -# -L "$DOWNLOAD_URL" -o "$VISIVO_DIR/visivo.zip"
 


### PR DESCRIPTION
## Summary

Even after v2.0.3 (which fixed the bundle to ship a single `jsonschema_rs.abi3.so`), `visivo` still crashed for users **upgrading** over a prior install:

```
ImportError: cannot import name 'EmailOptions' from 'jsonschema_rs.jsonschema_rs'
(~/.visivo/bin/_internal/jsonschema_rs/jsonschema_rs.cpython-312-darwin.so)
```

Root cause is in the **installer**, not the bundle. `install.sh` extracts with `unzip -o`, which overwrites files present in the new archive but **never removes files that were dropped between releases**. The v2.0.2 bundle shipped three `jsonschema_rs` `.so` files (`abi3`, `cpython-312`, `cpython-313`); v2.0.3 ships only `abi3`. On upgrade, the stale `cpython-312-darwin.so` (which predates `EmailOptions`) survived on disk, and Python loads the version-specific `.so` in preference to `abi3` — re-triggering the crash with the new `__init__.py` that imports `EmailOptions`.

**Fix:** `rm -rf "$VISIVO_BIN_DIR"` before `mkdir`/`unzip`, so every install/upgrade starts clean. `mkdocs/assets/install.sh` regenerated via `poetry run copy-install-script`.

## Delivery

`visivo.sh` is a Netlify site that serves the repo-root `install.sh` directly (`_redirects`: `/ → /install.sh 200`). Netlify deploys Git-based from `main`, so **this fix takes effect at `visivo.sh` as soon as it merges — no binary re-release required.** Users on the broken v2.0.3 are fixed the next time they run `curl -fsSL https://visivo.sh | bash` (the wipe clears the stale `.so`).

## Test plan

- [x] `bash -n install.sh` and `bash -n mkdocs/assets/install.sh` — syntax OK
- [x] Both copies identical after `copy-install-script`
- [x] Reproduced locally: deleting the stale `cpython-312/313` `.so` files from a polluted `~/.visivo/bin` made `visivo --version` succeed (2.0.3) with only `abi3.so` present — confirming stale-file shadowing was the cause
- [ ] Post-merge: confirm `curl -fsSL https://visivo.sh | bash` over an existing install yields a clean `~/.visivo/bin` and working `visivo init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)