### PR TITLE
fix(inputs): type-insensitive default-in-options validator (VIS-902)

### DIFF
--- a/tests/models/inputs/test_dropdown_validation.py
+++ b/tests/models/inputs/test_dropdown_validation.py
@@ -194,3 +194,64 @@ class TestMultiSelectValidation:
         assert result is not None
         assert result["range"]["start"] == 0
         assert result["range"]["end"] == 100
+
+
+class TestDefaultInOptionsTypeInsensitivity:
+    """
+    Regression tests for VIS-902.
+
+    The default-in-options validators compared the default against the options
+    list using a type-sensitive membership check. Because static options are
+    stored as strings while a default may be parsed as an int/float, a default
+    that is genuinely present (e.g. int 10 against options ["3", "5", "10"])
+    was falsely reported as "not found". The membership check now compares
+    string representations on both sides.
+    """
+
+    def test_single_select_int_default_matches_string_options(self):
+        """An int default validates against equivalent string options."""
+        input_obj = SingleSelectInput(
+            name="threshold",
+            options=["3", "5", "7", "10"],
+            display={"type": "dropdown", "default": {"value": 10}},
+        )
+
+        assert input_obj.display.default.value == 10
+
+    def test_single_select_string_default_matches_int_like_options(self):
+        """A string default validates against numeric-looking string options."""
+        input_obj = SingleSelectInput(
+            name="threshold",
+            options=["3", "5", "7", "10"],
+            display={"type": "dropdown", "default": {"value": "10"}},
+        )
+
+        assert input_obj.display.default.value == "10"
+
+    def test_single_select_absent_default_still_raises(self):
+        """A genuinely-absent default still raises a clear error."""
+        with pytest.raises(ValueError, match="not found in options"):
+            SingleSelectInput(
+                name="threshold",
+                options=["3", "5", "7"],
+                display={"type": "dropdown", "default": {"value": 99}},
+            )
+
+    def test_multi_select_int_defaults_match_string_options(self):
+        """Int default values validate against equivalent string options."""
+        input_obj = MultiSelectInput(
+            name="thresholds",
+            options=["3", "5", "7", "10"],
+            display={"type": "dropdown", "default": {"values": [10, 5]}},
+        )
+
+        assert input_obj.display.default.values == [10, 5]
+
+    def test_multi_select_absent_default_value_still_raises(self):
+        """A multi-select default value not present in options still raises."""
+        with pytest.raises(ValueError, match="not found in options"):
+            MultiSelectInput(
+                name="thresholds",
+                options=["3", "5", "7"],
+                display={"type": "dropdown", "default": {"values": [5, 99]}},
+            )

--- a/visivo/models/inputs/types/multi_select.py
+++ b/visivo/models/inputs/types/multi_select.py
@@ -204,8 +204,9 @@ class MultiSelectInput(Input):
             and isinstance(self.display.default.values, list)
             and isinstance(self.options, list)
         ):
+            option_strings = [str(opt) for opt in self.options]
             for value in self.display.default.values:
-                if value not in self.options:
+                if str(value) not in option_strings:
                     raise ValueError(
                         f"Input '{self.name}' default value '{value}' not found in options.\n"
                         f"Available options: {', '.join(str(opt) for opt in self.options)}"

--- a/visivo/models/inputs/types/single_select.py
+++ b/visivo/models/inputs/types/single_select.py
@@ -131,7 +131,7 @@ class SingleSelectInput(Input):
             and isinstance(self.options, list)
         ):
             default_value = self.display.default.value
-            if default_value not in self.options:
+            if str(default_value) not in [str(opt) for opt in self.options]:
                 raise ValueError(
                     f"Input '{self.name}' default value '{default_value}' not found in options.\n"
                     f"Available options: {', '.join(str(opt) for opt in self.options)}"


### PR DESCRIPTION
## Summary

Fixes [VIS-902](https://linear.app/visivo/issue/VIS-902/input-default-in-options-validator-is-type-sensitive-false-not-found): the single-select and multi-select default-in-options validators used a type-sensitive membership check (`default not in self.options`).

Static options are stored as strings while a default may parse as an int/float, so a genuinely-present default — e.g. int `10` against options `["3", "5", "7", "10"]` — was falsely rejected with `default value '10' not found in options. Available options: 3, 5, 7, 10`. Surfaced editing the integration project's `split_threshold` input.

## Fix

Compare string representations on both sides of the membership check, in both `single_select.py::validate_default_in_options` and `multi_select.py::validate_default_values_in_options`:

- `str(default_value) not in [str(opt) for opt in self.options]`
- multi-select applies the same coercion to each default value

The error message and the query-based / static guards are left intact. Genuinely-absent defaults still raise.

## Tests

Added `TestDefaultInOptionsTypeInsensitivity` in `tests/models/inputs/test_dropdown_validation.py` (5 cases):
- int default `10` validates against string options `["3","5","7","10"]` (single + multi)
- string default `"10"` validates against numeric-looking string options
- genuinely-absent defaults still raise `not found in options` (single + multi)

Verified against worktree code: `python -m pytest tests/ -k "single_select or multi_select or input"` → 149 passed. Black clean. No schema field changed, so no schema regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)