### PR TITLE
feat(viewer): right-rail Level + Defaults Edit forms (VIS-807 M-2b, VIS-809 M-3)

### DIFF
--- a/viewer/e2e/stories/right-rail-routing.spec.mjs
+++ b/viewer/e2e/stories/right-rail-routing.spec.mjs
@@ -49,6 +49,14 @@ const setOutlineKey = (page, key) =>
   page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
 const setRightTab = (page, tab) =>
   page.evaluate(t => window.useStore.getState().setWorkspaceRightTab(t), tab);
+// Level selection has no tab type — the Project Editor selects it by setting
+// the active object directly. Mirror that here.
+const selectLevel = (page, name, index) =>
+  page.evaluate(
+    ({ name, index }) =>
+      window.useStore.setState({ workspaceActiveObject: { type: 'level', name, index } }),
+    { name, index }
+  );
 
 test.describe('Right-rail routing (G-1)', () => {
   test.describe.configure({ mode: 'serial' });
@@ -172,6 +180,33 @@ test.describe('Right-rail routing (G-1)', () => {
     await expect(chip).toContainText('local-duckdb');
     await page.getByTestId('workspace-right-rail').screenshot({
       path: `${SCREENS}/vis802-05-edit-source.png`,
+    });
+  });
+
+  test('level selection → LevelEditForm with chip (VIS-807 / M-2b)', async () => {
+    await setRightTab(page, 'edit');
+    // Ensure defaults are loaded so the form resolves a level.
+    await page.evaluate(() => window.useStore.getState().fetchDefaults?.());
+    await selectLevel(page, 'Organization', 0);
+    // The real LevelEditForm mounts (not the old "deferred" placeholder).
+    await page.getByTestId('right-rail-edit-level').waitFor({ timeout: 10000 });
+    await expect(page.getByTestId('right-rail-edit-level-placeholder')).toHaveCount(0);
+    await expect(page.getByTestId('level-edit-save')).toBeVisible();
+    await page.getByTestId('workspace-right-rail').screenshot({
+      path: `${SCREENS}/vis807-06-edit-level.png`,
+    });
+  });
+
+  test('project-chrome selection → DefaultsEditForm with chip (VIS-809 / M-3)', async () => {
+    await setRightTab(page, 'edit');
+    await selectObject(page, 'project', 'project');
+    // The real DefaultsEditForm mounts (not the old "deferred" placeholder).
+    await page.getByTestId('right-rail-edit-defaults').waitFor({ timeout: 10000 });
+    await expect(page.getByTestId('right-rail-edit-project-placeholder')).toHaveCount(0);
+    const chip = page.getByTestId('right-rail-selection-chip');
+    await expect(chip).toHaveAttribute('data-object-type', 'defaults');
+    await page.getByTestId('workspace-right-rail').screenshot({
+      path: `${SCREENS}/vis809-07-edit-defaults.png`,
     });
   });
 

--- a/viewer/src/components/new-views/common/DefaultsEditForm.jsx
+++ b/viewer/src/components/new-views/common/DefaultsEditForm.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import useStore from '../../../stores/store';
+import SelectionChip from '../workspace/SelectionChip';
+import ProjectDefaultsEditForm from './ProjectDefaultsEditForm';
+
+/**
+ * DefaultsEditForm — VIS-809 (Track M M-3).
+ *
+ * The right-rail Edit-tab form for project `Defaults`. Thin wrapper that fronts
+ * the existing <ProjectDefaultsEditForm> with a <SelectionChip> (matching every
+ * other Edit-tab form) and resolves the singleton `defaults` record from the
+ * store. The underlying form edits `source_name`, `threads`, the default alert,
+ * telemetry, and the dashboard `levels` list, persisting through the
+ * `saveDefaults` action (defaults-cache → publish flow). Theme is v2-deferred.
+ *
+ * There is no modal to close in the rail, so `onClose` is a no-op.
+ */
+const DefaultsEditForm = ({ name }) => {
+  const defaults = useStore(s => s.defaults);
+  const fetchDefaults = useStore(s => s.fetchDefaults);
+
+  useEffect(() => {
+    if (!defaults && fetchDefaults) fetchDefaults();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const noop = () => {};
+
+  return (
+    <>
+      <SelectionChip type="defaults" name={name || 'Project settings'} subtitle="Project Settings" />
+      <div data-testid="right-rail-edit-defaults" className="flex flex-1 flex-col overflow-hidden">
+        <ProjectDefaultsEditForm defaults={defaults} onSave={noop} onClose={noop} />
+      </div>
+    </>
+  );
+};
+
+export default DefaultsEditForm;

--- a/viewer/src/components/new-views/common/DefaultsEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/DefaultsEditForm.test.jsx
@@ -1,0 +1,53 @@
+/**
+ * DefaultsEditForm tests (VIS-809 / Track M M-3).
+ *
+ * Thin wrapper that fronts <ProjectDefaultsEditForm> with a <SelectionChip> in
+ * the right rail. Verifies the chip identity + that the resolved `defaults`
+ * record is passed through to the underlying form, which self-fetches when the
+ * store has none yet.
+ */
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import DefaultsEditForm from './DefaultsEditForm';
+import useStore from '../../../stores/store';
+
+jest.mock('./ProjectDefaultsEditForm', () => ({
+  __esModule: true,
+  default: ({ defaults }) => (
+    <div data-testid="project-defaults-form-stub">
+      {`defaults:${defaults ? defaults.source_name || 'set' : 'none'}`}
+    </div>
+  ),
+}));
+
+const seed = (overrides = {}) => {
+  act(() => {
+    useStore.setState({
+      defaults: { source_name: 'local-duckdb', threads: 4 },
+      fetchDefaults: jest.fn(),
+      ...overrides,
+    });
+  });
+};
+
+describe('DefaultsEditForm', () => {
+  test('renders the defaults chip and passes defaults through to the form', () => {
+    seed();
+    render(<DefaultsEditForm name="analytics" />);
+    expect(screen.getByTestId('right-rail-edit-defaults')).toBeInTheDocument();
+    const chip = screen.getByTestId('right-rail-selection-chip');
+    expect(chip).toHaveAttribute('data-object-type', 'defaults');
+    expect(chip).toHaveTextContent('analytics');
+    expect(screen.getByTestId('project-defaults-form-stub')).toHaveTextContent(
+      'defaults:local-duckdb'
+    );
+  });
+
+  test('self-fetches defaults when the store has none', async () => {
+    const fetchDefaults = jest.fn();
+    seed({ defaults: null, fetchDefaults });
+    render(<DefaultsEditForm name="analytics" />);
+    await waitFor(() => expect(fetchDefaults).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('project-defaults-form-stub')).toHaveTextContent('defaults:none');
+  });
+});

--- a/viewer/src/components/new-views/common/LevelEditForm.jsx
+++ b/viewer/src/components/new-views/common/LevelEditForm.jsx
@@ -1,0 +1,241 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { PiArrowUp, PiArrowDown, PiTrash } from 'react-icons/pi';
+import CircularProgress from '@mui/material/CircularProgress';
+import useStore from '../../../stores/store';
+import { defaultLevels } from '../../../utils/dashboardUtils';
+import SelectionChip from '../workspace/SelectionChip';
+import { FormInput, FormTextarea, FormAlert } from '../../styled/FormComponents';
+import { Button } from '../../styled/Button';
+
+/**
+ * LevelEditForm — VIS-807 (Track M M-2b).
+ *
+ * The right-rail Edit-tab form for a dashboard **Level**. A level lives on
+ * `defaults.levels` (an ordered array of `{ title, description? }`); the active
+ * selection identifies which one by its `index` (the position the Project
+ * Editor surfaced it at). This form edits the level's **title + description**
+ * and persists through the store's index-based `updateLevel` action (the same
+ * `saveDefaults` → defaults-cache → publish path every level CRUD uses).
+ *
+ * The inline reorder / delete / add affordances already exist in the Project
+ * Editor (`LevelGroupHeader` / `ProjectEditor`, M-2a) and are NOT rebuilt here.
+ * For convenience this form surfaces the same reorder / delete operations as
+ * lightweight buttons that call the identical store actions — it does not
+ * re-implement their UI.
+ *
+ * Fronted by a <SelectionChip> like every other Edit-tab form. There is an
+ * explicit Save button (matching the leaf forms); title/description aren't
+ * auto-saved because a blank intermediate title would be rejected by the
+ * backend `Level` model.
+ */
+
+/**
+ * Resolve the concrete editable level list. Mirrors the store's `_resolveLevels`
+ * so the index the Project Editor selected maps to the same level the user saw:
+ * when `defaults.levels` is empty/absent we seed from the shared `defaultLevels`
+ * fallback (the first edit then persists a concrete list).
+ */
+const resolveLevels = defaults => {
+  const configured = defaults?.levels;
+  if (Array.isArray(configured) && configured.length > 0) {
+    return configured.map(l => ({ ...l }));
+  }
+  return defaultLevels.map(l => ({ ...l }));
+};
+
+const LevelEditForm = ({ index, onSaved }) => {
+  const defaults = useStore(s => s.defaults);
+  const fetchDefaults = useStore(s => s.fetchDefaults);
+  const updateLevel = useStore(s => s.updateLevel);
+  const reorderLevel = useStore(s => s.reorderLevel);
+  const deleteLevel = useStore(s => s.deleteLevel);
+
+  const levels = useMemo(() => resolveLevels(defaults), [defaults]);
+  const level = index >= 0 && index < levels.length ? levels[index] : null;
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  // Defaults may not be loaded yet (e.g. a direct workspace visit); self-fetch
+  // so the form can resolve its level.
+  useEffect(() => {
+    if (!defaults && fetchDefaults) fetchDefaults();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-seed the local fields whenever the resolved level changes (selection
+  // switch or an external defaults refresh).
+  useEffect(() => {
+    if (level) {
+      setTitle(level.title || '');
+      setDescription(level.description || '');
+      setError(null);
+      setConfirmingDelete(false);
+    }
+  }, [level]);
+
+  const chipName = level?.title || `Level ${index + 1}`;
+
+  if (!level) {
+    return (
+      <>
+        <SelectionChip type="dashboard" name={`Level ${index + 1}`} subtitle="Level" />
+        <div
+          data-testid="right-rail-edit-level-missing"
+          className="flex flex-1 items-start justify-center px-6 py-8 text-center"
+        >
+          <p className="text-[13px] text-gray-500">This level no longer exists.</p>
+        </div>
+      </>
+    );
+  }
+
+  const canMoveUp = index > 0;
+  const canMoveDown = index < levels.length - 1;
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError(null);
+    const trimmed = (title || '').trim();
+    if (!trimmed) {
+      setError('Title is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const result = await updateLevel(index, { title: trimmed, description });
+      if (result?.success || result?.error === 'unchanged') {
+        if (onSaved) onSaved();
+      } else {
+        setError(result?.error || 'Failed to save level.');
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to save level.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <SelectionChip type="dashboard" name={chipName} subtitle="Level" />
+      <div data-testid="right-rail-edit-level" className="flex-1 overflow-y-auto p-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && <FormAlert variant="error">{error}</FormAlert>}
+
+          <FormInput
+            id="level-title"
+            label="Title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            required
+            helperText="How this level is labelled in the Project Editor."
+            data-testid="level-edit-title"
+          />
+
+          <FormTextarea
+            id="level-description"
+            label="Description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={3}
+            helperText="What kinds of dashboards belong at this level."
+            data-testid="level-edit-description"
+          />
+
+          {/* Reorder / delete reuse the existing M-2a store actions — the inline
+              header affordances in the Project Editor are not rebuilt here. */}
+          <div className="flex items-center gap-1.5 border-t border-gray-200 pt-3">
+            <span className="mr-auto text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              Order
+            </span>
+            <button
+              type="button"
+              onClick={() => reorderLevel && reorderLevel(index, -1)}
+              disabled={!canMoveUp || saving}
+              aria-label="Move level up"
+              data-testid="level-edit-move-up"
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <PiArrowUp className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => reorderLevel && reorderLevel(index, 1)}
+              disabled={!canMoveDown || saving}
+              aria-label="Move level down"
+              data-testid="level-edit-move-down"
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <PiArrowDown className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              disabled={saving}
+              aria-label="Delete level"
+              data-testid="level-edit-delete"
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-gray-400 transition-colors hover:bg-highlight-50 hover:text-highlight disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <PiTrash className="h-4 w-4" />
+            </button>
+          </div>
+
+          {confirmingDelete && (
+            <div
+              role="dialog"
+              aria-label="Confirm delete level"
+              data-testid="level-edit-delete-confirm"
+              className="rounded-lg border border-gray-200 bg-gray-50 p-3"
+            >
+              <p className="text-[12.5px] leading-snug text-gray-700">
+                Delete level <span className="font-semibold">“{level.title}”</span>? Its dashboards
+                move to Unassigned.
+              </p>
+              <div className="mt-2.5 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setConfirmingDelete(false)}
+                  data-testid="level-edit-delete-cancel"
+                  className="inline-flex h-7 items-center rounded-md px-2 text-[12px] font-medium text-gray-600 hover:bg-gray-100"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setConfirmingDelete(false);
+                    if (deleteLevel) await deleteLevel(index);
+                    if (onSaved) onSaved();
+                  }}
+                  data-testid="level-edit-delete-confirm-btn"
+                  className="inline-flex h-7 items-center rounded-md bg-highlight px-2.5 text-[12px] font-semibold text-white hover:bg-highlight-700"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <Button type="submit" disabled={saving} className="text-sm" data-testid="level-edit-save">
+              {saving ? (
+                <>
+                  <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
+                  Saving...
+                </>
+              ) : (
+                'Save'
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+};
+
+export default LevelEditForm;

--- a/viewer/src/components/new-views/common/LevelEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/LevelEditForm.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * LevelEditForm tests (VIS-807 / Track M M-2b).
+ *
+ * The right-rail Edit-tab form for a dashboard Level. Verifies it resolves the
+ * level by index, seeds its fields, persists title + description through the
+ * store's `updateLevel`, and delegates reorder / delete to the existing M-2a
+ * store actions (it does not rebuild their UI).
+ */
+import React from 'react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import LevelEditForm from './LevelEditForm';
+import useStore from '../../../stores/store';
+
+const seed = (overrides = {}) => {
+  act(() => {
+    useStore.setState({
+      defaults: {
+        levels: [
+          { title: 'Organization', description: 'org desc' },
+          { title: 'Team', description: 'team desc' },
+          { title: 'Individual', description: 'ind desc' },
+        ],
+      },
+      fetchDefaults: jest.fn(),
+      updateLevel: jest.fn(async () => ({ success: true })),
+      reorderLevel: jest.fn(async () => ({ success: true })),
+      deleteLevel: jest.fn(async () => ({ success: true })),
+      ...overrides,
+    });
+  });
+};
+
+describe('LevelEditForm', () => {
+  test('seeds title + description from the resolved level and shows a chip', () => {
+    seed();
+    render(<LevelEditForm index={1} />);
+    expect(screen.getByTestId('right-rail-edit-level')).toBeInTheDocument();
+    const chip = screen.getByTestId('right-rail-selection-chip');
+    expect(chip).toHaveTextContent('Team');
+    expect(screen.getByTestId('level-edit-title')).toHaveValue('Team');
+    expect(screen.getByTestId('level-edit-description')).toHaveValue('team desc');
+  });
+
+  test('Save persists title + description via updateLevel', async () => {
+    const updateLevel = jest.fn(async () => ({ success: true }));
+    seed({ updateLevel });
+    render(<LevelEditForm index={0} />);
+
+    fireEvent.change(screen.getByTestId('level-edit-title'), { target: { value: 'Company' } });
+    fireEvent.change(screen.getByTestId('level-edit-description'), { target: { value: 'new' } });
+    fireEvent.click(screen.getByTestId('level-edit-save'));
+
+    await waitFor(() => expect(updateLevel).toHaveBeenCalledTimes(1));
+    expect(updateLevel).toHaveBeenCalledWith(0, { title: 'Company', description: 'new' });
+  });
+
+  test('blocks save and surfaces an error when the title is blank', async () => {
+    const updateLevel = jest.fn(async () => ({ success: true }));
+    seed({ updateLevel });
+    render(<LevelEditForm index={0} />);
+
+    fireEvent.change(screen.getByTestId('level-edit-title'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByTestId('level-edit-save'));
+
+    await screen.findByText('Title is required.');
+    expect(updateLevel).not.toHaveBeenCalled();
+  });
+
+  test('reorder buttons call reorderLevel; disabled at the boundaries', () => {
+    const reorderLevel = jest.fn();
+    seed({ reorderLevel });
+    render(<LevelEditForm index={0} />);
+    // index 0 → cannot move up.
+    expect(screen.getByTestId('level-edit-move-up')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('level-edit-move-down'));
+    expect(reorderLevel).toHaveBeenCalledWith(0, 1);
+  });
+
+  test('delete confirms then calls deleteLevel', async () => {
+    const deleteLevel = jest.fn(async () => ({ success: true }));
+    seed({ deleteLevel });
+    render(<LevelEditForm index={2} />);
+
+    fireEvent.click(screen.getByTestId('level-edit-delete'));
+    expect(screen.getByTestId('level-edit-delete-confirm')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('level-edit-delete-confirm-btn'));
+    await waitFor(() => expect(deleteLevel).toHaveBeenCalledWith(2));
+  });
+
+  test('renders a "no longer exists" state for an out-of-range index', () => {
+    seed();
+    render(<LevelEditForm index={9} />);
+    expect(screen.getByTestId('right-rail-edit-level-missing')).toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/new-views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/new-views/workspace/RightRailEditPanel.jsx
@@ -16,6 +16,8 @@ import ModelEditForm from '../common/ModelEditForm';
 import DimensionEditForm from '../common/DimensionEditForm';
 import MetricEditForm from '../common/MetricEditForm';
 import RelationEditForm from '../common/RelationEditForm';
+import LevelEditForm from '../common/LevelEditForm';
+import DefaultsEditForm from '../common/DefaultsEditForm';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { formatRef } from '../../../utils/refString';
 import { useObjectSave } from '../../../hooks/useObjectSave';
@@ -37,8 +39,11 @@ import { emitWorkspaceEvent } from './telemetry';
  *   - Scoped dashboard + Outline `row.N` key       → <RowEditForm>.
  *   - Scoped dashboard + Outline `row.N.item.M`    → the item's leaf form
  *     (Chart/Table/Markdown/Input) when it references one, else <ItemEditForm>.
- *   - Level + project-chrome                        → minimal placeholder
- *     ("edited in M-2b/M-3" — those forms are DEFERRED, not built here).
+ *   - Level (Outline / Project-Editor `level` selection) → <LevelEditForm>
+ *     (VIS-807 / M-2b — title + description, persisted via `updateLevel`).
+ *   - Project-chrome / defaults selection            → <DefaultsEditForm>
+ *     (VIS-809 / M-3 — source_name, threads, levels, persisted via
+ *     `saveDefaults`).
  *
  * Every form is fronted by a <SelectionChip> header (rainbow type colour +
  * name) and an inline auto-save indicator. There are NO Save buttons for the
@@ -227,28 +232,24 @@ const RightRailEditPanel = () => {
     );
   }
 
-  // ── Level + project-chrome → deferred placeholders (M-2b / M-3) ────────────
-  if (type === 'project') {
+  // ── Project-chrome / defaults → DefaultsEditForm (VIS-809 / M-3) ───────────
+  if (type === 'project' || type === 'defaults') {
     return (
       <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
-        <SelectionChip type="project" name={activeObject.name || 'project'} subtitle="Project settings" />
-        <Placeholder
-          testId="right-rail-edit-project-placeholder"
-          title="Project settings"
-          body="The project / defaults form is edited in M-3 — deferred."
-        />
+        <DefaultsEditForm name={activeObject.name} />
       </div>
     );
   }
-  if (type === 'level' || type === 'defaults') {
+
+  // ── Level → LevelEditForm (VIS-807 / M-2b) ─────────────────────────────────
+  if (type === 'level') {
+    // The selection carries the level's position in `defaults.levels` as
+    // `index`; fall back to the first level when it's absent (the form
+    // self-resolves the level from the store by index).
+    const levelIndex = Number.isInteger(activeObject.index) ? activeObject.index : 0;
     return (
       <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
-        <SelectionChip type={type === 'level' ? 'dashboard' : 'defaults'} name={activeObject.name || type} />
-        <Placeholder
-          testId="right-rail-edit-level-placeholder"
-          title={type === 'level' ? 'Level settings' : 'Defaults'}
-          body="This form is edited in M-2b / M-3 — deferred."
-        />
+        <LevelEditForm index={levelIndex} />
       </div>
     );
   }

--- a/viewer/src/components/new-views/workspace/RightRailEditPanel.test.jsx
+++ b/viewer/src/components/new-views/workspace/RightRailEditPanel.test.jsx
@@ -48,6 +48,17 @@ jest.mock('../common/ModelEditForm', () => stubForm('model-edit-form-stub', 'mod
 jest.mock('../common/DimensionEditForm', () => stubForm('dimension-edit-form-stub', 'dimension'));
 jest.mock('../common/MetricEditForm', () => stubForm('metric-edit-form-stub', 'metric'));
 jest.mock('../common/RelationEditForm', () => stubForm('relation-edit-form-stub', 'relation'));
+// VIS-807 (M-2b) + VIS-809 (M-3) — the level/defaults forms now render real
+// forms (not placeholders). Stub them so routing assertions stay focused; each
+// stub echoes the prop the router passes through (level index / defaults name).
+jest.mock('../common/LevelEditForm', () => ({
+  __esModule: true,
+  default: ({ index }) => <div data-testid="level-edit-form-stub">{`level:${index}`}</div>,
+}));
+jest.mock('../common/DefaultsEditForm', () => ({
+  __esModule: true,
+  default: ({ name }) => <div data-testid="defaults-edit-form-stub">{`defaults:${name || 'none'}`}</div>,
+}));
 
 const SIMPLE_DASHBOARD = {
   name: 'simple-dashboard',
@@ -170,16 +181,30 @@ describe('RightRailEditPanel routing (VIS-802 / Q25)', () => {
     expect(screen.getByTestId('markdown-edit-form-stub')).toHaveTextContent('notes');
   });
 
-  test('project-chrome → deferred placeholder (M-3)', () => {
+  test('project-chrome → DefaultsEditForm (VIS-809 / M-3)', () => {
     resetStore({ workspaceActiveObject: { type: 'project', name: 'proj' } });
     renderPanel('/workspace/dashboard/simple-dashboard');
-    expect(screen.getByTestId('right-rail-edit-project-placeholder')).toBeInTheDocument();
+    expect(screen.getByTestId('defaults-edit-form-stub')).toHaveTextContent('defaults:proj');
+    expect(screen.queryByTestId('right-rail-edit-project-placeholder')).not.toBeInTheDocument();
   });
 
-  test('level → deferred placeholder (M-2b)', () => {
+  test('defaults selection → DefaultsEditForm (VIS-809 / M-3)', () => {
+    resetStore({ workspaceActiveObject: { type: 'defaults', name: 'settings' } });
+    renderPanel('/workspace/dashboard/simple-dashboard');
+    expect(screen.getByTestId('defaults-edit-form-stub')).toHaveTextContent('defaults:settings');
+  });
+
+  test('level → LevelEditForm at the selected index (VIS-807 / M-2b)', () => {
+    resetStore({ workspaceActiveObject: { type: 'level', name: 'Team', index: 2 } });
+    renderPanel();
+    expect(screen.getByTestId('level-edit-form-stub')).toHaveTextContent('level:2');
+    expect(screen.queryByTestId('right-rail-edit-level-placeholder')).not.toBeInTheDocument();
+  });
+
+  test('level with no index → LevelEditForm defaulting to index 0', () => {
     resetStore({ workspaceActiveObject: { type: 'level', name: 'L0' } });
     renderPanel();
-    expect(screen.getByTestId('right-rail-edit-level-placeholder')).toBeInTheDocument();
+    expect(screen.getByTestId('level-edit-form-stub')).toHaveTextContent('level:0');
   });
 
   test('no selection → empty state', () => {

--- a/viewer/src/components/new-views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.test.jsx
@@ -44,6 +44,10 @@ jest.mock('../common/ModelEditForm', () => stubLeafForm('model-edit-form-stub'))
 jest.mock('../common/DimensionEditForm', () => stubLeafForm('dimension-edit-form-stub'));
 jest.mock('../common/MetricEditForm', () => stubLeafForm('metric-edit-form-stub'));
 jest.mock('../common/RelationEditForm', () => stubLeafForm('relation-edit-form-stub'));
+// The level/defaults Edit forms (VIS-807 / VIS-809) self-fetch (sources/defaults)
+// on mount; stub them so the shell-mount fetch assertions stay route-level.
+jest.mock('../common/LevelEditForm', () => stubLeafForm('level-edit-form-stub'));
+jest.mock('../common/DefaultsEditForm', () => stubLeafForm('defaults-edit-form-stub'));
 
 const resetWorkspaceStore = () => {
   act(() => {

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.js
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.js
@@ -104,14 +104,26 @@ export function useWorkspaceScope() {
       };
     }
 
-    // Unscoped — Project Editor surface. Selected item is the project
-    // itself (so the right-rail Edit form binds to project chrome).
-    const projectName = activeTab && activeTab.type === 'project' ? activeTab.name : null;
+    // Project-chrome tab → `project` scope. The Project Editor surface still
+    // mounts (MiddlePane keys off `workspaceActiveObject.type`, not scope) and
+    // the lineage selector stays `'*'` (Full project), but the right-rail Edit
+    // tab now binds to the project `Defaults` form (VIS-809 / M-3). When there
+    // is no project tab at all the workspace is truly unscoped → `root`.
+    if (activeTab && activeTab.type === 'project') {
+      return {
+        scope: 'project',
+        selector: '*',
+        dashboardName: null,
+        selectedItem: { type: 'project', name: activeTab.name },
+      };
+    }
+
+    // Unscoped — Project Editor surface with no selection bound.
     return {
       scope: 'root',
       selector: '*',
       dashboardName: null,
-      selectedItem: projectName ? { type: 'project', name: projectName } : null,
+      selectedItem: null,
     };
   }, [dashboardName, searchParams, activeTab]);
 }

--- a/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
+++ b/viewer/src/components/new-views/workspace/useWorkspaceScope.test.jsx
@@ -72,7 +72,7 @@ describe('useWorkspaceScope', () => {
     expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('null');
   });
 
-  test('returns root scope with project selectedItem when project tab is active', () => {
+  test('returns project scope with project selectedItem when project tab is active', () => {
     act(() => {
       useStore.setState({
         workspaceTabs: [
@@ -87,7 +87,11 @@ describe('useWorkspaceScope', () => {
       });
     });
     renderAt('/workspace');
-    expect(screen.getByTestId('probe-scope')).toHaveTextContent('root');
+    // VIS-809 (M-3): an active project-chrome tab now scopes to `project` so
+    // the right-rail Edit tab binds to the project Defaults form. The selector
+    // stays `'*'` (Full project) so lineage is unaffected.
+    expect(screen.getByTestId('probe-scope')).toHaveTextContent('project');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent('*');
     expect(screen.getByTestId('probe-selected-type')).toHaveTextContent(
       'project'
     );

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -180,6 +180,58 @@ const createDashboardSlice = (set, get) => ({
   },
 
   /**
+   * Update the level at `index` with a partial `{ title?, description? }` patch
+   * in one persist (VIS-807 / M-2b — the right-rail LevelEditForm edits title +
+   * description together). A blank title is rejected (the backend `Level` model
+   * requires a non-empty title). When the title changes, dashboards that
+   * referenced the level by its old title are re-pointed so they stay in the
+   * group — same behaviour as `renameLevel`. Returns `{ success: false,
+   * error: 'unchanged' }` when neither field actually changes.
+   */
+  updateLevel: async (index, patch = {}) => {
+    const levels = get()._resolveLevels();
+    if (index < 0 || index >= levels.length) {
+      return { success: false, error: 'level index out of range' };
+    }
+    const current = levels[index];
+    const previousTitle = current.title;
+    const nextTitle =
+      patch.title === undefined ? current.title : (patch.title ?? '').trim();
+    if (!nextTitle) {
+      return { success: false, error: 'title required' };
+    }
+    const nextDescription =
+      patch.description === undefined ? current.description : patch.description;
+
+    const titleChanged = nextTitle !== previousTitle;
+    const descriptionChanged = (nextDescription ?? '') !== (current.description ?? '');
+    if (!titleChanged && !descriptionChanged) {
+      return { success: false, error: 'unchanged' };
+    }
+
+    const nextLevels = levels.map((l, i) =>
+      i === index ? { ...l, title: nextTitle, description: nextDescription } : l
+    );
+    const result = await get()._persistLevels(nextLevels);
+
+    if (result?.success && titleChanged && previousTitle) {
+      const dashboards = get().dashboards || [];
+      const affected = dashboards.filter(
+        d =>
+          typeof d.config?.level === 'string' &&
+          d.config.level.toLowerCase() === previousTitle.toLowerCase()
+      );
+      for (const dashboard of affected) {
+        await get().saveDashboard(dashboard.name, {
+          ...(dashboard.config || {}),
+          level: nextTitle,
+        });
+      }
+    }
+    return result;
+  },
+
+  /**
    * Move the level at `index` by `direction` (-1 up, +1 down). No-op at the ends.
    */
   reorderLevel: async (index, direction) => {

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -128,6 +128,60 @@ describe('dashboardStore level CRUD (VIS-807 M-2a)', () => {
     expect(result.success).toBe(false);
   });
 
+  test('updateLevel persists title + description together (VIS-807 M-2b)', async () => {
+    const saveDefaults = jest.fn(async () => ({ success: true }));
+    seedLevels({
+      levels: [{ title: 'Org', description: 'old' }, { title: 'Team' }],
+      saveDefaults,
+    });
+    await act(async () => {
+      await useStore.getState().updateLevel(0, { title: 'Org', description: 'new desc' });
+    });
+    expect(saveDefaults).toHaveBeenCalledWith({
+      levels: [{ title: 'Org', description: 'new desc' }, { title: 'Team' }],
+    });
+  });
+
+  test('updateLevel re-points matching dashboards when the title changes', async () => {
+    const saveDefaults = jest.fn(async () => ({ success: true }));
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seedLevels({
+      levels: [{ title: 'Org', description: 'd' }, { title: 'Team' }],
+      dashboards: [{ name: 'exec', config: { level: 'Org' } }],
+      saveDefaults,
+      saveDashboard,
+    });
+    await act(async () => {
+      await useStore.getState().updateLevel(0, { title: 'Company', description: 'd' });
+    });
+    expect(saveDefaults).toHaveBeenCalledWith({
+      levels: [{ title: 'Company', description: 'd' }, { title: 'Team' }],
+    });
+    expect(saveDashboard).toHaveBeenCalledWith('exec', { level: 'Company' });
+  });
+
+  test('updateLevel is a no-op when neither title nor description changes', async () => {
+    const saveDefaults = jest.fn();
+    seedLevels({ levels: [{ title: 'Org', description: 'd' }], saveDefaults });
+    let result;
+    await act(async () => {
+      result = await useStore.getState().updateLevel(0, { title: 'Org', description: 'd' });
+    });
+    expect(saveDefaults).not.toHaveBeenCalled();
+    expect(result.error).toBe('unchanged');
+  });
+
+  test('updateLevel rejects a blank title', async () => {
+    const saveDefaults = jest.fn();
+    seedLevels({ levels: [{ title: 'Org' }], saveDefaults });
+    let result;
+    await act(async () => {
+      result = await useStore.getState().updateLevel(0, { title: '   ' });
+    });
+    expect(saveDefaults).not.toHaveBeenCalled();
+    expect(result.error).toBe('title required');
+  });
+
   test('reorderLevel swaps adjacent levels', async () => {
     const saveDefaults = jest.fn(async () => ({ success: true }));
     seedLevels({ levels: [{ title: 'A' }, { title: 'B' }, { title: 'C' }], saveDefaults });


### PR DESCRIPTION
## Summary

Replaces the two **deferred placeholder** branches in the Q25 right-rail Edit-tab router (`RightRailEditPanel.jsx`) with real forms.

### VIS-807 (M-2b) — `LevelEditForm`
- New `viewer/src/components/new-views/common/LevelEditForm.jsx`: a right-rail form to edit a dashboard **Level** — title + description.
- Persists through a new index-based store action `updateLevel(index, { title, description })` in `dashboardStore.js`, which round-trips the same `saveDefaults` → defaults-cache → publish path as the rest of the M-2a level CRUD (and re-points dashboards on a title change, like `renameLevel`).
- Surfaces reorder/delete by **delegating to the existing M-2a store actions** (`reorderLevel`/`deleteLevel`) — it does NOT rebuild the inline `LevelGroupHeader`/`ProjectEditor` affordances.
- Fronted by `<SelectionChip>` like the other Edit-tab forms.
- Wired into `RightRailEditPanel` for `type === 'level'` (level index read from `workspaceActiveObject.index`, default 0).

### VIS-809 (M-3) — `DefaultsEditForm`
- New `viewer/src/components/new-views/common/DefaultsEditForm.jsx`: a thin `<SelectionChip>` wrapper around the existing `ProjectDefaultsEditForm` (preferred over building from scratch). Edits `source_name`, `threads`, default alert, telemetry, and `levels`; persists via the established `saveDefaults` action. Theme is v2-deferred.
- Wired into `RightRailEditPanel` for `type === 'project'` / `'defaults'`.
- `useWorkspaceScope` now returns `scope: 'project'` for an active project-chrome tab (selector stays `'*'`, so lineage / Project Editor surface are unaffected).

### Scope
Stayed inside the right-rail Edit tab: `RightRailEditPanel.jsx`, the two form components, a minimal `useWorkspaceScope` addition, and the index-based `updateLevel` store action. No Outline tab / scope-sync (VIS-835) or canvas/DnD changes.

## Test Strategy
- **Unit (store + components):** `RightRailEditPanel.test.jsx` placeholder assertions replaced with `level → LevelEditForm` and `project`/`defaults → DefaultsEditForm` routing (+ index passthrough). New `LevelEditForm.test.jsx` (6) and `DefaultsEditForm.test.jsx` (2). New `updateLevel` tests in `dashboardStore.test.js` (4). Updated `useWorkspaceScope.test.jsx` for the new `project` scope. `Workspace.test.jsx` stubs the two new self-fetching forms (existing convention).
- **E2E story:** extended `right-rail-routing.spec.mjs` with Level + Project/Defaults routing steps.
- **Results:** full `bash scripts/viewer-check.sh` green — **1969 unit tests + lint clean**. E2E story **9/9 pass live** against an isolated sandbox (:3007/:8007), no console errors. Both forms verified visually.

References: VIS-807, VIS-809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)