### PR TITLE
feat(viewer/canvas): resize handles for width / height / fluid (VIS-777 / Track D D-4)

### DIFF
--- a/viewer/e2e/stories/canvas-resize.spec.mjs
+++ b/viewer/e2e/stories/canvas-resize.spec.mjs
@@ -1,0 +1,193 @@
+/**
+ * Story: Canvas resize handles (VIS-777 / Track D D-4, design D-3).
+ *
+ * The Workspace dashboard canvas (<ProjectCanvas>) mounts a resize-gesture layer
+ * (<CanvasResizeLayer>) over the render-only <Dashboard>. Selecting an item or
+ * row reveals edge handles; dragging them mutates the dashboard config and
+ * persists it through the shell's shared commitCanvasConfig (optimistic update +
+ * debounced save, backend-valid via sanitize):
+ *
+ *   1. Item RIGHT-EDGE handle (↔ width)  — drag changes the item's integer
+ *      col-span; siblings rebalance (relative grid).
+ *   2. Row BOTTOM-EDGE handle (↕ height) — drag snaps the row to a HeightEnum
+ *      tick stop (tick mode).
+ *   3. Shift held during a height drag    — writes a numeric pixel int to
+ *      Row.height (fluid mode; Row.height accepts Union[HeightEnum, int]).
+ *
+ * The chart inside the slot stays STATIC during the drag (the overlay paints a
+ * mulberry ghost; the Dashboard re-renders once, at drag-end).
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8044 VISIVO_SANDBOX_FRONTEND_PORT=3044 \
+ *   VISIVO_SANDBOX_NAME=vis777 bash scripts/sandbox.sh start
+ *   # then: VIS_RESIZE_BASE=http://localhost:3044 npx playwright test canvas-resize
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_RESIZE_BASE || 'http://localhost:3044';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+// A wide viewport keeps the canvas ≥768px so rows lay out side-by-side and the
+// item slots get real pixel boxes for the edge handles.
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+const selectKey = (page, key) =>
+  page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(dash.locator('[data-row-index]').first()).toBeVisible({ timeout: WAIT });
+};
+
+// Raw pointer drag of a resize handle: down on the handle centre, nudge, travel
+// to (centre + dx,dy), release. The handle uses pointer capture, so a reflow
+// mid-drag can't drop the gesture.
+const dragHandle = async (page, handle, dx, dy, { shift = false } = {}) => {
+  await handle.scrollIntoViewIfNeeded();
+  const b = await handle.boundingBox();
+  expect(b, 'the resize handle has a box').toBeTruthy();
+  const sx = b.x + b.width / 2;
+  const sy = b.y + b.height / 2;
+  if (shift) await page.keyboard.down('Shift');
+  await page.mouse.move(sx, sy);
+  await page.mouse.down();
+  await page.mouse.move(sx + Math.sign(dx) * 4, sy + Math.sign(dy) * 4, { steps: 4 });
+  await page.mouse.move(sx + dx, sy + dy, { steps: 20 });
+  await page.mouse.move(sx + dx, sy + dy, { steps: 4 });
+  await page.mouse.up();
+  if (shift) await page.keyboard.up('Shift');
+};
+
+test.describe('Canvas resize handles (VIS-777 / D-4)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('selecting an item reveals its width resize handle', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    const ri = rows.findIndex(r => (r.items || []).length >= 2);
+    expect(ri, 'a row with ≥2 items exists').toBeGreaterThanOrEqual(0);
+
+    const itemKey = `row.${ri}.item.0`;
+    await selectKey(page, itemKey);
+    await expect(page.getByTestId('canvas-resize-layer')).toBeAttached({ timeout: WAIT });
+    await expect(page.getByTestId(`canvas-resize-width-${itemKey}`)).toBeVisible({
+      timeout: WAIT,
+    });
+    await page.screenshot({ path: `${SCREENS}/vis777-01-handles.png`, fullPage: true });
+  });
+
+  test('dragging an item right-edge handle changes its width and persists', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    const ri = rows.findIndex(r => (r.items || []).length >= 2);
+    const itemKey = `row.${ri}.item.0`;
+    const beforeWidth = rows[ri].items[0].width || 1;
+
+    await selectKey(page, itemKey);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    // Drag the right edge LEFT by ~1/4 of the row → at least one column smaller
+    // (or right if already at the floor). We assert the width simply CHANGED and
+    // stayed a valid integer col-span, which is the resize contract.
+    const rowBox = await page.locator(`[data-canvas-path="row.${ri}"]`).first().boundingBox();
+    const colPx = rowBox.width / (rows[ri].items.reduce((s, it) => s + (it.width || 1), 0) || 1);
+    const dir = beforeWidth > 1 ? -1 : 1;
+    await dragHandle(page, handle, dir * Math.round(colPx * 2), 0);
+
+    await expect
+      .poll(async () => (await readRows(page))[ri].items[0].width, { timeout: WAIT })
+      .not.toBe(beforeWidth);
+    const after = (await readRows(page))[ri].items[0].width;
+    expect(Number.isInteger(after)).toBe(true);
+    expect(after).toBeGreaterThanOrEqual(1);
+    expect(after).toBeLessThanOrEqual(12);
+    await page.screenshot({ path: `${SCREENS}/vis777-02-width-resized.png`, fullPage: true });
+  });
+
+  test('dragging a row bottom-edge handle changes its height (tick mode)', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    const ri = 0;
+    const beforeHeight = rows[ri].height;
+
+    await selectKey(page, `row.${ri}`);
+    const handle = page.getByTestId(`canvas-resize-height-row.${ri}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    // Drag the bottom edge DOWN ~140px → steps up at least one HeightEnum stop.
+    await dragHandle(page, handle, 0, 140);
+
+    await expect
+      .poll(async () => (await readRows(page))[ri].height, { timeout: WAIT })
+      .not.toBe(beforeHeight);
+    const after = (await readRows(page))[ri].height;
+    // Tick mode → an enum token (string), not a raw pixel int.
+    expect(typeof after).toBe('string');
+    await page.screenshot({ path: `${SCREENS}/vis777-03-height-tick.png`, fullPage: true });
+  });
+
+  test('Shift-dragging a row height handle writes a numeric pixel value (fluid)', async () => {
+    await openCanvas(page);
+    const ri = 1;
+    await selectKey(page, `row.${ri}`);
+    const handle = page.getByTestId(`canvas-resize-height-row.${ri}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    await dragHandle(page, handle, 0, 90, { shift: true });
+
+    await expect
+      .poll(async () => typeof (await readRows(page))[ri].height, { timeout: WAIT })
+      .toBe('number');
+    const after = (await readRows(page))[ri].height;
+    expect(Number.isInteger(after)).toBe(true);
+    await page.screenshot({ path: `${SCREENS}/vis777-04-height-fluid.png`, fullPage: true });
+  });
+
+  test('no console errors AND no auto-save 400 across the resize gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'resize must persist backend-valid config (sanitize)').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/stories/canvas-selection.spec.mjs
+++ b/viewer/e2e/stories/canvas-selection.spec.mjs
@@ -155,9 +155,8 @@ test.describe('Canvas selection + hover overlays (VIS-768)', () => {
     await expect(page.getByTestId('canvas-overlay-hover-item')).toBeVisible({
       timeout: WAIT,
     });
-    await expect(page.getByTestId('canvas-overlay-resize-handle')).toBeVisible({
-      timeout: WAIT,
-    });
+    // The resize affordance moved to <CanvasResizeLayer> (VIS-777 / D-4), shown
+    // on the SELECTED node rather than as a hover-time placeholder.
 
     await page.screenshot({ path: `${SCREENS}/vis768-04-hover-overlay.png` });
   });

--- a/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.jsx
@@ -1,0 +1,538 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useStore from '../../../../stores/store';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { useCommitCanvasConfig } from '../../workspace/WorkspaceDndContext';
+import {
+  parseCanvasPath,
+  setItemWidth,
+  setRowHeight,
+  HEIGHT_ENUM_STOPS,
+  heightEnumToPixels,
+  pixelsToNearestHeightEnum,
+} from './canvasReorder';
+
+/**
+ * CanvasResizeLayer — VIS-777 / Track D D-4 (design D-3 "Resize handles").
+ *
+ * The resize-gesture overlay for the Workspace dashboard canvas. A SIBLING over
+ * the render-only <Dashboard> (mounted by ProjectCanvas next to the selection +
+ * DnD overlays), it MEASURES the live DOM via the same composite
+ * `data-canvas-path` markers the other overlays read, then paints edge handles
+ * on the CURRENTLY SELECTED item / row and turns a drag on them into a config
+ * mutation persisted through the shell's shared `commitCanvasConfig`
+ * (sanitize → optimistic → save).
+ *
+ * Three handle types (D-3 contract):
+ *   - Item RIGHT-EDGE (↔ width): drag changes the item's integer col-span
+ *     (1–12). Widths are relative within the row, so siblings rebalance live. A
+ *     `N / total` readout pill rides the handle.
+ *   - Row BOTTOM-EDGE (↕ height): drag snaps to HeightEnum tick stops by
+ *     default (label stack, active stop mulberry-filled). Holding Shift switches
+ *     to FLUID mode — a numeric pixel value written as an int to `Row.height`
+ *     (which accepts `Union[HeightEnum, int]`).
+ *   - Container CORNER (⤡ both axes): on a container item (Item.rows non-empty)
+ *     a se-resize corner resizes width + height in one gesture.
+ *
+ * The chart inside the slot stays STATIC during the drag: we never re-layout the
+ * Dashboard mid-gesture. The overlay paints a mulberry ghost at the live target
+ * geometry and only commits the new config on pointer-UP, so the expensive
+ * chart re-render happens once, at drag-end.
+ *
+ * Pointer handling is RAW (not dnd-kit): the handle calls `setPointerCapture` on
+ * pointer-down so a canvas reflow mid-drag (charts finishing load, the optimistic
+ * config swap) can never drop the gesture — the moves keep flowing to the
+ * captured handle regardless of what reflows underneath.
+ *
+ * Mulberry / primary (`#713b57`) is the SELECTION colour only (matches the
+ * selection overlay + DnD insertion bar). Type colours come from
+ * objectTypeConfigs.js elsewhere and are never used here.
+ */
+
+const MULBERRY = '#713b57';
+const COLS = 12;
+
+// Classify a composite selection key as item / row / chrome (mirrors the
+// selection overlay's kindForKey).
+const kindForKey = key => {
+  if (!key || key === 'dashboard') return 'chrome';
+  const parts = key.split('.');
+  return parts[parts.length - 2] === 'item' ? 'item' : 'row';
+};
+
+// Measure a node's box relative to the overlay root (same idiom as the sibling
+// overlays — absolute positioning inside the shared positioned ancestor).
+const measure = (el, rootEl) => {
+  if (!el || !rootEl) return null;
+  const node = el.getBoundingClientRect();
+  const root = rootEl.getBoundingClientRect();
+  return {
+    top: node.top - root.top,
+    left: node.left - root.left,
+    width: node.width,
+    height: node.height,
+  };
+};
+
+// Resolve the config node (item or row) addressed by a composite path, plus its
+// parent row's item-width context (so the width gesture can reason about the
+// per-column pixel width and the sibling total).
+const resolveSelection = (config, key) => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length) return null;
+  // Walk the spine to the addressed node + its parent items array.
+  let rows = Array.isArray(config?.rows) ? config.rows : null;
+  let row = null;
+  let item = null;
+  let itemsInRow = null;
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    if (seg.kind === 'row') {
+      if (!rows || !rows[seg.index]) return null;
+      row = rows[seg.index];
+      item = null;
+      itemsInRow = Array.isArray(row.items) ? row.items : [];
+    } else {
+      if (!itemsInRow || !itemsInRow[seg.index]) return null;
+      item = itemsInRow[seg.index];
+      rows = Array.isArray(item.rows) ? item.rows : null;
+    }
+  }
+  const last = segments[segments.length - 1];
+  return { segments, row, item, itemsInRow, isItem: last.kind === 'item' };
+};
+
+const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
+  const selectedKey = useStore(s => s.workspaceOutlineSelectedKey);
+  const dashboards = useStore(s => s.dashboards);
+  const commitCanvasConfig = useCommitCanvasConfig();
+
+  const dashboardConfig = useMemo(() => {
+    const entry = (dashboards || []).find(d => d.name === dashboardName);
+    if (!entry) return null;
+    return entry.config || entry;
+  }, [dashboards, dashboardName]);
+
+  // Measured box of the selected node, kept fresh against reflow.
+  const [box, setBox] = useState(null);
+  // Live drag state — null at rest; otherwise the in-flight gesture descriptor:
+  //   { kind: 'width'|'height'|'corner', startX, startY, colPx, startCols,
+  //     liveCols, startPx, livePx, fluid, label, box }
+  const [drag, setDrag] = useState(null);
+  const dragRef = useRef(null);
+
+  const selectedKind = kindForKey(selectedKey);
+
+  const selection = useMemo(() => {
+    if (!dashboardConfig || selectedKind === 'chrome') return null;
+    return resolveSelection(dashboardConfig, selectedKey);
+  }, [dashboardConfig, selectedKey, selectedKind]);
+
+  // Is the selected item a container (Item.rows non-empty)? Containers get the
+  // both-axes corner handle.
+  const isContainerItem = !!(
+    selection?.isItem &&
+    Array.isArray(selection.item?.rows) &&
+    selection.item.rows.length > 0
+  );
+
+  // The row that governs height for a width/height gesture: for an item
+  // selection it's the item's PARENT row; for a row selection it's the row
+  // itself. The width gesture targets the ITEM; the height gesture targets the
+  // ROW (or, for a row selection, that row).
+  const measureBox = useCallback(() => {
+    const root = rootRef.current;
+    if (!root || !selectedKey || selectedKind === 'chrome') {
+      setBox(null);
+      return;
+    }
+    const el = root.querySelector(`[data-canvas-path="${selectedKey}"]`);
+    setBox(el ? measure(el, root) : null);
+  }, [rootRef, selectedKey, selectedKind]);
+
+  // Re-measure on selection change + reflow. We deliberately DO NOT re-measure
+  // while a drag is in flight: the box is frozen to the gesture's start
+  // geometry so the ghost stays anchored even as the optimistic config swap
+  // reflows the canvas underneath (the gesture's pointer capture keeps the
+  // moves flowing regardless).
+  useEffect(() => {
+    measureBox();
+  }, [measureBox]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    const onReflow = () => {
+      if (dragRef.current) return; // frozen during a gesture
+      measureBox();
+    };
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(onReflow) : null;
+    if (ro) ro.observe(root);
+    window.addEventListener('resize', onReflow);
+    window.addEventListener('scroll', onReflow, true);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', onReflow);
+      window.removeEventListener('scroll', onReflow, true);
+    };
+  }, [rootRef, measureBox]);
+
+  // ── Gesture math ──────────────────────────────────────────────────────────
+  // Per-column pixel width = the row's pixel width / its total grid columns.
+  // The row's total columns = sum of sibling item widths (relative grid). For a
+  // width gesture we need the parent ROW's pixel width; the selected item box's
+  // own width is one item, so we read the parent row box for the denominator.
+  const rowPathForItem = useMemo(() => {
+    if (!selection?.isItem) return null;
+    const segs = selection.segments.slice(0, -1);
+    return segs.map(s => `${s.kind}.${s.index}`).join('.');
+  }, [selection]);
+
+  const beginDrag = useCallback(
+    (e, kind) => {
+      if (!box || !selection) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const root = rootRef.current;
+
+      // Width context: per-column px from the parent row's width / its grid total.
+      let colPx = 0;
+      let startCols = selection.item?.width || 1;
+      if ((kind === 'width' || kind === 'corner') && rowPathForItem && root) {
+        const rowEl = root.querySelector(`[data-canvas-path="${rowPathForItem}"]`);
+        const rowBox = rowEl ? measure(rowEl, root) : null;
+        const total =
+          (selection.itemsInRow || []).reduce((sum, it) => sum + (it.width || 1), 0) || 1;
+        const rowWidth = rowBox ? rowBox.width : box.width;
+        colPx = rowWidth / total;
+      }
+
+      // Height context: the gesture's row is the selection's row (item → parent
+      // row; row → itself). startPx from the row's current enum/px height.
+      const rowHeight = selection.row?.height;
+      const startPx =
+        typeof rowHeight === 'number' ? rowHeight : heightEnumToPixels(rowHeight);
+
+      const next = {
+        kind,
+        startX: e.clientX,
+        startY: e.clientY,
+        colPx: colPx || 1,
+        startCols,
+        liveCols: startCols,
+        startPx,
+        livePx: startPx,
+        fluid: !!e.shiftKey,
+        label:
+          kind === 'height' || kind === 'corner'
+            ? e.shiftKey
+              ? `${Math.round(startPx)} px`
+              : pixelsToNearestHeightEnum(startPx)
+            : `${startCols} / ${COLS}`,
+        box,
+      };
+      dragRef.current = next;
+      setDrag(next);
+
+      // Capture the pointer on the handle so a reflow mid-drag can't drop the
+      // gesture (the canvas-overlay gotcha — the canvas reflows on the
+      // optimistic config swap, but the captured handle keeps receiving moves).
+      try {
+        if (e.currentTarget && typeof e.currentTarget.setPointerCapture === 'function') {
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }
+      } catch {
+        // Pointer capture is best-effort; the window-level move listener below
+        // is the fallback so the gesture still completes.
+      }
+    },
+    [box, selection, rowPathForItem, rootRef]
+  );
+
+  // Window-level move/up handlers active only while a drag is in flight. They
+  // read dragRef (stable) and recompute the live width/height from the pointer
+  // delta at frame rate — pure arithmetic, no DOM reads, no reflow.
+  useEffect(() => {
+    if (!drag) return undefined;
+
+    const onMove = e => {
+      const d = dragRef.current;
+      if (!d) return;
+      const dx = e.clientX - d.startX;
+      const dy = e.clientY - d.startY;
+      let liveCols = d.liveCols;
+      let livePx = d.livePx;
+      const fluid = !!e.shiftKey;
+
+      if (d.kind === 'width' || d.kind === 'corner') {
+        const deltaCols = Math.round(dx / d.colPx);
+        liveCols = Math.max(1, Math.min(COLS, d.startCols + deltaCols));
+      }
+      if (d.kind === 'height' || d.kind === 'corner') {
+        livePx = Math.max(48, Math.min(2048, d.startPx + dy));
+      }
+
+      let label;
+      if (d.kind === 'width') {
+        label = `${liveCols} / ${COLS}`;
+      } else if (d.kind === 'corner') {
+        const hLabel = fluid ? `${Math.round(livePx)} px` : pixelsToNearestHeightEnum(livePx);
+        label = `width ${liveCols} · height ${hLabel}`;
+      } else {
+        label = fluid ? `${Math.round(livePx)} px` : pixelsToNearestHeightEnum(livePx);
+      }
+
+      const updated = { ...d, liveCols, livePx, fluid, label };
+      dragRef.current = updated;
+      setDrag(updated);
+    };
+
+    const onUp = () => {
+      const d = dragRef.current;
+      dragRef.current = null;
+      setDrag(null);
+      if (!d || !selection || !dashboardConfig) {
+        measureBox();
+        return;
+      }
+
+      let nextConfig = dashboardConfig;
+      const fluid = d.fluid;
+
+      // Width / corner-width → item col-span.
+      if ((d.kind === 'width' || d.kind === 'corner') && selection.isItem) {
+        nextConfig = setItemWidth(nextConfig, selectedKey, d.liveCols);
+      }
+      // Height / corner-height → row height (enum tick OR fluid px int).
+      if (d.kind === 'height' || d.kind === 'corner') {
+        const rowPath =
+          selection.isItem && rowPathForItem ? rowPathForItem : selectedKey;
+        const nextHeight = fluid
+          ? Math.round(d.livePx)
+          : pixelsToNearestHeightEnum(d.livePx);
+        nextConfig = setRowHeight(nextConfig, rowPath, nextHeight);
+      }
+
+      if (nextConfig !== dashboardConfig) {
+        commitCanvasConfig(dashboardName, nextConfig, { kind: 'resize_item', fluid });
+        emitWorkspaceEvent('canvas_action', {
+          kind: 'resize_item',
+          axis: d.kind,
+          fluid,
+          width: d.liveCols,
+          height: fluid ? Math.round(d.livePx) : pixelsToNearestHeightEnum(d.livePx),
+          path: selectedKey,
+        });
+      }
+      // Re-measure against the (re-laid-out) canvas after the commit.
+      measureBox();
+    };
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [
+    drag,
+    selection,
+    dashboardConfig,
+    dashboardName,
+    selectedKey,
+    rowPathForItem,
+    commitCanvasConfig,
+    measureBox,
+  ]);
+
+  if (!dashboardConfig || !box || selectedKind === 'chrome' || !selection) return null;
+
+  // Ghost geometry while dragging: width gesture stretches the item box to its
+  // live col-span (relative to the start span); height gesture stretches the
+  // box to its live pixel height. Pure transform on the overlay — the Dashboard
+  // render below is untouched (chart stays static).
+  const ghost = (() => {
+    if (!drag) return null;
+    let w = box.width;
+    let h = box.height;
+    if (drag.kind === 'width' || drag.kind === 'corner') {
+      w = box.width * (drag.liveCols / Math.max(1, drag.startCols));
+    }
+    if (drag.kind === 'height' || drag.kind === 'corner') {
+      h = box.height * (drag.livePx / Math.max(1, drag.startPx));
+    }
+    return { top: box.top, left: box.left, width: w, height: h };
+  })();
+
+  // Which handles to show: an ITEM selection gets the right-edge width handle
+  // (+ the bottom-edge height handle on its row is owned by a ROW selection);
+  // a container item additionally gets the corner. A ROW selection gets the
+  // bottom-edge height handle.
+  const showWidthHandle = selection.isItem;
+  const showHeightHandle = !selection.isItem; // row selection
+  const showCornerHandle = isContainerItem;
+
+  const handleBase =
+    'pointer-events-auto absolute z-30 transition-opacity hover:opacity-100';
+
+  return (
+    <div
+      data-testid="canvas-resize-layer"
+      className="pointer-events-none absolute inset-0 z-20"
+    >
+      {/* Selected-node frame (subtle, so the handles read as edge affordances). */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute rounded-md"
+        style={{
+          top: box.top,
+          left: box.left,
+          width: box.width,
+          height: box.height,
+          boxShadow: drag ? `inset 0 0 0 1px ${MULBERRY}55` : 'none',
+        }}
+      />
+
+      {/* Drag ghost — the live target geometry, painted only during a gesture. */}
+      {drag && ghost && (
+        <div
+          data-testid="canvas-resize-ghost"
+          aria-hidden="true"
+          className="pointer-events-none absolute rounded-md"
+          style={{
+            top: ghost.top,
+            left: ghost.left,
+            width: ghost.width,
+            height: ghost.height,
+            background: 'rgba(113,59,87,0.06)',
+            boxShadow: `0 0 0 2px ${MULBERRY}, 0 0 0 5px rgba(113,59,87,0.18)`,
+          }}
+        />
+      )}
+
+      {/* Item RIGHT-EDGE width handle (↔). A 2px rule hugging the slot's right
+          edge; full mulberry on hover, col-resize cursor. */}
+      {showWidthHandle && (
+        <div
+          role="button"
+          tabIndex={0}
+          data-testid={`canvas-resize-width-${selectedKey}`}
+          data-resize-axis="width"
+          aria-label="Resize item width"
+          title="Drag to resize width"
+          className={`${handleBase} opacity-80`}
+          onPointerDown={e => beginDrag(e, 'width')}
+          style={{
+            top: box.top + 6,
+            left: box.left + box.width - 3,
+            width: 6,
+            height: Math.max(0, box.height - 12),
+            cursor: 'col-resize',
+            background: drag?.kind === 'width' ? MULBERRY : `${MULBERRY}99`,
+            borderRadius: 3,
+            touchAction: 'none',
+          }}
+        />
+      )}
+
+      {/* Row BOTTOM-EDGE height handle (↕). */}
+      {showHeightHandle && (
+        <div
+          role="button"
+          tabIndex={0}
+          data-testid={`canvas-resize-height-${selectedKey}`}
+          data-resize-axis="height"
+          aria-label="Resize row height"
+          title="Drag to resize height — hold Shift for a precise pixel value"
+          className={`${handleBase} opacity-80`}
+          onPointerDown={e => beginDrag(e, 'height')}
+          style={{
+            top: box.top + box.height - 3,
+            left: box.left + 6,
+            width: Math.max(0, box.width - 12),
+            height: 6,
+            cursor: 'row-resize',
+            background: drag?.kind === 'height' ? MULBERRY : `${MULBERRY}99`,
+            borderRadius: 3,
+            touchAction: 'none',
+          }}
+        />
+      )}
+
+      {/* Container CORNER handle (⤡ both axes). */}
+      {showCornerHandle && (
+        <div
+          role="button"
+          tabIndex={0}
+          data-testid={`canvas-resize-corner-${selectedKey}`}
+          data-resize-axis="corner"
+          aria-label="Resize container width and height"
+          title="Drag to resize width and height"
+          className={`${handleBase} opacity-90`}
+          onPointerDown={e => beginDrag(e, 'corner')}
+          style={{
+            top: box.top + box.height - 9,
+            left: box.left + box.width - 9,
+            width: 14,
+            height: 14,
+            cursor: 'se-resize',
+            background: '#fff',
+            border: `2px solid ${MULBERRY}`,
+            borderRadius: 3,
+            touchAction: 'none',
+          }}
+        />
+      )}
+
+      {/* Live readout — rides near the active handle during the gesture. For a
+          height tick drag it shows the HeightEnum stack with the active stop
+          mulberry-filled; otherwise a single readout pill. */}
+      {drag && (
+        <div
+          data-testid="canvas-resize-readout"
+          aria-hidden="true"
+          className="pointer-events-none absolute z-40"
+          style={{
+            top: Math.max(2, box.top - 8),
+            left:
+              drag.kind === 'height'
+                ? box.left + box.width / 2 - 40
+                : box.left + box.width - 30,
+          }}
+        >
+          {drag.kind === 'height' && !drag.fluid ? (
+            <div className="flex flex-col gap-0.5 rounded-md bg-white/95 p-1 shadow-md ring-1 ring-[#c6b0bb]">
+              {HEIGHT_ENUM_STOPS.map(stop => {
+                const active = stop.label === drag.label;
+                return (
+                  <span
+                    key={stop.label}
+                    data-active={active ? 'true' : 'false'}
+                    className="rounded px-2 py-0.5 text-[10px] font-semibold tabular-nums"
+                    style={{
+                      background: active ? MULBERRY : 'transparent',
+                      color: active ? '#fff' : '#6b7280',
+                    }}
+                  >
+                    {stop.label}
+                  </span>
+                );
+              })}
+            </div>
+          ) : (
+            <div
+              className="rounded-md px-2 py-1 text-[11px] font-semibold text-white shadow-md tabular-nums"
+              style={{ background: MULBERRY }}
+            >
+              {drag.label}
+              {drag.fluid && drag.kind !== 'width' ? ' · fluid' : ''}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CanvasResizeLayer;

--- a/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.test.jsx
@@ -1,0 +1,225 @@
+/**
+ * CanvasResizeLayer tests (VIS-777 / Track D D-4).
+ *
+ * The layer measures the live Dashboard DOM via `data-canvas-path` markers and
+ * paints resize handles on the CURRENTLY SELECTED node, then turns a raw pointer
+ * drag into a config mutation committed through the shared `commitCanvasConfig`.
+ * We mock the commit hook (the WorkspaceDndContext provider isn't mounted here)
+ * and the telemetry emitter, give the canvas-path nodes measurable boxes via a
+ * mocked getBoundingClientRect, and drive synthetic pointer events. The full
+ * live gesture is exercised by the Playwright story.
+ *
+ * Mock spies are `mock`-prefixed so jest's `jest.mock` hoist allows the factory
+ * to reference them.
+ */
+import React, { useRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import CanvasResizeLayer from './CanvasResizeLayer';
+import useStore from '../../../../stores/store';
+
+// jsdom's PointerEvent drops clientX/clientY from its init dict, so the
+// component's window-level pointermove/up handlers would see `undefined`
+// coordinates. The gesture is coordinate-driven, so we dispatch a MouseEvent
+// (which jsdom DOES populate clientX/clientY on) under the pointer* type name —
+// the handler only reads clientX/clientY/shiftKey, all carried by MouseEvent.
+const makeEvt = (type, { clientX, clientY, shiftKey = false }) =>
+  new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, shiftKey });
+
+const firePointer = (type, coords) => {
+  act(() => {
+    window.dispatchEvent(makeEvt(type, coords));
+  });
+};
+
+// Pointer-DOWN goes to a React onPointerDown handler; dispatch on the element so
+// React's root delegation catches it with real clientX (the synthetic event
+// mirrors the native MouseEvent's coords, which jsdom populates).
+const firePointerDown = (el, coords) => {
+  act(() => {
+    el.dispatchEvent(makeEvt('pointerdown', coords));
+  });
+};
+
+const mockCommit = jest.fn();
+jest.mock('../../workspace/WorkspaceDndContext', () => ({
+  useCommitCanvasConfig: () => mockCommit,
+}));
+
+const mockEmit = jest.fn();
+jest.mock('../../workspace/telemetry', () => ({
+  emitWorkspaceEvent: (...args) => mockEmit(...args),
+}));
+
+const DASHBOARD = {
+  name: 'dash',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+      { height: 'small', items: [{ width: 12, chart: 'ref(c)' }] },
+    ],
+  },
+};
+
+const Host = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="r0">
+        <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+      </div>
+      <div data-canvas-path="row.1" data-testid="r1">
+        <div data-canvas-path="row.1.item.0" data-testid="r1i0" />
+      </div>
+      <CanvasResizeLayer rootRef={rootRef} dashboardName="dash" />
+    </div>
+  );
+};
+
+// row.0 is 800px wide with two 6/6 items → 400px each, per-column = 800/12 ≈ 66.7px.
+const BOXES = {
+  r0: { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+  r0i0: { top: 0, left: 0, width: 400, height: 200, bottom: 200, right: 400 },
+  r0i1: { top: 0, left: 410, width: 390, height: 200, bottom: 200, right: 800 },
+  r1: { top: 210, left: 0, width: 800, height: 150, bottom: 360, right: 800 },
+  r1i0: { top: 210, left: 0, width: 800, height: 150, bottom: 360, right: 800 },
+  root: { top: 0, left: 0, width: 800, height: 360, bottom: 360, right: 800 },
+};
+
+beforeEach(() => {
+  mockCommit.mockClear();
+  mockEmit.mockClear();
+  useStore.setState({ dashboards: [DASHBOARD], workspaceOutlineSelectedKey: 'dashboard' });
+  Element.prototype.getBoundingClientRect = function () {
+    const tid = this.getAttribute && this.getAttribute('data-testid');
+    if (tid && BOXES[tid]) return BOXES[tid];
+    return BOXES.root;
+  };
+  // jsdom lacks pointer capture; stub so the gesture's best-effort call is safe.
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+});
+
+describe('CanvasResizeLayer (VIS-777)', () => {
+  test('renders nothing when the dashboard chrome is selected', () => {
+    render(<Host />);
+    expect(screen.queryByTestId('canvas-resize-layer')).not.toBeInTheDocument();
+  });
+
+  test('paints a width handle on a selected item', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    expect(handle).toHaveAttribute('data-resize-axis', 'width');
+    expect(handle).toHaveAttribute('aria-label', 'Resize item width');
+    // No height handle on an item selection (that's a row affordance).
+    expect(screen.queryByTestId('canvas-resize-height-row.0.item.0')).not.toBeInTheDocument();
+  });
+
+  test('paints a height handle on a selected row', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0');
+    expect(handle).toHaveAttribute('data-resize-axis', 'height');
+  });
+
+  test('paints a corner handle on a selected container item', () => {
+    useStore.setState({
+      dashboards: [
+        {
+          name: 'dash',
+          config: {
+            rows: [{ items: [{ width: 12, rows: [{ items: [{ chart: 'ref(x)' }] }] }] }],
+          },
+        },
+      ],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+    });
+    const ContainerHost = () => {
+      const rootRef = useRef(null);
+      return (
+        <div ref={rootRef} style={{ position: 'relative' }}>
+          <div data-canvas-path="row.0" data-testid="r0">
+            <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+          </div>
+          <CanvasResizeLayer rootRef={rootRef} dashboardName="dash" />
+        </div>
+      );
+    };
+    render(<ContainerHost />);
+    expect(screen.getByTestId('canvas-resize-corner-row.0.item.0')).toHaveAttribute(
+      'data-resize-axis',
+      'corner'
+    );
+  });
+
+  test('dragging the width handle right commits an increased col-span', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+
+    // Down on the handle, move +135px right (~2 columns at 66.7px/col), release.
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    // A ghost + readout appear during the drag.
+    expect(screen.getByTestId('canvas-resize-ghost')).toBeInTheDocument();
+    firePointer("pointermove", { clientX: 397 + 135, clientY: 100 });
+    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('8 / 12');
+    firePointer("pointerup", { clientX: 397 + 135, clientY: 100 });
+
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [name, nextConfig, meta] = mockCommit.mock.calls[0];
+    expect(name).toBe('dash');
+    expect(nextConfig.rows[0].items[0].width).toBe(8);
+    expect(meta).toMatchObject({ kind: 'resize_item' });
+    // canvas_action telemetry fired with kind + fluid.
+    expect(mockEmit).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'resize_item', fluid: false })
+    );
+  });
+
+  test('dragging the row height handle down commits a taller HeightEnum (tick mode)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0');
+
+    // medium = 396px start; +120px → ~516px → nearest stop "large" (512px).
+    firePointerDown(handle, { clientX: 400, clientY: 195, pointerId: 1 });
+    firePointer("pointermove", { clientX: 400, clientY: 195 + 120 });
+    firePointer("pointerup", { clientX: 400, clientY: 195 + 120 });
+
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    expect(nextConfig.rows[0].height).toBe('large');
+  });
+
+  test('Shift held during a height drag writes a numeric pixel int (fluid mode)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0');
+
+    firePointerDown(handle, { clientX: 400, clientY: 195, pointerId: 1, shiftKey: true });
+    firePointer("pointermove", { clientX: 400, clientY: 195 - 39, shiftKey: true });
+    firePointer("pointerup", { clientX: 400, clientY: 195 - 39, shiftKey: true });
+
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    // 396 - 39 = 357 px, written as an int (Row.height accepts Union[enum, int]).
+    expect(nextConfig.rows[0].height).toBe(357);
+    expect(mockEmit).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'resize_item', fluid: true })
+    );
+  });
+
+  test('a drag with no net change does not commit (no-op)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer("pointermove", { clientX: 400, clientY: 100 }); // <1 col
+    firePointer("pointerup", { clientX: 400, clientY: 100 });
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasSelectionOverlay.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasSelectionOverlay.jsx
@@ -240,10 +240,11 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
         />
       )}
 
-      {/* Hover overlay — subtle mulberry-200 outline + resize-handle
-          PLACEHOLDER (no resize gesture; that's D-3). Suppressed when this
-          exact node is the persistent selection, so the selection ring reads
-          cleanly. */}
+      {/* Hover overlay — subtle mulberry-200 outline. The real resize handles
+          (VIS-777 / D-4) live in <CanvasResizeLayer>, painted on the SELECTED
+          node; the former hover-time resize-handle placeholder is removed so
+          there is exactly one resize affordance. Suppressed when this exact
+          node is the persistent selection, so the selection ring reads cleanly. */}
       {hoverBox &&
         hoverBox.rect &&
         !(
@@ -265,13 +266,7 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
               width: hoverBox.rect.width,
               height: hoverBox.rect.height,
             }}
-          >
-            {/* Resize-handle PLACEHOLDER — bottom-right grip, no gesture. */}
-            <span
-              data-testid="canvas-overlay-resize-handle"
-              className="pointer-events-none absolute -bottom-1 -right-1 h-2.5 w-2.5 rounded-sm border border-[#c6b0bb] bg-white shadow-sm"
-            />
-          </div>
+          />
         )}
 
       {/* Selection overlay — persistent mulberry-500 ring with offset

--- a/viewer/src/components/new-views/project/canvas/CanvasSelectionOverlay.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasSelectionOverlay.test.jsx
@@ -181,7 +181,7 @@ describe('CanvasSelectionOverlay (VIS-768)', () => {
     expect(chrome.className).toContain('ring-[#713b57]');
   });
 
-  test('hovering an item paints the outline + resize-handle placeholder', () => {
+  test('hovering an item paints the hover outline', () => {
     render(<Harness />);
     measureFakeDom();
     // Move off the default-selected dashboard chrome first by selecting a row,
@@ -191,7 +191,9 @@ describe('CanvasSelectionOverlay (VIS-768)', () => {
     });
     dispatch(fireEvent.mouseMove, screen.getByTestId('slot-0-0'));
     expect(screen.getByTestId('canvas-overlay-hover-item')).toBeInTheDocument();
-    expect(screen.getByTestId('canvas-overlay-resize-handle')).toBeInTheDocument();
+    // The resize affordance moved to <CanvasResizeLayer> (VIS-777 / D-4), painted
+    // on the SELECTED node — the hover overlay no longer carries a placeholder.
+    expect(screen.queryByTestId('canvas-overlay-resize-handle')).not.toBeInTheDocument();
   });
 
   test('mouse leave clears the hover overlay', () => {

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import Dashboard from '../../../project/Dashboard';
 import CanvasSelectionOverlay from './CanvasSelectionOverlay';
 import CanvasDndLayer from './CanvasDndLayer';
+import CanvasResizeLayer from './CanvasResizeLayer';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -49,6 +50,10 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
           zones). A SIBLING over the render, wired to the shell's shared
           <WorkspaceDndContext> — no second DndContext. */}
       <CanvasDndLayer rootRef={rootRef} dashboardName={dashboardName} />
+      {/* VIS-777 / D-4: resize-gesture layer (item width / row height /
+          container corner). Paints edge handles on the selected node and
+          persists width/height through the shared commitCanvasConfig. */}
+      <CanvasResizeLayer rootRef={rootRef} dashboardName={dashboardName} />
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -202,3 +202,116 @@ export const buildLibraryItem = (type, name) => {
   if (type && name) item[type] = formatRef(name);
   return item;
 };
+
+// ── Resize helpers (VIS-777 / Track D D-4) ──────────────────────────────────
+// The canvas resize overlay (CanvasResizeLayer) turns the selection's edge
+// handles into real gestures. These are the pure, immutable config transforms
+// behind them — they mirror the reorder helpers above: walk the composite
+// `data-canvas-path` spine, clone only the path to the target, return a NEW
+// config. The shell sanitises the result before persisting.
+
+/**
+ * Row.height accepts `Union[HeightEnum, int]` (VIS-770). The enum tick stops,
+ * ascending, with their pixel sizes mirroring Dashboard.getHeight(). `compact`
+ * is the smallest stop; the renderer treats it specially (no explicit height),
+ * so it maps to the same floor as `xsmall` for snapping purposes.
+ */
+export const HEIGHT_ENUM_STOPS = [
+  { label: 'compact', px: 96 },
+  { label: 'xsmall', px: 128 },
+  { label: 'small', px: 256 },
+  { label: 'medium', px: 396 },
+  { label: 'large', px: 512 },
+  { label: 'xlarge', px: 768 },
+  { label: 'xxlarge', px: 1024 },
+];
+
+/** Map a HeightEnum token to its pixel size (mirrors Dashboard.getHeight). */
+export const heightEnumToPixels = label => {
+  const stop = HEIGHT_ENUM_STOPS.find(s => s.label === label);
+  return stop ? stop.px : 396;
+};
+
+/**
+ * Snap a pixel height to the NEAREST HeightEnum token. Used in tick mode so a
+ * height drag steps through the enum stops with labels. Ties resolve to the
+ * smaller stop (stable as the cursor crosses a midpoint).
+ */
+export const pixelsToNearestHeightEnum = px => {
+  if (typeof px !== 'number' || Number.isNaN(px)) return 'medium';
+  let best = HEIGHT_ENUM_STOPS[0];
+  let bestDist = Math.abs(px - best.px);
+  for (const stop of HEIGHT_ENUM_STOPS) {
+    const dist = Math.abs(px - stop.px);
+    if (dist < bestDist) {
+      best = stop;
+      bestDist = dist;
+    }
+  }
+  return best.label;
+};
+
+/** Clamp a number to [min, max], rounding to an integer. */
+const clampInt = (value, min, max) => {
+  const n = Math.round(Number(value));
+  if (Number.isNaN(n)) return min;
+  return Math.max(min, Math.min(max, n));
+};
+
+/**
+ * Set the integer column WIDTH (grid span) of the item at `itemPath`. Widths
+ * are relative within their row (the row's grid total is the sum of item
+ * widths), so changing one item's span rebalances its siblings automatically —
+ * a 6/6 row where item 0 grows to 8 becomes an 8/6 row (8/14 vs 6/14). Width is
+ * clamped to [1, 12]. Works at any nesting depth. Returns the config unchanged
+ * when the width is already `nextWidth` or the path is invalid.
+ */
+export const setItemWidth = (config, itemPath, nextWidth) => {
+  const segments = parseCanvasPath(itemPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return config;
+  const width = clampInt(nextWidth, 1, 12);
+  const itemSeg = segments[segments.length - 1];
+  const rowSegments = segments.slice(0, -1);
+  if (!rowSegments.length || rowSegments[rowSegments.length - 1].kind !== 'row') return config;
+  let changed = false;
+  const next = withRowsAtRowPath(config, rowSegments, rows => {
+    const lastRowIndex = rowSegments[rowSegments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+      const items = row.items.map((it, ii) => {
+        if (ii !== itemSeg.index) return it;
+        if ((it.width || 1) === width) return it;
+        changed = true;
+        return { ...it, width };
+      });
+      return changed ? { ...row, items } : row;
+    });
+  });
+  return changed ? next : config;
+};
+
+/**
+ * Set the HEIGHT of the row at `rowPath`. `nextHeight` is either a HeightEnum
+ * token (string, tick mode) or a positive integer (px, Shift-fluid mode —
+ * Row.height accepts `Union[HeightEnum, int]`). Integers are clamped to a sane
+ * floor/ceiling. Works at any nesting depth (top-level rows interpret height as
+ * absolute px; nested sub-rows interpret the same field as a relative weight —
+ * see Dashboard.heightToWeight). Returns config unchanged on no-op / bad path.
+ */
+export const setRowHeight = (config, rowPath, nextHeight) => {
+  const segments = parseCanvasPath(rowPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+  const height =
+    typeof nextHeight === 'number' ? clampInt(nextHeight, 48, 2048) : nextHeight;
+  let changed = false;
+  const next = withRowsAtRowPath(config, segments, rows => {
+    const lastRowIndex = segments[segments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex) return row;
+      if (row.height === height) return row;
+      changed = true;
+      return { ...row, height };
+    });
+  });
+  return changed ? next : config;
+};

--- a/viewer/src/components/new-views/project/canvas/canvasReorderResize.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorderResize.test.js
@@ -1,0 +1,162 @@
+/**
+ * canvasReorder resize-helper tests (VIS-777 / Track D D-4).
+ *
+ * The pure, immutable config transforms behind the canvas resize gestures:
+ *   - setItemWidth        → item col-span (1–12), siblings rebalance relatively.
+ *   - setRowHeight        → Row.height (HeightEnum token OR int px / fluid mode).
+ *   - HeightEnum helpers  → enum ↔ pixel mapping + nearest-stop snapping.
+ *
+ * Every transform must return a NEW config (never mutate the input) and the
+ * SAME reference on a no-op, so the store's optimistic-update path can rely on
+ * referential identity.
+ */
+import {
+  setItemWidth,
+  setRowHeight,
+  HEIGHT_ENUM_STOPS,
+  heightEnumToPixels,
+  pixelsToNearestHeightEnum,
+} from './canvasReorder';
+
+const baseConfig = () => ({
+  rows: [
+    {
+      height: 'medium',
+      items: [
+        { width: 6, chart: 'ref(a)' },
+        { width: 6, table: 'ref(b)' },
+      ],
+    },
+    {
+      height: 'small',
+      items: [{ width: 12, chart: 'ref(c)' }],
+    },
+  ],
+});
+
+describe('setItemWidth (VIS-777)', () => {
+  test('sets the integer col-span of the addressed item', () => {
+    const cfg = baseConfig();
+    const next = setItemWidth(cfg, 'row.0.item.0', 8);
+    expect(next.rows[0].items[0].width).toBe(8);
+    // Sibling untouched — relative grid means it rebalances at render (8/14 vs 6/14).
+    expect(next.rows[0].items[1].width).toBe(6);
+  });
+
+  test('is immutable — returns a new config and never mutates the input', () => {
+    const cfg = baseConfig();
+    const snapshot = JSON.stringify(cfg);
+    const next = setItemWidth(cfg, 'row.0.item.0', 8);
+    expect(next).not.toBe(cfg);
+    expect(JSON.stringify(cfg)).toBe(snapshot);
+  });
+
+  test('clamps width to [1, 12]', () => {
+    const cfg = baseConfig();
+    expect(setItemWidth(cfg, 'row.0.item.0', 99).rows[0].items[0].width).toBe(12);
+    expect(setItemWidth(cfg, 'row.0.item.0', 0).rows[0].items[0].width).toBe(1);
+    expect(setItemWidth(cfg, 'row.0.item.0', -5).rows[0].items[0].width).toBe(1);
+  });
+
+  test('returns the SAME reference when the width is unchanged (no-op)', () => {
+    const cfg = baseConfig();
+    expect(setItemWidth(cfg, 'row.0.item.0', 6)).toBe(cfg);
+  });
+
+  test('returns the SAME reference for a row path or malformed path', () => {
+    const cfg = baseConfig();
+    expect(setItemWidth(cfg, 'row.0', 8)).toBe(cfg);
+    expect(setItemWidth(cfg, 'dashboard', 8)).toBe(cfg);
+    expect(setItemWidth(cfg, '', 8)).toBe(cfg);
+  });
+
+  test('works at nesting depth (container sub-row item)', () => {
+    const cfg = {
+      rows: [
+        {
+          items: [
+            {
+              width: 12,
+              rows: [{ items: [{ width: 4, chart: 'ref(x)' }, { width: 8, chart: 'ref(y)' }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const next = setItemWidth(cfg, 'row.0.item.0.row.0.item.1', 6);
+    expect(next.rows[0].items[0].rows[0].items[1].width).toBe(6);
+    expect(next).not.toBe(cfg);
+  });
+});
+
+describe('setRowHeight (VIS-777)', () => {
+  test('sets a HeightEnum token (tick mode)', () => {
+    const cfg = baseConfig();
+    const next = setRowHeight(cfg, 'row.0', 'large');
+    expect(next.rows[0].height).toBe('large');
+    expect(next).not.toBe(cfg);
+  });
+
+  test('sets a numeric pixel value (Shift-fluid mode) clamped to a sane range', () => {
+    const cfg = baseConfig();
+    expect(setRowHeight(cfg, 'row.0', 357).rows[0].height).toBe(357);
+    expect(setRowHeight(cfg, 'row.0', 10).rows[0].height).toBe(48); // floor
+    expect(setRowHeight(cfg, 'row.0', 9999).rows[0].height).toBe(2048); // ceil
+  });
+
+  test('rounds a fractional pixel value to an int', () => {
+    const cfg = baseConfig();
+    expect(setRowHeight(cfg, 'row.0', 357.6).rows[0].height).toBe(358);
+  });
+
+  test('is immutable and returns the SAME reference on a no-op', () => {
+    const cfg = baseConfig();
+    const snapshot = JSON.stringify(cfg);
+    expect(setRowHeight(cfg, 'row.0', 'medium')).toBe(cfg); // unchanged enum
+    expect(JSON.stringify(cfg)).toBe(snapshot);
+  });
+
+  test('returns the SAME reference for an item path or malformed path', () => {
+    const cfg = baseConfig();
+    expect(setRowHeight(cfg, 'row.0.item.0', 'large')).toBe(cfg);
+    expect(setRowHeight(cfg, '', 'large')).toBe(cfg);
+  });
+
+  test('works at nesting depth (sub-row weight via enum)', () => {
+    const cfg = {
+      rows: [
+        {
+          items: [
+            { width: 12, rows: [{ height: 'small', items: [{ chart: 'ref(x)' }] }] },
+          ],
+        },
+      ],
+    };
+    const next = setRowHeight(cfg, 'row.0.item.0.row.0', 'large');
+    expect(next.rows[0].items[0].rows[0].height).toBe('large');
+    expect(next).not.toBe(cfg);
+  });
+});
+
+describe('HeightEnum helpers (VIS-777)', () => {
+  test('enum stops are ascending in pixel size', () => {
+    for (let i = 1; i < HEIGHT_ENUM_STOPS.length; i += 1) {
+      expect(HEIGHT_ENUM_STOPS[i].px).toBeGreaterThan(HEIGHT_ENUM_STOPS[i - 1].px);
+    }
+  });
+
+  test('heightEnumToPixels mirrors the renderer mapping', () => {
+    expect(heightEnumToPixels('small')).toBe(256);
+    expect(heightEnumToPixels('medium')).toBe(396);
+    expect(heightEnumToPixels('large')).toBe(512);
+    expect(heightEnumToPixels('unknown')).toBe(396); // falls back to medium
+  });
+
+  test('pixelsToNearestHeightEnum snaps to the closest stop', () => {
+    expect(pixelsToNearestHeightEnum(260)).toBe('small'); // ~256
+    expect(pixelsToNearestHeightEnum(400)).toBe('medium'); // ~396
+    expect(pixelsToNearestHeightEnum(500)).toBe('large'); // ~512
+    expect(pixelsToNearestHeightEnum(5000)).toBe('xxlarge'); // ceil stop
+    expect(pixelsToNearestHeightEnum(0)).toBe('compact'); // floor stop
+  });
+});

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -53,7 +53,16 @@ import {
 const WorkspaceDragContext = createContext(null);
 
 /** Read the live shell-level drag state ({ kind, name, level } | null). */
-export const useWorkspaceDrag = () => useContext(WorkspaceDragContext);
+export const useWorkspaceDrag = () => useContext(WorkspaceDragContext)?.activeDrag ?? null;
+
+/**
+ * Read the shared `commitCanvasConfig(dashboardName, nextConfig, meta)` —
+ * sanitize → optimistic → save. Surfaced for the canvas resize overlay
+ * (VIS-777 / D-4), which persists width/height/weight gestures through the SAME
+ * dashboard save path the DnD router uses. Returns a no-op outside the provider.
+ */
+export const useCommitCanvasConfig = () =>
+  useContext(WorkspaceDragContext)?.commitCanvasConfig ?? (() => {});
 
 /**
  * Pure router for the shared `onDragEnd`. Decides what a finished drag means
@@ -239,6 +248,14 @@ const WorkspaceDndContext = ({ children }) => {
     [updateDashboardConfigOptimistic, saveDashboard]
   );
 
+  // Context value: the live drag state PLUS the shared commit path. Consumers
+  // read `useWorkspaceDrag()` (drag only) or `useCommitCanvasConfig()` (commit
+  // only); both unwrap this object so neither re-renders on the other's change.
+  const contextValue = useMemo(
+    () => ({ activeDrag, commitCanvasConfig }),
+    [activeDrag, commitCanvasConfig]
+  );
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
   );
@@ -290,7 +307,7 @@ const WorkspaceDndContext = ({ children }) => {
   );
 
   return (
-    <WorkspaceDragContext.Provider value={activeDrag}>
+    <WorkspaceDragContext.Provider value={contextValue}>
       <DndContext
         sensors={sensors}
         onDragStart={handleDragStart}


### PR DESCRIPTION
## VIS-777 — Track D D-4: Canvas resize handles (design D-3)

Turns the canvas selection's resize-handle PLACEHOLDER (from D-2/VIS-768) into real resize gestures. This is the keystone that unblocks D-5/D-6/D-7. Targets `feature/dashboard-building-v1`.

### What shipped
A new sibling overlay **`CanvasResizeLayer`** (mounted by `ProjectCanvas` next to the selection + DnD overlays) paints edge handles on the **selected** item / row and turns a raw pointer drag into a config mutation persisted through the shell's shared `commitCanvasConfig` (sanitize → optimistic → save — the same path the DnD router uses):

- **Item right-edge handle (↔ width)** — drag changes the item's integer col-span (1–12); siblings rebalance live (relative 12-col grid). A `N / 12` readout pill rides the handle.
- **Row bottom-edge handle (↕ height)** — drag snaps to `HeightEnum` tick stops by default (floating label stack, active stop mulberry-filled). Holding **Shift** switches to **fluid** mode: a numeric pixel int written to `Row.height` (which accepts `Union[HeightEnum, int]`, per VIS-770), with a `… px · fluid` readout.
- **Container corner handle (⤡)** — both axes in one gesture on a container item (`Item.rows` non-empty).

**Chart stays static during the drag** (AC): the overlay paints a mulberry ghost at the live target geometry and only commits the new config on pointer-up, so the expensive chart re-render happens once, at drag-end.

**Pointer handling is raw (not dnd-kit) with `setPointerCapture`** — per the canvas-overlay gotcha, a reflow mid-drag (the optimistic config swap, charts finishing load) can't drop the gesture; the measured box is frozen to the gesture's start geometry for the duration.

Pure, immutable config transforms (`setItemWidth`, `setRowHeight`, + `HeightEnum` ↔ pixel helpers) live alongside the existing reorder helpers in `canvasReorder.js`. The former hover-time resize-handle placeholder is **removed** from `CanvasSelectionOverlay` so there is exactly one resize affordance, painted on the selection (reused, not parallel). Fires `canvas_action` telemetry with `kind: 'resize_item'` and `fluid: bool`.

Selection colour is mulberry `#713b57` (selection only); no type colours are hand-rolled.

### Tests
- **Unit** — `canvasReorderResize.test.js` (pure/immutable width + height + enum helpers) and `CanvasResizeLayer.test.jsx` (handle rendering per selection kind; width drag → col-span commit; tick-height drag → enum; Shift-drag → pixel int; no-op guard; `canvas_action` telemetry). Full viewer suite + lint green.
- **Playwright story** — `canvas-resize.spec.mjs` against an isolated sandbox: item width resize, row tick-height resize, Shift fluid-height resize, and a no-console-error / no-400 guard. **5/5 pass.** Screenshots captured under `e2e/stories/__screens__/` (gitignored by convention).

### Sandbox note (for reviewers)
The VIS-770 `Union[HeightEnum, int]` `Row.height` change is on `feature/dashboard-building-v1` (this stack) but NOT on `main`. A vanilla `bash scripts/sandbox.sh start` launches the backend from the editable install resolving to the `main` checkout, which rejects the fluid pixel int (400). Run the backend against this worktree's `visivo` (e.g. `PYTHONPATH=<worktree> visivo serve`) — then all 5 story tests pass, including the no-400 guard. The frontend gesture/persistence path is correct; this is purely an env mismatch with the shared editable install.

### AC status
Implemented this PR: item right-edge width (siblings rebalance), row bottom-edge enum tick stops + labels, Shift→pixel-int fluid, container corner (both axes), static chart during drag, `canvas_action` telemetry (`resize_item` + `fluid`), `canvas-resize.spec.mjs`.

**Deferred (noted for follow-ups, smaller than the core gesture):** sub-row weight handle exposed as its own bottom-edge gesture inside containers (the renderer already supports relative weights — the corner currently covers container resize); double-click expand-to-full-width + revert; maximize-icon full-bleed zoom + Esc; cross-row height adoption. The core width + height resize is built and well-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)