### PR TITLE
fix(viewer): model-data tables stuck loading at /project (VIS-827)

### DIFF
--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -73,6 +73,35 @@ const resolveItem = (itemRef, getItemByName) => {
 const isModelData = data => data && (data.sql || data.args || data.models);
 
 /**
+ * Resolve a table's `data` ref into a `{ name, isModel }` classification used to
+ * route the name into the right prefetch bucket (insightNames vs modelNames).
+ *
+ * A table's `data` can be (per the Table Pydantic model) a ${ ref() } to EITHER
+ * a model OR an insight, and it arrives from the `/api/tables/` store endpoint in
+ * one of two shapes:
+ *   - a STRING context-ref ("${ref(wide-columns-table)}") — the common case, and
+ *     the one that regressed (VIS-827). The string alone carries no model/insight
+ *     signal, so we consult the model registry: a name that is a known model is
+ *     model-data; otherwise it's treated as an insight (preserving the prior
+ *     behavior for insight-backed simple tables).
+ *   - an OBJECT carrying `name` + `sql|args|models` (an embedded/inlined model
+ *     definition) — classified directly via isModelData().
+ *
+ * Returns null when no data name can be derived.
+ */
+const classifyTableData = (tableData, isKnownModel) => {
+  if (!tableData) return null;
+  if (typeof tableData === 'string') {
+    const name = parseRefValue(tableData);
+    if (!name) return null;
+    return { name, isModel: isKnownModel(name) };
+  }
+  const name = tableData?.name;
+  if (!name) return null;
+  return { name, isModel: isModelData(tableData) };
+};
+
+/**
  * Recursively yield every Item across a list of rows, descending through
  * `item.rows` row-containers. Used by the data-collection helpers below so
  * nested charts/tables/inputs are also prefetched.
@@ -90,7 +119,7 @@ const forEachItemDeep = (rows, callback) => {
   }
 };
 
-const collectDataNames = (rows, visibleRowIndices, shouldShowItem, getChartByName, getTableByName, knownInsightNames = new Set()) => {
+const collectDataNames = (rows, visibleRowIndices, shouldShowItem, getChartByName, getTableByName, knownInsightNames = new Set(), isKnownModel = () => false) => {
   const insightNames = new Set();
   const modelNames = new Set();
   const pivotRefStrings = [];
@@ -113,14 +142,14 @@ const collectDataNames = (rows, visibleRowIndices, shouldShowItem, getChartByNam
 
     const table = resolveItem(item.table, getTableByName);
     if (table?.data) {
-      const tableData = typeof table.data === 'string' ? table.data : table.data;
-      const name = typeof tableData === 'string' ? parseRefValue(tableData) : tableData?.name;
-      if (name) {
-        if (typeof tableData === 'object' && isModelData(tableData)) {
-          modelNames.add(name);
-        } else {
-          insightNames.add(name);
-        }
+      // A string-ref `data` (the common case) carries no model/insight signal on
+      // its own; classifyTableData consults the model registry so model-data
+      // tables route into modelNames (VIS-827). Previously every string ref fell
+      // into insightNames, so useModelsData never fetched the model and the table
+      // spun forever.
+      const classified = classifyTableData(table.data, isKnownModel);
+      if (classified) {
+        (classified.isModel ? modelNames : insightNames).add(classified.name);
       }
     }
     const tableConfig = table?.config || table || {};
@@ -186,6 +215,13 @@ const Dashboard = ({ projectId, dashboardName, eagerLoad = true, stackBreakpoint
   const tables = useStore(state => state.tables);
   const getTableByName = useStore(state => state.getTableByName);
 
+  // Model registry — used to classify a table's `data` string ref as model-data
+  // vs insight-data so model-backed tables get fetched via useModelsData (VIS-827).
+  // The /api/tables/ store hands `data` to us as a bare context-ref string with no
+  // model/insight signal, so we look the name up against the fetched model list.
+  const fetchModels = useStore(state => state.fetchModels);
+  const models = useStore(state => state.models);
+
   // Markdown store
   const fetchMarkdowns = useStore(state => state.fetchMarkdowns);
   const getMarkdownByName = useStore(state => state.getMarkdownByName);
@@ -228,13 +264,27 @@ const Dashboard = ({ projectId, dashboardName, eagerLoad = true, stackBreakpoint
 
   const isColumn = shouldStack(width);
 
-  // Fetch item data on mount (dashboards fetched by Project container)
+  // Fetch item data on mount (dashboards fetched by Project container).
+  // `fetchModels` populates the model registry consumed by `isKnownModel` below;
+  // the Workspace canvas already fetches it (via Workspace.jsx), but the /project
+  // View route does not, so Dashboard fetches it itself to classify model-data
+  // tables correctly on both surfaces (VIS-827).
   useEffect(() => {
     fetchCharts();
     fetchTables();
     fetchMarkdowns();
     fetchInputs();
-  }, [fetchCharts, fetchTables, fetchMarkdowns, fetchInputs]);
+    fetchModels();
+  }, [fetchCharts, fetchTables, fetchMarkdowns, fetchInputs, fetchModels]);
+
+  // Stable membership test against the fetched model registry. A name not present
+  // in the registry is treated as a non-model (insight), preserving the prior
+  // behavior for insight-backed simple tables.
+  const modelNameSet = useMemo(
+    () => new Set((models || []).map(m => m.name)),
+    [models]
+  );
+  const isKnownModel = useCallback(name => modelNameSet.has(name), [modelNameSet]);
 
   // Find the current dashboard and extract its config
   const dashboard = useMemo(() => {
@@ -316,15 +366,18 @@ const Dashboard = ({ projectId, dashboardName, eagerLoad = true, stackBreakpoint
       });
       const table = resolveItem(item.table, getTableByName);
       if (table?.data) {
-        const tableData = typeof table.data === 'string' ? table.data : table.data;
-        const name = typeof tableData === 'string' ? parseRefValue(tableData) : tableData?.name;
-        if (name && !(typeof tableData === 'object' && isModelData(tableData))) {
-          names.add(name);
+        // Only insight-classified table data contributes to the known-insight set
+        // used to disambiguate pivot refs; model-data tables (string ref to a
+        // known model, or embedded sql/args/models) must NOT be treated as
+        // insights (VIS-827).
+        const classified = classifyTableData(table.data, isKnownModel);
+        if (classified && !classified.isModel) {
+          names.add(classified.name);
         }
       }
     });
     return names;
-  }, [dashboard?.rows, getChartByName, getTableByName]);
+  }, [dashboard?.rows, getChartByName, getTableByName, isKnownModel]);
 
   const { visibleInsightNames, visibleModelNames } = useMemo(() => {
     if (!dashboard?.rows) return { visibleInsightNames: [], visibleModelNames: [] };
@@ -335,11 +388,12 @@ const Dashboard = ({ projectId, dashboardName, eagerLoad = true, stackBreakpoint
       shouldShowItem,
       getChartByName,
       getTableByName,
-      knownInsightNames
+      knownInsightNames,
+      isKnownModel
     );
     return { visibleInsightNames: insightNames, visibleModelNames: modelNames };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dashboard?.rows, charts, tables, getChartByName, getTableByName, shouldShowItem]);
+  }, [dashboard?.rows, charts, tables, models, getChartByName, getTableByName, shouldShowItem, knownInsightNames, isKnownModel]);
 
   useInsightsData(projectId, visibleInsightNames);
   useModelsData(projectId, visibleModelNames);

--- a/viewer/src/components/project/Dashboard.test.jsx
+++ b/viewer/src/components/project/Dashboard.test.jsx
@@ -4,6 +4,8 @@ import { BrowserRouter } from 'react-router-dom';
 import { futureFlags } from '../../router-config';
 import Dashboard from './Dashboard';
 import useStore from '../../stores/store';
+import { useModelsData } from '../../hooks/useModelsData';
+import { useInsightsData } from '../../hooks/useInsightsData';
 
 // Mock the stores
 jest.mock('../../stores/store');
@@ -33,6 +35,10 @@ jest.mock('react-cool-dimensions', () => ({
 // Mock the hooks
 jest.mock('../../hooks/useInsightsData', () => ({
   useInsightsData: jest.fn(),
+}));
+
+jest.mock('../../hooks/useModelsData', () => ({
+  useModelsData: jest.fn(),
 }));
 
 jest.mock('../../hooks/useInputsData', () => ({
@@ -114,6 +120,8 @@ describe('Dashboard', () => {
         fetchTables: jest.fn(),
         fetchMarkdowns: jest.fn(),
         fetchInputs: jest.fn(),
+        fetchModels: jest.fn(),
+        models: [],
         getChartByName: jest.fn((name) => name === 'test-chart' ? mockChart : null),
         getTableByName: jest.fn(() => null),
         getMarkdownByName: jest.fn(() => null),
@@ -133,6 +141,8 @@ describe('Dashboard', () => {
         fetchTables: jest.fn(),
         fetchMarkdowns: jest.fn(),
         fetchInputs: jest.fn(),
+        fetchModels: jest.fn(),
+        models: [],
         getChartByName: jest.fn(),
         getTableByName: jest.fn(),
         getMarkdownByName: jest.fn(),
@@ -179,6 +189,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => chartConfigs[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -221,6 +233,8 @@ describe('Dashboard', () => {
         fetchTables: jest.fn(),
         fetchMarkdowns: jest.fn(),
         fetchInputs: jest.fn(),
+        fetchModels: jest.fn(),
+        models: [],
         getChartByName: jest.fn(),
         getTableByName: jest.fn(),
         getMarkdownByName: jest.fn(),
@@ -258,6 +272,8 @@ describe('Dashboard', () => {
         fetchTables: jest.fn(),
         fetchMarkdowns: jest.fn(),
         fetchInputs: jest.fn(),
+        fetchModels: jest.fn(),
+        models: [],
         getChartByName: jest.fn(() => null), // Chart not found
         getTableByName: jest.fn(() => null),
         getMarkdownByName: jest.fn(() => null),
@@ -280,6 +296,7 @@ describe('Dashboard', () => {
     const fetchTables = jest.fn();
     const fetchMarkdowns = jest.fn();
     const fetchInputs = jest.fn();
+    const fetchModels = jest.fn();
 
     useStore.mockImplementation((selector) => {
       const state = {
@@ -289,6 +306,8 @@ describe('Dashboard', () => {
         fetchTables,
         fetchMarkdowns,
         fetchInputs,
+        fetchModels,
+        models: [],
         getChartByName: jest.fn((name) => name === 'test-chart' ? mockChart : null),
         getTableByName: jest.fn(() => null),
         getMarkdownByName: jest.fn(() => null),
@@ -307,6 +326,9 @@ describe('Dashboard', () => {
     expect(fetchTables).toHaveBeenCalled();
     expect(fetchMarkdowns).toHaveBeenCalled();
     expect(fetchInputs).toHaveBeenCalled();
+    // VIS-827: the model registry must be fetched so model-data tables can be
+    // classified into the model-fetch bucket (useModelsData).
+    expect(fetchModels).toHaveBeenCalled();
   });
 
   // ---------- VIS-748: nested item.rows rendering ----------
@@ -331,6 +353,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => charts[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -588,6 +612,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn((name) => (name === 'test-chart' ? mockChart : null)),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -640,6 +666,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => charts[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -755,6 +783,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => charts[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -820,6 +850,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => charts[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -905,6 +937,8 @@ describe('Dashboard', () => {
           fetchTables: jest.fn(),
           fetchMarkdowns: jest.fn(),
           fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
           getChartByName: jest.fn(name => charts[name] ?? null),
           getTableByName: jest.fn(() => null),
           getMarkdownByName: jest.fn(() => null),
@@ -945,4 +979,100 @@ describe('Dashboard', () => {
       expect(nestedRow.style.display).toBe('flex');
     });
   });
+
+  // ---------- VIS-827: model-data table data collection ----------
+  //
+  // A "model-data table" sources its `data` from a model via a context-string ref
+  // (`"${ref(model-name)}"`). The /api/tables/ store endpoint delivers `data` as a
+  // bare string with no model/insight signal. The regression: every string-ref
+  // `data` was bucketed into the insight-fetch set, so useModelsData never fetched
+  // the backing model and the Table spun on a permanent loading spinner at /project
+  // (and on the Workspace canvas, same renderer). Dashboard must classify a
+  // string-ref `data` against the fetched model registry and route a known model
+  // name into useModelsData (and OUT of useInsightsData).
+  /* eslint-disable no-template-curly-in-string */
+  describe('model-data table data collection (VIS-827)', () => {
+    const tableDashboard = {
+      name: 'model-table-dash',
+      rows: [
+        {
+          height: 'large',
+          items: [
+            { width: 12, table: 'wide-columns-overflow-test-table' },
+          ],
+        },
+      ],
+    };
+
+    // Mirrors the /api/tables/ envelope: data is a bare context-string ref.
+    const modelDataTable = {
+      name: 'wide-columns-overflow-test-table',
+      config: {
+        name: 'wide-columns-overflow-test-table',
+        data: '${ref(wide-columns-table)}',
+        rows_per_page: 25,
+      },
+    };
+
+    const renderWithModels = (models = []) => {
+      useStore.mockImplementation(selector => {
+        const state = {
+          project: mockProject,
+          dashboards: [tableDashboard],
+          fetchDashboards: jest.fn(),
+          fetchCharts: jest.fn(),
+          fetchTables: jest.fn(),
+          fetchMarkdowns: jest.fn(),
+          fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models,
+          getChartByName: jest.fn(() => null),
+          getTableByName: jest.fn(name =>
+            name === 'wide-columns-overflow-test-table' ? modelDataTable : null
+          ),
+          getMarkdownByName: jest.fn(() => null),
+          getInputByName: jest.fn(() => null),
+        };
+        return selector(state);
+      });
+      return render(
+        <BrowserRouter future={futureFlags}>
+          <Dashboard project={mockProject} dashboardName={tableDashboard.name} />
+        </BrowserRouter>
+      );
+    };
+
+    const lastModelNames = () => {
+      const calls = useModelsData.mock.calls;
+      return calls.length ? calls[calls.length - 1][1] : [];
+    };
+    const lastInsightNames = () => {
+      const calls = useInsightsData.mock.calls;
+      return calls.length ? calls[calls.length - 1][1] : [];
+    };
+
+    it('collects a known model into useModelsData (not useInsightsData)', () => {
+      renderWithModels([{ name: 'wide-columns-table' }]);
+      // The model backing the table must be fetched as a MODEL.
+      expect(lastModelNames()).toContain('wide-columns-table');
+      // ...and must NOT leak into the insight-fetch set (would 404 / never resolve).
+      expect(lastInsightNames()).not.toContain('wide-columns-table');
+    });
+
+    it('renders the table item once classified as model-data', () => {
+      renderWithModels([{ name: 'wide-columns-table' }]);
+      expect(screen.getByTestId('table')).toHaveTextContent(
+        'wide-columns-overflow-test-table'
+      );
+    });
+
+    it('falls back to the insight bucket when the ref is not a known model', () => {
+      // A string-ref data whose name is NOT in the model registry preserves the
+      // prior behavior: it's treated as an insight-backed simple table.
+      renderWithModels([]); // empty model registry
+      expect(lastInsightNames()).toContain('wide-columns-table');
+      expect(lastModelNames()).not.toContain('wide-columns-table');
+    });
+  });
+  /* eslint-enable no-template-curly-in-string */
 });


### PR DESCRIPTION
## Summary

Model-data tables (a `Table` whose `data` is a `${ ref(model) }`) were stuck on perpetual loading spinners at the store-driven `/project` View route — and on the Workspace canvas, which shares the same `components/project/Dashboard.jsx` renderer. This surfaced after #449 promoted the store-driven Project view as the default `/project` and the renderer was consolidated (`new-views/project/DashboardNew.jsx` → `components/project/Dashboard.jsx`).

In `test-projects/integration`, `wide-table-dashboard` contains ONLY model-data tables (`wide-columns-overflow-test-table`, `wide-columns-narrow-slot-test-table`, both `data: ${ref(wide-columns-table)}`), so it reproduced cleanly: the markdown title rendered, `networkidle` settled, no failed requests — but the table widgets showed 2 spinners and the grid never rendered.

This is the known open **VIS-827** "model-data-table render gap," newly surfaced at the `/project` View route.

## Root cause

A table's `data` arrives from the `/api/tables/` store endpoint as a **bare context-string ref** (`"${ref(wide-columns-table)}"`) with no model/insight signal. In `Dashboard.jsx#collectDataNames`, the classifier only routed **object-form** `data` (carrying `sql|args|models`) into the model-fetch bucket; every **string** ref fell through to `insightNames`:

```js
if (typeof tableData === 'object' && isModelData(tableData)) {
  modelNames.add(name);   // never reached for a string ref
} else {
  insightNames.add(name); // string ref to a MODEL landed here (wrong)
}
```

So for `data: ${ref(wide-columns-table)}` (a SQL model), `wide-columns-table` was bucketed as an insight. `useModelsData` never fetched it → `modelJobs['wide-columns-table']` stayed `undefined`. `Table.jsx` resolves a string-ref `data` via `insightJobs[name] || modelJobs[name]`; the server has no insight by that name either, so `sourceData` was `undefined` and `Table.jsx` returned `<Loading>` forever (`isPivotableTable && !sourceData`).

The old `project_json` route (`ProjectContainer`) was unaffected because it pre-resolved table data inline. Verified against the live API: `/api/tables/` returns `config.data = "${ref(wide-columns-table)}"`; `wide-columns-table` is present in `/api/models/`, absent from `/api/insights/`.

## Fix

Classify a string-ref `data` against the fetched **model registry** (new `classifyTableData` helper + `isKnownModel`):
- A name that is a **known model** routes into `visibleModelNames` (fetched by `useModelsData`) and is kept OUT of the insight-fetch set.
- An unknown name preserves the prior insight-backed-table behavior.

`Dashboard` now also fetches the model registry on mount. The Workspace canvas already fetched it (via `Workspace.jsx`); the `/project` route did not, so the renderer fetches it itself — classification works on both surfaces with no spurious network requests. The same classifier is applied to `knownInsightNames` so a model-data table's name is never miscounted as a known insight when disambiguating pivot refs.

## Files changed
- `viewer/src/components/project/Dashboard.jsx` — `classifyTableData` helper; model-registry fetch + `isKnownModel`; `collectDataNames`/`knownInsightNames` route model refs to `modelNames`.
- `viewer/src/components/project/Dashboard.test.jsx` — new "model-data table data collection (VIS-827)" suite + `fetchModels`-on-mount assertion.

## Test results
- **Unit:** full `bash scripts/viewer-check.sh` green — 1958 tests pass (up from 1955; +3 new), lint clean.
- **E2E (live, isolated sandbox):**
  - `table-wide-and-narrow.spec.mjs` — all 5 steps pass (was failing pre-fix).
  - `table-render-loop.spec.mjs` — 3 tests pass (/project View, Workspace canvas, Explorer) — no regression.

Refs VIS-827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)