### PR TITLE
style(viewer): render chart ref-insights as styled insight pills

### DIFF
--- a/viewer/src/components/new-views/common/ChartEditForm.jsx
+++ b/viewer/src/components/new-views/common/ChartEditForm.jsx
@@ -4,7 +4,6 @@ import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
-import RemoveIcon from '@mui/icons-material/Remove';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { validateName } from './namedModel';
 import { SchemaEditor } from './SchemaEditor';
@@ -12,6 +11,7 @@ import { getSchema, isSchemaLoaded } from '../../../schemas/schemas';
 import { getTypeByValue } from './objectTypeConfigs';
 import { setAtPath } from './embeddedObjectUtils';
 import { parseRefValue, formatRef } from '../../../utils/refString';
+import EmbeddedPill from '../lineage/EmbeddedPill';
 
 /**
  * ChartEditForm - Form component for editing/creating charts
@@ -273,11 +273,26 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded 
               </p>
             ) : (
               insights.map((insight, index) => (
-                <div key={index} className="flex items-center gap-2">
+                <div
+                  key={index}
+                  className="flex items-center gap-2"
+                  data-testid={`ref-insight-row-${index}`}
+                >
+                  <EmbeddedPill
+                    objectType="insight"
+                    label={insight}
+                    size="md"
+                    as="div"
+                    tooltip={`Insight: ${insight}`}
+                    onRemove={() => removeInsight(index)}
+                    className="flex-1 min-w-0"
+                  />
                   <select
+                    aria-label={`Change insight ${index + 1}`}
                     value={insight}
                     onChange={e => updateInsight(index, e.target.value)}
-                    className="flex-1 px-3 py-2 text-sm text-gray-900 bg-white rounded-md border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                    className="px-2 py-2 text-sm text-gray-900 bg-white rounded-md border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                    title="Change insight"
                   >
                     {availableInsights.map(i => (
                       <option key={i} value={i} disabled={insights.includes(i) && i !== insight}>
@@ -285,14 +300,6 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded 
                       </option>
                     ))}
                   </select>
-                  <button
-                    type="button"
-                    onClick={() => removeInsight(index)}
-                    className="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
-                    title="Remove insight"
-                  >
-                    <RemoveIcon fontSize="small" />
-                  </button>
                 </div>
               ))
             )}

--- a/viewer/src/components/new-views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/ChartEditForm.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import ChartEditForm from './ChartEditForm';
+import useStore from '../../../stores/store';
+
+jest.mock('../../../stores/store', () => {
+  const fn = jest.fn();
+  fn.ObjectStatus = { NEW: 'new' };
+  return { __esModule: true, default: fn, ObjectStatus: { NEW: 'new' } };
+});
+
+// Layout schema loading is async + irrelevant to the insight pill behavior.
+jest.mock('../../../schemas/schemas', () => ({
+  getSchema: jest.fn().mockResolvedValue(null),
+  isSchemaLoaded: jest.fn().mockReturnValue(true),
+}));
+
+const mockFetchInsights = jest.fn();
+const mockDeleteChart = jest.fn();
+const mockCheckPublishStatus = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useStore.mockImplementation(selector => {
+    const state = {
+      deleteChart: mockDeleteChart,
+      checkPublishStatus: mockCheckPublishStatus,
+      fetchInsights: mockFetchInsights,
+      insights: [{ name: 'revenue_insight' }, { name: 'cost_insight' }],
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  });
+});
+
+const chartWithRefInsight = {
+  name: 'rev_chart',
+  status: 'published',
+  config: {
+    insights: ['ref(revenue_insight)'],
+    layout: {},
+  },
+};
+
+// Renders and flushes the async layout-schema effect (await a findBy* query) so
+// no act() warnings leak from the schema load resolving after the initial render.
+const renderForm = async (props = {}) => {
+  const utils = render(
+    <ChartEditForm
+      chart={chartWithRefInsight}
+      isCreate={false}
+      onClose={jest.fn()}
+      onSave={jest.fn()}
+      onNavigateToEmbedded={jest.fn()}
+      {...props}
+    />
+  );
+  await screen.findByTestId('ref-insight-row-0');
+  return utils;
+};
+
+// The pill label is a <span>; the change-select repeats the name in an <option>,
+// so scope text queries to the span to assert on the styled pill specifically.
+const getPillLabel = (row, name) =>
+  within(row)
+    .getAllByText(name)
+    .find(el => el.tagName === 'SPAN');
+
+describe('ChartEditForm — ref insight pills', () => {
+  test('renders a selected ref insight as a styled insight pill (not a bare select)', async () => {
+    await renderForm();
+
+    const row = screen.getByTestId('ref-insight-row-0');
+    const label = getPillLabel(row, 'revenue_insight');
+    expect(label).toBeInTheDocument();
+    // Uses the shared insight type color (purple-800) from objectTypeConfigs.
+    expect(label.className).toContain('text-purple-800');
+
+    // The pill carries the insight type icon (svg) and a remove affordance.
+    expect(within(row).getByTestId('pill-remove')).toBeInTheDocument();
+  });
+
+  test('the pill exposes a working remove (x) that drops the insight', async () => {
+    await renderForm();
+
+    expect(screen.getByTestId('ref-insight-row-0')).toBeInTheDocument();
+    const removeBtn = within(screen.getByTestId('ref-insight-row-0')).getByTestId('pill-remove');
+    fireEvent.click(removeBtn);
+
+    expect(screen.queryByTestId('ref-insight-row-0')).not.toBeInTheDocument();
+    expect(screen.getByText(/No insights added/i)).toBeInTheDocument();
+  });
+
+  test('Add Insight appends another ref insight pill', async () => {
+    await renderForm();
+    expect(screen.queryByTestId('ref-insight-row-1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Add Insight'));
+    expect(screen.getByTestId('ref-insight-row-1')).toBeInTheDocument();
+  });
+
+  test('the change-select still lets you swap which insight is referenced', async () => {
+    await renderForm();
+    const select = screen.getByLabelText('Change insight 1');
+    expect(select).toHaveValue('revenue_insight');
+    fireEvent.change(select, { target: { value: 'cost_insight' } });
+    const row = screen.getByTestId('ref-insight-row-0');
+    expect(getPillLabel(row, 'cost_insight')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

In the chart **Edit** form (`viewer/src/components/new-views/common/ChartEditForm.jsx`), selected **ref insights** (string refs) were rendered as a plain native `<select>`, while **embedded insights** in the same form already rendered as styled pills using the shared `objectTypeConfigs` palette (insight = purple node styling + insight icon).

This restyles the ref-insight rows to match the mockup and the embedded-insight rows:

- Each selected ref insight now renders as an `EmbeddedPill` (`objectType="insight"`) — the shared component already used for embedded objects — giving it the insight type color (`bg-purple-100` / `text-purple-800`), the insight icon, and a remove (x). No hand-rolled Tailwind colors/hex; everything flows through `objectTypeConfigs` per the project rule.
- A small `<select>` beside each pill remains as the affordance to **change** which insight is referenced (`Change insight N`), preserving the existing `updateInsight` capability.
- `+ Add Insight`, removal, and the `>= 1 insight` requirement are unchanged.
- The saved config shape is unchanged — ref insights still serialize via `formatRef(name)`.

Also removes the now-unused `RemoveIcon` import.

## Tests

- New `ChartEditForm.test.jsx` (4 tests): a selected ref insight renders as a styled insight pill (purple `text-purple-800` + icon) with a working remove; `+ Add Insight` appends a pill; the change-select still swaps the referenced insight.
- `bash scripts/viewer-check.sh ChartEditForm` — tests + lint green.

## Visual

Verified in an isolated sandbox (ports 8043/3043) on `/workspace/dashboard/insights-dashboard`, opening a chart's right-rail **Edit** tab. The ref insight renders as a purple insight pill matching the embedded-insight style; contrast is good (purple-800 on purple-100), no dark-on-dark/light-on-light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)