### PR TITLE
feat(viewer/canvas): DnD polish — drop-on-slot, smart width, level section + reorder, row preview, dropdown portal (VIS-901)

### DIFF
--- a/viewer/e2e/stories/canvas-input-dropdown-portal.spec.mjs
+++ b/viewer/e2e/stories/canvas-input-dropdown-portal.spec.mjs
@@ -1,0 +1,117 @@
+/**
+ * Story: Canvas input dropdown escapes the item slot (VIS-901 #6 — regression).
+ *
+ * The canvas build surface renders each item in a slot that clips its content
+ * with `overflow-hidden` (Dashboard.renderRow). An input's option menu used to be
+ * an `absolute`-positioned child INSIDE that slot, so it was cut off below the
+ * item div — the "Search options…" box and the option list were invisible on the
+ * canvas. This has regressed more than once, so this spec is a hard regression
+ * guard.
+ *
+ * The fix (PortalDropdownMenu) portals the menu to <body> with fixed positioning
+ * so it overlays OUTSIDE the slot regardless of any ancestor overflow. This spec
+ * opens a single-select dropdown input on the canvas and asserts:
+ *   - the menu is portalled to <body> (not a descendant of its item slot), and
+ *   - it visually extends BEYOND the slot's bounding box (i.e. it would have been
+ *     clipped without the portal), and
+ *   - the "Search options…" search box is present in the menu.
+ *
+ * Precondition: an isolated sandbox running the integration project, which has the
+ * `insights-dashboard` with single-select dropdown inputs on the canvas.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8048 VISIVO_SANDBOX_FRONTEND_PORT=3048 \
+ *   VISIVO_SANDBOX_NAME=vis901 bash scripts/sandbox.sh start
+ *   # then: VIS_CANVAS_DND_BASE=http://localhost:3048 npx playwright test canvas-input-dropdown-portal
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_CANVAS_DND_BASE || 'http://localhost:3008';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'insights-dashboard';
+// "Split Threshold (Dropdown)" — a single-select Dropdown.jsx input on the canvas.
+const DROPDOWN_LABEL = 'Split Threshold (Dropdown)';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+};
+
+test.describe('Canvas input dropdown portal (VIS-901 #6)', () => {
+  test.setTimeout(120000);
+
+  test('an input dropdown opens OUTSIDE its overflow-clipped item slot', async ({ page }) => {
+    await openCanvas(page);
+
+    // Locate the single-select dropdown's trigger button by its label wrapper
+    // (Dropdown.jsx renders `<div class="w-full min-w-[200px]">` with the label).
+    const found = await page.evaluate(label => {
+      const wrappers = Array.from(document.querySelectorAll('div.min-w-\\[200px\\]'));
+      const w = wrappers.find(x => (x.textContent || '').includes(label));
+      if (!w) return { ok: false, reason: 'no dropdown wrapper' };
+      const btn = w.querySelector('button');
+      if (!btn) return { ok: false, reason: 'no trigger button' };
+      btn.scrollIntoView({ block: 'center' });
+      // The slot clips with overflow-hidden — assert the precondition holds so a
+      // passing test really proves the portal escape (not just "menu renders").
+      const slot = btn.closest('[data-canvas-path]');
+      const slotClips = slot && getComputedStyle(slot).overflow === 'hidden';
+      return { ok: true, slotClips };
+    }, DROPDOWN_LABEL);
+    expect(found.ok, found.reason || 'dropdown trigger found').toBe(true);
+    expect(found.slotClips, 'the item slot clips with overflow:hidden').toBe(true);
+
+    // Open the dropdown via a real pointer sequence on its trigger.
+    const result = await page.evaluate(async label => {
+      const wrappers = Array.from(document.querySelectorAll('div.min-w-\\[200px\\]'));
+      const w = wrappers.find(x => (x.textContent || '').includes(label));
+      const btn = w.querySelector('button');
+      btn.scrollIntoView({ block: 'center' });
+      await new Promise(r => setTimeout(r, 120));
+      const r = btn.getBoundingClientRect();
+      const o = {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: r.left + r.width / 2,
+        clientY: r.top + r.height / 2,
+        button: 0,
+      };
+      btn.dispatchEvent(new PointerEvent('pointerdown', { ...o, pointerId: 1 }));
+      btn.dispatchEvent(new MouseEvent('mousedown', o));
+      btn.dispatchEvent(new PointerEvent('pointerup', { ...o, pointerId: 1 }));
+      btn.dispatchEvent(new MouseEvent('mouseup', o));
+      btn.dispatchEvent(new MouseEvent('click', o));
+      await new Promise(r => setTimeout(r, 300));
+
+      const menu = document.querySelector('[data-testid="portal-dropdown-menu"]');
+      if (!menu) return { menuFound: false };
+      const slot = btn.closest('[data-canvas-path]');
+      const mr = menu.getBoundingClientRect();
+      const sr = slot.getBoundingClientRect();
+      return {
+        menuFound: true,
+        parentIsBody: menu.parentElement === document.body,
+        insideSlot: slot.contains(menu),
+        hasSearchInput: !!menu.querySelector('input'),
+        // The menu overflows the slot vertically (it would have been clipped).
+        extendsBeyondSlot: mr.bottom > sr.bottom + 1 || mr.top < sr.top - 1,
+      };
+    }, DROPDOWN_LABEL);
+
+    expect(result.menuFound, 'the dropdown option menu opened').toBe(true);
+    // Portalled to <body>, NOT nested in the clipped slot.
+    expect(result.parentIsBody, 'menu portals to <body>').toBe(true);
+    expect(result.insideSlot, 'menu is NOT a descendant of the item slot').toBe(false);
+    // The "Search options…" search box is part of the menu.
+    expect(result.hasSearchInput, 'menu contains the search box').toBe(true);
+    // The whole point of the fix: the menu paints beyond the slot bounds.
+    expect(result.extendsBeyondSlot, 'menu escapes the slot bounding box').toBe(true);
+
+    await page.screenshot({ path: `${SCREENS}/vis901-06-dropdown-portal.png`, fullPage: false });
+  });
+});

--- a/viewer/e2e/stories/canvas-row-drag-preview.spec.mjs
+++ b/viewer/e2e/stories/canvas-row-drag-preview.spec.mjs
@@ -1,0 +1,130 @@
+/**
+ * Story: Canvas ROW drag shows a "Row" preview, not a chart pill (VIS-901 #5).
+ *
+ * Regression guard for the acceptance bug: a canvas ROW drag used to render the
+ * chart drag pill in the shared <DragOverlay> because handleDragStart defaulted
+ * every canvas drag's `type` to 'chart' (a row has no `refType`). The fix routes
+ * the drag-start mapping through `mapDragStartData`, which gives a row its own
+ * `canvasKind: 'row'` shape rendered by <CanvasRowDragPreview> — a mulberry "Row"
+ * pill (data-testid="canvas-row-drag-preview"), NOT the chart pill
+ * (data-testid="library-drag-preview").
+ *
+ * This spec starts a real row drag (grip → between-rows gap, pointer held down)
+ * and asserts the ROW preview is visible while the chart pill is NOT, then
+ * releases without asserting a reorder (covered by canvas-dnd.spec.mjs).
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8048 VISIVO_SANDBOX_FRONTEND_PORT=3048 \
+ *   VISIVO_SANDBOX_NAME=vis901 bash scripts/sandbox.sh start
+ *   # then: VIS_CANVAS_DND_BASE=http://localhost:3048 npx playwright test canvas-row-drag-preview
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_CANVAS_DND_BASE || 'http://localhost:3008';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+// Grips are gated on selection — selecting an item in the row reveals the row grip.
+const revealRowHandle = async (page, rowIndex) => {
+  await page
+    .locator(`[data-canvas-path="row.${rowIndex}.item.0"]`)
+    .first()
+    .click({ position: { x: 6, y: 6 }, force: true });
+  const handle = page.getByTestId(`canvas-drag-handle-row.${rowIndex}`);
+  await expect(handle).toBeVisible({ timeout: WAIT });
+  return handle;
+};
+
+// Arm dnd-kit's PointerSensor by dispatching pointerdown on the grip node itself
+// (the overlay grip is occluded for coordinate hit-testing — see canvas-dnd.spec
+// for the full rationale), then travel to the target centre. Leaves pointer DOWN.
+const startRowDrag = async (page, source, target) => {
+  await expect(source).toBeVisible();
+  await page.waitForTimeout(150);
+  const tb = await target.boundingBox();
+  expect(tb, 'target has a box').toBeTruthy();
+  const tx = tb.x + tb.width / 2;
+  const ty = tb.y + tb.height / 2;
+  await source.evaluate(el => {
+    const r = el.getBoundingClientRect();
+    window.__rowDndSrc = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    const ev = (x, y) => ({
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      pointerId: 1,
+      button: 0,
+      pointerType: 'mouse',
+      isPrimary: true,
+      view: window,
+    });
+    el.dispatchEvent(new PointerEvent('pointerdown', ev(window.__rowDndSrc.x, window.__rowDndSrc.y)));
+  });
+  await page.waitForTimeout(40);
+  await page.evaluate(
+    ([tx, ty]) => {
+      const s = window.__rowDndSrc;
+      const ev = (x, y) => ({
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        button: 0,
+        pointerType: 'mouse',
+        isPrimary: true,
+        view: window,
+      });
+      document.dispatchEvent(new PointerEvent('pointermove', ev(s.x + 10, s.y + 10)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev((s.x + tx) / 2, (s.y + ty) / 2)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev(tx, ty)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev(tx, ty)));
+    },
+    [tx, ty]
+  );
+  await page.waitForTimeout(40);
+};
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-dnd-layer')).toBeAttached({ timeout: WAIT });
+};
+
+test.describe('Canvas row drag preview (VIS-901 #5)', () => {
+  test.setTimeout(120000);
+
+  test('dragging a ROW shows the "Row" preview pill, NOT the chart pill', async ({ page }) => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    expect(rows.length, 'dashboard has ≥2 rows').toBeGreaterThanOrEqual(2);
+
+    const rowHandle = await revealRowHandle(page, 0);
+    const gapZone = page.getByTestId(`canvas-dropzone-row-before-${rows.length}`);
+    await startRowDrag(page, rowHandle, gapZone);
+
+    // Mid-drag: the ROW preview is visible and the chart pill is NOT (the bug
+    // was the chart pill showing for a row drag).
+    await expect(page.getByTestId('canvas-row-drag-preview')).toBeVisible({ timeout: 4000 });
+    await expect(page.getByTestId('canvas-row-drag-preview')).toContainText('Row');
+    await expect(page.getByTestId('library-drag-preview')).toHaveCount(0);
+
+    await page.screenshot({ path: `${SCREENS}/vis901-05-row-drag-preview.png`, fullPage: false });
+    await page.mouse.up();
+  });
+});

--- a/viewer/src/components/items/inputs/AutocompleteInput.jsx
+++ b/viewer/src/components/items/inputs/AutocompleteInput.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { FaChevronDown, FaTimes } from 'react-icons/fa';
-import { DropdownLabel, DropdownMenu } from '../../styled/DropdownButton';
+import { DropdownLabel } from '../../styled/DropdownButton';
+import PortalDropdownMenu from './PortalDropdownMenu';
 
 /**
  * AutocompleteInput - Single-select input with searchable dropdown.
@@ -24,6 +25,7 @@ const AutocompleteInput = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef(null);
+  const menuRef = useRef(null);
   const inputRef = useRef(null);
 
   // Derive display text from selectedValue prop
@@ -51,7 +53,11 @@ const AutocompleteInput = ({
   // Handle click outside to close dropdown
   useEffect(() => {
     const handleClickOutside = event => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+      // The option menu is portalled to <body> (outside dropdownRef's subtree),
+      // so a click inside it must NOT close the dropdown — check the menu too.
+      const inAnchor = dropdownRef.current && dropdownRef.current.contains(event.target);
+      const inMenu = menuRef.current && menuRef.current.contains(event.target);
+      if (!inAnchor && !inMenu) {
         setIsOpen(false);
         setHighlightedIndex(-1);
         // Reset search term to show selected value when closing
@@ -203,9 +209,10 @@ const AutocompleteInput = ({
           </div>
         </div>
 
-        {/* Dropdown menu */}
+        {/* Dropdown menu — portalled to <body> so it escapes the canvas item
+            slot's overflow clipping (VIS-901 #6). */}
         {isOpen && (
-          <DropdownMenu>
+          <PortalDropdownMenu anchorRef={dropdownRef} menuRef={menuRef}>
             <div className="max-h-64 overflow-y-auto">
               {filteredOptions.length === 0 ? (
                 <div className="p-3 text-sm text-gray-500 text-center">
@@ -231,7 +238,7 @@ const AutocompleteInput = ({
                 })
               )}
             </div>
-          </DropdownMenu>
+          </PortalDropdownMenu>
         )}
       </div>
     </div>

--- a/viewer/src/components/items/inputs/Dropdown.jsx
+++ b/viewer/src/components/items/inputs/Dropdown.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { FaChevronDown } from 'react-icons/fa';
 import DropdownOptions from './DropdownOptions';
+import PortalDropdownMenu from './PortalDropdownMenu';
 import {
   DropdownButton,
   DropdownLabel,
-  DropdownMenu,
   LoadingBar,
   LoadingContainer,
   SearchInput,
@@ -38,6 +38,7 @@ const Dropdown = ({
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [loading, setLoading] = useState(true);
   const dropdownRef = useRef(null);
+  const menuRef = useRef(null);
   const searchInputRef = useRef(null);
 
   // Derive selectedItems from selectedValue prop (display only)
@@ -70,7 +71,11 @@ const Dropdown = ({
 
   useEffect(() => {
     const handleClickOutside = event => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+      // The menu is portalled to <body> (outside dropdownRef's subtree), so a
+      // click inside it must NOT close the dropdown — check the menu node too.
+      const inAnchor = dropdownRef.current && dropdownRef.current.contains(event.target);
+      const inMenu = menuRef.current && menuRef.current.contains(event.target);
+      if (!inAnchor && !inMenu) {
         setIsOpen(false);
         setHighlightedIndex(-1);
       }
@@ -165,7 +170,7 @@ const Dropdown = ({
         </DropdownButton>
 
         {isOpen && (
-          <DropdownMenu>
+          <PortalDropdownMenu anchorRef={dropdownRef} menuRef={menuRef}>
             <div className="p-3 border-b border-gray-200">
               <SearchInput
                 ref={searchInputRef}
@@ -189,7 +194,7 @@ const Dropdown = ({
               isMulti={false}
               selectedItems={selectedItems}
             />
-          </DropdownMenu>
+          </PortalDropdownMenu>
         )}
       </div>
     </div>

--- a/viewer/src/components/items/inputs/PortalDropdownMenu.jsx
+++ b/viewer/src/components/items/inputs/PortalDropdownMenu.jsx
@@ -1,0 +1,75 @@
+import React, { useLayoutEffect, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * PortalDropdownMenu — VIS-901 #6.
+ *
+ * Renders an input dropdown's option menu into `document.body` (a portal),
+ * positioned directly under its anchor. The canvas item slot clips its content
+ * with `overflow-hidden` (Dashboard.renderRow), so an `absolute`-positioned menu
+ * inside the slot was cut off below the item div. Escaping to the body via a
+ * portal makes the menu overlay OUTSIDE the slot regardless of any ancestor
+ * overflow — fixing the regression where the option list (and the "Search
+ * options…" box) were invisible on the canvas.
+ *
+ * The menu is positioned with FIXED coordinates measured from the anchor's
+ * bounding box, and re-measured on scroll / resize so it tracks the anchor while
+ * open. It flips ABOVE the anchor when there isn't enough room below.
+ *
+ * @param {React.RefObject} anchorRef - ref to the trigger wrapper (the menu is
+ *        positioned to its bounding box).
+ * @param {React.ReactNode} children - the menu contents.
+ * @param {number} [maxHeight=320] - max menu height (px) used for flip math.
+ */
+const PortalDropdownMenu = ({ anchorRef, menuRef, children, maxHeight = 320 }) => {
+  const [style, setStyle] = useState(null);
+
+  const reposition = useCallback(() => {
+    const anchor = anchorRef?.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    // Flip above only when there's clearly more room there.
+    const flipUp = spaceBelow < Math.min(maxHeight, 240) && spaceAbove > spaceBelow;
+    const next = {
+      position: 'fixed',
+      left: rect.left,
+      width: rect.width,
+      zIndex: 9999,
+      maxHeight: Math.max(120, (flipUp ? spaceAbove : spaceBelow) - 12),
+    };
+    if (flipUp) {
+      next.bottom = window.innerHeight - rect.top + 4;
+    } else {
+      next.top = rect.bottom + 4;
+    }
+    setStyle(next);
+  }, [anchorRef, maxHeight]);
+
+  useLayoutEffect(() => {
+    reposition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [reposition]);
+
+  if (typeof document === 'undefined' || !style) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      data-testid="portal-dropdown-menu"
+      className="overflow-hidden rounded-lg border border-gray-300 bg-white shadow-lg"
+      style={style}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+};
+
+export default PortalDropdownMenu;

--- a/viewer/src/components/items/inputs/PortalDropdownMenu.test.jsx
+++ b/viewer/src/components/items/inputs/PortalDropdownMenu.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * PortalDropdownMenu tests (VIS-901 #6).
+ *
+ * The canvas item slot clips with `overflow-hidden`, so an in-slot dropdown was
+ * cut off. This component portals the menu to <body> with fixed positioning so
+ * it overlays OUTSIDE the slot. These tests assert the portal target + the
+ * anchored fixed positioning (the regression-relevant behaviour).
+ */
+import React, { useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import PortalDropdownMenu from './PortalDropdownMenu';
+
+const Harness = ({ children }) => {
+  const anchorRef = useRef(null);
+  return (
+    <div>
+      <div ref={anchorRef} data-testid="anchor" style={{ width: 200 }}>
+        anchor
+      </div>
+      <PortalDropdownMenu anchorRef={anchorRef}>{children}</PortalDropdownMenu>
+    </div>
+  );
+};
+
+describe('PortalDropdownMenu', () => {
+  beforeAll(() => {
+    // jsdom returns a zero rect by default; give the anchor a deterministic box.
+    Element.prototype.getBoundingClientRect = function () {
+      return { top: 100, bottom: 130, left: 40, right: 240, width: 200, height: 30 };
+    };
+  });
+
+  test('renders its children into document.body (escapes the slot)', () => {
+    render(
+      <Harness>
+        <div data-testid="opt">Search options…</div>
+      </Harness>
+    );
+    const menu = screen.getByTestId('portal-dropdown-menu');
+    expect(menu).toBeInTheDocument();
+    // Portalled OUTSIDE the anchor's subtree — the menu must NOT be a descendant
+    // of the slot/anchor (that's what the overflow clipping fix is about).
+    const anchor = screen.getByTestId('anchor');
+    expect(anchor).not.toContainElement(menu);
+    // Portalled directly under <body>, so it escapes any ancestor overflow clip.
+    expect(document.body).toContainElement(menu);
+    expect(screen.getByTestId('opt')).toHaveTextContent('Search options…');
+  });
+
+  test('positions itself fixed, anchored to the trigger box', () => {
+    render(
+      <Harness>
+        <div>x</div>
+      </Harness>
+    );
+    const menu = screen.getByTestId('portal-dropdown-menu');
+    expect(menu.style.position).toBe('fixed');
+    // Left + width track the anchor's bounding box.
+    expect(menu.style.left).toBe('40px');
+    expect(menu.style.width).toBe('200px');
+    // Below the anchor by default (anchor.bottom + 4).
+    expect(menu.style.top).toBe('134px');
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
@@ -185,11 +185,16 @@ const CanvasDropZone = ({ id, box, intent, data }) => {
     );
   }
 
-  if (intent === 'in-container') {
+  if (intent === 'on-item' || intent === 'in-container') {
+    // Slot-fill / container drop → a tinted region over the slot. `on-item`
+    // sits BELOW the thin between-items/end-of-row bars (z-[18] < z-20) so a
+    // precise edge drop still resolves to the insertion bar, while a drop over
+    // the slot body resolves here.
+    const z = intent === 'on-item' ? 'z-[18]' : 'z-[19]';
     return (
       <div
         {...common}
-        className={`${peClass} absolute z-[19]`}
+        className={`${peClass} absolute ${z}`}
         style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
       >
         {isDragging && isOver && (
@@ -311,6 +316,25 @@ const useCanvasDndModel = (rootRef, dashboardName, dashboardConfig) => {
             target: { kind: 'between-items', rowPath, index: ii },
           },
         });
+
+        // on-item drop zone over the slot itself (VIS-901 #4) — lets a Library
+        // object be dropped DIRECTLY onto an existing slot (fill an empty slot,
+        // or insert before a filled one). Painted as a tinted region like
+        // in-container; only acted on for Library drags by the router. Skipped
+        // for container items (they get the in-container zone instead).
+        if (!isContainer) {
+          zones.push({
+            id: `${itemPath}-on-item`,
+            intent: 'on-item',
+            box,
+            data: {
+              kind: 'canvas-drop',
+              dashboardName,
+              config: dashboardConfig,
+              target: { kind: 'on-item', rowPath, index: ii },
+            },
+          });
+        }
 
         // in-container drop zone over container items.
         if (isContainer) {

--- a/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.jsx
@@ -5,6 +5,7 @@ import { useCommitCanvasConfig } from '../../workspace/WorkspaceDndContext';
 import {
   parseCanvasPath,
   setItemWidth,
+  resizeItemFromLeft,
   setRowHeight,
   HEIGHT_ENUM_STOPS,
   heightEnumToPixels,
@@ -22,10 +23,15 @@ import {
  * mutation persisted through the shell's shared `commitCanvasConfig`
  * (sanitize → optimistic → save).
  *
- * Three handle types (D-3 contract):
+ * Handle types (D-3 contract):
  *   - Item RIGHT-EDGE (↔ width): drag changes the item's integer col-span
  *     (1–12). Widths are relative within the row, so siblings rebalance live. A
  *     `N / total` readout pill rides the handle.
+ *   - Item LEFT-EDGE (↔ width): drag moves the boundary shared with the PREVIOUS
+ *     sibling, transferring grid columns between this item and its left neighbour
+ *     (drag left grows this item / shrinks the neighbour; drag right inverts),
+ *     clamped so neither drops below width 1. The first item in a row has no
+ *     shared left boundary, so it gets no left handle.
  *   - Row BOTTOM-EDGE (↕ height): drag snaps to HeightEnum tick stops by
  *     default (label stack, active stop mulberry-filled). Holding Shift switches
  *     to FLUID mode — a numeric pixel value written as an int to `Row.height`
@@ -187,6 +193,15 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     return segs.map(s => `${s.kind}.${s.index}`).join('.');
   }, [selection]);
 
+  // The selected item's index within its parent row. Drives the LEFT-edge
+  // handle: only items past index 0 share a boundary with a previous sibling,
+  // so the first item in a row gets no left handle.
+  const itemIndexInRow = useMemo(() => {
+    if (!selection?.isItem || !selection.segments.length) return -1;
+    return selection.segments[selection.segments.length - 1].index;
+  }, [selection]);
+  const hasLeftNeighbor = itemIndexInRow > 0;
+
   const beginDrag = useCallback(
     (e, kind) => {
       if (!box || !selection) return;
@@ -197,7 +212,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       // Width context: per-column px from the parent row's width / its grid total.
       let colPx = 0;
       let startCols = selection.item?.width || 1;
-      if ((kind === 'width' || kind === 'corner') && rowPathForItem && root) {
+      if ((kind === 'width' || kind === 'width-left' || kind === 'corner') && rowPathForItem && root) {
         const rowEl = root.querySelector(`[data-canvas-path="${rowPathForItem}"]`);
         const rowBox = rowEl ? measure(rowEl, root) : null;
         const total =
@@ -205,6 +220,13 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         const rowWidth = rowBox ? rowBox.width : box.width;
         colPx = rowWidth / total;
       }
+
+      // Left-edge context: the previous sibling's start width bounds how far the
+      // shared boundary can move (the neighbour can't drop below width 1).
+      const neighborStartCols =
+        kind === 'width-left' && hasLeftNeighbor
+          ? (selection.itemsInRow?.[itemIndexInRow - 1]?.width || 1)
+          : 1;
 
       // Height context: the gesture's row is the selection's row (item → parent
       // row; row → itself). startPx from the row's current enum/px height.
@@ -219,6 +241,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         colPx: colPx || 1,
         startCols,
         liveCols: startCols,
+        neighborStartCols,
         startPx,
         livePx: startPx,
         fluid: !!e.shiftKey,
@@ -245,7 +268,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         // is the fallback so the gesture still completes.
       }
     },
-    [box, selection, rowPathForItem, rootRef]
+    [box, selection, rowPathForItem, itemIndexInRow, hasLeftNeighbor, rootRef]
   );
 
   // Window-level move/up handlers active only while a drag is in flight. They
@@ -267,12 +290,21 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         const deltaCols = Math.round(dx / d.colPx);
         liveCols = Math.max(1, Math.min(COLS, d.startCols + deltaCols));
       }
+      if (d.kind === 'width-left') {
+        // Dragging the LEFT edge left (dx < 0) grows the item; dragging it right
+        // shrinks it. Columns transfer across the shared boundary with the left
+        // neighbour, so the live span is bounded by the neighbour's spare width.
+        const deltaCols = -Math.round(dx / d.colPx);
+        const maxGrow = Math.max(0, (d.neighborStartCols || 1) - 1);
+        const transfer = Math.max(-(d.startCols - 1), Math.min(maxGrow, deltaCols));
+        liveCols = d.startCols + transfer;
+      }
       if (d.kind === 'height' || d.kind === 'corner') {
         livePx = Math.max(48, Math.min(2048, d.startPx + dy));
       }
 
       let label;
-      if (d.kind === 'width') {
+      if (d.kind === 'width' || d.kind === 'width-left') {
         label = `${liveCols} / ${COLS}`;
       } else if (d.kind === 'corner') {
         const hLabel = fluid ? `${Math.round(livePx)} px` : pixelsToNearestHeightEnum(livePx);
@@ -301,6 +333,18 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       // Width / corner-width → item col-span.
       if ((d.kind === 'width' || d.kind === 'corner') && selection.isItem) {
         nextConfig = setItemWidth(nextConfig, selectedKey, d.liveCols);
+      }
+      // Left-edge width → transfer columns across the boundary with the left
+      // neighbour (this item gains `liveCols - startCols`; the neighbour loses
+      // the same). Clamping lives in `resizeItemFromLeft`.
+      if (d.kind === 'width-left' && selection.isItem && rowPathForItem) {
+        const deltaCols = d.liveCols - d.startCols;
+        nextConfig = resizeItemFromLeft(
+          nextConfig,
+          rowPathForItem,
+          itemIndexInRow,
+          deltaCols
+        );
       }
       // Height / corner-height → row height (enum tick OR fluid px int).
       if (d.kind === 'height' || d.kind === 'corner') {
@@ -342,6 +386,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     dashboardName,
     selectedKey,
     rowPathForItem,
+    itemIndexInRow,
     commitCanvasConfig,
     measureBox,
   ]);
@@ -356,20 +401,30 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     if (!drag) return null;
     let w = box.width;
     let h = box.height;
+    let left = box.left;
     if (drag.kind === 'width' || drag.kind === 'corner') {
       w = box.width * (drag.liveCols / Math.max(1, drag.startCols));
+    }
+    if (drag.kind === 'width-left') {
+      // The left-edge gesture moves the LEFT boundary: anchor the right edge and
+      // extend leftward as the span grows.
+      w = box.width * (drag.liveCols / Math.max(1, drag.startCols));
+      left = box.left + box.width - w;
     }
     if (drag.kind === 'height' || drag.kind === 'corner') {
       h = box.height * (drag.livePx / Math.max(1, drag.startPx));
     }
-    return { top: box.top, left: box.left, width: w, height: h };
+    return { top: box.top, left, width: w, height: h };
   })();
 
   // Which handles to show: an ITEM selection gets the right-edge width handle
   // (+ the bottom-edge height handle on its row is owned by a ROW selection);
   // a container item additionally gets the corner. A ROW selection gets the
-  // bottom-edge height handle.
+  // bottom-edge height handle. An item with a LEFT neighbour also gets a
+  // left-edge width handle that moves the shared boundary; the first item in a
+  // row has no shared left boundary and so gets no left handle.
   const showWidthHandle = selection.isItem;
+  const showLeftWidthHandle = selection.isItem && hasLeftNeighbor;
   const showHeightHandle = !selection.isItem; // row selection
   const showCornerHandle = isContainerItem;
 
@@ -407,6 +462,32 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
             height: ghost.height,
             background: 'rgba(113,59,87,0.06)',
             boxShadow: `0 0 0 2px ${MULBERRY}, 0 0 0 5px rgba(113,59,87,0.18)`,
+          }}
+        />
+      )}
+
+      {/* Item LEFT-EDGE width handle (↔). Mirrors the right-edge handle but moves
+          the boundary shared with the PREVIOUS sibling — only rendered when the
+          item has a left neighbour. */}
+      {showLeftWidthHandle && (
+        <div
+          role="button"
+          tabIndex={0}
+          data-testid={`canvas-resize-width-left-${selectedKey}`}
+          data-resize-axis="width-left"
+          aria-label="Resize item width from left edge"
+          title="Drag to resize width from the left"
+          className={`${handleBase} opacity-80`}
+          onPointerDown={e => beginDrag(e, 'width-left')}
+          style={{
+            top: box.top + 6,
+            left: box.left - 3,
+            width: 6,
+            height: Math.max(0, box.height - 12),
+            cursor: 'col-resize',
+            background: drag?.kind === 'width-left' ? MULBERRY : `${MULBERRY}99`,
+            borderRadius: 3,
+            touchAction: 'none',
           }}
         />
       )}
@@ -498,7 +579,9 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
             left:
               drag.kind === 'height'
                 ? box.left + box.width / 2 - 40
-                : box.left + box.width - 30,
+                : drag.kind === 'width-left'
+                  ? box.left
+                  : box.left + box.width - 30,
           }}
         >
           {drag.kind === 'height' && !drag.fluid ? (

--- a/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasResizeLayer.test.jsx
@@ -117,6 +117,48 @@ describe('CanvasResizeLayer (VIS-777)', () => {
     expect(screen.queryByTestId('canvas-resize-height-row.0.item.0')).not.toBeInTheDocument();
   });
 
+  test('paints a LEFT-edge width handle on an item that has a left neighbour', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.1' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-left-row.0.item.1');
+    expect(handle).toHaveAttribute('data-resize-axis', 'width-left');
+    expect(handle).toHaveAttribute('aria-label', 'Resize item width from left edge');
+  });
+
+  test('omits the LEFT-edge width handle on the FIRST item in a row', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    // Right-edge handle present, left-edge handle absent (no shared boundary).
+    expect(screen.getByTestId('canvas-resize-width-row.0.item.0')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('canvas-resize-width-left-row.0.item.0')
+    ).not.toBeInTheDocument();
+  });
+
+  test('dragging the LEFT edge left grows the item and shrinks the left neighbour', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.1' });
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-left-row.0.item.1');
+
+    // Down on the left handle, move -135px left (~2 cols at 66.7px/col), release.
+    firePointerDown(handle, { clientX: 410, clientY: 100, pointerId: 1 });
+    expect(screen.getByTestId('canvas-resize-ghost')).toBeInTheDocument();
+    firePointer('pointermove', { clientX: 410 - 135, clientY: 100 });
+    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('8 / 12');
+    firePointer('pointerup', { clientX: 410 - 135, clientY: 100 });
+
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = mockCommit.mock.calls[0];
+    expect(name).toBe('dash');
+    // Item 1 gains 2 cols, neighbour (item 0) loses 2 — row total stays 12.
+    expect(nextConfig.rows[0].items[1].width).toBe(8);
+    expect(nextConfig.rows[0].items[0].width).toBe(4);
+    expect(mockEmit).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'resize_item', axis: 'width-left' })
+    );
+  });
+
   test('paints a height handle on a selected row', () => {
     useStore.setState({ workspaceOutlineSelectedKey: 'row.0' });
     render(<Host />);

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -50,6 +50,7 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
         dashboardName={dashboardName}
         stackBreakpoint={768}
         hideEmptyPlaceholder
+        canvasMode
       />
       <CanvasSelectionOverlay rootRef={rootRef} />
       {/* VIS-771 / D-3: drag-and-drop affordance layer (drag handles + drop

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -390,6 +390,58 @@ export const setItemWidth = (config, itemPath, nextWidth) => {
 };
 
 /**
+ * Resize the item at `rowPath`/`itemIndex` from its LEFT boundary — the edge it
+ * shares with the PREVIOUS sibling in the row. `deltaCols` is the integer number
+ * of grid columns to transfer ACROSS that shared boundary: a positive `deltaCols`
+ * grows this item by that many columns and shrinks the left neighbour by the same
+ * amount; a negative `deltaCols` does the inverse. Neither item is allowed below
+ * width 1, so the transfer is clamped to the columns actually available. The row
+ * grid total is unchanged (columns only move between the two adjacent items).
+ *
+ * The FIRST item in a row (index 0) has no left neighbour and therefore no shared
+ * boundary, so this is a no-op there — it never invents a phantom neighbour.
+ * Returns the config unchanged on a no-op (delta 0, clamped to 0, index 0, or an
+ * invalid path).
+ */
+export const resizeItemFromLeft = (config, rowPath, itemIndex, deltaCols) => {
+  const segments = parseCanvasPath(rowPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+  if (!Number.isInteger(itemIndex) || itemIndex <= 0) return config;
+  const delta = Math.round(Number(deltaCols));
+  if (Number.isNaN(delta) || delta === 0) return config;
+
+  let changed = false;
+  const next = withRowsAtRowPath(config, segments, rows => {
+    const lastRowIndex = segments[segments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+      const neighbourIndex = itemIndex - 1;
+      const self = row.items[itemIndex];
+      const neighbour = row.items[neighbourIndex];
+      if (!self || !neighbour) return row;
+      const selfWidth = self.width || 1;
+      const neighbourWidth = neighbour.width || 1;
+      // Clamp the transfer so neither item drops below width 1: growing self
+      // (positive delta) is bounded by the neighbour's spare columns; shrinking
+      // self (negative delta) is bounded by self's spare columns.
+      const transfer = Math.max(
+        -(selfWidth - 1),
+        Math.min(neighbourWidth - 1, delta)
+      );
+      if (transfer === 0) return row;
+      changed = true;
+      const items = row.items.map((it, ii) => {
+        if (ii === itemIndex) return { ...it, width: selfWidth + transfer };
+        if (ii === neighbourIndex) return { ...it, width: neighbourWidth - transfer };
+        return it;
+      });
+      return { ...row, items };
+    });
+  });
+  return changed ? next : config;
+};
+
+/**
  * Set the HEIGHT of the row at `rowPath`. `nextHeight` is either a HeightEnum
  * token (string, tick mode) or a positive integer (px, Shift-fluid mode —
  * Row.height accepts `Union[HeightEnum, int]`). Integers are clamped to a sane

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -127,6 +127,48 @@ export const reorderTopLevelRows = (config, fromIndex, toIndex) => {
 const NEW_ROW = items => ({ height: 'medium', items });
 
 /**
+ * Resolve the `items` array of the row addressed by `rowPath` (any nesting
+ * depth). Returns `[]` for a missing / malformed path. Used by the smart-width
+ * helper so an insert can read its target row's existing item widths.
+ */
+const itemsAtRowPath = (config, rowPath) => {
+  const segments = parseCanvasPath(rowPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'row') return [];
+  let rows = Array.isArray(config?.rows) ? config.rows : [];
+  let row = null;
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    if (seg.kind === 'row') {
+      row = rows[seg.index];
+      if (!row) return [];
+      rows = null;
+    } else {
+      const item = Array.isArray(row?.items) ? row.items[seg.index] : null;
+      if (!item) return [];
+      rows = Array.isArray(item.rows) ? item.rows : [];
+      row = null;
+    }
+  }
+  return Array.isArray(row?.items) ? row.items : [];
+};
+
+/**
+ * The smallest item `width` in the row addressed by `rowPath` (VIS-901 #4). An
+ * insert between items defaults the new item to this width so an all-width-1 row
+ * stays width-1 (balanced) rather than dropping in a default-width-1 that may not
+ * match a row of wider slots. Returns `1` when the row is empty / unknown (the
+ * existing default). Item width defaults to 1 when unset, mirroring the renderer.
+ */
+export const smallestWidthInRow = (config, rowPath) => {
+  const items = itemsAtRowPath(config, rowPath);
+  if (!items.length) return 1;
+  return items.reduce((min, it) => {
+    const w = Math.max(1, Math.round(it?.width || 1));
+    return w < min ? w : min;
+  }, Infinity);
+};
+
+/**
  * Insert `newItem` into the config at a canvas drop target. `target` is the
  * normalised descriptor the canvas droppables carry:
  *
@@ -135,9 +177,38 @@ const NEW_ROW = items => ({ height: 'medium', items });
  *   { kind: 'between-rows',  index }             → new top-level row at index.
  *   { kind: 'in-container',  itemPath }          → append a sub-row to the
  *                                                  container item at itemPath.
+ *   { kind: 'on-item', rowPath, index }          → drop directly ONTO a slot
+ *                                                  (VIS-901 #4): fill an EMPTY
+ *                                                  slot in place, else splice in
+ *                                                  before the filled slot.
+ *
+ * Smart width (VIS-901 #4): for a NEW item inserted between/end-of-row items the
+ * default width is the SMALLEST item width in the target row, so an all-width-1
+ * row stays balanced. A slot-fill (`on-item` onto an empty slot) inherits the
+ * slot's existing width. Both only apply when `newItem` carries the default
+ * width 1 (an explicit width from the caller is preserved).
  *
  * Returns the config unchanged for an unrecognised target.
  */
+const isEmptySlot = item =>
+  !!item &&
+  typeof item === 'object' &&
+  !item.chart &&
+  !item.table &&
+  !item.markdown &&
+  !item.input &&
+  !(Array.isArray(item.rows) && item.rows.length > 0);
+
+// Apply the smart default width to a freshly-built item unless the caller set a
+// non-default width. `buildLibraryItem` always seeds `width: 1`, so a value of 1
+// is treated as "use the smart default".
+const withDefaultWidth = (item, width) => {
+  if (!item || typeof item !== 'object') return item;
+  if ((item.width || 1) !== 1) return item; // caller set an explicit width
+  if (!Number.isFinite(width) || width <= 1) return item;
+  return { ...item, width };
+};
+
 export const insertItemAtTarget = (config, target, newItem) => {
   if (!config || !Array.isArray(config.rows) || !target) return config;
   const item = newItem || { width: 1 };
@@ -149,9 +220,37 @@ export const insertItemAtTarget = (config, target, newItem) => {
     return { ...config, rows: nextRows };
   }
 
+  // Drop directly onto an existing item slot (VIS-901 #4). An EMPTY slot is
+  // filled in place (the new leaf inherits the slot's width); a FILLED slot
+  // splices the new item in just before it (smart-width default).
+  if (target.kind === 'on-item') {
+    const segments = parseCanvasPath(target.rowPath);
+    if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+    const smart = smallestWidthInRow(config, target.rowPath);
+    return withRowsAtRowPath(config, segments, rows => {
+      const lastRowIndex = segments[segments.length - 1].index;
+      return rows.map((row, ri) => {
+        if (ri !== lastRowIndex) return row;
+        const items = Array.isArray(row.items) ? [...row.items] : [];
+        const idx = Math.max(0, Math.min(target.index ?? items.length, items.length));
+        const existing = items[idx];
+        if (isEmptySlot(existing)) {
+          // Fill the empty slot in place, preserving its width.
+          const slotWidth = existing.width || 1;
+          items[idx] = { ...existing, ...item, width: slotWidth };
+        } else {
+          items.splice(idx, 0, withDefaultWidth(item, smart));
+        }
+        return { ...row, items };
+      });
+    });
+  }
+
   if (target.kind === 'between-items' || target.kind === 'end-of-row') {
     const segments = parseCanvasPath(target.rowPath);
     if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+    const smart = smallestWidthInRow(config, target.rowPath);
+    const sized = withDefaultWidth(item, smart);
     return withRowsAtRowPath(config, segments, rows => {
       const lastRowIndex = segments[segments.length - 1].index;
       return rows.map((row, ri) => {
@@ -161,7 +260,7 @@ export const insertItemAtTarget = (config, target, newItem) => {
           target.kind === 'end-of-row'
             ? items.length
             : Math.max(0, Math.min(target.index ?? items.length, items.length));
-        items.splice(insertAt, 0, item);
+        items.splice(insertAt, 0, sized);
         return { ...row, items };
       });
     });

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
@@ -12,6 +12,7 @@ import {
   reorderTopLevelRows,
   insertItemAtTarget,
   buildLibraryItem,
+  smallestWidthInRow,
   ROW_TEMPLATES,
   buildTemplateRow,
   insertRowAtIndex,
@@ -176,6 +177,90 @@ describe('insertItemAtTarget', () => {
   test('unrecognised target returns the config unchanged', () => {
     const before = config();
     expect(insertItemAtTarget(before, { kind: 'nope' }, {})).toBe(before);
+  });
+});
+
+describe('smallestWidthInRow (VIS-901 #4 smart width)', () => {
+  test('returns the smallest item width in the target row', () => {
+    expect(smallestWidthInRow(config(), 'row.0')).toBe(3); // 6/3/3 → 3
+    expect(smallestWidthInRow(config(), 'row.1')).toBe(12); // single 12-wide slot
+  });
+  test('treats a missing width as 1', () => {
+    const cfg = { rows: [{ items: [{ chart: 'ref(a)' }, { width: 4 }] }] };
+    expect(smallestWidthInRow(cfg, 'row.0')).toBe(1);
+  });
+  test('returns 1 for an empty / unknown row', () => {
+    expect(smallestWidthInRow({ rows: [{ items: [] }] }, 'row.0')).toBe(1);
+    expect(smallestWidthInRow(config(), 'row.9')).toBe(1);
+  });
+  test('reads a nested row path', () => {
+    const cfg = {
+      rows: [{ items: [{ width: 6, rows: [{ items: [{ width: 2 }, { width: 5 }] }] }] }],
+    };
+    expect(smallestWidthInRow(cfg, 'row.0.item.0.row.0')).toBe(2);
+  });
+});
+
+describe('insertItemAtTarget — smart width (VIS-901 #4)', () => {
+  test('between-items default width = smallest item width in the row', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'between-items', rowPath: 'row.0', index: 1 },
+      buildLibraryItem('chart', 'x')
+    );
+    // row.0 widths are 6/3/3 → smallest 3, so the new item inserts at width 3.
+    expect(after.rows[0].items[1]).toEqual({ width: 3, chart: 'ref(x)' });
+  });
+
+  test('all-width-1 row stays width 1 on insert', () => {
+    const cfg = { rows: [{ items: [{ width: 1, chart: 'ref(a)' }, { width: 1, chart: 'ref(b)' }] }] };
+    const after = insertItemAtTarget(
+      cfg,
+      { kind: 'end-of-row', rowPath: 'row.0' },
+      buildLibraryItem('table', 't')
+    );
+    expect(after.rows[0].items[2]).toEqual({ width: 1, table: 'ref(t)' });
+  });
+
+  test('an explicit caller width is preserved (not overridden by smart width)', () => {
+    const after = insertItemAtTarget(
+      config(),
+      { kind: 'end-of-row', rowPath: 'row.0' },
+      { width: 8, chart: 'ref(big)' }
+    );
+    expect(after.rows[0].items[3]).toEqual({ width: 8, chart: 'ref(big)' });
+  });
+});
+
+describe('insertItemAtTarget — on-item slot drop (VIS-901 #4)', () => {
+  test('filling an EMPTY slot in place preserves the slot width', () => {
+    const cfg = { rows: [{ items: [{ width: 4 }, { width: 8, chart: 'ref(a)' }] }] };
+    const after = insertItemAtTarget(
+      cfg,
+      { kind: 'on-item', rowPath: 'row.0', index: 0 },
+      buildLibraryItem('chart', 'new')
+    );
+    expect(after.rows[0].items).toHaveLength(2); // no new slot — filled in place
+    expect(after.rows[0].items[0]).toEqual({ width: 4, chart: 'ref(new)' });
+  });
+
+  test('dropping onto a FILLED slot inserts a new item before it (smart width)', () => {
+    const cfg = { rows: [{ items: [{ width: 6, chart: 'ref(a)' }, { width: 6, chart: 'ref(b)' }] }] };
+    const after = insertItemAtTarget(
+      cfg,
+      { kind: 'on-item', rowPath: 'row.0', index: 1 },
+      buildLibraryItem('table', 't')
+    );
+    expect(after.rows[0].items).toHaveLength(3);
+    // Smart width = smallest in row (6); new item lands before index 1.
+    expect(after.rows[0].items[1]).toEqual({ width: 6, table: 'ref(t)' });
+    expect(after.rows[0].items[2]).toEqual({ width: 6, chart: 'ref(b)' });
+  });
+
+  test('input is never mutated', () => {
+    const before = { rows: [{ items: [{ width: 2 }] }] };
+    insertItemAtTarget(before, { kind: 'on-item', rowPath: 'row.0', index: 0 }, buildLibraryItem('chart', 'z'));
+    expect(before.rows[0].items[0]).toEqual({ width: 2 });
   });
 });
 

--- a/viewer/src/components/new-views/project/canvas/canvasReorderResize.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorderResize.test.js
@@ -12,6 +12,7 @@
  */
 import {
   setItemWidth,
+  resizeItemFromLeft,
   setRowHeight,
   HEIGHT_ENUM_STOPS,
   heightEnumToPixels,
@@ -85,6 +86,88 @@ describe('setItemWidth (VIS-777)', () => {
     };
     const next = setItemWidth(cfg, 'row.0.item.0.row.0.item.1', 6);
     expect(next.rows[0].items[0].rows[0].items[1].width).toBe(6);
+    expect(next).not.toBe(cfg);
+  });
+});
+
+describe('resizeItemFromLeft (VIS-901)', () => {
+  test('transfers columns from the left neighbour to grow this item (drag left)', () => {
+    const cfg = baseConfig();
+    // Grow item 1 by 2 cols → neighbour (item 0) loses 2. Row total unchanged.
+    const next = resizeItemFromLeft(cfg, 'row.0', 1, 2);
+    expect(next.rows[0].items[1].width).toBe(8);
+    expect(next.rows[0].items[0].width).toBe(4);
+    expect(next.rows[0].items[0].width + next.rows[0].items[1].width).toBe(12);
+  });
+
+  test('transfers columns to the left neighbour to shrink this item (drag right)', () => {
+    const cfg = baseConfig();
+    const next = resizeItemFromLeft(cfg, 'row.0', 1, -2);
+    expect(next.rows[0].items[1].width).toBe(4);
+    expect(next.rows[0].items[0].width).toBe(8);
+  });
+
+  test('clamps so the LEFT NEIGHBOUR never drops below width 1 (growing)', () => {
+    const cfg = baseConfig(); // both items width 6
+    // Asking for +10 can only take 5 from the neighbour (6 → 1).
+    const next = resizeItemFromLeft(cfg, 'row.0', 1, 10);
+    expect(next.rows[0].items[1].width).toBe(11);
+    expect(next.rows[0].items[0].width).toBe(1);
+  });
+
+  test('clamps so THIS ITEM never drops below width 1 (shrinking)', () => {
+    const cfg = baseConfig(); // both items width 6
+    const next = resizeItemFromLeft(cfg, 'row.0', 1, -10);
+    expect(next.rows[0].items[1].width).toBe(1);
+    expect(next.rows[0].items[0].width).toBe(11);
+  });
+
+  test('is a no-op for the FIRST item in a row (no left neighbour)', () => {
+    const cfg = baseConfig();
+    expect(resizeItemFromLeft(cfg, 'row.0', 0, 3)).toBe(cfg);
+  });
+
+  test('is immutable — returns a new config and never mutates the input', () => {
+    const cfg = baseConfig();
+    const snapshot = JSON.stringify(cfg);
+    const next = resizeItemFromLeft(cfg, 'row.0', 1, 2);
+    expect(next).not.toBe(cfg);
+    expect(JSON.stringify(cfg)).toBe(snapshot);
+  });
+
+  test('returns the SAME reference on a zero / fully-clamped-to-zero transfer', () => {
+    const cfg = baseConfig();
+    expect(resizeItemFromLeft(cfg, 'row.0', 1, 0)).toBe(cfg);
+    // Item already width 1 can't shrink further → transfer clamps to 0.
+    const tight = {
+      rows: [{ items: [{ width: 11, chart: 'ref(a)' }, { width: 1, chart: 'ref(b)' }] }],
+    };
+    expect(resizeItemFromLeft(tight, 'row.0', 1, -3)).toBe(tight);
+  });
+
+  test('returns the SAME reference for an item path or malformed path', () => {
+    const cfg = baseConfig();
+    expect(resizeItemFromLeft(cfg, 'row.0.item.1', 1, 2)).toBe(cfg);
+    expect(resizeItemFromLeft(cfg, 'dashboard', 1, 2)).toBe(cfg);
+    expect(resizeItemFromLeft(cfg, '', 1, 2)).toBe(cfg);
+  });
+
+  test('works at nesting depth (container sub-row item)', () => {
+    const cfg = {
+      rows: [
+        {
+          items: [
+            {
+              width: 12,
+              rows: [{ items: [{ width: 4, chart: 'ref(x)' }, { width: 8, chart: 'ref(y)' }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const next = resizeItemFromLeft(cfg, 'row.0.item.0.row.0', 1, 2);
+    expect(next.rows[0].items[0].rows[0].items[1].width).toBe(10);
+    expect(next.rows[0].items[0].rows[0].items[0].width).toBe(2);
     expect(next).not.toBe(cfg);
   });
 });

--- a/viewer/src/components/new-views/project/editor/LevelGroup.jsx
+++ b/viewer/src/components/new-views/project/editor/LevelGroup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useDroppable } from '@dnd-kit/core';
+import { useDroppable, useDraggable } from '@dnd-kit/core';
+import { PiDotsSixVertical } from 'react-icons/pi';
 import LevelGroupHeader from './LevelGroupHeader';
 import DashboardTile from './DashboardTile';
 
@@ -14,6 +15,7 @@ import DashboardTile from './DashboardTile';
  */
 const LevelGroup = ({
   group,
+  levelIndex = -1,
   collapsed,
   onToggle,
   selectedDashboardName,
@@ -28,29 +30,61 @@ const LevelGroup = ({
   onMoveDown,
   onDelete,
 }) => {
+  // Drop target for BOTH a dashboard tile (reassign level) AND a level-header
+  // drag (reorder levels — VIS-901 #5). `levelIndex` lets the router compute the
+  // reorder destination.
   const { setNodeRef, isOver } = useDroppable({
     id: group.levelKey,
-    data: { levelKey: group.levelKey, levelValue: group.levelValue },
+    data: { levelKey: group.levelKey, levelValue: group.levelValue, levelIndex },
+  });
+
+  // The level itself is draggable by its grip (only for real, editable levels —
+  // not the trailing Unassigned bucket). Reorder is routed through the shared
+  // WorkspaceDndContext (VIS-901 #5).
+  const levelDrag = useDraggable({
+    id: `level-handle:${group.levelKey}`,
+    data: { source: 'level', levelIndex, levelKey: group.levelKey, title: group.title },
+    disabled: !editable,
   });
 
   const isInvalidTarget = !!activeDragName && isActiveSourceGroup;
 
   return (
     <section className="mt-1 mb-6" data-testid={`level-group-${group.levelKey}`}>
-      <LevelGroupHeader
-        title={group.title}
-        count={group.dashboards.length}
-        collapsed={collapsed}
-        onToggle={onToggle}
-        testId={`level-group-header-${group.levelKey}`}
-        editable={editable}
-        canMoveUp={canMoveUp}
-        canMoveDown={canMoveDown}
-        onRename={onRename}
-        onMoveUp={onMoveUp}
-        onMoveDown={onMoveDown}
-        onDelete={onDelete}
-      />
+      <div className="flex items-center gap-1">
+        {editable && (
+          <button
+            ref={levelDrag.setNodeRef}
+            {...levelDrag.listeners}
+            {...levelDrag.attributes}
+            type="button"
+            data-testid={`level-drag-handle-${group.levelKey}`}
+            aria-label={`Reorder level ${group.title}`}
+            title="Drag to reorder level"
+            onClick={e => e.stopPropagation()}
+            className="inline-flex h-6 w-5 shrink-0 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary"
+            style={{ cursor: levelDrag.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
+          >
+            <PiDotsSixVertical className="h-4 w-4" />
+          </button>
+        )}
+        <div className="min-w-0 flex-1">
+          <LevelGroupHeader
+            title={group.title}
+            count={group.dashboards.length}
+            collapsed={collapsed}
+            onToggle={onToggle}
+            testId={`level-group-header-${group.levelKey}`}
+            editable={editable}
+            canMoveUp={canMoveUp}
+            canMoveDown={canMoveDown}
+            onRename={onRename}
+            onMoveUp={onMoveUp}
+            onMoveDown={onMoveDown}
+            onDelete={onDelete}
+          />
+        </div>
+      </div>
       {!collapsed && (
         <div
           ref={setNodeRef}

--- a/viewer/src/components/new-views/project/editor/ProjectEditor.jsx
+++ b/viewer/src/components/new-views/project/editor/ProjectEditor.jsx
@@ -398,6 +398,7 @@ const ProjectEditor = () => {
                     <LevelGroup
                       key={group.levelKey}
                       group={group}
+                      levelIndex={levelIndex}
                       collapsed={!!collapsed[group.levelKey]}
                       onToggle={() => handleToggle(group.levelKey)}
                       selectedDashboardName={selectedDashboardName}

--- a/viewer/src/components/new-views/project/editor/useProjectEditorData.js
+++ b/viewer/src/components/new-views/project/editor/useProjectEditorData.js
@@ -59,10 +59,14 @@ const toTile = dashboard => ({
 
 export const groupDashboardsByLevel = (dashboards, defaults) => {
   const safeDashboards = Array.isArray(dashboards) ? dashboards : [];
-  const configuredLevels =
-    Array.isArray(defaults?.levels) && defaults.levels.length > 0
-      ? defaults.levels
-      : defaultLevels;
+  // When the project EXPLICITLY configures levels, every configured level is a
+  // real, user-created bucket — render ALL of them (even empty ones) so a level
+  // added via "Add Level" shows as an empty droppable SECTION dashboards can be
+  // dragged into (VIS-901 #5). When we fall back to the shared `defaultLevels`
+  // (no levels configured yet) we keep the conservative windowing below so an
+  // empty project doesn't show every default level as noise.
+  const hasConfiguredLevels = Array.isArray(defaults?.levels) && defaults.levels.length > 0;
+  const configuredLevels = hasConfiguredLevels ? defaults.levels : defaultLevels;
 
   // Bucket dashboards by resolved level index.
   const buckets = new Map(); // index -> tiles[]
@@ -86,13 +90,15 @@ export const groupDashboardsByLevel = (dashboards, defaults) => {
 
   configuredLevels.forEach((lvl, idx) => {
     const tiles = buckets.get(idx) || [];
-    // Show a configured level if it has dashboards, OR it precedes the last
-    // populated level (so a populated L2 always shows an empty L0/L1 above it
-    // as a valid drop destination).
-    const maxPopulated = populatedIndices.size
-      ? Math.max(...populatedIndices)
-      : -1;
-    if (tiles.length === 0 && idx > maxPopulated) return;
+    // Explicitly-configured levels ALWAYS render (so a newly-added empty level
+    // is a visible drop target — VIS-901 #5). For the default-fallback case,
+    // show a level if it has dashboards OR it precedes the last populated level
+    // (so a populated L2 always shows an empty L0/L1 above it as a valid drop
+    // destination), but hide trailing empty defaults.
+    if (!hasConfiguredLevels) {
+      const maxPopulated = populatedIndices.size ? Math.max(...populatedIndices) : -1;
+      if (tiles.length === 0 && idx > maxPopulated) return;
+    }
     groups.push({
       levelKey: `level:${idx}`,
       title: lvl.title || `Level ${idx + 1}`,

--- a/viewer/src/components/new-views/project/editor/useProjectEditorData.test.js
+++ b/viewer/src/components/new-views/project/editor/useProjectEditorData.test.js
@@ -19,9 +19,13 @@ describe('groupDashboardsByLevel', () => {
       [dash('exec', 'Organization'), dash('sales', 'Department'), dash('rev', 'Organization')],
       defaults
     );
-    expect(groups.map(g => g.title)).toEqual(['Organization', 'Department']);
+    // Explicitly-configured levels ALL render (even empty ones) so a newly-added
+    // level is a visible drop target — VIS-901. Team has no dashboards but still
+    // shows as an empty droppable section.
+    expect(groups.map(g => g.title)).toEqual(['Organization', 'Department', 'Team']);
     expect(groups[0].dashboards.map(d => d.name)).toEqual(['exec', 'rev']);
     expect(groups[1].dashboards.map(d => d.name)).toEqual(['sales']);
+    expect(groups[2].dashboards).toEqual([]);
   });
 
   test('resolves numeric and L-prefixed levels to configured titles', () => {
@@ -62,8 +66,17 @@ describe('groupDashboardsByLevel', () => {
     expect(groups[0].title).toBe('Organization');
   });
 
-  test('returns empty array for no dashboards', () => {
-    expect(groupDashboardsByLevel([], defaults)).toEqual([]);
+  test('renders all configured levels (as empty drop targets) when there are no dashboards', () => {
+    // With levels explicitly configured, every level is a real user-created
+    // bucket and renders as an empty droppable section — VIS-901. No Unassigned
+    // group is added because there are no orphaned dashboards.
+    const groups = groupDashboardsByLevel([], defaults);
+    expect(groups.map(g => g.title)).toEqual(['Organization', 'Department', 'Team']);
+    groups.forEach(g => expect(g.dashboards).toEqual([]));
+  });
+
+  test('returns empty array for no dashboards and no configured levels', () => {
+    expect(groupDashboardsByLevel([], { levels: [] })).toEqual([]);
   });
 });
 

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -88,8 +88,13 @@ const workspaceCollisionDetection = args => {
       const scoped = { ...args, droppableContainers: droppableContainers.filter(isBetweenRows) };
       return closestCenter(scoped);
     }
-    // Item drag → everything except between-rows zones, pointer-precise.
-    droppableContainers = droppableContainers.filter(c => !isBetweenRows(c));
+    // Item drag → everything except between-rows zones AND except the on-item
+    // slot-fill zones (VIS-901 #4): those are a LIBRARY-only affordance (fill /
+    // insert-before a slot). A canvas item reorder must always resolve to a
+    // gap (between-items / end-of-row), never to the slot body, so it can't
+    // silently no-op on an on-item zone.
+    const isOnItem = c => c?.data?.current?.target?.kind === 'on-item';
+    droppableContainers = droppableContainers.filter(c => !isBetweenRows(c) && !isOnItem(c));
   }
   const scoped = { ...args, droppableContainers };
   const hits = pointerWithin(scoped);
@@ -128,6 +133,8 @@ export const useWorkspaceCommit = () => useContext(WorkspaceCommitContext);
  * @param {Array}  deps.dashboards    current dashboards list (for level groups).
  * @param {object} deps.projectDefaults defaults used to resolve level groups.
  * @param {Function} deps.reassignDashboardLevel store action.
+ * @param {Function} deps.moveLevel  store action `(fromIndex, toIndex) => void`
+ *                   for canvas level reorder (VIS-901 #5).
  * @param {Function} deps.commitCanvasConfig  applies a next dashboard config
  *                   (sanitize → optimistic → save) for canvas D-3 mutations:
  *                   `(dashboardName, nextConfig, meta) => void`.
@@ -139,13 +146,33 @@ export const useWorkspaceCommit = () => useContext(WorkspaceCommitContext);
  */
 export const routeWorkspaceDragEnd = (
   event,
-  { dashboards, projectDefaults, reassignDashboardLevel, commitCanvasConfig, emit }
+  { dashboards, projectDefaults, reassignDashboardLevel, moveLevel, commitCanvasConfig, emit }
 ) => {
   const { active, over } = event || {};
   if (!over) return 'noop';
   const dragData = active?.data?.current;
   const dropData = over?.data?.current;
   if (!dragData || !dropData) return 'noop';
+
+  // ── Branch 0: ProjectEditor level → level reorder (VIS-901 #5) ───────────
+  // A level-header drag carries `{ source: 'level', levelIndex }`; dropping it
+  // on another level group (which exposes `levelIndex`) reorders the levels.
+  if (dragData.source === 'level' && dropData.levelKey !== undefined) {
+    const fromIndex = dragData.levelIndex;
+    const toIndex = dropData.levelIndex;
+    if (
+      typeof fromIndex !== 'number' ||
+      typeof toIndex !== 'number' ||
+      fromIndex === toIndex ||
+      toIndex < 0
+    ) {
+      return 'noop';
+    }
+    if (moveLevel) moveLevel(fromIndex, toIndex);
+    emit &&
+      emit('project_editor_action', { kind: 'level_reorder_dnd', from: fromIndex, to: toIndex });
+    return 'level_reorder';
+  }
 
   // ── Branch 1: ProjectEditor tile → level reassignment (M-1) ─────────────
   if (dragData.type === 'dashboard' && dropData.levelKey !== undefined) {
@@ -256,8 +283,96 @@ export const routeWorkspaceDragEnd = (
   return 'noop';
 };
 
+/**
+ * Pure mapper for `onDragStart` (VIS-901 #5): turn the dnd-kit `active.data`
+ * payload into the `activeDrag` shape the DragOverlay reads. Exported so the
+ * mapping (especially the row-vs-item distinction for the preview pill) is
+ * unit-testable without simulating a real drag. Returns `null` for no payload.
+ *
+ *   - dashboard tile        → { kind: 'dashboard', name, level, type }
+ *   - library row           → { kind: 'library', name, type, data }
+ *   - canvas ROW drag       → { kind: 'canvas', canvasKind: 'row', name }
+ *   - canvas ITEM drag      → { kind: 'canvas', canvasKind: 'item', name, type, data }
+ *
+ * A ROW has no `refType`, so it gets a dedicated row preview rather than the
+ * old chart pill (the bug this fixes: row drags showed a "chart" pill).
+ */
+export const mapDragStartData = data => {
+  if (!data) return null;
+  if (data.type === 'dashboard') {
+    return { kind: 'dashboard', name: data.name, level: data.level, type: 'dashboard' };
+  }
+  if (data.source === 'library') {
+    return { kind: 'library', name: data.name, type: data.type, data };
+  }
+  if (data.source === 'level') {
+    return { kind: 'level', name: data.title || 'Level' };
+  }
+  if (data.source === 'canvas') {
+    if (data.kind === 'row') {
+      return { kind: 'canvas', canvasKind: 'row', name: data.label || data.name || 'Row' };
+    }
+    const name = data.label || data.name;
+    const type = data.refType || 'chart';
+    return {
+      kind: 'canvas',
+      canvasKind: 'item',
+      name,
+      type,
+      data: { source: 'library', type, name },
+    };
+  }
+  return null;
+};
+
 const DashboardIcon = getTypeIcon('dashboard');
 const DASH_COLORS = getTypeColors('dashboard');
+
+/**
+ * CanvasRowDragPreview — the DragOverlay pill for a canvas ROW drag (VIS-901 #5).
+ * A row has no referenced object type, so it gets its own preview (a mulberry
+ * "Row" pill with a stacked-bars glyph) rather than borrowing the chart pill.
+ */
+const CanvasRowDragPreview = ({ name }) => (
+  <div
+    data-testid="canvas-row-drag-preview"
+    className="pointer-events-none inline-flex items-center gap-2 rounded-md bg-white px-2.5 py-1.5 shadow-lg ring-1 ring-[#713b57]"
+  >
+    <svg viewBox="0 0 14 14" width="14" height="14" aria-hidden="true" className="text-[#713b57]">
+      <g fill="currentColor">
+        <rect x="1" y="2" width="12" height="3" rx="1" />
+        <rect x="1" y="9" width="12" height="3" rx="1" />
+      </g>
+    </svg>
+    <span className="text-[13px] font-medium text-gray-900">{name}</span>
+    <span className="ml-1 inline-flex h-4 items-center rounded-sm bg-[#e2d7dd] px-1 text-[10px] font-bold uppercase tracking-wide text-[#5a2f45]">
+      Row
+    </span>
+  </div>
+);
+
+/**
+ * CanvasLevelDragPreview — the DragOverlay pill for a level-header drag
+ * (VIS-901 #5). A simple mulberry "Level" pill with the level title.
+ */
+const CanvasLevelDragPreview = ({ name }) => (
+  <div
+    data-testid="level-drag-preview"
+    className="pointer-events-none inline-flex items-center gap-2 rounded-md bg-white px-2.5 py-1.5 shadow-lg ring-1 ring-[#713b57]"
+  >
+    <svg viewBox="0 0 14 14" width="14" height="14" aria-hidden="true" className="text-[#713b57]">
+      <g fill="currentColor">
+        <rect x="1" y="2" width="12" height="2.5" rx="1" />
+        <rect x="1" y="6" width="9" height="2.5" rx="1" />
+        <rect x="1" y="10" width="6" height="2.5" rx="1" />
+      </g>
+    </svg>
+    <span className="text-[13px] font-medium text-gray-900">{name}</span>
+    <span className="ml-1 inline-flex h-4 items-center rounded-sm bg-[#e2d7dd] px-1 text-[10px] font-bold uppercase tracking-wide text-[#5a2f45]">
+      Level
+    </span>
+  </div>
+);
 
 const DashboardTilePreview = ({ name }) => (
   <div className="flex h-9 items-center gap-2 rounded-lg bg-white px-3 text-[13px] font-semibold text-gray-900 shadow-lg ring-2 ring-primary">
@@ -275,6 +390,7 @@ const WorkspaceDndContext = ({ children }) => {
   const defaults = useStore(s => s.defaults);
   const project = useStore(s => s.project);
   const reassignDashboardLevel = useStore(s => s.reassignDashboardLevel);
+  const moveLevel = useStore(s => s.moveLevel);
   const saveDashboard = useStore(s => s.saveDashboard);
   const updateDashboardConfigOptimistic = useStore(s => s.updateDashboardConfigOptimistic);
 
@@ -319,28 +435,7 @@ const WorkspaceDndContext = ({ children }) => {
   );
 
   const handleDragStart = useCallback(event => {
-    const data = event.active?.data?.current;
-    if (!data) return;
-    if (data.type === 'dashboard') {
-      setActiveDrag({ kind: 'dashboard', name: data.name, level: data.level, type: 'dashboard' });
-      return;
-    }
-    if (data.source === 'library') {
-      setActiveDrag({ kind: 'library', name: data.name, type: data.type, data });
-      return;
-    }
-    // Canvas item/row drag (VIS-771 / D-3). The drag preview IS the source pill
-    // (no thumbnail, per architecture §2.6) — for an item we render the same
-    // Library-style pill keyed on the referenced object's type + name.
-    if (data.source === 'canvas') {
-      setActiveDrag({
-        kind: 'canvas',
-        canvasKind: data.kind,
-        name: data.label || data.name,
-        type: data.refType || 'chart',
-        data: { source: 'library', type: data.refType || 'chart', name: data.label || data.name },
-      });
-    }
+    setActiveDrag(mapDragStartData(event.active?.data?.current));
   }, []);
 
   const handleDragCancel = useCallback(() => setActiveDrag(null), []);
@@ -352,11 +447,12 @@ const WorkspaceDndContext = ({ children }) => {
         dashboards,
         projectDefaults,
         reassignDashboardLevel,
+        moveLevel,
         commitCanvasConfig,
         emit: emitWorkspaceEvent,
       });
     },
-    [dashboards, projectDefaults, reassignDashboardLevel, commitCanvasConfig]
+    [dashboards, projectDefaults, reassignDashboardLevel, moveLevel, commitCanvasConfig]
   );
 
   return (
@@ -379,9 +475,15 @@ const WorkspaceDndContext = ({ children }) => {
         <DragOverlay dropAnimation={null}>
           {activeDrag?.kind === 'dashboard' ? (
             <DashboardTilePreview name={activeDrag.name} />
+          ) : activeDrag?.kind === 'level' ? (
+            <CanvasLevelDragPreview name={activeDrag.name} />
+          ) : activeDrag?.kind === 'canvas' && activeDrag.canvasKind === 'row' ? (
+            // Canvas ROW drag → a dedicated row pill (VIS-901 #5). A row has no
+            // refType, so it must NOT borrow the chart pill.
+            <CanvasRowDragPreview name={activeDrag.name} />
           ) : activeDrag?.kind === 'library' || activeDrag?.kind === 'canvas' ? (
-            // Canvas item/row drags reuse the SAME pill shape as a Library drag
-            // (architecture §2.6: "the drag preview IS the source pill").
+            // Library drags + canvas ITEM drags reuse the SAME pill shape as a
+            // Library drag (architecture §2.6: "the drag preview IS the source pill").
             <LibraryDragPreview data={activeDrag.data} />
           ) : null}
         </DragOverlay>

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
@@ -15,6 +15,7 @@ import { render, screen } from '@testing-library/react';
 import WorkspaceDndContext, {
   useWorkspaceDrag,
   routeWorkspaceDragEnd,
+  mapDragStartData,
 } from './WorkspaceDndContext';
 import useStore from '../../../stores/store';
 
@@ -45,6 +46,56 @@ describe('WorkspaceDndContext provider (VIS-802)', () => {
       </WorkspaceDndContext>
     );
     expect(screen.getByTestId('drag-probe')).toHaveTextContent('null');
+  });
+});
+
+describe('mapDragStartData — drag preview mapping (VIS-901 #5)', () => {
+  test('returns null for no payload', () => {
+    expect(mapDragStartData(null)).toBeNull();
+    expect(mapDragStartData(undefined)).toBeNull();
+  });
+
+  test('dashboard tile → dashboard kind', () => {
+    const out = mapDragStartData({ type: 'dashboard', name: 'd0', level: 'L1' });
+    expect(out).toMatchObject({ kind: 'dashboard', name: 'd0', level: 'L1', type: 'dashboard' });
+  });
+
+  test('library row → library kind carrying the source payload', () => {
+    const data = { source: 'library', type: 'chart', name: 'sales' };
+    const out = mapDragStartData(data);
+    expect(out).toMatchObject({ kind: 'library', name: 'sales', type: 'chart' });
+    expect(out.data).toBe(data);
+  });
+
+  test('canvas ROW drag → row preview (NOT a chart pill)', () => {
+    const out = mapDragStartData({ source: 'canvas', kind: 'row', rowIndex: 2, rowPath: 'row.2' });
+    expect(out).toMatchObject({ kind: 'canvas', canvasKind: 'row' });
+    // A row has no referenced object type — it must not borrow the chart pill.
+    expect(out.type).toBeUndefined();
+    expect(out.data).toBeUndefined();
+  });
+
+  test('canvas ROW drag falls back to a "Row" label when unnamed', () => {
+    const out = mapDragStartData({ source: 'canvas', kind: 'row', rowPath: 'row.0' });
+    expect(out.name).toBe('Row');
+  });
+
+  test('canvas ITEM drag → item pill keyed on the referenced type + name', () => {
+    const out = mapDragStartData({
+      source: 'canvas',
+      kind: 'item',
+      rowPath: 'row.0',
+      itemIndex: 1,
+      refType: 'table',
+      label: 'orders',
+    });
+    expect(out).toMatchObject({ kind: 'canvas', canvasKind: 'item', name: 'orders', type: 'table' });
+    expect(out.data).toMatchObject({ source: 'library', type: 'table', name: 'orders' });
+  });
+
+  test('canvas ITEM drag defaults to chart type when refType is absent', () => {
+    const out = mapDragStartData({ source: 'canvas', kind: 'item', rowPath: 'row.0', itemIndex: 0 });
+    expect(out.type).toBe('chart');
   });
 });
 

--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -211,6 +211,11 @@ const Dashboard = ({
   // state instead. The dashboard root still mounts so the overlay's measuring
   // ancestor exists. (VIS-794)
   hideEmptyPlaceholder = false,
+  // When true (canvas build surface only), render a visible placeholder for an
+  // EMPTY item slot (no chart/table/markdown/input/rows) so users can see — and
+  // drop onto — an otherwise-invisible empty slot. View mode keeps the legacy
+  // behaviour (an empty slot renders nothing). (VIS-901 #3)
+  canvasMode = false,
 }) => {
   // Dashboard store (fetched by Project container)
   const dashboards = useStore(state => state.dashboards);
@@ -582,6 +587,23 @@ const Dashboard = ({
           row={row}
           height={effectiveSlotHeight}
         />
+      );
+    }
+
+    // Empty layout slot ({ width } with no leaf ref / rows). In View mode this
+    // renders nothing (parity preserved); on the canvas build surface we paint a
+    // visible dashed placeholder so the slot is discoverable + a drop target
+    // (VIS-901 #3). Backend persistence of a truly-empty item lands with VIS-900.
+    if (canvasMode) {
+      return (
+        <div
+          key={key}
+          data-testid="canvas-empty-slot"
+          className="flex h-full w-full items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50/40 text-[11px] font-medium text-gray-400"
+          style={{ minHeight: 48 }}
+        >
+          Empty slot
+        </div>
       );
     }
 

--- a/viewer/src/components/project/Dashboard.test.jsx
+++ b/viewer/src/components/project/Dashboard.test.jsx
@@ -252,6 +252,49 @@ describe('Dashboard', () => {
     expect(screen.getByText('This dashboard is empty')).toBeInTheDocument();
   });
 
+  // ---------- VIS-901 #3: empty-slot placeholder (canvas build surface) ----------
+  describe('empty-slot placeholder (VIS-901 #3)', () => {
+    const emptySlotDashboard = {
+      name: 'with-empty-slot',
+      rows: [{ height: 'medium', items: [{ width: 1 }] }],
+    };
+    const renderEmptySlot = (props = {}) => {
+      useStore.mockImplementation(selector => {
+        const state = {
+          project: mockProject,
+          dashboards: [emptySlotDashboard],
+          fetchDashboards: jest.fn(),
+          fetchCharts: jest.fn(),
+          fetchTables: jest.fn(),
+          fetchMarkdowns: jest.fn(),
+          fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
+          getChartByName: jest.fn(() => null),
+          getTableByName: jest.fn(() => null),
+          getMarkdownByName: jest.fn(() => null),
+          getInputByName: jest.fn(() => null),
+        };
+        return selector(state);
+      });
+      return render(
+        <BrowserRouter future={futureFlags}>
+          <Dashboard project={mockProject} dashboardName="with-empty-slot" {...props} />
+        </BrowserRouter>
+      );
+    };
+
+    it('renders a visible placeholder for an empty slot in canvasMode', () => {
+      renderEmptySlot({ canvasMode: true });
+      expect(screen.getByTestId('canvas-empty-slot')).toBeInTheDocument();
+    });
+
+    it('renders nothing for an empty slot in View mode (parity preserved)', () => {
+      renderEmptySlot();
+      expect(screen.queryByTestId('canvas-empty-slot')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders chart when found in store', () => {
     render(
       <BrowserRouter future={futureFlags}>

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -247,6 +247,29 @@ const createDashboardSlice = (set, get) => ({
   },
 
   /**
+   * Move the level from `fromIndex` to `toIndex` (VIS-901 #5 — canvas level
+   * reorder via DnD). Unlike `reorderLevel` (single-step arrow), this moves a
+   * level to an arbitrary slot, matching a drag-and-drop gesture. Persists
+   * through the same `_persistLevels` path. No-op for out-of-range / unchanged.
+   */
+  moveLevel: async (fromIndex, toIndex) => {
+    const levels = get()._resolveLevels();
+    if (
+      fromIndex < 0 ||
+      fromIndex >= levels.length ||
+      toIndex < 0 ||
+      toIndex >= levels.length ||
+      fromIndex === toIndex
+    ) {
+      return { success: false, error: 'move out of range or unchanged' };
+    }
+    const nextLevels = [...levels];
+    const [moved] = nextLevels.splice(fromIndex, 1);
+    nextLevels.splice(toIndex, 0, moved);
+    return get()._persistLevels(nextLevels);
+  },
+
+  /**
    * Delete the level at `index`. Dashboards assigned to that level (by title)
    * fall to the Unassigned bucket — their `level` key is removed via
    * `reassignDashboardLevel(name, null)`.


### PR DESCRIPTION
## VIS-901 — Canvas DnD improvements

Acceptance follow-ups from the merged Track D canvas work. Picks up the prior (uncommitted) implementation, makes the suite green, verifies on a sandbox, and adds regression e2e coverage.

### What's in this PR (per sub-item)

| # | Item | Status |
|---|------|--------|
| #5 | Row-drag preview shows a **"Row"** pill (not a chart pill) | ✅ shipped |
| #4 | Library **drop directly onto a slot** (fill empty / insert-before) + **smart default width** (smallest item width in the row) | ✅ shipped |
| #2 / #5 | **Add Level** renders an empty droppable level **section** on the canvas + **level reorder via DnD** | ✅ shipped |
| #6 | Input dropdown (Search options…) **portals to `<body>`** so it escapes the slot's `overflow-hidden` clip (recurring regression) | ✅ shipped |
| #3 | Empty item slot shows a **dashed placeholder** on the canvas build surface (View-mode parity preserved) | ✅ shipped |
| #9 | Row-height edge-drag resize | ✅ verified working in merged build (no change needed) |

### Key changes
- `mapDragStartData` — pure, unit-tested drag-start mapper; row drags get `canvasKind:'row'` with no `refType`, rendered by new `CanvasRowDragPreview`.
- `PortalDropdownMenu` — new component portaling input option menus to `<body>` with fixed, anchor-tracked positioning (flips above when low on space). Wired into `Dropdown.jsx` + `AutocompleteInput.jsx` (click-outside now also checks the portalled menu node).
- `canvasReorder.js` — `on-item` drop target (fill empty slot in place / splice before filled) + `smallestWidthInRow` smart-width default; explicit caller width preserved.
- `WorkspaceDndContext` — collision filter excludes `on-item` zones from item reorders (Library-only affordance); level→level reorder branch routed to new `moveLevel` store action.
- `useProjectEditorData` — explicitly-configured levels always render as droppable sections (default-fallback windowing unchanged).
- `Dashboard.jsx` — `canvasMode` empty-slot placeholder.
- `dashboardStore.moveLevel` — arbitrary-slot level move persisted via `_persistLevels`.

### Preserved invariants
Shared DnD context's `pointerWithin`/`closestCenter` collision, continuous measuring, and hover/selection-gated grips are all intact. No backend changes (empty-item persistence is VIS-900).

### Testing
- **Unit + lint:** full viewer suite **2110 passing**, lint clean. Updated `useProjectEditorData` + `PortalDropdownMenu` specs to match the new behaviour; added smart-width / on-item / `mapDragStartData` / empty-slot unit tests (carried from the implementation).
- **New e2e regression stories:**
  - `canvas-input-dropdown-portal.spec.mjs` (#6) — asserts the dropdown menu portals to `<body>`, is not a descendant of its `overflow-hidden` slot, and extends beyond the slot bounds.
  - `canvas-row-drag-preview.spec.mjs` (#5) — asserts a row drag shows the "Row" pill and **not** the chart pill.
  - Both pass against the sandbox.
- **Sandbox spot-checks (8048/3048):** #6 dropdown escapes the slot (menu bottom 858 vs slot bottom 689); #2 "Add Level" → "New level · 0 dashboards · Drag a dashboard here" section + per-level drag grips; #9 `canvas-resize-height-row.0` handle appears on row select. No app console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)