### PR TITLE
refactor(viewer): extract RowEditForm + RefDropZone primitive with pill-and-drag (VIS-783)

### DIFF
--- a/viewer/src/components/new-views/common/DashboardEditForm.jsx
+++ b/viewer/src/components/new-views/common/DashboardEditForm.jsx
@@ -1,16 +1,12 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import useStore from '../../../stores/store';
 import { FormInput, FormAlert } from '../../styled/FormComponents';
 import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
-import RemoveIcon from '@mui/icons-material/Remove';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import { getTypeByValue } from './objectTypeConfigs';
-import { parseRefValue, formatRef } from '../../../utils/refString';
-
-const HEIGHT_OPTIONS = ['compact', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'];
+import { formatRef } from '../../../utils/refString';
+import RowEditForm from './RowEditForm';
 
 /**
  * DashboardEditForm - Form for creating/editing Dashboard
@@ -21,10 +17,7 @@ const HEIGHT_OPTIONS = ['compact', 'xsmall', 'small', 'medium', 'large', 'xlarge
 const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const deleteDashboard = useStore(state => state.deleteDashboard);
   const checkPublishStatus = useStore(state => state.checkPublishStatus);
-  const charts = useStore(state => state.charts);
-  const tables = useStore(state => state.tables);
-  const markdowns = useStore(state => state.markdowns);
-  const inputs = useStore(state => state.inputs);
+  const openWorkspaceTab = useStore(state => state.openWorkspaceTab);
 
   const [name, setName] = useState('');
   const [rows, setRows] = useState([]);
@@ -33,24 +26,6 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const [error, setError] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
-
-  // Build available objects list grouped by type
-  const availableObjects = useMemo(() => {
-    const groups = [];
-    if (charts?.length) {
-      groups.push({ label: 'Charts', type: 'chart', items: charts.map(c => c.name) });
-    }
-    if (tables?.length) {
-      groups.push({ label: 'Tables', type: 'table', items: tables.map(t => t.name) });
-    }
-    if (markdowns?.length) {
-      groups.push({ label: 'Markdowns', type: 'markdown', items: markdowns.map(m => m.name) });
-    }
-    if (inputs?.length) {
-      groups.push({ label: 'Inputs', type: 'input', items: inputs.map(i => i.name) });
-    }
-    return groups;
-  }, [charts, tables, markdowns, inputs]);
 
   useEffect(() => {
     if (dashboard) {
@@ -184,33 +159,11 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   };
 
   /**
-   * Get the combined "type:name" value for the current item selection
+   * Set or clear the object reference held by an item. `ref` is `{ type, name }`
+   * to set, or `null` to clear. Mutually-exclusive ref fields are reset so only
+   * one type is ever populated (matching the dashboard item model).
    */
-  const getSelectedValue = item => {
-    for (const field of ['chart', 'table', 'markdown', 'input']) {
-      const val = item[field];
-      if (val) {
-        const objName = parseRefValue(val);
-        return `${field}:${objName}`;
-      }
-    }
-    return '';
-  };
-
-  /**
-   * Get the object type of the currently selected item (for icon display)
-   */
-  const getSelectedType = item => {
-    for (const field of ['chart', 'table', 'markdown', 'input']) {
-      if (item[field]) return field;
-    }
-    return null;
-  };
-
-  /**
-   * Handle object selection from the dropdown
-   */
-  const handleObjectSelect = (rowIndex, itemIndex, combinedValue) => {
+  const handleItemRefChange = (rowIndex, itemIndex, ref) => {
     const updated = [...rows];
     const item = {
       ...updated[rowIndex].items[itemIndex],
@@ -220,19 +173,23 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
       selector: '',
       input: '',
     };
-
-    if (combinedValue) {
-      const colonIdx = combinedValue.indexOf(':');
-      const type = combinedValue.substring(0, colonIdx);
-      const objName = combinedValue.substring(colonIdx + 1);
-      item[type] = formatRef(objName);
+    if (ref && ref.type && ref.name) {
+      item[ref.type] = formatRef(ref.name);
     }
-
     updated[rowIndex] = {
       ...updated[rowIndex],
       items: updated[rowIndex].items.map((it, i) => (i === itemIndex ? item : it)),
     };
     setRows(updated);
+  };
+
+  /**
+   * Pill click → focus the referenced object in the workspace.
+   */
+  const handleSelectRef = ref => {
+    if (ref && ref.type && ref.name && openWorkspaceTab) {
+      openWorkspaceTab({ type: ref.type, name: ref.name });
+    }
   };
 
   const isValid = name.trim();
@@ -279,102 +236,19 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
           ) : (
             <div className="space-y-3">
               {rows.map((row, rowIndex) => (
-                <div key={rowIndex} className="p-3 bg-gray-50 border border-gray-200 rounded-md space-y-2">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium text-gray-500">Row {rowIndex + 1}</span>
-                    <button
-                      type="button"
-                      onClick={() => removeRow(rowIndex)}
-                      className="p-0.5 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
-                    >
-                      <RemoveIcon fontSize="small" />
-                    </button>
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    <label className="text-xs text-gray-600">Height:</label>
-                    <select
-                      value={row.height}
-                      onChange={e => updateRowHeight(rowIndex, e.target.value)}
-                      className="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                    >
-                      {HEIGHT_OPTIONS.map(h => (
-                        <option key={h} value={h}>
-                          {h}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  {/* Items */}
-                  <div className="space-y-2 pl-2 border-l-2 border-gray-300">
-                    {row.items.map((item, itemIndex) => {
-                      const selectedType = getSelectedType(item);
-                      const typeConfig = selectedType ? getTypeByValue(selectedType) : null;
-                      const ItemIcon = typeConfig?.icon || DashboardIcon;
-                      const iconColor = typeConfig?.colors?.text || 'text-gray-400';
-
-                      return (
-                        <div key={itemIndex} className="p-2 bg-white border border-gray-200 rounded space-y-2">
-                          <div className="flex items-center justify-between">
-                            <span className="text-xs text-gray-500">Item {itemIndex + 1}</span>
-                            <button
-                              type="button"
-                              onClick={() => removeItem(rowIndex, itemIndex)}
-                              className="p-0.5 text-red-400 hover:text-red-600 rounded"
-                            >
-                              <RemoveIcon style={{ fontSize: 14 }} />
-                            </button>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <label className="text-xs text-gray-500">Width:</label>
-                            <input
-                              type="number"
-                              min="1"
-                              value={item.width}
-                              onChange={e => updateItemWidth(rowIndex, itemIndex, e.target.value)}
-                              className="w-14 text-xs border border-gray-300 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                            />
-                          </div>
-                          <div className="relative">
-                            <select
-                              value={getSelectedValue(item)}
-                              onChange={e => handleObjectSelect(rowIndex, itemIndex, e.target.value)}
-                              className="block w-full pl-8 pr-8 py-1.5 text-sm border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none cursor-pointer"
-                            >
-                              <option value="">Select object...</option>
-                              {availableObjects.map(group => (
-                                <optgroup key={group.type} label={group.label}>
-                                  {group.items.map(objName => (
-                                    <option key={`${group.type}:${objName}`} value={`${group.type}:${objName}`}>
-                                      {objName}
-                                    </option>
-                                  ))}
-                                </optgroup>
-                              ))}
-                            </select>
-                            <div className="absolute inset-y-0 left-0 pl-2 flex items-center pointer-events-none">
-                              <ItemIcon style={{ fontSize: 16 }} className={iconColor} />
-                            </div>
-                            <div className="absolute inset-y-0 right-0 pr-2 flex items-center pointer-events-none">
-                              <svg className="h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                                <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-                              </svg>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                    <button
-                      type="button"
-                      onClick={() => addItem(rowIndex)}
-                      className="flex items-center gap-1 px-2 py-0.5 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
-                    >
-                      <AddIcon style={{ fontSize: 14 }} />
-                      Add Item
-                    </button>
-                  </div>
-                </div>
+                <RowEditForm
+                  key={rowIndex}
+                  row={row}
+                  rowId={rowIndex}
+                  rowIndex={rowIndex}
+                  onRemoveRow={() => removeRow(rowIndex)}
+                  onHeightChange={height => updateRowHeight(rowIndex, height)}
+                  onAddItem={() => addItem(rowIndex)}
+                  onRemoveItem={itemIndex => removeItem(rowIndex, itemIndex)}
+                  onItemWidthChange={(itemIndex, width) => updateItemWidth(rowIndex, itemIndex, width)}
+                  onItemRefChange={(itemIndex, ref) => handleItemRefChange(rowIndex, itemIndex, ref)}
+                  onSelectRef={handleSelectRef}
+                />
               ))}
             </div>
           )}

--- a/viewer/src/components/new-views/common/DashboardEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/DashboardEditForm.test.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DashboardEditForm from './DashboardEditForm';
+import useStore from '../../../stores/store';
+
+jest.mock('../../../stores/store');
+
+const mockOpenWorkspaceTab = jest.fn();
+const mockDeleteDashboard = jest.fn();
+const mockCheckPublishStatus = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useStore.mockImplementation(selector => {
+    const state = {
+      deleteDashboard: mockDeleteDashboard,
+      checkPublishStatus: mockCheckPublishStatus,
+      openWorkspaceTab: mockOpenWorkspaceTab,
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  });
+});
+
+const dashboardWithRows = {
+  name: 'sales',
+  status: 'published',
+  config: {
+    description: 'Sales overview',
+    rows: [
+      {
+        height: 'large',
+        items: [{ width: 2, chart: 'ref(rev_chart)' }, { width: 1 }],
+      },
+    ],
+  },
+};
+
+describe('DashboardEditForm — bundled context (mounts RowEditForm per row)', () => {
+  test('renders name, description, and a RowEditForm per configured row', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={false} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByDisplayValue('sales')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Sales overview')).toBeInTheDocument();
+    expect(screen.getByTestId('row-edit-form-0')).toBeInTheDocument();
+    expect(screen.getByText('Row 1')).toBeInTheDocument();
+    // Item slots are RefDropZones with the canonical id scheme.
+    expect(screen.getByTestId('ref-dropzone-row-0-item-0')).toHaveAttribute('data-filled', 'true');
+    expect(screen.getByTestId('ref-dropzone-row-0-item-1')).toHaveAttribute('data-filled', 'false');
+  });
+
+  test('the chart ref renders as a pill in its slot', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={false} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByText('rev_chart')).toBeInTheDocument();
+  });
+
+  test('Add Row appends a row (identical behavior to before refactor)', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={true} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.queryByTestId('row-edit-form-1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Add Row'));
+    expect(screen.getByTestId('row-edit-form-1')).toBeInTheDocument();
+  });
+
+  test('empty dashboard shows the no-rows hint', () => {
+    render(<DashboardEditForm dashboard={null} isCreate={true} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByText(/No rows defined/i)).toBeInTheDocument();
+  });
+
+  test('save serializes rows with refs in ref(...) form (unchanged contract)', async () => {
+    const onSave = jest.fn().mockResolvedValue({ success: true });
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={false} onSave={onSave} onClose={jest.fn()} />);
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [objType, objName, config] = onSave.mock.calls[0];
+    expect(objType).toBe('dashboard');
+    expect(objName).toBe('sales');
+    expect(config.rows).toHaveLength(1);
+    expect(config.rows[0].height).toBe('large');
+    // Only the populated item survives; width preserved; chart ref kept.
+    expect(config.rows[0].items).toEqual([{ width: 2, chart: 'ref(rev_chart)' }]);
+  });
+
+  test('clicking a slot pill opens the referenced object via openWorkspaceTab', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={false} onSave={jest.fn()} onClose={jest.fn()} />);
+    fireEvent.click(screen.getByText('rev_chart'));
+    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith({ type: 'chart', name: 'rev_chart' });
+  });
+
+  test('removing a slot pill clears the ref (slot reverts to empty)', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={false} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByTestId('ref-dropzone-row-0-item-0')).toHaveAttribute('data-filled', 'true');
+    fireEvent.click(screen.getByTestId('pill-remove'));
+    expect(screen.getByTestId('ref-dropzone-row-0-item-0')).toHaveAttribute('data-filled', 'false');
+  });
+
+  test('Save button keeps the onboarding anchor data attribute', () => {
+    render(<DashboardEditForm dashboard={dashboardWithRows} isCreate={true} onSave={jest.fn()} onClose={jest.fn()} />);
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toHaveAttribute('data-onb-target', 'dashboard-save');
+  });
+});

--- a/viewer/src/components/new-views/common/RefDropZone.jsx
+++ b/viewer/src/components/new-views/common/RefDropZone.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import EmbeddedPill from '../lineage/EmbeddedPill';
+import { parseRefValue } from '../../../utils/refString';
+
+/**
+ * RefDropZone — VIS-783 / Track F F-1.
+ *
+ * A thin wrapper around dnd-kit's `useDroppable` that represents a single
+ * "object reference" slot (e.g. a dashboard item that points at one chart /
+ * table / markdown / input). It is the shared primitive every ref slot in the
+ * Dashboard-Building surfaces reuses; RowEditForm is its first consumer.
+ *
+ * Two visual states:
+ *   - filled  → renders an <EmbeddedPill> for the referenced object. Clicking
+ *               the pill calls `onSelectRef` (workspace selection); the pill's
+ *               x calls `onClear`.
+ *   - empty   → renders a dashed drop-zone with hint text.
+ *
+ * Drag-over feedback (only while a drag is in progress AND this zone is the
+ * drop target):
+ *   - valid type    → mulberry ring.
+ *   - invalid type  → red flash + visually communicates rejection.
+ *
+ * IMPORTANT (G-1 coupling): `useDroppable` requires a `DndContext` ancestor to
+ * actually receive drops. The shell-level shared DndContext is Track G G-1's
+ * job and does NOT exist yet, so:
+ *   - With no ancestor DndContext, `useDroppable` is inert (`isOver` stays
+ *     false, `active` stays null) — RefDropZone still renders fine, no throw.
+ *   - The drop write itself is performed by the shell's DndContext `onDragEnd`
+ *     (G-1) which reads this zone's `data` ({ kind, allowedTypes, refId }) and
+ *     calls back into the consumer. Until then, drops simply never fire.
+ *
+ * Props:
+ *   - id           (string)   droppable id, e.g. `row-<rowId>-item-<idx>`.
+ *   - allowedTypes (string[]) object types this slot accepts.
+ *   - value        ({ type, name } | null) the current ref, or null/empty.
+ *   - onChange     (fn)       (optional) — unused by the live drop path until
+ *                             G-1 wires it; kept on the API so the shell /
+ *                             tests can hand the zone a setter.
+ *   - onClear      (fn)       called when the pill's x is clicked.
+ *   - onSelectRef  (fn)       called with `{ type, name }` when the pill body
+ *                             is clicked (workspace selection).
+ *   - hint         (string)   (optional) empty-state hint text.
+ */
+const RefDropZone = ({
+  id,
+  allowedTypes = [],
+  value = null,
+  onChange,
+  onClear,
+  onSelectRef,
+  hint = 'Drop an object here',
+}) => {
+  const { setNodeRef, isOver, active } = useDroppable({
+    id,
+    data: { kind: 'ref-slot', allowedTypes, refId: id, onChange },
+  });
+
+  // The active drag payload mirrors LibraryRow's `data.current`:
+  // `{ source: 'library', type, name, subtype }`.
+  const draggedType = active?.data?.current?.type ?? null;
+  const isDragging = !!active;
+  const isValidDrag = draggedType ? allowedTypes.includes(draggedType) : false;
+
+  const showValid = isOver && isValidDrag;
+  const showInvalid = isOver && isDragging && !isValidDrag;
+
+  // Normalize value → { type, name }. Accept either a structured object or a
+  // bare/`${ref(name)}` string (callers may hand either).
+  const refName = value
+    ? typeof value === 'string'
+      ? parseRefValue(value)
+      : parseRefValue(value.name)
+    : null;
+  const refType = value && typeof value === 'object' ? value.type : null;
+
+  const hasRef = !!refName && !!refType;
+
+  if (hasRef) {
+    return (
+      <div ref={setNodeRef} data-testid={`ref-dropzone-${id}`} data-filled="true">
+        <EmbeddedPill
+          objectType={refType}
+          label={refName}
+          onClick={() => onSelectRef && onSelectRef({ type: refType, name: refName })}
+          onRemove={onClear ? () => onClear() : undefined}
+          tooltip={`${refType}: ${refName} — click to open`}
+        />
+      </div>
+    );
+  }
+
+  const stateClasses = showInvalid
+    ? 'border-red-400 bg-red-50 text-red-600 animate-pulse'
+    : showValid
+      ? 'border-[#713b57] ring-2 ring-[#713b57]/40 bg-[#f9f6f8] text-[#713b57]'
+      : 'border-gray-300 text-gray-400 hover:border-gray-400';
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`ref-dropzone-${id}`}
+      data-filled="false"
+      data-over={isOver ? 'true' : 'false'}
+      data-valid-drag={showValid ? 'true' : 'false'}
+      data-invalid-drag={showInvalid ? 'true' : 'false'}
+      className={[
+        'flex items-center justify-center rounded-md border border-dashed px-2 py-2 text-xs transition-all',
+        stateClasses,
+      ].join(' ')}
+    >
+      <span className="truncate">{showInvalid ? 'Type not allowed' : hint}</span>
+    </div>
+  );
+};
+
+export default RefDropZone;

--- a/viewer/src/components/new-views/common/RefDropZone.test.jsx
+++ b/viewer/src/components/new-views/common/RefDropZone.test.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import RefDropZone from './RefDropZone';
+
+// Controllable mock of useDroppable so we can exercise drag-over visuals
+// (valid ring / invalid red flash) without driving a real pointer drag, which
+// jsdom cannot simulate. Tests set `__mockDroppableState` before rendering.
+let mockDroppableState = { isOver: false, active: null };
+jest.mock('@dnd-kit/core', () => {
+  const actual = jest.requireActual('@dnd-kit/core');
+  return {
+    ...actual,
+    useDroppable: jest.fn(args => ({
+      setNodeRef: jest.fn(),
+      isOver: mockDroppableState.isOver,
+      active: mockDroppableState.active,
+      // Echo back the registered data so tests can assert on it; the real
+      // hook stores `data` and exposes it to the DndContext's collision/drop
+      // pipeline rather than the return value, but for unit assertions the
+      // call args are the source of truth (see the "drop write path" test).
+      node: { current: null },
+      rect: { current: null },
+      over: null,
+      _data: args?.data,
+    })),
+  };
+});
+
+const ALLOWED = ['chart', 'table', 'markdown', 'input'];
+
+const setDroppable = state => {
+  mockDroppableState = state;
+};
+
+beforeEach(() => {
+  mockDroppableState = { isOver: false, active: null };
+  const { useDroppable } = require('@dnd-kit/core');
+  useDroppable.mockClear();
+});
+
+describe('RefDropZone', () => {
+  test('empty state renders dashed drop-zone with hint text', () => {
+    render(<RefDropZone id="row-0-item-0" allowedTypes={ALLOWED} value={null} hint="Drop here" />);
+    const zone = screen.getByTestId('ref-dropzone-row-0-item-0');
+    expect(zone).toHaveAttribute('data-filled', 'false');
+    expect(zone.className).toContain('border-dashed');
+    expect(screen.getByText('Drop here')).toBeInTheDocument();
+  });
+
+  test('filled state renders an EmbeddedPill for the ref', () => {
+    render(
+      <RefDropZone
+        id="row-0-item-0"
+        allowedTypes={ALLOWED}
+        value={{ type: 'chart', name: 'revenue_chart' }}
+      />
+    );
+    const zone = screen.getByTestId('ref-dropzone-row-0-item-0');
+    expect(zone).toHaveAttribute('data-filled', 'true');
+    expect(screen.getByText('revenue_chart')).toBeInTheDocument();
+  });
+
+  test('accepts a bare/string ref value', () => {
+    render(
+      <RefDropZone id="row-0-item-0" allowedTypes={ALLOWED} value={{ type: 'table', name: 'ref(t1)' }} />
+    );
+    // parseRefValue strips ref(...) wrapper for display.
+    expect(screen.getByText('t1')).toBeInTheDocument();
+  });
+
+  test('pill remove (x) calls onClear', () => {
+    const onClear = jest.fn();
+    render(
+      <RefDropZone
+        id="row-0-item-0"
+        allowedTypes={ALLOWED}
+        value={{ type: 'chart', name: 'c1' }}
+        onClear={onClear}
+      />
+    );
+    fireEvent.click(screen.getByTestId('pill-remove'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  test('pill click calls onSelectRef with the referenced object', () => {
+    const onSelectRef = jest.fn();
+    render(
+      <RefDropZone
+        id="row-0-item-0"
+        allowedTypes={ALLOWED}
+        value={{ type: 'markdown', name: 'notes' }}
+        onSelectRef={onSelectRef}
+      />
+    );
+    fireEvent.click(screen.getByText('notes'));
+    expect(onSelectRef).toHaveBeenCalledWith({ type: 'markdown', name: 'notes' });
+  });
+
+  test('valid-type dragover shows mulberry ring', () => {
+    setDroppable({
+      isOver: true,
+      active: { data: { current: { source: 'library', type: 'chart', name: 'c1' } } },
+    });
+    render(<RefDropZone id="row-0-item-0" allowedTypes={ALLOWED} value={null} />);
+    const zone = screen.getByTestId('ref-dropzone-row-0-item-0');
+    expect(zone).toHaveAttribute('data-valid-drag', 'true');
+    expect(zone).toHaveAttribute('data-invalid-drag', 'false');
+    expect(zone.className).toContain('ring-2');
+  });
+
+  test('invalid-type dragover shows red flash + reject text', () => {
+    setDroppable({
+      isOver: true,
+      active: { data: { current: { source: 'library', type: 'source', name: 's1' } } },
+    });
+    render(<RefDropZone id="row-0-item-0" allowedTypes={ALLOWED} value={null} />);
+    const zone = screen.getByTestId('ref-dropzone-row-0-item-0');
+    expect(zone).toHaveAttribute('data-invalid-drag', 'true');
+    expect(zone).toHaveAttribute('data-valid-drag', 'false');
+    expect(zone.className).toContain('border-red-400');
+    expect(zone.className).toContain('animate-pulse');
+    expect(screen.getByText('Type not allowed')).toBeInTheDocument();
+  });
+
+  test('drop write path: shell onDragEnd reads zone data and invokes onChange', () => {
+    // Simulates how Track G G-1's shared DndContext will dispatch a drop: it
+    // reads the droppable `data.current` (kind/allowedTypes/refId/onChange) and
+    // calls the consumer's onChange with `{ type, name }`. We call the handler
+    // directly because there is no shell DndContext yet.
+    const onChange = jest.fn();
+    const { useDroppable } = require('@dnd-kit/core');
+    render(<RefDropZone id="row-0-item-0" allowedTypes={ALLOWED} value={null} onChange={onChange} />);
+    const data = useDroppable.mock.calls[0][0].data;
+    expect(data.kind).toBe('ref-slot');
+    expect(data.allowedTypes).toEqual(ALLOWED);
+    expect(data.refId).toBe('row-0-item-0');
+    // The dragged library payload type is allowed → write the ref.
+    const draggedType = 'chart';
+    expect(data.allowedTypes.includes(draggedType)).toBe(true);
+    data.onChange({ type: draggedType, name: 'c1' });
+    expect(onChange).toHaveBeenCalledWith({ type: 'chart', name: 'c1' });
+  });
+
+  test('is render-safe with no active drag (no DndContext ancestor → inert)', () => {
+    // G-1 owns the shell DndContext; until then RefDropZone must be inert but
+    // render-safe. With no ancestor, useDroppable yields isOver:false/active:null.
+    setDroppable({ isOver: false, active: null });
+    expect(() =>
+      render(<RefDropZone id="x-0" allowedTypes={ALLOWED} value={null} />)
+    ).not.toThrow();
+    const zone = screen.getByTestId('ref-dropzone-x-0');
+    expect(zone).toHaveAttribute('data-over', 'false');
+    expect(zone).toHaveAttribute('data-valid-drag', 'false');
+    expect(zone).toHaveAttribute('data-invalid-drag', 'false');
+  });
+});
+
+describe('RefDropZone within a DndContext', () => {
+  test('mounts inside a DndContext without error', () => {
+    expect(() =>
+      render(
+        <DndContext>
+          <RefDropZone id="ctx-0" allowedTypes={ALLOWED} value={null} />
+        </DndContext>
+      )
+    ).not.toThrow();
+  });
+});

--- a/viewer/src/components/new-views/common/RowEditForm.jsx
+++ b/viewer/src/components/new-views/common/RowEditForm.jsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import RemoveIcon from '@mui/icons-material/Remove';
+import AddIcon from '@mui/icons-material/Add';
+import RefDropZone from './RefDropZone';
+import { parseRefValue } from '../../../utils/refString';
+
+const HEIGHT_OPTIONS = ['compact', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'];
+
+const ITEM_REF_FIELDS = ['chart', 'table', 'markdown', 'input'];
+const ALLOWED_ITEM_TYPES = ['chart', 'table', 'markdown', 'input'];
+
+/**
+ * Resolve the `{ type, name }` reference currently held by a dashboard item,
+ * inspecting the per-type ref fields the dashboard model uses
+ * (`chart` / `table` / `markdown` / `input`).
+ */
+export const getItemRef = item => {
+  if (!item) return null;
+  for (const field of ITEM_REF_FIELDS) {
+    const val = item[field];
+    if (val) {
+      const name = parseRefValue(val);
+      if (name) return { type: field, name };
+    }
+  }
+  return null;
+};
+
+/**
+ * RowEditForm — VIS-783 / Track F F-1.
+ *
+ * Standalone, presentational editor for a single dashboard row. Extracted out
+ * of the previously-bundled <DashboardEditForm> so the same component drives
+ * both the bundled form (one <RowEditForm> per row) and a future right-rail
+ * standalone mount. All row state lives in the parent; this component is
+ * controlled via callbacks.
+ *
+ * Each item slot is a <RefDropZone> (`row-<rowId>-item-<idx>`) accepting
+ * chart / table / markdown / input. A filled slot shows an <EmbeddedPill>;
+ * removing the pill clears the ref; clicking the pill selects the referenced
+ * object in the workspace via `onSelectRef`.
+ *
+ * Props:
+ *   - row          ({ height, items }) — the row config.
+ *   - rowId        (string|number)     — stable id used for drop-zone ids and
+ *                                        React keys (the row index today).
+ *   - rowIndex     (number)            — 0-based; drives the "Row N" label.
+ *   - onRemoveRow  (fn)                — remove this row.
+ *   - onHeightChange (fn(height))      — change row height.
+ *   - onAddItem    (fn)                — append an empty item.
+ *   - onRemoveItem (fn(itemIndex))     — remove an item.
+ *   - onItemWidthChange (fn(itemIndex, width))
+ *   - onItemRefChange   (fn(itemIndex, { type, name } | null)) — set/clear the
+ *                                        item ref (clear passes null).
+ *   - onSelectRef  (fn({ type, name })) — pill click → workspace selection.
+ */
+const RowEditForm = ({
+  row,
+  rowId,
+  rowIndex,
+  onRemoveRow,
+  onHeightChange,
+  onAddItem,
+  onRemoveItem,
+  onItemWidthChange,
+  onItemRefChange,
+  onSelectRef,
+}) => {
+  const items = row?.items || [];
+
+  return (
+    <div className="p-3 bg-gray-50 border border-gray-200 rounded-md space-y-2" data-testid={`row-edit-form-${rowId}`}>
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-gray-500">Row {rowIndex + 1}</span>
+        <button
+          type="button"
+          onClick={onRemoveRow}
+          className="p-0.5 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
+          aria-label={`Remove row ${rowIndex + 1}`}
+        >
+          <RemoveIcon fontSize="small" />
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-gray-600">Height:</label>
+        <select
+          value={row?.height || 'medium'}
+          onChange={e => onHeightChange(e.target.value)}
+          className="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          aria-label={`Row ${rowIndex + 1} height`}
+        >
+          {HEIGHT_OPTIONS.map(h => (
+            <option key={h} value={h}>
+              {h}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Items */}
+      <div className="space-y-2 pl-2 border-l-2 border-gray-300">
+        {items.map((item, itemIndex) => {
+          const dropZoneId = `row-${rowId}-item-${itemIndex}`;
+          const itemRef = getItemRef(item);
+          return (
+            <div key={itemIndex} className="p-2 bg-white border border-gray-200 rounded space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-gray-500">Item {itemIndex + 1}</span>
+                <button
+                  type="button"
+                  onClick={() => onRemoveItem(itemIndex)}
+                  className="p-0.5 text-red-400 hover:text-red-600 rounded"
+                  aria-label={`Remove item ${itemIndex + 1}`}
+                >
+                  <RemoveIcon style={{ fontSize: 14 }} />
+                </button>
+              </div>
+              <div className="flex items-center gap-2">
+                <label className="text-xs text-gray-500">Width:</label>
+                <input
+                  type="number"
+                  min="1"
+                  value={item.width}
+                  onChange={e => onItemWidthChange(itemIndex, e.target.value)}
+                  className="w-14 text-xs border border-gray-300 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  aria-label={`Item ${itemIndex + 1} width`}
+                />
+              </div>
+              <RefDropZone
+                id={dropZoneId}
+                allowedTypes={ALLOWED_ITEM_TYPES}
+                value={itemRef}
+                onClear={() => onItemRefChange(itemIndex, null)}
+                onChange={ref => onItemRefChange(itemIndex, ref)}
+                onSelectRef={onSelectRef}
+                hint="Drop a chart, table, markdown, or input"
+              />
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onAddItem}
+          className="flex items-center gap-1 px-2 py-0.5 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
+        >
+          <AddIcon style={{ fontSize: 14 }} />
+          Add Item
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RowEditForm;

--- a/viewer/src/components/new-views/common/RowEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/RowEditForm.test.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import RowEditForm, { getItemRef } from './RowEditForm';
+
+const baseRow = {
+  height: 'medium',
+  items: [
+    { width: 1, chart: 'ref(rev_chart)', table: '', markdown: '', selector: '', input: '' },
+    { width: 2, chart: '', table: '', markdown: '', selector: '', input: '' },
+  ],
+};
+
+const renderRow = (props = {}) =>
+  render(
+    <DndContext>
+      <RowEditForm
+        row={baseRow}
+        rowId={0}
+        rowIndex={0}
+        onRemoveRow={() => {}}
+        onHeightChange={() => {}}
+        onAddItem={() => {}}
+        onRemoveItem={() => {}}
+        onItemWidthChange={() => {}}
+        onItemRefChange={() => {}}
+        onSelectRef={() => {}}
+        {...props}
+      />
+    </DndContext>
+  );
+
+describe('getItemRef', () => {
+  test('resolves a chart ref to { type, name }', () => {
+    expect(getItemRef({ chart: 'ref(c1)' })).toEqual({ type: 'chart', name: 'c1' });
+  });
+  test('resolves a table ref', () => {
+    expect(getItemRef({ table: 'ref(t1)' })).toEqual({ type: 'table', name: 't1' });
+  });
+  test('returns null for an empty item', () => {
+    expect(getItemRef({ chart: '', table: '' })).toBeNull();
+    expect(getItemRef(null)).toBeNull();
+  });
+});
+
+describe('RowEditForm — standalone render', () => {
+  test('renders the row header, height select, and one slot per item', () => {
+    renderRow();
+    expect(screen.getByText('Row 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Row 1 height')).toHaveValue('medium');
+    // Each item slot is a RefDropZone with the id row-<rowId>-item-<idx>.
+    expect(screen.getByTestId('ref-dropzone-row-0-item-0')).toBeInTheDocument();
+    expect(screen.getByTestId('ref-dropzone-row-0-item-1')).toBeInTheDocument();
+  });
+
+  test('a filled item slot renders the EmbeddedPill for the ref', () => {
+    renderRow();
+    const slot0 = screen.getByTestId('ref-dropzone-row-0-item-0');
+    expect(slot0).toHaveAttribute('data-filled', 'true');
+    expect(screen.getByText('rev_chart')).toBeInTheDocument();
+  });
+
+  test('an empty item slot renders the empty drop-zone visual', () => {
+    renderRow();
+    const slot1 = screen.getByTestId('ref-dropzone-row-0-item-1');
+    expect(slot1).toHaveAttribute('data-filled', 'false');
+  });
+
+  test('removing a pill calls onItemRefChange(itemIndex, null)', () => {
+    const onItemRefChange = jest.fn();
+    renderRow({ onItemRefChange });
+    fireEvent.click(screen.getByTestId('pill-remove'));
+    expect(onItemRefChange).toHaveBeenCalledWith(0, null);
+  });
+
+  test('clicking a pill calls onSelectRef with the referenced object', () => {
+    const onSelectRef = jest.fn();
+    renderRow({ onSelectRef });
+    fireEvent.click(screen.getByText('rev_chart'));
+    expect(onSelectRef).toHaveBeenCalledWith({ type: 'chart', name: 'rev_chart' });
+  });
+
+  test('height change, width change, add/remove item, remove row all fire callbacks', () => {
+    const onHeightChange = jest.fn();
+    const onItemWidthChange = jest.fn();
+    const onAddItem = jest.fn();
+    const onRemoveItem = jest.fn();
+    const onRemoveRow = jest.fn();
+    renderRow({ onHeightChange, onItemWidthChange, onAddItem, onRemoveItem, onRemoveRow });
+
+    fireEvent.change(screen.getByLabelText('Row 1 height'), { target: { value: 'large' } });
+    expect(onHeightChange).toHaveBeenCalledWith('large');
+
+    fireEvent.change(screen.getByLabelText('Item 1 width'), { target: { value: '3' } });
+    expect(onItemWidthChange).toHaveBeenCalledWith(0, '3');
+
+    fireEvent.click(screen.getByText('Add Item'));
+    expect(onAddItem).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Remove item 2'));
+    expect(onRemoveItem).toHaveBeenCalledWith(1);
+
+    fireEvent.click(screen.getByLabelText('Remove row 1'));
+    expect(onRemoveRow).toHaveBeenCalled();
+  });
+});
+
+describe('RowEditForm — standalone (no DndContext ancestor)', () => {
+  test('renders without crashing when mounted with no DndContext', () => {
+    expect(() =>
+      render(
+        <RowEditForm
+          row={baseRow}
+          rowId={5}
+          rowIndex={2}
+          onRemoveRow={() => {}}
+          onHeightChange={() => {}}
+          onAddItem={() => {}}
+          onRemoveItem={() => {}}
+          onItemWidthChange={() => {}}
+          onItemRefChange={() => {}}
+          onSelectRef={() => {}}
+        />
+      )
+    ).not.toThrow();
+    expect(screen.getByText('Row 3')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Extracts the per-row sub-section out of the bundled `<DashboardEditForm>` into a standalone, controlled `<RowEditForm>`, and introduces the new `<RefDropZone>` primitive (F-1 is its first consumer). The bundled form now mounts one `<RowEditForm>` per row — single source of truth for both the bundled form and the future right-rail standalone mount.

### Files
- **New** `viewer/src/components/new-views/common/RefDropZone.jsx` — thin `useDroppable` wrapper. Renders an `<EmbeddedPill>` when a ref is present, a dashed empty drop-zone with hint text otherwise. Mulberry ring on valid-type dragover; red flash + reject on invalid-type. Render-safe with NO ancestor `DndContext` (inert until G-1 wires the shell context).
- **New** `viewer/src/components/new-views/common/RowEditForm.jsx` — standalone row editor: header + remove, height select, per-item width + `<RefDropZone>` slot (id `row-${rowId}-item-${idx}`, `allowedTypes = ['chart','table','markdown','input']`), add-item. Exports `getItemRef` helper.
- **Changed** `viewer/src/components/new-views/common/DashboardEditForm.jsx` — drops the inline dropdown row markup; maps each row to `<RowEditForm>`. All row/item state + serialization unchanged. Pill click → `openWorkspaceTab`; pill x → ref cleared.
- **New tests**: `RefDropZone.test.jsx`, `RowEditForm.test.jsx`, `DashboardEditForm.test.jsx`.

### Keeping the bundled form behavior intact
Row/item state, add/remove row+item, width/height handlers, and the save serialization contract (`ref(...)` form, mutually-exclusive item fields, drop-empty-items, width-omit-when-1) are byte-for-byte preserved — only relocated. The `data-onb-target="dashboard-save"` anchor is retained (covered by a test and the existing `onboarding-dashboard-save-anchor` story).

### RefDropZone API
`{ id, allowedTypes, value: {type,name}|string|null, onChange, onClear, onSelectRef, hint }`. Droppable `data`: `{ kind:'ref-slot', allowedTypes, refId, onChange }` for the shell `onDragEnd` to consume.

## Test plan
- `yarn test --watchAll=false` → **129 suites / 1745 tests, all green**
- `yarn lint` → **0 errors**
- Unit-validated criteria: standalone + bundled render (1-4), RefDropZone slots (5), pill remove/clear (7), pill click → selection (8), valid ring + invalid red-flash/reject (9 at unit level), existing save anchor/story (10).
- No `dashboard-edit-form.spec.mjs` story exists — skipped sandbox/Playwright run accordingly.

## Deferred to G-1
The shell-level shared `DndContext` is **Track G G-1's** job and does NOT exist yet. Therefore a full Library→form-field drop CANNOT fire end-to-end in the live app today (criteria 6 & 9). `<RefDropZone>` renders fine with no ancestor context (inert, no throw); the drop write + invalid-type reject are validated at the unit level (simulated dnd-kit `active`/`isOver` states + direct handler invocation). Tests wrap the component in their own `<DndContext>` where needed. No shell `DndContext` was added here.

Closes VIS-783