### PR TITLE
fix(viewer): sync Outline scope to active dashboard tab over stale URL (VIS-835)

### DIFF
--- a/viewer/e2e/stories/project-editor.spec.mjs
+++ b/viewer/e2e/stories/project-editor.spec.mjs
@@ -256,6 +256,77 @@ test.describe('Project Editor (M-1)', () => {
     await page.screenshot({ path: 'e2e/stories/__screens__/vis805-06-after-drop.png', fullPage: true });
   });
 
+  test('VIS-835: opening a dashboard via a tile populates the right-rail Outline (even over a stale dashboard URL)', async () => {
+    // Repro the cross-path scope bug: the Outline must follow the dashboard the
+    // user just opened from a tile, agreeing with the canvas, instead of
+    // sticking to a previously-visited dashboard's URL.
+
+    // 1) Open dashboard A by URL so the route param + Outline are populated.
+    const firstTileId = await page
+      .locator('[data-testid^="project-tile-"]')
+      .first()
+      .getAttribute('data-testid');
+    const dashA = firstTileId.replace('project-tile-', '');
+    await page.goto(`${WORKSPACE_URL}/dashboard/${dashA}`);
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('workspace-middle-dashboard').waitFor({ timeout: WAIT_FOR_PAGE });
+
+    // Show the Outline tab and assert it is scoped to A.
+    await page.getByTestId('workspace-right-rail-tab-outline').click();
+    await page.getByTestId('workspace-right-rail-outline').waitFor({ timeout: WAIT_FOR_PAGE });
+    await expect(page.getByTestId('outline-tree-node-dashboard')).toContainText(dashA, {
+      timeout: 10000,
+    });
+
+    // 2) Return to the Project Editor WITHOUT changing the route away from A's
+    //    URL: click the project tab so the middle pane shows the tile grid while
+    //    the `/workspace/dashboard/<A>` URL param lingers (the bug's setup). The
+    //    project tab's id is `project:<projectName>`; select it by the
+    //    `workspace-tab-select-project:` testid prefix.
+    const projectTab = page.locator('[data-testid^="workspace-tab-select-project:"]').first();
+    await projectTab.click();
+    await page.getByTestId('project-editor').waitFor({ timeout: WAIT_FOR_PAGE });
+    await page.locator('[data-testid^="project-tile-"]').first().waitFor({ timeout: WAIT_FOR_PAGE });
+
+    // 3) Pick a DIFFERENT dashboard tile (B) and open it via the tile.
+    const tiles = page.locator('[data-testid^="project-tile-"]');
+    const count = await tiles.count();
+    let dashB = null;
+    for (let i = 0; i < count; i++) {
+      const id = await tiles.nth(i).getAttribute('data-testid');
+      const name = id.replace('project-tile-', '');
+      if (name !== dashA) {
+        dashB = name;
+        await tiles.nth(i).click();
+        break;
+      }
+    }
+    expect(dashB, 'needs a second distinct dashboard tile').toBeTruthy();
+
+    // Canvas switches to B.
+    await expect(page.getByTestId('workspace-middle-dashboard')).toBeVisible({ timeout: 10000 });
+
+    // 4) The Outline must now show B's tree — NOT the stale A — and must not be
+    //    blank. (Before the fix, the URL param A won, leaving the Outline stuck.)
+    await page.getByTestId('workspace-right-rail-tab-outline').click().catch(() => {});
+    await page.getByTestId('workspace-right-rail-outline').waitFor({ timeout: WAIT_FOR_PAGE });
+    await expect(page.getByTestId('outline-tree-no-dashboard')).toHaveCount(0);
+    await expect(page.getByTestId('outline-tree-node-dashboard')).toContainText(dashB, {
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('outline-tree-node-dashboard')).not.toContainText(dashA);
+
+    await page.screenshot({
+      path: 'e2e/stories/__screens__/vis835-tile-outline-sync.png',
+      fullPage: true,
+    });
+
+    // Reset to the unscoped pane for the remaining step.
+    await page.goto(WORKSPACE_URL);
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('project-editor').waitFor({ timeout: WAIT_FOR_PAGE });
+  });
+
   test('No console errors during the happy path', async () => {
     const realErrors = page._consoleErrors.filter(
       e =>

--- a/viewer/src/components/new-views/workspace/OutlineTreePanel.test.jsx
+++ b/viewer/src/components/new-views/workspace/OutlineTreePanel.test.jsx
@@ -25,17 +25,22 @@ const DASH = 'simple-dashboard';
 // expression, which the lint rule (no-template-curly-in-string) flags.
 const ref = name => '${ref(' + name + ')}';
 
-const makeDashboard = (rows) => ({
-  name: DASH,
-  config: { name: DASH, rows },
+const makeDashboard = (name, rows) => ({
+  name,
+  config: { name, rows },
 });
 
 const resetStore = (rows) => {
   act(() => {
     useStore.setState({
-      dashboards: rows === undefined ? [] : [makeDashboard(rows)],
+      dashboards: rows === undefined ? [] : [makeDashboard(DASH, rows)],
       workspaceOutlineSelectedKey: 'dashboard',
       saveDashboard: jest.fn(() => Promise.resolve({ success: true })),
+      // Clear workspace tabs so URL-scoped tests aren't influenced by a
+      // lingering active dashboard tab (which now wins per VIS-835).
+      workspaceTabs: [],
+      workspaceActiveTabId: null,
+      workspaceActiveObject: null,
     });
   });
 };
@@ -152,6 +157,64 @@ describe('OutlineTreePanel', () => {
     resetStore([]);
     renderPanel('/workspace');
     expect(screen.getByTestId('outline-tree-no-dashboard')).toBeInTheDocument();
+  });
+
+  describe('tile-open path drives the Outline via the active dashboard tab (VIS-835)', () => {
+    // The Project Editor tile-open path calls openWorkspaceTab without changing
+    // the route, so the Outline must populate from the active dashboard tab even
+    // when the URL has no (or a stale) dashboard param.
+
+    test('an active dashboard tab populates the Outline at /workspace (no URL param)', () => {
+      resetStore([{ height: 'medium', items: [{ chart: 'c1', width: 1 }] }]);
+      act(() => {
+        useStore.setState({
+          workspaceTabs: [
+            { id: 'project:p', type: 'project', name: 'p', dirty: false },
+            { id: `dashboard:${DASH}`, type: 'dashboard', name: DASH, dirty: false },
+          ],
+          workspaceActiveTabId: `dashboard:${DASH}`,
+          workspaceActiveObject: { type: 'dashboard', name: DASH },
+        });
+      });
+      renderPanel('/workspace');
+
+      // Tree renders (no the no-dashboard / blank state).
+      expect(screen.queryByTestId('outline-tree-no-dashboard')).not.toBeInTheDocument();
+      const root = screen.getByTestId('outline-tree-node-dashboard');
+      expect(root).toHaveTextContent(DASH);
+      expect(screen.getByTestId('outline-tree-node-row.0')).toBeInTheDocument();
+    });
+
+    test('a freshly tile-opened dashboard tab wins over a STALE dashboard URL param', () => {
+      // Repro: user viewed /workspace/dashboard/other-dashboard, then opened
+      // `DASH` via a tile (active tab = DASH) without the route changing. The
+      // Outline must show DASH's tree, not the stale URL dashboard's.
+      act(() => {
+        useStore.setState({
+          dashboards: [
+            makeDashboard('other-dashboard', [{ height: 'medium', items: [] }]),
+            makeDashboard(DASH, [
+              { height: 'medium', items: [{ chart: 'c1', width: 1 }] },
+              { height: 'small', items: [] },
+            ]),
+          ],
+          workspaceOutlineSelectedKey: 'dashboard',
+          saveDashboard: jest.fn(() => Promise.resolve({ success: true })),
+          workspaceTabs: [
+            { id: 'dashboard:other-dashboard', type: 'dashboard', name: 'other-dashboard', dirty: false },
+            { id: `dashboard:${DASH}`, type: 'dashboard', name: DASH, dirty: false },
+          ],
+          workspaceActiveTabId: `dashboard:${DASH}`,
+          workspaceActiveObject: { type: 'dashboard', name: DASH },
+        });
+      });
+      renderPanel('/workspace/dashboard/other-dashboard');
+
+      const root = screen.getByTestId('outline-tree-node-dashboard');
+      expect(root).toHaveTextContent(DASH);
+      expect(root).not.toHaveTextContent('other-dashboard');
+      expect(root).toHaveTextContent('2 rows');
+    });
   });
 
   describe('nested Item.rows container layouts (VIS-825)', () => {

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.js
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.js
@@ -22,12 +22,18 @@ import useStore from '../../../stores/store';
  *
  * Scope semantics, in order of precedence:
  *
- *   1. `:dashboardName` URL param → `dashboard` scope.
- *   2. `?edit=<type>:<name>` query (Q19 redirect target) → `item` scope.
- *   3. Active workspace tab whose type is not `project` → matches tab's
+ *   1. Active workspace tab whose type is neither `project` nor `dashboard`
+ *      → `item` scope (an expanded chart/model/insight/etc.).
+ *   2. Active `dashboard` tab whose name differs from the `:dashboardName` URL
+ *      param → `dashboard` scope for the TAB's dashboard (VIS-835). The tab is
+ *      the user's most recent explicit selection, so it wins over a stale URL.
+ *   3. `:dashboardName` URL param → `dashboard` scope (the URL-open path; when
+ *      a matching tab is active they agree and resolve identically).
+ *   4. `?edit=<type>:<name>` query (Q19 redirect target) → `item` scope.
+ *   5. Active workspace tab whose type is not `project` → matches tab's
  *      scope. Tabs are how multi-object editing is plumbed; the URL still
  *      shows `/workspace` for non-dashboard objects in Phase 0.
- *   4. Otherwise `root` (the unscoped Project Editor surface). The project
+ *   6. Otherwise `root` (the unscoped Project Editor surface). The project
  *      tab is the implicit selected item — Edit form binds to the project.
  *
  * NB: this hook does not subscribe to URL changes itself — it relies on
@@ -66,6 +72,26 @@ export function useWorkspaceScope() {
         selector: `+${activeTab.name}`,
         dashboardName: dashboardName || null,
         selectedItem: { type: activeTab.type, name: activeTab.name },
+      };
+    }
+
+    // Active dashboard tab takes precedence over a STALE `:dashboardName` URL
+    // param (VIS-835). The Project Editor tile-open path (and any other
+    // store-driven open) calls `openWorkspaceTab` without changing the route,
+    // so after a user has visited `/workspace/dashboard/A` the URL param lingers
+    // at `A` even when they then open dashboard `B` via a tile. The canvas reads
+    // the active object (`B`) directly, so without this the Outline/Library
+    // scope would read the stale URL (`A`) and disagree with the canvas — the
+    // "outline doesn't change with the dashboard in context" report. The tab is
+    // the user's most recent explicit selection, so it wins when they differ.
+    // When the URL param and the active dashboard tab agree (the URL-open path),
+    // this branch and the URL branch below resolve identically.
+    if (activeTab && activeTab.type === 'dashboard' && activeTab.name !== dashboardName) {
+      return {
+        scope: 'dashboard',
+        selector: `+${activeTab.name}`,
+        dashboardName: activeTab.name,
+        selectedItem: { type: 'dashboard', name: activeTab.name },
       };
     }
 

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
@@ -157,6 +157,45 @@ describe('useWorkspaceScope', () => {
     );
   });
 
+  test('an active dashboard tab at /workspace (tile-open, no URL) scopes to that dashboard (VIS-835)', () => {
+    // The Project Editor tile-open path calls openWorkspaceTab without changing
+    // the route, so a dashboard tab must scope the Outline even with no URL param.
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          { id: 'project:p', type: 'project', name: 'p', dirty: false },
+          { id: 'dashboard:table-dashboard', type: 'dashboard', name: 'table-dashboard', dirty: false },
+        ],
+        workspaceActiveTabId: 'dashboard:table-dashboard',
+      });
+    });
+    renderAt('/workspace');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
+    expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('table-dashboard');
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent('table-dashboard');
+  });
+
+  test('a freshly tile-opened dashboard tab wins over a STALE dashboard URL param (VIS-835)', () => {
+    // User was on /workspace/dashboard/A, then opened B via a tile (active tab
+    // = B) without the route changing. Scope must follow the tab (B) so the
+    // Outline + Library agree with the canvas (which reads the active object),
+    // instead of sticking to the stale URL dashboard (A).
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          { id: 'dashboard:A', type: 'dashboard', name: 'A', dirty: false },
+          { id: 'dashboard:B', type: 'dashboard', name: 'B', dirty: false },
+        ],
+        workspaceActiveTabId: 'dashboard:B',
+      });
+    });
+    renderAt('/workspace/dashboard/A');
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
+    expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('B');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent('+B');
+    expect(screen.getByTestId('probe-selected-name')).toHaveTextContent('B');
+  });
+
   test('an active dashboard tab on a dashboard URL keeps dashboard scope', () => {
     // The dashboard route opens a matching dashboard tab; the tab and the URL
     // agree, so the scope is the dashboard either way.


### PR DESCRIPTION
## VIS-835 — opening a dashboard via a Project Editor tile leaves the right-rail Outline blank (scope not synced)

Fixes [VIS-835](https://linear.app/visivo/issue/VIS-835).

### Root cause
The Project Editor tile-open path (`dispatchDashboardSelection` → `openWorkspaceTab({type:'dashboard', name})`) sets the active workspace tab + `workspaceActiveObject` **without changing the route**. `useWorkspaceScope` resolved dashboard scope from the `:dashboardName` URL param **before** the active workspace tab. So once a user has visited `/workspace/dashboard/A`, the URL param lingers at `A` even after they open dashboard `B` via a tile.

- The middle-pane canvas reads `workspaceActiveObject` directly → it switches to `B`.
- `<OutlineTreePanel>` (and the Library scope) read `dashboardName` from `useWorkspaceScope` → they kept reading the **stale URL `A`**.

Result: canvas shows `B`, Outline shows `A` (or appears blank/stuck) — exactly the cofounder report, *"the outline doesn't change with the dashboard in context."* The URL-open and Library-row paths worked because there the URL param and the tab agreed.

### Fix (minimal, scope-sync path only)
In `viewer/src/components/new-views/workspace/useWorkspaceScope.js`, an active `dashboard` tab whose name differs from the `:dashboardName` URL param now takes precedence over the stale URL param. The tab is the user's most recent explicit selection and is the same source the canvas (`workspaceActiveObject`) renders, so **canvas + Outline + scope now agree from every open path** (tile / Library row / URL) — without forcing a route change, matching how URL-scoping already works.

When the tab and URL agree (the URL-open path), the new branch and the existing URL branch resolve identically, so existing paths are unchanged. The Edit-tab Q25 router (`RightRailEditPanel.jsx`) was not touched.

### Tests (count increases: +4 unit, +1 e2e step)
- `useWorkspaceScope.test.jsx` — a dashboard tab at `/workspace` (no URL param) scopes to that dashboard; a freshly tile-opened dashboard tab wins over a **stale** dashboard URL param.
- `OutlineTreePanel.test.jsx` — the tile-open path (active dashboard tab) renders the tree at `/workspace` and over a stale dashboard URL.
- `project-editor.spec.mjs` — **navigation-driven** e2e (per AC): open dashboard A by URL → assert Outline root = A; return to the tile grid via the project tab (URL stays on A) → open B via a tile → assert Outline root = B (not A) and not blank.

Verified live against an isolated sandbox (`:8006`/`:3006`): all 11 project-editor story steps pass, including the new VIS-835 step. Neutralizing the fix makes both the new unit tests and the e2e step fail (load-bearing). Full `bash scripts/viewer-check.sh` green: 1959 unit tests + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)