### PR TITLE
feat(viewer): canvas drag-and-drop (VIS-771 / Track D D-3)

### DIFF
--- a/viewer/e2e/stories/canvas-dnd.spec.mjs
+++ b/viewer/e2e/stories/canvas-dnd.spec.mjs
@@ -1,0 +1,258 @@
+/**
+ * Story: Canvas drag-and-drop (VIS-771 / Track D D-3).
+ *
+ * The Workspace dashboard canvas (<ProjectCanvas>) now mounts a drag-and-drop
+ * affordance layer (<CanvasDndLayer>) over the render-only <Dashboard>, wired to
+ * the shell's SINGLE shared <WorkspaceDndContext> (no second DndContext). It
+ * supports three real gestures, each persisting through the dashboard store
+ * (optimistic update + debounced save, backend-valid via sanitize):
+ *
+ *   1. Reorder an item WITHIN a row  — drag an item's handle onto the
+ *      end-of-row / between-items drop zone of the same row.
+ *   2. Reorder TOP-LEVEL rows         — drag a row's handle onto a between-rows
+ *      drop zone.
+ *   3. Drop a Library object onto the canvas — drag a Library row onto a canvas
+ *      drop zone → a new item referencing that object is inserted.
+ *
+ * The drag preview is the source pill (architecture §2.6 — no thumbnails); the
+ * shared <DragOverlay> renders it.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8008 VISIVO_SANDBOX_FRONTEND_PORT=3008 \
+ *   VISIVO_SANDBOX_NAME=vis771 bash scripts/sandbox.sh start
+ *   # then: VIS_CANVAS_DND_BASE=http://localhost:3008 npx playwright test canvas-dnd
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_CANVAS_DND_BASE || 'http://localhost:3008';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+// A wide viewport keeps the canvas ≥768px so flat dashboards lay rows out
+// side-by-side (real boxes for item drag handles + drop zones).
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+// A STABLE per-item signature for order comparison. Items may carry either a
+// string ref (`ref(name)` / `${ref(name)}`) OR an embedded leaf object (the
+// integration project pre-resolves charts into objects with a `name`/`path`).
+// We extract a string key that survives a save → refetch round-trip (new object
+// identities) so `.toBe`/`.toEqual` order assertions are meaningful.
+const itemKey = it => {
+  if (!it || typeof it !== 'object') return '(slot)';
+  const leaf = it.chart ?? it.table ?? it.markdown ?? it.input;
+  if (leaf == null) return Array.isArray(it.rows) ? '(container)' : '(slot)';
+  if (typeof leaf === 'string') return leaf;
+  // Embedded object: prefer its name, then its path (both stable across saves).
+  return leaf.name || leaf.path || JSON.stringify(leaf).slice(0, 64);
+};
+
+const readItemOrder = async (page, rowIndex) => {
+  const rows = await readRows(page);
+  const items = rows[rowIndex]?.items || [];
+  return items.map(itemKey);
+};
+
+// dnd-kit PointerSensor needs down → nudge (clears 5px activation) → travel →
+// settle on target so the collision detector registers `over` before the drop.
+const dndDrag = async (page, source, target) => {
+  await source.scrollIntoViewIfNeeded();
+  const sb = await source.boundingBox();
+  const tb = await target.boundingBox();
+  expect(sb && tb, 'both drag endpoints have a box').toBeTruthy();
+  const sx = sb.x + sb.width / 2;
+  const sy = sb.y + sb.height / 2;
+  const tx = tb.x + tb.width / 2;
+  const ty = tb.y + tb.height / 2;
+  await page.mouse.move(sx, sy);
+  await page.mouse.down();
+  await page.mouse.move(sx + 8, sy + 8, { steps: 6 }); // clear activation distance
+  await page.mouse.move(tx, ty, { steps: 24 });
+  await page.mouse.move(tx + 1, ty + 1, { steps: 4 });
+  await page.mouse.move(tx, ty, { steps: 4 });
+  return { sb, tb };
+};
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(dash.locator('[data-row-index]').first()).toBeVisible({ timeout: WAIT });
+  // The DnD affordance layer mounted over the render.
+  await expect(page.getByTestId('canvas-dnd-layer')).toBeAttached({ timeout: WAIT });
+};
+
+test.describe('Canvas drag-and-drop (VIS-771 / D-3)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('the canvas mounts drag handles + drop zones over rows and items', async () => {
+    await openCanvas(page);
+
+    // Find a row that has ≥2 items so reorder is meaningful; the integration
+    // simple-dashboard's first multi-item row works.
+    const rows = await readRows(page);
+    const multiItemRow = rows.findIndex(r => (r.items || []).length >= 2);
+    expect(multiItemRow, 'a row with ≥2 items exists').toBeGreaterThanOrEqual(0);
+
+    // Handles + zones for that row are present in the DOM.
+    await expect(page.getByTestId(`canvas-drag-handle-row.${multiItemRow}`)).toBeAttached({
+      timeout: WAIT,
+    });
+    await expect(
+      page.getByTestId(`canvas-drag-handle-row.${multiItemRow}.item.0`)
+    ).toBeAttached({ timeout: WAIT });
+    await expect(page.getByTestId(`canvas-dropzone-row.${multiItemRow}-end`)).toBeAttached({
+      timeout: WAIT,
+    });
+    await page.screenshot({ path: `${SCREENS}/vis771-01-affordances.png`, fullPage: true });
+  });
+
+  test('reorder an item within a row → persists to the store config', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    const ri = rows.findIndex(r => (r.items || []).length >= 2);
+    const before = await readItemOrder(page, ri);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+
+    // Drag item 0's handle onto the end-of-row drop zone → item 0 → last.
+    const handle = page.getByTestId(`canvas-drag-handle-row.${ri}.item.0`);
+    const endZone = page.getByTestId(`canvas-dropzone-row.${ri}-end`);
+    await dndDrag(page, handle, endZone);
+    // Mid-flight: the shared drag overlay pill is visible (proves the canvas
+    // drag reaches the SAME shared DndContext).
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // The config reorders: the first item moved to the end.
+    await expect
+      .poll(async () => (await readItemOrder(page, ri))[before.length - 1], { timeout: WAIT })
+      .toBe(before[0]);
+    const after = await readItemOrder(page, ri);
+    expect(after).toHaveLength(before.length);
+    expect(after).not.toEqual(before);
+    await page.screenshot({ path: `${SCREENS}/vis771-02-item-reordered.png`, fullPage: true });
+  });
+
+  test('reorder top-level rows → persists to the store config', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    expect(rows.length, 'dashboard has ≥2 rows').toBeGreaterThanOrEqual(2);
+
+    // Item-name signatures per row are a stable order-revealing fingerprint
+    // (heights can repeat; the item refs are unique per row here).
+    const sig = rs => rs.map(r => (r.items || []).map(itemKey).join('|')).join('#');
+    const beforeSig = sig(rows);
+
+    // Drag ROW 0's handle DOWN into the gap before row 2 → row 0 moves to
+    // index 1. Source handle + target gap are both within one viewport (the
+    // canvas is a tall inner scroll container, so we keep both endpoints near
+    // the top to avoid scroll-induced stale boxes).
+    const row0Sig = (rows[0].items || []).map(itemKey).join('|');
+    const rowHandle = page.getByTestId('canvas-drag-handle-row.0');
+    const gapZone = page.getByTestId('canvas-dropzone-row-before-2');
+    await dndDrag(page, rowHandle, gapZone);
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // The row order changes and the moved row lands at index 1.
+    await expect
+      .poll(async () => sig(await readRows(page)), { timeout: WAIT })
+      .not.toBe(beforeSig);
+    const afterRows = await readRows(page);
+    expect(afterRows).toHaveLength(rows.length);
+    expect((afterRows[1].items || []).map(itemKey).join('|')).toBe(row0Sig);
+    await page.screenshot({ path: `${SCREENS}/vis771-03-rows-reordered.png`, fullPage: true });
+  });
+
+  test('drop a Library object onto the canvas → inserts a new item', async () => {
+    await openCanvas(page);
+    const rowsBefore = await readRows(page);
+    const totalItemsBefore = rowsBefore.reduce((n, r) => n + (r.items || []).length, 0);
+
+    // Expand the Charts subsection in the Library (collapsed by default) and
+    // grab a chart row as the drag source.
+    const chartHeader = page.getByTestId('library-subsection-chart-header');
+    await chartHeader.waitFor({ timeout: WAIT });
+    const anyChartRow = page.locator('[data-testid^="library-row-chart-"]').first();
+    if (!(await anyChartRow.count())) {
+      await chartHeader.click();
+    }
+    await anyChartRow.waitFor({ timeout: WAIT });
+    const chartName = await anyChartRow.evaluate(el =>
+      (el.getAttribute('data-testid') || '').replace('library-row-chart-', '')
+    );
+    expect(chartName).toBeTruthy();
+
+    // Drop it on the end-of-row zone of row 0 (near the top of the canvas, so
+    // both the Library source row and the canvas target are within one
+    // viewport) → a new item appends to that row.
+    const endZone = page.getByTestId('canvas-dropzone-row.0-end');
+    await endZone.waitFor({ timeout: WAIT });
+    await dndDrag(page, anyChartRow, endZone);
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // A new item referencing the chart lands somewhere in the config.
+    await expect
+      .poll(
+        async () => {
+          const rows = await readRows(page);
+          return rows.some(r =>
+            (r.items || []).some(
+              it => typeof it.chart === 'string' && it.chart.includes(chartName)
+            )
+          );
+        },
+        { timeout: WAIT }
+      )
+      .toBe(true);
+
+    const rowsAfter = await readRows(page);
+    const totalItemsAfter = rowsAfter.reduce((n, r) => n + (r.items || []).length, 0);
+    expect(totalItemsAfter).toBeGreaterThan(totalItemsBefore);
+    await page.screenshot({ path: `${SCREENS}/vis771-04-library-dropped.png`, fullPage: true });
+  });
+
+  test('no console errors AND no auto-save 400 across the canvas DnD gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'canvas DnD must persist backend-valid config (sanitize)').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
@@ -1,0 +1,459 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import useStore from '../../../../stores/store';
+import { parseRefValue } from '../../../../utils/refString';
+
+/**
+ * CanvasDndLayer — VIS-771 / Track D D-3.
+ *
+ * The drag-and-drop affordance overlay for the Workspace dashboard canvas. It
+ * is a SIBLING layer over the render-only <Dashboard> (mounted by ProjectCanvas
+ * next to CanvasSelectionOverlay), so it never mutates Dashboard's render — it
+ * MEASURES the live DOM via the same composite `data-canvas-path` markers the
+ * selection overlay reads, then paints:
+ *
+ *   - a **drag handle** (grip) over every row + item box → a dnd-kit
+ *     `useDraggable` whose drag preview is the source pill (the shared
+ *     <DragOverlay> in WorkspaceDndContext renders it; §2.6 — no thumbnails).
+ *   - **drop zones** in the gaps → dnd-kit `useDroppable`s carrying a
+ *     `{ kind: 'canvas-drop', target, dashboardName, config }` payload that the
+ *     shared `routeWorkspaceDragEnd` router turns into a reorder / insert and
+ *     commits through the dashboard save path.
+ *
+ * Drop intents (matching the D-2 mockup):
+ *   - between-items  → vertical mulberry bar in an item gap.
+ *   - end-of-row     → vertical mulberry bar at a row's trailing edge (append).
+ *   - between-rows   → horizontal mulberry bar in a top-level row gap.
+ *   - in-container   → mulberry-tinted region over a container item (append a
+ *                      sub-row).
+ *
+ * There is NO second DndContext: every draggable/droppable here talks to the
+ * single shell-level <WorkspaceDndContext>. The overlay layer itself is
+ * pointer-events-none; only the handles + drop zones opt back into pointer
+ * events so Dashboard's own interactivity (Plotly hover, links) is preserved.
+ *
+ * Mulberry (`#713b57`) is the active/insertion colour (NOT a type colour).
+ */
+
+const MULBERRY = '#713b57';
+
+// Measure a node's box relative to the overlay root (so we can absolutely
+// position handles/zones inside the same positioned ancestor).
+const measure = (el, rootEl) => {
+  if (!el || !rootEl) return null;
+  const node = el.getBoundingClientRect();
+  const root = rootEl.getBoundingClientRect();
+  return {
+    top: node.top - root.top,
+    left: node.left - root.left,
+    width: node.width,
+    height: node.height,
+  };
+};
+
+/** The referenced object type for a dashboard item (for the drag pill). */
+const itemRefType = item => {
+  if (!item || typeof item !== 'object') return 'chart';
+  if (item.chart) return 'chart';
+  if (item.table) return 'table';
+  if (item.markdown) return 'markdown';
+  if (item.input) return 'input';
+  if (Array.isArray(item.rows)) return 'dashboard';
+  return 'chart';
+};
+
+const itemRefName = item => {
+  if (!item || typeof item !== 'object') return 'item';
+  const raw = item.chart || item.table || item.markdown || item.input;
+  if (typeof raw === 'string') return parseRefValue(raw) || 'item';
+  return 'item';
+};
+
+// ── Drag handle ────────────────────────────────────────────────────────────
+// A grip positioned at the top-left of a row/item box. Dragging it starts a
+// canvas reorder. `rowPath` is the path of the ROW the item lives in (for an
+// item) so the router can reorder within it.
+const CanvasDragHandle = ({ id, box, kind, dragData, label }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id, data: dragData });
+  if (!box) return null;
+  const isRow = kind === 'row';
+  // Rows: handle sits in the LEFT GUTTER beside the row (clamped to ≥2px so it
+  // never escapes the canvas) and is taller — this keeps it clear of the row's
+  // first ITEM handle, which sits at the item's top-left corner. Without the
+  // gutter offset the row + item-0 handles overlap and the item handle (painted
+  // last) swallows every row-drag pointer.
+  const top = isRow ? box.top + box.height / 2 - 16 : box.top + 4;
+  const left = isRow ? Math.max(2, box.left - 22) : box.left + 4;
+  return (
+    <button
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      type="button"
+      data-testid={`canvas-drag-handle-${id}`}
+      data-canvas-handle-kind={kind}
+      aria-label={label}
+      title={label}
+      className="pointer-events-auto absolute z-20 inline-flex items-center justify-center rounded-md border border-[#c6b0bb] bg-white/95 text-[#713b57] shadow-sm transition-opacity hover:bg-[#f9f6f8]"
+      style={{
+        top,
+        left,
+        width: 18,
+        height: isRow ? 32 : 18,
+        cursor: isDragging ? 'grabbing' : 'grab',
+        opacity: isDragging ? 0.5 : 1,
+        touchAction: 'none',
+      }}
+    >
+      {/* Six-dot grip (matches the Library row grip idiom). */}
+      <svg viewBox="0 0 12 12" width="11" height="11" aria-hidden="true">
+        <g fill="currentColor">
+          <circle cx="3.5" cy="3" r="1" />
+          <circle cx="8.5" cy="3" r="1" />
+          <circle cx="3.5" cy="6" r="1" />
+          <circle cx="8.5" cy="6" r="1" />
+          <circle cx="3.5" cy="9" r="1" />
+          <circle cx="8.5" cy="9" r="1" />
+        </g>
+      </svg>
+    </button>
+  );
+};
+
+// ── Drop zone ────────────────────────────────────────────────────────────────
+// A droppable region painting a mulberry insertion bar / tinted region when it
+// is the active target under the cursor. `intent` styles the indicator.
+const CanvasDropZone = ({ id, box, intent, data }) => {
+  const { setNodeRef, isOver, active } = useDroppable({ id, data });
+  if (!box) return null;
+  const isDragging = !!active;
+
+  // Hit areas are generous (the gaps are thin); the visible indicator is the
+  // mulberry bar/region, shown only while a drag is over this zone.
+  const common = {
+    ref: setNodeRef,
+    'data-testid': `canvas-dropzone-${id}`,
+    'data-intent': intent,
+    'data-over': isOver ? 'true' : 'false',
+  };
+
+  if (intent === 'between-rows') {
+    // The hit box is intentionally taller than the visible gap (it extends into
+    // the adjacent rows) so the thin row gap is a comfortable drop target. The
+    // mulberry bar is painted at `barTop` (the true gap centre within the box).
+    const barTop = typeof box.barTop === 'number' ? box.barTop : box.height / 2 - 1.5;
+    return (
+      <div
+        {...common}
+        className="pointer-events-auto absolute z-20"
+        style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
+      >
+        {isDragging && isOver && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute rounded-full"
+            style={{
+              left: 0,
+              right: 0,
+              top: barTop,
+              height: 3,
+              background: MULBERRY,
+              boxShadow: '0 0 0 2px rgba(113,59,87,0.18)',
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (intent === 'in-container') {
+    return (
+      <div
+        {...common}
+        className="pointer-events-auto absolute z-[19]"
+        style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
+      >
+        {isDragging && isOver && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 rounded-md"
+            style={{
+              background: 'rgba(113,59,87,0.08)',
+              boxShadow: `inset 0 0 0 2px ${MULBERRY}, inset 0 0 0 4px rgba(255,255,255,0.6)`,
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  // between-items / end-of-row → vertical bar.
+  return (
+    <div
+      {...common}
+      className="pointer-events-auto absolute z-20"
+      style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
+    >
+      {isDragging && isOver && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute rounded-full"
+          style={{
+            left: box.width / 2 - 1.5,
+            top: 0,
+            bottom: 0,
+            width: 3,
+            background: MULBERRY,
+            boxShadow: '0 0 0 2px rgba(113,59,87,0.18)',
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * Build the list of handles + drop zones from the live DOM geometry. We read
+ * the config (top-level row count + per-row item counts + which items are
+ * containers) from the store, then measure each `data-canvas-path` node. The
+ * gaps are derived from adjacent item/row boxes.
+ */
+const useCanvasDndModel = (rootRef, dashboardName, dashboardConfig) => {
+  const [model, setModel] = useState({ handles: [], zones: [] });
+
+  const rows = useMemo(
+    () => (Array.isArray(dashboardConfig?.rows) ? dashboardConfig.rows : []),
+    [dashboardConfig]
+  );
+
+  const rebuild = useCallback(() => {
+    const root = rootRef.current;
+    if (!root || !rows.length) {
+      setModel({ handles: [], zones: [] });
+      return;
+    }
+    const handles = [];
+    const zones = [];
+    const at = path => {
+      const el = root.querySelector(`[data-canvas-path="${path}"]`);
+      return el ? measure(el, root) : null;
+    };
+
+    rows.forEach((row, ri) => {
+      const rowPath = `row.${ri}`;
+      const rowBox = at(rowPath);
+      if (!rowBox) return;
+
+      // Row drag handle.
+      handles.push({
+        id: rowPath,
+        box: rowBox,
+        kind: 'row',
+        label: `Reorder row ${ri + 1}`,
+        dragData: { source: 'canvas', kind: 'row', rowIndex: ri, rowPath },
+      });
+
+      const items = Array.isArray(row.items) ? row.items : [];
+      const itemBoxes = items.map((_, ii) => at(`${rowPath}.item.${ii}`));
+
+      items.forEach((item, ii) => {
+        const itemPath = `${rowPath}.item.${ii}`;
+        const box = itemBoxes[ii];
+        if (!box) return;
+        const isContainer = Array.isArray(item.rows) && item.rows.length > 0;
+
+        // Item drag handle.
+        handles.push({
+          id: itemPath,
+          box,
+          kind: 'item',
+          label: `Reorder item ${ii + 1} in row ${ri + 1}`,
+          dragData: {
+            source: 'canvas',
+            kind: 'item',
+            rowPath,
+            itemIndex: ii,
+            refType: itemRefType(item),
+            label: itemRefName(item),
+          },
+        });
+
+        // between-items drop zone in the gap BEFORE this item (index ii).
+        const prevBox = ii > 0 ? itemBoxes[ii - 1] : null;
+        const gapLeft = prevBox ? prevBox.left + prevBox.width : box.left - 12;
+        zones.push({
+          id: `${rowPath}-before-${ii}`,
+          intent: 'between-items',
+          box: { top: box.top, left: gapLeft - 6, width: Math.max(12, box.left - gapLeft + 12), height: box.height },
+          data: {
+            kind: 'canvas-drop',
+            dashboardName,
+            config: dashboardConfig,
+            target: { kind: 'between-items', rowPath, index: ii },
+          },
+        });
+
+        // in-container drop zone over container items.
+        if (isContainer) {
+          zones.push({
+            id: `${itemPath}-container`,
+            intent: 'in-container',
+            box,
+            data: {
+              kind: 'canvas-drop',
+              dashboardName,
+              config: dashboardConfig,
+              target: { kind: 'in-container', itemPath },
+            },
+          });
+        }
+      });
+
+      // end-of-row drop zone at the row's trailing edge.
+      const lastBox = itemBoxes[itemBoxes.length - 1];
+      if (lastBox) {
+        zones.push({
+          id: `${rowPath}-end`,
+          intent: 'end-of-row',
+          box: {
+            top: lastBox.top,
+            left: lastBox.left + lastBox.width - 6,
+            width: 18,
+            height: lastBox.height,
+          },
+          data: {
+            kind: 'canvas-drop',
+            dashboardName,
+            config: dashboardConfig,
+            target: { kind: 'end-of-row', rowPath },
+          },
+        });
+      }
+
+      // between-rows drop zone in the gap before this row (top-level only). The
+      // hit box is widened to ±18px around the gap centre (a comfortable target
+      // for the thin inter-row gap); the bar is painted at the true gap centre.
+      const prevRowBox = ri > 0 ? at(`row.${ri - 1}`) : null;
+      const gapCenter = prevRowBox
+        ? (prevRowBox.top + prevRowBox.height + rowBox.top) / 2
+        : rowBox.top - 6;
+      // Keep the band inside the inter-row gap so it doesn't overlap (and steal
+      // the collision from) the item drop zones at a row's top edge.
+      const HALF = 11;
+      zones.push({
+        id: `row-before-${ri}`,
+        intent: 'between-rows',
+        box: {
+          top: gapCenter - HALF,
+          left: rowBox.left,
+          width: rowBox.width,
+          height: HALF * 2,
+          barTop: HALF - 1.5,
+        },
+        data: {
+          kind: 'canvas-drop',
+          dashboardName,
+          config: dashboardConfig,
+          target: { kind: 'between-rows', index: ri },
+        },
+      });
+    });
+
+    // between-rows zone AFTER the last row (append). A generous 36px band so
+    // the trailing append target is easy to hit below the last row.
+    const lastRowBox = at(`row.${rows.length - 1}`);
+    if (lastRowBox) {
+      zones.push({
+        id: `row-before-${rows.length}`,
+        intent: 'between-rows',
+        box: {
+          top: lastRowBox.top + lastRowBox.height,
+          left: lastRowBox.left,
+          width: lastRowBox.width,
+          height: 36,
+          barTop: 4,
+        },
+        data: {
+          kind: 'canvas-drop',
+          dashboardName,
+          config: dashboardConfig,
+          target: { kind: 'between-rows', index: rows.length },
+        },
+      });
+    }
+
+    setModel({ handles, zones });
+  }, [rootRef, rows, dashboardName, dashboardConfig]);
+
+  // Initial + on-change measure. A PASSIVE effect (not layout) on purpose:
+  // <CanvasDndLayer> is a SIBLING rendered over the canvas-path nodes inside a
+  // parent-owned `rootRef`. With a ref OBJECT, the parent's ref is not yet
+  // attached when a child's *layout* effect runs (child layout effects fire
+  // before the parent ref attaches), so a layout-effect rebuild would measure
+  // against a null root on mount. A passive effect runs after the whole tree
+  // (incl. parent refs) commits. The layer paints no dashboard layout, so the
+  // one-frame-later paint is imperceptible.
+  useEffect(() => {
+    rebuild();
+  }, [rebuild]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      // Root not attached yet (mount race) — retry on the next frame so the
+      // ResizeObserver can bind once the parent ref lands.
+      const raf =
+        typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame(rebuild) : null;
+      return () => {
+        if (raf && typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(raf);
+      };
+    }
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(rebuild) : null;
+    if (ro) ro.observe(root);
+    window.addEventListener('resize', rebuild);
+    window.addEventListener('scroll', rebuild, true);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', rebuild);
+      window.removeEventListener('scroll', rebuild, true);
+    };
+  }, [rootRef, rebuild]);
+
+  return model;
+};
+
+const CanvasDndLayer = ({ rootRef, dashboardName }) => {
+  const dashboards = useStore(s => s.dashboards);
+  const dashboardConfig = useMemo(() => {
+    const entry = (dashboards || []).find(d => d.name === dashboardName);
+    if (!entry) return null;
+    return entry.config || entry;
+  }, [dashboards, dashboardName]);
+
+  const { handles, zones } = useCanvasDndModel(rootRef, dashboardName, dashboardConfig);
+
+  if (!dashboardConfig) return null;
+
+  return (
+    <div
+      data-testid="canvas-dnd-layer"
+      className="pointer-events-none absolute inset-0 z-10"
+    >
+      {zones.map(z => (
+        <CanvasDropZone key={z.id} id={z.id} box={z.box} intent={z.intent} data={z.data} />
+      ))}
+      {handles.map(h => (
+        <CanvasDragHandle
+          key={h.id}
+          id={h.id}
+          box={h.box}
+          kind={h.kind}
+          dragData={h.dragData}
+          label={h.label}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CanvasDndLayer;

--- a/viewer/src/components/new-views/project/canvas/CanvasDndLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasDndLayer.test.jsx
@@ -1,0 +1,165 @@
+/**
+ * CanvasDndLayer tests (VIS-771 / Track D D-3).
+ *
+ * The layer measures the live Dashboard DOM via `data-canvas-path` markers and
+ * paints a drag handle over every row/item + drop zones in the gaps. dnd-kit's
+ * `useDraggable`/`useDroppable` are mocked (no DndContext / real pointer drag in
+ * jsdom) so this stays a focused geometry/wiring test — the live drag is
+ * exercised by the Playwright story. We render a fake Dashboard carrying the
+ * same composite paths the real renderer emits, give the nodes measurable boxes
+ * via a mocked getBoundingClientRect, and assert the handles + zones land.
+ */
+import React, { useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import CanvasDndLayer from './CanvasDndLayer';
+import useStore from '../../../../stores/store';
+
+jest.mock('@dnd-kit/core', () => ({
+  useDraggable: ({ id }) => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    isDragging: false,
+    node: { current: null },
+    transform: null,
+    __id: id,
+  }),
+  useDroppable: ({ id }) => ({
+    setNodeRef: () => {},
+    isOver: false,
+    active: null,
+    __id: id,
+  }),
+}));
+
+const DASHBOARD = {
+  name: 'dash',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+      { height: 'small', items: [{ width: 12, chart: 'ref(c)' }] },
+    ],
+  },
+};
+
+// A test host that renders fake Dashboard nodes (carrying data-canvas-path) +
+// the layer, sharing one positioned root ref — exactly ProjectCanvas's shape.
+const Host = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="r0">
+        <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+      </div>
+      <div data-canvas-path="row.1" data-testid="r1">
+        <div data-canvas-path="row.1.item.0" data-testid="r1i0" />
+      </div>
+      <CanvasDndLayer rootRef={rootRef} dashboardName="dash" />
+    </div>
+  );
+};
+
+// Assign deterministic boxes so measure() produces non-null geometry.
+const BOXES = {
+  r0: { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+  r0i0: { top: 0, left: 0, width: 400, height: 200, bottom: 200, right: 400 },
+  r0i1: { top: 0, left: 410, width: 390, height: 200, bottom: 200, right: 800 },
+  r1: { top: 210, left: 0, width: 800, height: 150, bottom: 360, right: 800 },
+  r1i0: { top: 210, left: 0, width: 800, height: 150, bottom: 360, right: 800 },
+  root: { top: 0, left: 0, width: 800, height: 360, bottom: 360, right: 800 },
+};
+
+beforeEach(() => {
+  useStore.setState({ dashboards: [DASHBOARD] });
+  // Mock getBoundingClientRect off the element's data-testid.
+  Element.prototype.getBoundingClientRect = function () {
+    const tid = this.getAttribute && this.getAttribute('data-testid');
+    if (tid && BOXES[tid]) return BOXES[tid];
+    // The positioned root has no testid here — give it the root box.
+    return BOXES.root;
+  };
+});
+
+describe('CanvasDndLayer (VIS-771)', () => {
+  test('renders a drag handle over each row and item', () => {
+    render(<Host />);
+    expect(screen.getByTestId('canvas-dnd-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-drag-handle-row.0')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-drag-handle-row.1')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-drag-handle-row.0.item.0')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-drag-handle-row.0.item.1')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-drag-handle-row.1.item.0')).toBeInTheDocument();
+  });
+
+  test('row handles are tagged row, item handles tagged item', () => {
+    render(<Host />);
+    expect(screen.getByTestId('canvas-drag-handle-row.0')).toHaveAttribute(
+      'data-canvas-handle-kind',
+      'row'
+    );
+    expect(screen.getByTestId('canvas-drag-handle-row.0.item.0')).toHaveAttribute(
+      'data-canvas-handle-kind',
+      'item'
+    );
+  });
+
+  test('renders between-items, end-of-row and between-rows drop zones', () => {
+    render(<Host />);
+    // between-items: a zone before each item.
+    expect(screen.getByTestId('canvas-dropzone-row.0-before-0')).toHaveAttribute(
+      'data-intent',
+      'between-items'
+    );
+    expect(screen.getByTestId('canvas-dropzone-row.0-before-1')).toBeInTheDocument();
+    // end-of-row: one per row.
+    expect(screen.getByTestId('canvas-dropzone-row.0-end')).toHaveAttribute(
+      'data-intent',
+      'end-of-row'
+    );
+    expect(screen.getByTestId('canvas-dropzone-row.1-end')).toBeInTheDocument();
+    // between-rows: one before each row + one after the last (append).
+    expect(screen.getByTestId('canvas-dropzone-row-before-0')).toHaveAttribute(
+      'data-intent',
+      'between-rows'
+    );
+    expect(screen.getByTestId('canvas-dropzone-row-before-1')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-dropzone-row-before-2')).toBeInTheDocument();
+  });
+
+  test('renders nothing when the dashboard is not found', () => {
+    useStore.setState({ dashboards: [] });
+    render(<Host />);
+    expect(screen.queryByTestId('canvas-dnd-layer')).not.toBeInTheDocument();
+  });
+
+  test('mounts an in-container zone over a container item', () => {
+    useStore.setState({
+      dashboards: [
+        {
+          name: 'dash',
+          config: {
+            rows: [{ items: [{ width: 12, rows: [{ items: [{ chart: 'ref(x)' }] }] }] }],
+          },
+        },
+      ],
+    });
+    // The container item needs a measurable box.
+    const ContainerHost = () => {
+      const rootRef = useRef(null);
+      return (
+        <div ref={rootRef} style={{ position: 'relative' }}>
+          <div data-canvas-path="row.0" data-testid="r0">
+            <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+          </div>
+          <CanvasDndLayer rootRef={rootRef} dashboardName="dash" />
+        </div>
+      );
+    };
+    render(<ContainerHost />);
+    expect(screen.getByTestId('canvas-dropzone-row.0.item.0-container')).toHaveAttribute(
+      'data-intent',
+      'in-container'
+    );
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import Dashboard from '../../../project/Dashboard';
 import CanvasSelectionOverlay from './CanvasSelectionOverlay';
+import CanvasDndLayer from './CanvasDndLayer';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -14,8 +15,14 @@ import CanvasSelectionOverlay from './CanvasSelectionOverlay';
  *   - Writes the workspace selection (`workspaceOutlineSelectedKey`) on click,
  *     using the SAME key scheme as the OutlineTreePanel so the canvas + tree
  *     are one selection source of truth.
- *   - Paints hover outlines (+ a resize-handle PLACEHOLDER, no gesture yet —
- *     D-3) and a persistent mulberry selection ring per the D-1 design states.
+ *   - Paints hover outlines (+ a resize-handle PLACEHOLDER) and a persistent
+ *     mulberry selection ring per the D-1 design states.
+ *
+ * VIS-771 / D-3 adds a second sibling overlay, <CanvasDndLayer>, that mounts the
+ * drag-and-drop affordances (drag handles on rows/items + drop zones in the
+ * gaps). It is wired to the shell's shared <WorkspaceDndContext> (no second
+ * DndContext) and persists reorders / Library inserts through the dashboard
+ * save path.
  *
  * The right rail is NOT mounted here (that's G-1); D-2 only SETS selection
  * state + renders overlays. This is the *build* surface by construction (only
@@ -38,6 +45,10 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
     >
       <Dashboard projectId={projectId} dashboardName={dashboardName} stackBreakpoint={768} />
       <CanvasSelectionOverlay rootRef={rootRef} />
+      {/* VIS-771 / D-3: drag-and-drop affordance layer (drag handles + drop
+          zones). A SIBLING over the render, wired to the shell's shared
+          <WorkspaceDndContext> — no second DndContext. */}
+      <CanvasDndLayer rootRef={rootRef} dashboardName={dashboardName} />
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.test.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ProjectCanvas from './ProjectCanvas';
+import useStore from '../../../../stores/store';
 
 jest.mock('../../../project/Dashboard', () => {
   const Mock = ({ projectId, dashboardName }) => (
@@ -48,5 +49,17 @@ describe('ProjectCanvas (VIS-767 / VIS-768)', () => {
   test('the canvas root is positioned so the overlay can anchor to it', () => {
     render(<ProjectCanvas projectId="proj-1" dashboardName="sales" />);
     expect(screen.getByTestId('project-canvas').className).toContain('relative');
+  });
+
+  test('mounts the DnD affordance layer when the scoped dashboard exists (VIS-771)', () => {
+    useStore.setState({
+      dashboards: [{ name: 'sales', config: { rows: [{ items: [{ chart: 'ref(a)' }] }] } }],
+    });
+    render(<ProjectCanvas projectId="proj-1" dashboardName="sales" />);
+    // The DnD layer is wired to the shell's shared DndContext (no second
+    // context); it mounts as a pointer-events-none sibling over the render.
+    const dndLayer = screen.getByTestId('canvas-dnd-layer');
+    expect(dndLayer).toBeInTheDocument();
+    expect(dndLayer.className).toContain('pointer-events-none');
   });
 });

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -1,0 +1,204 @@
+/**
+ * canvasReorder — VIS-771 / Track D D-3.
+ *
+ * Pure, immutable config transforms backing the Workspace canvas drag-and-drop
+ * gestures. The canvas DnD overlay (CanvasDndLayer) and the shared
+ * `routeWorkspaceDragEnd` router (WorkspaceDndContext) read the same composite
+ * `data-canvas-path` scheme the selection overlay + Outline tree share:
+ *
+ *   `row.<ri>`                              → a (possibly nested) row
+ *   `row.<ri>.item.<ii>`                    → an item slot
+ *   `row.<ri>.item.<ii>.row.<rj>.item.<ij>` → arbitrarily nested rows/items
+ *
+ * Every function here returns a NEW config (never mutates) so the store's
+ * optimistic-update path can swap the reference and React re-renders cleanly.
+ * The shell sanitises the result with `sanitizeDashboardConfig` before it is
+ * persisted, so these helpers only restructure the rows/items tree — they never
+ * have to worry about backend-validity of the leaf fields.
+ *
+ * Three gestures, four drop intents (matching the D-2 mockup):
+ *   - reorderItemsInRow   → reorder items WITHIN one row (between-items / end-of-row).
+ *   - reorderTopLevelRows → reorder TOP-LEVEL rows (between-rows).
+ *   - insertItemAtTarget  → insert a new item from a Library drop:
+ *       · between-items   → splice into the target row at an index.
+ *       · end-of-row      → append to the target row.
+ *       · between-rows    → wrap in a brand-new top-level row at an index.
+ *       · in-container    → append a sub-row to a container item's `rows`.
+ */
+
+import { formatRef } from '../../../../utils/refString';
+
+/**
+ * Parse a composite canvas path into a list of `{ kind, index }` segments.
+ * `row.0.item.1.row.2` → [{row,0},{item,1},{row,2}]. Returns `[]` for the
+ * `dashboard` chrome key or any malformed input.
+ */
+export const parseCanvasPath = path => {
+  if (!path || typeof path !== 'string' || path === 'dashboard') return [];
+  const parts = path.split('.');
+  const segments = [];
+  for (let i = 0; i < parts.length; i += 2) {
+    const kind = parts[i];
+    const index = Number(parts[i + 1]);
+    if ((kind !== 'row' && kind !== 'item') || Number.isNaN(index)) return [];
+    segments.push({ kind, index });
+  }
+  return segments;
+};
+
+/** Shallow-immutable array move: returns a new array with `from` moved to `to`. */
+const arrayMove = (arr, from, to) => {
+  const next = [...arr];
+  if (from < 0 || from >= next.length) return next;
+  const [moved] = next.splice(from, 1);
+  const clamped = Math.max(0, Math.min(to, next.length));
+  next.splice(clamped, 0, moved);
+  return next;
+};
+
+/**
+ * Resolve the `rows` array a path's segments live inside, transforming it with
+ * `transformRows` and returning a new config. The path describes the CONTAINER
+ * whose `items`/`rows` we mutate; we walk every segment except the last pair,
+ * descending row→item→row.rows as needed. Used by both reorder + insert paths.
+ *
+ * `rowPathSegments` is the parsed segment list of a ROW path (ends in a `row`
+ * segment). We rebuild the tree top-down, cloning only the spine to the target.
+ */
+const withRowsAtRowPath = (config, rowPathSegments, transformRows) => {
+  if (!config || !Array.isArray(config.rows)) return config;
+
+  // Top-level row path: [{ row, ri }].
+  if (rowPathSegments.length === 1 && rowPathSegments[0].kind === 'row') {
+    return { ...config, rows: transformRows(config.rows) };
+  }
+
+  // Nested: walk row → item → (descend into item.rows) repeatedly. The path
+  // shape is row.<ri>.item.<ii>[.row.<rj>.item.<ij>…].row.<rk>. We recurse on
+  // the item's `rows` field with the remaining segments.
+  const [rowSeg, itemSeg, ...rest] = rowPathSegments;
+  if (rowSeg.kind !== 'row' || !itemSeg || itemSeg.kind !== 'item') return config;
+
+  const rows = config.rows;
+  const targetRow = rows[rowSeg.index];
+  if (!targetRow || !Array.isArray(targetRow.items)) return config;
+  const targetItem = targetRow.items[itemSeg.index];
+  if (!targetItem || !Array.isArray(targetItem.rows)) return config;
+
+  const nextItem = withRowsAtRowPath(
+    { rows: targetItem.rows },
+    rest,
+    transformRows
+  );
+  const nextItems = targetRow.items.map((it, i) =>
+    i === itemSeg.index ? { ...it, rows: nextItem.rows } : it
+  );
+  const nextRows = rows.map((r, i) =>
+    i === rowSeg.index ? { ...r, items: nextItems } : r
+  );
+  return { ...config, rows: nextRows };
+};
+
+/**
+ * Reorder items within the row addressed by `rowPath`. `fromIndex`/`toIndex`
+ * are item indices in that row's `items` array. Works at any nesting depth.
+ */
+export const reorderItemsInRow = (config, rowPath, fromIndex, toIndex) => {
+  const segments = parseCanvasPath(rowPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+  if (fromIndex === toIndex) return config;
+  return withRowsAtRowPath(config, segments, rows => {
+    const lastRowIndex = segments[segments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+      return { ...row, items: arrayMove(row.items, fromIndex, toIndex) };
+    });
+  });
+};
+
+/** Reorder TOP-LEVEL rows. `fromIndex`/`toIndex` are top-level row indices. */
+export const reorderTopLevelRows = (config, fromIndex, toIndex) => {
+  if (!config || !Array.isArray(config.rows)) return config;
+  if (fromIndex === toIndex) return config;
+  return { ...config, rows: arrayMove(config.rows, fromIndex, toIndex) };
+};
+
+/** Default empty layout slot height for a freshly-created top-level row. */
+const NEW_ROW = items => ({ height: 'medium', items });
+
+/**
+ * Insert `newItem` into the config at a canvas drop target. `target` is the
+ * normalised descriptor the canvas droppables carry:
+ *
+ *   { kind: 'between-items', rowPath, index }   → splice into rowPath's items.
+ *   { kind: 'end-of-row',    rowPath }           → append to rowPath's items.
+ *   { kind: 'between-rows',  index }             → new top-level row at index.
+ *   { kind: 'in-container',  itemPath }          → append a sub-row to the
+ *                                                  container item at itemPath.
+ *
+ * Returns the config unchanged for an unrecognised target.
+ */
+export const insertItemAtTarget = (config, target, newItem) => {
+  if (!config || !Array.isArray(config.rows) || !target) return config;
+  const item = newItem || { width: 1 };
+
+  if (target.kind === 'between-rows') {
+    const idx = Math.max(0, Math.min(target.index ?? config.rows.length, config.rows.length));
+    const nextRows = [...config.rows];
+    nextRows.splice(idx, 0, NEW_ROW([item]));
+    return { ...config, rows: nextRows };
+  }
+
+  if (target.kind === 'between-items' || target.kind === 'end-of-row') {
+    const segments = parseCanvasPath(target.rowPath);
+    if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+    return withRowsAtRowPath(config, segments, rows => {
+      const lastRowIndex = segments[segments.length - 1].index;
+      return rows.map((row, ri) => {
+        if (ri !== lastRowIndex) return row;
+        const items = Array.isArray(row.items) ? [...row.items] : [];
+        const insertAt =
+          target.kind === 'end-of-row'
+            ? items.length
+            : Math.max(0, Math.min(target.index ?? items.length, items.length));
+        items.splice(insertAt, 0, item);
+        return { ...row, items };
+      });
+    });
+  }
+
+  if (target.kind === 'in-container') {
+    const segments = parseCanvasPath(target.itemPath);
+    if (!segments.length || segments[segments.length - 1].kind !== 'item') return config;
+    // The container's `rows` lives under the item; reuse the row-path walker by
+    // treating the item's parent row path + the item index.
+    const itemSeg = segments[segments.length - 1];
+    const rowSegments = segments.slice(0, -1); // ends in a `row` segment
+    return withRowsAtRowPath(config, rowSegments, rows => {
+      const lastRowIndex = rowSegments[rowSegments.length - 1].index;
+      return rows.map((row, ri) => {
+        if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+        const nextItems = row.items.map((it, ii) => {
+          if (ii !== itemSeg.index) return it;
+          const subRows = Array.isArray(it.rows) ? it.rows : [];
+          return { ...it, rows: [...subRows, NEW_ROW([item])] };
+        });
+        return { ...row, items: nextItems };
+      });
+    });
+  }
+
+  return config;
+};
+
+/**
+ * Build the dashboard-item leaf field for a Library-dropped object. A chart /
+ * table / markdown / input becomes `{ width: 1, <type>: '${ref(name)}' }`. The
+ * shell sanitises the ref string, so we store the bare `ref(name)` form the
+ * other right-rail writers use.
+ */
+export const buildLibraryItem = (type, name) => {
+  const item = { width: 1 };
+  if (type && name) item[type] = formatRef(name);
+  return item;
+};

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
@@ -1,0 +1,187 @@
+/**
+ * canvasReorder tests (VIS-771 / Track D D-3).
+ *
+ * The pure config transforms backing the canvas drag-and-drop gestures. dnd-kit
+ * pointer drags can't run in jsdom, so the geometry/wiring is exercised by the
+ * Playwright story; here we lock the (immutable) reshape logic at every nesting
+ * depth + drop intent.
+ */
+import {
+  parseCanvasPath,
+  reorderItemsInRow,
+  reorderTopLevelRows,
+  insertItemAtTarget,
+  buildLibraryItem,
+} from './canvasReorder';
+
+const config = () => ({
+  rows: [
+    {
+      height: 'medium',
+      items: [
+        { width: 6, chart: 'ref(a)' },
+        { width: 3, table: 'ref(b)' },
+        { width: 3, markdown: 'ref(c)' },
+      ],
+    },
+    {
+      height: 'small',
+      items: [{ width: 12, chart: 'ref(d)' }],
+    },
+  ],
+});
+
+const names = items => items.map(it => it.chart || it.table || it.markdown || it.input);
+
+describe('parseCanvasPath', () => {
+  test('parses a top-level row path', () => {
+    expect(parseCanvasPath('row.2')).toEqual([{ kind: 'row', index: 2 }]);
+  });
+  test('parses an item path', () => {
+    expect(parseCanvasPath('row.0.item.1')).toEqual([
+      { kind: 'row', index: 0 },
+      { kind: 'item', index: 1 },
+    ]);
+  });
+  test('parses a nested path', () => {
+    expect(parseCanvasPath('row.0.item.1.row.2.item.0')).toEqual([
+      { kind: 'row', index: 0 },
+      { kind: 'item', index: 1 },
+      { kind: 'row', index: 2 },
+      { kind: 'item', index: 0 },
+    ]);
+  });
+  test('returns [] for the dashboard chrome key and malformed input', () => {
+    expect(parseCanvasPath('dashboard')).toEqual([]);
+    expect(parseCanvasPath('')).toEqual([]);
+    expect(parseCanvasPath('row.x')).toEqual([]);
+    expect(parseCanvasPath(null)).toEqual([]);
+  });
+});
+
+describe('reorderItemsInRow', () => {
+  test('moves an item earlier in its row (immutably)', () => {
+    const before = config();
+    const after = reorderItemsInRow(before, 'row.0', 2, 0);
+    expect(names(after.rows[0].items)).toEqual(['ref(c)', 'ref(a)', 'ref(b)']);
+    // Input is never mutated.
+    expect(names(before.rows[0].items)).toEqual(['ref(a)', 'ref(b)', 'ref(c)']);
+    // Untouched row is preserved.
+    expect(after.rows[1]).toBe(before.rows[1]);
+  });
+
+  test('moves an item later in its row', () => {
+    const after = reorderItemsInRow(config(), 'row.0', 0, 2);
+    expect(names(after.rows[0].items)).toEqual(['ref(b)', 'ref(c)', 'ref(a)']);
+  });
+
+  test('a no-op (from === to) returns the same config reference', () => {
+    const before = config();
+    expect(reorderItemsInRow(before, 'row.0', 1, 1)).toBe(before);
+  });
+
+  test('reorders within a nested row container', () => {
+    const nested = {
+      rows: [
+        {
+          items: [
+            {
+              width: 12,
+              rows: [{ items: [{ chart: 'ref(x)' }, { chart: 'ref(y)' }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const after = reorderItemsInRow(nested, 'row.0.item.0.row.0', 0, 1);
+    expect(names(after.rows[0].items[0].rows[0].items)).toEqual(['ref(y)', 'ref(x)']);
+  });
+});
+
+describe('reorderTopLevelRows', () => {
+  test('swaps two top-level rows', () => {
+    const after = reorderTopLevelRows(config(), 1, 0);
+    expect(after.rows[0].height).toBe('small');
+    expect(after.rows[1].height).toBe('medium');
+  });
+  test('a no-op returns the same reference', () => {
+    const before = config();
+    expect(reorderTopLevelRows(before, 0, 0)).toBe(before);
+  });
+});
+
+describe('insertItemAtTarget', () => {
+  test('between-items splices into the target row at the index', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'between-items', rowPath: 'row.0', index: 1 },
+      { width: 1, chart: 'ref(new)' }
+    );
+    expect(names(after.rows[0].items)).toEqual(['ref(a)', 'ref(new)', 'ref(b)', 'ref(c)']);
+  });
+
+  test('end-of-row appends to the target row', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'end-of-row', rowPath: 'row.1' },
+      { width: 1, table: 'ref(new)' }
+    );
+    expect(names(after.rows[1].items)).toEqual(['ref(d)', 'ref(new)']);
+  });
+
+  test('between-rows wraps the new item in a new top-level row at the index', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'between-rows', index: 1 },
+      { width: 1, chart: 'ref(new)' }
+    );
+    expect(after.rows).toHaveLength(3);
+    expect(after.rows[1].items).toHaveLength(1);
+    expect(after.rows[1].items[0].chart).toBe('ref(new)');
+    expect(after.rows[1].height).toBe('medium');
+    // Existing rows shifted down.
+    expect(after.rows[2].height).toBe('small');
+  });
+
+  test('between-rows at the end appends a new row', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'between-rows', index: 2 },
+      { width: 1, chart: 'ref(new)' }
+    );
+    expect(after.rows).toHaveLength(3);
+    expect(after.rows[2].items[0].chart).toBe('ref(new)');
+  });
+
+  test('in-container appends a sub-row to the container item', () => {
+    const withContainer = {
+      rows: [
+        {
+          items: [{ width: 12, rows: [{ items: [{ chart: 'ref(x)' }] }] }],
+        },
+      ],
+    };
+    const after = insertItemAtTarget(
+      withContainer,
+      { kind: 'in-container', itemPath: 'row.0.item.0' },
+      { width: 1, chart: 'ref(new)' }
+    );
+    expect(after.rows[0].items[0].rows).toHaveLength(2);
+    expect(after.rows[0].items[0].rows[1].items[0].chart).toBe('ref(new)');
+  });
+
+  test('unrecognised target returns the config unchanged', () => {
+    const before = config();
+    expect(insertItemAtTarget(before, { kind: 'nope' }, {})).toBe(before);
+  });
+});
+
+describe('buildLibraryItem', () => {
+  test('builds a width-1 item referencing the dropped object by type', () => {
+    expect(buildLibraryItem('chart', 'my-chart')).toEqual({ width: 1, chart: 'ref(my-chart)' });
+    expect(buildLibraryItem('table', 't1')).toEqual({ width: 1, table: 'ref(t1)' });
+  });
+  test('returns a bare layout slot when type/name are missing', () => {
+    expect(buildLibraryItem(null, null)).toEqual({ width: 1 });
+  });
+});

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -11,6 +11,13 @@ import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
 import LibraryDragPreview from './library/LibraryDragPreview';
 import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
 import { emitWorkspaceEvent } from './telemetry';
+import sanitizeDashboardConfig from './sanitizeDashboardConfig';
+import {
+  reorderItemsInRow,
+  reorderTopLevelRows,
+  insertItemAtTarget,
+  buildLibraryItem,
+} from '../project/canvas/canvasReorder';
 
 /**
  * WorkspaceDndContext — VIS-802 / Track G G-1.
@@ -59,13 +66,18 @@ export const useWorkspaceDrag = () => useContext(WorkspaceDragContext);
  * @param {Array}  deps.dashboards    current dashboards list (for level groups).
  * @param {object} deps.projectDefaults defaults used to resolve level groups.
  * @param {Function} deps.reassignDashboardLevel store action.
+ * @param {Function} deps.commitCanvasConfig  applies a next dashboard config
+ *                   (sanitize → optimistic → save) for canvas D-3 mutations:
+ *                   `(dashboardName, nextConfig, meta) => void`.
  * @param {Function} deps.emit        telemetry emitter.
  * @returns {string} a short tag describing the routed action (for tests):
- *          'reassign_level' | 'ref_accepted' | 'ref_rejected' | 'noop'.
+ *          'reassign_level' | 'ref_accepted' | 'ref_rejected' |
+ *          'canvas_reorder_items' | 'canvas_reorder_rows' |
+ *          'canvas_library_insert' | 'noop'.
  */
 export const routeWorkspaceDragEnd = (
   event,
-  { dashboards, projectDefaults, reassignDashboardLevel, emit }
+  { dashboards, projectDefaults, reassignDashboardLevel, commitCanvasConfig, emit }
 ) => {
   const { active, over } = event || {};
   if (!over) return 'noop';
@@ -107,6 +119,78 @@ export const routeWorkspaceDragEnd = (
     return 'ref_accepted';
   }
 
+  // ── Branch 3: Canvas drop zones (VIS-771 / D-3) ──────────────────────────
+  // Canvas droppables carry `{ kind: 'canvas-drop', target, dashboardName,
+  // config }`. `target` is the normalised insertion / reorder descriptor (see
+  // canvasReorder.insertItemAtTarget). The live dashboard config is snapshotted
+  // onto the droppable's `data` so the router transforms the same object the
+  // canvas rendered, then commits it through the shared save path.
+  if (dropData.kind === 'canvas-drop') {
+    const { target, dashboardName, config } = dropData;
+    if (!target || !dashboardName || !config) return 'noop';
+    if (typeof commitCanvasConfig !== 'function') return 'noop';
+
+    // 3a. Canvas → canvas reorder (item within a row, or top-level rows).
+    if (dragData.source === 'canvas') {
+      // Item reorder: drag item path + drop a `between-items`/`end-of-row`
+      // target on the SAME row → move the item inside that row.
+      if (
+        dragData.kind === 'item' &&
+        (target.kind === 'between-items' || target.kind === 'end-of-row') &&
+        target.rowPath === dragData.rowPath
+      ) {
+        const fromIndex = dragData.itemIndex;
+        let toIndex =
+          target.kind === 'end-of-row'
+            ? Number.MAX_SAFE_INTEGER
+            : target.index;
+        // Dropping just after the source slot is a no-op; normalise so a 1-step
+        // right move lands correctly (splice removes the source first).
+        if (target.kind === 'between-items' && toIndex > fromIndex) toIndex -= 1;
+        const next = reorderItemsInRow(config, dragData.rowPath, fromIndex, toIndex);
+        if (next === config) return 'noop';
+        commitCanvasConfig(dashboardName, next, { kind: 'reorder_items' });
+        emit &&
+          emit('canvas_dnd', {
+            kind: 'reorder_items',
+            rowPath: dragData.rowPath,
+            from: fromIndex,
+          });
+        return 'canvas_reorder_items';
+      }
+
+      // Row reorder: drag a top-level row + drop a `between-rows` target.
+      if (dragData.kind === 'row' && target.kind === 'between-rows') {
+        const fromIndex = dragData.rowIndex;
+        let toIndex = target.index;
+        if (toIndex > fromIndex) toIndex -= 1;
+        const next = reorderTopLevelRows(config, fromIndex, toIndex);
+        if (next === config) return 'noop';
+        commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
+        emit && emit('canvas_dnd', { kind: 'reorder_rows', from: fromIndex, to: toIndex });
+        return 'canvas_reorder_rows';
+      }
+
+      return 'noop';
+    }
+
+    // 3b. Library → canvas insert (creates a new item referencing the object).
+    if (dragData.source === 'library') {
+      const newItem = buildLibraryItem(dragData.type, dragData.name);
+      const next = insertItemAtTarget(config, target, newItem);
+      if (next === config) return 'noop';
+      commitCanvasConfig(dashboardName, next, { kind: 'library_insert' });
+      emit &&
+        emit('canvas_dnd', {
+          kind: 'library_insert',
+          type: dragData.type,
+          name: dragData.name,
+          target: target.kind,
+        });
+      return 'canvas_library_insert';
+    }
+  }
+
   return 'noop';
 };
 
@@ -129,10 +213,31 @@ const WorkspaceDndContext = ({ children }) => {
   const defaults = useStore(s => s.defaults);
   const project = useStore(s => s.project);
   const reassignDashboardLevel = useStore(s => s.reassignDashboardLevel);
+  const saveDashboard = useStore(s => s.saveDashboard);
+  const updateDashboardConfigOptimistic = useStore(s => s.updateDashboardConfigOptimistic);
 
   // `activeDrag` mirrors the dnd-kit `active` payload in a shape both overlays
   // and consumers (ProjectEditor) can read: `{ kind, name, level, type }`.
   const [activeDrag, setActiveDrag] = useState(null);
+
+  // Commit a canvas-driven config mutation (D-3): sanitize so the payload is
+  // always backend-valid (GAP-3 — see sanitizeDashboardConfig), optimistically
+  // swap the store config so the canvas + Outline reflect it immediately, then
+  // persist through the shared dashboard save path (the SAME path the right-rail
+  // forms use via RightRailEditPanel.persistConfig).
+  const commitCanvasConfig = useCallback(
+    (dashboardName, nextConfig) => {
+      if (!dashboardName) return;
+      const clean = sanitizeDashboardConfig(nextConfig);
+      if (updateDashboardConfigOptimistic) {
+        updateDashboardConfigOptimistic(dashboardName, clean);
+      }
+      if (typeof saveDashboard === 'function') {
+        saveDashboard(dashboardName, clean);
+      }
+    },
+    [updateDashboardConfigOptimistic, saveDashboard]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -152,6 +257,19 @@ const WorkspaceDndContext = ({ children }) => {
     }
     if (data.source === 'library') {
       setActiveDrag({ kind: 'library', name: data.name, type: data.type, data });
+      return;
+    }
+    // Canvas item/row drag (VIS-771 / D-3). The drag preview IS the source pill
+    // (no thumbnail, per architecture §2.6) — for an item we render the same
+    // Library-style pill keyed on the referenced object's type + name.
+    if (data.source === 'canvas') {
+      setActiveDrag({
+        kind: 'canvas',
+        canvasKind: data.kind,
+        name: data.label || data.name,
+        type: data.refType || 'chart',
+        data: { source: 'library', type: data.refType || 'chart', name: data.label || data.name },
+      });
     }
   }, []);
 
@@ -164,10 +282,11 @@ const WorkspaceDndContext = ({ children }) => {
         dashboards,
         projectDefaults,
         reassignDashboardLevel,
+        commitCanvasConfig,
         emit: emitWorkspaceEvent,
       });
     },
-    [dashboards, projectDefaults, reassignDashboardLevel]
+    [dashboards, projectDefaults, reassignDashboardLevel, commitCanvasConfig]
   );
 
   return (
@@ -182,7 +301,9 @@ const WorkspaceDndContext = ({ children }) => {
         <DragOverlay dropAnimation={null}>
           {activeDrag?.kind === 'dashboard' ? (
             <DashboardTilePreview name={activeDrag.name} />
-          ) : activeDrag?.kind === 'library' ? (
+          ) : activeDrag?.kind === 'library' || activeDrag?.kind === 'canvas' ? (
+            // Canvas item/row drags reuse the SAME pill shape as a Library drag
+            // (architecture §2.6: "the drag preview IS the source pill").
             <LibraryDragPreview data={activeDrag.data} />
           ) : null}
         </DragOverlay>

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
@@ -142,3 +142,134 @@ describe('routeWorkspaceDragEnd (VIS-802)', () => {
     expect(result).toBe('noop');
   });
 });
+
+describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
+  const canvasConfig = () => ({
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+      { height: 'small', items: [{ width: 12, chart: 'ref(c)' }] },
+    ],
+  });
+
+  const overCanvas = target => ({
+    data: {
+      current: { kind: 'canvas-drop', dashboardName: 'dash', config: canvasConfig(), target },
+    },
+  });
+
+  test('canvas item drag → between-items on the same row reorders the items', () => {
+    const commitCanvasConfig = jest.fn();
+    const emit = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: { current: { source: 'canvas', kind: 'item', rowPath: 'row.0', itemIndex: 0 } },
+        },
+        // Drop before index 2 (after item 1) → item 0 moves to the end of the row.
+        over: overCanvas({ kind: 'between-items', rowPath: 'row.0', index: 2 }),
+      },
+      { commitCanvasConfig, emit }
+    );
+    expect(result).toBe('canvas_reorder_items');
+    expect(commitCanvasConfig).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = commitCanvasConfig.mock.calls[0];
+    expect(name).toBe('dash');
+    const order = nextConfig.rows[0].items.map(it => it.chart || it.table);
+    expect(order).toEqual(['ref(b)', 'ref(a)']);
+    expect(emit).toHaveBeenCalledWith('canvas_dnd', expect.objectContaining({ kind: 'reorder_items' }));
+  });
+
+  test('canvas item drag → end-of-row appends the item to the end', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: { current: { source: 'canvas', kind: 'item', rowPath: 'row.0', itemIndex: 0 } },
+        },
+        over: overCanvas({ kind: 'end-of-row', rowPath: 'row.0' }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('canvas_reorder_items');
+    const order = commitCanvasConfig.mock.calls[0][1].rows[0].items.map(it => it.chart || it.table);
+    expect(order).toEqual(['ref(b)', 'ref(a)']);
+  });
+
+  test('canvas item drag onto a DIFFERENT row is a noop (cross-row move not supported)', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: { current: { source: 'canvas', kind: 'item', rowPath: 'row.0', itemIndex: 0 } },
+        },
+        over: overCanvas({ kind: 'between-items', rowPath: 'row.1', index: 0 }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('noop');
+    expect(commitCanvasConfig).not.toHaveBeenCalled();
+  });
+
+  test('canvas row drag → between-rows reorders the top-level rows', () => {
+    const commitCanvasConfig = jest.fn();
+    const emit = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'canvas', kind: 'row', rowIndex: 1, rowPath: 'row.1' } } },
+        // Drop before index 0 → row 1 moves to the top.
+        over: overCanvas({ kind: 'between-rows', index: 0 }),
+      },
+      { commitCanvasConfig, emit }
+    );
+    expect(result).toBe('canvas_reorder_rows');
+    const heights = commitCanvasConfig.mock.calls[0][1].rows.map(r => r.height);
+    expect(heights).toEqual(['small', 'medium']);
+    expect(emit).toHaveBeenCalledWith('canvas_dnd', expect.objectContaining({ kind: 'reorder_rows' }));
+  });
+
+  test('library drag → canvas between-items inserts a new item referencing the object', () => {
+    const commitCanvasConfig = jest.fn();
+    const emit = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'library', type: 'chart', name: 'new-chart' } } },
+        over: overCanvas({ kind: 'between-items', rowPath: 'row.0', index: 1 }),
+      },
+      { commitCanvasConfig, emit }
+    );
+    expect(result).toBe('canvas_library_insert');
+    const items = commitCanvasConfig.mock.calls[0][1].rows[0].items;
+    expect(items).toHaveLength(3);
+    expect(items[1].chart).toBe('ref(new-chart)');
+    expect(emit).toHaveBeenCalledWith(
+      'canvas_dnd',
+      expect.objectContaining({ kind: 'library_insert', type: 'chart', name: 'new-chart' })
+    );
+  });
+
+  test('library drag → canvas between-rows inserts a new top-level row', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'library', type: 'table', name: 't1' } } },
+        over: overCanvas({ kind: 'between-rows', index: 1 }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('canvas_library_insert');
+    const rows = commitCanvasConfig.mock.calls[0][1].rows;
+    expect(rows).toHaveLength(3);
+    expect(rows[1].items[0].table).toBe('ref(t1)');
+  });
+
+  test('canvas-drop without a commit callback is a safe noop', () => {
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'canvas', kind: 'row', rowIndex: 0, rowPath: 'row.0' } } },
+        over: overCanvas({ kind: 'between-rows', index: 1 }),
+      },
+      {}
+    );
+    expect(result).toBe('noop');
+  });
+});


### PR DESCRIPTION
## VIS-771 / Track D, D-3 — Canvas drag-and-drop

dnd-kit drag-and-drop ON the Workspace dashboard canvas (Build mode): reorder items within a row, reorder top-level rows, and drop a Library object onto the canvas to insert a new item. Each gesture persists optimistically and saves through the existing dashboard auto-save path (backend-valid via `sanitizeDashboardConfig`). The drag preview is the source **pill** (no thumbnails), per `03-architecture-proposal.md` §2.6.

### Design approach (one shared DndContext — no second context)
- **Extended the shared shell-level `<WorkspaceDndContext>`** rather than adding a new context (dnd-kit contexts don't compose). `routeWorkspaceDragEnd` gains a `canvas-drop` branch:
  - `source:'canvas'` + `between-items`/`end-of-row` on the same row → **reorder item within row**.
  - `source:'canvas'` (row) + `between-rows` → **reorder top-level rows**.
  - `source:'library'` + any canvas target → **insert** a new item referencing the dropped object.
  - All commit via a new `commitCanvasConfig` helper that **sanitizes (GAP-3) → optimistic update → saveDashboard** — the same path `RightRailEditPanel.persistConfig` uses. The shared `<DragOverlay>` renders the source pill for canvas drags too.
- **New `<CanvasDndLayer>`** — a SIBLING overlay in `ProjectCanvas` (like `CanvasSelectionOverlay`). It measures the live `<Dashboard>` DOM via the existing composite `data-canvas-path` markers and paints **drag handles** (rows in the left gutter, items at their corner) + **drop zones**: between-items / end-of-row (vertical mulberry bar), between-rows (horizontal bar), in-container (mulberry-tinted region). Mostly `pointer-events-none` so Dashboard's interactivity is preserved.
- **New `canvasReorder.js`** — pure, immutable config transforms (`reorderItemsInRow`, `reorderTopLevelRows`, `insertItemAtTarget`, `buildLibraryItem`) working at any nesting depth (incl. nested sub-row containers).

### Dashboard.jsx — NOT touched
Zero edits to the shared `components/project/Dashboard.jsx` renderer → **no rebase risk vs PR #451**. No store edits either; canvas writes reuse `updateDashboardConfigOptimistic` + `saveDashboard`.

### Files changed
- `viewer/src/components/new-views/project/canvas/canvasReorder.js` (new) + tests
- `viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx` (new) + tests
- `viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx` (mount the layer) + test
- `viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx` (canvas routing + commit helper) + tests
- `viewer/e2e/stories/canvas-dnd.spec.mjs` (new live story)

### Test results
- **Live Playwright** (`canvas-dnd.spec.mjs`, isolated sandbox :3008): reorder-within-row, reorder-rows, Library→canvas drop all persist to the store/config; no console errors / no auto-save 400. **5/5 passing.**
- **Regression**: `right-rail-pill-drag.spec.mjs` 2/2 and `canvas-selection.spec.mjs` 7/7 still pass against the same sandbox → no shared-DndContext regression.
- **Unit**: +31 new tests (canvasReorder 18, CanvasDndLayer 5, router canvas branches 7, ProjectCanvas mount 1). Full `viewer-check`: **1986 tests passing, lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)