### PR TITLE
feat(viewer): Track N — per-object preview components (VIS-784/791/795/796/798/801)

### DIFF
--- a/viewer/e2e/stories/workspace-object-previews-deep.spec.mjs
+++ b/viewer/e2e/stories/workspace-object-previews-deep.spec.mjs
@@ -1,0 +1,366 @@
+/**
+ * Story: Per-object Preview lens — DEEP coverage (Track N validation hardening).
+ *
+ * The sibling `workspace-object-previews.spec.mjs` is happy-path only (chart /
+ * table / insight + one source fallback). This spec hardens Track N by covering:
+ *
+ *   - EVERY preview type: chart, table, insight, input (control + value), model
+ *     (read-only SQL editor + Run → result table). Markdown has NO standalone
+ *     object in the integration project (markdowns are inline-in-dashboard), so
+ *     its Library subsection is empty — asserted here, with the renderer itself
+ *     covered by MarkdownPreview.test.jsx at the unit layer.
+ *   - The Preview⇄Lineage lens toggle for each previewable type.
+ *   - Preview-less types (source / dimension / metric / relation) muting the
+ *     Preview lens option and defaulting to (and locking onto) Lineage.
+ *   - The "not found" empty state for a previewable type.
+ *   - Cross-component interaction: selecting an object in the Library updates BOTH
+ *     the middle-pane preview AND the right-rail Edit form (selection chip), and
+ *     switching object types swaps both surfaces with no stale state (the
+ *     Workspace.test isolation bug guard — VIS-775).
+ *
+ * Precondition: sandbox running on the configured base URL (default :3001;
+ * this hardening pass runs it on :3021 via VISIVO_BASE_URL).
+ *
+ * Object names are from the integration project (verified live against the API):
+ *   chart   = simple-scatter-chart
+ *   table   = new_table
+ *   insight = simple-scatter-insight
+ *   input   = show_markers   (single-select toggle)
+ *   model   = local_test_table
+ *   source  = local-sqlite
+ *   metric  = total_value · dimension = x_rounded · relation = local_to_local
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+
+/** Expand a Library per-type subsection (collapsed by default, VIS-828) and
+ *  click the named row, returning the row locator. Idempotent: the header
+ *  toggles, so only click it when the subsection is currently collapsed — this
+ *  lets the helper be called repeatedly for the same type without re-collapsing. */
+async function openObject(page, type, name) {
+  const subsection = page.getByTestId(`library-subsection-${type}`);
+  if ((await subsection.getAttribute('data-collapsed')) === 'true') {
+    await page.getByTestId(`library-subsection-${type}-header`).click();
+  }
+  const row = page.getByTestId(`library-row-${type}-${name}`);
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.click();
+  return row;
+}
+
+async function gotoWorkspace(page) {
+  await page.goto(`${BASE_URL}/workspace`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Track N deep — every preview type renders', () => {
+  test('chart preview draws a real Plotly surface', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openObject(page, 'chart', 'simple-scatter-chart');
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('chart-preview')).toBeVisible();
+    await expect(page.locator('.js-plotly-plot').first()).toBeVisible({ timeout: 30000 });
+    const drawn = await page.evaluate(() => ({
+      svgs: document.querySelectorAll('.js-plotly-plot svg.main-svg').length,
+      canvases: document.querySelectorAll('.js-plotly-plot canvas').length,
+    }));
+    expect(drawn.svgs + drawn.canvases).toBeGreaterThanOrEqual(1);
+  });
+
+  test('table preview renders the data toolbar (rows loaded)', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openObject(page, 'table', 'new_table');
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('table-preview')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="table-preview"]').getByPlaceholder('Search...')
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test('insight preview draws a real Plotly surface', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openObject(page, 'insight', 'simple-scatter-insight');
+    await expect(page.getByTestId('workspace-middle-insight-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('insight-preview')).toBeVisible();
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('input preview mounts the control AND surfaces its current value', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openObject(page, 'input', 'show_markers');
+    await expect(page.getByTestId('workspace-middle-input-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('input-preview')).toBeVisible();
+    // The "Current value:" panel is part of the Track N input preview contract;
+    // show_markers defaults to "markers+lines", so the value must be surfaced.
+    const valueBox = page.getByTestId('input-preview-value');
+    await expect(valueBox).toBeVisible({ timeout: 15000 });
+    await expect(valueBox).toContainText('Current value:');
+    await expect(valueBox).toContainText('markers+lines');
+    // The actual control (a real <Input> widget) renders inside the preview. A
+    // toggle/single-select renders the label heading + an interactive control
+    // (the toggle is a `button[role="switch"]`, other types use input/combobox),
+    // so assert on the label plus any interactive element.
+    await expect(
+      page.locator('[data-testid="input-preview"]').getByText('Show Markers (Toggle)')
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page
+        .locator(
+          '[data-testid="input-preview"] button[role="switch"], ' +
+            '[data-testid="input-preview"] input, ' +
+            '[data-testid="input-preview"] [role="combobox"]'
+        )
+        .first()
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('model preview shows a read-only SQL editor + Run gating, then a result table', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+    // sales_data declares an explicit `source: ${ref(local-duckdb)}` and returns
+    // rows, exercising the full Run → result-table path deterministically.
+    await openObject(page, 'model', 'sales_data');
+    await expect(page.getByTestId('workspace-middle-model-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('model-preview')).toBeVisible();
+
+    // The Monaco SQL editor mounts (read-only). Wait for the editor surface.
+    await expect(page.locator('[data-testid="model-preview"] .monaco-editor').first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    // Before Run, the results pane shows the "Run the query to preview results." prompt.
+    const results = page.getByTestId('model-preview-results');
+    await expect(results).toContainText('Run the query to preview results.');
+
+    // Run executes the model SQL via the model-query-jobs path and renders a table.
+    const runBtn = page.getByTestId('model-preview-run');
+    await expect(runBtn).toBeEnabled({ timeout: 10000 });
+    await runBtn.click();
+
+    // A result <table> appears (or, defensively, an explicit no-rows / error
+    // state — all three are valid terminal states the preview must reach, never
+    // a perpetual spinner).
+    await expect(async () => {
+      const hasTable = await results.locator('table').count();
+      const text = (await results.textContent()) || '';
+      const settled =
+        hasTable > 0 ||
+        /no rows/i.test(text) ||
+        (await page.getByTestId('model-preview-error').count()) > 0;
+      expect(settled).toBeTruthy();
+    }).toPass({ timeout: 45000 });
+
+    // Happy path for this model: it returns rows, so a header cell is visible.
+    await expect(results.locator('table thead th').first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('a source-less model resolves the PROJECT DEFAULT source, not the first source', async ({
+    page,
+  }) => {
+    // Regression for the clickhouse-fallback bug: local_test_table has no
+    // `source` field. The fallback must be the project default (local-duckdb),
+    // NOT sources[0] (local-clickhouse, an uninstalled dialect that errors).
+    await gotoWorkspace(page);
+    await openObject(page, 'model', 'local_test_table');
+    await expect(page.getByTestId('workspace-middle-model-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('model-preview')).toContainText('local-duckdb', {
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('model-preview')).not.toContainText('local-clickhouse');
+  });
+
+  test('markdown has no standalone Library object in this project (subsection empty)', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+    await page.getByTestId('library-subsection-markdown-header').click();
+    // The subsection renders its empty-state, not any row.
+    await expect(page.getByTestId('library-subsection-markdown-empty')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.locator('[data-testid^="library-row-markdown-"]')
+    ).toHaveCount(0);
+  });
+});
+
+test.describe('Track N deep — Preview⇄Lineage lens toggle per type', () => {
+  for (const { type, name } of [
+    { type: 'chart', name: 'simple-scatter-chart' },
+    { type: 'table', name: 'new_table' },
+    { type: 'insight', name: 'simple-scatter-insight' },
+    { type: 'input', name: 'show_markers' },
+    { type: 'model', name: 'local_test_table' },
+  ]) {
+    test(`${type}: flips Preview → Lineage → Preview`, async ({ page }) => {
+      await gotoWorkspace(page);
+      await openObject(page, type, name);
+
+      // Defaults to Preview for a previewable type.
+      await expect(page.getByTestId(`workspace-middle-${type}-preview`)).toBeVisible({
+        timeout: 15000,
+      });
+
+      // Flip to Lineage.
+      await page.getByTestId('workspace-lens-picker-option-lineage').click();
+      await expect(page.getByTestId(`workspace-middle-${type}-lineage`)).toBeVisible();
+      await expect(page.getByTestId(`workspace-middle-${type}-preview`)).toHaveCount(0);
+
+      // Flip back to Preview.
+      await page.getByTestId('workspace-lens-picker-option-preview').click();
+      await expect(page.getByTestId(`workspace-middle-${type}-preview`)).toBeVisible();
+    });
+  }
+});
+
+test.describe('Track N deep — preview-less types mute Preview + lock onto Lineage', () => {
+  for (const { type, name } of [
+    { type: 'source', name: 'local-sqlite' },
+    { type: 'dimension', name: 'x_rounded' },
+    { type: 'metric', name: 'total_value' },
+    { type: 'relation', name: 'local_to_local' },
+  ]) {
+    test(`${type}: defaults to Lineage, Preview option is disabled`, async ({ page }) => {
+      await gotoWorkspace(page);
+      await openObject(page, type, name);
+
+      // Parks on Lineage — no preview surface exists.
+      await expect(page.getByTestId(`workspace-middle-${type}-lineage`)).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(page.getByTestId(`workspace-middle-${type}-preview`)).toHaveCount(0);
+
+      // The Preview lens option is muted (disabled) — clicking it cannot switch.
+      const previewOpt = page.getByTestId('workspace-lens-picker-option-preview');
+      await expect(previewOpt).toBeDisabled();
+      await previewOpt.click({ force: true }).catch(() => {});
+      await expect(page.getByTestId(`workspace-middle-${type}-lineage`)).toBeVisible();
+      await expect(page.getByTestId(`workspace-middle-${type}-preview`)).toHaveCount(0);
+    });
+  }
+});
+
+test.describe('Track N deep — cross-component interaction (middle preview ⇄ right-rail Edit)', () => {
+  test('selecting a chart updates BOTH the middle preview and the right-rail Edit form', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+    await openObject(page, 'chart', 'simple-scatter-chart');
+
+    // Middle pane: chart preview.
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    // Right rail: the selection chip identifies the same chart.
+    const chip = page.getByTestId('right-rail-selection-chip');
+    await expect(chip).toBeVisible({ timeout: 10000 });
+    await expect(chip).toHaveAttribute('data-object-type', 'chart');
+    await expect(chip).toContainText('simple-scatter-chart');
+  });
+
+  test('switching object TYPES swaps both surfaces with no stale state', async ({ page }) => {
+    await gotoWorkspace(page);
+
+    // 1) Start on a chart.
+    await openObject(page, 'chart', 'simple-scatter-chart');
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('right-rail-selection-chip')).toHaveAttribute(
+      'data-object-type',
+      'chart'
+    );
+
+    // 2) Switch to a table — chart preview must unmount, table preview mounts,
+    //    and the right-rail chip must re-key to the table.
+    await openObject(page, 'table', 'new_table');
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toHaveCount(0);
+    await expect(page.getByTestId('right-rail-selection-chip')).toHaveAttribute(
+      'data-object-type',
+      'table'
+    );
+    await expect(page.getByTestId('right-rail-selection-chip')).toContainText('new_table');
+
+    // 3) Switch to a preview-less source — middle pane swaps to Lineage, the
+    //    Preview lens mutes, and the chip re-keys to the source. No stale table
+    //    preview or chart preview is left mounted.
+    await openObject(page, 'source', 'local-sqlite');
+    await expect(page.getByTestId('workspace-middle-source-lineage')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-middle-table-preview')).toHaveCount(0);
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toHaveCount(0);
+    await expect(page.getByTestId('workspace-lens-picker-option-preview')).toBeDisabled();
+    await expect(page.getByTestId('right-rail-selection-chip')).toHaveAttribute(
+      'data-object-type',
+      'source'
+    );
+
+    // 4) Back to an insight — Preview lens un-mutes and the insight chart mounts,
+    //    proving the lens un-locks when moving from a preview-less type to a
+    //    previewable one (no stale "locked on lineage" state).
+    await openObject(page, 'insight', 'simple-scatter-insight');
+    await expect(page.getByTestId('workspace-middle-insight-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-lens-picker-option-preview')).toBeEnabled();
+    await expect(page.getByTestId('right-rail-selection-chip')).toHaveAttribute(
+      'data-object-type',
+      'insight'
+    );
+  });
+
+  test('a Lineage-flipped object does NOT leak its lens to the next previewable object', async ({
+    page,
+  }) => {
+    // Regression (found during the Track N hardening pass): PerObjectPane is a
+    // single reused React instance, so a chart flipped to Lineage leaked its
+    // lens — selecting a table next opened it on Lineage instead of its Preview
+    // default. The lens must reset to the new object's default on every switch.
+    await gotoWorkspace(page);
+
+    // Cross-type: chart (flip to Lineage) → table must default to Preview.
+    await openObject(page, 'chart', 'simple-scatter-chart');
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.getByTestId('workspace-lens-picker-option-lineage').click();
+    await expect(page.getByTestId('workspace-middle-chart-lineage')).toBeVisible();
+
+    await openObject(page, 'table', 'new_table');
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-middle-table-lineage')).toHaveCount(0);
+
+    // Same-type: table (flip to Lineage) → a different table must default to Preview.
+    await page.getByTestId('workspace-lens-picker-option-lineage').click();
+    await expect(page.getByTestId('workspace-middle-table-lineage')).toBeVisible();
+    await openObject(page, 'table', 'awesome-table');
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-middle-table-lineage')).toHaveCount(0);
+  });
+});

--- a/viewer/e2e/stories/workspace-object-previews.spec.mjs
+++ b/viewer/e2e/stories/workspace-object-previews.spec.mjs
@@ -1,0 +1,135 @@
+/**
+ * Story: Per-object Preview lens in the Workspace middle pane (Track N).
+ *
+ * Covers VIS-784 (ChartPreview), VIS-791 (TablePreview), and VIS-798
+ * (InsightPreview) — the three non-trivial renderers. Selecting a chart /
+ * table / insight from the Library opens it as the active object; the middle
+ * pane defaults to the Preview lens and mounts that type's custom preview
+ * component, which reuses the existing renderer (Plotly chart for chart +
+ * insight, a data table for tables). Flipping to the Lineage lens swaps to the
+ * universal DAG view, and back.
+ *
+ * Precondition: sandbox running on :3001/:8001
+ *   cd test-projects/integration && visivo serve --port 8001
+ *   (Vite on :3001 proxying to :8001 — `bash scripts/sandbox.sh start`)
+ *
+ * Object names are from the integration project:
+ *   chart   = simple-scatter-chart
+ *   table   = new_table
+ *   insight = simple-scatter-insight
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+
+/** Expand a Library per-type subsection (collapsed by default, VIS-828) and
+ *  click the named row, returning the row locator. */
+async function openObject(page, type, name) {
+  await page.getByTestId(`library-subsection-${type}-header`).click();
+  const row = page.getByTestId(`library-row-${type}-${name}`);
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.click();
+  return row;
+}
+
+test.describe('Workspace per-object Preview lens (Track N)', () => {
+  test('Step 1: selecting a chart mounts the ChartPreview with a real Plotly chart', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 10000 });
+
+    await openObject(page, 'chart', 'simple-scatter-chart');
+
+    // Preview lens is the default for a chart; the custom preview mounts.
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('chart-preview')).toBeVisible();
+
+    // The existing <Chart> renderer draws a real Plotly surface.
+    const plot = page.locator('.js-plotly-plot').first();
+    await expect(plot).toBeVisible({ timeout: 30000 });
+    const drawn = await page.evaluate(() => ({
+      svgs: document.querySelectorAll('.js-plotly-plot svg.main-svg').length,
+      canvases: document.querySelectorAll('.js-plotly-plot canvas').length,
+    }));
+    expect(drawn.svgs + drawn.canvases).toBeGreaterThanOrEqual(1);
+  });
+
+  test('Step 2: a chart can flip from Preview to the Lineage lens and back', async ({ page }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+    await openObject(page, 'chart', 'simple-scatter-chart');
+
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Flip to Lineage.
+    await page.getByTestId('workspace-lens-picker-option-lineage').click();
+    await expect(page.getByTestId('workspace-middle-chart-lineage')).toBeVisible();
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toHaveCount(0);
+
+    // Flip back to Preview.
+    await page.getByTestId('workspace-lens-picker-option-preview').click();
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible();
+  });
+
+  test('Step 3: selecting a table mounts the TablePreview with rendered rows', async ({ page }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    await openObject(page, 'table', 'new_table');
+
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('table-preview')).toBeVisible();
+
+    // The existing <Table> renderer (PivotableTable) replaces its Loading
+    // spinner with the toolbar's "Search..." field once the model data loads,
+    // so a visible Search box inside the preview proves data rendered.
+    await expect(
+      page.locator('[data-testid="table-preview"]').getByPlaceholder('Search...')
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test('Step 4: selecting an insight mounts the InsightPreview as a chart', async ({ page }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    await openObject(page, 'insight', 'simple-scatter-insight');
+
+    await expect(page.getByTestId('workspace-middle-insight-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('insight-preview')).toBeVisible();
+
+    // The Explorer insight render path draws a real Plotly chart.
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('Step 5: a preview-less object (source) falls back to the Lineage lens', async ({ page }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    // Sources have no custom preview — the pane must lock onto Lineage.
+    const sourceRow = page
+      .getByTestId('library-subsection-source-rows')
+      .locator('[data-testid^="library-row-source-"]')
+      .first();
+    await page.getByTestId('library-subsection-source-header').click();
+    await expect(sourceRow).toBeVisible({ timeout: 10000 });
+    await sourceRow.click();
+
+    await expect(page.getByTestId('workspace-middle-source-lineage')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('workspace-middle-source-preview')).toHaveCount(0);
+  });
+});

--- a/viewer/e2e/stories/workspace-previews-visual-capture.spec.mjs
+++ b/viewer/e2e/stories/workspace-previews-visual-capture.spec.mjs
@@ -1,0 +1,118 @@
+/**
+ * Visual capture for Track N preview surfaces (aesthetic sweep tooling).
+ *
+ * NOT an assertion spec — it navigates to each preview surface at desktop and
+ * mobile viewports and saves a full-page PNG to /tmp/hard-n/ so the captured
+ * frames can be reviewed for contrast / overflow / responsiveness. Each preview
+ * type is captured in BOTH its Preview and (for previewable types) Lineage lens,
+ * plus the preview-less Lineage-lock case.
+ *
+ * Run: VISIVO_BASE_URL=http://localhost:3021 npx playwright test \
+ *        e2e/stories/workspace-previews-visual-capture.spec.mjs --project=parallel
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+const BASE_URL = process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const OUT = '/tmp/hard-n';
+fs.mkdirSync(OUT, { recursive: true });
+
+const VIEWPORTS = [
+  { tag: 'desktop', width: 1440, height: 900 },
+  { tag: 'mobile', width: 390, height: 844 },
+];
+
+// type → representative object name (verified live).
+const PREVIEWABLE = [
+  { type: 'chart', name: 'simple-scatter-chart' },
+  { type: 'table', name: 'new_table' },
+  { type: 'insight', name: 'simple-scatter-insight' },
+  { type: 'input', name: 'show_markers' },
+  { type: 'model', name: 'sales_data' },
+];
+const PREVIEW_LESS = [
+  { type: 'source', name: 'local-sqlite' },
+  { type: 'metric', name: 'total_value' },
+];
+
+async function openObject(page, type, name) {
+  await page.getByTestId(`library-subsection-${type}-header`).click();
+  const row = page.getByTestId(`library-row-${type}-${name}`);
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.click();
+}
+
+for (const vp of VIEWPORTS) {
+  test.describe(`visual capture @ ${vp.tag}`, () => {
+    test.use({ viewport: { width: vp.width, height: vp.height } });
+
+    test(`capture ${vp.tag} preview surfaces`, async ({ page }) => {
+      // Pure capture tooling — it visits many surfaces with deliberate settle
+      // waits, so the default 30s test budget is too small. Use a generous
+      // finite budget (NOT 0) so an off-screen mobile click can't hang forever.
+      test.setTimeout(240000);
+      await page.goto(`${BASE_URL}/workspace`);
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 10000 });
+
+      // Bare workspace shell first.
+      await page.screenshot({ path: `${OUT}/${vp.tag}-00-shell.png`, fullPage: false });
+
+      // On a wide viewport the three-rail shell shows the middle pane in-frame,
+      // so a plain viewport screenshot captures the preview. On a narrow
+      // (mobile) viewport the shell does NOT reflow — it overflows horizontally
+      // and the middle pane sits off-screen-right inside an overflow-hidden
+      // parent, so it cannot be scrolled into the viewport. Capturing the
+      // visible viewport there is the honest representation of what a mobile
+      // user actually sees (the Library, with the editor clipped off-screen).
+      // We never use element.screenshot()/scrollIntoView here because that hangs
+      // on a clipped off-screen element.
+      const shotMiddle = async file => {
+        await page.screenshot({ path: file, fullPage: false }).catch(() => {});
+      };
+
+      // Every interaction is timeout-guarded (5s) and swallowed so a single
+      // off-screen control on mobile degrades to "no extra shot", never a hang.
+      const safeClick = sel =>
+        page.getByTestId(sel).click({ timeout: 5000 }).catch(() => {});
+
+      let idx = 1;
+      for (const { type, name } of PREVIEWABLE) {
+        await openObject(page, type, name).catch(() => {});
+        await page
+          .getByTestId(`workspace-middle-${type}-preview`)
+          .waitFor({ timeout: 15000 })
+          .catch(() => {});
+        await page.waitForTimeout(2500);
+        if (type === 'model') {
+          await safeClick('model-preview-run');
+          await page.waitForTimeout(4000);
+        }
+        await shotMiddle(
+          `${OUT}/${vp.tag}-${String(idx).padStart(2, '0')}-${type}-preview.png`
+        );
+
+        await safeClick('workspace-lens-picker-option-lineage');
+        await page.waitForTimeout(1500);
+        await shotMiddle(
+          `${OUT}/${vp.tag}-${String(idx).padStart(2, '0')}-${type}-lineage.png`
+        );
+        idx += 1;
+      }
+
+      for (const { type, name } of PREVIEW_LESS) {
+        await openObject(page, type, name).catch(() => {});
+        await page
+          .getByTestId(`workspace-middle-${type}-lineage`)
+          .waitFor({ timeout: 12000 })
+          .catch(() => {});
+        await page.waitForTimeout(1500);
+        await shotMiddle(
+          `${OUT}/${vp.tag}-${String(idx).padStart(2, '0')}-${type}-lineagelock.png`
+        );
+        idx += 1;
+      }
+    });
+  });
+}

--- a/viewer/src/components/new-views/workspace/ChartPreview.jsx
+++ b/viewer/src/components/new-views/workspace/ChartPreview.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import useStore from '../../../stores/store';
+import Chart from '../../items/Chart';
+import { useInsightsData } from '../../../hooks/useInsightsData';
+import { useInputsData } from '../../../hooks/useInputsData';
+import { parseRefValue } from '../../../utils/refString';
+
+/**
+ * ChartPreview — VIS-784 / N-1.
+ *
+ * Renders the active chart full-size via the EXISTING `<Chart>` renderer — the
+ * same component the Dashboard mounts for a chart item — so a saved chart
+ * previews identically to how it renders on a dashboard. No editing
+ * affordances; editing lives in the right rail.
+ *
+ * The chart record is resolved from the chart store by name (RightRailEditPanel
+ * COLLECTION_KEY['chart'] = 'charts'). Its `insights` arrive as un-resolved
+ * context-string refs from the store endpoint; we normalize them into
+ * `{ name }` objects exactly as <Dashboard> does (the VIS-827 fix) so
+ * Chart.jsx's `chart.insights.map(i => i.name)` resolves, and we load each
+ * insight's data via the same `useInsightsData` hook the Dashboard uses.
+ */
+const ChartPreview = ({ activeObject, projectId }) => {
+  const name = activeObject?.name || null;
+  const charts = useStore(s => s.charts);
+  const fetchCharts = useStore(s => s.fetchCharts);
+
+  useEffect(() => {
+    if ((!charts || charts.length === 0) && typeof fetchCharts === 'function') {
+      fetchCharts();
+    }
+  }, [charts, fetchCharts]);
+
+  const record = useMemo(
+    () => (Array.isArray(charts) ? charts.find(c => c.name === name) || null : null),
+    [charts, name]
+  );
+
+  // Normalize insight refs ("${ref(name)}") → { name } objects so <Chart>
+  // resolves the insight names it loads (mirrors <Dashboard>'s VIS-827 fix).
+  const chart = useMemo(() => {
+    if (!record) return null;
+    const config = record.config || record;
+    const rawInsights = Array.isArray(config.insights) ? config.insights : [];
+    const insights = rawInsights.map(insight =>
+      typeof insight === 'string' ? { name: parseRefValue(insight) } : insight
+    );
+    return {
+      name: record.name,
+      insights,
+      traces: [],
+      layout: config.layout || {},
+    };
+  }, [record]);
+
+  const insightNames = useMemo(
+    () => (chart?.insights || []).map(i => i?.name).filter(Boolean),
+    [chart]
+  );
+
+  // Load each insight's data from the main run (the same hook the Dashboard
+  // drives) plus any inputs those insights depend on.
+  useInsightsData(projectId, insightNames);
+  const inputDeps = useStore(
+    useShallow(s => {
+      const names = new Set();
+      for (const n of insightNames) {
+        const job = s.insightJobs?.[n];
+        (job?.inputDependencies || []).forEach(dep => names.add(dep));
+      }
+      return Array.from(names).sort();
+    })
+  );
+  useInputsData(projectId, inputDeps);
+
+  if (!chart) {
+    return (
+      <div
+        data-testid="chart-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Chart "${name}" not found.` : 'No chart selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="chart-preview" className="flex flex-1 min-h-0 bg-white p-4">
+      <div className="relative h-full w-full" style={{ minWidth: 0 }}>
+        <Chart chart={chart} projectId={projectId} shouldLoad={true} hideToolbar={true} />
+      </div>
+    </div>
+  );
+};
+
+export default ChartPreview;

--- a/viewer/src/components/new-views/workspace/ChartPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/ChartPreview.test.jsx
@@ -1,0 +1,70 @@
+/**
+ * ChartPreview tests (VIS-784 / N-1).
+ *
+ * The Track-N chart preview reuses the EXISTING <Chart> renderer, resolving the
+ * saved chart from the chart store by name and normalizing its insight refs
+ * into { name } objects (the VIS-827 normalization) so <Chart> loads the right
+ * data. <Chart> and the data hooks are mocked so this stays a focused unit test.
+ */
+/* eslint-disable no-template-curly-in-string -- literal ${ref(...)} strings under test */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import ChartPreview from './ChartPreview';
+import useStore from '../../../stores/store';
+
+// Capture the chart prop handed to the (mocked) renderer so we can assert the
+// resolved/normalized config.
+const mockChartSpy = jest.fn();
+jest.mock('../../items/Chart', () => ({
+  __esModule: true,
+  default: props => {
+    mockChartSpy(props);
+    return <div data-testid="chart-renderer-mock">{props.chart?.name}</div>;
+  },
+}));
+jest.mock('../../../hooks/useInsightsData', () => ({
+  useInsightsData: jest.fn(),
+}));
+jest.mock('../../../hooks/useInputsData', () => ({
+  useInputsData: jest.fn(),
+}));
+
+const seed = (charts = []) => {
+  act(() => {
+    useStore.setState({ charts, fetchCharts: jest.fn(), insightJobs: {} });
+  });
+};
+
+describe('ChartPreview (VIS-784)', () => {
+  beforeEach(() => mockChartSpy.mockClear());
+
+  test('renders the existing Chart renderer for a saved chart', () => {
+    seed([
+      { name: 'revenue', config: { insights: ['${ref(rev-insight)}'], layout: { title: 'Rev' } } },
+    ]);
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'revenue' }} projectId="p1" />);
+    expect(screen.getByTestId('chart-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toHaveTextContent('revenue');
+  });
+
+  test('normalizes string insight refs into { name } objects for the renderer', () => {
+    seed([{ name: 'revenue', config: { insights: ['${ref(rev-insight)}'] } }]);
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'revenue' }} projectId="p1" />);
+    const passedChart = mockChartSpy.mock.calls[0][0].chart;
+    expect(passedChart.insights).toEqual([{ name: 'rev-insight' }]);
+    expect(passedChart.name).toBe('revenue');
+  });
+
+  test('preserves embedded insight objects untouched', () => {
+    seed([{ name: 'revenue', config: { insights: [{ name: 'inline', props: { type: 'bar' } }] } }]);
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'revenue' }} projectId="p1" />);
+    const passedChart = mockChartSpy.mock.calls[0][0].chart;
+    expect(passedChart.insights).toEqual([{ name: 'inline', props: { type: 'bar' } }]);
+  });
+
+  test('renders an empty state when the chart is not found', () => {
+    seed([]);
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'missing' }} projectId="p1" />);
+    expect(screen.getByTestId('chart-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/InputPreview.jsx
+++ b/viewer/src/components/new-views/workspace/InputPreview.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useMemo } from 'react';
+import useStore from '../../../stores/store';
+import Input from '../../items/Input';
+import { useInputsData } from '../../../hooks/useInputsData';
+
+/**
+ * InputPreview — VIS-796 / N-4.
+ *
+ * Renders the active input CONTROL via the EXISTING `<Input>` renderer (the
+ * same widget the Dashboard mounts) plus its current selected value. No editing
+ * affordances — editing lives in the right rail.
+ *
+ * The input record is resolved from the input store collection by name
+ * (RightRailEditPanel COLLECTION_KEY['input'] = 'inputs'). Query-based inputs
+ * need their dropdown options loaded; `useInputsData` (the same hook the
+ * Dashboard uses) fetches them. The current value is read from the input-jobs
+ * store the renderer already drives, surfaced beside the control so the preview
+ * shows BOTH the control and "its current value" per the issue.
+ */
+const InputPreview = ({ activeObject, projectId }) => {
+  const name = activeObject?.name || null;
+  const inputs = useStore(s => s.inputs);
+  const fetchInputs = useStore(s => s.fetchInputs);
+  const selectedValue = useStore(s => s.inputSelectedValues?.[name]);
+
+  useEffect(() => {
+    if ((!inputs || inputs.length === 0) && typeof fetchInputs === 'function') {
+      fetchInputs();
+    }
+  }, [inputs, fetchInputs]);
+
+  const record = useMemo(
+    () => (Array.isArray(inputs) ? inputs.find(i => i.name === name) || null : null),
+    [inputs, name]
+  );
+
+  const inputConfig = useMemo(() => {
+    if (!record) return null;
+    const config = record.config || record;
+    return { name: record.name, ...config };
+  }, [record]);
+
+  const namesToLoad = useMemo(() => (inputConfig ? [inputConfig.name] : []), [inputConfig]);
+  useInputsData(projectId, namesToLoad);
+
+  if (!inputConfig) {
+    return (
+      <div
+        data-testid="input-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Input "${name}" not found.` : 'No input selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  const displayValue =
+    selectedValue === undefined || selectedValue === null
+      ? '—'
+      : Array.isArray(selectedValue)
+        ? selectedValue.join(', ') || '—'
+        : String(selectedValue);
+
+  return (
+    <div
+      data-testid="input-preview"
+      className="flex flex-1 min-h-0 flex-col items-center justify-center gap-6 bg-gray-50 p-8"
+    >
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <Input input={inputConfig} projectId={projectId} itemWidth={1} />
+      </div>
+      <div
+        data-testid="input-preview-value"
+        className="text-[13px] text-gray-600"
+      >
+        <span className="font-medium text-gray-500">Current value: </span>
+        <span className="font-mono text-gray-900">{displayValue}</span>
+      </div>
+    </div>
+  );
+};
+
+export default InputPreview;

--- a/viewer/src/components/new-views/workspace/InputPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/InputPreview.test.jsx
@@ -1,0 +1,68 @@
+/**
+ * InputPreview tests (VIS-796 / N-4).
+ *
+ * The Track-N input preview reuses the EXISTING <Input> control renderer,
+ * resolving the saved input from the input store by name and surfacing its
+ * current selected value. <Input> and the options-loading hook are mocked.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import InputPreview from './InputPreview';
+import useStore from '../../../stores/store';
+
+const mockInputSpy = jest.fn();
+jest.mock('../../items/Input', () => ({
+  __esModule: true,
+  default: props => {
+    mockInputSpy(props);
+    return <div data-testid="input-renderer-mock">{props.input?.name}</div>;
+  },
+}));
+jest.mock('../../../hooks/useInputsData', () => ({
+  useInputsData: jest.fn(),
+}));
+
+const seed = (inputs = [], selectedValues = {}) => {
+  act(() => {
+    useStore.setState({
+      inputs,
+      fetchInputs: jest.fn(),
+      inputSelectedValues: selectedValues,
+    });
+  });
+};
+
+describe('InputPreview (VIS-796)', () => {
+  beforeEach(() => mockInputSpy.mockClear());
+
+  test('renders the existing Input control for a saved input', () => {
+    seed([{ name: 'region', config: { type: 'single-select' } }]);
+    render(<InputPreview activeObject={{ type: 'input', name: 'region' }} projectId="p1" />);
+    expect(screen.getByTestId('input-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('input-renderer-mock')).toHaveTextContent('region');
+  });
+
+  test('surfaces the current selected value beside the control', () => {
+    seed([{ name: 'region', config: { type: 'single-select' } }], { region: 'west' });
+    render(<InputPreview activeObject={{ type: 'input', name: 'region' }} projectId="p1" />);
+    expect(screen.getByTestId('input-preview-value')).toHaveTextContent('west');
+  });
+
+  test('renders a placeholder dash when no value is selected', () => {
+    seed([{ name: 'region', config: { type: 'single-select' } }], {});
+    render(<InputPreview activeObject={{ type: 'input', name: 'region' }} projectId="p1" />);
+    expect(screen.getByTestId('input-preview-value')).toHaveTextContent('—');
+  });
+
+  test('joins multi-select array values for display', () => {
+    seed([{ name: 'tags', config: { type: 'multi-select' } }], { tags: ['a', 'b'] });
+    render(<InputPreview activeObject={{ type: 'input', name: 'tags' }} projectId="p1" />);
+    expect(screen.getByTestId('input-preview-value')).toHaveTextContent('a, b');
+  });
+
+  test('renders an empty state when the input is not found', () => {
+    seed([], {});
+    render(<InputPreview activeObject={{ type: 'input', name: 'missing' }} projectId="p1" />);
+    expect(screen.getByTestId('input-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/InsightPreview.jsx
+++ b/viewer/src/components/new-views/workspace/InsightPreview.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useMemo } from 'react';
+import useStore from '../../../stores/store';
+import ExplorerInsightPreview from '../common/InsightPreview';
+
+/**
+ * InsightPreview — VIS-798 / N-5.
+ *
+ * Renders the active insight as a chart via Explorer's EXISTING render path —
+ * the `common/InsightPreview` component (the one the Explorer / right-rail
+ * editor use), which builds a synthetic single-insight chart, mounts the input
+ * controls the insight depends on, and drives data through
+ * `useInsightPreviewData`. No editing affordances — editing lives in the right
+ * rail.
+ *
+ * The insight record is resolved from the insight store by name
+ * (RightRailEditPanel COLLECTION_KEY['insight'] = 'insights'); we hand the saved
+ * config (with its name) to the shared preview, which reuses the main-run data
+ * when present and otherwise triggers a preview run.
+ */
+const InsightPreview = ({ activeObject, projectId }) => {
+  const name = activeObject?.name || null;
+  const insights = useStore(s => s.insights);
+  const fetchInsights = useStore(s => s.fetchInsights);
+
+  useEffect(() => {
+    if ((!insights || insights.length === 0) && typeof fetchInsights === 'function') {
+      fetchInsights();
+    }
+  }, [insights, fetchInsights]);
+
+  const record = useMemo(
+    () => (Array.isArray(insights) ? insights.find(i => i.name === name) || null : null),
+    [insights, name]
+  );
+
+  const insightConfig = useMemo(() => {
+    if (!record) return null;
+    const config = record.config || record;
+    return { name: record.name, ...config };
+  }, [record]);
+
+  if (!insightConfig) {
+    return (
+      <div
+        data-testid="insight-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Insight "${name}" not found.` : 'No insight selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="insight-preview" className="flex flex-1 min-h-0 flex-col bg-white">
+      <ExplorerInsightPreview insightConfig={insightConfig} projectId={projectId} />
+    </div>
+  );
+};
+
+export default InsightPreview;

--- a/viewer/src/components/new-views/workspace/InsightPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/InsightPreview.test.jsx
@@ -1,0 +1,52 @@
+/**
+ * InsightPreview tests (VIS-798 / N-5).
+ *
+ * The Track-N insight preview reuses Explorer's EXISTING render path — the
+ * common/InsightPreview component — resolving the saved insight from the insight
+ * store by name and handing it the config. The Explorer preview is mocked for a
+ * focused unit test.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import InsightPreview from './InsightPreview';
+import useStore from '../../../stores/store';
+
+const mockExplorerInsightSpy = jest.fn();
+jest.mock('../common/InsightPreview', () => ({
+  __esModule: true,
+  default: props => {
+    mockExplorerInsightSpy(props);
+    return <div data-testid="explorer-insight-preview-mock">{props.insightConfig?.name}</div>;
+  },
+}));
+
+const seed = (insights = []) => {
+  act(() => {
+    useStore.setState({ insights, fetchInsights: jest.fn() });
+  });
+};
+
+describe('InsightPreview (VIS-798)', () => {
+  beforeEach(() => mockExplorerInsightSpy.mockClear());
+
+  test('renders the Explorer insight render path for a saved insight', () => {
+    seed([{ name: 'sales', config: { props: { type: 'bar' } } }]);
+    render(<InsightPreview activeObject={{ type: 'insight', name: 'sales' }} projectId="p1" />);
+    expect(screen.getByTestId('insight-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('explorer-insight-preview-mock')).toHaveTextContent('sales');
+  });
+
+  test('passes the resolved config (with name) and projectId to the Explorer preview', () => {
+    seed([{ name: 'sales', config: { props: { type: 'bar' } } }]);
+    render(<InsightPreview activeObject={{ type: 'insight', name: 'sales' }} projectId="p1" />);
+    const props = mockExplorerInsightSpy.mock.calls[0][0];
+    expect(props.insightConfig).toMatchObject({ name: 'sales', props: { type: 'bar' } });
+    expect(props.projectId).toBe('p1');
+  });
+
+  test('renders an empty state when the insight is not found', () => {
+    seed([]);
+    render(<InsightPreview activeObject={{ type: 'insight', name: 'missing' }} projectId="p1" />);
+    expect(screen.getByTestId('insight-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/MarkdownPreview.jsx
+++ b/viewer/src/components/new-views/workspace/MarkdownPreview.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useMemo } from 'react';
+import useStore from '../../../stores/store';
+import Markdown from '../../items/Markdown';
+
+/**
+ * MarkdownPreview — VIS-795 / N-3.
+ *
+ * Renders the active markdown object full-size via the EXISTING markdown render
+ * path (`<Markdown>`, the same component the Dashboard mounts for a markdown
+ * item). No editing affordances — editing lives in the right rail.
+ *
+ * The markdown record is resolved from the markdown store collection by name
+ * (mirroring RightRailEditPanel's COLLECTION_KEY['markdown'] = 'markdowns').
+ * <Markdown> takes `markdown` (the config), a `row` (for height behaviour) and
+ * an optional `height`; the preview gives it a non-compact row so the content
+ * scrolls within the pane.
+ */
+const MarkdownPreview = ({ activeObject }) => {
+  const name = activeObject?.name || null;
+  const markdowns = useStore(s => s.markdowns);
+  const fetchMarkdowns = useStore(s => s.fetchMarkdowns);
+
+  useEffect(() => {
+    if ((!markdowns || markdowns.length === 0) && typeof fetchMarkdowns === 'function') {
+      fetchMarkdowns();
+    }
+  }, [markdowns, fetchMarkdowns]);
+
+  const record = useMemo(
+    () => (Array.isArray(markdowns) ? markdowns.find(m => m.name === name) || null : null),
+    [markdowns, name]
+  );
+
+  const markdownConfig = useMemo(() => {
+    if (!record) return null;
+    const config = record.config || record;
+    return { name: record.name, ...config };
+  }, [record]);
+
+  if (!markdownConfig) {
+    return (
+      <div
+        data-testid="markdown-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Markdown "${name}" not found.` : 'No markdown selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="markdown-preview"
+      className="flex flex-1 min-h-0 overflow-auto bg-white p-6"
+    >
+      <div className="mx-auto w-full max-w-[820px]">
+        <Markdown markdown={markdownConfig} row={{ height: 'medium' }} height="100%" />
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownPreview;

--- a/viewer/src/components/new-views/workspace/MarkdownPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/MarkdownPreview.test.jsx
@@ -1,0 +1,50 @@
+/**
+ * MarkdownPreview tests (VIS-795 / N-3).
+ *
+ * The Track-N markdown preview reuses the EXISTING <Markdown> renderer,
+ * resolving the saved markdown from the markdown store by name. <Markdown> is
+ * mocked for a focused unit test.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import MarkdownPreview from './MarkdownPreview';
+import useStore from '../../../stores/store';
+
+const mockMdSpy = jest.fn();
+jest.mock('../../items/Markdown', () => ({
+  __esModule: true,
+  default: props => {
+    mockMdSpy(props);
+    return <div data-testid="markdown-renderer-mock">{props.markdown?.content}</div>;
+  },
+}));
+
+const seed = (markdowns = []) => {
+  act(() => {
+    useStore.setState({ markdowns, fetchMarkdowns: jest.fn() });
+  });
+};
+
+describe('MarkdownPreview (VIS-795)', () => {
+  beforeEach(() => mockMdSpy.mockClear());
+
+  test('renders the existing Markdown renderer for a saved markdown', () => {
+    seed([{ name: 'intro', config: { content: '# Hello' } }]);
+    render(<MarkdownPreview activeObject={{ type: 'markdown', name: 'intro' }} />);
+    expect(screen.getByTestId('markdown-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('markdown-renderer-mock')).toHaveTextContent('# Hello');
+  });
+
+  test('passes the resolved config (with name) to the renderer', () => {
+    seed([{ name: 'intro', config: { content: '# Hi', align: 'center' } }]);
+    render(<MarkdownPreview activeObject={{ type: 'markdown', name: 'intro' }} />);
+    const passed = mockMdSpy.mock.calls[0][0].markdown;
+    expect(passed).toMatchObject({ name: 'intro', content: '# Hi', align: 'center' });
+  });
+
+  test('renders an empty state when the markdown is not found', () => {
+    seed([]);
+    render(<MarkdownPreview activeObject={{ type: 'markdown', name: 'missing' }} />);
+    expect(screen.getByTestId('markdown-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/MiddlePane.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.jsx
@@ -3,6 +3,7 @@ import SubBar, { PreviewLensPicker } from './SubBar';
 import ProjectCanvas from '../project/canvas/ProjectCanvas';
 import ProjectEditor from '../project/editor/ProjectEditor';
 import LineageCanvas from '../lineage/LineageCanvas';
+import { getPreviewComponent } from './previewRegistry';
 import useStore from '../../../stores/store';
 
 /**
@@ -12,9 +13,12 @@ import useStore from '../../../stores/store';
  *   dashboard  → ProjectCanvas (render-only Dashboard wrapper, VIS-767) when
  *                scoped, placeholder otherwise; the Lineage lens mounts <LineageCanvas>
  *   _          → PerObjectPane (chart/model/insight/input/table/markdown/
- *                source/dimension/metric/relation/unknown). The Lineage lens is
- *                universal (VIS-779) and the per-object default — it mounts
- *                <LineageCanvas>; the Preview lens shows the Track N placeholder.
+ *                source/dimension/metric/relation/unknown). Track-N types
+ *                (chart/table/markdown/input/insight/model) mount their custom
+ *                Preview component (from previewRegistry, reusing the existing
+ *                renderer) in the Preview lens; every other type has no preview
+ *                and falls back to the universal Lineage lens (VIS-779),
+ *                mounting <LineageCanvas> with the Preview option muted.
  *
  * Each variant renders the `<SubBar>` above its viewport so the lens picker
  * stays close to the surface it switches the view of (per the chat
@@ -108,17 +112,28 @@ const DashboardPane = ({ activeObject, lens, onLensChange, projectId }) => {
   );
 };
 
-const PerObjectPane = ({ activeObject }) => {
+const PerObjectPane = ({ activeObject, projectId }) => {
   const name = activeObject?.name || '(unnamed)';
   const type = activeObject?.type || 'object';
-  // No custom previews exist yet (Track N), so Lineage is the default lens for
-  // any selected non-dashboard object — selecting one immediately shows its DAG
-  // via <LineageCanvas> (scoped through useWorkspaceScope). The shared store
-  // lens defaults to 'preview' (the dashboard *canvas* default), which is not a
-  // meaningful default for objects with no preview surface, so the per-object
-  // lens is tracked locally and defaults to 'lineage'. Preview stays selectable
-  // in the picker (it shows the Track N placeholder until custom previews ship).
-  const [lensEffective, setLensEffective] = React.useState('lineage');
+  // Track N: a subset of object types (chart / table / markdown / input /
+  // insight / model) now have a custom Preview component registered in
+  // previewRegistry; each reuses that type's EXISTING renderer. Types WITHOUT a
+  // registered preview (source, dimension, metric, relation, unknown, …) have no
+  // preview surface, so they default to — and stay parked on — the universal
+  // Lineage lens (VIS-779), with the Preview option muted (N-7 / VIS-803 is
+  // canceled; the fallback is the plain Lineage lens, not a bespoke component).
+  const PreviewComponent = getPreviewComponent(type);
+  const hasPreview = Boolean(PreviewComponent);
+  // Types with a custom preview default to the Preview lens (it's their primary
+  // surface); fallback types default to — and lock onto — Lineage. The shared
+  // store lens defaults to 'preview' (the dashboard *canvas* default), which is
+  // not meaningful for objects with no preview surface, so the per-object lens
+  // is tracked locally.
+  const [lensEffective, setLensEffective] = React.useState(
+    hasPreview ? 'preview' : 'lineage'
+  );
+  // A fallback type can never show Preview — clamp any stale 'preview' selection.
+  const lens = hasPreview ? lensEffective : 'lineage';
   return (
     <section
       data-testid={`workspace-middle-${type}`}
@@ -135,13 +150,14 @@ const PerObjectPane = ({ activeObject }) => {
         }
         right={
           <PreviewLensPicker
-            value={lensEffective}
+            value={lens}
             onChange={setLensEffective}
             previewLabel="Preview"
+            previewDisabled={!hasPreview}
           />
         }
       />
-      {lensEffective === 'lineage' ? (
+      {lens === 'lineage' ? (
         <div
           data-testid={`workspace-middle-${type}-lineage`}
           className="flex flex-1 min-h-0"
@@ -149,11 +165,12 @@ const PerObjectPane = ({ activeObject }) => {
           <LineageCanvas />
         </div>
       ) : (
-        <Placeholder
-          testId={`workspace-middle-${type}-placeholder`}
-          title="Per-object preview coming soon (Track N)"
-          body={`Custom previews for ${type}s ship in Phase 4. The Lineage lens shows this object's DAG today.`}
-        />
+        <div
+          data-testid={`workspace-middle-${type}-preview`}
+          className="flex flex-1 min-h-0"
+        >
+          <PreviewComponent activeObject={activeObject} projectId={projectId} />
+        </div>
       )}
     </section>
   );
@@ -182,9 +199,10 @@ const MiddlePane = () => {
     );
   }
   // Every non-dashboard object (chart, model, insight, input, table, markdown,
-  // source, dimension, metric, relation, unknown) routes through PerObjectPane,
-  // which defaults to the universal Lineage lens (VIS-779).
-  return <PerObjectPane activeObject={obj} />;
+  // source, dimension, metric, relation, unknown) routes through PerObjectPane.
+  // Track-N types render their custom Preview; the rest fall back to the
+  // universal Lineage lens (VIS-779).
+  return <PerObjectPane activeObject={obj} projectId={projectId} />;
 };
 
 export default MiddlePane;

--- a/viewer/src/components/new-views/workspace/MiddlePane.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.jsx
@@ -132,6 +132,21 @@ const PerObjectPane = ({ activeObject, projectId }) => {
   const [lensEffective, setLensEffective] = React.useState(
     hasPreview ? 'preview' : 'lineage'
   );
+  // Reset the lens to the new object's DEFAULT whenever the active object
+  // changes. React reuses this same PerObjectPane instance when the user
+  // switches between two non-dashboard objects (same component, same tree
+  // position), so without this the previous object's lens selection would leak:
+  // flipping a chart to Lineage and then selecting a table would open the table
+  // on Lineage instead of its Preview default. Keyed on type+name so navigating
+  // between two objects of the same type also re-defaults.
+  const objectKey = `${type}:${name}`;
+  const prevKeyRef = React.useRef(objectKey);
+  React.useEffect(() => {
+    if (prevKeyRef.current !== objectKey) {
+      prevKeyRef.current = objectKey;
+      setLensEffective(hasPreview ? 'preview' : 'lineage');
+    }
+  }, [objectKey, hasPreview]);
   // A fallback type can never show Preview — clamp any stale 'preview' selection.
   const lens = hasPreview ? lensEffective : 'lineage';
   return (

--- a/viewer/src/components/new-views/workspace/MiddlePane.test.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.test.jsx
@@ -147,6 +147,34 @@ describe('MiddlePane — Track-N custom previews for non-dashboard objects (VIS-
     expect(screen.getByTestId('lineage-canvas-mock')).toBeInTheDocument();
     expect(screen.queryByTestId('chart-preview-mock')).not.toBeInTheDocument();
   });
+
+  test('flipping one object to Lineage does NOT leak the lens to the next object (resets to Preview)', () => {
+    // Regression: PerObjectPane is a single reused React instance, so a chart
+    // flipped to Lineage would leak its lens — selecting a table next opened it
+    // on Lineage instead of its Preview default. The lens must reset on switch.
+    seed({ workspaceActiveObject: { type: 'chart', name: 'revenue' }, workspaceLens: 'preview' });
+    const { rerender } = render(<MiddlePane />);
+    fireEvent.click(screen.getByTestId('workspace-lens-picker-option-lineage'));
+    expect(screen.getByTestId('workspace-middle-chart-lineage')).toBeInTheDocument();
+
+    // Switch to a different previewable object (cross-type).
+    act(() => {
+      useStore.setState({ workspaceActiveObject: { type: 'table', name: 'orders' } });
+    });
+    rerender(<MiddlePane />);
+    expect(screen.getByTestId('workspace-middle-table-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('table-preview-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-middle-table-lineage')).not.toBeInTheDocument();
+
+    // Same-type navigation also re-defaults: flip table → Lineage, pick another table.
+    fireEvent.click(screen.getByTestId('workspace-lens-picker-option-lineage'));
+    expect(screen.getByTestId('workspace-middle-table-lineage')).toBeInTheDocument();
+    act(() => {
+      useStore.setState({ workspaceActiveObject: { type: 'table', name: 'revenue_table' } });
+    });
+    rerender(<MiddlePane />);
+    expect(screen.getByTestId('workspace-middle-table-preview')).toBeInTheDocument();
+  });
 });
 
 describe('MiddlePane — universal Lineage fallback for preview-less objects (VIS-779)', () => {

--- a/viewer/src/components/new-views/workspace/MiddlePane.test.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.test.jsx
@@ -6,12 +6,16 @@
  *     replacing the old "coming soon" placeholder.
  *   - dashboard + lineage lens → mounts `<LineageCanvas>` (VIS-E1); the canvas
  *     lens renders `<ProjectCanvas>` (render-only Dashboard wrapper, VIS-767).
- *   - any non-dashboard object → `<PerObjectPane>`, which defaults to the
- *     universal Lineage lens (VIS-779) and keeps Preview as the Track N
- *     placeholder.
+ *   - a non-dashboard object WITH a Track-N preview (chart/table/markdown/
+ *     input/insight/model) → `<PerObjectPane>` defaulting to the Preview lens,
+ *     mounting that type's custom Preview component (from previewRegistry).
+ *   - a non-dashboard object WITHOUT a preview (source/dimension/…/unknown) →
+ *     `<PerObjectPane>` locked to the universal Lineage lens (VIS-779), Preview
+ *     muted.
  *
- * Child surfaces (ProjectEditor, ProjectCanvas, LineageCanvas) are mocked so this
- * stays a focused dispatcher test, not the heavy React Flow / Plotly trees.
+ * Child surfaces (ProjectEditor, ProjectCanvas, LineageCanvas, the Track-N
+ * preview components) are mocked so this stays a focused dispatcher test, not
+ * the heavy React Flow / Plotly trees.
  */
 import React from 'react';
 import { render, screen, act, fireEvent } from '@testing-library/react';
@@ -35,6 +39,35 @@ jest.mock('../lineage/LineageCanvas', () => {
   Mock.displayName = 'MockLineageCanvas';
   return { __esModule: true, default: Mock };
 });
+
+// Mock the Track-N preview components so the dispatcher test stays focused — it
+// only verifies WHICH preview mounts, not the heavy renderers themselves (those
+// have their own component tests). The factory is inlined per-mock because
+// jest.mock is hoisted above module-scope helpers.
+jest.mock('./ChartPreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="chart-preview-mock" />,
+}));
+jest.mock('./TablePreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="table-preview-mock" />,
+}));
+jest.mock('./MarkdownPreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="markdown-preview-mock" />,
+}));
+jest.mock('./InputPreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="input-preview-mock" />,
+}));
+jest.mock('./InsightPreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="insight-preview-mock" />,
+}));
+jest.mock('./ModelPreview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="model-preview-mock" />,
+}));
 
 const seed = (extra = {}) => {
   act(() => {
@@ -86,33 +119,57 @@ describe('MiddlePane — dashboard lineage lens (VIS-E1)', () => {
   });
 });
 
-describe('MiddlePane — universal Lineage lens for non-dashboard objects (VIS-779)', () => {
-  test.each(['chart', 'model', 'insight', 'input', 'table', 'markdown', 'source'])(
-    'defaults a selected %s to the Lineage lens, mounting LineageCanvas',
+describe('MiddlePane — Track-N custom previews for non-dashboard objects (VIS-784/791/795/796/798/801)', () => {
+  test.each([
+    ['chart', 'chart-preview-mock'],
+    ['table', 'table-preview-mock'],
+    ['markdown', 'markdown-preview-mock'],
+    ['input', 'input-preview-mock'],
+    ['insight', 'insight-preview-mock'],
+    ['model', 'model-preview-mock'],
+  ])('defaults a selected %s to the Preview lens, mounting its custom preview', (type, previewTestId) => {
+    seed({ workspaceActiveObject: { type, name: `my-${type}` }, workspaceLens: 'preview' });
+    render(<MiddlePane />);
+    expect(screen.getByTestId(`workspace-middle-${type}-preview`)).toBeInTheDocument();
+    expect(screen.getByTestId(previewTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId('lineage-canvas-mock')).not.toBeInTheDocument();
+  });
+
+  test('a Track-N type can flip from its Preview to the Lineage lens', () => {
+    seed({ workspaceActiveObject: { type: 'chart', name: 'revenue' }, workspaceLens: 'preview' });
+    render(<MiddlePane />);
+    // Defaults to its custom preview.
+    expect(screen.getByTestId('chart-preview-mock')).toBeInTheDocument();
+
+    // Lineage is selectable — clicking it flips to the universal DAG view.
+    fireEvent.click(screen.getByTestId('workspace-lens-picker-option-lineage'));
+    expect(screen.getByTestId('workspace-middle-chart-lineage')).toBeInTheDocument();
+    expect(screen.getByTestId('lineage-canvas-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('chart-preview-mock')).not.toBeInTheDocument();
+  });
+});
+
+describe('MiddlePane — universal Lineage fallback for preview-less objects (VIS-779)', () => {
+  test.each(['source', 'dimension', 'metric', 'relation'])(
+    'a selected %s (no custom preview) locks onto the Lineage lens',
     (type) => {
-      // Store lens default is 'preview' (the dashboard canvas default); the
-      // per-object pane must still default to lineage regardless.
       seed({ workspaceActiveObject: { type, name: `my-${type}` }, workspaceLens: 'preview' });
       render(<MiddlePane />);
       expect(screen.getByTestId(`workspace-middle-${type}-lineage`)).toBeInTheDocument();
       expect(screen.getByTestId('lineage-canvas-mock')).toBeInTheDocument();
-      expect(
-        screen.queryByTestId(`workspace-middle-${type}-placeholder`)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`workspace-middle-${type}-preview`)).not.toBeInTheDocument();
     }
   );
 
-  test('switching a non-dashboard object to the Preview lens shows the Track N placeholder', () => {
-    seed({ workspaceActiveObject: { type: 'chart', name: 'revenue' }, workspaceLens: 'preview' });
+  test('the Preview option is muted for a preview-less type and cannot flip away from Lineage', () => {
+    seed({ workspaceActiveObject: { type: 'source', name: 'db' }, workspaceLens: 'preview' });
     render(<MiddlePane />);
-    // Defaults to lineage.
     expect(screen.getByTestId('lineage-canvas-mock')).toBeInTheDocument();
 
-    // Preview is selectable — clicking it flips to the Track N placeholder.
+    // The Preview option is disabled — clicking it does not flip away from Lineage.
     fireEvent.click(screen.getByTestId('workspace-lens-picker-option-preview'));
-    expect(screen.getByTestId('workspace-middle-chart-placeholder')).toBeInTheDocument();
-    expect(screen.getByText(/Per-object preview coming soon \(Track N\)/i)).toBeInTheDocument();
-    expect(screen.queryByTestId('lineage-canvas-mock')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-middle-source-lineage')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-middle-source-preview')).not.toBeInTheDocument();
   });
 
   test('an unknown object type also defaults to the universal Lineage lens', () => {

--- a/viewer/src/components/new-views/workspace/ModelPreview.jsx
+++ b/viewer/src/components/new-views/workspace/ModelPreview.jsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import Editor from '@monaco-editor/react';
+import CircularProgress from '@mui/material/CircularProgress';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import useStore from '../../../stores/store';
+import { useModelQueryJob } from '../../../hooks/useModelQueryJob';
+import { parseRefValue } from '../../../utils/refString';
+
+/**
+ * ModelPreview — VIS-801 / N-6.
+ *
+ * Renders the active model as a READ-ONLY SQL editor (the same Monaco editor
+ * ModelEditForm uses, in read-only mode) plus a result-table preview. The
+ * result table renders only AFTER the user clicks Run — running executes the
+ * model's SQL against its source via the EXISTING `useModelQueryJob` hook (the
+ * same /api/model-query-jobs path the Explorer SQL editor uses). No editing
+ * affordances — editing lives in the right rail.
+ *
+ * The model record is resolved from the model store by name (RightRailEditPanel
+ * COLLECTION_KEY['model'] = 'models'). The source name is read from the model's
+ * `source` ref (falling back to the first available source / project default).
+ */
+const ModelPreview = ({ activeObject }) => {
+  const name = activeObject?.name || null;
+  const models = useStore(s => s.models);
+  const fetchModels = useStore(s => s.fetchModels);
+  const sources = useStore(s => s.sources);
+  const fetchSources = useStore(s => s.fetchSources);
+
+  const { status, progress, progressMessage, result, error, isRunning, executeQuery } =
+    useModelQueryJob();
+
+  useEffect(() => {
+    if ((!models || models.length === 0) && typeof fetchModels === 'function') {
+      fetchModels();
+    }
+    if ((!sources || sources.length === 0) && typeof fetchSources === 'function') {
+      fetchSources();
+    }
+  }, [models, fetchModels, sources, fetchSources]);
+
+  const record = useMemo(
+    () => (Array.isArray(models) ? models.find(m => m.name === name) || null : null),
+    [models, name]
+  );
+
+  const config = useMemo(() => (record ? record.config || record : null), [record]);
+  const sql = config?.sql || '';
+
+  const sourceName = useMemo(() => {
+    if (config?.source && typeof config.source === 'string') {
+      return parseRefValue(config.source);
+    }
+    // Fall back to the first available named source so Run still works for
+    // models that rely on the project's default source.
+    const list = Array.isArray(sources) ? sources : [];
+    return list[0]?.name || null;
+  }, [config, sources]);
+
+  const [hasRun, setHasRun] = useState(false);
+
+  const handleRun = () => {
+    if (!sourceName || !sql) return;
+    setHasRun(true);
+    executeQuery(sourceName, sql).catch(() => {});
+  };
+
+  const rows = useMemo(() => result?.rows || result?.data || [], [result]);
+  const columns = useMemo(() => {
+    if (result?.columns) return result.columns;
+    if (Array.isArray(rows) && rows.length > 0) return Object.keys(rows[0]);
+    return [];
+  }, [result, rows]);
+
+  if (!config) {
+    return (
+      <div
+        data-testid="model-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Model "${name}" not found.` : 'No model selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="model-preview" className="flex flex-1 min-h-0 flex-col bg-white">
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2">
+        <span className="text-[12px] text-gray-500">
+          {sourceName ? (
+            <>
+              Source: <span className="font-mono text-gray-700">{sourceName}</span>
+            </>
+          ) : (
+            'No source resolved'
+          )}
+        </span>
+        <button
+          type="button"
+          data-testid="model-preview-run"
+          onClick={handleRun}
+          disabled={isRunning || !sourceName || !sql}
+          className="inline-flex h-7 items-center gap-1 rounded-md bg-[#713b57] px-3 text-[12px] font-semibold text-white shadow-sm transition-colors hover:bg-[#5a2f45] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isRunning ? (
+            <CircularProgress size={12} style={{ color: 'white' }} />
+          ) : (
+            <PlayArrowIcon style={{ fontSize: 16 }} />
+          )}
+          Run
+        </button>
+      </div>
+
+      <div className="border-b border-gray-200" style={{ height: 240 }}>
+        <Editor
+          height="240px"
+          language="sql"
+          theme="vs-dark"
+          value={sql}
+          options={{
+            readOnly: true,
+            domReadOnly: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            fontSize: 13,
+            automaticLayout: true,
+            wordWrap: 'on',
+            lineNumbers: 'on',
+            folding: false,
+          }}
+        />
+      </div>
+
+      <div data-testid="model-preview-results" className="flex-1 min-h-0 overflow-auto p-3">
+        {!hasRun ? (
+          <div className="flex h-full items-center justify-center text-center">
+            <span className="text-sm text-gray-500">Run the query to preview results.</span>
+          </div>
+        ) : isRunning ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+            <CircularProgress size={32} />
+            <span className="text-sm text-gray-600">{progressMessage || 'Running query…'}</span>
+            <div className="h-1.5 w-48 overflow-hidden rounded-full bg-gray-200">
+              <div
+                className="h-full bg-[#713b57] transition-all duration-300"
+                style={{ width: `${(progress || 0) * 100}%` }}
+              />
+            </div>
+          </div>
+        ) : error ? (
+          <div
+            data-testid="model-preview-error"
+            className="rounded bg-red-50 p-3 font-mono text-sm text-red-700"
+          >
+            {typeof error === 'string' ? error : error?.message || String(error)}
+          </div>
+        ) : status === 'completed' && columns.length > 0 ? (
+          <table className="min-w-full border-collapse text-left text-[12px]">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                {columns.map(col => (
+                  <th key={col} className="px-3 py-1.5 font-semibold text-gray-700">
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.slice(0, 200).map((row, ri) => (
+                <tr key={ri} className="border-b border-gray-100">
+                  {columns.map(col => (
+                    <td key={col} className="px-3 py-1 font-mono text-gray-800">
+                      {row[col] === null || row[col] === undefined ? '' : String(row[col])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="flex h-full items-center justify-center text-center">
+            <span className="text-sm text-gray-500">Query returned no rows.</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ModelPreview;

--- a/viewer/src/components/new-views/workspace/ModelPreview.jsx
+++ b/viewer/src/components/new-views/workspace/ModelPreview.jsx
@@ -26,6 +26,8 @@ const ModelPreview = ({ activeObject }) => {
   const fetchModels = useStore(s => s.fetchModels);
   const sources = useStore(s => s.sources);
   const fetchSources = useStore(s => s.fetchSources);
+  const defaults = useStore(s => s.defaults);
+  const fetchDefaults = useStore(s => s.fetchDefaults);
 
   const { status, progress, progressMessage, result, error, isRunning, executeQuery } =
     useModelQueryJob();
@@ -37,7 +39,10 @@ const ModelPreview = ({ activeObject }) => {
     if ((!sources || sources.length === 0) && typeof fetchSources === 'function') {
       fetchSources();
     }
-  }, [models, fetchModels, sources, fetchSources]);
+    if (!defaults && typeof fetchDefaults === 'function') {
+      fetchDefaults();
+    }
+  }, [models, fetchModels, sources, fetchSources, defaults, fetchDefaults]);
 
   const record = useMemo(
     () => (Array.isArray(models) ? models.find(m => m.name === name) || null : null),
@@ -51,11 +56,13 @@ const ModelPreview = ({ activeObject }) => {
     if (config?.source && typeof config.source === 'string') {
       return parseRefValue(config.source);
     }
-    // Fall back to the first available named source so Run still works for
-    // models that rely on the project's default source.
+    // A source-less model uses the PROJECT DEFAULT source (defaults.source_name),
+    // exactly as the run/compile path resolves it — NOT just the first source in
+    // the list (which may be an unusable / uninstalled dialect). Mirrors the
+    // explorerNewStore `defaults.source_name || firstAvailableSource` convention.
     const list = Array.isArray(sources) ? sources : [];
-    return list[0]?.name || null;
-  }, [config, sources]);
+    return defaults?.source_name || list[0]?.name || null;
+  }, [config, sources, defaults]);
 
   const [hasRun, setHasRun] = useState(false);
 

--- a/viewer/src/components/new-views/workspace/ModelPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/ModelPreview.test.jsx
@@ -1,0 +1,101 @@
+/* eslint-disable no-template-curly-in-string -- literal ${ref(...)} strings under test */
+/**
+ * ModelPreview tests (VIS-801 / N-6).
+ *
+ * The Track-N model preview shows a READ-ONLY SQL editor + a result table that
+ * renders only AFTER Run. Run executes the model's SQL against its source via
+ * the EXISTING useModelQueryJob hook. Monaco and the query hook are mocked.
+ */
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import ModelPreview from './ModelPreview';
+import useStore from '../../../stores/store';
+
+const mockEditorSpy = jest.fn();
+jest.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: props => {
+    mockEditorSpy(props);
+    return <div data-testid="monaco-mock" data-readonly={String(!!props.options?.readOnly)} />;
+  },
+}));
+
+const mockExecuteQuery = jest.fn(() => Promise.resolve('job-1'));
+let mockJobState;
+jest.mock('../../../hooks/useModelQueryJob', () => ({
+  useModelQueryJob: () => mockJobState,
+}));
+
+const seed = (models = [], sources = []) => {
+  act(() => {
+    useStore.setState({
+      models,
+      sources,
+      fetchModels: jest.fn(),
+      fetchSources: jest.fn(),
+    });
+  });
+};
+
+describe('ModelPreview (VIS-801)', () => {
+  beforeEach(() => {
+    mockEditorSpy.mockClear();
+    mockExecuteQuery.mockClear();
+    mockJobState = {
+      status: null,
+      progress: 0,
+      progressMessage: '',
+      result: null,
+      error: null,
+      isRunning: false,
+      executeQuery: mockExecuteQuery,
+    };
+  });
+
+  test('renders a read-only SQL editor with the model SQL', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    expect(screen.getByTestId('model-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('monaco-mock')).toHaveAttribute('data-readonly', 'true');
+    expect(mockEditorSpy.mock.calls[0][0].value).toBe('SELECT 1');
+  });
+
+  test('does not render results until Run is clicked', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    expect(screen.getByTestId('model-preview-results')).toHaveTextContent(/Run the query/i);
+  });
+
+  test('Run executes the model SQL against its resolved source', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('db', 'SELECT 1');
+  });
+
+  test('renders a result table after a completed Run', () => {
+    mockJobState.status = 'completed';
+    mockJobState.result = { columns: ['x', 'y'], rows: [{ x: 1, y: 2 }] };
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    const results = screen.getByTestId('model-preview-results');
+    expect(results).toHaveTextContent('x');
+    expect(results).toHaveTextContent('y');
+    expect(results).toHaveTextContent('1');
+    expect(results).toHaveTextContent('2');
+  });
+
+  test('falls back to the first available source when the model has none', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1' } }], [{ name: 'fallback_db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('fallback_db', 'SELECT 1');
+  });
+
+  test('renders an empty state when the model is not found', () => {
+    seed([], []);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'missing' }} />);
+    expect(screen.getByTestId('model-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/ModelPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/ModelPreview.test.jsx
@@ -26,13 +26,15 @@ jest.mock('../../../hooks/useModelQueryJob', () => ({
   useModelQueryJob: () => mockJobState,
 }));
 
-const seed = (models = [], sources = []) => {
+const seed = (models = [], sources = [], defaults = null) => {
   act(() => {
     useStore.setState({
       models,
       sources,
+      defaults,
       fetchModels: jest.fn(),
       fetchSources: jest.fn(),
+      fetchDefaults: jest.fn(),
     });
   });
 };
@@ -86,11 +88,37 @@ describe('ModelPreview (VIS-801)', () => {
     expect(results).toHaveTextContent('2');
   });
 
-  test('falls back to the first available source when the model has none', () => {
+  test('falls back to the first available source when the model has none and no project default', () => {
     seed([{ name: 'orders', config: { sql: 'SELECT 1' } }], [{ name: 'fallback_db' }]);
     render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
     fireEvent.click(screen.getByTestId('model-preview-run'));
     expect(mockExecuteQuery).toHaveBeenCalledWith('fallback_db', 'SELECT 1');
+  });
+
+  test('a source-less model uses the PROJECT DEFAULT source, not just the first source', () => {
+    // Regression for the clickhouse-fallback bug: with multiple sources and a
+    // project default, the default must win over sources[0]. sources[0] here is
+    // an unusable dialect, exactly mirroring the integration project.
+    seed(
+      [{ name: 'orders', config: { sql: 'SELECT 1' } }],
+      [{ name: 'local-clickhouse' }, { name: 'local-duckdb' }],
+      { source_name: 'local-duckdb' }
+    );
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    expect(screen.getByTestId('model-preview')).toHaveTextContent('local-duckdb');
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('local-duckdb', 'SELECT 1');
+  });
+
+  test('an explicit model source still overrides the project default', () => {
+    seed(
+      [{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(explicit_db)}' } }],
+      [{ name: 'local-clickhouse' }, { name: 'explicit_db' }],
+      { source_name: 'local-duckdb' }
+    );
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('explicit_db', 'SELECT 1');
   });
 
   test('renders an empty state when the model is not found', () => {

--- a/viewer/src/components/new-views/workspace/TablePreview.jsx
+++ b/viewer/src/components/new-views/workspace/TablePreview.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo } from 'react';
+import useStore from '../../../stores/store';
+import Table from '../../items/Table';
+import { useInsightsData } from '../../../hooks/useInsightsData';
+import { useModelsData } from '../../../hooks/useModelsData';
+import { useInputsData } from '../../../hooks/useInputsData';
+import {
+  parseRefValue,
+  extractRefNamesFromStrings,
+} from '../../../utils/refString';
+
+/**
+ * TablePreview — VIS-791 / N-2.
+ *
+ * Renders the active table full-size via the EXISTING `<Table>` renderer (the
+ * same component the Dashboard mounts; tables provide their own internal scroll
+ * / pagination). No editing affordances — editing lives in the right rail.
+ *
+ * A table's `data` is a `${ref()}` to EITHER a model OR an insight (and its
+ * pivot `columns`/`rows`/`values` carry further refs). We classify the data ref
+ * against the model registry exactly as <Dashboard> does (the VIS-827 fix) and
+ * load it via the same `useModelsData` / `useInsightsData` hooks, so a saved
+ * table previews identically to how it renders on a dashboard.
+ */
+const TablePreview = ({ activeObject, projectId }) => {
+  const name = activeObject?.name || null;
+  const tables = useStore(s => s.tables);
+  const fetchTables = useStore(s => s.fetchTables);
+  const models = useStore(s => s.models);
+  const fetchModels = useStore(s => s.fetchModels);
+
+  useEffect(() => {
+    if ((!tables || tables.length === 0) && typeof fetchTables === 'function') {
+      fetchTables();
+    }
+    if ((!models || models.length === 0) && typeof fetchModels === 'function') {
+      fetchModels();
+    }
+  }, [tables, fetchTables, models, fetchModels]);
+
+  const record = useMemo(
+    () => (Array.isArray(tables) ? tables.find(t => t.name === name) || null : null),
+    [tables, name]
+  );
+
+  const tableConfig = useMemo(() => {
+    if (!record) return null;
+    const config = record.config || record;
+    return { name: record.name, ...config };
+  }, [record]);
+
+  const knownModelNames = useMemo(
+    () => new Set((Array.isArray(models) ? models : []).map(m => m.name)),
+    [models]
+  );
+
+  // Classify the data ref + pivot refs into model vs insight buckets, mirroring
+  // <Dashboard>'s collectDataNames so the right hook fetches the right data.
+  const { modelNames, insightNames } = useMemo(() => {
+    const modelSet = new Set();
+    const insightSet = new Set();
+    if (tableConfig) {
+      const { data } = tableConfig;
+      if (typeof data === 'string') {
+        const dataName = parseRefValue(data);
+        if (dataName) (knownModelNames.has(dataName) ? modelSet : insightSet).add(dataName);
+      } else if (data && data.name) {
+        const isModel = !!(data.sql || data.args || data.models);
+        (isModel ? modelSet : insightSet).add(data.name);
+      }
+      const pivotRefStrings = [
+        ...(tableConfig.columns || []),
+        ...(tableConfig.rows || []),
+        ...(tableConfig.values || []),
+      ];
+      extractRefNamesFromStrings(pivotRefStrings).forEach(n => {
+        (knownModelNames.has(n) ? modelSet : insightSet).add(n);
+      });
+    }
+    return { modelNames: [...modelSet], insightNames: [...insightSet] };
+  }, [tableConfig, knownModelNames]);
+
+  useModelsData(projectId, modelNames);
+  useInsightsData(projectId, insightNames);
+  // Inputs referenced by insight-backed tables (pivot/data) so input-driven
+  // tables resolve their pending values.
+  useInputsData(projectId, []);
+
+  if (!tableConfig) {
+    return (
+      <div
+        data-testid="table-preview-empty"
+        className="flex flex-1 items-center justify-center bg-gray-50 p-8 text-center"
+      >
+        <span className="text-sm text-gray-500">
+          {name ? `Table "${name}" not found.` : 'No table selected.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="table-preview" className="flex flex-1 min-h-0 overflow-auto bg-white p-4">
+      <div className="w-full">
+        <Table table={tableConfig} projectId={projectId} shouldLoad={true} height={600} />
+      </div>
+    </div>
+  );
+};
+
+export default TablePreview;

--- a/viewer/src/components/new-views/workspace/TablePreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/TablePreview.test.jsx
@@ -1,0 +1,80 @@
+/* eslint-disable no-template-curly-in-string -- literal ${ref(...)} strings under test */
+/**
+ * TablePreview tests (VIS-791 / N-2).
+ *
+ * The Track-N table preview reuses the EXISTING <Table> renderer, resolving the
+ * saved table from the table store by name and classifying its data ref against
+ * the model registry (the VIS-827 classification) so the right data hook loads
+ * it. <Table> and the data hooks are mocked for a focused unit test.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import TablePreview from './TablePreview';
+import useStore from '../../../stores/store';
+
+const mockTableSpy = jest.fn();
+jest.mock('../../items/Table', () => ({
+  __esModule: true,
+  default: props => {
+    mockTableSpy(props);
+    return <div data-testid="table-renderer-mock">{props.table?.name}</div>;
+  },
+}));
+
+const mockUseModelsData = jest.fn();
+const mockUseInsightsData = jest.fn();
+jest.mock('../../../hooks/useModelsData', () => ({
+  useModelsData: (...args) => mockUseModelsData(...args),
+}));
+jest.mock('../../../hooks/useInsightsData', () => ({
+  useInsightsData: (...args) => mockUseInsightsData(...args),
+}));
+jest.mock('../../../hooks/useInputsData', () => ({
+  useInputsData: jest.fn(),
+}));
+
+const seed = (tables = [], models = []) => {
+  act(() => {
+    useStore.setState({
+      tables,
+      models,
+      fetchTables: jest.fn(),
+      fetchModels: jest.fn(),
+    });
+  });
+};
+
+describe('TablePreview (VIS-791)', () => {
+  beforeEach(() => {
+    mockTableSpy.mockClear();
+    mockUseModelsData.mockClear();
+    mockUseInsightsData.mockClear();
+  });
+
+  test('renders the existing Table renderer for a saved table', () => {
+    seed([{ name: 'orders', config: { data: '${ref(orders_model)}' } }], [{ name: 'orders_model' }]);
+    render(<TablePreview activeObject={{ type: 'table', name: 'orders' }} projectId="p1" />);
+    expect(screen.getByTestId('table-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('table-renderer-mock')).toHaveTextContent('orders');
+  });
+
+  test('classifies a model-backed data ref into the models data hook', () => {
+    seed([{ name: 'orders', config: { data: '${ref(orders_model)}' } }], [{ name: 'orders_model' }]);
+    render(<TablePreview activeObject={{ type: 'table', name: 'orders' }} projectId="p1" />);
+    expect(mockUseModelsData).toHaveBeenCalledWith('p1', ['orders_model']);
+    expect(mockUseInsightsData).toHaveBeenCalledWith('p1', []);
+  });
+
+  test('classifies an insight-backed data ref into the insights data hook', () => {
+    seed([{ name: 't', config: { data: '${ref(sales_insight)}' } }], []);
+    render(<TablePreview activeObject={{ type: 'table', name: 't' }} projectId="p1" />);
+    expect(mockUseInsightsData).toHaveBeenCalledWith('p1', ['sales_insight']);
+    expect(mockUseModelsData).toHaveBeenCalledWith('p1', []);
+  });
+
+  test('renders an empty state when the table is not found', () => {
+    seed([], []);
+    render(<TablePreview activeObject={{ type: 'table', name: 'missing' }} projectId="p1" />);
+    expect(screen.getByTestId('table-preview-empty')).toHaveTextContent(/not found/i);
+  });
+});

--- a/viewer/src/components/new-views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.test.jsx
@@ -54,6 +54,11 @@ const resetWorkspaceStore = () => {
     useStore.setState({
       workspaceTabs: [],
       workspaceActiveTabId: null,
+      // Reset the active object so tests are isolated: a non-project active
+      // object makes MiddlePane mount that type's preview (Track N), whose
+      // on-mount data fetch would otherwise leak into the next test's
+      // "fetches every collection once" assertion.
+      workspaceActiveObject: null,
       workspaceLeftCollapsed: false,
       workspaceRightCollapsed: false,
       workspaceRightTab: 'edit',

--- a/viewer/src/components/new-views/workspace/previewRegistry.js
+++ b/viewer/src/components/new-views/workspace/previewRegistry.js
@@ -1,0 +1,52 @@
+import ChartPreview from './ChartPreview';
+import TablePreview from './TablePreview';
+import MarkdownPreview from './MarkdownPreview';
+import InputPreview from './InputPreview';
+import InsightPreview from './InsightPreview';
+import ModelPreview from './ModelPreview';
+
+/**
+ * previewRegistry — the single shared seam for Track N per-object previews.
+ *
+ * MiddlePane's PerObjectPane (VIS-775) looks an object's `type` up here to
+ * decide whether a custom Preview lens exists. The six Track N previews
+ * (chart / table / markdown / input / insight / model) each reuse the
+ * EXISTING renderer for their type, framed by the already-built MiddlePane /
+ * SubBar preview chrome (the `[Preview | Lineage]` lens picker shipped by
+ * Tracks D/E). They invent NO new visual design — they inherit it.
+ *
+ * Any type NOT in this map (source, dimension, metric, relation, unknown,
+ * etc.) has no custom preview and falls back to the universal Lineage lens
+ * via the existing PerObjectPane mechanism — the Preview lens reads muted /
+ * "no preview available yet" and the pane parks on Lineage. N-7
+ * (LineageFallbackPreview / VIS-803) is CANCELED; the fallback is the plain
+ * Lineage lens, not a bespoke component.
+ *
+ * Each component receives `{ activeObject, projectId }` and is responsible for
+ * resolving its own config from the store (the per-type collections keyed in
+ * RightRailEditPanel's COLLECTION_KEY) and loading its data via the same hooks
+ * the Dashboard renderer uses, so a saved object previews identically to how it
+ * renders on a dashboard.
+ */
+export const PREVIEW_REGISTRY = {
+  chart: ChartPreview,
+  table: TablePreview,
+  markdown: MarkdownPreview,
+  input: InputPreview,
+  insight: InsightPreview,
+  model: ModelPreview,
+};
+
+/**
+ * Resolve the preview component for an object type, or null when none exists
+ * (caller falls back to the Lineage lens).
+ */
+export const getPreviewComponent = type => PREVIEW_REGISTRY[type] || null;
+
+/**
+ * Whether a given object type has a custom Preview lens. Drives the
+ * PreviewLensPicker's `previewDisabled` muted state for fallback types.
+ */
+export const hasPreview = type => Boolean(PREVIEW_REGISTRY[type]);
+
+export default PREVIEW_REGISTRY;


### PR DESCRIPTION
## Track N — Per-object preview components (Dashboard Building v1, Wave 1 / Lane 1)

Every editable object type now gets a middle-pane preview when it's the active object, reusing the **already-shipped renderer** for that type behind the existing `Preview | Lineage` sub-bar.

### Issues
- VIS-784 / N-1 ChartPreview — reuses `<Chart>`
- VIS-791 / N-2 TablePreview — reuses `<Table>`
- VIS-795 / N-3 MarkdownPreview — reuses `<Markdown>`
- VIS-796 / N-4 InputPreview — reuses `<Input>` + current value
- VIS-798 / N-5 InsightPreview — wraps Explorer's existing insight render path
- VIS-801 / N-6 ModelPreview — read-only Monaco SQL + result table (renders after Run)
- N-7 (VIS-803) — skipped (canceled); preview-less types (source/dimension/metric/relation) fall back to the Lineage lens with Preview muted.

### Key change
`previewRegistry.js` (new) + a single `MiddlePane.jsx` seam map active object type → preview component.

### Tests
- Unit: **2259 pass / 178 suites**, lint clean.
- E2E: `workspace-object-previews.spec.mjs` **5/5** (chart real-Plotly, preview↔lineage flip, table data, insight, source fallback).

> ⚠️ **Validation depth:** e2e coverage here is an initial happy-path pass. A hardening sweep (broader states/object types + Playwright MCP desktop+mobile aesthetic/contrast review) is planned before this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
