### PR TITLE
fix(viewer): stop Library rail scrolling blank during a row drag (VIS-836)

### DIFF
--- a/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
@@ -193,17 +193,17 @@ const LibraryRow = ({ obj, selected = false, draggable = true, onClick, onContex
     disabled: !draggable,
   });
 
-  const dragStyle = drag.transform
-    ? `translate3d(${drag.transform.x}px, ${drag.transform.y}px, 0)`
-    : undefined;
-
+  // The shared <DragOverlay> (WorkspaceDndContext) renders the drag preview, so
+  // the source row must NOT also translate with the cursor. Applying the dnd-kit
+  // transform here too made the source slide right with the pointer, which grew
+  // the Library rail's scroll width and let dnd-kit auto-scroll the rail
+  // horizontally until it went blank during a drag (VIS-836).
   const dragProps = draggable
     ? {
         ref: drag.setNodeRef,
         ...drag.listeners,
         ...drag.attributes,
         style: {
-          transform: dragStyle,
           touchAction: 'none',
         },
       }

--- a/viewer/src/components/new-views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRow.test.jsx
@@ -11,9 +11,16 @@
  */
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { DndContext } from '@dnd-kit/core';
+import { DndContext, useDraggable } from '@dnd-kit/core';
 import LibraryRow, { getTypeDef } from './LibraryRow';
 import { getTypeByValue, getTypeIcon } from '../../common/objectTypeConfigs';
+
+// Wrap the real dnd-kit so existing tests keep their real draggable wiring,
+// while individual tests can override useDraggable (e.g. to simulate mid-drag).
+jest.mock('@dnd-kit/core', () => {
+  const actual = jest.requireActual('@dnd-kit/core');
+  return { __esModule: true, ...actual, useDraggable: jest.fn(actual.useDraggable) };
+});
 
 const withDnd = (ui) => <DndContext>{ui}</DndContext>;
 
@@ -171,5 +178,22 @@ describe('LibraryRow', () => {
     expect(
       screen.getByTestId('library-row-chart-waterfall-drag-handle')
     ).toBeInTheDocument();
+  });
+
+  // VIS-836: the source row must NOT translate with the cursor during a drag —
+  // the shared <DragOverlay> renders the preview. Translating the source slid it
+  // right, grew the Library rail's scroll width, and let dnd-kit auto-scroll the
+  // rail horizontally until it went blank.
+  test('draggable source row does not apply a translate transform while dragging', () => {
+    useDraggable.mockReturnValueOnce({
+      transform: { x: 180, y: 12, scaleX: 1, scaleY: 1 },
+      setNodeRef: jest.fn(),
+      listeners: {},
+      attributes: {},
+      isDragging: true,
+    });
+    render(withDnd(<LibraryRow obj={CHART} draggable />));
+    const row = screen.getByTestId('library-row-chart-waterfall');
+    expect(row.style.transform || '').not.toMatch(/translate/);
   });
 });


### PR DESCRIPTION
**VIS-836** — found during integrated smoke testing, reproduced + root-caused in-browser.

## Bug
Dragging any row out of the Library left rail (e.g. a chart toward the canvas) scrolled the Library rail horizontally to the right until it went **blank** for the duration of the drag.

## Root cause
`LibraryRow.jsx` applied the dnd-kit drag `transform` (`translate3d`) to the **source** row — but `WorkspaceDndContext` already renders the drag preview via a portaled `<DragOverlay>` (`LibraryDragPreview`). With a DragOverlay you must not also translate the source. The source slid right with the cursor, grew the Library scroll container's `scrollWidth` (319 → 1103px), and dnd-kit auto-scrolled the rail horizontally (`scrollLeft` 0 → 734px).

(A CSS-only `overflow-x: hidden/clip` doesn't help — `overflow-y-auto` coerces it back to `hidden`, which is still programmatically scrollable. The fix is to stop moving the source.)

## Fix
Remove the `transform` from the source row's style. The source stays put (already dims via `opacity-40`); the `<DragOverlay>` is the drag visual.

## Verification
- Live (:3011): rail `scrollWidth` stays 319 / `scrollLeft` stays 0 through a full rightward drag; the drag-preview pill still follows the cursor.
- Unit: 40 LibraryRow tests + lint green, incl. a new regression test (a draggable row given a dnd-kit transform applies no translate transform to the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)