### PR TITLE
feat(viewer): EditPanel structural breadcrumb + keyboard nav (VIS-804 / Track G G-2)

### DIFF
--- a/viewer/e2e/stories/editpanel-breadcrumb.spec.mjs
+++ b/viewer/e2e/stories/editpanel-breadcrumb.spec.mjs
@@ -1,0 +1,114 @@
+/**
+ * Story: EditPanel structural breadcrumb + keyboard nav (VIS-804 / Track G G-2)
+ *
+ * The right-rail Edit tab now carries a slim STRUCTURAL BREADCRUMB band between
+ * the tab header and the form body. It reflects the current
+ * `workspaceOutlineSelectedKey` ancestry (`dashboard ▸ row 2 ▸ item 1`):
+ *
+ *   - Each segment is a button that SELECTS that ancestor (writes the parent
+ *     key via `setWorkspaceOutlineSelectedKey`) — the same selection source the
+ *     Outline tree + canvas read.
+ *   - Keyboard nav on the band: ↑/↓ step siblings, ←/→ step the hierarchy,
+ *     ⌘↑/↓ reorder, Enter focuses the form, Esc deselects.
+ *
+ * Driven against the deeply-nested `nested-layouts-dashboard` so the breadcrumb
+ * renders a multi-segment chain (dashboard ▸ row ▸ container ▸ row ▸ item).
+ *
+ * Precondition: an isolated sandbox running the integration project. BASE
+ * defaults to :3045 but is env-overridable:
+ *   VISIVO_SANDBOX_BACKEND_PORT=8045 VISIVO_SANDBOX_FRONTEND_PORT=3045 \
+ *   VISIVO_SANDBOX_NAME=vis804 bash scripts/sandbox.sh start
+ *   # then: VIS_EDITPANEL_BREADCRUMB_BASE=http://localhost:3045 \
+ *   #         npx playwright test editpanel-breadcrumb
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_EDITPANEL_BREADCRUMB_BASE || 'http://localhost:3045';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'nested-layouts-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+const setKey = (page, key) =>
+  page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
+
+const readKey = page =>
+  page.evaluate(() => window.useStore.getState().workspaceOutlineSelectedKey);
+
+const openEditRail = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  // Ensure the Edit tab is active (it is the default, but click to be explicit).
+  const editTab = page.getByTestId('workspace-right-rail-tab-edit');
+  await expect(editTab).toBeVisible({ timeout: WAIT });
+  await editTab.click();
+  await expect(page.getByTestId('workspace-right-rail-edit')).toBeVisible({ timeout: WAIT });
+};
+
+test.describe('EditPanel breadcrumb + keyboard nav (VIS-804)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(90000);
+
+  test('breadcrumb renders the selection ancestry and segments are clickable', async ({
+    page,
+  }) => {
+    await openEditRail(page);
+
+    // Dashboard selection → a single root segment.
+    await setKey(page, 'dashboard');
+    const band = page.getByTestId('edit-breadcrumb');
+    await expect(band).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('edit-breadcrumb-segment-dashboard')).toHaveText(/.+/);
+
+    // Row selection → dashboard ▸ row.
+    await setKey(page, 'row.0');
+    await expect(page.getByTestId('edit-breadcrumb-segment-dashboard')).toBeVisible();
+    await expect(page.getByTestId('edit-breadcrumb-segment-row.0')).toContainText('Row 1');
+
+    // Item selection → dashboard ▸ row ▸ item (3 segments).
+    await setKey(page, 'row.0.item.0');
+    await expect(page.getByTestId('edit-breadcrumb-segment-row.0.item.0')).toBeVisible({
+      timeout: WAIT,
+    });
+    const segs = page.locator('[data-testid^="edit-breadcrumb-segment-"]');
+    expect(await segs.count()).toBe(3);
+
+    // Click the row ancestor → selection jumps to that ancestor.
+    await page.getByTestId('edit-breadcrumb-segment-row.0').click();
+    expect(await readKey(page)).toBe('row.0');
+
+    await page.screenshot({ path: `${SCREENS}/editpanel-breadcrumb-item.png`, fullPage: false });
+  });
+
+  test('keyboard nav moves the selection along the outline', async ({ page }) => {
+    await openEditRail(page);
+
+    // Start at the first top-level row, focus the band.
+    await setKey(page, 'row.0');
+    const band = page.getByTestId('edit-breadcrumb');
+    await band.focus();
+
+    // → descends into the first child item.
+    await band.press('ArrowRight');
+    await expect.poll(() => readKey(page)).toBe('row.0.item.0');
+
+    // ← steps back up to the row.
+    await band.press('ArrowLeft');
+    await expect.poll(() => readKey(page)).toBe('row.0');
+
+    // ↓ steps to the next sibling row (the dashboard has multiple top rows).
+    await band.press('ArrowDown');
+    await expect.poll(() => readKey(page)).not.toBe('row.0');
+
+    // Esc deselects back to the dashboard root.
+    await band.press('Escape');
+    await expect.poll(() => readKey(page)).toBe('dashboard');
+
+    await page.screenshot({
+      path: `${SCREENS}/editpanel-breadcrumb-keyboard.png`,
+      fullPage: false,
+    });
+  });
+});

--- a/viewer/src/components/new-views/workspace/EditPanelBreadcrumb.jsx
+++ b/viewer/src/components/new-views/workspace/EditPanelBreadcrumb.jsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import { PiPencil, PiCaretRight, PiSquaresFour } from 'react-icons/pi';
+import { getTypeIcon } from '../common/objectTypeConfigs';
+import {
+  buildBreadcrumbSegments,
+  computeSiblingKey,
+  computeHierarchyKey,
+  computeReorder,
+} from './breadcrumbNav';
+
+/**
+ * EditPanelBreadcrumb — VIS-804 / Track G G-2.
+ *
+ * A slim structural breadcrumb band that sits BETWEEN the right-rail tab bar
+ * and the Edit form body. It reflects the current `workspaceOutlineSelectedKey`
+ * selection's ancestry (`dashboard ▸ row 2 ▸ great_fib`) and is the keyboard
+ * navigation surface for the selection (Q7 = C; ships alongside canvas-direct
+ * nav VIS-D7):
+ *
+ *   - Each segment is a button that selects that ancestor
+ *     (`setWorkspaceOutlineSelectedKey(segment.key)`).
+ *   - ↑/↓   step among siblings at the current depth.
+ *   - ←/→   step UP / DOWN through the hierarchy.
+ *   - ⌘↑/⌘↓ reorder the focused node within its parent.
+ *   - Enter  focus the form's first field (`onFocusForm`).
+ *   - Esc    deselect (jump to the dashboard root).
+ *
+ * Type colour + icon come exclusively from `objectTypeConfigs` (rainbow);
+ * `row` has no config entry so it uses a Phosphor squares glyph, and the
+ * CURRENT (last) segment carries the mulberry selection chip (`#713b57`).
+ *
+ * The whole logic is pure-function-backed (`editPanelBreadcrumb.js`) so the
+ * key derivation + nav handlers are unit-tested in isolation.
+ */
+
+const ROW_ICON_CLASS = 'h-3 w-3 shrink-0';
+
+const segmentIcon = segment => {
+  if (segment.type === 'row') {
+    return <PiSquaresFour aria-hidden="true" className={`${ROW_ICON_CLASS} text-gray-500`} />;
+  }
+  const Icon = getTypeIcon(segment.type);
+  return Icon ? <Icon aria-hidden="true" style={{ fontSize: 12 }} className="shrink-0" /> : null;
+};
+
+const Segment = ({ segment, isCurrent, isFocused, onSelect }) => {
+  const cls = [
+    'group/crumb inline-flex h-6 max-w-[140px] items-center gap-1 rounded-md px-1.5 text-[11.5px] outline-none transition-colors',
+    isCurrent
+      ? 'bg-[#e2d7dd] font-semibold text-[#5a2f45]'
+      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 cursor-pointer',
+    isFocused ? 'ring-2 ring-[#713b57] bg-white text-gray-900' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      data-testid={`edit-breadcrumb-segment-${segment.key}`}
+      data-segment-kind={segment.kind}
+      data-object-type={segment.type}
+      data-current={isCurrent ? 'true' : 'false'}
+      aria-current={isCurrent ? 'true' : undefined}
+      onClick={() => onSelect(segment.key)}
+      className={cls}
+    >
+      {segmentIcon(segment)}
+      <span className="truncate" title={segment.label}>
+        {segment.label}
+      </span>
+    </button>
+  );
+};
+
+const EditPanelBreadcrumb = ({
+  outlineKey,
+  dashboardName,
+  rows,
+  onSelectKey,
+  onReorder,
+  onFocusForm,
+}) => {
+  const containerRef = useRef(null);
+
+  const segments = useMemo(
+    () => buildBreadcrumbSegments(outlineKey, dashboardName, rows),
+    [outlineKey, dashboardName, rows]
+  );
+
+  // The focused segment is always the current (last) one — keyboard nav moves
+  // the selection itself, so focus tracks the selection's depth.
+  const focusedIndex = segments.length - 1;
+
+  const handleSelect = useCallback(
+    key => {
+      if (onSelectKey) onSelectKey(key);
+    },
+    [onSelectKey]
+  );
+
+  const handleKeyDown = useCallback(
+    e => {
+      // Don't hijack typing inside the form bodies below the band.
+      const target = e.target;
+      const isField =
+        target &&
+        target !== containerRef.current &&
+        /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName || '');
+      if (isField) return;
+
+      const key = outlineKey || 'dashboard';
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleSelect('dashboard');
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (onFocusForm) onFocusForm();
+        return;
+      }
+
+      const isReorder = e.metaKey || e.ctrlKey;
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (isReorder) {
+          const op = computeReorder(key, rows, -1);
+          if (op && onReorder) onReorder(op);
+        } else {
+          handleSelect(computeSiblingKey(key, rows, -1));
+        }
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (isReorder) {
+          const op = computeReorder(key, rows, 1);
+          if (op && onReorder) onReorder(op);
+        } else {
+          handleSelect(computeSiblingKey(key, rows, 1));
+        }
+        return;
+      }
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        handleSelect(computeHierarchyKey(key, rows, 'up'));
+        return;
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        handleSelect(computeHierarchyKey(key, rows, 'down'));
+      }
+    },
+    [outlineKey, rows, handleSelect, onReorder, onFocusForm]
+  );
+
+  // Empty / no-selection band — keep the layout steady with a quiet hint.
+  if (!segments || segments.length === 0) {
+    return (
+      <div
+        data-testid="edit-breadcrumb-empty"
+        className="flex h-7 items-center gap-1.5 border-b border-gray-100 bg-gray-50 px-3 text-[11px] text-gray-400"
+      >
+        <PiPencil aria-hidden="true" className="h-3 w-3 opacity-60" />
+        <span>Select something to edit</span>
+      </div>
+    );
+  }
+
+  // A11y: announce the current breadcrumb position for screen readers.
+  const positionLabel = segments.map(s => s.label).join(' / ');
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="edit-breadcrumb"
+      role="navigation"
+      aria-label="Selection breadcrumb"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="sticky top-0 z-10 flex h-7 items-center gap-1 border-b border-gray-100 bg-gray-50 px-2 outline-none focus-visible:ring-2 focus-visible:ring-[#713b57]/40"
+    >
+      <span data-testid="edit-breadcrumb-position" className="sr-only" aria-live="polite">
+        {positionLabel}
+      </span>
+      {segments.map((segment, i) => {
+        const isLast = i === segments.length - 1;
+        return (
+          <React.Fragment key={segment.key}>
+            <Segment
+              segment={segment}
+              isCurrent={isLast}
+              isFocused={i === focusedIndex && i !== 0 && isLast}
+              onSelect={handleSelect}
+            />
+            {!isLast && (
+              <PiCaretRight aria-hidden="true" className="h-2.5 w-2.5 shrink-0 text-gray-300" />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+export default EditPanelBreadcrumb;

--- a/viewer/src/components/new-views/workspace/EditPanelBreadcrumb.test.jsx
+++ b/viewer/src/components/new-views/workspace/EditPanelBreadcrumb.test.jsx
@@ -1,0 +1,143 @@
+/**
+ * EditPanelBreadcrumb component tests (VIS-804 / Track G G-2).
+ *
+ * The breadcrumb band renders the selection's ancestry as clickable segments
+ * and is the keyboard-nav surface for the selection. These tests exercise the
+ * rendered segments for several selection depths, segment clicks (select the
+ * ancestor), and the keydown handlers (↑/↓ siblings, ←/→ hierarchy, Enter
+ * focuses the form, Esc deselects, ⌘↑/↓ reorder).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditPanelBreadcrumb from './EditPanelBreadcrumb';
+
+const ref = name => '${ref(' + name + ')}';
+
+const ROWS = [
+  {
+    height: 'medium',
+    items: [{ chart: ref('great_fib'), width: 2 }, { table: 'sales_table', width: 1 }],
+  },
+  {
+    height: 'small',
+    items: [{ width: 1, rows: [{ height: 'medium', items: [{ markdown: 'notes' }] }] }],
+  },
+];
+
+const renderBreadcrumb = (props = {}) => {
+  const onSelectKey = jest.fn();
+  const onReorder = jest.fn();
+  const onFocusForm = jest.fn();
+  render(
+    <EditPanelBreadcrumb
+      outlineKey={props.outlineKey ?? 'dashboard'}
+      dashboardName="my-dash"
+      rows={ROWS}
+      onSelectKey={onSelectKey}
+      onReorder={onReorder}
+      onFocusForm={onFocusForm}
+    />
+  );
+  return { onSelectKey, onReorder, onFocusForm };
+};
+
+describe('EditPanelBreadcrumb rendering', () => {
+  test('dashboard selection → single mulberry segment', () => {
+    renderBreadcrumb({ outlineKey: 'dashboard' });
+    const seg = screen.getByTestId('edit-breadcrumb-segment-dashboard');
+    expect(seg).toHaveTextContent('my-dash');
+    expect(seg).toHaveAttribute('data-current', 'true');
+    expect(screen.queryByTestId('edit-breadcrumb-segment-row.0')).not.toBeInTheDocument();
+  });
+
+  test('row selection → two segments', () => {
+    renderBreadcrumb({ outlineKey: 'row.0' });
+    expect(screen.getByTestId('edit-breadcrumb-segment-dashboard')).toHaveAttribute(
+      'data-current',
+      'false'
+    );
+    expect(screen.getByTestId('edit-breadcrumb-segment-row.0')).toHaveTextContent('Row 1');
+  });
+
+  test('nested item selection → full chain with leaf name', () => {
+    const key = 'row.1.item.0.row.0.item.0';
+    renderBreadcrumb({ outlineKey: key });
+    expect(screen.getByTestId('edit-breadcrumb-segment-dashboard')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-breadcrumb-segment-row.1')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-breadcrumb-segment-row.1.item.0')).toBeInTheDocument();
+    expect(screen.getByTestId(`edit-breadcrumb-segment-${key}`)).toHaveTextContent('notes');
+  });
+
+  test('a11y position announced for screen readers', () => {
+    renderBreadcrumb({ outlineKey: 'row.0.item.0' });
+    expect(screen.getByTestId('edit-breadcrumb-position')).toHaveTextContent(
+      'my-dash / Row 1 / great_fib'
+    );
+  });
+});
+
+describe('EditPanelBreadcrumb interactions', () => {
+  test('clicking an ancestor segment selects it', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0.item.0' });
+    fireEvent.click(screen.getByTestId('edit-breadcrumb-segment-row.0'));
+    expect(onSelectKey).toHaveBeenCalledWith('row.0');
+  });
+
+  test('↓ steps to the next sibling', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'ArrowDown' });
+    expect(onSelectKey).toHaveBeenCalledWith('row.1');
+  });
+
+  test('↑ wraps among siblings', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'ArrowUp' });
+    expect(onSelectKey).toHaveBeenCalledWith('row.1');
+  });
+
+  test('← steps up the hierarchy', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0.item.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'ArrowLeft' });
+    expect(onSelectKey).toHaveBeenCalledWith('row.0');
+  });
+
+  test('→ steps down into the first child', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'ArrowRight' });
+    expect(onSelectKey).toHaveBeenCalledWith('row.0.item.0');
+  });
+
+  test('Esc deselects to the dashboard root', () => {
+    const { onSelectKey } = renderBreadcrumb({ outlineKey: 'row.0.item.1' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'Escape' });
+    expect(onSelectKey).toHaveBeenCalledWith('dashboard');
+  });
+
+  test('Enter focuses the form', () => {
+    const { onFocusForm } = renderBreadcrumb({ outlineKey: 'row.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'Enter' });
+    expect(onFocusForm).toHaveBeenCalled();
+  });
+
+  test('⌘↓ reorders the focused node', () => {
+    const { onReorder } = renderBreadcrumb({ outlineKey: 'row.0' });
+    fireEvent.keyDown(screen.getByTestId('edit-breadcrumb'), { key: 'ArrowDown', metaKey: true });
+    expect(onReorder).toHaveBeenCalledWith(
+      expect.objectContaining({ axis: 'row', fromIndex: 0, toIndex: 1 })
+    );
+  });
+
+  test('empty band when no segments resolve', () => {
+    render(
+      <EditPanelBreadcrumb
+        outlineKey="dashboard"
+        dashboardName={null}
+        rows={null}
+        onSelectKey={jest.fn()}
+      />
+    );
+    // dashboardName null still yields a 'Dashboard' fallback segment, so the
+    // band is present (never collapses) — verify it renders the root segment.
+    expect(screen.getByTestId('edit-breadcrumb-segment-dashboard')).toHaveTextContent('Dashboard');
+  });
+});

--- a/viewer/src/components/new-views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/new-views/workspace/RightRailEditPanel.jsx
@@ -4,6 +4,8 @@ import useStore from '../../../stores/store';
 import useWorkspaceScope from './useWorkspaceScope';
 import useDebouncedSave from './useDebouncedSave';
 import SelectionChip from './SelectionChip';
+import EditPanelBreadcrumb from './EditPanelBreadcrumb';
+import { applyReorder } from './breadcrumbNav';
 import RowEditForm from '../common/RowEditForm';
 import ItemEditForm, { getItemLeafRef } from '../common/ItemEditForm';
 import MarkdownEditForm from '../common/MarkdownEditForm';
@@ -142,6 +144,7 @@ const COLLECTION_KEY = {
 const RightRailEditPanel = () => {
   const activeObject = useStore(s => s.workspaceActiveObject);
   const outlineKey = useStore(s => s.workspaceOutlineSelectedKey);
+  const setOutlineKey = useStore(s => s.setWorkspaceOutlineSelectedKey);
   const dashboards = useStore(s => s.dashboards);
   const saveDashboard = useStore(s => s.saveDashboard);
   const updateDashboardConfigOptimistic = useStore(s => s.updateDashboardConfigOptimistic);
@@ -223,6 +226,47 @@ const RightRailEditPanel = () => {
     [openWorkspaceTab]
   );
 
+  // ⌘↑/⌘↓ reorder from the breadcrumb: swap the node within its siblings in the
+  // live config (optimistic + debounced save) and re-key the selection so the
+  // breadcrumb + Edit form follow the node to its new index.
+  const handleBreadcrumbReorder = useCallback(
+    op => {
+      if (!op || !dashboardConfig) return;
+      const nextConfig = applyReorder(dashboardConfig, op);
+      persistConfig(nextConfig, { kind: 'reorder', axis: op.axis });
+      const nextKey = op.parentKey === 'dashboard'
+        ? `${op.axis}.${op.toIndex}`
+        : `${op.parentKey}.${op.axis}.${op.toIndex}`;
+      if (setOutlineKey) setOutlineKey(nextKey);
+    },
+    [dashboardConfig, persistConfig, setOutlineKey]
+  );
+
+  // Enter on the breadcrumb focuses the Edit form's first focusable field.
+  const handleFocusForm = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    const panel = document.querySelector('[data-testid="workspace-right-rail-edit"]');
+    if (!panel) return;
+    const field = panel.querySelector(
+      'input:not([type="hidden"]), textarea, select, [contenteditable="true"]'
+    );
+    if (field && typeof field.focus === 'function') field.focus();
+  }, []);
+
+  // The breadcrumb band — rendered at the top of every dashboard-scoped Edit
+  // view (dashboard / row / item). Reflects the Outline selection's ancestry
+  // and is the keyboard-nav surface (Q7 = C).
+  const breadcrumb = (
+    <EditPanelBreadcrumb
+      outlineKey={outlineKey}
+      dashboardName={dashboardName}
+      rows={rows}
+      onSelectKey={setOutlineKey}
+      onReorder={handleBreadcrumbReorder}
+      onFocusForm={handleFocusForm}
+    />
+  );
+
   // ── Nothing selected ──────────────────────────────────────────────────────
   if (!activeObject) {
     return (
@@ -269,6 +313,7 @@ const RightRailEditPanel = () => {
 
       return (
         <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
+          {breadcrumb}
           <SelectionChip
             type="dashboard"
             name={dashboardName}
@@ -367,6 +412,7 @@ const RightRailEditPanel = () => {
 
       return (
         <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
+          {breadcrumb}
           <SelectionChip
             type="dashboard"
             name={`Row ${sel.rowIndex + 1}`}
@@ -443,6 +489,7 @@ const RightRailEditPanel = () => {
       if (leafRef && LEAF_TYPES.includes(leafRef.type)) {
         return (
           <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
+            {breadcrumb}
             <LeafObjectForm type={leafRef.type} name={leafRef.name} onSelectRef={handleSelectRef} />
           </div>
         );
@@ -474,6 +521,7 @@ const RightRailEditPanel = () => {
 
       return (
         <div data-testid="workspace-right-rail-edit" className="flex flex-1 flex-col overflow-hidden">
+          {breadcrumb}
           <SelectionChip
             type="dashboard"
             name={`Item ${sel.itemIndex + 1}`}

--- a/viewer/src/components/new-views/workspace/breadcrumbNav.js
+++ b/viewer/src/components/new-views/workspace/breadcrumbNav.js
@@ -1,0 +1,317 @@
+/**
+ * editPanelBreadcrumb — VIS-804 / Track G G-2.
+ *
+ * Pure helpers backing the right-rail Edit-panel structural breadcrumb and its
+ * keyboard navigation. Kept framework-free (no React, no store) so the
+ * key-derivation + nav logic is unit-testable in isolation and reused by both
+ * the <EditPanelBreadcrumb> component and its keydown handler.
+ *
+ * SELECTION KEY GRAMMAR (the same composite key OutlineTreePanel writes):
+ *   - `dashboard`                          — the dashboard chrome.
+ *   - `row.<N>`                            — a top-level row.
+ *   - `row.<N>.item.<M>`                   — an item in a top-level row.
+ *   - `…item.<M>.row.<P>.item.<Q>`         — nested container rows/items
+ *                                            (a container item carries `.rows`).
+ *
+ * A "segment" is one step in the ancestry chain:
+ *   { key, kind, type, label }
+ *     - key   — the selection key that selects THIS segment.
+ *     - kind  — 'dashboard' | 'row' | 'item' | 'container'.
+ *     - type  — canonical object type for icon/colour lookup
+ *               ('dashboard' for the root + containers, 'row' for rows,
+ *               the leaf object type — chart/table/markdown/input — for items).
+ *     - label — human label ('Row 2', the chart name, the dashboard name, …).
+ */
+
+const ITEM_TYPE_KEYS = ['chart', 'table', 'markdown', 'input'];
+
+/** Strip `${ref(name)}` / `ref(name)` / bare name → display name. */
+const refToName = value => {
+  if (typeof value !== 'string') return value && value.name ? value.name : null;
+  const match = value.match(/ref\(\s*(?:'|")?([^'")]+)(?:'|")?\s*\)/);
+  if (match) return match[1].trim();
+  return value;
+};
+
+/**
+ * Derive `{ type, name }` from a leaf dashboard Item (the first carrier key
+ * present wins). Mirrors OutlineTreePanel.resolveItem so the breadcrumb label
+ * matches the tree label exactly.
+ */
+const resolveLeafItem = item => {
+  if (!item || typeof item !== 'object') return { type: 'chart', name: '(item)' };
+  for (const key of ITEM_TYPE_KEYS) {
+    const value = item[key];
+    if (value === undefined || value === null || value === '') continue;
+    const name = refToName(value) || `(${key})`;
+    return { type: key, name };
+  }
+  return { type: 'chart', name: '(empty item)' };
+};
+
+/**
+ * Tokenise a selection key into ordered steps:
+ *   'row.0.item.1.row.0.item.2'
+ *     → [{ axis:'row', index:0 }, { axis:'item', index:1 },
+ *        { axis:'row', index:0 }, { axis:'item', index:2 }]
+ * Returns [] for the dashboard root (or a falsy/`'dashboard'` key).
+ */
+export const tokenizeOutlineKey = key => {
+  if (!key || typeof key !== 'string' || key === 'dashboard') return [];
+  const parts = key.split('.');
+  const tokens = [];
+  for (let i = 0; i < parts.length - 1; i += 2) {
+    const axis = parts[i];
+    const index = Number(parts[i + 1]);
+    if ((axis !== 'row' && axis !== 'item') || !Number.isInteger(index)) return tokens;
+    tokens.push({ axis, index });
+  }
+  return tokens;
+};
+
+/** Re-assemble tokens into a key. Empty tokens → `'dashboard'`. */
+export const tokensToKey = tokens => {
+  if (!tokens || tokens.length === 0) return 'dashboard';
+  return tokens.map(t => `${t.axis}.${t.index}`).join('.');
+};
+
+/**
+ * Walk the dashboard `rows` along the token path, returning the list of nodes
+ * touched (each `{ node, axis, index, kind }`) so labels can be derived. Stops
+ * early (returns what it resolved) when the path points past the live config.
+ */
+const walkTokens = (rows, tokens) => {
+  const nodes = [];
+  let currentRows = Array.isArray(rows) ? rows : [];
+  for (let t = 0; t < tokens.length; t += 1) {
+    const { axis, index } = tokens[t];
+    if (axis === 'row') {
+      const row = currentRows[index];
+      if (!row) break;
+      nodes.push({ node: row, axis, index, kind: 'row' });
+      currentRows = [];
+    } else {
+      // item axis — the item lives on the most-recently-seen row.
+      const parentRow = nodes.length ? nodes[nodes.length - 1].node : null;
+      const items = Array.isArray(parentRow?.items) ? parentRow.items : [];
+      const item = items[index];
+      if (!item) break;
+      const isContainer = Array.isArray(item?.rows) && item.rows.length > 0;
+      nodes.push({ node: item, axis, index, kind: isContainer ? 'container' : 'item' });
+      currentRows = isContainer ? item.rows : [];
+    }
+  }
+  return nodes;
+};
+
+/**
+ * Build the ordered breadcrumb segment list for a selection key.
+ *
+ * Always begins with the dashboard segment. Each subsequent segment maps to a
+ * prefix of the token path so its `key` selects that ancestor.
+ */
+export const buildBreadcrumbSegments = (outlineKey, dashboardName, rows) => {
+  const dashSegment = {
+    key: 'dashboard',
+    kind: 'dashboard',
+    type: 'dashboard',
+    label: dashboardName || 'Dashboard',
+  };
+  const tokens = tokenizeOutlineKey(outlineKey);
+  if (tokens.length === 0) return [dashSegment];
+
+  const walked = walkTokens(rows, tokens);
+  const segments = [dashSegment];
+
+  walked.forEach((entry, i) => {
+    const prefixTokens = tokens.slice(0, i + 1);
+    const key = tokensToKey(prefixTokens);
+    if (entry.kind === 'row') {
+      segments.push({ key, kind: 'row', type: 'row', label: `Row ${entry.index + 1}` });
+    } else if (entry.kind === 'container') {
+      segments.push({
+        key,
+        kind: 'container',
+        type: 'dashboard',
+        label: `Container ${entry.index + 1}`,
+      });
+    } else {
+      const { type, name } = resolveLeafItem(entry.node);
+      segments.push({ key, kind: 'item', type, label: name });
+    }
+  });
+
+  // If the live config no longer contains the full path (walk stopped early),
+  // the segments we DID resolve are still a valid, clickable ancestry.
+  return segments;
+};
+
+/**
+ * The number of siblings at the level the key terminates at, for the given
+ * rows. Used to clamp ↑/↓ sibling stepping. Returns 0 when the key is the
+ * dashboard root (no siblings).
+ */
+const siblingCount = (rows, tokens) => {
+  if (tokens.length === 0) return 0;
+  const parentTokens = tokens.slice(0, -1);
+  const last = tokens[tokens.length - 1];
+  if (last.axis === 'row') {
+    // Rows live either at the dashboard root or under a container item.
+    if (parentTokens.length === 0) return Array.isArray(rows) ? rows.length : 0;
+    const walked = walkTokens(rows, parentTokens);
+    const container = walked[walked.length - 1];
+    return Array.isArray(container?.node?.rows) ? container.node.rows.length : 0;
+  }
+  // item axis — siblings are the items of the parent row.
+  const walked = walkTokens(rows, parentTokens);
+  const parentRow = walked[walked.length - 1];
+  return Array.isArray(parentRow?.node?.items) ? parentRow.node.items.length : 0;
+};
+
+/**
+ * ↑/↓ — step among siblings at the current depth. `delta` is -1 (up/prev) or
+ * +1 (down/next). Wraps within the sibling range. Returns the next key, or the
+ * unchanged key when there are no siblings to step to (dashboard root, or a
+ * single-child level).
+ */
+export const computeSiblingKey = (outlineKey, rows, delta) => {
+  const tokens = tokenizeOutlineKey(outlineKey);
+  if (tokens.length === 0) return 'dashboard';
+  const count = siblingCount(rows, tokens);
+  if (count <= 1) return tokensToKey(tokens);
+  const last = tokens[tokens.length - 1];
+  const nextIndex = (last.index + delta + count) % count;
+  const nextTokens = [...tokens.slice(0, -1), { axis: last.axis, index: nextIndex }];
+  return tokensToKey(nextTokens);
+};
+
+/**
+ * ←/→ — step UP / DOWN the hierarchy. `direction` is 'up' (←) or 'down' (→).
+ *   - up   → the parent key (drop the last token; dashboard root is the floor).
+ *   - down → the first child of the current node, when it has children.
+ * Returns the unchanged key when the move isn't possible.
+ */
+export const computeHierarchyKey = (outlineKey, rows, direction) => {
+  const tokens = tokenizeOutlineKey(outlineKey);
+  if (direction === 'up') {
+    if (tokens.length === 0) return 'dashboard';
+    return tokensToKey(tokens.slice(0, -1));
+  }
+  // down — descend into the first child.
+  if (tokens.length === 0) {
+    // Dashboard → first row.
+    if (Array.isArray(rows) && rows.length > 0) return 'row.0';
+    return 'dashboard';
+  }
+  const walked = walkTokens(rows, tokens);
+  const current = walked[walked.length - 1];
+  if (!current) return tokensToKey(tokens);
+  if (current.kind === 'row') {
+    const items = Array.isArray(current.node?.items) ? current.node.items : [];
+    if (items.length > 0) return `${tokensToKey(tokens)}.item.0`;
+  } else if (current.kind === 'container') {
+    const nestedRows = Array.isArray(current.node?.rows) ? current.node.rows : [];
+    if (nestedRows.length > 0) return `${tokensToKey(tokens)}.row.0`;
+  }
+  return tokensToKey(tokens);
+};
+
+/**
+ * ⌘↑/⌘↓ — reorder the selected node within its siblings. Returns a descriptor
+ *   { axis, parentKey, fromIndex, toIndex }
+ * (or null when the move isn't possible: dashboard root, or already at the
+ * range edge). The caller applies the swap against the live config and re-keys
+ * the selection to `toIndex`. `delta` is -1 (move up/earlier) or +1 (down).
+ */
+export const computeReorder = (outlineKey, rows, delta) => {
+  const tokens = tokenizeOutlineKey(outlineKey);
+  if (tokens.length === 0) return null;
+  const count = siblingCount(rows, tokens);
+  if (count <= 1) return null;
+  const last = tokens[tokens.length - 1];
+  const toIndex = last.index + delta;
+  if (toIndex < 0 || toIndex >= count) return null;
+  return {
+    axis: last.axis,
+    parentKey: tokensToKey(tokens.slice(0, -1)),
+    fromIndex: last.index,
+    toIndex,
+  };
+};
+
+/** Immutable array swap of `from` ↔ `to`. */
+const swap = (arr, from, to) => {
+  const next = [...arr];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+};
+
+/**
+ * Apply a `computeReorder` descriptor to a dashboard config, returning the next
+ * config (or the unchanged config when the path can't be resolved). Reorders
+ * the `rows` array at the dashboard root or a container, or the `items` array
+ * of a row, depending on `op.axis`. Pure — does not mutate `config`.
+ */
+export const applyReorder = (config, op) => {
+  if (!config || !op) return config;
+  const rows = Array.isArray(config.rows) ? config.rows : [];
+  const parentTokens = tokenizeOutlineKey(op.parentKey);
+
+  // Top-level row reorder (parent is the dashboard root).
+  if (op.axis === 'row' && parentTokens.length === 0) {
+    return { ...config, rows: swap(rows, op.fromIndex, op.toIndex) };
+  }
+
+  // Reorder the leaf axis at the resolved parent node: a row reorders its
+  // `items`, a container item reorders its `rows`.
+  const reorderParent = parentNode => {
+    if (op.axis === 'item') {
+      const items = Array.isArray(parentNode.items) ? parentNode.items : [];
+      return { ...parentNode, items: swap(items, op.fromIndex, op.toIndex) };
+    }
+    const nestedRows = Array.isArray(parentNode.rows) ? parentNode.rows : [];
+    return { ...parentNode, rows: swap(nestedRows, op.fromIndex, op.toIndex) };
+  };
+
+  // Build a path-aware setter that, when it reaches the parent, applies
+  // reorderParent. The root is the rows array itself.
+  const applyAtRoot = (rootRows, tokens) => {
+    if (tokens.length === 0) return rootRows;
+    const { axis, index } = tokens[0];
+    if (axis !== 'row') return rootRows; // top-level path always starts at a row
+    const row = rootRows[index];
+    if (!row) return rootRows;
+    const nextRow =
+      tokens.length === 1 ? reorderParent(row) : applyDeep(row, tokens.slice(1));
+    const next = [...rootRows];
+    next[index] = nextRow;
+    return next;
+  };
+
+  const applyDeep = (node, tokens) => {
+    if (tokens.length === 0) return reorderParent(node);
+    const { axis, index } = tokens[0];
+    if (axis === 'item') {
+      const items = Array.isArray(node.items) ? node.items : [];
+      const item = items[index];
+      if (!item) return node;
+      const nextItem =
+        tokens.length === 1 ? reorderParent(item) : applyDeep(item, tokens.slice(1));
+      const nextItems = [...items];
+      nextItems[index] = nextItem;
+      return { ...node, items: nextItems };
+    }
+    // row axis inside a container
+    const nestedRows = Array.isArray(node.rows) ? node.rows : [];
+    const row = nestedRows[index];
+    if (!row) return node;
+    const nextRow =
+      tokens.length === 1 ? reorderParent(row) : applyDeep(row, tokens.slice(1));
+    const nextRows = [...nestedRows];
+    nextRows[index] = nextRow;
+    return { ...node, rows: nextRows };
+  };
+
+  return { ...config, rows: applyAtRoot(rows, parentTokens) };
+};

--- a/viewer/src/components/new-views/workspace/breadcrumbNav.test.js
+++ b/viewer/src/components/new-views/workspace/breadcrumbNav.test.js
@@ -1,0 +1,161 @@
+/**
+ * breadcrumbNav pure-helper tests (VIS-804 / Track G G-2).
+ *
+ * Covers the breadcrumb segment derivation and the keyboard-nav handlers
+ * (sibling step ↑/↓, hierarchy step ←/→, reorder ⌘↑/↓, and the immutable
+ * reorder applier) against flat AND nested-container selection keys.
+ */
+import {
+  tokenizeOutlineKey,
+  tokensToKey,
+  buildBreadcrumbSegments,
+  computeSiblingKey,
+  computeHierarchyKey,
+  computeReorder,
+  applyReorder,
+} from './breadcrumbNav';
+
+const ref = name => '${ref(' + name + ')}';
+
+// A dashboard with two top-level rows; row 0 has a chart + table, row 1 has a
+// container item whose nested row holds a markdown.
+const ROWS = [
+  {
+    height: 'medium',
+    items: [{ chart: ref('great_fib'), width: 2 }, { table: 'sales_table', width: 1 }],
+  },
+  {
+    height: 'small',
+    items: [
+      {
+        width: 1,
+        rows: [{ height: 'medium', items: [{ markdown: 'notes' }] }],
+      },
+    ],
+  },
+];
+
+describe('tokenizeOutlineKey / tokensToKey', () => {
+  test('dashboard root → no tokens', () => {
+    expect(tokenizeOutlineKey('dashboard')).toEqual([]);
+    expect(tokenizeOutlineKey(null)).toEqual([]);
+    expect(tokensToKey([])).toBe('dashboard');
+  });
+
+  test('round-trips flat + nested keys', () => {
+    expect(tokenizeOutlineKey('row.1.item.0.row.0.item.0')).toEqual([
+      { axis: 'row', index: 1 },
+      { axis: 'item', index: 0 },
+      { axis: 'row', index: 0 },
+      { axis: 'item', index: 0 },
+    ]);
+    expect(tokensToKey(tokenizeOutlineKey('row.1.item.0'))).toBe('row.1.item.0');
+  });
+});
+
+describe('buildBreadcrumbSegments', () => {
+  test('dashboard selection → single dashboard segment', () => {
+    const segs = buildBreadcrumbSegments('dashboard', 'my-dash', ROWS);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toMatchObject({ key: 'dashboard', kind: 'dashboard', label: 'my-dash' });
+  });
+
+  test('row selection → dashboard ▸ row', () => {
+    const segs = buildBreadcrumbSegments('row.0', 'my-dash', ROWS);
+    expect(segs.map(s => s.key)).toEqual(['dashboard', 'row.0']);
+    expect(segs[1]).toMatchObject({ kind: 'row', type: 'row', label: 'Row 1' });
+  });
+
+  test('item selection → dashboard ▸ row ▸ item (leaf name + type)', () => {
+    const segs = buildBreadcrumbSegments('row.0.item.0', 'my-dash', ROWS);
+    expect(segs.map(s => s.key)).toEqual(['dashboard', 'row.0', 'row.0.item.0']);
+    expect(segs[2]).toMatchObject({ kind: 'item', type: 'chart', label: 'great_fib' });
+  });
+
+  test('nested container selection → full ancestry chain', () => {
+    const key = 'row.1.item.0.row.0.item.0';
+    const segs = buildBreadcrumbSegments(key, 'my-dash', ROWS);
+    expect(segs.map(s => s.key)).toEqual([
+      'dashboard',
+      'row.1',
+      'row.1.item.0',
+      'row.1.item.0.row.0',
+      key,
+    ]);
+    expect(segs[2]).toMatchObject({ kind: 'container', type: 'dashboard' });
+    expect(segs[4]).toMatchObject({ kind: 'item', type: 'markdown', label: 'notes' });
+  });
+
+  test('stale key past the live config → resolves the valid prefix only', () => {
+    const segs = buildBreadcrumbSegments('row.0.item.9', 'my-dash', ROWS);
+    // item.9 does not exist → walk stops at the row.
+    expect(segs.map(s => s.key)).toEqual(['dashboard', 'row.0']);
+  });
+});
+
+describe('computeSiblingKey (↑/↓)', () => {
+  test('steps among row siblings and wraps', () => {
+    expect(computeSiblingKey('row.0', ROWS, 1)).toBe('row.1');
+    expect(computeSiblingKey('row.1', ROWS, 1)).toBe('row.0'); // wrap
+    expect(computeSiblingKey('row.0', ROWS, -1)).toBe('row.1'); // wrap back
+  });
+
+  test('steps among item siblings within a row', () => {
+    expect(computeSiblingKey('row.0.item.0', ROWS, 1)).toBe('row.0.item.1');
+    expect(computeSiblingKey('row.0.item.1', ROWS, 1)).toBe('row.0.item.0');
+  });
+
+  test('dashboard root has no siblings', () => {
+    expect(computeSiblingKey('dashboard', ROWS, 1)).toBe('dashboard');
+  });
+
+  test('single-child level stays put', () => {
+    // row.1 has a single item → no sibling step.
+    expect(computeSiblingKey('row.1.item.0', ROWS, 1)).toBe('row.1.item.0');
+  });
+});
+
+describe('computeHierarchyKey (←/→)', () => {
+  test('up steps to the parent', () => {
+    expect(computeHierarchyKey('row.0.item.0', ROWS, 'up')).toBe('row.0');
+    expect(computeHierarchyKey('row.0', ROWS, 'up')).toBe('dashboard');
+    expect(computeHierarchyKey('dashboard', ROWS, 'up')).toBe('dashboard');
+  });
+
+  test('down descends into the first child', () => {
+    expect(computeHierarchyKey('dashboard', ROWS, 'down')).toBe('row.0');
+    expect(computeHierarchyKey('row.0', ROWS, 'down')).toBe('row.0.item.0');
+    // container item → first nested row.
+    expect(computeHierarchyKey('row.1.item.0', ROWS, 'down')).toBe('row.1.item.0.row.0');
+  });
+
+  test('down on a leaf item with no children stays put', () => {
+    expect(computeHierarchyKey('row.0.item.0', ROWS, 'down')).toBe('row.0.item.0');
+  });
+});
+
+describe('computeReorder + applyReorder (⌘↑/↓)', () => {
+  test('reorder descriptor clamps at range edges', () => {
+    expect(computeReorder('row.0', ROWS, -1)).toBeNull(); // already first
+    expect(computeReorder('row.1', ROWS, 1)).toBeNull(); // already last
+    expect(computeReorder('dashboard', ROWS, 1)).toBeNull(); // root
+  });
+
+  test('swaps top-level rows immutably', () => {
+    const op = computeReorder('row.0', ROWS, 1);
+    expect(op).toMatchObject({ axis: 'row', parentKey: 'dashboard', fromIndex: 0, toIndex: 1 });
+    const next = applyReorder({ rows: ROWS }, op);
+    expect(next.rows[0]).toBe(ROWS[1]);
+    expect(next.rows[1]).toBe(ROWS[0]);
+    // original untouched
+    expect(ROWS[0].items[0].chart).toBe(ref('great_fib'));
+  });
+
+  test('swaps items within a row', () => {
+    const op = computeReorder('row.0.item.1', ROWS, -1);
+    expect(op).toMatchObject({ axis: 'item', parentKey: 'row.0', fromIndex: 1, toIndex: 0 });
+    const next = applyReorder({ rows: ROWS }, op);
+    expect(next.rows[0].items[0].table).toBe('sales_table');
+    expect(next.rows[0].items[1].chart).toBe(ref('great_fib'));
+  });
+});


### PR DESCRIPTION
## VIS-804 — Track G G-2

Adds a slim **structural breadcrumb** band to the right-rail Edit panel that reflects the current selection's ancestry (`dashboard ▸ row 2 ▸ great_fib`) and serves as the **keyboard-navigation surface** for the Outline selection (per Q7 = C, ships alongside canvas-direct nav VIS-D7).

### What shipped
- **`breadcrumbNav.js`** — pure, framework-free helpers: key tokenisation, segment derivation (flat **and** nested-container keys like `row.1.item.0.row.0.item.0`), sibling/hierarchy stepping, reorder descriptors, and an immutable reorder applier.
- **`EditPanelBreadcrumb.jsx`** — the band UI. Each segment is a clickable button that selects that ancestor via `setWorkspaceOutlineSelectedKey`. Type colour + icon come exclusively from `objectTypeConfigs` (rainbow); the **current** segment uses the mulberry selection chip (`#713b57`). Keyboard contract: `↑/↓` step siblings, `←/→` step the hierarchy, `⌘↑/⌘↓` reorder the focused node, `Enter` focuses the form's first field, `Esc` deselects. Screen-reader position announced via an `sr-only` `aria-live` region.
- **`RightRailEditPanel.jsx`** — mounts the band atop every dashboard-scoped Edit view (dashboard / row / item / leaf drill-in), wires the reorder + form-focus handlers, keeps the existing Edit-tab form routing intact.

### Acceptance criteria
- [x] Breadcrumb renders for all selection depths (dashboard / row / item / nested container).
- [x] Arrow keys step siblings.
- [x] ←/→ step hierarchy.
- [x] ⌘↑/↓ reorder.
- [x] Enter focuses form.
- [x] Screen-reader announces breadcrumb position.
- [x] Unit tests for keyboard handlers.
- [x] Visual QA against design brief G-2.

### Tests
- `breadcrumbNav.test.js` — segment derivation, nav handlers, reorder (17 tests).
- `EditPanelBreadcrumb.test.jsx` — rendering, segment clicks, keydown handlers, a11y.
- `editpanel-breadcrumb.spec.mjs` — Playwright story driven on the deeply-nested `nested-layouts-dashboard` (sandbox ports 8045/3045). Both story tests pass; screenshots captured.
- **Full viewer suite green: 2037 tests / 156 suites; lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)