### PR TITLE
fix(viewer): canvas ↔ editor dashboard-levels parity — single source of truth + parity tests (VIS-899)

### DIFF
--- a/viewer/e2e/stories/project-levels-parity.spec.mjs
+++ b/viewer/e2e/stories/project-levels-parity.spec.mjs
@@ -1,0 +1,112 @@
+/**
+ * Story: Canvas ↔ editor LEVELS parity (VIS-899)
+ *
+ * Guards the single-source-of-truth fix: the canvas Project Editor level groups
+ * and the right-rail Project-Settings "Dashboard Levels" list must show the
+ * SAME levels. Before the fix the canvas rendered derived default level names
+ * while the settings form read the literal (empty) `defaults.levels` and showed
+ * "No dashboard levels defined" — two sources, one mismatch.
+ *
+ * This story (on `/workspace?view=project`):
+ *   1. reads the level titles the canvas renders (level-group headers),
+ *   2. opens the right-rail Project-Settings form (click canvas whitespace →
+ *      project-chrome selection → <DefaultsEditForm>),
+ *   3. reads the level titles the form shows (the "Title" inputs),
+ *   4. asserts the canvas list is an in-order prefix of the editor list and
+ *      that the editor is NOT empty when the canvas shows levels (the original
+ *      bug). The integration project configures no `defaults.levels`, so this
+ *      exercises the no-config derived case.
+ *
+ * Port: BASE defaults to :3051 (this ticket's sandbox) but is env-overridable:
+ *   VISIVO_SANDBOX_BACKEND_PORT=8051 VISIVO_SANDBOX_FRONTEND_PORT=3051 \
+ *   VISIVO_SANDBOX_NAME=vis899 bash scripts/sandbox.sh start
+ *   # then: VIS_LEVELS_PARITY_BASE=http://localhost:3051 \
+ *   #       npx playwright test project-levels-parity --reporter=list
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_LEVELS_PARITY_BASE || 'http://localhost:3051';
+const WORKSPACE_URL = `${BASE}/workspace?view=project`;
+const SCREENS = 'e2e/stories/__screens__';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+// Canvas level titles, in render order, from the level-group headers.
+const canvasLevelTitles = page =>
+  page
+    .locator('[data-testid$="-title"]')
+    .filter({ has: page.locator(':scope') })
+    .evaluateAll(els =>
+      els
+        .filter(el => (el.getAttribute('data-testid') || '').startsWith('level-group-header-level:'))
+        .map(el => el.textContent.trim())
+        .filter(Boolean)
+    );
+
+// Editor level titles, in order, from the right-rail form's "Title" inputs.
+const editorLevelTitles = page =>
+  page
+    .getByTestId('right-rail-edit-defaults')
+    .locator('input[placeholder="Title"]')
+    .evaluateAll(inputs => inputs.map(i => i.value).filter(v => v !== undefined));
+
+test.describe('Canvas ↔ editor levels parity (VIS-899)', () => {
+  test.setTimeout(90000);
+
+  test('canvas level groups match the right-rail Dashboard Levels list', async ({ browser }) => {
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto(WORKSPACE_URL);
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('project-editor').waitFor({ timeout: WAIT });
+    await page
+      .locator('[data-testid^="level-group-header-level:"]')
+      .first()
+      .waitFor({ timeout: WAIT });
+
+    const canvas = await canvasLevelTitles(page);
+    expect(canvas.length).toBeGreaterThan(0);
+    await page.screenshot({ path: `${SCREENS}/vis899-01-canvas-levels.png`, fullPage: true });
+
+    // Open the right-rail Project Settings by selecting project chrome — click
+    // canvas whitespace (the project-editor container handles the chrome click).
+    await page.getByTestId('project-editor').click({ position: { x: 5, y: 5 } });
+    await page.getByTestId('right-rail-edit-defaults').waitFor({ timeout: WAIT });
+    await page
+      .getByTestId('right-rail-edit-defaults')
+      .locator('input[placeholder="Title"]')
+      .first()
+      .waitFor({ timeout: WAIT });
+
+    const editor = await editorLevelTitles(page);
+    await page.screenshot({ path: `${SCREENS}/vis899-02-editor-and-canvas.png`, fullPage: true });
+
+    // The original bug: editor shows none while canvas shows levels.
+    expect(editor.length).toBeGreaterThan(0);
+    expect(editor).not.toEqual([]);
+
+    // Parity: the canvas list is an in-order prefix of the editor's full
+    // editable list (canvas applies display windowing on top of the shared
+    // source), and both draw the SAME first levels.
+    canvas.forEach((title, i) => {
+      expect(editor[i]).toBe(title);
+    });
+
+    const realErrors = consoleErrors.filter(
+      e =>
+        !e.includes('favicon') &&
+        !e.includes('DevTools') &&
+        !e.includes('ResizeObserver') &&
+        !e.includes('react-cool')
+    );
+    expect(realErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/viewer/src/components/new-views/common/ProjectDefaultsEditForm.jsx
+++ b/viewer/src/components/new-views/common/ProjectDefaultsEditForm.jsx
@@ -7,11 +7,19 @@ import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
+import { getEffectiveLevels } from '../../../utils/effectiveLevels';
 
 /**
  * ProjectDefaultsEditForm - Form for editing project-level defaults (singleton)
  *
  * Fields: source_name, alert_name, threads, telemetry_enabled, levels
+ *
+ * Levels (VIS-899): the form seeds its level list from `getEffectiveLevels` —
+ * the SAME single source of truth the canvas Project Editor renders. So when no
+ * levels are configured the form shows the shared default levels (the list the
+ * canvas already displays) rather than "No dashboard levels defined", and the
+ * two surfaces always agree. Edits persist through `saveDefaults` (the same
+ * path the canvas level-CRUD actions use), so both surfaces reflect changes.
  */
 const ProjectDefaultsEditForm = ({ defaults, onSave, onClose }) => {
   const saveDefaults = useStore(state => state.saveDefaults);
@@ -36,8 +44,11 @@ const ProjectDefaultsEditForm = ({ defaults, onSave, onClose }) => {
       setAlertName(defaults.alert_name || '');
       setThreads(defaults.threads ?? 8);
       setTelemetryEnabled(defaults.telemetry_enabled ?? true);
-      setLevels(defaults.levels || []);
     }
+    // Seed from the shared effective-levels source so the form shows the same
+    // levels the canvas Project Editor renders (configured levels when present,
+    // else the shared defaults) — VIS-899 parity.
+    setLevels(getEffectiveLevels(defaults));
   }, [defaults]);
 
   const handleSubmit = async e => {

--- a/viewer/src/components/new-views/common/ProjectDefaultsEditForm.test.jsx
+++ b/viewer/src/components/new-views/common/ProjectDefaultsEditForm.test.jsx
@@ -1,0 +1,50 @@
+/**
+ * ProjectDefaultsEditForm level-seeding tests (VIS-899).
+ *
+ * Guards the fix that makes the right-rail Project-Settings form read the SAME
+ * effective levels the canvas Project Editor shows: when no levels are
+ * configured the form must seed from the shared defaults (NOT show
+ * "No dashboard levels defined"), and when levels are configured it shows them.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import ProjectDefaultsEditForm from './ProjectDefaultsEditForm';
+import { defaultLevels } from '../../../utils/dashboardUtils';
+import useStore from '../../../stores/store';
+
+const seedStore = () => {
+  act(() => {
+    useStore.setState({
+      fetchSources: jest.fn(),
+      saveDefaults: jest.fn().mockResolvedValue({ success: true }),
+      checkPublishStatus: jest.fn(),
+      sources: [],
+    });
+  });
+};
+
+const renderForm = defaults =>
+  render(<ProjectDefaultsEditForm defaults={defaults} onSave={() => {}} onClose={() => {}} />);
+
+const titleValues = () =>
+  screen.queryAllByPlaceholderText('Title').map(input => input.value);
+
+describe('ProjectDefaultsEditForm levels', () => {
+  beforeEach(seedStore);
+
+  test('seeds the shared default levels when none configured (no empty-state)', () => {
+    renderForm({ levels: [] });
+    expect(screen.queryByText('No dashboard levels defined.')).not.toBeInTheDocument();
+    expect(titleValues()).toEqual(defaultLevels.map(l => l.title));
+  });
+
+  test('shows configured levels in order when present', () => {
+    renderForm({ levels: [{ title: 'Exec', description: 'top' }, { title: 'Ops', description: 'x' }] });
+    expect(titleValues()).toEqual(['Exec', 'Ops']);
+  });
+
+  test('handles null defaults by falling back to shared defaults', () => {
+    renderForm(null);
+    expect(titleValues()).toEqual(defaultLevels.map(l => l.title));
+  });
+});

--- a/viewer/src/components/new-views/common/levelsParity.test.jsx
+++ b/viewer/src/components/new-views/common/levelsParity.test.jsx
@@ -1,0 +1,122 @@
+/**
+ * Canvas ↔ editor LEVELS parity (VIS-899).
+ *
+ * The regression this guards: the canvas Project Editor rendered level groups
+ * derived from the shared default level names while the right-rail
+ * Project-Settings form read the literal `defaults.levels` and showed
+ * "No dashboard levels defined" — two sources, one mismatch.
+ *
+ * These tests assert the two surfaces show the SAME ordered level labels for
+ * BOTH cases:
+ *   1. no levels configured  → both fall back to the shared defaults
+ *   2. levels configured     → both show the configured list, in order
+ *
+ * "Canvas" labels come from the real `groupDashboardsByLevel` (the function
+ * ProjectEditor renders). "Editor" labels come from the real
+ * <ProjectDefaultsEditForm> rendered into the DOM (the level <input> titles).
+ * Both read through the shared `getEffectiveLevels` source of truth.
+ *
+ * The comparison goes through the reusable `assertSurfacesMatch` harness so
+ * future object types can add a sibling descriptor + test.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import ProjectDefaultsEditForm from './ProjectDefaultsEditForm';
+import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
+import {
+  canvasLevelLabels,
+  editorLevelLabels,
+  assertSurfacesMatch,
+} from '../../../utils/parityTestUtils';
+import { defaultLevels } from '../../../utils/dashboardUtils';
+import useStore from '../../../stores/store';
+
+// The form pulls a couple of unrelated store actions on mount; stub them so the
+// render is self-contained and we only exercise the level surface.
+const seedStore = () => {
+  act(() => {
+    useStore.setState({
+      fetchSources: jest.fn(),
+      saveDefaults: jest.fn().mockResolvedValue({ success: true }),
+      checkPublishStatus: jest.fn(),
+      sources: [],
+    });
+  });
+};
+
+// Read the level titles the rendered editor form actually shows: each level row
+// renders a title <input> with placeholder "Title".
+const readEditorTitles = () =>
+  screen
+    .queryAllByPlaceholderText('Title')
+    .map(input => input.value);
+
+const renderEditor = defaults => {
+  render(<ProjectDefaultsEditForm defaults={defaults} onSave={() => {}} onClose={() => {}} />);
+};
+
+describe('canvas ↔ editor levels parity (VIS-899)', () => {
+  beforeEach(seedStore);
+
+  test('no levels configured: both surfaces show the shared default levels', () => {
+    const defaults = { levels: [] };
+
+    // Canvas surface — grouped output (with some dashboards so groups render).
+    const groups = groupDashboardsByLevel(
+      [{ name: 'exec', config: { level: 0 } }],
+      defaults
+    );
+    const canvas = canvasLevelLabels(groups);
+
+    // Editor surface — actually rendered form.
+    renderEditor(defaults);
+    const editor = editorLevelLabels(
+      readEditorTitles().map(title => ({ title }))
+    );
+
+    // The editor shows the full editable set (the shared defaults) — NOT empty
+    // / "No levels defined" (the original VIS-899 bug). The canvas applies
+    // display windowing on top of the SAME source, so it is an in-order prefix.
+    expect(editor.length).toBeGreaterThan(0);
+    expect(editor).toEqual(defaultLevels.map(l => l.title));
+    expect(canvas.length).toBeGreaterThan(0);
+    expect(() =>
+      assertSurfacesMatch({ objectType: 'levels', canvas, editor, mode: 'prefix' })
+    ).not.toThrow();
+  });
+
+  test('levels configured: both surfaces show the configured list in order', () => {
+    const defaults = {
+      levels: [
+        { title: 'Exec', description: 'top' },
+        { title: 'Ops', description: 'day to day' },
+        { title: 'Squad', description: 'team' },
+      ],
+    };
+
+    const groups = groupDashboardsByLevel(
+      [{ name: 'a', config: { level: 'Exec' } }, { name: 'b', config: { level: 'Squad' } }],
+      defaults
+    );
+    const canvas = canvasLevelLabels(groups);
+
+    renderEditor(defaults);
+    const editor = editorLevelLabels(readEditorTitles().map(title => ({ title })));
+
+    expect(canvas).toEqual(['Exec', 'Ops', 'Squad']);
+    expect(editor).toEqual(['Exec', 'Ops', 'Squad']);
+    expect(() => assertSurfacesMatch({ objectType: 'levels', canvas, editor })).not.toThrow();
+  });
+
+  test('parity harness detects the original bug (canvas non-empty, editor empty)', () => {
+    // The exact VIS-899 regression: canvas renders levels, editor shows none.
+    expect(() =>
+      assertSurfacesMatch({
+        objectType: 'levels',
+        canvas: ['Organization', 'Department'],
+        editor: [],
+        mode: 'prefix',
+      })
+    ).toThrow(/parity mismatch for "levels"/);
+  });
+});

--- a/viewer/src/components/new-views/project/editor/useProjectEditorData.js
+++ b/viewer/src/components/new-views/project/editor/useProjectEditorData.js
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
-import { defaultLevels } from '../../../../utils/dashboardUtils';
+import {
+  getEffectiveLevels,
+  hasConfiguredLevels as projectHasConfiguredLevels,
+} from '../../../../utils/effectiveLevels';
 
 /**
  * useProjectEditorData — VIS-805 / Track M M-1.
@@ -65,8 +68,11 @@ export const groupDashboardsByLevel = (dashboards, defaults) => {
   // dragged into (VIS-901 #5). When we fall back to the shared `defaultLevels`
   // (no levels configured yet) we keep the conservative windowing below so an
   // empty project doesn't show every default level as noise.
-  const hasConfiguredLevels = Array.isArray(defaults?.levels) && defaults.levels.length > 0;
-  const configuredLevels = hasConfiguredLevels ? defaults.levels : defaultLevels;
+  // The effective level list is the SINGLE source of truth shared with the
+  // right-rail Project-Settings form (VIS-899): configured `defaults.levels`
+  // when present, else the shared `defaultLevels` fallback.
+  const hasConfiguredLevels = projectHasConfiguredLevels(defaults);
+  const configuredLevels = getEffectiveLevels(defaults);
 
   // Bucket dashboards by resolved level index.
   const buckets = new Map(); // index -> tiles[]

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -1,6 +1,6 @@
 import * as dashboardsApi from '../api/dashboards';
 import { recordOnboardingAction } from '../components/onboarding/onboardingState';
-import { defaultLevels } from '../utils/dashboardUtils';
+import { getEffectiveLevels } from '../utils/effectiveLevels';
 
 /**
  * Dashboard Store Slice
@@ -106,13 +106,7 @@ const createDashboardSlice = (set, get) => ({
    * delete affordances act on exactly the levels the user sees, we seed from
    * that same fallback here — the first edit persists a concrete list.
    */
-  _resolveLevels: () => {
-    const configured = get().defaults?.levels;
-    if (Array.isArray(configured) && configured.length > 0) {
-      return configured.map(l => ({ ...l }));
-    }
-    return defaultLevels.map(l => ({ ...l }));
-  },
+  _resolveLevels: () => getEffectiveLevels(get().defaults),
 
   _persistLevels: async nextLevels => {
     const saveDefaults = get().saveDefaults;

--- a/viewer/src/utils/effectiveLevels.js
+++ b/viewer/src/utils/effectiveLevels.js
@@ -1,0 +1,45 @@
+import { defaultLevels } from './dashboardUtils';
+
+/**
+ * effectiveLevels — VIS-899 single source of truth for dashboard levels.
+ *
+ * The canvas Project Editor and the right-rail Project-Settings form used to
+ * read DIFFERENT representations of the same level list, which produced a
+ * mismatch: the canvas rendered groups derived from the shared `defaultLevels`
+ * fallback ("Organization" / "Department" …) when no levels were configured,
+ * while the settings form read the LITERAL `defaults.levels` (empty) and showed
+ * "No dashboard levels defined."
+ *
+ * `getEffectiveLevels` is the ONE function both surfaces (and the level-CRUD
+ * store actions) call to answer "which levels should we display/edit?". It
+ * returns the configured `defaults.levels` when the project defines any, and
+ * otherwise the shared `defaultLevels` fallback — exactly the list the canvas
+ * Project Editor derives. Because both the canvas and the editor read through
+ * this helper, they can never diverge.
+ *
+ * Returns a fresh array of `{ title, description }` copies so callers can mutate
+ * their working list without aliasing the canonical defaults.
+ *
+ * @param {object|null|undefined} defaults - the project `defaults` record.
+ * @returns {{title: string, description: string}[]}
+ */
+export const getEffectiveLevels = defaults => {
+  const configured = defaults?.levels;
+  if (Array.isArray(configured) && configured.length > 0) {
+    return configured.map(l => ({ ...l }));
+  }
+  return defaultLevels.map(l => ({ ...l }));
+};
+
+/**
+ * Whether the project has EXPLICITLY configured its own levels (vs. falling
+ * back to the shared defaults). Surfaces use this to label/treat configured
+ * levels as real, user-created buckets.
+ *
+ * @param {object|null|undefined} defaults - the project `defaults` record.
+ * @returns {boolean}
+ */
+export const hasConfiguredLevels = defaults =>
+  Array.isArray(defaults?.levels) && defaults.levels.length > 0;
+
+export default getEffectiveLevels;

--- a/viewer/src/utils/effectiveLevels.test.js
+++ b/viewer/src/utils/effectiveLevels.test.js
@@ -1,0 +1,46 @@
+import { getEffectiveLevels, hasConfiguredLevels } from './effectiveLevels';
+import { defaultLevels } from './dashboardUtils';
+
+describe('getEffectiveLevels (VIS-899 single source of truth)', () => {
+  test('returns configured levels when defaults.levels is non-empty', () => {
+    const defaults = {
+      levels: [
+        { title: 'Exec', description: 'top' },
+        { title: 'Ops', description: 'day to day' },
+      ],
+    };
+    expect(getEffectiveLevels(defaults)).toEqual(defaults.levels);
+  });
+
+  test('falls back to the shared defaultLevels when none configured', () => {
+    expect(getEffectiveLevels({ levels: [] })).toEqual(defaultLevels);
+    expect(getEffectiveLevels({})).toEqual(defaultLevels);
+    expect(getEffectiveLevels(null)).toEqual(defaultLevels);
+    expect(getEffectiveLevels(undefined)).toEqual(defaultLevels);
+  });
+
+  test('returns fresh copies so callers cannot mutate the canonical defaults', () => {
+    const a = getEffectiveLevels(null);
+    a[0].title = 'mutated';
+    const b = getEffectiveLevels(null);
+    expect(b[0].title).not.toBe('mutated');
+    expect(b[0].title).toBe(defaultLevels[0].title);
+  });
+
+  test('configured copies are detached from the source array', () => {
+    const defaults = { levels: [{ title: 'Exec', description: 'top' }] };
+    const result = getEffectiveLevels(defaults);
+    result[0].title = 'changed';
+    expect(defaults.levels[0].title).toBe('Exec');
+  });
+});
+
+describe('hasConfiguredLevels', () => {
+  test('true only when defaults define a non-empty levels array', () => {
+    expect(hasConfiguredLevels({ levels: [{ title: 'A' }] })).toBe(true);
+    expect(hasConfiguredLevels({ levels: [] })).toBe(false);
+    expect(hasConfiguredLevels({})).toBe(false);
+    expect(hasConfiguredLevels(null)).toBe(false);
+    expect(hasConfiguredLevels(undefined)).toBe(false);
+  });
+});

--- a/viewer/src/utils/parityTestUtils.js
+++ b/viewer/src/utils/parityTestUtils.js
@@ -1,0 +1,87 @@
+/**
+ * parityTestUtils — VIS-899 canvas ↔ editor parity harness.
+ *
+ * The canvas (Project Editor) and the right-rail editor forms must render the
+ * SAME objects from the SAME source of truth. These helpers extract the labels
+ * each surface displays for a given object type and assert they match, so a
+ * regression that re-introduces a divergent source fails loudly in CI.
+ *
+ * The harness is intentionally object-type-agnostic: register a label extractor
+ * per surface per object type and the parity assertion compares them. Today it
+ * is wired for dashboard "levels" (the VIS-899 example); future object types
+ * (items, inputs, …) extend `LEVELS_PARITY` → add a sibling descriptor and a
+ * test that calls `assertSurfacesMatch`.
+ *
+ * Pure JS (no test framework imports) so it can be consumed from any Jest test.
+ */
+
+/**
+ * Pull the ordered level labels the CANVAS Project Editor renders, from the
+ * grouped output of `groupDashboardsByLevel`. The trailing "Unassigned" bucket
+ * is NOT a configured level, so it is excluded from the level identity list.
+ *
+ * @param {{ levelKey: string, title: string }[]} groups
+ * @param {string} unassignedKey
+ * @returns {string[]} ordered level titles
+ */
+export const canvasLevelLabels = (groups, unassignedKey = '__unassigned__') =>
+  (groups || []).filter(g => g.levelKey !== unassignedKey).map(g => g.title);
+
+/**
+ * Pull the ordered level labels the EDITOR form (ProjectDefaultsEditForm)
+ * displays, from its working `levels` state (each `{ title, description }`).
+ *
+ * @param {{ title: string }[]} levels
+ * @returns {string[]} ordered level titles
+ */
+export const editorLevelLabels = levels => (levels || []).map(l => l.title);
+
+/**
+ * Assert two surfaces agree on the labels they render for an object type, both
+ * drawn from the SAME source of truth. Throws a descriptive Error (consumed via
+ * `expect(() => …).not.toThrow` or wrapped in a custom matcher) when they
+ * diverge, including BOTH lists so a failure pinpoints the mismatch.
+ *
+ * Two modes:
+ *   - 'exact' (default): identical ordered lists. Use when both surfaces render
+ *     the full source (e.g. configured levels — canvas renders every configured
+ *     level as a drop target, the editor edits every one).
+ *   - 'prefix': the canvas list is an in-order PREFIX/subset of the editor list
+ *     AND neither is empty when the other is non-empty. Use for the no-config
+ *     derived case, where the canvas applies display windowing (hides trailing
+ *     empty default levels) on top of the shared source while the editor shows
+ *     the whole editable set. The original VIS-899 bug — canvas non-empty while
+ *     editor empty — still fails loudly under this mode.
+ *
+ * @param {object} params
+ * @param {string} params.objectType   - e.g. 'levels' (for the failure message)
+ * @param {string[]} params.canvas     - labels the canvas renders
+ * @param {string[]} params.editor     - labels the editor renders
+ * @param {'exact'|'prefix'} [params.mode='exact']
+ */
+export const assertSurfacesMatch = ({ objectType, canvas, editor, mode = 'exact' }) => {
+  const a = canvas || [];
+  const b = editor || [];
+
+  let ok;
+  if (mode === 'prefix') {
+    // The bug being guarded: one surface shows levels while the other shows
+    // none. Under windowing the canvas is a prefix of the editor's full list.
+    const bothEmptyOrBothNot = a.length === 0 ? true : b.length > 0;
+    const isPrefix = a.every((label, i) => label === b[i]);
+    ok = bothEmptyOrBothNot && isPrefix;
+  } else {
+    ok = a.length === b.length && a.every((label, i) => label === b[i]);
+  }
+
+  if (!ok) {
+    throw new Error(
+      `canvas ↔ editor parity mismatch for "${objectType}" (mode=${mode}):\n` +
+        `  canvas: ${JSON.stringify(a)}\n` +
+        `  editor: ${JSON.stringify(b)}`
+    );
+  }
+  return true;
+};
+
+export default assertSurfacesMatch;

--- a/viewer/src/utils/parityTestUtils.test.js
+++ b/viewer/src/utils/parityTestUtils.test.js
@@ -1,0 +1,95 @@
+import {
+  canvasLevelLabels,
+  editorLevelLabels,
+  assertSurfacesMatch,
+} from './parityTestUtils';
+
+describe('parityTestUtils', () => {
+  describe('canvasLevelLabels', () => {
+    test('extracts level titles in order, excluding the Unassigned bucket', () => {
+      const groups = [
+        { levelKey: 'level:0', title: 'Org' },
+        { levelKey: 'level:1', title: 'Dept' },
+        { levelKey: '__unassigned__', title: 'Unassigned' },
+      ];
+      expect(canvasLevelLabels(groups)).toEqual(['Org', 'Dept']);
+    });
+
+    test('handles empty / nullish input', () => {
+      expect(canvasLevelLabels([])).toEqual([]);
+      expect(canvasLevelLabels(null)).toEqual([]);
+      expect(canvasLevelLabels(undefined)).toEqual([]);
+    });
+  });
+
+  describe('editorLevelLabels', () => {
+    test('extracts titles in order', () => {
+      expect(editorLevelLabels([{ title: 'A' }, { title: 'B' }])).toEqual(['A', 'B']);
+    });
+
+    test('handles nullish input', () => {
+      expect(editorLevelLabels(null)).toEqual([]);
+    });
+  });
+
+  describe('assertSurfacesMatch', () => {
+    test('passes when labels match in order', () => {
+      expect(() =>
+        assertSurfacesMatch({ objectType: 'levels', canvas: ['A', 'B'], editor: ['A', 'B'] })
+      ).not.toThrow();
+    });
+
+    test('throws on length mismatch', () => {
+      expect(() =>
+        assertSurfacesMatch({ objectType: 'levels', canvas: ['A'], editor: ['A', 'B'] })
+      ).toThrow(/parity mismatch for "levels"/);
+    });
+
+    test('throws on order mismatch and reports both lists', () => {
+      expect(() =>
+        assertSurfacesMatch({ objectType: 'levels', canvas: ['A', 'B'], editor: ['B', 'A'] })
+      ).toThrow(/canvas: \["A","B"\][\s\S]*editor: \["B","A"\]/);
+    });
+
+    describe('prefix mode (canvas windowing on the shared source)', () => {
+      test('passes when canvas is an in-order prefix of editor', () => {
+        expect(() =>
+          assertSurfacesMatch({
+            objectType: 'levels',
+            canvas: ['A'],
+            editor: ['A', 'B', 'C'],
+            mode: 'prefix',
+          })
+        ).not.toThrow();
+      });
+
+      test('passes when both are empty', () => {
+        expect(() =>
+          assertSurfacesMatch({ objectType: 'levels', canvas: [], editor: [], mode: 'prefix' })
+        ).not.toThrow();
+      });
+
+      test('throws when canvas non-empty but editor empty (the VIS-899 bug)', () => {
+        expect(() =>
+          assertSurfacesMatch({
+            objectType: 'levels',
+            canvas: ['A'],
+            editor: [],
+            mode: 'prefix',
+          })
+        ).toThrow(/parity mismatch for "levels" \(mode=prefix\)/);
+      });
+
+      test('throws when canvas is not an in-order prefix', () => {
+        expect(() =>
+          assertSurfacesMatch({
+            objectType: 'levels',
+            canvas: ['B'],
+            editor: ['A', 'B'],
+            mode: 'prefix',
+          })
+        ).toThrow(/parity mismatch/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## VIS-899 — Canvas ↔ editor parity (dashboard levels)

Linear: https://linear.app/visivo/issue/VIS-899

### The bug
The canvas **Project Editor** (`/workspace?view=project`) and the right-rail **Project-Settings** form read two different representations of dashboard levels:
- Canvas: derived groups from the shared default level names ("Organization"/"Department"…) when none configured.
- Settings form: the literal (empty) `defaults.levels` → "No dashboard levels defined."

Two sources → mismatch.

### The fix — one shared "effective levels" source
New `viewer/src/utils/effectiveLevels.js` (`getEffectiveLevels` / `hasConfiguredLevels`) returns the configured `defaults.levels` when present, else the shared `defaultLevels` fallback (the same list the canvas already derived). Both surfaces now read through it:
- `useProjectEditorData.groupDashboardsByLevel` (canvas)
- the store's `_resolveLevels` (level CRUD: create/rename/reorder/delete — unchanged behavior)
- `ProjectDefaultsEditForm` seeds its level list from it, so the settings form shows the same effective levels the canvas shows; edits persist through the same `saveDefaults` path. Existing M-2a/M-3 level CRUD is preserved.

Editor-side only — the canvas DnD overlay files are untouched.

### Parity tests (core of the ticket)
Reusable, object-type-agnostic harness `viewer/src/utils/parityTestUtils.js` asserting "what the canvas renders == what the editor edits" for levels, across:
- **no-levels-configured (derived)** — `'prefix'` mode: canvas list is an in-order prefix of the editor's full editable list (canvas applies display windowing on top of the shared source); the original bug (canvas non-empty / editor empty) fails loudly.
- **levels-configured** — `'exact'` mode: identical ordered lists.

Future object types (items, inputs…) extend the harness with a sibling descriptor.

New tests:
- `viewer/src/utils/effectiveLevels.test.js`
- `viewer/src/utils/parityTestUtils.test.js`
- `viewer/src/components/new-views/common/ProjectDefaultsEditForm.test.jsx`
- `viewer/src/components/new-views/common/levelsParity.test.jsx` (renders the real form + real `groupDashboardsByLevel`)
- `viewer/e2e/stories/project-levels-parity.spec.mjs` (Playwright; BASE override, default `http://localhost:3051`)

### Verification
- `yarn test --watchAll=false`: **168 suites / 2166 tests pass**.
- `yarn lint`: clean.
- Playwright story `project-levels-parity` passed against the isolated sandbox (`:8051`/`:3051`, integration project — no `defaults.levels`, the exact derived case). Screenshot confirms the settings form now lists Organization/Department/Team/Individual/Operational and the canvas leading groups match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)