### PR TITLE
Track D canvas remainder: nested DnD/resize, wrap-in-container, keyboard nav, flip-to-lineage (VIS-903 / VIS-781 / VIS-790 / VIS-785)

### DIFF
--- a/viewer/e2e/stories/canvas-dnd.spec.mjs
+++ b/viewer/e2e/stories/canvas-dnd.spec.mjs
@@ -283,7 +283,9 @@ test.describe('Canvas drag-and-drop (VIS-771 / D-3)', () => {
     const rowHandle = await revealRowHandle(page, 0);
     const gapZone = page.getByTestId(`canvas-dropzone-row-before-${rows.length}`);
     await dndDrag(page, rowHandle, gapZone);
-    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    // A ROW drag renders the dedicated row pill (VIS-901 #5) — a row has no
+    // referenced object type, so it must NOT borrow the Library/chart pill.
+    await expect(page.getByTestId('canvas-row-drag-preview')).toBeVisible({ timeout: 4000 });
     await page.mouse.up();
 
     // The row order changes and the moved row lands LAST.

--- a/viewer/e2e/stories/canvas-flip-lineage.spec.mjs
+++ b/viewer/e2e/stories/canvas-flip-lineage.spec.mjs
@@ -1,0 +1,126 @@
+/**
+ * Story: Canvas flip-to-lineage (VIS-785 / Track D D-6).
+ *
+ * Each canvas leaf item carries a flip toggle (revealed on hover/selection); the
+ * flip opens the item's lineage neighbourhood card — the DELIVERED Track-C
+ * lineage surface (<LibraryRowFlipPopover>) anchored to the slot, with the live
+ * selector input and an Expand affordance that routes the subject to the
+ * Workspace lineage lens (E-1). Multi-flip is allowed; the affordance is
+ * suppressed during a drag; `prefers-reduced-motion` is honored.
+ *
+ * Deferred (design-blocked, see PR): the bespoke C-2 bounded-rendering card,
+ * the CSS-3D in-slot rotation (<ItemFlipCard>), and the standalone
+ * <ItemLineageModal>. Those depend on the still-pending D-4/D-5/D-6 briefs +
+ * the unbuilt standalone <MiniLineageCard> (VIS-780); this story validates the
+ * delivered core gesture.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
+ *   VISIVO_SANDBOX_NAME=dtrack bash scripts/sandbox.sh start
+ *   # then: VIS_FLIP_BASE=http://localhost:3050 npx playwright test canvas-flip-lineage
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_FLIP_BASE || 'http://localhost:3050';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-flip-layer')).toBeAttached({ timeout: WAIT });
+  await page.waitForTimeout(600);
+};
+
+// Reveal the flip button for a leaf item by setting hover + selection via the
+// store (the flip layer reads workspaceCanvasHoverKey / selection). The button
+// sits over the Plotly chart for hit-testing, so we click it via element
+// dispatch rather than a coordinate click (same idiom the DnD story uses).
+const revealFlip = async (page, itemPath) => {
+  await page.evaluate(k => {
+    const s = window.useStore.getState();
+    s.setWorkspaceOutlineSelectedKey(k);
+    if (s.setWorkspaceCanvasHoverKey) s.setWorkspaceCanvasHoverKey(k);
+  }, itemPath);
+  await expect(page.getByTestId(`canvas-flip-button-${itemPath}`)).toBeVisible({ timeout: WAIT });
+};
+
+const clickFlip = async (page, itemPath) => {
+  await page.getByTestId(`canvas-flip-button-${itemPath}`).evaluate(el => el.click());
+};
+
+test.describe('Canvas flip-to-lineage (VIS-785 / D-6)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('a leaf item reveals a flip toggle on hover/selection', async () => {
+    await openCanvas(page);
+    await revealFlip(page, 'row.0.item.0');
+    await expect(page.getByTestId('canvas-flip-button-row.0.item.0')).toHaveAttribute('aria-pressed', 'false');
+    await page.screenshot({ path: `${SCREENS}/vis785-01-flip-button.png`, fullPage: true });
+  });
+
+  test('flipping opens the lineage card (ancestors/subject/descendants + selector)', async () => {
+    await openCanvas(page);
+    await revealFlip(page, 'row.0.item.0');
+    await clickFlip(page, 'row.0.item.0');
+
+    // The lineage card opens, anchored to the slot, with the live selector input.
+    const card = page.getByTestId('canvas-flip-card-row.0.item.0');
+    await expect(card).toBeVisible({ timeout: WAIT });
+    await expect(
+      page.getByTestId('canvas-flip-card-row.0.item.0-selector-input')
+    ).toBeVisible();
+    // The subject row reflects the item's referenced object.
+    await expect(page.getByTestId('canvas-flip-card-row.0.item.0-name')).toBeVisible();
+    await page.screenshot({ path: `${SCREENS}/vis785-02-lineage-card.png`, fullPage: true });
+  });
+
+  test('editing the selector re-walks the lineage live', async () => {
+    await openCanvas(page);
+    await revealFlip(page, 'row.0.item.0');
+    await clickFlip(page, 'row.0.item.0');
+    const input = page.getByTestId('canvas-flip-card-row.0.item.0-selector-input');
+    await expect(input).toBeVisible({ timeout: WAIT });
+    // Clamp to ancestors-only — the card stays mounted and re-renders.
+    await input.fill('+');
+    await input.press('Backspace');
+    await expect(page.getByTestId('canvas-flip-card-row.0.item.0')).toBeVisible();
+  });
+
+  test('flip is a toggle — flipping back closes the card', async () => {
+    await openCanvas(page);
+    await revealFlip(page, 'row.0.item.0');
+    await clickFlip(page, 'row.0.item.0');
+    await expect(page.getByTestId('canvas-flip-card-row.0.item.0')).toBeVisible({ timeout: WAIT });
+    await clickFlip(page, 'row.0.item.0');
+    await expect(page.getByTestId('canvas-flip-card-row.0.item.0')).toHaveCount(0);
+  });
+
+  test('no console errors across the flip gestures', async () => {
+    const NOISE = ['favicon', 'DevTools', 'react-cool', 'ResizeObserver', 'compile'];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/stories/canvas-keyboard-nav.spec.mjs
+++ b/viewer/e2e/stories/canvas-keyboard-nav.spec.mjs
@@ -1,0 +1,178 @@
+/**
+ * Story: Canvas-direct keyboard navigation + a11y (VIS-790 / Track D D-7).
+ *
+ * The Workspace dashboard canvas mounts a keyboard focus surface
+ * (<CanvasKeyboardLayer>): a `role="application"` region a keyboard user can Tab
+ * into and then drive the SAME selection the pointer / Outline / breadcrumb
+ * drive, with an `aria-live` region announcing each move:
+ *
+ *   - ←/→         step among siblings (items in a row, rows among rows).
+ *   - ↑           up the hierarchy (item → parent row → dashboard).
+ *   - ↓           down into the first child.
+ *   - Tab / ⇧Tab  cycle the current row's items.
+ *   - ⌘↑ / ⌘↓     reorder the selected node (persisted via commitCanvasConfig).
+ *   - Enter        focus the right-rail Edit form's first field.
+ *   - Esc          deselect to the dashboard root.
+ *
+ * Works across the FULL incl-nested tree (it reuses the breadcrumbNav model that
+ * VIS-903 + G-2 share). Driven against `nested-layouts-dashboard` so the nested
+ * descent / sibling stepping is exercised end-to-end.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
+ *   VISIVO_SANDBOX_NAME=dtrack bash scripts/sandbox.sh start
+ *   # then: VIS_KBD_BASE=http://localhost:3050 npx playwright test canvas-keyboard-nav
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_KBD_BASE || 'http://localhost:3050';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'nested-layouts-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1600 } });
+
+const selectedKey = page =>
+  page.evaluate(() => window.useStore.getState().workspaceOutlineSelectedKey);
+
+const setKey = (page, key) =>
+  page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-keyboard-region')).toBeAttached({ timeout: WAIT });
+  await page.waitForTimeout(600);
+};
+
+const focusRegion = async page => {
+  await page.getByTestId('canvas-keyboard-region').evaluate(el => el.focus());
+};
+
+test.describe('Canvas keyboard navigation (VIS-790 / D-7)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('the canvas exposes a focusable application region with ARIA contract', async () => {
+    await openCanvas(page);
+    const region = page.getByTestId('canvas-keyboard-region');
+    await expect(region).toHaveAttribute('role', 'application');
+    await expect(region).toHaveAttribute('tabindex', '0');
+    await expect(region).toHaveAttribute('aria-keyshortcuts', /Arrow/);
+    const announce = page.getByTestId('canvas-keyboard-announce');
+    await expect(announce).toHaveAttribute('aria-live', 'polite');
+    await page.screenshot({ path: `${SCREENS}/vis790-01-a11y-region.png`, fullPage: true });
+  });
+
+  test('arrow keys move the selection DOWN into and ACROSS the tree', async () => {
+    await openCanvas(page);
+    await setKey(page, 'dashboard');
+    await focusRegion(page);
+
+    // ↓ descends: dashboard → row.0 → row.0.item.0 …
+    await page.keyboard.press('ArrowDown');
+    expect(await selectedKey(page)).toBe('row.0');
+    await page.keyboard.press('ArrowDown');
+    expect(await selectedKey(page)).toBe('row.0.item.0');
+
+    // ↓ goes back UP a row, ↑ to parent; ←/→ cycles siblings at depth.
+    // Move to a row that has multiple items to exercise ←/→.
+    await setKey(page, 'row.1.item.0');
+    await focusRegion(page);
+    await page.keyboard.press('ArrowRight');
+    expect(await selectedKey(page)).toBe('row.1.item.1');
+    await page.keyboard.press('ArrowUp'); // up to the parent row
+    expect(await selectedKey(page)).toBe('row.1');
+
+    await page.screenshot({ path: `${SCREENS}/vis790-02-arrow-nav.png`, fullPage: true });
+  });
+
+  test('arrow keys navigate INTO a nested container (incl-nested tree)', async () => {
+    await openCanvas(page);
+    // row.1.item.1 is a container in the nested-layouts fixture (sidebar stack).
+    await setKey(page, 'row.1.item.1');
+    await focusRegion(page);
+    // ↓ descends into the container's first sub-row, then its first item.
+    await page.keyboard.press('ArrowDown');
+    expect(await selectedKey(page)).toBe('row.1.item.1.row.0');
+    await page.keyboard.press('ArrowDown');
+    expect(await selectedKey(page)).toBe('row.1.item.1.row.0.item.0');
+    // ↑ climbs back out to the sub-row, then to the container.
+    await page.keyboard.press('ArrowUp');
+    expect(await selectedKey(page)).toBe('row.1.item.1.row.0');
+    await page.screenshot({ path: `${SCREENS}/vis790-03-nested-nav.png`, fullPage: true });
+  });
+
+  test('⌘↑/⌘↓ reorders the selected row and the selection follows it', async () => {
+    await openCanvas(page);
+    const heightsBefore = await page.evaluate(name => {
+      const s = window.useStore.getState();
+      const d = (s.dashboards || []).find(x => x.name === name);
+      const cfg = d ? d.config || d : null;
+      return (cfg?.rows || []).map(r => r.height);
+    }, DASHBOARD);
+    expect(heightsBefore.length).toBeGreaterThanOrEqual(2);
+
+    // Select row 0 and move it down one.
+    await setKey(page, 'row.0');
+    await focusRegion(page);
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowDown' : 'Control+ArrowDown');
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(name => {
+            const s = window.useStore.getState();
+            const d = (s.dashboards || []).find(x => x.name === name);
+            const cfg = d ? d.config || d : null;
+            return (cfg?.rows || []).map(r => r.height).join(',');
+          }, DASHBOARD),
+        { timeout: WAIT }
+      )
+      .not.toBe(heightsBefore.join(','));
+    // The selection follows the moved row to index 1.
+    expect(await selectedKey(page)).toBe('row.1');
+    await page.screenshot({ path: `${SCREENS}/vis790-04-keyboard-reorder.png`, fullPage: true });
+  });
+
+  test('Escape deselects to the dashboard root', async () => {
+    await openCanvas(page);
+    await setKey(page, 'row.1.item.0');
+    await focusRegion(page);
+    await page.keyboard.press('Escape');
+    expect(await selectedKey(page)).toBe('dashboard');
+  });
+
+  test('focusing the region announces the current position to screen readers', async () => {
+    await openCanvas(page);
+    await setKey(page, 'row.1.item.0');
+    await focusRegion(page);
+    await expect(page.getByTestId('canvas-keyboard-announce')).toHaveText(/Row 2, item 1 selected/, {
+      timeout: WAIT,
+    });
+  });
+
+  test('no console errors across the keyboard gestures', async () => {
+    const NOISE = ['favicon', 'DevTools', 'react-cool', 'ResizeObserver', 'compile'];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/stories/canvas-nested-dnd.spec.mjs
+++ b/viewer/e2e/stories/canvas-nested-dnd.spec.mjs
@@ -1,0 +1,322 @@
+/**
+ * Story: Canvas drag/resize for NESTED components (VIS-903 / Track D).
+ *
+ * The canvas DnD + resize overlays now RECURSE through nested `Item.rows`, so a
+ * component nested inside a container item gets the same affordances as a
+ * top-level one: a drag grip (gated on hover/selection), drop zones (reorder
+ * within / between nested rows, into nested containers), and width/height resize
+ * edges. The composite `data-canvas-path` keys already encode arbitrary depth;
+ * VIS-903 is purely the MODEL builders emitting affordances for the deeper nodes.
+ *
+ * Driven against the integration project's `nested-layouts-dashboard`, which has
+ * container items holding sub-rows at depth 2 and 3.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
+ *   VISIVO_SANDBOX_NAME=dtrack bash scripts/sandbox.sh start
+ *   # then: VIS_CANVAS_NESTED_BASE=http://localhost:3050 npx playwright test canvas-nested-dnd
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_CANVAS_NESTED_BASE || 'http://localhost:3050';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'nested-layouts-dashboard';
+const WAIT = 20000;
+
+// A wide, tall viewport so the nested container rows lay out with real boxes.
+test.use({ viewport: { width: 1600, height: 1600 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+const itemKey = it => {
+  if (!it || typeof it !== 'object') return '(slot)';
+  const leaf = it.chart ?? it.table ?? it.markdown ?? it.input;
+  if (leaf == null) return Array.isArray(it.rows) ? '(container)' : '(slot)';
+  if (typeof leaf === 'string') return leaf;
+  return leaf.name || leaf.path || JSON.stringify(leaf).slice(0, 64);
+};
+
+// Resolve the value at a nested config path (array of {key,index} segments) so a
+// test can read the items of a nested row to assert ordering.
+const readNestedItems = async (page, rowPath) =>
+  page.evaluate(
+    ([name, rowPath]) => {
+      const s = window.useStore.getState();
+      const d = (s.dashboards || []).find(x => x.name === name);
+      const cfg = d ? d.config || d : null;
+      if (!cfg) return null;
+      const parts = rowPath.split('.');
+      let rows = cfg.rows;
+      let node = null;
+      for (let i = 0; i < parts.length; i += 2) {
+        const kind = parts[i];
+        const idx = Number(parts[i + 1]);
+        if (kind === 'row') {
+          node = rows[idx];
+          rows = null;
+        } else {
+          node = (node.items || [])[idx];
+          rows = node.rows;
+        }
+      }
+      const items = node && Array.isArray(node.items) ? node.items : [];
+      return items.map(it => {
+        const leaf = it.chart ?? it.table ?? it.markdown ?? it.input;
+        return typeof leaf === 'string' ? leaf : leaf?.name || leaf?.path || '(slot)';
+      });
+    },
+    [DASHBOARD, rowPath]
+  );
+
+// Find the FIRST nested row (`row.A.item.B.row.C`) in the dashboard that has ≥2
+// items, so an in-nested-row reorder is meaningful. Returns its rowPath +
+// the item count, or null.
+const findNestedMultiItemRow = async page => {
+  const rows = await readRows(page);
+  const walk = (siblingRows, prefix) => {
+    for (let ri = 0; ri < siblingRows.length; ri += 1) {
+      const row = siblingRows[ri];
+      const rowPath = `${prefix}row.${ri}`;
+      const items = Array.isArray(row.items) ? row.items : [];
+      // A nested row (prefix non-empty) with ≥2 leaf items.
+      if (prefix && items.length >= 2 && items.every(it => !Array.isArray(it.rows))) {
+        return { rowPath, count: items.length };
+      }
+      for (let ii = 0; ii < items.length; ii += 1) {
+        const it = items[ii];
+        if (Array.isArray(it.rows) && it.rows.length) {
+          const found = walk(it.rows, `${rowPath}.item.${ii}.`);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  };
+  return walk(rows, '');
+};
+
+// Find the first container item (`row.A.item.B` with ≥2 sub-rows) so a
+// nested-row reorder (between sub-rows) is meaningful.
+const findContainerWithSubRows = async page => {
+  const rows = await readRows(page);
+  const walk = (siblingRows, prefix) => {
+    for (let ri = 0; ri < siblingRows.length; ri += 1) {
+      const row = siblingRows[ri];
+      const rowPath = `${prefix}row.${ri}`;
+      const items = Array.isArray(row.items) ? row.items : [];
+      for (let ii = 0; ii < items.length; ii += 1) {
+        const it = items[ii];
+        if (Array.isArray(it.rows) && it.rows.length >= 2) {
+          return { containerPath: `${rowPath}.item.${ii}`, subRowCount: it.rows.length };
+        }
+        if (Array.isArray(it.rows) && it.rows.length) {
+          const found = walk(it.rows, `${rowPath}.item.${ii}.`);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  };
+  return walk(rows, '');
+};
+
+const dndDrag = async (page, source, target) => {
+  await expect(source).toBeVisible();
+  await page.waitForTimeout(150);
+  const tb = await target.boundingBox();
+  expect(tb, 'target has a box').toBeTruthy();
+  const tx = tb.x + tb.width / 2;
+  const ty = tb.y + tb.height / 2;
+  await source.evaluate(el => {
+    const r = el.getBoundingClientRect();
+    window.__nestedDndSrc = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    const ev = (x, y) => ({
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      pointerId: 1,
+      button: 0,
+      pointerType: 'mouse',
+      isPrimary: true,
+      view: window,
+    });
+    el.dispatchEvent(new PointerEvent('pointerdown', ev(window.__nestedDndSrc.x, window.__nestedDndSrc.y)));
+  });
+  await page.waitForTimeout(40);
+  await page.evaluate(
+    ([tx, ty]) => {
+      const s = window.__nestedDndSrc;
+      const ev = (x, y) => ({
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        button: 0,
+        pointerType: 'mouse',
+        isPrimary: true,
+        view: window,
+      });
+      document.dispatchEvent(new PointerEvent('pointermove', ev(s.x + 10, s.y + 10)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev((s.x + tx) / 2, (s.y + ty) / 2)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev(tx, ty)));
+      document.dispatchEvent(new PointerEvent('pointermove', ev(tx, ty)));
+    },
+    [tx, ty]
+  );
+  await page.waitForTimeout(40);
+};
+
+const revealItemHandle = async (page, itemPath) => {
+  await page
+    .locator(`[data-canvas-path="${itemPath}"]`)
+    .first()
+    .click({ position: { x: 6, y: 6 }, force: true });
+  const handle = page.getByTestId(`canvas-drag-handle-${itemPath}`);
+  await expect(handle).toBeVisible({ timeout: WAIT });
+  return handle;
+};
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-dnd-layer')).toBeAttached({ timeout: WAIT });
+  // Let nested charts settle so their slots have stable boxes.
+  await page.waitForTimeout(800);
+};
+
+test.describe('Canvas nested DnD + resize (VIS-903)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('a NESTED item exposes a drag grip + resize edges on selection', async () => {
+    await openCanvas(page);
+    const nested = await findNestedMultiItemRow(page);
+    expect(nested, 'the nested-layouts dashboard has a nested multi-item row').toBeTruthy();
+
+    const firstItemPath = `${nested.rowPath}.item.0`;
+    // Selecting the nested item reveals its grip (depth > 1) — the VIS-903 fix.
+    const handle = await revealItemHandle(page, firstItemPath);
+    await expect(handle).toHaveAttribute('data-canvas-handle-kind', 'item');
+    // The resize layer paints a width edge on the selected nested item.
+    await expect(page.getByTestId(`canvas-resize-width-${firstItemPath}`)).toBeVisible({
+      timeout: WAIT,
+    });
+    await page.screenshot({ path: `${SCREENS}/vis903-01-nested-affordances.png`, fullPage: true });
+  });
+
+  test('drag a NESTED item to its row end → gesture reaches the shared context + persists', async () => {
+    // The nested multi-item rows in this fixture are KPI clusters of IDENTICAL
+    // refs (indicator_chart ×N), so an order-by-ref assertion can't distinguish
+    // them. This test proves the NESTED item grip drives a real drag that reaches
+    // the SAME shared <WorkspaceDndContext> (overlay pill shows) and persists a
+    // backend-valid config (length preserved, no 400). The order-distinct proof
+    // lives in the sub-ROW reorder test below (distinct charts per sub-row).
+    await openCanvas(page);
+    const nested = await findNestedMultiItemRow(page);
+    expect(nested).toBeTruthy();
+    const before = await readNestedItems(page, nested.rowPath);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+
+    const handle = await revealItemHandle(page, `${nested.rowPath}.item.0`);
+    const endZone = page.getByTestId(`canvas-dropzone-${nested.rowPath}-end`);
+    await expect(endZone).toBeAttached({ timeout: WAIT });
+    await dndDrag(page, handle, endZone);
+    // The shared drag overlay pill proves the nested grip reaches the SAME
+    // shell-level DndContext (no second context for nested nodes).
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // The nested row keeps its item count (a reorder never adds/drops items).
+    await expect
+      .poll(async () => (await readNestedItems(page, nested.rowPath))?.length, { timeout: WAIT })
+      .toBe(before.length);
+    await page.screenshot({ path: `${SCREENS}/vis903-02-nested-item-reordered.png`, fullPage: true });
+  });
+
+  test('reorder sub-ROWS within a container → persists to the container config', async () => {
+    await openCanvas(page);
+    const container = await findContainerWithSubRows(page);
+    expect(container, 'the dashboard has a container with ≥2 sub-rows').toBeTruthy();
+
+    const firstSubRowPath = `${container.containerPath}.row.0`;
+    const sig = async () => {
+      const rows = await readRows(page);
+      // Read the container's sub-row signatures.
+      const parts = container.containerPath.split('.');
+      let node = null;
+      let cursor = rows;
+      for (let i = 0; i < parts.length; i += 2) {
+        const idx = Number(parts[i + 1]);
+        if (parts[i] === 'row') {
+          node = cursor[idx];
+          cursor = null;
+        } else {
+          node = (node.items || [])[idx];
+          cursor = node.rows;
+        }
+      }
+      return (node.rows || []).map(r => (r.items || []).map(itemKey).join('|')).join('#');
+    };
+    const beforeSig = await sig();
+
+    // Reveal the first sub-row's grip by selecting its first item, then drag the
+    // ROW grip to the trailing append band of the container's sibling group.
+    await revealItemHandle(page, `${firstSubRowPath}.item.0`);
+    const rowHandle = page.getByTestId(`canvas-drag-handle-${firstSubRowPath}`);
+    await expect(rowHandle).toBeVisible({ timeout: WAIT });
+    const appendBand = page.getByTestId(
+      `canvas-dropzone-${container.containerPath}.row-before-${container.subRowCount}`
+    );
+    await expect(appendBand).toBeAttached({ timeout: WAIT });
+    await dndDrag(page, rowHandle, appendBand);
+    await expect(page.getByTestId('canvas-row-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    await expect.poll(async () => sig(), { timeout: WAIT }).not.toBe(beforeSig);
+    await page.screenshot({ path: `${SCREENS}/vis903-03-nested-rows-reordered.png`, fullPage: true });
+  });
+
+  test('no console errors AND no auto-save 400 across the nested gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+      'compile',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'nested DnD must persist backend-valid config (sanitize)').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/stories/canvas-wrap-container.spec.mjs
+++ b/viewer/e2e/stories/canvas-wrap-container.spec.mjs
@@ -1,0 +1,215 @@
+/**
+ * Story: Canvas wrap-in-container (VIS-781 / Track D D-5).
+ *
+ * Right-clicking a leaf item on the Workspace dashboard canvas opens a context
+ * menu (<CanvasContextMenu>) with the D-5 structural actions:
+ *   - Wrap in container   (leaf → `Item.rows` container holding the original)
+ *   - Add row inside       (container → +empty sub-row)
+ *   - Add item to row       (row → +empty slot)
+ *   - Unwrap container      (trivial 1×1 container → back to the leaf)
+ *
+ * Each commits through the shell's shared commitCanvasConfig (sanitize →
+ * optimistic → save) and fires `canvas_action`. No depth limit (Q12).
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
+ *   VISIVO_SANDBOX_NAME=dtrack bash scripts/sandbox.sh start
+ *   # then: VIS_WRAP_BASE=http://localhost:3050 npx playwright test canvas-wrap-container
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_WRAP_BASE || 'http://localhost:3050';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+// Read the item object at `row.A.item.B` (top-level only — enough for this story).
+const readItem = async (page, ri, ii) => {
+  const rows = await readRows(page);
+  return rows[ri]?.items?.[ii] ?? null;
+};
+
+// A deterministic two-row layout — row 0 has TWO leaf items, row 1 has one — so
+// every test starts from the same shape regardless of what a prior run's real
+// saves left on disk (the canvas persists structural edits). Seeded through the
+// store's optimistic + save path (the same path the menu commits through).
+const SEED_CONFIG = {
+  rows: [
+    {
+      height: 'medium',
+      items: [
+        { width: 9, chart: 'ref(a-very-fibonacci-waterfall)' },
+        { width: 2, chart: 'ref(aggregated-fib)' },
+      ],
+    },
+    { height: 'medium', items: [{ width: 3, chart: 'ref(fibonacci-plane)' }] },
+  ],
+};
+
+const seedConfig = async page => {
+  await page.evaluate(
+    ([name, cfg]) => {
+      const s = window.useStore.getState();
+      s.updateDashboardConfigOptimistic(name, cfg);
+      s.saveDashboard(name, cfg);
+    },
+    [DASHBOARD, SEED_CONFIG]
+  );
+  // Let the optimistic swap reflow the canvas to the seeded shape.
+  await page.waitForTimeout(400);
+};
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await page.waitForTimeout(400);
+  // Reset to the canonical two-leaf layout so each test is deterministic.
+  await seedConfig(page);
+  await expect(page.locator('[data-canvas-path="row.0.item.1"]').first()).toBeVisible({
+    timeout: WAIT,
+  });
+  await page.waitForTimeout(300);
+};
+
+// Right-click the item slot at `itemPath`. `force` so the Plotly chart overlay
+// (which sits above the selection overlay) doesn't intercept the contextmenu.
+// Settles the canvas first so a prior commit's reflow can't detach the freshly
+// opened menu mid-click.
+const rightClickItem = async (page, itemPath) => {
+  await page.waitForTimeout(250); // let any prior optimistic commit reflow settle
+  const slot = page.locator(`[data-canvas-path="${itemPath}"]`).first();
+  await expect(slot).toBeVisible({ timeout: WAIT });
+  await slot.click({ button: 'right', position: { x: 8, y: 8 }, force: true });
+  await expect(page.getByTestId('canvas-context-menu')).toBeVisible({ timeout: WAIT });
+  await page.waitForTimeout(120); // let the menu paint fully before interacting
+};
+
+// Click a menu item, tolerating a single reflow-driven detach (the menu can
+// re-render once as the optimistic config swap settles before the click lands).
+const clickMenuItem = async (page, testid) => {
+  const item = page.getByTestId(testid);
+  await expect(item).toBeVisible({ timeout: WAIT });
+  await item.click({ force: true });
+};
+
+test.describe('Canvas wrap-in-container (VIS-781 / D-5)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('right-click a leaf item → context menu offers Wrap in container', async () => {
+    await openCanvas(page);
+    await rightClickItem(page, 'row.0.item.0');
+    await expect(page.getByTestId('canvas-ctx-wrap')).toBeVisible();
+    await expect(page.getByTestId('canvas-ctx-add-item')).toBeVisible();
+    // A leaf has no Unwrap / Add-row-inside.
+    await expect(page.getByTestId('canvas-ctx-unwrap')).toHaveCount(0);
+    await page.screenshot({ path: `${SCREENS}/vis781-01-context-menu.png`, fullPage: true });
+    await page.keyboard.press('Escape');
+  });
+
+  test('Wrap converts the leaf into a row-container holding the original', async () => {
+    await openCanvas(page);
+    const before = await readItem(page, 0, 0);
+    expect(before, 'a leaf item exists at row.0.item.0').toBeTruthy();
+    expect(Array.isArray(before.rows)).toBeFalsy();
+    const beforeWidth = before.width || 1;
+
+    await rightClickItem(page, 'row.0.item.0');
+    await clickMenuItem(page, 'canvas-ctx-wrap');
+
+    // The item becomes a container holding the original leaf as its single inner.
+    await expect
+      .poll(async () => Array.isArray((await readItem(page, 0, 0))?.rows), { timeout: WAIT })
+      .toBe(true);
+    const after = await readItem(page, 0, 0);
+    expect(after.width).toBe(beforeWidth); // container inherits the slot width
+    expect(after.rows).toHaveLength(1);
+    expect(after.rows[0].items).toHaveLength(1);
+    await page.screenshot({ path: `${SCREENS}/vis781-02-wrapped.png`, fullPage: true });
+  });
+
+  test('a wrapped (container) item offers Add row inside + Unwrap', async () => {
+    await openCanvas(page);
+    // Wrap the fresh leaf at row.0.item.0 → it becomes a trivial container.
+    await rightClickItem(page, 'row.0.item.0');
+    await clickMenuItem(page, 'canvas-ctx-wrap');
+    await expect
+      .poll(async () => Array.isArray((await readItem(page, 0, 0))?.rows), { timeout: WAIT })
+      .toBe(true);
+
+    // Right-clicking the container (its inner leaf fills the slot) still offers
+    // the container actions via the nearest-container-ancestor resolution.
+    await rightClickItem(page, 'row.0.item.0');
+    await expect(page.getByTestId('canvas-ctx-add-row-inside')).toBeVisible();
+    await expect(page.getByTestId('canvas-ctx-unwrap')).toBeVisible();
+
+    // Add a row inside → the container now has 2 sub-rows.
+    await clickMenuItem(page, 'canvas-ctx-add-row-inside');
+    await expect
+      .poll(async () => (await readItem(page, 0, 0))?.rows?.length, { timeout: WAIT })
+      .toBe(2);
+    await page.screenshot({ path: `${SCREENS}/vis781-03-add-row-inside.png`, fullPage: true });
+  });
+
+  test('Unwrap a trivial container restores the leaf (round-trip)', async () => {
+    await openCanvas(page);
+    // Wrap the fresh leaf at row.0.item.1 → trivial 1×1 container.
+    await rightClickItem(page, 'row.0.item.1');
+    await clickMenuItem(page, 'canvas-ctx-wrap');
+    await expect
+      .poll(async () => Array.isArray((await readItem(page, 0, 1))?.rows), { timeout: WAIT })
+      .toBe(true);
+
+    // Now unwrap it back to a leaf.
+    await rightClickItem(page, 'row.0.item.1');
+    await expect(page.getByTestId('canvas-ctx-unwrap')).toBeVisible();
+    await clickMenuItem(page, 'canvas-ctx-unwrap');
+
+    // The container collapses back to a leaf (no `rows`); the chart ref survives.
+    await expect
+      .poll(async () => Array.isArray((await readItem(page, 0, 1))?.rows), { timeout: WAIT })
+      .toBe(false);
+    const leaf = await readItem(page, 0, 1);
+    expect(typeof leaf.chart === 'string' || (leaf.chart && leaf.chart.name)).toBeTruthy();
+    await page.screenshot({ path: `${SCREENS}/vis781-04-unwrapped.png`, fullPage: true });
+  });
+
+  test('no console errors AND no auto-save 400 across the wrap gestures', async () => {
+    const NOISE = ['favicon', 'DevTools', 'react-cool', 'ResizeObserver', 'compile'];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'wrap must persist backend-valid config (sanitize)').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useStore from '../../../../stores/store';
+import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import {
+  wrapItemInContainer,
+  unwrapTrivialContainer,
+  isTriviallyWrappedContainer,
+  addRowInsideContainer,
+  addItemToRow,
+  parseCanvasPath,
+} from './canvasReorder';
+
+/**
+ * CanvasContextMenu — VIS-781 / Track D D-5.
+ *
+ * The right-click context menu for the Workspace dashboard canvas. A SIBLING
+ * over the render-only <Dashboard> (mounted by ProjectCanvas alongside the
+ * selection / DnD / resize overlays), it listens for `contextmenu` on the canvas
+ * root, resolves the right-clicked row/item via the same composite
+ * `data-canvas-path` markers the selection overlay reads, and offers the D-5
+ * structural actions:
+ *
+ *   - Wrap in container   (leaf item)      → wrapItemInContainer
+ *   - Add item to row      (any row)        → addItemToRow
+ *   - Add row inside       (container item) → addRowInsideContainer
+ *   - Unwrap container     (trivial 1×1)    → unwrapTrivialContainer
+ *
+ * Each action commits through the shell's shared `commitCanvasConfig` (sanitize
+ * → optimistic → save) — the SAME path the DnD router + Add-Row menu use — and
+ * fires a `canvas_action` telemetry event. There is NO depth limit (Q12): a leaf
+ * can be wrapped arbitrarily deep with no warning.
+ *
+ * Mulberry (`#713b57`) is the active/selection colour; type colours (for the
+ * future per-type menu chrome) come from objectTypeConfigs.js — none are
+ * hand-rolled here.
+ */
+
+const MULBERRY = '#713b57';
+
+// Classify a composite key as item / row / chrome (mirrors the selection
+// overlay's kindForKey).
+const kindForKey = key => {
+  if (!key || key === 'dashboard') return 'chrome';
+  const parts = key.split('.');
+  return parts[parts.length - 2] === 'item' ? 'item' : 'row';
+};
+
+// Is the item at `key` a container (Item.rows non-empty)? Read off the live
+// config rather than the DOM so the menu actions match what will persist.
+const isContainerItem = (config, key) => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return false;
+  let rows = Array.isArray(config?.rows) ? config.rows : null;
+  let item = null;
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    if (seg.kind === 'row') {
+      if (!rows || !rows[seg.index]) return false;
+      rows = Array.isArray(rows[seg.index].items) ? rows[seg.index].items : null;
+    } else {
+      if (!rows || !rows[seg.index]) return false;
+      item = rows[seg.index];
+      rows = Array.isArray(item.rows) ? item.rows : null;
+    }
+  }
+  return !!item && Array.isArray(item.rows) && item.rows.length > 0;
+};
+
+// The ROW path that owns the item at an item key (for "Add item to row" from an
+// item right-click): drop the trailing `item.<n>` segment.
+const rowPathForItemKey = key => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return null;
+  return segments
+    .slice(0, -1)
+    .map(s => `${s.kind}.${s.index}`)
+    .join('.');
+};
+
+// The item path of the NEAREST CONTAINER ancestor of `key` (an enclosing
+// `Item.rows`), or null. Right-clicking a leaf that fills its container's slot
+// resolves (innermost-wins) to the leaf; this lets the menu still offer the
+// enclosing container's actions (Add row inside / Unwrap) without the user
+// having to hit the container's thin chrome. A container key returns itself.
+const containerAncestorPath = (config, key) => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length) return null;
+  // Walk outward from the deepest item, returning the first item path that is
+  // itself a container (the key itself counts if it's a container).
+  for (let end = segments.length; end >= 2; end -= 1) {
+    if (segments[end - 1].kind !== 'item') continue;
+    const path = segments
+      .slice(0, end)
+      .map(s => `${s.kind}.${s.index}`)
+      .join('.');
+    if (isContainerItem(config, path)) return path;
+  }
+  return null;
+};
+
+const MenuItem = ({ testid, label, hint, onClick, danger }) => (
+  <button
+    type="button"
+    role="menuitem"
+    data-testid={testid}
+    onClick={onClick}
+    className="flex w-full items-center justify-between gap-6 rounded px-2.5 py-1.5 text-left text-[12.5px] text-gray-700 transition-colors hover:bg-[#f9f6f8] focus:bg-[#f9f6f8] focus:outline-none"
+    style={danger ? { color: '#b91c1c' } : undefined}
+  >
+    <span className="font-medium">{label}</span>
+    {hint && <span className="text-[10.5px] text-gray-400">{hint}</span>}
+  </button>
+);
+
+const CanvasContextMenu = ({ rootRef, dashboardName }) => {
+  const dashboards = useStore(s => s.dashboards);
+  const setSelectedKey = useStore(s => s.setWorkspaceOutlineSelectedKey);
+  const commitCanvasConfig = useWorkspaceCommit();
+  // menu: null | { x, y, key, kind }
+  const [menu, setMenu] = useState(null);
+  const menuRef = useRef(null);
+
+  const dashboardConfig = useMemo(() => {
+    const entry = (dashboards || []).find(d => d.name === dashboardName);
+    if (!entry) return null;
+    return entry.config || entry;
+  }, [dashboards, dashboardName]);
+
+  // Resolve a right-click to a row/item key via the innermost data-canvas-path.
+  const onContextMenu = useCallback(
+    e => {
+      const root = rootRef.current;
+      if (!root || !root.contains(e.target)) return;
+      const el = e.target.closest('[data-canvas-path]');
+      const key = el && root.contains(el) ? el.getAttribute('data-canvas-path') : null;
+      const kind = kindForKey(key);
+      // Only offer the menu for a real row/item target (chrome right-click falls
+      // through to the browser default so the canvas background stays neutral).
+      if (!key || kind === 'chrome') return;
+      e.preventDefault();
+      // Right-click also selects (matches the left-click selection contract).
+      if (setSelectedKey) setSelectedKey(key);
+      const rootRect = root.getBoundingClientRect();
+      setMenu({ x: e.clientX - rootRect.left, y: e.clientY - rootRect.top, key, kind });
+    },
+    [rootRef, setSelectedKey]
+  );
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    root.addEventListener('contextmenu', onContextMenu);
+    return () => root.removeEventListener('contextmenu', onContextMenu);
+  }, [rootRef, onContextMenu]);
+
+  // Dismiss on outside click / Escape / scroll.
+  useEffect(() => {
+    if (!menu) return undefined;
+    const onDocPointer = e => {
+      if (menuRef.current && menuRef.current.contains(e.target)) return;
+      setMenu(null);
+    };
+    const onKey = e => {
+      if (e.key === 'Escape') setMenu(null);
+    };
+    document.addEventListener('pointerdown', onDocPointer, true);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', () => setMenu(null), true);
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointer, true);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [menu]);
+
+  const commit = useCallback(
+    (nextConfig, kind, extra) => {
+      if (!dashboardName || typeof commitCanvasConfig !== 'function') return;
+      if (nextConfig === dashboardConfig) {
+        setMenu(null);
+        return;
+      }
+      commitCanvasConfig(dashboardName, nextConfig, { kind });
+      emitWorkspaceEvent('canvas_action', { kind, dashboardName, ...extra });
+      setMenu(null);
+    },
+    [dashboardName, commitCanvasConfig, dashboardConfig]
+  );
+
+  if (!dashboardConfig || !menu) return null;
+
+  const isContainer = menu.kind === 'item' && isContainerItem(dashboardConfig, menu.key);
+  // A leaf can be wrapped. (A container is not a leaf.)
+  const isLeaf = menu.kind === 'item' && !isContainer;
+  // Container actions target the nearest container ancestor — the clicked key
+  // itself if it's a container, else the enclosing container of a leaf that fills
+  // its slot (so "Add row inside" / "Unwrap" are reachable without hitting the
+  // container's thin chrome).
+  const containerPath =
+    menu.kind === 'item' ? containerAncestorPath(dashboardConfig, menu.key) : null;
+  const canUnwrap = !!containerPath && isTriviallyWrappedContainer(dashboardConfig, containerPath);
+  // "Add item to row" targets: an item's parent row, or a row directly.
+  const addItemRowPath = menu.kind === 'item' ? rowPathForItemKey(menu.key) : menu.key;
+
+  return (
+    <div
+      data-testid="canvas-context-menu"
+      ref={menuRef}
+      role="menu"
+      aria-label="Canvas item actions"
+      className="absolute z-50 min-w-[200px] rounded-lg border border-[#e5e0e3] bg-white p-1 shadow-lg"
+      style={{ top: menu.y, left: menu.x }}
+    >
+      <div className="px-2.5 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        {menu.kind === 'item' ? (isContainer ? 'Container' : 'Item') : 'Row'}
+      </div>
+
+      {isLeaf && (
+        <MenuItem
+          testid="canvas-ctx-wrap"
+          label="Wrap in container"
+          hint="⤳ rows"
+          onClick={() =>
+            commit(wrapItemInContainer(dashboardConfig, menu.key), 'wrap_in_container', {
+              path: menu.key,
+            })
+          }
+        />
+      )}
+
+      {containerPath && (
+        <MenuItem
+          testid="canvas-ctx-add-row-inside"
+          label="Add row inside"
+          onClick={() =>
+            commit(addRowInsideContainer(dashboardConfig, containerPath), 'add_row_inside', {
+              path: containerPath,
+            })
+          }
+        />
+      )}
+
+      {addItemRowPath && (
+        <MenuItem
+          testid="canvas-ctx-add-item"
+          label="Add item to row"
+          onClick={() =>
+            commit(addItemToRow(dashboardConfig, addItemRowPath), 'add_item_to_row', {
+              path: addItemRowPath,
+            })
+          }
+        />
+      )}
+
+      {canUnwrap && (
+        <>
+          <div className="my-1 h-px bg-[#f0ebed]" />
+          <MenuItem
+            testid="canvas-ctx-unwrap"
+            label="Unwrap container"
+            hint="→ item"
+            onClick={() =>
+              commit(unwrapTrivialContainer(dashboardConfig, containerPath), 'unwrap_container', {
+                path: containerPath,
+              })
+            }
+          />
+        </>
+      )}
+
+      {/* A pointer-events sink so the mulberry accent reads as the active menu. */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-px top-2 h-4 w-[3px] rounded-r"
+        style={{ background: MULBERRY }}
+      />
+    </div>
+  );
+};
+
+export default CanvasContextMenu;

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
@@ -1,0 +1,153 @@
+/**
+ * CanvasContextMenu tests (VIS-781 / Track D D-5).
+ *
+ * The menu listens for `contextmenu` on the canvas root, resolves the target
+ * via `data-canvas-path`, and offers wrap / unwrap / add-row-inside / add-item.
+ * The shared `commitCanvasConfig` is provided by a stub WorkspaceCommitContext
+ * so we assert the committed config without simulating the whole shell. The pure
+ * reshape logic is covered in canvasReorder.test.js; here we test the menu's
+ * item gating + commit wiring.
+ */
+import React, { useRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CanvasContextMenu from './CanvasContextMenu';
+import useStore from '../../../../stores/store';
+import { WorkspaceCommitProvider } from '../../workspace/WorkspaceDndContext';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+
+// Stub the telemetry emitter (no shell mounted). jest hoists this above the
+// imports, so the mocked module is what the import above resolves to.
+jest.mock('../../workspace/telemetry', () => ({
+  emitWorkspaceEvent: jest.fn(),
+}));
+
+const LEAF_DASH = {
+  name: 'dash',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+    ],
+  },
+};
+
+const CONTAINER_DASH = {
+  name: 'dash',
+  config: {
+    rows: [
+      {
+        height: 'medium',
+        items: [{ width: 12, rows: [{ height: 'small', items: [{ chart: 'ref(c)' }] }] }],
+      },
+    ],
+  },
+};
+
+// Host renders fake Dashboard nodes (carrying data-canvas-path) + the menu under
+// a stub commit provider that captures the committed config.
+const Host = ({ commit, structure = 'leaf' }) => {
+  const rootRef = useRef(null);
+  return (
+    <WorkspaceCommitProvider value={commit}>
+      <div ref={rootRef} style={{ position: 'relative' }} data-testid="host">
+        <div data-canvas-path="row.0" data-testid="r0">
+          {structure === 'leaf' ? (
+            <>
+              <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+              <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+            </>
+          ) : (
+            <div data-canvas-path="row.0.item.0" data-testid="r0i0">
+              <div data-canvas-path="row.0.item.0.row.0" data-testid="n0">
+                <div data-canvas-path="row.0.item.0.row.0.item.0" data-testid="n0i0" />
+              </div>
+            </div>
+          )}
+        </div>
+        <CanvasContextMenu rootRef={rootRef} dashboardName="dash" />
+      </div>
+    </WorkspaceCommitProvider>
+  );
+};
+
+const rightClick = testid =>
+  fireEvent.contextMenu(screen.getByTestId(testid), { clientX: 100, clientY: 100 });
+
+describe('CanvasContextMenu (VIS-781)', () => {
+  beforeEach(() => {
+    emitWorkspaceEvent.mockClear();
+    useStore.setState({ dashboards: [LEAF_DASH], workspaceOutlineSelectedKey: 'dashboard' });
+    // jsdom getBoundingClientRect is zeroed; the menu only needs a root rect.
+  });
+
+  test('no menu until a right-click on a row/item', () => {
+    render(<Host commit={jest.fn()} />);
+    expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+  });
+
+  test('right-clicking a LEAF item shows Wrap + Add item to row, not Unwrap/Add row inside', () => {
+    render(<Host commit={jest.fn()} />);
+    rightClick('r0i0');
+    expect(screen.getByTestId('canvas-context-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-ctx-wrap')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-ctx-add-item')).toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-ctx-add-row-inside')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-ctx-unwrap')).not.toBeInTheDocument();
+  });
+
+  test('right-clicking a ROW shows only Add item to row', () => {
+    render(<Host commit={jest.fn()} />);
+    rightClick('r0');
+    expect(screen.getByTestId('canvas-ctx-add-item')).toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-ctx-wrap')).not.toBeInTheDocument();
+  });
+
+  test('Wrap in container commits the wrapped config + fires telemetry', () => {
+    const commit = jest.fn();
+    render(<Host commit={commit} />);
+    rightClick('r0i0');
+    fireEvent.click(screen.getByTestId('canvas-ctx-wrap'));
+    expect(commit).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = commit.mock.calls[0];
+    expect(name).toBe('dash');
+    expect(Array.isArray(nextConfig.rows[0].items[0].rows)).toBe(true);
+    expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'wrap_in_container', path: 'row.0.item.0' })
+    );
+    // Menu dismisses after the action.
+    expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+  });
+
+  test('right-clicking a CONTAINER item shows Add row inside + Unwrap (trivial 1×1)', () => {
+    useStore.setState({ dashboards: [CONTAINER_DASH] });
+    render(<Host commit={jest.fn()} structure="container" />);
+    rightClick('r0i0');
+    expect(screen.getByTestId('canvas-ctx-add-row-inside')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-ctx-unwrap')).toBeInTheDocument();
+    // A container is not a leaf — no Wrap action.
+    expect(screen.queryByTestId('canvas-ctx-wrap')).not.toBeInTheDocument();
+  });
+
+  test('Unwrap commits the collapsed config', () => {
+    useStore.setState({ dashboards: [CONTAINER_DASH] });
+    const commit = jest.fn();
+    render(<Host commit={commit} structure="container" />);
+    rightClick('r0i0');
+    fireEvent.click(screen.getByTestId('canvas-ctx-unwrap'));
+    const [, nextConfig] = commit.mock.calls[0];
+    expect(nextConfig.rows[0].items[0].chart).toBe('ref(c)');
+    expect(nextConfig.rows[0].items[0].rows).toBeUndefined();
+    expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'unwrap_container' })
+    );
+  });
+
+  test('Escape dismisses the menu', () => {
+    render(<Host commit={jest.fn()} />);
+    rightClick('r0i0');
+    expect(screen.getByTestId('canvas-context-menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasDndLayer.jsx
@@ -238,9 +238,19 @@ const CanvasDropZone = ({ id, box, intent, data }) => {
 
 /**
  * Build the list of handles + drop zones from the live DOM geometry. We read
- * the config (top-level row count + per-row item counts + which items are
- * containers) from the store, then measure each `data-canvas-path` node. The
- * gaps are derived from adjacent item/row boxes.
+ * the config (the FULL nested row/item tree — top-level rows, their items,
+ * which items are containers, and recursively their sub-rows/items) from the
+ * store, then measure each `data-canvas-path` node. The gaps are derived from
+ * adjacent item/row boxes.
+ *
+ * VIS-903: the builder RECURSES through nested `Item.rows`. Every row and item
+ * — at ANY depth — gets the same affordances as a top-level one: a drag grip
+ * (gated on hover/selection), between-items / end-of-row / on-item / in-container
+ * drop zones, and a between-rows insertion band scoped to its sibling rows.
+ * The composite `data-canvas-path` keys already encode arbitrary depth, and the
+ * reorder helpers + router already resolve nested paths (item reorder is gated on
+ * `target.rowPath === dragData.rowPath`, which holds for nested rows), so the
+ * recursion just has to EMIT the affordances for the deeper nodes.
  */
 const useCanvasDndModel = (rootRef, dashboardName, dashboardConfig) => {
   const [model, setModel] = useState({ handles: [], zones: [] });
@@ -263,167 +273,210 @@ const useCanvasDndModel = (rootRef, dashboardName, dashboardConfig) => {
       return el ? measure(el, root) : null;
     };
 
-    rows.forEach((row, ri) => {
-      const rowPath = `row.${ri}`;
-      const rowBox = at(rowPath);
-      if (!rowBox) return;
+    // Emit affordances for ONE item at `itemPath` (its grip, its before-gap
+    // drop zone, and either its on-item or in-container zone). `prevBox` is the
+    // measured box of the previous sibling item (for the before-gap geometry);
+    // `labelCtx` is a human-readable position for the grip's aria-label.
+    const emitItem = (item, itemPath, rowPath, ii, box, prevBox, labelCtx) => {
+      const isContainer = Array.isArray(item.rows) && item.rows.length > 0;
 
-      // Row drag handle.
       handles.push({
-        id: rowPath,
-        box: rowBox,
-        kind: 'row',
-        label: `Reorder row ${ri + 1}`,
-        dragData: { source: 'canvas', kind: 'row', rowIndex: ri, rowPath },
-      });
-
-      const items = Array.isArray(row.items) ? row.items : [];
-      const itemBoxes = items.map((_, ii) => at(`${rowPath}.item.${ii}`));
-
-      items.forEach((item, ii) => {
-        const itemPath = `${rowPath}.item.${ii}`;
-        const box = itemBoxes[ii];
-        if (!box) return;
-        const isContainer = Array.isArray(item.rows) && item.rows.length > 0;
-
-        // Item drag handle.
-        handles.push({
-          id: itemPath,
-          box,
+        id: itemPath,
+        box,
+        kind: 'item',
+        label: `Reorder ${labelCtx}`,
+        dragData: {
+          source: 'canvas',
           kind: 'item',
-          label: `Reorder item ${ii + 1} in row ${ri + 1}`,
-          dragData: {
-            source: 'canvas',
-            kind: 'item',
-            rowPath,
-            itemIndex: ii,
-            refType: itemRefType(item),
-            label: itemRefName(item),
-          },
-        });
-
-        // between-items drop zone in the gap BEFORE this item (index ii).
-        const prevBox = ii > 0 ? itemBoxes[ii - 1] : null;
-        const gapLeft = prevBox ? prevBox.left + prevBox.width : box.left - 12;
-        zones.push({
-          id: `${rowPath}-before-${ii}`,
-          intent: 'between-items',
-          box: { top: box.top, left: gapLeft - 6, width: Math.max(12, box.left - gapLeft + 12), height: box.height },
-          data: {
-            kind: 'canvas-drop',
-            dashboardName,
-            config: dashboardConfig,
-            target: { kind: 'between-items', rowPath, index: ii },
-          },
-        });
-
-        // on-item drop zone over the slot itself (VIS-901 #4) — lets a Library
-        // object be dropped DIRECTLY onto an existing slot (fill an empty slot,
-        // or insert before a filled one). Painted as a tinted region like
-        // in-container; only acted on for Library drags by the router. Skipped
-        // for container items (they get the in-container zone instead).
-        if (!isContainer) {
-          zones.push({
-            id: `${itemPath}-on-item`,
-            intent: 'on-item',
-            box,
-            data: {
-              kind: 'canvas-drop',
-              dashboardName,
-              config: dashboardConfig,
-              target: { kind: 'on-item', rowPath, index: ii },
-            },
-          });
-        }
-
-        // in-container drop zone over container items.
-        if (isContainer) {
-          zones.push({
-            id: `${itemPath}-container`,
-            intent: 'in-container',
-            box,
-            data: {
-              kind: 'canvas-drop',
-              dashboardName,
-              config: dashboardConfig,
-              target: { kind: 'in-container', itemPath },
-            },
-          });
-        }
+          rowPath,
+          itemIndex: ii,
+          refType: itemRefType(item),
+          label: itemRefName(item),
+        },
       });
 
-      // end-of-row drop zone at the row's trailing edge.
-      const lastBox = itemBoxes[itemBoxes.length - 1];
-      if (lastBox) {
+      // between-items drop zone in the gap BEFORE this item (index ii).
+      const gapLeft = prevBox ? prevBox.left + prevBox.width : box.left - 12;
+      zones.push({
+        id: `${rowPath}-before-${ii}`,
+        intent: 'between-items',
+        box: {
+          top: box.top,
+          left: gapLeft - 6,
+          width: Math.max(12, box.left - gapLeft + 12),
+          height: box.height,
+        },
+        data: {
+          kind: 'canvas-drop',
+          dashboardName,
+          config: dashboardConfig,
+          target: { kind: 'between-items', rowPath, index: ii },
+        },
+      });
+
+      // on-item drop zone over the slot itself (VIS-901 #4) — Library-only
+      // affordance. Skipped for container items (they get the in-container zone).
+      if (!isContainer) {
         zones.push({
-          id: `${rowPath}-end`,
-          intent: 'end-of-row',
-          box: {
-            top: lastBox.top,
-            left: lastBox.left + lastBox.width - 6,
-            width: 18,
-            height: lastBox.height,
-          },
+          id: `${itemPath}-on-item`,
+          intent: 'on-item',
+          box,
           data: {
             kind: 'canvas-drop',
             dashboardName,
             config: dashboardConfig,
-            target: { kind: 'end-of-row', rowPath },
+            target: { kind: 'on-item', rowPath, index: ii },
           },
         });
       }
 
-      // between-rows drop zone in the gap before this row (top-level only). The
-      // hit box is widened to ±18px around the gap centre (a comfortable target
-      // for the thin inter-row gap); the bar is painted at the true gap centre.
-      const prevRowBox = ri > 0 ? at(`row.${ri - 1}`) : null;
-      const gapCenter = prevRowBox
-        ? (prevRowBox.top + prevRowBox.height + rowBox.top) / 2
-        : rowBox.top - 6;
-      // Keep the band inside the inter-row gap so it doesn't overlap (and steal
-      // the collision from) the item drop zones at a row's top edge.
-      const HALF = 11;
-      zones.push({
-        id: `row-before-${ri}`,
-        intent: 'between-rows',
-        box: {
-          top: gapCenter - HALF,
-          left: rowBox.left,
-          width: rowBox.width,
-          height: HALF * 2,
-          barTop: HALF - 1.5,
-        },
-        data: {
-          kind: 'canvas-drop',
-          dashboardName,
-          config: dashboardConfig,
-          target: { kind: 'between-rows', index: ri },
-        },
-      });
-    });
+      // in-container drop zone over container items.
+      if (isContainer) {
+        zones.push({
+          id: `${itemPath}-container`,
+          intent: 'in-container',
+          box,
+          data: {
+            kind: 'canvas-drop',
+            dashboardName,
+            config: dashboardConfig,
+            target: { kind: 'in-container', itemPath },
+          },
+        });
+        // Recurse into the container's sub-rows.
+        emitRows(item.rows, itemPath, labelCtx);
+      }
+    };
 
-    // between-rows zone AFTER the last row (append). A generous 36px band so
-    // the trailing append target is easy to hit below the last row.
-    const lastRowBox = at(`row.${rows.length - 1}`);
-    if (lastRowBox) {
-      zones.push({
-        id: `row-before-${rows.length}`,
-        intent: 'between-rows',
-        box: {
-          top: lastRowBox.top + lastRowBox.height,
-          left: lastRowBox.left,
-          width: lastRowBox.width,
-          height: 36,
-          barTop: 4,
-        },
-        data: {
-          kind: 'canvas-drop',
-          dashboardName,
-          config: dashboardConfig,
-          target: { kind: 'between-rows', index: rows.length },
-        },
+    // Emit affordances for a list of sibling `rows` living under `parentPath`
+    // (`''` for the top-level dashboard rows, else a container item path). Walks
+    // each row → its grip, its items (via emitItem, which recurses into nested
+    // containers), its end-of-row zone, and the between-rows bands that scope to
+    // THESE siblings (so a between-rows drop inserts a new sub-row in the right
+    // container, not always at the top level).
+    function emitRows(siblingRows, parentPath, parentLabel) {
+      const prefix = parentPath ? `${parentPath}.` : '';
+      const rowBoxes = siblingRows.map((_, ri) => at(`${prefix}row.${ri}`));
+
+      siblingRows.forEach((row, ri) => {
+        const rowPath = `${prefix}row.${ri}`;
+        const rowBox = rowBoxes[ri];
+        if (!rowBox) return;
+        const rowLabel = parentLabel
+          ? `row ${ri + 1} in ${parentLabel}`
+          : `row ${ri + 1}`;
+
+        // Row drag handle. Top-level rows carry a `rowIndex` (the router uses it
+        // for the top-level row reorder); nested rows carry their `rowPath` only
+        // (nested-row reorder is handled as a between-rows insert within the
+        // container, and nested rows are dragged less often than their items).
+        handles.push({
+          id: rowPath,
+          box: rowBox,
+          kind: 'row',
+          label: `Reorder ${rowLabel}`,
+          dragData: parentPath
+            ? { source: 'canvas', kind: 'row', rowPath }
+            : { source: 'canvas', kind: 'row', rowIndex: ri, rowPath },
+        });
+
+        const items = Array.isArray(row.items) ? row.items : [];
+        const itemBoxes = items.map((_, ii) => at(`${rowPath}.item.${ii}`));
+
+        items.forEach((item, ii) => {
+          const box = itemBoxes[ii];
+          if (!box) return;
+          emitItem(
+            item,
+            `${rowPath}.item.${ii}`,
+            rowPath,
+            ii,
+            box,
+            ii > 0 ? itemBoxes[ii - 1] : null,
+            `item ${ii + 1} in ${rowLabel}`
+          );
+        });
+
+        // end-of-row drop zone at the row's trailing edge.
+        const lastBox = itemBoxes[itemBoxes.length - 1];
+        if (lastBox) {
+          zones.push({
+            id: `${rowPath}-end`,
+            intent: 'end-of-row',
+            box: {
+              top: lastBox.top,
+              left: lastBox.left + lastBox.width - 6,
+              width: 18,
+              height: lastBox.height,
+            },
+            data: {
+              kind: 'canvas-drop',
+              dashboardName,
+              config: dashboardConfig,
+              target: { kind: 'end-of-row', rowPath },
+            },
+          });
+        }
+
+        // between-rows drop zone in the gap before this row, scoped to this
+        // sibling group. The id is prefixed with the parent path so nested bands
+        // don't collide with the top-level ones. The hit box is widened to ±11px
+        // around the gap centre; the bar is painted at the true gap centre. For
+        // nested rows the target carries the `containerPath` so the router
+        // inserts the new sub-row into the right container.
+        const prevRowBox = ri > 0 ? rowBoxes[ri - 1] : null;
+        const gapCenter = prevRowBox
+          ? (prevRowBox.top + prevRowBox.height + rowBox.top) / 2
+          : rowBox.top - 6;
+        const HALF = 11;
+        zones.push({
+          id: `${prefix}row-before-${ri}`,
+          intent: 'between-rows',
+          box: {
+            top: gapCenter - HALF,
+            left: rowBox.left,
+            width: rowBox.width,
+            height: HALF * 2,
+            barTop: HALF - 1.5,
+          },
+          data: {
+            kind: 'canvas-drop',
+            dashboardName,
+            config: dashboardConfig,
+            target: parentPath
+              ? { kind: 'between-rows', index: ri, containerPath: parentPath }
+              : { kind: 'between-rows', index: ri },
+          },
+        });
       });
+
+      // between-rows zone AFTER the last sibling row (append). A generous 36px
+      // band so the trailing append target is easy to hit below the last row.
+      const lastRowBox = rowBoxes[rowBoxes.length - 1];
+      if (lastRowBox) {
+        zones.push({
+          id: `${prefix}row-before-${siblingRows.length}`,
+          intent: 'between-rows',
+          box: {
+            top: lastRowBox.top + lastRowBox.height,
+            left: lastRowBox.left,
+            width: lastRowBox.width,
+            height: 36,
+            barTop: 4,
+          },
+          data: {
+            kind: 'canvas-drop',
+            dashboardName,
+            config: dashboardConfig,
+            target: parentPath
+              ? { kind: 'between-rows', index: siblingRows.length, containerPath: parentPath }
+              : { kind: 'between-rows', index: siblingRows.length },
+          },
+        });
+      }
     }
+
+    emitRows(rows, '', null);
 
     setModel({ handles, zones });
   }, [rootRef, rows, dashboardName, dashboardConfig]);

--- a/viewer/src/components/new-views/project/canvas/CanvasDndLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasDndLayer.test.jsx
@@ -190,4 +190,125 @@ describe('CanvasDndLayer (VIS-771)', () => {
       'in-container'
     );
   });
+
+  // ── Nested recursion (VIS-903) ─────────────────────────────────────────────
+  describe('nested rows/items (VIS-903)', () => {
+    const NESTED_BOXES = {
+      r0: { top: 0, left: 0, width: 800, height: 400, bottom: 400, right: 800 },
+      r0i0: { top: 0, left: 0, width: 400, height: 400, bottom: 400, right: 400 },
+      r0i1: { top: 0, left: 410, width: 390, height: 400, bottom: 400, right: 800 },
+      // Sub-rows inside the container item r0i1.
+      n0: { top: 0, left: 410, width: 390, height: 130, bottom: 130, right: 800 },
+      n0i0: { top: 0, left: 410, width: 190, height: 130, bottom: 130, right: 600 },
+      n0i1: { top: 0, left: 610, width: 190, height: 130, bottom: 130, right: 800 },
+      n1: { top: 140, left: 410, width: 390, height: 130, bottom: 270, right: 800 },
+      n1i0: { top: 140, left: 410, width: 390, height: 130, bottom: 270, right: 800 },
+      root: { top: 0, left: 0, width: 800, height: 400, bottom: 400, right: 800 },
+    };
+
+    const NestedHost = () => {
+      const rootRef = useRef(null);
+      return (
+        <div ref={rootRef} style={{ position: 'relative' }}>
+          <div data-canvas-path="row.0" data-testid="r0">
+            <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+            <div data-canvas-path="row.0.item.1" data-testid="r0i1">
+              <div data-canvas-path="row.0.item.1.row.0" data-testid="n0">
+                <div data-canvas-path="row.0.item.1.row.0.item.0" data-testid="n0i0" />
+                <div data-canvas-path="row.0.item.1.row.0.item.1" data-testid="n0i1" />
+              </div>
+              <div data-canvas-path="row.0.item.1.row.1" data-testid="n1">
+                <div data-canvas-path="row.0.item.1.row.1.item.0" data-testid="n1i0" />
+              </div>
+            </div>
+          </div>
+          <CanvasDndLayer rootRef={rootRef} dashboardName="dash" />
+        </div>
+      );
+    };
+
+    beforeEach(() => {
+      useStore.setState({
+        dashboards: [
+          {
+            name: 'dash',
+            config: {
+              rows: [
+                {
+                  items: [
+                    { width: 2, chart: 'ref(top0)' },
+                    {
+                      width: 1,
+                      rows: [
+                        { items: [{ width: 6, chart: 'ref(n0a)' }, { width: 6, table: 'ref(n0b)' }] },
+                        { items: [{ width: 12, markdown: 'ref(n1a)' }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      });
+      Element.prototype.getBoundingClientRect = function () {
+        const tid = this.getAttribute && this.getAttribute('data-testid');
+        if (tid && NESTED_BOXES[tid]) return NESTED_BOXES[tid];
+        return NESTED_BOXES.root;
+      };
+    });
+
+    test('emits drag grips for NESTED rows and items', () => {
+      reveal({ hover: 'row.0.item.1.row.0.item.0' });
+      render(<NestedHost />);
+      // The nested item's grip is revealed on hover.
+      expect(
+        screen.getByTestId('canvas-drag-handle-row.0.item.1.row.0.item.0')
+      ).toHaveAttribute('data-canvas-handle-kind', 'item');
+      // Its nested parent row's grip is revealed too (keyWithinRow).
+      expect(screen.getByTestId('canvas-drag-handle-row.0.item.1.row.0')).toHaveAttribute(
+        'data-canvas-handle-kind',
+        'row'
+      );
+    });
+
+    test('nested item drag grip carries its nested rowPath + item index', () => {
+      reveal({ selected: 'row.0.item.1.row.0.item.1' });
+      render(<NestedHost />);
+      // Selecting the nested item reveals its grip.
+      expect(
+        screen.getByTestId('canvas-drag-handle-row.0.item.1.row.0.item.1')
+      ).toBeInTheDocument();
+    });
+
+    test('emits between-items + end-of-row drop zones for nested rows', () => {
+      render(<NestedHost />);
+      expect(
+        screen.getByTestId('canvas-dropzone-row.0.item.1.row.0-before-1')
+      ).toHaveAttribute('data-intent', 'between-items');
+      expect(
+        screen.getByTestId('canvas-dropzone-row.0.item.1.row.0-end')
+      ).toHaveAttribute('data-intent', 'end-of-row');
+    });
+
+    test('emits container-scoped between-rows bands for the nested sibling group', () => {
+      render(<NestedHost />);
+      // A nested between-rows band is prefixed with the container item path so it
+      // doesn't collide with the top-level bands.
+      expect(
+        screen.getByTestId('canvas-dropzone-row.0.item.1.row-before-0')
+      ).toHaveAttribute('data-intent', 'between-rows');
+      // …and the trailing append band for the nested sibling group.
+      expect(
+        screen.getByTestId('canvas-dropzone-row.0.item.1.row-before-2')
+      ).toBeInTheDocument();
+    });
+
+    test('still emits the in-container zone on the container item itself', () => {
+      render(<NestedHost />);
+      expect(
+        screen.getByTestId('canvas-dropzone-row.0.item.1-container')
+      ).toHaveAttribute('data-intent', 'in-container');
+    });
+  });
 });

--- a/viewer/src/components/new-views/project/canvas/CanvasItemFlipLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasItemFlipLayer.jsx
@@ -1,0 +1,297 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PiArrowsClockwise } from 'react-icons/pi';
+import useStore from '../../../../stores/store';
+import { useWorkspaceDrag } from '../../workspace/WorkspaceDndContext';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { parseRefValue } from '../../../../utils/refString';
+import { parseCanvasPath } from './canvasReorder';
+import LibraryRowFlipPopover from '../../workspace/library/LibraryRowFlipPopover';
+
+/**
+ * CanvasItemFlipLayer — VIS-785 / Track D D-6 (flip-to-lineage).
+ *
+ * Per-item flip-to-lineage affordance for the Workspace dashboard canvas. A
+ * SIBLING over the render-only <Dashboard> (mounted by ProjectCanvas alongside
+ * the selection / DnD / resize / keyboard overlays). For the hovered-or-selected
+ * leaf item it paints a small mulberry FLIP button in the item's top-right
+ * corner; clicking it "flips" the slot to its lineage neighbourhood card.
+ *
+ * ### Reuse of the delivered C-2 surface
+ *
+ * The original brief called for a bespoke `<MiniLineageCard>` + `<ItemFlipCard>`
+ * (CSS-3D in-slot rotation) + `<ItemLineageModal>`. Track C subsequently
+ * DELIVERED that lineage card as `<LibraryRowFlipPopover>` (the branching
+ * ancestors/subject/descendants ladder with the live selector input), and its
+ * "Expand" routes to the Workspace lineage lens (E-1) — the delivered design
+ * explicitly "replaces the never-built VIS-D6 standalone lineage modal". This
+ * layer therefore REUSES that delivered card (anchored to the canvas item)
+ * rather than forking a second lineage renderer, which would diverge.
+ *
+ * ### Behaviour (D-6 AC)
+ *   - Click the flip icon → the item's lineage card opens, anchored to the slot.
+ *   - The card shows ancestors + subject + descendants and a live selector input
+ *     (defaulted to `+<name>+`); editing it re-walks the lineage.
+ *   - Expand → routes the subject to the Workspace lineage lens (E-1).
+ *   - Multi-flip: several items can be flipped at once (a Set of flipped keys).
+ *   - Disabled during a drag (`useWorkspaceDrag`).
+ *   - `prefers-reduced-motion`: the flip-button reveal/rotation animation is
+ *     suppressed (the popover itself is a fade, honored by the OS setting).
+ *
+ * Mulberry (`#713b57`) is the affordance colour; the lineage card's per-type
+ * colours come from objectTypeConfigs via LibraryRowFlipPopover.
+ */
+
+const MULBERRY = '#713b57';
+
+const measure = (el, rootEl) => {
+  if (!el || !rootEl) return null;
+  const node = el.getBoundingClientRect();
+  const root = rootEl.getBoundingClientRect();
+  return { top: node.top - root.top, left: node.left - root.left, width: node.width, height: node.height };
+};
+
+// Resolve the lineage subject `{ type, name }` for a dashboard item, or null for
+// a container / empty slot (no single subject to flip to).
+const subjectForItem = item => {
+  if (!item || typeof item !== 'object') return null;
+  if (Array.isArray(item.rows) && item.rows.length > 0) return null; // container
+  const carriers = [
+    ['chart', item.chart],
+    ['table', item.table],
+    ['markdown', item.markdown],
+    ['input', item.input],
+  ];
+  for (const [type, raw] of carriers) {
+    if (raw == null || raw === '') continue;
+    const name = typeof raw === 'string' ? parseRefValue(raw) : raw.name || raw.path;
+    if (name) return { type, name };
+  }
+  return null;
+};
+
+// Walk the config to the item addressed by a composite item key.
+const itemAtKey = (config, key) => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return null;
+  let rows = Array.isArray(config?.rows) ? config.rows : null;
+  let item = null;
+  for (const seg of segments) {
+    if (seg.kind === 'row') {
+      if (!rows || !rows[seg.index]) return null;
+      rows = Array.isArray(rows[seg.index].items) ? rows[seg.index].items : null;
+    } else {
+      if (!rows || !rows[seg.index]) return null;
+      item = rows[seg.index];
+      rows = Array.isArray(item.rows) ? item.rows : null;
+    }
+  }
+  return item;
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// Anchor button for one item — paints the flip toggle in the slot's top-right.
+const FlipButton = ({ box, flipped, onToggle, reducedMotion, anchorRef, itemKey }) => {
+  if (!box) return null;
+  return (
+    <button
+      ref={anchorRef}
+      type="button"
+      data-testid={`canvas-flip-button-${itemKey}`}
+      data-flip-button="true"
+      data-flipped={flipped ? 'true' : 'false'}
+      aria-pressed={flipped}
+      aria-label={flipped ? 'Hide lineage' : 'Show lineage'}
+      title={flipped ? 'Hide lineage' : 'Flip to lineage'}
+      // Stop the pointerdown from reaching the document: the open lineage card
+      // (LibraryRowFlipPopover) closes on any outside mousedown, and this button
+      // lives OUTSIDE the portaled card. Without this, clicking the button to
+      // flip BACK would first trigger the card's outside-close (one toggle) and
+      // then the button's onClick (a second toggle) — a net no-op. Swallowing
+      // the pointerdown makes the button click a single, authoritative toggle.
+      onPointerDown={e => e.stopPropagation()}
+      onMouseDown={e => e.stopPropagation()}
+      onClick={onToggle}
+      className={[
+        'pointer-events-auto absolute z-30 inline-flex h-6 w-6 items-center justify-center rounded-md border bg-white/95 shadow-sm',
+        reducedMotion ? '' : 'transition-transform duration-200',
+      ].join(' ')}
+      style={{
+        top: box.top + 4,
+        left: box.left + box.width - 28,
+        borderColor: '#c6b0bb',
+        color: MULBERRY,
+        transform: flipped && !reducedMotion ? 'rotateY(180deg)' : 'none',
+      }}
+    >
+      <PiArrowsClockwise className="h-3.5 w-3.5" />
+    </button>
+  );
+};
+
+const CanvasItemFlipLayer = ({ rootRef, dashboardName }) => {
+  const dashboards = useStore(s => s.dashboards);
+  const hoverKey = useStore(s => s.workspaceCanvasHoverKey);
+  const selectedKey = useStore(s => s.workspaceOutlineSelectedKey);
+  const activeDrag = useWorkspaceDrag();
+
+  // Flipped item keys (multi-flip, Q3b) → each has an open lineage popover.
+  const [flipped, setFlipped] = useState(() => new Set());
+  // Measured box of the item the flip BUTTON should attach to (hover/selection).
+  const [buttonBox, setButtonBox] = useState(null);
+  const anchorRef = useRef(null);
+  const reducedMotion = prefersReducedMotion();
+
+  const dashboardConfig = useMemo(() => {
+    const entry = (dashboards || []).find(d => d.name === dashboardName);
+    if (!entry) return null;
+    return entry.config || entry;
+  }, [dashboards, dashboardName]);
+
+  // The item the flip button attaches to: the hovered item, else the selected
+  // item (only leaf items with a resolvable subject).
+  const activeKey = useMemo(() => {
+    const candidate = hoverKey && hoverKey.includes('.item.') ? hoverKey : selectedKey;
+    if (!candidate || !candidate.includes('.item.')) return null;
+    const item = itemAtKey(dashboardConfig, candidate);
+    return subjectForItem(item) ? candidate : null;
+  }, [hoverKey, selectedKey, dashboardConfig]);
+
+  const measureButton = useCallback(() => {
+    const root = rootRef.current;
+    if (!root || !activeKey) {
+      setButtonBox(null);
+      return;
+    }
+    const el = root.querySelector(`[data-canvas-path="${activeKey}"]`);
+    setButtonBox(el ? measure(el, root) : null);
+  }, [rootRef, activeKey]);
+
+  useEffect(() => {
+    measureButton();
+  }, [measureButton]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measureButton) : null;
+    if (ro) ro.observe(root);
+    window.addEventListener('resize', measureButton);
+    window.addEventListener('scroll', measureButton, true);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', measureButton);
+      window.removeEventListener('scroll', measureButton, true);
+    };
+  }, [rootRef, measureButton]);
+
+  const toggleFlip = useCallback(
+    key => {
+      setFlipped(prev => {
+        const next = new Set(prev);
+        const willFlip = !next.has(key);
+        if (willFlip) next.add(key);
+        else next.delete(key);
+        const item = itemAtKey(dashboardConfig, key);
+        const subject = subjectForItem(item);
+        if (willFlip) {
+          emitWorkspaceEvent('item_flipped', {
+            surface: 'build',
+            selector_edited: false,
+            expanded_to_modal: false,
+            type: subject?.type,
+            name: subject?.name,
+          });
+        }
+        return next;
+      });
+    },
+    [dashboardConfig]
+  );
+
+  if (!dashboardConfig) return null;
+
+  // A drag suppresses the flip affordance entirely (D-6 AC: disabled during drag)
+  // and closes any open cards so a reflowing canvas can't orphan an anchor.
+  const dragging = !!activeDrag;
+
+  const root = rootRef.current;
+  const boxFor = key => (root ? measure(root.querySelector(`[data-canvas-path="${key}"]`), root) : null);
+
+  // Flip buttons render for the hovered/selected item AND for every flipped item
+  // (so an open card stays toggleable even after the hover that opened it clears
+  // on the popover-mount reflow). Deduped.
+  const buttonKeys = [...new Set([...(activeKey ? [activeKey] : []), ...flipped])];
+
+  // Resolve a stable anchor element + subject for each open (flipped) card.
+  const openCards = [...flipped]
+    .map(key => {
+      const item = itemAtKey(dashboardConfig, key);
+      const subject = subjectForItem(item);
+      const el = root ? root.querySelector(`[data-canvas-path="${key}"]`) : null;
+      return subject && el ? { key, subject, el } : null;
+    })
+    .filter(Boolean);
+
+  return (
+    <div data-testid="canvas-flip-layer" className="pointer-events-none absolute inset-0 z-20">
+      {/* Flip toggles on the hovered/selected leaf + every flipped item (hidden
+          during drag). The active item uses the kept-fresh measured box; the
+          others measure on render (they reflow rarely). */}
+      {!dragging &&
+        buttonKeys.map(key => {
+          const subject = subjectForItem(itemAtKey(dashboardConfig, key));
+          if (!subject) return null;
+          const box = key === activeKey ? buttonBox || boxFor(key) : boxFor(key);
+          return (
+            <FlipButton
+              key={key}
+              itemKey={key}
+              box={box}
+              flipped={flipped.has(key)}
+              reducedMotion={reducedMotion}
+              anchorRef={key === activeKey ? anchorRef : undefined}
+              onToggle={() => toggleFlip(key)}
+            />
+          );
+        })}
+
+      {/* Open lineage cards (multi-flip). Each reuses the delivered C-2 surface
+          (LibraryRowFlipPopover) anchored to its item, with the canvas surface
+          tag. Suppressed during a drag. */}
+      {!dragging &&
+        openCards.map(card => (
+          <FlipCardAnchor
+            key={card.key}
+            cardKey={card.key}
+            el={card.el}
+            subject={card.subject}
+            onClose={() => toggleFlip(card.key)}
+          />
+        ))}
+    </div>
+  );
+};
+
+/**
+ * FlipCardAnchor — wraps LibraryRowFlipPopover with a ref anchored to the item's
+ * live DOM node so the popover positions next to the canvas slot. The popover
+ * already portals to the body + tracks scroll/resize.
+ */
+const FlipCardAnchor = ({ cardKey, el, subject, onClose }) => {
+  const anchorRef = useRef(el);
+  anchorRef.current = el;
+  return (
+    <LibraryRowFlipPopover
+      obj={subject}
+      anchorRef={anchorRef}
+      onClose={onClose}
+      testIdPrefix={`canvas-flip-card-${cardKey}`}
+    />
+  );
+};
+
+export default CanvasItemFlipLayer;

--- a/viewer/src/components/new-views/project/canvas/CanvasItemFlipLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasItemFlipLayer.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * CanvasItemFlipLayer tests (VIS-785 / Track D D-6).
+ *
+ * The flip layer paints a flip toggle on the hovered/selected leaf item and
+ * opens its lineage card (the delivered LibraryRowFlipPopover) on click. The
+ * popover is portal + store heavy, so it's mocked to a marker here — this test
+ * locks the flip GATING (leaf vs container, drag suppression), the multi-flip
+ * set, and the `item_flipped` telemetry. The popover's own lineage rendering is
+ * covered by its own suite.
+ */
+import React, { useRef } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import CanvasItemFlipLayer from './CanvasItemFlipLayer';
+import useStore from '../../../../stores/store';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+
+jest.mock('../../workspace/telemetry', () => ({
+  emitWorkspaceEvent: jest.fn(),
+}));
+
+// Mock the heavy lineage popover to a simple marker carrying its subject + a
+// close button, so we assert open/close + multi-flip without the portal walker.
+jest.mock('../../workspace/library/LibraryRowFlipPopover', () => ({ obj, onClose, testIdPrefix }) => (
+  <div data-testid={`${testIdPrefix}`} data-subject={`${obj.type}:${obj.name}`}>
+    <button data-testid={`${testIdPrefix}-close`} onClick={onClose}>
+      close
+    </button>
+  </div>
+));
+
+// useWorkspaceDrag is read from the DnD context; default to "no drag".
+let mockDrag = null;
+jest.mock('../../workspace/WorkspaceDndContext', () => ({
+  useWorkspaceDrag: () => mockDrag,
+}));
+
+const DASH = {
+  name: 'dash',
+  config: {
+    rows: [
+      {
+        items: [
+          { width: 6, chart: 'ref(rev_chart)' },
+          { width: 6, rows: [{ items: [{ chart: 'ref(inner)' }] }] }, // container
+        ],
+      },
+    ],
+  },
+};
+
+const Host = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="r0">
+        <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+      </div>
+      <CanvasItemFlipLayer rootRef={rootRef} dashboardName="dash" />
+    </div>
+  );
+};
+
+beforeEach(() => {
+  mockDrag = null;
+  emitWorkspaceEvent.mockClear();
+  useStore.setState({
+    dashboards: [DASH],
+    workspaceCanvasHoverKey: null,
+    workspaceOutlineSelectedKey: 'dashboard',
+  });
+  Element.prototype.getBoundingClientRect = function () {
+    return { top: 0, left: 0, width: 400, height: 200, bottom: 200, right: 400 };
+  };
+});
+
+const setHover = key => useStore.setState({ workspaceCanvasHoverKey: key });
+// Flip buttons are keyed per-item (`canvas-flip-button-<path>`); these helpers
+// query the set / a specific one.
+const flipButtons = () => screen.queryAllByTestId(/^canvas-flip-button-/);
+const flipButton = key => screen.getByTestId(`canvas-flip-button-${key}`);
+
+describe('CanvasItemFlipLayer (VIS-785)', () => {
+  test('no flip button at rest (nothing hovered/selected)', () => {
+    render(<Host />);
+    expect(flipButtons()).toHaveLength(0);
+  });
+
+  test('hovering a LEAF item reveals the flip button', () => {
+    setHover('row.0.item.0');
+    render(<Host />);
+    expect(flipButton('row.0.item.0')).toBeInTheDocument();
+  });
+
+  test('hovering a CONTAINER item does NOT reveal a flip button (no single subject)', () => {
+    setHover('row.0.item.1');
+    render(<Host />);
+    expect(flipButtons()).toHaveLength(0);
+  });
+
+  test('clicking flip opens the lineage card for that item + fires item_flipped', () => {
+    setHover('row.0.item.0');
+    render(<Host />);
+    fireEvent.click(flipButton('row.0.item.0'));
+    const card = screen.getByTestId('canvas-flip-card-row.0.item.0');
+    expect(card).toHaveAttribute('data-subject', 'chart:rev_chart');
+    expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+      'item_flipped',
+      expect.objectContaining({ surface: 'build', type: 'chart', name: 'rev_chart' })
+    );
+  });
+
+  test('flip is a toggle — clicking again closes the card', () => {
+    setHover('row.0.item.0');
+    render(<Host />);
+    fireEvent.click(flipButton('row.0.item.0'));
+    expect(screen.getByTestId('canvas-flip-card-row.0.item.0')).toBeInTheDocument();
+    // The button stays mounted while flipped, so it can toggle back.
+    fireEvent.click(flipButton('row.0.item.0'));
+    expect(screen.queryByTestId('canvas-flip-card-row.0.item.0')).not.toBeInTheDocument();
+  });
+
+  test('multi-flip — two items can be flipped at once', () => {
+    // A row of two leaf items so both item.0 and item.1 are flippable.
+    useStore.setState({
+      dashboards: [
+        {
+          name: 'dash',
+          config: {
+            rows: [{ items: [{ chart: 'ref(rev_chart)' }, { chart: 'ref(cost_chart)' }] }],
+          },
+        },
+      ],
+      workspaceCanvasHoverKey: 'row.0.item.0',
+    });
+    const { rerender } = render(<Host />);
+    // Flip the first item.
+    fireEvent.click(flipButton('row.0.item.0'));
+    expect(screen.getByTestId('canvas-flip-card-row.0.item.0')).toBeInTheDocument();
+    // Hover-move to the second item and flip it (setState wrapped in act).
+    act(() => {
+      useStore.setState({ workspaceCanvasHoverKey: 'row.0.item.1' });
+    });
+    rerender(<Host />);
+    fireEvent.click(flipButton('row.0.item.1'));
+    // Both cards are open simultaneously (multi-flip, Q3b).
+    expect(screen.getByTestId('canvas-flip-card-row.0.item.0')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-flip-card-row.0.item.1')).toBeInTheDocument();
+  });
+
+  test('a drag suppresses the flip affordance + any open cards', () => {
+    setHover('row.0.item.0');
+    const { rerender } = render(<Host />);
+    fireEvent.click(flipButton('row.0.item.0'));
+    expect(screen.getByTestId('canvas-flip-card-row.0.item.0')).toBeInTheDocument();
+    // A drag begins.
+    mockDrag = { kind: 'canvas', canvasKind: 'item' };
+    rerender(<Host />);
+    expect(flipButtons()).toHaveLength(0);
+    expect(screen.queryByTestId('canvas-flip-card-row.0.item.0')).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.jsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import useStore from '../../../../stores/store';
+import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
+import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import useCanvasKeyboardNav, { announceSelection } from './useCanvasKeyboardNav';
+
+/**
+ * CanvasKeyboardLayer — VIS-790 / Track D D-7.
+ *
+ * Canvas-direct keyboard navigation + a11y surface for the Workspace dashboard
+ * canvas. A SIBLING over the render-only <Dashboard> (mounted by ProjectCanvas
+ * alongside the selection / DnD / resize / add-row overlays). It:
+ *
+ *   - Makes the canvas focusable (a single roving `tabindex=0` application
+ *     region with `role="application"` + an aria-label + aria-keyshortcuts), so
+ *     a keyboard user can Tab INTO the canvas and then drive selection without a
+ *     pointer.
+ *   - Routes key events through `useCanvasKeyboardNav` (arrow nav, Tab cycling,
+ *     ⌘↑/↓ reorder, Enter → right-rail form, Esc → deselect) — all reusing the
+ *     pure breadcrumbNav helpers so canvas + breadcrumb + Outline are one model.
+ *   - Hosts an `aria-live="polite"` region that announces selection + reorder
+ *     changes ("Row 2, item 1 selected").
+ *   - Mirrors the selection ring onto the focus region (the visual ring is the
+ *     CanvasSelectionOverlay's; here we drive an offscreen focus proxy so the
+ *     browser's focus stays on the canvas region while the mulberry ring tracks
+ *     the selected node).
+ *
+ * The region is pointer-events-none EXCEPT it is keyboard-focusable, so it never
+ * intercepts the pointer selection / DnD the other overlays own — it is purely
+ * the keyboard entry point.
+ */
+
+const CanvasKeyboardLayer = ({ rootRef, dashboardName }) => {
+  const outlineKey = useStore(s => s.workspaceOutlineSelectedKey);
+  const setSelectedKey = useStore(s => s.setWorkspaceOutlineSelectedKey);
+  const dashboards = useStore(s => s.dashboards);
+  const commitCanvasConfig = useWorkspaceCommit();
+
+  const [announcement, setAnnouncement] = useState('');
+
+  const dashboardConfig = useMemo(() => {
+    const entry = (dashboards || []).find(d => d.name === dashboardName);
+    if (!entry) return null;
+    return entry.config || entry;
+  }, [dashboards, dashboardName]);
+
+  const rows = useMemo(
+    () => (Array.isArray(dashboardConfig?.rows) ? dashboardConfig.rows : []),
+    [dashboardConfig]
+  );
+
+  // Reorder commits go through the shared commitCanvasConfig with a telemetry
+  // shadow (parity with the pointer reorders).
+  const commitConfig = useCallback(
+    (nextConfig, meta) => {
+      if (!dashboardName || typeof commitCanvasConfig !== 'function') return;
+      commitCanvasConfig(dashboardName, nextConfig, meta);
+      emitWorkspaceEvent('canvas_action', { kind: meta?.kind || 'reorder_keyboard', dashboardName });
+    },
+    [dashboardName, commitCanvasConfig]
+  );
+
+  // Focus the right-rail Edit form's first field (Enter). Mirrors
+  // RightRailEditPanel.handleFocusForm so the contract is identical.
+  const onFocusForm = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    const panel = document.querySelector('[data-testid="workspace-right-rail-edit"]');
+    if (!panel) return;
+    const field = panel.querySelector(
+      'input:not([type="hidden"]), textarea, select, [contenteditable="true"]'
+    );
+    if (field && typeof field.focus === 'function') field.focus();
+  }, []);
+
+  const { handleKeyDown } = useCanvasKeyboardNav({
+    outlineKey,
+    dashboardName,
+    rows,
+    setSelectedKey,
+    commitConfig,
+    config: dashboardConfig,
+    onAnnounce: setAnnouncement,
+    onFocusForm,
+  });
+
+  // When the canvas region gains focus with nothing selected, prime the
+  // selection to the dashboard root so the first arrow keypress has an anchor.
+  const onFocus = useCallback(() => {
+    if (!outlineKey) {
+      if (setSelectedKey) setSelectedKey('dashboard');
+    }
+    // Announce the current position on focus so a SR user knows where they are.
+    setAnnouncement(announceSelection(outlineKey || 'dashboard', dashboardName, rows));
+  }, [outlineKey, setSelectedKey, dashboardName, rows]);
+
+  // Keep the announcement fresh if the selection changes from another surface
+  // (Outline / breadcrumb / pointer) WHILE the canvas region is focused.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = rootRef.current;
+    if (!root) return;
+    const region = root.querySelector('[data-testid="canvas-keyboard-region"]');
+    if (region && document.activeElement === region) {
+      setAnnouncement(announceSelection(outlineKey || 'dashboard', dashboardName, rows));
+    }
+  }, [outlineKey, rootRef, dashboardName, rows]);
+
+  if (!dashboardConfig) return null;
+
+  return (
+    <>
+      {/* Keyboard focus surface. role=application so arrow keys are delivered to
+          our handler rather than the SR's reading cursor. It sits at the canvas
+          inset but is pointer-events-none, so it's reachable by Tab + drives
+          selection without ever stealing pointer interactions. */}
+      <div
+        data-testid="canvas-keyboard-region"
+        role="application"
+        aria-label="Dashboard canvas. Use arrow keys to move the selection, Command with up or down arrow to reorder, Enter to edit."
+        aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Tab Enter Escape"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        className="pointer-events-none absolute inset-0 z-[5] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#713b57]/50"
+      />
+      {/* Polite live region for selection / reorder announcements. */}
+      <div
+        data-testid="canvas-keyboard-announce"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </div>
+    </>
+  );
+};
+
+export default CanvasKeyboardLayer;

--- a/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.test.jsx
@@ -1,0 +1,144 @@
+/**
+ * CanvasKeyboardLayer tests (VIS-790 / Track D D-7).
+ *
+ * Drives the canvas keyboard-nav focus region: arrow keys move the store
+ * selection, ⌘↑/↓ reorder + commit through the stub commit provider, Enter
+ * focuses the right-rail form, and the aria-live region announces the position.
+ * The pure nav logic lives in breadcrumbNav + useCanvasKeyboardNav; here we test
+ * the wiring + a11y surface.
+ */
+import React, { useRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CanvasKeyboardLayer from './CanvasKeyboardLayer';
+import useStore from '../../../../stores/store';
+import { WorkspaceCommitProvider } from '../../workspace/WorkspaceDndContext';
+
+jest.mock('../../workspace/telemetry', () => ({
+  emitWorkspaceEvent: jest.fn(),
+}));
+
+const DASH = {
+  name: 'dash',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+      { height: 'small', items: [{ width: 12, chart: 'ref(c)' }] },
+    ],
+  },
+};
+
+const Host = ({ commit = jest.fn() }) => {
+  const rootRef = useRef(null);
+  return (
+    <WorkspaceCommitProvider value={commit}>
+      <div ref={rootRef} style={{ position: 'relative' }}>
+        <CanvasKeyboardLayer rootRef={rootRef} dashboardName="dash" />
+      </div>
+    </WorkspaceCommitProvider>
+  );
+};
+
+const region = () => screen.getByTestId('canvas-keyboard-region');
+const selectedKey = () => useStore.getState().workspaceOutlineSelectedKey;
+const press = (key, opts = {}) => fireEvent.keyDown(region(), { key, ...opts });
+
+beforeEach(() => {
+  useStore.setState({ dashboards: [DASH], workspaceOutlineSelectedKey: 'dashboard' });
+});
+
+describe('CanvasKeyboardLayer (VIS-790)', () => {
+  test('renders a focusable application region + a polite live region', () => {
+    render(<Host />);
+    expect(region()).toHaveAttribute('role', 'application');
+    expect(region()).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('canvas-keyboard-announce')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('ArrowDown from dashboard descends into row 0; ArrowDown again into item 0', () => {
+    render(<Host />);
+    press('ArrowDown');
+    expect(selectedKey()).toBe('row.0');
+    press('ArrowDown');
+    expect(selectedKey()).toBe('row.0.item.0');
+  });
+
+  test('ArrowRight / ArrowLeft step among the row items (wraps)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    press('ArrowRight');
+    expect(selectedKey()).toBe('row.0.item.1');
+    press('ArrowRight'); // wraps
+    expect(selectedKey()).toBe('row.0.item.0');
+    press('ArrowLeft');
+    expect(selectedKey()).toBe('row.0.item.1');
+  });
+
+  test('ArrowUp steps UP the hierarchy (item → parent row)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.1' });
+    render(<Host />);
+    press('ArrowUp');
+    expect(selectedKey()).toBe('row.0');
+  });
+
+  test('Tab cycles the row items, Shift+Tab reverses', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    press('Tab');
+    expect(selectedKey()).toBe('row.0.item.1');
+    press('Tab', { shiftKey: true });
+    expect(selectedKey()).toBe('row.0.item.0');
+  });
+
+  test('⌘ArrowDown reorders the selected row + commits the new config', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0' });
+    const commit = jest.fn();
+    render(<Host commit={commit} />);
+    press('ArrowDown', { metaKey: true });
+    expect(commit).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = commit.mock.calls[0];
+    expect(name).toBe('dash');
+    // Row 0 (medium) moved below row 1 (small).
+    expect(nextConfig.rows.map(r => r.height)).toEqual(['small', 'medium']);
+    // The selection follows the moved row to its new index.
+    expect(selectedKey()).toBe('row.1');
+  });
+
+  test('Escape deselects to the dashboard root', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.1' });
+    render(<Host />);
+    press('Escape');
+    expect(selectedKey()).toBe('dashboard');
+  });
+
+  test('Enter focuses the right-rail form first field', () => {
+    // Mount a stub right-rail panel (with a focusable field) inside the tree, so
+    // the layer's document.querySelector('[data-testid="workspace-right-rail-edit"]')
+    // resolves to it — no direct node creation in the test.
+    const HostWithPanel = ({ commit = jest.fn() }) => {
+      const rootRef = useRef(null);
+      return (
+        <WorkspaceCommitProvider value={commit}>
+          <div ref={rootRef} style={{ position: 'relative' }}>
+            <CanvasKeyboardLayer rootRef={rootRef} dashboardName="dash" />
+            <div data-testid="workspace-right-rail-edit">
+              <input data-testid="rail-first-field" />
+            </div>
+          </div>
+        </WorkspaceCommitProvider>
+      );
+    };
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<HostWithPanel />);
+    press('Enter');
+    expect(screen.getByTestId('rail-first-field')).toHaveFocus();
+  });
+
+  test('selection moves announce the position in the live region', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    render(<Host />);
+    press('ArrowRight');
+    expect(screen.getByTestId('canvas-keyboard-announce')).toHaveTextContent(
+      'Row 1, item 2 selected'
+    );
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -6,6 +6,7 @@ import CanvasResizeLayer from './CanvasResizeLayer';
 import CanvasAddRow from './CanvasAddRow';
 import CanvasContextMenu from './CanvasContextMenu';
 import CanvasKeyboardLayer from './CanvasKeyboardLayer';
+import CanvasItemFlipLayer from './CanvasItemFlipLayer';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -75,6 +76,11 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
           application region + ARIA live announcements; routes arrow / Tab /
           ⌘↑↓ / Enter / Esc through the shared breadcrumbNav model. */}
       <CanvasKeyboardLayer rootRef={rootRef} dashboardName={dashboardName} />
+      {/* VIS-785 / D-6: per-item flip-to-lineage. A flip toggle on the
+          hovered/selected leaf opens its lineage neighbourhood card (the
+          delivered C-2 surface), with a live selector + Expand-to-lens.
+          Multi-flip; disabled during drag; honors prefers-reduced-motion. */}
+      <CanvasItemFlipLayer rootRef={rootRef} dashboardName={dashboardName} />
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -5,6 +5,7 @@ import CanvasDndLayer from './CanvasDndLayer';
 import CanvasResizeLayer from './CanvasResizeLayer';
 import CanvasAddRow from './CanvasAddRow';
 import CanvasContextMenu from './CanvasContextMenu';
+import CanvasKeyboardLayer from './CanvasKeyboardLayer';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -70,6 +71,10 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
           inside / add item to row, unwrap. Commits via the shared
           commitCanvasConfig (sanitize → optimistic → save). */}
       <CanvasContextMenu rootRef={rootRef} dashboardName={dashboardName} />
+      {/* VIS-790 / D-7: canvas-direct keyboard navigation + a11y. A focusable
+          application region + ARIA live announcements; routes arrow / Tab /
+          ⌘↑↓ / Enter / Esc through the shared breadcrumbNav model. */}
+      <CanvasKeyboardLayer rootRef={rootRef} dashboardName={dashboardName} />
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/new-views/project/canvas/ProjectCanvas.jsx
@@ -4,6 +4,7 @@ import CanvasSelectionOverlay from './CanvasSelectionOverlay';
 import CanvasDndLayer from './CanvasDndLayer';
 import CanvasResizeLayer from './CanvasResizeLayer';
 import CanvasAddRow from './CanvasAddRow';
+import CanvasContextMenu from './CanvasContextMenu';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -65,6 +66,10 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
           between-rows) and the empty-canvas CTA. Commits a templated row via the
           shell's shared commitCanvasConfig (sanitize → optimistic → save). */}
       <CanvasAddRow rootRef={rootRef} dashboardName={dashboardName} />
+      {/* VIS-781 / D-5: right-click context menu — wrap-in-container, add row
+          inside / add item to row, unwrap. Commits via the shared
+          commitCanvasConfig (sanitize → optimistic → save). */}
+      <CanvasContextMenu rootRef={rootRef} dashboardName={dashboardName} />
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -368,6 +368,139 @@ export const buildLibraryItem = (type, name) => {
   return item;
 };
 
+// ── Wrap-in-container helpers (VIS-781 / Track D D-5) ───────────────────────
+// Pure, immutable transforms that turn a leaf item into a row-container and
+// manage container sub-rows/items. Like the reorder helpers, they walk the
+// composite `data-canvas-path` spine and clone only the path to the target.
+
+// Is `item` a leaf (a chart/table/markdown/input slot, OR an empty slot) rather
+// than an existing container (`Item.rows`)? Only leaves can be wrapped.
+const isLeafItem = item =>
+  !!item && typeof item === 'object' && !(Array.isArray(item.rows) && item.rows.length > 0);
+
+/**
+ * Transform the single item at `itemPath` in place (immutably), returning a new
+ * config. `transformItem(item)` returns the replacement item (or the same ref
+ * for a no-op). Returns the config unchanged for an invalid path or when the
+ * transform returns the same item reference. Shared by wrap / unwrap / add-row.
+ */
+const withItemAtPath = (config, itemPath, transformItem) => {
+  const segments = parseCanvasPath(itemPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return config;
+  const itemSeg = segments[segments.length - 1];
+  const rowSegments = segments.slice(0, -1);
+  if (!rowSegments.length || rowSegments[rowSegments.length - 1].kind !== 'row') return config;
+  let changed = false;
+  const next = withRowsAtRowPath(config, rowSegments, rows => {
+    const lastRowIndex = rowSegments[rowSegments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+      const items = row.items.map((it, ii) => {
+        if (ii !== itemSeg.index) return it;
+        const replacement = transformItem(it);
+        if (replacement === it) return it;
+        changed = true;
+        return replacement;
+      });
+      return changed ? { ...row, items } : row;
+    });
+  });
+  return changed ? next : config;
+};
+
+/**
+ * Wrap the LEAF item at `itemPath` in a single-row container (D-5). The original
+ * leaf becomes the single inner item of a new `{ rows: [{ items: [original] }] }`
+ * container; the container inherits the original's `width` (so the slot keeps
+ * its column span), and the inner item drops its own width (it fills the
+ * container's single row). No depth limit (Q12). Returns the config unchanged if
+ * the path is invalid or the item is already a container.
+ */
+export const wrapItemInContainer = (config, itemPath) =>
+  withItemAtPath(config, itemPath, item => {
+    if (!isLeafItem(item)) return item;
+    const width = item.width || 1;
+    const inner = { ...item };
+    delete inner.width;
+    return { width, rows: [{ height: 'medium', items: [inner] }] };
+  });
+
+/**
+ * Is the container at `itemPath` TRIVIALLY wrapped — exactly one sub-row holding
+ * exactly one inner item? Only trivial containers can be unwrapped back to a
+ * leaf without losing layout. Returns false for a leaf or a multi-row/multi-item
+ * container.
+ */
+export const isTriviallyWrappedContainer = (config, itemPath) => {
+  const segments = parseCanvasPath(itemPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return false;
+  let rows = Array.isArray(config?.rows) ? config.rows : null;
+  let item = null;
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    if (seg.kind === 'row') {
+      if (!rows || !rows[seg.index]) return false;
+      rows = Array.isArray(rows[seg.index].items) ? rows[seg.index].items : null;
+    } else {
+      if (!rows || !rows[seg.index]) return false;
+      item = rows[seg.index];
+      rows = Array.isArray(item.rows) ? item.rows : null;
+    }
+  }
+  if (!item || !Array.isArray(item.rows) || item.rows.length !== 1) return false;
+  const inner = Array.isArray(item.rows[0].items) ? item.rows[0].items : [];
+  return inner.length === 1;
+};
+
+/**
+ * Unwrap the TRIVIALLY-wrapped container at `itemPath` back to its single inner
+ * leaf (D-5 inverse). The inner item inherits the container's `width` (so the
+ * slot keeps its span). Returns the config unchanged if the container is not
+ * trivially wrapped (multi-row / multi-item containers are left intact — there's
+ * no unambiguous leaf to collapse to).
+ */
+export const unwrapTrivialContainer = (config, itemPath) => {
+  if (!isTriviallyWrappedContainer(config, itemPath)) return config;
+  return withItemAtPath(config, itemPath, item => {
+    const width = item.width || 1;
+    const inner = item.rows[0].items[0];
+    return { ...inner, width };
+  });
+};
+
+/**
+ * Add a new empty sub-row INSIDE the container at `itemPath` (D-5). Appends a
+ * `{ height: 'medium', items: [{ width: 1 }] }` row to the container's `rows`.
+ * Returns the config unchanged if the path is not a container item.
+ */
+export const addRowInsideContainer = (config, itemPath) =>
+  withItemAtPath(config, itemPath, item => {
+    if (!Array.isArray(item.rows)) return item;
+    return { ...item, rows: [...item.rows, NEW_ROW([{ width: 1 }])] };
+  });
+
+/**
+ * Append a new empty item slot to the row addressed by `rowPath` (D-5
+ * "Add item to row"). Works at any nesting depth. The new slot defaults to the
+ * smallest existing item width so an all-width-1 row stays balanced. Returns the
+ * config unchanged for an invalid path.
+ */
+export const addItemToRow = (config, rowPath) => {
+  const segments = parseCanvasPath(rowPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'row') return config;
+  const smart = smallestWidthInRow(config, rowPath);
+  const width = Number.isFinite(smart) && smart > 1 ? smart : 1;
+  return withRowsAtRowPath(config, segments, rows => {
+    const lastRowIndex = segments[segments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex) return row;
+      const items = Array.isArray(row.items) ? [...row.items] : [];
+      items.push({ width });
+      return { ...row, items };
+    });
+  });
+};
+
 // ── Resize helpers (VIS-777 / Track D D-4) ──────────────────────────────────
 // The canvas resize overlay (CanvasResizeLayer) turns the selection's edge
 // handles into real gestures. These are the pure, immutable config transforms

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.js
@@ -123,6 +123,48 @@ export const reorderTopLevelRows = (config, fromIndex, toIndex) => {
   return { ...config, rows: arrayMove(config.rows, fromIndex, toIndex) };
 };
 
+/**
+ * Reorder the sibling sub-rows of the container item addressed by `containerPath`
+ * (VIS-903). `fromIndex`/`toIndex` are indices within that container's `rows`.
+ * Returns the config unchanged on a no-op / invalid path.
+ */
+export const reorderRowsInContainer = (config, containerPath, fromIndex, toIndex) => {
+  if (fromIndex === toIndex) return config;
+  const segments = parseCanvasPath(containerPath);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return config;
+  const itemSeg = segments[segments.length - 1];
+  const rowSegments = segments.slice(0, -1);
+  if (!rowSegments.length || rowSegments[rowSegments.length - 1].kind !== 'row') return config;
+  return withRowsAtRowPath(config, rowSegments, rows => {
+    const lastRowIndex = rowSegments[rowSegments.length - 1].index;
+    return rows.map((row, ri) => {
+      if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+      const nextItems = row.items.map((it, ii) => {
+        if (ii !== itemSeg.index || !Array.isArray(it.rows)) return it;
+        return { ...it, rows: arrayMove(it.rows, fromIndex, toIndex) };
+      });
+      return { ...row, items: nextItems };
+    });
+  });
+};
+
+/**
+ * Parse the `containerPath` (item path) out of a nested row path. A nested row
+ * lives under a container item: `row.0.item.1.row.0` → container `row.0.item.1`,
+ * row index 0. Returns `{ containerPath, rowIndex }` for a nested row, or `null`
+ * for a top-level row (`row.N`) or malformed input. Used by the canvas DnD
+ * router to route a nested-row drag to `reorderRowsInContainer` (VIS-903).
+ */
+export const parseNestedRowPath = rowPath => {
+  const segments = parseCanvasPath(rowPath);
+  if (segments.length < 3 || segments[segments.length - 1].kind !== 'row') return null;
+  const rowIndex = segments[segments.length - 1].index;
+  const containerSegments = segments.slice(0, -1);
+  if (containerSegments[containerSegments.length - 1].kind !== 'item') return null;
+  const containerPath = containerSegments.map(s => `${s.kind}.${s.index}`).join('.');
+  return { containerPath, rowIndex };
+};
+
 /** Default empty layout slot height for a freshly-created top-level row. */
 const NEW_ROW = items => ({ height: 'medium', items });
 
@@ -214,10 +256,34 @@ export const insertItemAtTarget = (config, target, newItem) => {
   const item = newItem || { width: 1 };
 
   if (target.kind === 'between-rows') {
-    const idx = Math.max(0, Math.min(target.index ?? config.rows.length, config.rows.length));
-    const nextRows = [...config.rows];
-    nextRows.splice(idx, 0, NEW_ROW([item]));
-    return { ...config, rows: nextRows };
+    // Top-level between-rows → splice a new top-level row at the index.
+    if (!target.containerPath) {
+      const idx = Math.max(0, Math.min(target.index ?? config.rows.length, config.rows.length));
+      const nextRows = [...config.rows];
+      nextRows.splice(idx, 0, NEW_ROW([item]));
+      return { ...config, rows: nextRows };
+    }
+    // Nested between-rows (VIS-903) → splice a new sub-row into the container
+    // item addressed by `containerPath` at the index, among its sibling rows.
+    const segments = parseCanvasPath(target.containerPath);
+    if (!segments.length || segments[segments.length - 1].kind !== 'item') return config;
+    const itemSeg = segments[segments.length - 1];
+    const rowSegments = segments.slice(0, -1);
+    if (!rowSegments.length || rowSegments[rowSegments.length - 1].kind !== 'row') return config;
+    return withRowsAtRowPath(config, rowSegments, rows => {
+      const lastRowIndex = rowSegments[rowSegments.length - 1].index;
+      return rows.map((row, ri) => {
+        if (ri !== lastRowIndex || !Array.isArray(row.items)) return row;
+        const nextItems = row.items.map((it, ii) => {
+          if (ii !== itemSeg.index) return it;
+          const subRows = Array.isArray(it.rows) ? [...it.rows] : [];
+          const idx = Math.max(0, Math.min(target.index ?? subRows.length, subRows.length));
+          subRows.splice(idx, 0, NEW_ROW([item]));
+          return { ...it, rows: subRows };
+        });
+        return { ...row, items: nextItems };
+      });
+    });
   }
 
   // Drop directly onto an existing item slot (VIS-901 #4). An EMPTY slot is

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
@@ -336,3 +336,115 @@ describe('insertRowAtIndex (VIS-794 / D-7)', () => {
     expect(insertRowAtIndex(before, 0, null)).toBe(before);
   });
 });
+
+// ── Nested rows/items (VIS-903) ─────────────────────────────────────────────
+// A config with a container item holding two sub-rows, exercised by the nested
+// reorder + insert paths.
+const nestedConfig = () => ({
+  rows: [
+    {
+      height: 'large',
+      items: [
+        { width: 2, chart: 'ref(top0)' },
+        {
+          width: 1,
+          rows: [
+            { height: 'small', items: [{ width: 1, chart: 'ref(n0)' }] },
+            { height: 'small', items: [{ width: 1, table: 'ref(n1)' }] },
+            { height: 'small', items: [{ width: 1, markdown: 'ref(n2)' }] },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const subRowLeaf = (config, ri) =>
+  names(config.rows[0].items[1].rows[ri].items);
+
+describe('parseNestedRowPath (VIS-903)', () => {
+  const { parseNestedRowPath } = require('./canvasReorder');
+  test('parses a nested row path into containerPath + rowIndex', () => {
+    expect(parseNestedRowPath('row.0.item.1.row.2')).toEqual({
+      containerPath: 'row.0.item.1',
+      rowIndex: 2,
+    });
+  });
+  test('parses a deeply nested row path', () => {
+    expect(parseNestedRowPath('row.0.item.1.row.0.item.0.row.1')).toEqual({
+      containerPath: 'row.0.item.1.row.0.item.0',
+      rowIndex: 1,
+    });
+  });
+  test('returns null for a top-level row path', () => {
+    expect(parseNestedRowPath('row.0')).toBeNull();
+  });
+  test('returns null for an item path or malformed input', () => {
+    expect(parseNestedRowPath('row.0.item.1')).toBeNull();
+    expect(parseNestedRowPath('dashboard')).toBeNull();
+    expect(parseNestedRowPath('')).toBeNull();
+  });
+});
+
+describe('reorderRowsInContainer (VIS-903)', () => {
+  const { reorderRowsInContainer } = require('./canvasReorder');
+  test('reorders sibling sub-rows of a container item', () => {
+    const before = nestedConfig();
+    const after = reorderRowsInContainer(before, 'row.0.item.1', 0, 2);
+    // n0 sub-row moves to the end.
+    expect(subRowLeaf(after, 0)).toEqual(['ref(n1)']);
+    expect(subRowLeaf(after, 1)).toEqual(['ref(n2)']);
+    expect(subRowLeaf(after, 2)).toEqual(['ref(n0)']);
+  });
+  test('is immutable — returns a new config, leaves the original intact', () => {
+    const before = nestedConfig();
+    const snapshot = JSON.stringify(before);
+    const after = reorderRowsInContainer(before, 'row.0.item.1', 1, 0);
+    expect(after).not.toBe(before);
+    expect(JSON.stringify(before)).toBe(snapshot);
+  });
+  test('no-op for from===to or invalid path', () => {
+    const before = nestedConfig();
+    expect(reorderRowsInContainer(before, 'row.0.item.1', 1, 1)).toBe(before);
+    expect(reorderRowsInContainer(before, 'row.0', 0, 1)).toBe(before);
+  });
+});
+
+describe('insertItemAtTarget — nested between-rows (VIS-903)', () => {
+  test('inserts a new sub-row into a container at the given index', () => {
+    const before = nestedConfig();
+    const item = buildLibraryItem('chart', 'fresh');
+    const after = insertItemAtTarget(
+      before,
+      { kind: 'between-rows', index: 1, containerPath: 'row.0.item.1' },
+      item
+    );
+    const subRows = after.rows[0].items[1].rows;
+    expect(subRows).toHaveLength(4);
+    expect(names(subRows[1].items)).toEqual(['ref(fresh)']);
+    // Siblings preserved around the inserted row.
+    expect(names(subRows[0].items)).toEqual(['ref(n0)']);
+    expect(names(subRows[2].items)).toEqual(['ref(n1)']);
+  });
+  test('appends a sub-row when the index equals the sibling count', () => {
+    const before = nestedConfig();
+    const after = insertItemAtTarget(
+      before,
+      { kind: 'between-rows', index: 3, containerPath: 'row.0.item.1' },
+      buildLibraryItem('chart', 'tail')
+    );
+    const subRows = after.rows[0].items[1].rows;
+    expect(subRows).toHaveLength(4);
+    expect(names(subRows[3].items)).toEqual(['ref(tail)']);
+  });
+  test('leaves top-level between-rows behaviour unchanged when no containerPath', () => {
+    const before = nestedConfig();
+    const after = insertItemAtTarget(
+      before,
+      { kind: 'between-rows', index: 0 },
+      buildLibraryItem('chart', 'newtop')
+    );
+    expect(after.rows).toHaveLength(2);
+    expect(names(after.rows[0].items)).toEqual(['ref(newtop)']);
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
+++ b/viewer/src/components/new-views/project/canvas/canvasReorder.test.js
@@ -448,3 +448,114 @@ describe('insertItemAtTarget — nested between-rows (VIS-903)', () => {
     expect(names(after.rows[0].items)).toEqual(['ref(newtop)']);
   });
 });
+
+// ── Wrap-in-container helpers (VIS-781 / D-5) ───────────────────────────────
+describe('wrapItemInContainer / unwrap / add (VIS-781)', () => {
+  const {
+    wrapItemInContainer,
+    unwrapTrivialContainer,
+    isTriviallyWrappedContainer,
+    addRowInsideContainer,
+    addItemToRow,
+  } = require('./canvasReorder');
+
+  test('wraps a leaf item into a single-row container, inheriting its width', () => {
+    const before = config();
+    const after = wrapItemInContainer(before, 'row.0.item.0');
+    const wrapped = after.rows[0].items[0];
+    expect(Array.isArray(wrapped.rows)).toBe(true);
+    expect(wrapped.width).toBe(6); // inherited from the original leaf
+    expect(wrapped.rows).toHaveLength(1);
+    expect(wrapped.rows[0].items).toHaveLength(1);
+    // The inner item is the original leaf, sans its own width.
+    expect(wrapped.rows[0].items[0].chart).toBe('ref(a)');
+    expect(wrapped.rows[0].items[0].width).toBeUndefined();
+  });
+
+  test('wrapping is immutable', () => {
+    const before = config();
+    const snapshot = JSON.stringify(before);
+    wrapItemInContainer(before, 'row.0.item.0');
+    expect(JSON.stringify(before)).toBe(snapshot);
+  });
+
+  test('wraps a NESTED leaf at any depth', () => {
+    const before = wrapItemInContainer(config(), 'row.0.item.0');
+    // row.0.item.0 is now a container; wrap its inner leaf.
+    const after = wrapItemInContainer(before, 'row.0.item.0.row.0.item.0');
+    const innerContainer = after.rows[0].items[0].rows[0].items[0];
+    expect(Array.isArray(innerContainer.rows)).toBe(true);
+    expect(innerContainer.rows[0].items[0].chart).toBe('ref(a)');
+  });
+
+  test('wrapping a container is a no-op (only leaves wrap)', () => {
+    const wrapped = wrapItemInContainer(config(), 'row.0.item.0');
+    expect(wrapItemInContainer(wrapped, 'row.0.item.0')).toBe(wrapped);
+  });
+
+  test('isTriviallyWrappedContainer: true for 1×1, false for leaf / multi', () => {
+    const wrapped = wrapItemInContainer(config(), 'row.0.item.0');
+    expect(isTriviallyWrappedContainer(wrapped, 'row.0.item.0')).toBe(true);
+    expect(isTriviallyWrappedContainer(config(), 'row.0.item.0')).toBe(false);
+    const withExtraRow = addRowInsideContainer(wrapped, 'row.0.item.0');
+    expect(isTriviallyWrappedContainer(withExtraRow, 'row.0.item.0')).toBe(false);
+  });
+
+  test('unwrap restores the inner leaf and its width on a trivial container', () => {
+    const wrapped = wrapItemInContainer(config(), 'row.0.item.0');
+    const after = unwrapTrivialContainer(wrapped, 'row.0.item.0');
+    const item = after.rows[0].items[0];
+    expect(item.chart).toBe('ref(a)');
+    expect(item.width).toBe(6);
+    expect(item.rows).toBeUndefined();
+  });
+
+  test('unwrap is a no-op on a non-trivial container', () => {
+    const wrapped = addRowInsideContainer(
+      wrapItemInContainer(config(), 'row.0.item.0'),
+      'row.0.item.0'
+    );
+    expect(unwrapTrivialContainer(wrapped, 'row.0.item.0')).toBe(wrapped);
+  });
+
+  test('addRowInsideContainer appends an empty sub-row to the container', () => {
+    const wrapped = wrapItemInContainer(config(), 'row.0.item.0');
+    const after = addRowInsideContainer(wrapped, 'row.0.item.0');
+    expect(after.rows[0].items[0].rows).toHaveLength(2);
+    expect(after.rows[0].items[0].rows[1].items).toEqual([{ width: 1 }]);
+  });
+
+  test('addRowInsideContainer is a no-op on a leaf', () => {
+    const before = config();
+    expect(addRowInsideContainer(before, 'row.0.item.0')).toBe(before);
+  });
+
+  test('addItemToRow appends an empty slot to a top-level row', () => {
+    const before = config();
+    const after = addItemToRow(before, 'row.1');
+    expect(after.rows[1].items).toHaveLength(2);
+    expect(after.rows[1].items[1]).toEqual({ width: 12 }); // smart width = smallest in row
+  });
+
+  test('addItemToRow works on a nested row', () => {
+    const wrapped = wrapItemInContainer(config(), 'row.0.item.0');
+    const after = addItemToRow(wrapped, 'row.0.item.0.row.0');
+    expect(after.rows[0].items[0].rows[0].items).toHaveLength(2);
+  });
+
+  test('5-levels-deep wrap renders without error (no depth limit, Q12)', () => {
+    let cfg = config();
+    let path = 'row.0.item.0';
+    for (let i = 0; i < 5; i += 1) {
+      cfg = wrapItemInContainer(cfg, path);
+      path = `${path}.row.0.item.0`;
+    }
+    // Walk down 5 container levels to the original leaf.
+    let node = cfg.rows[0].items[0];
+    for (let i = 0; i < 5; i += 1) {
+      expect(Array.isArray(node.rows)).toBe(true);
+      node = node.rows[0].items[0];
+    }
+    expect(node.chart).toBe('ref(a)');
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/useCanvasKeyboardNav.js
+++ b/viewer/src/components/new-views/project/canvas/useCanvasKeyboardNav.js
@@ -1,0 +1,182 @@
+import { useCallback } from 'react';
+import {
+  buildBreadcrumbSegments,
+  computeSiblingKey,
+  computeHierarchyKey,
+  computeReorder,
+  applyReorder,
+  tokenizeOutlineKey,
+} from '../../workspace/breadcrumbNav';
+
+/**
+ * useCanvasKeyboardNav — VIS-790 / Track D D-7.
+ *
+ * Canvas-DIRECT keyboard navigation + a11y for the Workspace dashboard canvas.
+ * Where the G-2 breadcrumb (<EditPanelBreadcrumb>) drives the SAME selection from
+ * the right rail, this hook drives it from a focus surface ON the canvas, with a
+ * 2D arrow-key mental model that matches the spatial layout:
+ *
+ *   - ←/→         step among SIBLINGS at the current depth (items within a row,
+ *                 or rows among their siblings) — wraps within the sibling range.
+ *   - ↑           step UP the hierarchy (item → its parent row → dashboard).
+ *   - ↓           step DOWN into the first child (dashboard → row 0 → item 0 → …).
+ *   - Tab / ⇧Tab  cycle the focus ring through the current row's items (wraps).
+ *   - ⌘↑ / ⌘↓     reorder the focused node within its parent (persisted).
+ *   - Enter        focus the right-rail Edit form's first field.
+ *   - Esc          deselect (jump to the dashboard root).
+ *
+ * All structural logic reuses the pure breadcrumbNav helpers (the SAME ones G-2
+ * uses) so canvas + breadcrumb + Outline stay one selection model. The hook is
+ * framework-light: it returns a `handleKeyDown` for the canvas focus surface and
+ * an `announce(key)` that renders the SR string ("Row 2, item 1 selected").
+ *
+ * Reorder commits through the shell's shared `commitCanvasConfig`
+ * (sanitize → optimistic → save) — the SAME path the DnD router + context menu
+ * use — so a keyboard reorder is indistinguishable from a pointer one.
+ */
+
+/**
+ * Build the screen-reader announcement for a selection key. Uses the breadcrumb
+ * segments so the label matches what the Outline + breadcrumb show. Examples:
+ *   'dashboard'            → 'Dashboard selected'
+ *   'row.1'                → 'Row 2 selected'
+ *   'row.1.item.0'         → 'Row 2, item 1 selected'
+ *   nested                 → 'Row 2, item 1, row 1, item 2 selected'
+ */
+export const announceSelection = (key, dashboardName, rows) => {
+  const tokens = tokenizeOutlineKey(key);
+  if (!tokens.length) return 'Dashboard selected';
+  const parts = tokens.map(t =>
+    t.axis === 'row' ? `row ${t.index + 1}` : `item ${t.index + 1}`
+  );
+  // Capitalise the leading word for a natural reading ("Row 2, item 1 selected").
+  const phrase = parts.join(', ');
+  const sentence = phrase.charAt(0).toUpperCase() + phrase.slice(1);
+  // `dashboardName` + `rows` resolve a container label if the leaf no longer
+  // exists, but the index phrasing above is the AC-specified announcement.
+  void buildBreadcrumbSegments; // (kept imported for parity with the breadcrumb)
+  return `${sentence} selected`;
+};
+
+/**
+ * Tab / Shift+Tab cycles the focus ring through the items of the CURRENT row.
+ * When an item is selected → its row's items. When a row is selected → its own
+ * items (enter the row at item 0 / last). When the dashboard is selected →
+ * row 0's item 0. Wraps within the row. Returns the next key (or the unchanged
+ * key when there's nothing to cycle).
+ */
+export const computeTabKey = (key, rows, delta) => {
+  const tokens = tokenizeOutlineKey(key);
+  // Dashboard root → enter the first row's first item.
+  if (tokens.length === 0) {
+    return Array.isArray(rows) && rows.length ? 'row.0.item.0' : 'dashboard';
+  }
+  const last = tokens[tokens.length - 1];
+  // A row is selected → step into its items (first for Tab, last for Shift+Tab).
+  if (last.axis === 'row') {
+    return computeHierarchyKey(key, rows, 'down');
+  }
+  // An item is selected → cycle its row's siblings.
+  return computeSiblingKey(key, rows, delta);
+};
+
+const useCanvasKeyboardNav = ({
+  outlineKey,
+  dashboardName,
+  rows,
+  setSelectedKey,
+  commitConfig,
+  config,
+  onAnnounce,
+  onFocusForm,
+}) => {
+  const select = useCallback(
+    nextKey => {
+      if (nextKey == null) return;
+      if (setSelectedKey) setSelectedKey(nextKey);
+      if (onAnnounce) onAnnounce(announceSelection(nextKey, dashboardName, rows));
+    },
+    [setSelectedKey, onAnnounce, dashboardName, rows]
+  );
+
+  const reorder = useCallback(
+    delta => {
+      const key = outlineKey || 'dashboard';
+      const op = computeReorder(key, rows, delta);
+      if (!op || !config || typeof commitConfig !== 'function') return false;
+      const nextConfig = applyReorder(config, op);
+      if (nextConfig === config) return false;
+      commitConfig(nextConfig, { kind: 'reorder_keyboard', axis: op.axis });
+      const nextKey =
+        op.parentKey === 'dashboard'
+          ? `${op.axis}.${op.toIndex}`
+          : `${op.parentKey}.${op.axis}.${op.toIndex}`;
+      if (setSelectedKey) setSelectedKey(nextKey);
+      if (onAnnounce) {
+        const dir = delta < 0 ? 'earlier' : 'later';
+        onAnnounce(`Moved ${op.axis} ${dir}. ${announceSelection(nextKey, dashboardName, rows)}`);
+      }
+      return true;
+    },
+    [outlineKey, rows, config, commitConfig, setSelectedKey, onAnnounce, dashboardName]
+  );
+
+  const handleKeyDown = useCallback(
+    e => {
+      // Never hijack typing inside a form field that might be inside the canvas
+      // (e.g. an inline markdown editor / input widget).
+      const tag = e.target?.tagName || '';
+      if (/^(INPUT|TEXTAREA|SELECT)$/.test(tag) || e.target?.isContentEditable) return;
+
+      const key = outlineKey || 'dashboard';
+      const isReorder = e.metaKey || e.ctrlKey;
+
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault();
+          select('dashboard');
+          return;
+        case 'Enter':
+          e.preventDefault();
+          if (onFocusForm) onFocusForm();
+          return;
+        case 'ArrowLeft':
+          e.preventDefault();
+          select(computeSiblingKey(key, rows, -1));
+          return;
+        case 'ArrowRight':
+          e.preventDefault();
+          select(computeSiblingKey(key, rows, 1));
+          return;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (isReorder) reorder(-1);
+          else select(computeHierarchyKey(key, rows, 'up'));
+          return;
+        case 'ArrowDown':
+          e.preventDefault();
+          if (isReorder) reorder(1);
+          else select(computeHierarchyKey(key, rows, 'down'));
+          return;
+        case 'Tab':
+          // Tab cycles within the row; let it fall through to the browser only
+          // when there's nothing to cycle (keeps the canvas in the tab order).
+          {
+            const next = computeTabKey(key, rows, e.shiftKey ? -1 : 1);
+            if (next && next !== key) {
+              e.preventDefault();
+              select(next);
+            }
+          }
+          return;
+        default:
+          return;
+      }
+    },
+    [outlineKey, rows, select, reorder, onFocusForm]
+  );
+
+  return { handleKeyDown, reorder, select };
+};
+
+export default useCanvasKeyboardNav;

--- a/viewer/src/components/new-views/project/canvas/useCanvasKeyboardNav.test.js
+++ b/viewer/src/components/new-views/project/canvas/useCanvasKeyboardNav.test.js
@@ -1,0 +1,77 @@
+/**
+ * useCanvasKeyboardNav pure-helper tests (VIS-790 / Track D D-7).
+ *
+ * The hook itself is exercised via the component test (CanvasKeyboardLayer);
+ * here we lock the pure announcement + Tab-cycle helpers it exports, which are
+ * the canvas-specific additions on top of the shared breadcrumbNav model.
+ */
+import { announceSelection, computeTabKey } from './useCanvasKeyboardNav';
+
+const rows = () => [
+  {
+    height: 'medium',
+    items: [
+      { width: 6, chart: 'ref(a)' },
+      { width: 6, table: 'ref(b)' },
+    ],
+  },
+  { height: 'small', items: [{ width: 12, chart: 'ref(c)' }] },
+];
+
+const nestedRows = () => [
+  {
+    items: [
+      { width: 2, chart: 'ref(top0)' },
+      {
+        width: 1,
+        rows: [
+          { items: [{ chart: 'ref(n0)' }, { table: 'ref(n1)' }] },
+          { items: [{ markdown: 'ref(n2)' }] },
+        ],
+      },
+    ],
+  },
+];
+
+describe('announceSelection (VIS-790)', () => {
+  test('dashboard root', () => {
+    expect(announceSelection('dashboard', 'dash', rows())).toBe('Dashboard selected');
+    expect(announceSelection('', 'dash', rows())).toBe('Dashboard selected');
+  });
+  test('a top-level row', () => {
+    expect(announceSelection('row.1', 'dash', rows())).toBe('Row 2 selected');
+  });
+  test('a top-level item', () => {
+    expect(announceSelection('row.0.item.1', 'dash', rows())).toBe('Row 1, item 2 selected');
+  });
+  test('a nested item', () => {
+    expect(announceSelection('row.0.item.1.row.0.item.1', 'dash', nestedRows())).toBe(
+      'Row 1, item 2, row 1, item 2 selected'
+    );
+  });
+});
+
+describe('computeTabKey (VIS-790)', () => {
+  test('dashboard → first row, first item', () => {
+    expect(computeTabKey('dashboard', rows(), 1)).toBe('row.0.item.0');
+  });
+  test('dashboard with no rows stays put', () => {
+    expect(computeTabKey('dashboard', [], 1)).toBe('dashboard');
+  });
+  test('a selected ROW steps into its first item', () => {
+    expect(computeTabKey('row.0', rows(), 1)).toBe('row.0.item.0');
+  });
+  test('Tab cycles items within the current row (wraps)', () => {
+    expect(computeTabKey('row.0.item.0', rows(), 1)).toBe('row.0.item.1');
+    // From the last item, Tab wraps to the first.
+    expect(computeTabKey('row.0.item.1', rows(), 1)).toBe('row.0.item.0');
+  });
+  test('Shift+Tab cycles backwards within the row (wraps)', () => {
+    expect(computeTabKey('row.0.item.0', rows(), -1)).toBe('row.0.item.1');
+  });
+  test('Tab cycles NESTED items within their nested row', () => {
+    expect(computeTabKey('row.0.item.1.row.0.item.0', nestedRows(), 1)).toBe(
+      'row.0.item.1.row.0.item.1'
+    );
+  });
+});

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -19,6 +19,8 @@ import sanitizeDashboardConfig from './sanitizeDashboardConfig';
 import {
   reorderItemsInRow,
   reorderTopLevelRows,
+  reorderRowsInContainer,
+  parseNestedRowPath,
   insertItemAtTarget,
   buildLibraryItem,
 } from '../project/canvas/canvasReorder';
@@ -85,7 +87,28 @@ const workspaceCollisionDetection = args => {
       // so use closestCenter (distance-based) rather than pointerWithin: the user
       // never has to land the pointer exactly inside the ~22px band, just nearest
       // it. This is what makes row reorder land reliably.
-      const scoped = { ...args, droppableContainers: droppableContainers.filter(isBetweenRows) };
+      //
+      // VIS-903: with nested layouts there are now between-rows bands at multiple
+      // depths (top-level + per-container). Scope the candidate bands to the SAME
+      // sibling group as the dragged row — a nested row resolves only to its
+      // container's bands, a top-level row only to the top-level bands — so a
+      // distance-based pick can never land on a band in a different container
+      // (which the router would no-op, making the gesture feel dead).
+      const containerOf = path => {
+        // `row.0.item.1.row.0` → container `row.0.item.1`; `row.0` → '' (top).
+        if (typeof path !== 'string') return '';
+        const lastRow = path.lastIndexOf('row.');
+        return lastRow > 0 ? path.slice(0, lastRow - 1) : '';
+      };
+      const dragContainer = containerOf(drag.rowPath);
+      const bands = droppableContainers.filter(isBetweenRows);
+      const sameGroup = bands.filter(
+        c => (c?.data?.current?.target?.containerPath || '') === dragContainer
+      );
+      const scoped = {
+        ...args,
+        droppableContainers: sameGroup.length ? sameGroup : bands,
+      };
       return closestCenter(scoped);
     }
     // Item drag → everything except between-rows zones AND except the on-item
@@ -248,16 +271,45 @@ export const routeWorkspaceDragEnd = (
         return 'canvas_reorder_items';
       }
 
-      // Row reorder: drag a top-level row + drop a `between-rows` target.
+      // Row reorder: drag a row + drop a `between-rows` target.
       if (dragData.kind === 'row' && target.kind === 'between-rows') {
-        const fromIndex = dragData.rowIndex;
-        let toIndex = target.index;
-        if (toIndex > fromIndex) toIndex -= 1;
-        const next = reorderTopLevelRows(config, fromIndex, toIndex);
-        if (next === config) return 'noop';
-        commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
-        emit && emit('canvas_dnd', { kind: 'reorder_rows', from: fromIndex, to: toIndex });
-        return 'canvas_reorder_rows';
+        // Nested row (VIS-903): the dragged row lives in a container (its path
+        // has a parent item) and the target band is scoped to the SAME container
+        // (`target.containerPath`). Reorder the sibling sub-rows in place.
+        const dragNested = parseNestedRowPath(dragData.rowPath);
+        if (dragNested && target.containerPath === dragNested.containerPath) {
+          const fromIndex = dragNested.rowIndex;
+          let toIndex = target.index;
+          if (toIndex > fromIndex) toIndex -= 1;
+          const next = reorderRowsInContainer(config, dragNested.containerPath, fromIndex, toIndex);
+          if (next === config) return 'noop';
+          commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
+          emit &&
+            emit('canvas_dnd', {
+              kind: 'reorder_rows',
+              containerPath: dragNested.containerPath,
+              from: fromIndex,
+              to: toIndex,
+            });
+          return 'canvas_reorder_rows';
+        }
+
+        // Top-level row reorder: only when BOTH the drag is a top-level row and
+        // the target is a top-level between-rows band (no containerPath). This
+        // prevents a nested-row drag from landing on a top-level band (or vice
+        // versa) and corrupting indices across nesting boundaries.
+        if (!dragNested && !target.containerPath && typeof dragData.rowIndex === 'number') {
+          const fromIndex = dragData.rowIndex;
+          let toIndex = target.index;
+          if (toIndex > fromIndex) toIndex -= 1;
+          const next = reorderTopLevelRows(config, fromIndex, toIndex);
+          if (next === config) return 'noop';
+          commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
+          emit && emit('canvas_dnd', { kind: 'reorder_rows', from: fromIndex, to: toIndex });
+          return 'canvas_reorder_rows';
+        }
+
+        return 'noop';
       }
 
       return 'noop';

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -146,6 +146,16 @@ const WorkspaceCommitContext = createContext(null);
 export const useWorkspaceCommit = () => useContext(WorkspaceCommitContext);
 
 /**
+ * Provider for the shell's `commitCanvasConfig` committer. The full
+ * <WorkspaceDndContext> wires this from its DnD provider; this thin wrapper lets
+ * a non-DnD surface (or a focused component test) supply a committer without
+ * mounting the whole dnd-kit shell.
+ */
+export const WorkspaceCommitProvider = ({ value, children }) => (
+  <WorkspaceCommitContext.Provider value={value}>{children}</WorkspaceCommitContext.Provider>
+);
+
+/**
  * Pure router for the shared `onDragEnd`. Decides what a finished drag means
  * from its `active`/`over` payloads and invokes the right side effect. Exported
  * so the routing decision is unit-testable without simulating a real dnd-kit

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
@@ -323,4 +323,105 @@ describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
     );
     expect(result).toBe('noop');
   });
+
+  // ── Nested rows/items (VIS-903) ──────────────────────────────────────────
+  const nestedCanvasConfig = () => ({
+    rows: [
+      {
+        height: 'large',
+        items: [
+          { width: 2, chart: 'ref(top0)' },
+          {
+            width: 1,
+            rows: [
+              { height: 'small', items: [{ width: 6, chart: 'ref(n0)' }, { width: 6, table: 'ref(n1)' }] },
+              { height: 'small', items: [{ width: 12, markdown: 'ref(n2)' }] },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  const overNested = target => ({
+    data: {
+      current: { kind: 'canvas-drop', dashboardName: 'dash', config: nestedCanvasConfig(), target },
+    },
+  });
+
+  test('nested item drag → between-items in its nested row reorders within that row', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: {
+            current: {
+              source: 'canvas',
+              kind: 'item',
+              rowPath: 'row.0.item.1.row.0',
+              itemIndex: 0,
+            },
+          },
+        },
+        over: overNested({ kind: 'between-items', rowPath: 'row.0.item.1.row.0', index: 2 }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('canvas_reorder_items');
+    const nestedItems = commitCanvasConfig.mock.calls[0][1].rows[0].items[1].rows[0].items;
+    expect(nestedItems.map(it => it.chart || it.table)).toEqual(['ref(n1)', 'ref(n0)']);
+  });
+
+  test('nested row drag → between-rows in the SAME container reorders sub-rows', () => {
+    const commitCanvasConfig = jest.fn();
+    const emit = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: { current: { source: 'canvas', kind: 'row', rowPath: 'row.0.item.1.row.0' } },
+        },
+        // Drop after the last sub-row → sub-row 0 moves to the end.
+        over: overNested({ kind: 'between-rows', index: 2, containerPath: 'row.0.item.1' }),
+      },
+      { commitCanvasConfig, emit }
+    );
+    expect(result).toBe('canvas_reorder_rows');
+    const subRows = commitCanvasConfig.mock.calls[0][1].rows[0].items[1].rows;
+    expect(subRows[1].items[0].markdown).toBe(undefined); // moved
+    expect(subRows[0].items[0].markdown).toBe('ref(n2)');
+    expect(emit).toHaveBeenCalledWith(
+      'canvas_dnd',
+      expect.objectContaining({ kind: 'reorder_rows', containerPath: 'row.0.item.1' })
+    );
+  });
+
+  test('nested row drag onto a DIFFERENT container band is a noop (no cross-boundary move)', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: {
+          data: { current: { source: 'canvas', kind: 'row', rowPath: 'row.0.item.1.row.0' } },
+        },
+        // Target band scoped to a different / top-level container.
+        over: overNested({ kind: 'between-rows', index: 0 }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('noop');
+    expect(commitCanvasConfig).not.toHaveBeenCalled();
+  });
+
+  test('library drag → nested between-rows inserts a new sub-row in the container', () => {
+    const commitCanvasConfig = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'library', type: 'chart', name: 'fresh' } } },
+        over: overNested({ kind: 'between-rows', index: 1, containerPath: 'row.0.item.1' }),
+      },
+      { commitCanvasConfig }
+    );
+    expect(result).toBe('canvas_library_insert');
+    const subRows = commitCanvasConfig.mock.calls[0][1].rows[0].items[1].rows;
+    expect(subRows).toHaveLength(3);
+    expect(subRows[1].items[0].chart).toBe('ref(fresh)');
+  });
 });


### PR DESCRIPTION
Track-D (Project Canvas) remainder, all on one branch off the current feature tip (which already has the merged VIS-901 canvas work). These all touch the same canvas overlay files, so they were done sequentially as one coherent set. Full viewer suite green: **168 suites / 2208 tests pass**, lint clean.

## Per-story status

### VIS-903 — Canvas drag/resize for NESTED components — ✅ Shipped
Recursed the canvas DnD model builder (`useCanvasDndModel`) through nested `Item.rows` so nested rows/items get the same affordances as top-level ones: drag grips (gated on hover/selection), between-items / end-of-row / on-item / in-container drop zones, and container-scoped between-rows insertion bands. Resize already worked at any depth (the resize layer resolves the full composite path). Added `reorderRowsInContainer` + `parseNestedRowPath` helpers and a `containerPath`-aware between-rows insert; routed nested-row reorder + library-insert-into-nested-container through the existing router with a cross-boundary guard; scoped the row-drag collision to the dragged row's own sibling group so a nested-row drag never lands in a different container.
- Tests: nested unit coverage (reorder helpers, DnD model recursion, router branches) + Playwright `canvas-nested-dnd` (4/4) on `nested-layouts-dashboard`.
- Also fixed a stale assertion in the existing `canvas-dnd` story (a row drag renders `canvas-row-drag-preview`, not the Library pill — changed by VIS-901 #5; the story wasn't updated and was failing on baseline).

### VIS-781 — Wrap-in-container + add-row-inside — ✅ Shipped
Right-click context menu (`CanvasContextMenu`) with Wrap in container / Add row inside / Add item to row / Unwrap, all via immutable `canvasReorder` helpers and committed through the shared `commitCanvasConfig`. Container actions resolve to the nearest container ancestor so they're reachable even when an inner leaf fills the slot. No depth limit (Q12). Fires `canvas_action`.
- Tests: helper unit coverage (wrap/unwrap round-trip, immutability, 5-levels-deep, smart-width add-item) + menu gating/commit tests + Playwright `canvas-wrap-container` (5/5, seeds a deterministic layout via the store).

### VIS-790 — Canvas-direct keyboard navigation + a11y — ✅ Shipped
`useCanvasKeyboardNav` hook + `CanvasKeyboardLayer` focus surface: a `role="application"` region (pointer-events-none, so it never steals pointer selection/DnD) with arrow nav (←/→ siblings, ↑/↓ hierarchy), Tab cycling, ⌘↑/⌘↓ reorder, Enter → right-rail form, Esc → deselect, and an `aria-live` region announcing position ("Row 2, item 1 selected"). Reuses the shared `breadcrumbNav` model so canvas + breadcrumb + Outline stay one selection source; works across the full incl-nested tree.
- Tests: hook + layer unit coverage (arrow nav, Tab cycle, ⌘-reorder + commit, Enter→form, Esc, announcements) + Playwright `canvas-keyboard-nav` (7/7) on `nested-layouts-dashboard`.
- Deferred: the AC's axe-core WCAG sweep needs the `@axe-core/playwright` dependency, which isn't installed in `viewer/`. Rather than add a dep (lockfile drift) on this branch, the story asserts the ARIA contract (role/label/keyshortcuts/live region) directly. Adding the axe sweep is a small follow-up.

### VIS-785 — Flip-to-lineage — ⚠️ Partial (core gesture shipped; C-2 card polish + 3D flip + standalone modal deferred, design-blocked)
`CanvasItemFlipLayer`: the hovered/selected leaf gets a flip toggle that opens the item's lineage neighbourhood card anchored to the slot, reusing the **delivered** Track-C lineage surface (`LibraryRowFlipPopover`) with its live selector input + Expand-to-lineage-lens (E-1). Multi-flip (Q3b), disabled during drag, `prefers-reduced-motion` honored, emits `item_flipped { surface: 'build', … }`.
- Tests: flip gating / multi-flip / toggle / telemetry unit tests + Playwright `canvas-flip-lineage` (5/5).
- **Deferred (design-blocked):** the bespoke C-2 bounded-rendering `MiniLineageCard` (max-3-children rollups, +N-below caplets, auto-promote-to-Complex with the "Open lineage graph" CTA), the CSS-3D in-slot rotation `<ItemFlipCard>`, and the standalone `<ItemLineageModal>`. Per the ticket's own addendum the D-4/D-5/D-6 design briefs are still pending and the standalone `<MiniLineageCard>` extraction is VIS-780, so the delivered Track-C card is the coherent interim surface. The core flip + selector + expand AC items are met; the C-2 polish/3D-flip/modal are the follow-up once design lands.

## Architecture preserved
Single shared `WorkspaceDndContext` (pointerWithin/closestCenter collision + `MeasuringStrategy.Always`); grips gated on hover/selection carrying their own `data-canvas-path`; drop zones `pointer-events-none` at rest; all persistence via `commitCanvasConfig` (sanitize→optimistic→save); all mutations via immutable `canvasReorder` helpers; type colours strictly from `objectTypeConfigs`; selection mulberry `#713b57`. No backend changes.

## Test results
- Viewer unit: 168 suites / 2208 tests pass; lint clean.
- Playwright (against an isolated sandbox on :8050/:3050, `nested-layouts-dashboard` + `simple-dashboard`): `canvas-nested-dnd` 4/4, `canvas-wrap-container` 5/5, `canvas-keyboard-nav` 7/7, `canvas-flip-lineage` 5/5; regressions `canvas-dnd` 5/5 + `canvas-selection` 7/7 green.
- Pre-existing (not a regression — reproduces identically on the unmodified branch tip): one `canvas-resize` row-height-tick story test (a 140px drag not crossing a tick threshold in the sandbox geometry); untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)