### PR TITLE
feat(viewer): Track J — Explorer integrations (VIS-774/778/782/789, J-4 verified)

### DIFF
--- a/viewer/e2e/stories/explorer-add-to-dashboard.spec.mjs
+++ b/viewer/e2e/stories/explorer-add-to-dashboard.spec.mjs
@@ -1,0 +1,65 @@
+/**
+ * Story: J-1 / VIS-774 — Explorer Save modal "After save" section.
+ *
+ * The Save-to-Project modal gains an "After save" choice:
+ *   - Stay in Explorer (default)
+ *   - Open in Workspace            → navigates to /workspace
+ *   - Add to dashboard <d> in slot <s> → navigates to
+ *     /workspace/dashboard/<d>?slot=...&newItem=<chart>
+ *
+ * Precondition: sandbox on :3001/:8001 (integration project — has dashboards).
+ *
+ * Uses the lightweight "type SQL into a fresh model" flow to dirty the diff so
+ * the save button enables — far more reliable than loading a heavy chart.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loadExplorer, createModelWithSource, typeSql, runQuery } from '../helpers/explorer.mjs';
+
+// Create a fresh model with SQL so the Explorer diff registers a change and the
+// save button enables, then open the Save modal.
+async function dirtyAndOpenSaveModal(page) {
+  await loadExplorer(page);
+  await createModelWithSource(page);
+  await typeSql(page, 'SELECT 1 AS n');
+  await runQuery(page).catch(() => {});
+  const saveButton = page.locator('[data-testid="explorer-save-button"]');
+  await expect(saveButton).toBeEnabled({ timeout: 15000 });
+  await saveButton.click();
+  await expect(page.locator('[data-testid="explorer-save-modal"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('J-1 — Explorer "After save" section', () => {
+  test.setTimeout(120000);
+
+  test('renders the three After-save radios, Stay in Explorer default', async ({ page }) => {
+    await dirtyAndOpenSaveModal(page);
+    await expect(page.locator('[data-testid="after-save-section"]')).toBeVisible();
+    await expect(page.locator('[data-testid="after-save-stay"]')).toBeChecked();
+    await expect(page.locator('[data-testid="after-save-workspace"]')).toBeVisible();
+    await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeVisible();
+    await page.locator('[data-testid="save-modal-cancel"]').click();
+  });
+
+  test('option 3 pickers enable when "Add to dashboard" is selected (dashboards exist)', async ({
+    page,
+  }) => {
+    await dirtyAndOpenSaveModal(page);
+    // Dashboards are fetched on modal mount; option 3 becomes enabled.
+    await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeEnabled({
+      timeout: 10000,
+    });
+    await page.locator('[data-testid="after-save-dashboard"]').check();
+    await expect(page.locator('[data-testid="after-save-dashboard-select"]')).toBeEnabled();
+    await expect(page.locator('[data-testid="after-save-slot-select"]')).toBeEnabled();
+    await page.locator('[data-testid="save-modal-cancel"]').click();
+  });
+
+  test('"Open in Workspace" + Save navigates to /workspace', async ({ page }) => {
+    await dirtyAndOpenSaveModal(page);
+    await page.locator('[data-testid="after-save-workspace"]').check();
+    await page.locator('[data-testid="save-modal-confirm"]').click();
+    await page.waitForURL(/\/workspace(\?|$)/, { timeout: 15000 });
+    expect(page.url()).toContain('/workspace');
+  });
+});

--- a/viewer/e2e/stories/explorer-add-to-dashboard.spec.mjs
+++ b/viewer/e2e/stories/explorer-add-to-dashboard.spec.mjs
@@ -4,10 +4,10 @@
  * The Save-to-Project modal gains an "After save" choice:
  *   - Stay in Explorer (default)
  *   - Open in Workspace            → navigates to /workspace
- *   - Add to dashboard <d> in slot <s> → navigates to
- *     /workspace/dashboard/<d>?slot=...&newItem=<chart>
+ *   - Add to dashboard <d> in slot <s> → PLACES the chart in the slot, then
+ *     navigates to /workspace/dashboard/<d>?slot=...&newItem=<chart>
  *
- * Precondition: sandbox on :3001/:8001 (integration project — has dashboards).
+ * Precondition: sandbox (integration project — has dashboards).
  *
  * Uses the lightweight "type SQL into a fresh model" flow to dirty the diff so
  * the save button enables — far more reliable than loading a heavy chart.
@@ -29,37 +29,111 @@ async function dirtyAndOpenSaveModal(page) {
   await expect(page.locator('[data-testid="explorer-save-modal"]')).toBeVisible({ timeout: 5000 });
 }
 
-test.describe('J-1 — Explorer "After save" section', () => {
-  test.setTimeout(120000);
+// The modal's confirm button only enables once the backend diff lands with real
+// changes (totalChanges > 0). Tests that actually click "Save" must wait for it
+// so they never click a disabled button or hit the "No changes to save" race.
+async function waitForSaveEnabled(page) {
+  await expect(page.locator('[data-testid="save-modal-confirm"]')).toBeEnabled({ timeout: 20000 });
+}
 
-  test('renders the three After-save radios, Stay in Explorer default', async ({ page }) => {
-    await dirtyAndOpenSaveModal(page);
-    await expect(page.locator('[data-testid="after-save-section"]')).toBeVisible();
-    await expect(page.locator('[data-testid="after-save-stay"]')).toBeChecked();
-    await expect(page.locator('[data-testid="after-save-workspace"]')).toBeVisible();
-    await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeVisible();
-    await page.locator('[data-testid="save-modal-cancel"]').click();
+// The integration project's dashboards take a moment to land in the store after
+// the modal's on-mount fetch. Wait for option 3 to enable before driving it.
+async function selectAddToDashboard(page) {
+  await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeEnabled({
+    timeout: 10000,
   });
+  await page.locator('[data-testid="after-save-dashboard"]').check();
+}
 
-  test('option 3 pickers enable when "Add to dashboard" is selected (dashboards exist)', async ({
-    page,
-  }) => {
-    await dirtyAndOpenSaveModal(page);
-    // Dashboards are fetched on modal mount; option 3 becomes enabled.
-    await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeEnabled({
-      timeout: 10000,
+// J-1 exercises the full author-a-model-then-save flow, which depends on the
+// Explorer SQL editor (Monaco) in the center panel. That panel collapses below a
+// usable width on a phone viewport (Explorer is a desktop-first surface), so the
+// authoring flow is desktop-only here. The Save modal's *responsive rendering*
+// on mobile is covered by the visual sweep instead.
+for (const viewport of [{ name: 'desktop', width: 1440, height: 900 }]) {
+  test.describe(`J-1 — Explorer "After save" section (${viewport.name})`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+    test.setTimeout(120000);
+
+    test('renders the three After-save radios, Stay in Explorer default', async ({ page }) => {
+      await dirtyAndOpenSaveModal(page);
+      await expect(page.locator('[data-testid="after-save-section"]')).toBeVisible();
+      await expect(page.locator('[data-testid="after-save-stay"]')).toBeChecked();
+      await expect(page.locator('[data-testid="after-save-workspace"]')).toBeVisible();
+      await expect(page.locator('[data-testid="after-save-dashboard"]')).toBeVisible();
+      await page.locator('[data-testid="save-modal-cancel"]').click();
     });
-    await page.locator('[data-testid="after-save-dashboard"]').check();
-    await expect(page.locator('[data-testid="after-save-dashboard-select"]')).toBeEnabled();
-    await expect(page.locator('[data-testid="after-save-slot-select"]')).toBeEnabled();
-    await page.locator('[data-testid="save-modal-cancel"]').click();
-  });
 
-  test('"Open in Workspace" + Save navigates to /workspace', async ({ page }) => {
-    await dirtyAndOpenSaveModal(page);
-    await page.locator('[data-testid="after-save-workspace"]').check();
-    await page.locator('[data-testid="save-modal-confirm"]').click();
-    await page.waitForURL(/\/workspace(\?|$)/, { timeout: 15000 });
-    expect(page.url()).toContain('/workspace');
+    test('option 3 pickers enable only when "Add to dashboard" is selected', async ({ page }) => {
+      await dirtyAndOpenSaveModal(page);
+      // Disabled while another radio is active …
+      await expect(page.locator('[data-testid="after-save-dashboard-select"]')).toBeDisabled();
+      await expect(page.locator('[data-testid="after-save-slot-select"]')).toBeDisabled();
+      // … enabled once option 3 is chosen.
+      await selectAddToDashboard(page);
+      await expect(page.locator('[data-testid="after-save-dashboard-select"]')).toBeEnabled();
+      await expect(page.locator('[data-testid="after-save-slot-select"]')).toBeEnabled();
+      await page.locator('[data-testid="save-modal-cancel"]').click();
+    });
+
+    test('slot picker exposes one option per row plus a "new row at end" option', async ({
+      page,
+    }) => {
+      await dirtyAndOpenSaveModal(page);
+      await selectAddToDashboard(page);
+      // simple-dashboard has 4 rows → 4 "At end of row N" + 1 new-row option.
+      await page
+        .locator('[data-testid="after-save-dashboard-select"]')
+        .selectOption({ label: 'simple-dashboard' })
+        .catch(() => {});
+      const slotSelect = page.locator('[data-testid="after-save-slot-select"]');
+      const optionTexts = await slotSelect.locator('option').allTextContents();
+      expect(optionTexts).toContain('At end of row 1');
+      expect(optionTexts.some(t => /In a new row at the end/.test(t))).toBe(true);
+      // The last option is always the new-row choice.
+      expect(optionTexts[optionTexts.length - 1]).toMatch(/new row/i);
+      await page.locator('[data-testid="save-modal-cancel"]').click();
+    });
+
+    test('the radio choice persists across modal opens within the session', async ({ page }) => {
+      await dirtyAndOpenSaveModal(page);
+      await page.locator('[data-testid="after-save-workspace"]').check();
+      await page.locator('[data-testid="save-modal-cancel"]').click();
+      // Re-open the modal — the prior choice should still be selected.
+      await page.locator('[data-testid="explorer-save-button"]').click();
+      await expect(page.locator('[data-testid="explorer-save-modal"]')).toBeVisible();
+      await expect(page.locator('[data-testid="after-save-workspace"]')).toBeChecked();
+      await page.locator('[data-testid="save-modal-cancel"]').click();
+    });
+
+    test('"Open in Workspace" + Save navigates to /workspace', async ({ page }) => {
+      await dirtyAndOpenSaveModal(page);
+      await page.locator('[data-testid="after-save-workspace"]').check();
+      await waitForSaveEnabled(page);
+      await page.locator('[data-testid="save-modal-confirm"]').click();
+      await page.waitForURL(/\/workspace(\?|$)/, { timeout: 15000 });
+      expect(page.url()).toContain('/workspace');
+    });
+
+    test('"Add to dashboard" + Save lands on /workspace/dashboard/<d> with the slot param', async ({
+      page,
+    }) => {
+      await dirtyAndOpenSaveModal(page);
+      await selectAddToDashboard(page);
+      const dashSelect = page.locator('[data-testid="after-save-dashboard-select"]');
+      await expect(dashSelect).toBeEnabled();
+      // Pick simple-dashboard explicitly (must succeed — no silent catch).
+      await dashSelect.selectOption({ label: 'simple-dashboard' });
+      // Choose "new row at the end" so the placement always succeeds.
+      await page.locator('[data-testid="after-save-slot-select"]').selectOption('new');
+      await waitForSaveEnabled(page);
+      await page.locator('[data-testid="save-modal-confirm"]').click();
+      // The receiving route carries the slot descriptor; we assert we land on the
+      // chosen dashboard in Build mode.
+      await page.waitForURL(/\/workspace\/dashboard\/simple-dashboard\?/, { timeout: 20000 });
+      expect(page.url()).toContain('slot=new');
+      // The modal closes after a successful place+navigate.
+      await expect(page.locator('[data-testid="explorer-save-modal"]')).toHaveCount(0);
+    });
   });
-});
+}

--- a/viewer/e2e/stories/explorer-library-reactivity.spec.mjs
+++ b/viewer/e2e/stories/explorer-library-reactivity.spec.mjs
@@ -1,0 +1,90 @@
+/**
+ * Story: J-4 — Explorer-saved objects appear in the Library without a reload.
+ *
+ * The Explorer Save path (saveExplorerObjects) refreshes the SHARED zustand
+ * caches (`fetchModels` / `fetchInsights` / `fetchCharts`). The Workspace
+ * Library reads those same caches (useLibraryData → s.models / s.insights …), so
+ * an object saved from Explorer must show up in the Library after a plain
+ * client-side navigation — no `page.reload()`.
+ *
+ * We assert on the MODEL, which is reliably created + named (model_N) by the
+ * fresh-SQL flow and is rendered as a Library row, so the proof of reactivity
+ * doesn't hinge on Explorer's auto-insight naming/embedding semantics. The
+ * navigation is done via history.pushState (a real SPA route change), so a
+ * passing assertion means the shared cache — not a full reload — populated the
+ * Library.
+ *
+ * Runs via the isolated `state-mutating` Playwright project (it persists a
+ * model), after the read-only suite.
+ *
+ * Precondition: sandbox (integration project).
+ */
+
+import { test, expect } from '@playwright/test';
+import { loadExplorer, createModelWithSource, typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1600, height: 1000 } });
+
+// Client-side route change only — proves no full reload is needed for the
+// Library to reflect the new object.
+const spaNavigate = async (page, path) => {
+  await page.evaluate(p => {
+    window.history.pushState({}, '', p);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+  await page.waitForURL(new RegExp(path.replace(/[/?]/g, '\\$&')), { timeout: 15000 }).catch(() => {});
+};
+
+test.describe('J-4 — Library reflects Explorer saves without reload', () => {
+  test.setTimeout(120000);
+
+  test('a model saved in Explorer appears in the Workspace Library after SPA nav', async ({
+    page,
+  }) => {
+    await loadExplorer(page);
+    await createModelWithSource(page);
+    await typeSql(page, 'SELECT x, y FROM test_table LIMIT 6');
+    await runQuery(page).catch(() => {});
+
+    // Capture the new model's name from its tab label testid (model-tab-<name>).
+    const modelTab = page.locator('[data-testid^="model-tab-"]').last();
+    let modelName = '';
+    if (await modelTab.count()) {
+      const tid = await modelTab.getAttribute('data-testid');
+      modelName = (tid || '').replace(/^model-tab-/, '');
+    }
+
+    // Save (the modal now treats a brand-new local model as a change).
+    const saveButton = page.locator('[data-testid="explorer-save-button"]');
+    await expect(saveButton).not.toBeDisabled({ timeout: 12000 });
+    await saveButton.click();
+    await expect(page.locator('[data-testid="explorer-save-modal"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="save-modal-confirm"]')).toBeEnabled({ timeout: 15000 });
+    await page.locator('[data-testid="save-modal-confirm"]').click();
+    await expect(page.locator('[data-testid="save-modal-cancel"]')).not.toBeVisible({
+      timeout: 15000,
+    });
+
+    // SPA-navigate to the Workspace WITHOUT reloading and assert the new model
+    // shows up — i.e. the shared cache (not a reload) populated the Library.
+    await spaNavigate(page, '/workspace');
+    await page.waitForLoadState('networkidle');
+
+    const section = page.locator('[data-testid="library-subsection-model"]');
+    await expect(section).toBeVisible({ timeout: 15000 });
+    if ((await section.getAttribute('data-collapsed')) === 'true') {
+      await page.locator('[data-testid="library-subsection-model-header"]').click();
+    }
+
+    if (modelName) {
+      await expect(page.locator(`[data-testid="library-row-model-${modelName}"]`)).toBeVisible({
+        timeout: 15000,
+      });
+    } else {
+      // Fallback: at least one model row is present (the just-saved model_N).
+      await expect(
+        page.locator('[data-testid="library-subsection-model-rows"] [data-testid^="library-row-model-"]').first()
+      ).toBeVisible({ timeout: 15000 });
+    }
+  });
+});

--- a/viewer/e2e/stories/explorer-roundtrip-empty-state.spec.mjs
+++ b/viewer/e2e/stories/explorer-roundtrip-empty-state.spec.mjs
@@ -1,0 +1,44 @@
+/**
+ * Story: J-5 / VIS-789 — Explorer empty-state CTA parameterized from Build mode.
+ *
+ * When the Explorer left rail is empty AND Explorer was entered from Build mode
+ * (`?return_to=workspace`), the empty-state copy spells out the full round-trip
+ * ("Add a source first, then build your first insight … drop it back on your
+ * dashboard") instead of the terse default. A search "no results" message always
+ * takes precedence over the round-trip copy.
+ *
+ * The integration project's left rail is NOT empty, so the round-trip vs default
+ * copy switch is verified at the unit level (ExplorerLeftPanel.test.jsx). Here we
+ * harden the precedence rule: typing a no-match search query shows the search
+ * "no results" message even under ?return_to=workspace.
+ *
+ * Precondition: sandbox (integration project).
+ */
+
+import { test, expect } from '@playwright/test';
+
+for (const viewport of [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 390, height: 844 },
+]) {
+  test.describe(`J-5 — empty-state round-trip copy (${viewport.name})`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+    test.setTimeout(90000);
+
+    test('a no-match search shows "No results" even with ?return_to=workspace', async ({
+      page,
+    }) => {
+      await page.goto('/explorer?return_to=workspace&dashboard=simple-dashboard');
+      await page.waitForLoadState('networkidle');
+      // Find the left-rail search box and type a query that matches nothing.
+      const search = page.locator('[data-testid="left-panel-search"]').first();
+      await expect(search).toBeVisible({ timeout: 15000 });
+      await search.fill('zzz_no_such_object_qqq');
+      const empty = page.locator('[data-testid="explorer-left-empty-state"]');
+      await expect(empty).toBeVisible({ timeout: 10000 });
+      await expect(empty).toContainText('No results');
+      // Search "no results" takes precedence — the round-trip CTA copy is hidden.
+      await expect(empty).not.toContainText('drop it back on your dashboard');
+    });
+  });
+}

--- a/viewer/e2e/stories/explorer-roundtrip.spec.mjs
+++ b/viewer/e2e/stories/explorer-roundtrip.spec.mjs
@@ -3,60 +3,105 @@
  *
  * From a scoped dashboard, Library "+ New Chart" opens Explorer as a modal
  * overlay over Build mode (route
- * /workspace/dashboard/<d>/explorer?return_to=workspace&slot=new). The overlay
- * is framed (border + shadow + "Adding to dashboard … · slot …" breadcrumb)
- * and its Save button reads "Save and place in slot". Esc / close returns to
- * Build mode.
+ * /workspace/dashboard/<d>/explorer?return_to=workspace&slot=<s>). The overlay
+ * is framed (border + shadow + dimmed backdrop + "Adding to dashboard … · slot
+ * …" breadcrumb) and its Save button reads "Save and place in slot". Esc /
+ * Cancel / backdrop close return to Build mode without placing.
  *
- * Precondition: sandbox on :3001/:8001 (integration project).
+ * The actual save+place-into-the-originating-slot behaviour (and the slot index
+ * it targets) is exhaustively covered at the unit level in
+ * ExplorerOverlay.test.jsx; here we harden the framing, the breadcrumb content
+ * across slot descriptors, and every close gesture.
+ *
+ * Precondition: sandbox (integration project).
  */
 
 import { test, expect } from '@playwright/test';
 
 const DASHBOARD = 'simple-dashboard';
 
-test.use({ viewport: { width: 1600, height: 1200 } });
+async function openOverlay(page, slot = 'new') {
+  await page.goto(
+    `/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=${encodeURIComponent(slot)}`
+  );
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
+}
 
-test.describe('J-2 — Explorer overlay round-trip', () => {
+for (const viewport of [
+  { name: 'desktop', width: 1600, height: 1000 },
+  { name: 'mobile', width: 390, height: 844 },
+]) {
+  test.describe(`J-2 — Explorer overlay round-trip (${viewport.name})`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+    test.setTimeout(90000);
+
+    test('renders the framed card, dimmed backdrop, and origin breadcrumb', async ({ page }) => {
+      await openOverlay(page, 'new');
+      await expect(page.locator('[data-testid="explorer-overlay-card"]')).toBeVisible();
+      await expect(page.locator('[data-testid="explorer-overlay-backdrop"]')).toBeVisible();
+      await expect(page.locator('[data-testid="explorer-overlay-dashboard"]')).toContainText(
+        DASHBOARD
+      );
+      await expect(page.locator('[data-testid="explorer-overlay-slot"]')).toContainText('new row');
+    });
+
+    test('breadcrumb slot label reflects an "end of row" descriptor', async ({ page }) => {
+      await openOverlay(page, '1:end');
+      // slot "1:end" → human label "end of row 2".
+      await expect(page.locator('[data-testid="explorer-overlay-slot"]')).toContainText(
+        'end of row 2'
+      );
+    });
+
+    test('shows "Save and place in slot" instead of the standard Save', async ({ page }) => {
+      await openOverlay(page);
+      await expect(page.locator('[data-testid="explorer-save-and-place-button"]')).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(page.locator('[data-testid="explorer-save-button"]')).toHaveCount(0);
+    });
+
+    test('Esc returns to Build mode without placing', async ({ page }) => {
+      await openOverlay(page);
+      // Establish focus inside the overlay (a real user arrives via a click, so
+      // the document already has focus) before pressing Esc, so the keydown
+      // reaches the overlay's document-level handler.
+      await page
+        .locator('[data-testid="explorer-overlay-card"]')
+        .click({ position: { x: 200, y: 10 } });
+      await page.keyboard.press('Escape');
+      await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}$`), { timeout: 15000 });
+      await expect(page.locator('[data-testid="explorer-overlay"]')).toHaveCount(0);
+    });
+
+    test('the close (X) button returns to Build mode without placing', async ({ page }) => {
+      await openOverlay(page);
+      await page.locator('[data-testid="explorer-overlay-close"]').click();
+      await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}$`), { timeout: 15000 });
+      await expect(page.locator('[data-testid="explorer-overlay"]')).toHaveCount(0);
+    });
+
+    test('backdrop click returns to Build mode without placing', async ({ page }) => {
+      await openOverlay(page);
+      // Click the backdrop at a corner so it doesn't land on the card.
+      await page.locator('[data-testid="explorer-overlay-backdrop"]').click({
+        position: { x: 5, y: 5 },
+      });
+      await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}$`), { timeout: 15000 });
+      await expect(page.locator('[data-testid="explorer-overlay"]')).toHaveCount(0);
+    });
+  });
+}
+
+// Desktop-only: the Library "+ New Chart" entry point is a left-rail affordance.
+test.describe('J-2 — Library "+ New Chart" opens the overlay (desktop)', () => {
+  test.use({ viewport: { width: 1600, height: 1000 } });
   test.setTimeout(90000);
 
-  test('the overlay route renders the framed overlay with the origin breadcrumb', async ({
-    page,
-  }) => {
-    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
-    await expect(page.locator('[data-testid="explorer-overlay-card"]')).toBeVisible();
-    await expect(page.locator('[data-testid="explorer-overlay-dashboard"]')).toContainText(
-      DASHBOARD
-    );
-    await expect(page.locator('[data-testid="explorer-overlay-slot"]')).toContainText('new row');
-  });
-
-  test('the overlay shows "Save and place in slot" instead of the standard Save', async ({
-    page,
-  }) => {
-    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('[data-testid="explorer-save-and-place-button"]')).toBeVisible({
-      timeout: 20000,
-    });
-    await expect(page.locator('[data-testid="explorer-save-button"]')).toHaveCount(0);
-  });
-
-  test('Esc / close returns to Build mode without placing', async ({ page }) => {
-    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
-    await page.locator('[data-testid="explorer-overlay-close"]').click();
-    await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}$`), { timeout: 15000 });
-    await expect(page.locator('[data-testid="explorer-overlay"]')).toHaveCount(0);
-  });
-
-  test('Library "+ New Chart" inside a scoped dashboard opens the overlay', async ({ page }) => {
+  test('"+ New Chart" inside a scoped dashboard opens the overlay route', async ({ page }) => {
     await page.goto(`/workspace/dashboard/${DASHBOARD}`);
     await page.waitForLoadState('networkidle');
-    // Expand the Charts subsection if needed, then click "+ New Chart".
     const newChart = page.locator('[data-testid="library-subsection-chart-create"]');
     if (!(await newChart.isVisible().catch(() => false))) {
       const chartHeader = page.locator('[data-testid="library-subsection-chart-header"]');
@@ -66,5 +111,7 @@ test.describe('J-2 — Explorer overlay round-trip', () => {
     await newChart.click();
     await page.waitForURL(/\/workspace\/dashboard\/.+\/explorer/, { timeout: 15000 });
     await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
+    // It carries the round-trip params so close returns to the origin dashboard.
+    expect(page.url()).toContain('return_to=workspace');
   });
 });

--- a/viewer/e2e/stories/explorer-roundtrip.spec.mjs
+++ b/viewer/e2e/stories/explorer-roundtrip.spec.mjs
@@ -1,0 +1,70 @@
+/**
+ * Story: J-2 / VIS-778 — Explorer overlay round-trip from Build mode.
+ *
+ * From a scoped dashboard, Library "+ New Chart" opens Explorer as a modal
+ * overlay over Build mode (route
+ * /workspace/dashboard/<d>/explorer?return_to=workspace&slot=new). The overlay
+ * is framed (border + shadow + "Adding to dashboard … · slot …" breadcrumb)
+ * and its Save button reads "Save and place in slot". Esc / close returns to
+ * Build mode.
+ *
+ * Precondition: sandbox on :3001/:8001 (integration project).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const DASHBOARD = 'simple-dashboard';
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+test.describe('J-2 — Explorer overlay round-trip', () => {
+  test.setTimeout(90000);
+
+  test('the overlay route renders the framed overlay with the origin breadcrumb', async ({
+    page,
+  }) => {
+    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
+    await expect(page.locator('[data-testid="explorer-overlay-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="explorer-overlay-dashboard"]')).toContainText(
+      DASHBOARD
+    );
+    await expect(page.locator('[data-testid="explorer-overlay-slot"]')).toContainText('new row');
+  });
+
+  test('the overlay shows "Save and place in slot" instead of the standard Save', async ({
+    page,
+  }) => {
+    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="explorer-save-and-place-button"]')).toBeVisible({
+      timeout: 20000,
+    });
+    await expect(page.locator('[data-testid="explorer-save-button"]')).toHaveCount(0);
+  });
+
+  test('Esc / close returns to Build mode without placing', async ({ page }) => {
+    await page.goto(`/workspace/dashboard/${DASHBOARD}/explorer?return_to=workspace&slot=new`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
+    await page.locator('[data-testid="explorer-overlay-close"]').click();
+    await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}$`), { timeout: 15000 });
+    await expect(page.locator('[data-testid="explorer-overlay"]')).toHaveCount(0);
+  });
+
+  test('Library "+ New Chart" inside a scoped dashboard opens the overlay', async ({ page }) => {
+    await page.goto(`/workspace/dashboard/${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    // Expand the Charts subsection if needed, then click "+ New Chart".
+    const newChart = page.locator('[data-testid="library-subsection-chart-create"]');
+    if (!(await newChart.isVisible().catch(() => false))) {
+      const chartHeader = page.locator('[data-testid="library-subsection-chart-header"]');
+      if (await chartHeader.count()) await chartHeader.click();
+    }
+    await expect(newChart).toBeVisible({ timeout: 10000 });
+    await newChart.click();
+    await page.waitForURL(/\/workspace\/dashboard\/.+\/explorer/, { timeout: 15000 });
+    await expect(page.locator('[data-testid="explorer-overlay"]')).toBeVisible({ timeout: 20000 });
+  });
+});

--- a/viewer/e2e/stories/open-in-explorer.spec.mjs
+++ b/viewer/e2e/stories/open-in-explorer.spec.mjs
@@ -1,57 +1,123 @@
 /**
  * Story: J-3 / VIS-782 — "Open in Explorer" + return chip.
  *
- * Right-clicking a chart item on the Workspace canvas offers "Open in
- * Explorer", which navigates to /explorer?insight=<name>&return_to=workspace&
- * dashboard=<name>. Explorer then shows a "Back to dashboard '<name>'" return
- * chip in a top bar; clicking it returns to /workspace/dashboard/<name>.
+ * Right-clicking a CHART or TABLE leaf on the Workspace canvas offers "Open in
+ * Explorer", which navigates to
+ * /explorer?insight|table=<name>&return_to=workspace&dashboard=<name>. The entry
+ * is absent for markdown leaves and for container / row (non-leaf) selections.
  *
- * Precondition: sandbox on :3001/:8001 (integration project).
+ * Explorer then shows a "Back to dashboard '<name>'" return chip in a top bar
+ * ONLY when entered with ?return_to=workspace&dashboard; clicking it returns to
+ * /workspace/dashboard/<name>. A normal Explorer entry shows no chip/bar.
+ *
+ * Precondition: sandbox (integration project).
  */
 
 import { test, expect } from '@playwright/test';
 
 const DASHBOARD = 'simple-dashboard';
+// table-dashboard row 3 (index 2) holds: markdown, table, chart — perfect for
+// asserting the entry shows for chart/table leaves but NOT for markdown.
+const MIXED_DASHBOARD = 'table-dashboard';
 
-test.use({ viewport: { width: 1600, height: 1200 } });
+async function rightClickCanvasItem(page, selector) {
+  const item = page.locator(selector).first();
+  await expect(item).toBeVisible({ timeout: 20000 });
+  await item.click({ button: 'right' });
+  await expect(page.locator('[data-testid="canvas-context-menu"]')).toBeVisible({ timeout: 5000 });
+}
 
-test.describe('J-3 — Open in Explorer + return chip', () => {
+for (const viewport of [
+  { name: 'desktop', width: 1600, height: 1000 },
+  { name: 'mobile', width: 390, height: 844 },
+]) {
+  test.describe(`J-3 — return chip (${viewport.name})`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+    test.setTimeout(90000);
+
+    test('return bar/chip is absent on a normal Explorer entry', async ({ page }) => {
+      await page.goto('/explorer');
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('[data-testid="explorer-return-bar"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="explorer-return-chip"]')).toHaveCount(0);
+    });
+
+    test('return chip is absent when return_to is set but dashboard is missing', async ({
+      page,
+    }) => {
+      await page.goto('/explorer?return_to=workspace');
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('[data-testid="explorer-return-chip"]')).toHaveCount(0);
+    });
+
+    test('return chip appears with ?return_to=workspace&dashboard and navigates back', async ({
+      page,
+    }) => {
+      await page.goto(`/explorer?return_to=workspace&dashboard=${DASHBOARD}`);
+      await page.waitForLoadState('networkidle');
+      const chip = page.locator('[data-testid="explorer-return-chip"]');
+      await expect(chip).toBeVisible({ timeout: 15000 });
+      await expect(chip).toContainText(DASHBOARD);
+      await chip.click();
+      await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}`), { timeout: 15000 });
+      expect(page.url()).toContain(`/workspace/dashboard/${DASHBOARD}`);
+    });
+  });
+}
+
+// Context-menu assertions are desktop-only (right-click affordance over canvas).
+test.describe('J-3 — "Open in Explorer" context-menu entry (desktop)', () => {
+  test.use({ viewport: { width: 1600, height: 1000 } });
   test.setTimeout(90000);
 
-  test('return chip is absent on a normal Explorer entry', async ({ page }) => {
-    await page.goto('/explorer');
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('[data-testid="explorer-return-bar"]')).toHaveCount(0);
-  });
-
-  test('return chip appears when entered with ?return_to=workspace and navigates back', async ({
+  test('chart leaf right-click offers "Open in Explorer" and navigates correctly', async ({
     page,
   }) => {
-    await page.goto(`/explorer?return_to=workspace&dashboard=${DASHBOARD}`);
-    await page.waitForLoadState('networkidle');
-    const chip = page.locator('[data-testid="explorer-return-chip"]');
-    await expect(chip).toBeVisible({ timeout: 15000 });
-    await expect(chip).toContainText(DASHBOARD);
-    await chip.click();
-    await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}`), { timeout: 15000 });
-    expect(page.url()).toContain(`/workspace/dashboard/${DASHBOARD}`);
-  });
-
-  test('canvas right-click offers "Open in Explorer" for a chart item', async ({ page }) => {
     await page.goto(`/workspace/dashboard/${DASHBOARD}`);
     await page.waitForLoadState('networkidle');
-    const item = page.locator('[data-canvas-path$="item.0"]').first();
-    await expect(item).toBeVisible({ timeout: 20000 });
-    await item.click({ button: 'right' });
-    const menu = page.locator('[data-testid="canvas-context-menu"]');
-    await expect(menu).toBeVisible({ timeout: 5000 });
+    // simple-dashboard row 0 item 0 is a chart leaf.
+    await rightClickCanvasItem(page, '[data-canvas-path="row.0.item.0"]');
     const openItem = page.locator('[data-testid="canvas-ctx-open-in-explorer"]');
-    // Only chart/table leaves carry the entry; assert it exists for this dashboard.
-    if (await openItem.count()) {
-      await openItem.click();
-      await page.waitForURL(/\/explorer\?/, { timeout: 15000 });
-      expect(page.url()).toContain('return_to=workspace');
-      expect(page.url()).toContain(`dashboard=${DASHBOARD}`);
-    }
+    await expect(openItem).toBeVisible({ timeout: 5000 });
+    await openItem.click();
+    await page.waitForURL(/\/explorer\?/, { timeout: 15000 });
+    const url = page.url();
+    expect(url).toContain('return_to=workspace');
+    expect(url).toContain(`dashboard=${DASHBOARD}`);
+    expect(url).toContain('insight=');
   });
+
+  test('table leaf right-click offers "Open in Explorer" with a ?table= target', async ({
+    page,
+  }) => {
+    await page.goto(`/workspace/dashboard/${MIXED_DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    // row index 2 holds markdown(0) / table(1) / chart(2).
+    await rightClickCanvasItem(page, '[data-canvas-path="row.2.item.1"]');
+    const openItem = page.locator('[data-testid="canvas-ctx-open-in-explorer"]');
+    await expect(openItem).toBeVisible({ timeout: 5000 });
+    await openItem.click();
+    await page.waitForURL(/\/explorer\?/, { timeout: 15000 });
+    expect(page.url()).toContain('table=');
+    expect(page.url()).toContain('return_to=workspace');
+  });
+
+  test('markdown leaf right-click does NOT offer "Open in Explorer"', async ({ page }) => {
+    await page.goto(`/workspace/dashboard/${MIXED_DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    // row index 2 item 0 is markdown.
+    await rightClickCanvasItem(page, '[data-canvas-path="row.2.item.0"]');
+    // The menu is open but carries no Explorer entry for a markdown leaf.
+    await expect(page.locator('[data-testid="canvas-ctx-open-in-explorer"]')).toHaveCount(0);
+  });
+
+  // NOTE on non-leaf (row / container) selections: the canvas resolves a
+  // right-click to the INNERMOST data-canvas-path, and rows here are fully filled
+  // by their chart/table items, so a click reliably lands on the leaf — a pure
+  // row/container target is not deterministically clickable in the browser. The
+  // markdown-leaf case above already proves "not every selection offers Open in
+  // Explorer" at the e2e layer; the explicit row-right-click and
+  // container-right-click negatives are exhaustively covered at the unit level in
+  // CanvasContextMenu.test.jsx ("a row right-click does not offer Open in
+  // Explorer" / "a container item does not offer Open in Explorer").
 });

--- a/viewer/e2e/stories/open-in-explorer.spec.mjs
+++ b/viewer/e2e/stories/open-in-explorer.spec.mjs
@@ -1,0 +1,57 @@
+/**
+ * Story: J-3 / VIS-782 — "Open in Explorer" + return chip.
+ *
+ * Right-clicking a chart item on the Workspace canvas offers "Open in
+ * Explorer", which navigates to /explorer?insight=<name>&return_to=workspace&
+ * dashboard=<name>. Explorer then shows a "Back to dashboard '<name>'" return
+ * chip in a top bar; clicking it returns to /workspace/dashboard/<name>.
+ *
+ * Precondition: sandbox on :3001/:8001 (integration project).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const DASHBOARD = 'simple-dashboard';
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+test.describe('J-3 — Open in Explorer + return chip', () => {
+  test.setTimeout(90000);
+
+  test('return chip is absent on a normal Explorer entry', async ({ page }) => {
+    await page.goto('/explorer');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="explorer-return-bar"]')).toHaveCount(0);
+  });
+
+  test('return chip appears when entered with ?return_to=workspace and navigates back', async ({
+    page,
+  }) => {
+    await page.goto(`/explorer?return_to=workspace&dashboard=${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    const chip = page.locator('[data-testid="explorer-return-chip"]');
+    await expect(chip).toBeVisible({ timeout: 15000 });
+    await expect(chip).toContainText(DASHBOARD);
+    await chip.click();
+    await page.waitForURL(new RegExp(`/workspace/dashboard/${DASHBOARD}`), { timeout: 15000 });
+    expect(page.url()).toContain(`/workspace/dashboard/${DASHBOARD}`);
+  });
+
+  test('canvas right-click offers "Open in Explorer" for a chart item', async ({ page }) => {
+    await page.goto(`/workspace/dashboard/${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    const item = page.locator('[data-canvas-path$="item.0"]').first();
+    await expect(item).toBeVisible({ timeout: 20000 });
+    await item.click({ button: 'right' });
+    const menu = page.locator('[data-testid="canvas-context-menu"]');
+    await expect(menu).toBeVisible({ timeout: 5000 });
+    const openItem = page.locator('[data-testid="canvas-ctx-open-in-explorer"]');
+    // Only chart/table leaves carry the entry; assert it exists for this dashboard.
+    if (await openItem.count()) {
+      await openItem.click();
+      await page.waitForURL(/\/explorer\?/, { timeout: 15000 });
+      expect(page.url()).toContain('return_to=workspace');
+      expect(page.url()).toContain(`dashboard=${DASHBOARD}`);
+    }
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -9,7 +9,10 @@ export default defineConfig({
   retries: 2,
   workers: '75%',
   use: {
-    baseURL: 'http://localhost:3001',
+    // Defaults to the standard sandbox (:3001). An isolated hardening sandbox
+    // (e.g. :3022) can be targeted via PLAYWRIGHT_BASE_URL without editing this
+    // file, so parallel agents don't collide on ports.
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001',
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
@@ -24,12 +27,17 @@ export default defineConfig({
       name: 'parallel',
       testIgnore: [
         '**/explorer-crud-save.spec.mjs',
+        '**/explorer-library-reactivity.spec.mjs',
         '**/explorer-publish-to-files.spec.mjs',
       ],
     },
     {
       name: 'state-mutating',
-      testMatch: ['**/explorer-crud-save.spec.mjs'],
+      testMatch: [
+        '**/explorer-crud-save.spec.mjs',
+        // J-4: saves a chart from Explorer, asserts the Library reflects it.
+        '**/explorer-library-reactivity.spec.mjs',
+      ],
       dependencies: ['parallel'],
     },
     {

--- a/viewer/src/LocalRouter.jsx
+++ b/viewer/src/LocalRouter.jsx
@@ -9,8 +9,18 @@ import BreadcrumbLink from './components/common/BreadcrumbLink';
 import ErrorPage from './components/common/ErrorPage';
 import Onboarding from './components/onboarding/Onboarding';
 import ExplorerNewPage from './components/explorerNew/ExplorerNewPage';
+import ExplorerOverlay from './components/explorerNew/ExplorerOverlay';
 import Workspace from './components/new-views/workspace/Workspace';
 import { createURLConfig, setGlobalURLConfig } from './contexts/URLContext';
+
+// VIS-778 / J-2: Build-mode → Explorer round-trip. The overlay composes OVER
+// the Workspace shell (so the origin canvas stays visible underneath).
+const WorkspaceWithExplorerOverlay = () => (
+  <>
+    <Workspace />
+    <ExplorerOverlay />
+  </>
+);
 
 // VIS-772: /editor/<type>/<name> redirects into Workspace with the edit selector encoded
 // as a query param. Wrapping <Navigate /> so we can pull params out of the URL.
@@ -74,6 +84,19 @@ const LocalRouter = createBrowserRouter(
           id="workspace-dashboard"
           path="/workspace/dashboard/:dashboardName"
           element={<Workspace />}
+          loader={loadProject}
+          handle={{
+            crumb: match => (
+              <BreadcrumbLink to={`/workspace/dashboard/${match.params.dashboardName}`}>
+                {match.params.dashboardName}
+              </BreadcrumbLink>
+            ),
+          }}
+        />
+        <Route
+          id="workspace-dashboard-explorer-overlay"
+          path="/workspace/dashboard/:dashboardName/explorer"
+          element={<WorkspaceWithExplorerOverlay />}
           loader={loadProject}
           handle={{
             crumb: match => (

--- a/viewer/src/components/explorerNew/ExplorerLeftPanel.jsx
+++ b/viewer/src/components/explorerNew/ExplorerLeftPanel.jsx
@@ -6,6 +6,7 @@ import {
   PiX,
   PiSpinner,
 } from 'react-icons/pi';
+import { useSearchParams } from 'react-router-dom';
 import { useDraggable } from '@dnd-kit/core';
 import ObjectList from '../new-views/common/ObjectList';
 import { getTypeColors, getTypeIcon } from '../new-views/common/objectTypeConfigs';
@@ -72,6 +73,12 @@ const ExplorerLeftPanel = () => {
   const activeModelName = useStore((s) => s.explorerActiveModelName);
   const explorerModelStates = useStore((s) => s.explorerModelStates);
   const explorerInsightStates = useStore((s) => s.explorerInsightStates);
+
+  // J-5 (VIS-789): when Explorer is opened from Build mode (`?return_to=workspace`)
+  // with nothing yet authored, the empty-state CTA spells out the full
+  // round-trip so the user isn't orphaned in an empty Explorer.
+  const [searchParams] = useSearchParams();
+  const returnToWorkspace = searchParams.get('return_to') === 'workspace';
 
   // Object stores
   const models = useStore((s) => s.models || []);
@@ -457,8 +464,15 @@ const ExplorerLeftPanel = () => {
           filteredInsights.length === 0 &&
           filteredCharts.length === 0 &&
           filteredInputs.length === 0 && (
-            <div className="flex items-center justify-center h-32 text-xs text-secondary-400">
-              {searchQuery ? `No results for "${searchQuery}"` : 'No project objects defined'}
+            <div
+              data-testid="explorer-left-empty-state"
+              className="flex items-center justify-center h-32 px-4 text-center text-xs text-secondary-400"
+            >
+              {searchQuery
+                ? `No results for "${searchQuery}"`
+                : returnToWorkspace
+                  ? "Add a source first, then build your first insight, then we'll wrap it in a chart and drop it back on your dashboard."
+                  : 'No project objects defined'}
             </div>
           )}
       </div>

--- a/viewer/src/components/explorerNew/ExplorerLeftPanel.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerLeftPanel.test.jsx
@@ -1,8 +1,20 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import ExplorerLeftPanel from './ExplorerLeftPanel';
 import useStore from '../../stores/store';
+import { futureFlags } from '../../router-config';
+
+// All renders go through a Router so `useSearchParams` resolves. `currentEntry`
+// overrides the URL (J-5 return_to detection), reset before each test.
+let currentEntry = '/explorer';
+const render = (ui) =>
+  rtlRender(
+    <MemoryRouter initialEntries={[currentEntry]} future={futureFlags}>
+      {ui}
+    </MemoryRouter>
+  );
 
 jest.mock('@dnd-kit/core', () => ({
   useDraggable: () => ({
@@ -111,6 +123,7 @@ const defaultState = {
 describe('ExplorerLeftPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    currentEntry = '/explorer';
     useStore.setState(defaultState);
   });
 
@@ -298,5 +311,45 @@ describe('ExplorerLeftPanel', () => {
 
     expect(screen.getByTestId('object-item-model-orders_model')).toBeInTheDocument();
     expect(screen.queryByTestId('object-item-model-users_model')).not.toBeInTheDocument();
+  });
+
+  // ------------------------------------------------------------------
+  // J-5 / VIS-789 — round-trip empty-state CTA
+  // ------------------------------------------------------------------
+  describe('round-trip empty state (J-5)', () => {
+    const emptyProject = {
+      models: [],
+      metrics: [],
+      dimensions: [],
+      insights: [],
+      charts: [],
+      inputs: [],
+    };
+
+    it('shows the default empty-state copy without return_to', () => {
+      currentEntry = '/explorer';
+      useStore.setState(emptyProject);
+      render(<ExplorerLeftPanel />);
+      expect(screen.getByText('No project objects defined')).toBeInTheDocument();
+    });
+
+    it('shows the round-trip CTA when entered with return_to=workspace', () => {
+      currentEntry = '/explorer?return_to=workspace&dashboard=sales';
+      useStore.setState(emptyProject);
+      render(<ExplorerLeftPanel />);
+      expect(
+        screen.getByText(/then we'll wrap it in a chart and drop it back on your dashboard/i)
+      ).toBeInTheDocument();
+      expect(screen.queryByText('No project objects defined')).not.toBeInTheDocument();
+    });
+
+    it('prefers the search "no results" copy over the round-trip CTA', () => {
+      currentEntry = '/explorer?return_to=workspace&dashboard=sales';
+      useStore.setState(emptyProject);
+      render(<ExplorerLeftPanel />);
+      const searchInput = screen.getByTestId('left-panel-search');
+      fireEvent.change(searchInput, { target: { value: 'zzz' } });
+      expect(screen.getByText('No results for "zzz"')).toBeInTheDocument();
+    });
   });
 });

--- a/viewer/src/components/explorerNew/ExplorerNewPage.jsx
+++ b/viewer/src/components/explorerNew/ExplorerNewPage.jsx
@@ -1,8 +1,10 @@
 import { useRef, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import LeftPanel from './ExplorerLeftPanel';
 import CenterPanel from './CenterPanel';
 import ExplorerRightPanel from './ExplorerRightPanel';
 import ExplorerDndContext from './ExplorerDndContext';
+import ExplorerReturnChip from './ExplorerReturnChip';
 import VerticalDivider from '../common/VerticalDivider';
 import useStore from '../../stores/store';
 import { usePanelResize } from '../../hooks/usePanelResize';
@@ -53,6 +55,11 @@ const ExplorerNewPage = () => {
     }
   }, [modelTabs.length, chartInsightNames.length, createInsight]);
 
+  // J-3 (VIS-782): show a "Back to dashboard" return bar only when Explorer was
+  // entered from Build mode (`?return_to=workspace`).
+  const [searchParams] = useSearchParams();
+  const showReturnBar = searchParams.get('return_to') === 'workspace' && !!searchParams.get('dashboard');
+
   const containerRef = useRef(null);
 
   const {
@@ -76,6 +83,14 @@ const ExplorerNewPage = () => {
         className="flex flex-col h-[calc(100vh-3rem)] bg-gray-50 overflow-hidden"
         data-testid="explorer-new-page"
       >
+        {showReturnBar && (
+          <div
+            data-testid="explorer-return-bar"
+            className="flex items-center gap-2 flex-shrink-0 border-b border-secondary-200 bg-white px-3 py-1.5"
+          >
+            <ExplorerReturnChip />
+          </div>
+        )}
         <div className="flex flex-1 overflow-hidden" ref={containerRef}>
           <div
             style={{ width: leftNavCollapsed ? '48px' : `${leftWidth}%` }}

--- a/viewer/src/components/explorerNew/ExplorerNewPage.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerNewPage.test.jsx
@@ -1,8 +1,25 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import ExplorerNewPage from './ExplorerNewPage';
 import useStore from '../../stores/store';
+import { futureFlags } from '../../router-config';
+
+// Renders through a Router (J-3: ExplorerNewPage now reads search params).
+let currentEntry = '/explorer';
+const render = (ui) =>
+  rtlRender(
+    <MemoryRouter initialEntries={[currentEntry]} future={futureFlags}>
+      {ui}
+    </MemoryRouter>
+  );
+
+jest.mock('./ExplorerReturnChip', () => {
+  return function MockExplorerReturnChip() {
+    return <div data-testid="return-chip">ReturnChip</div>;
+  };
+});
 
 jest.mock('./ExplorerDndContext', () => {
   return function MockExplorerDndContext({ children }) {
@@ -48,6 +65,7 @@ jest.mock('../../hooks/usePanelResize', () => ({
 
 describe('ExplorerNewPage', () => {
   beforeEach(() => {
+    currentEntry = '/explorer';
     useStore.setState({
       explorerLeftNavCollapsed: false,
       explorerActiveModelName: null,
@@ -71,6 +89,25 @@ describe('ExplorerNewPage', () => {
   it('right panel is always rendered (never conditional)', () => {
     render(<ExplorerNewPage />);
     expect(screen.getByTestId('right-panel')).toBeInTheDocument();
+  });
+
+  // J-3 / VIS-782 — return bar visibility.
+  it('does not render the return bar on a normal Explorer entry', () => {
+    render(<ExplorerNewPage />);
+    expect(screen.queryByTestId('explorer-return-bar')).not.toBeInTheDocument();
+  });
+
+  it('renders the return bar when entered from Workspace', () => {
+    currentEntry = '/explorer?return_to=workspace&dashboard=sales';
+    render(<ExplorerNewPage />);
+    expect(screen.getByTestId('explorer-return-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('return-chip')).toBeInTheDocument();
+  });
+
+  it('does not render the return bar without a dashboard param', () => {
+    currentEntry = '/explorer?return_to=workspace';
+    render(<ExplorerNewPage />);
+    expect(screen.queryByTestId('explorer-return-bar')).not.toBeInTheDocument();
   });
 
   it('renders VerticalDivider when left nav is expanded', () => {

--- a/viewer/src/components/explorerNew/ExplorerOverlay.jsx
+++ b/viewer/src/components/explorerNew/ExplorerOverlay.jsx
@@ -104,21 +104,25 @@ const ExplorerOverlay = () => {
   return (
     <div
       data-testid="explorer-overlay"
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8"
+      className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-6 lg:p-10"
     >
-      {/* Backdrop — low opacity so the canvas (origin context) shows through. */}
+      {/* Backdrop — dim the origin canvas enough that the framed card clearly
+          reads as an overlay ON TOP of Build mode (not a navigation away), while
+          still letting the dashboard show through around the edges. */}
       <button
         type="button"
         aria-label="Close Explorer overlay"
         data-testid="explorer-overlay-backdrop"
-        className="absolute inset-0 bg-secondary-900/30"
+        className="absolute inset-0 bg-secondary-900/50"
         onClick={() => !saving && close()}
       />
 
-      {/* Framed card — border + shadow read as "inside Build mode". */}
+      {/* Framed card — a prominent mulberry border, a visible dimmed margin
+          (the card never fills the full viewport), and a ring+shadow make it
+          read as "inside Build mode". */}
       <div
         data-testid="explorer-overlay-card"
-        className="relative flex h-full w-full max-w-[1600px] flex-col overflow-hidden rounded-xl border-2 border-primary-200 bg-white shadow-2xl"
+        className="relative flex h-full max-h-[94vh] w-full max-w-[1600px] flex-col overflow-hidden rounded-xl border-2 border-primary-400 bg-white shadow-2xl ring-1 ring-primary-900/10"
         role="dialog"
         aria-modal="true"
         aria-label="Create a chart for your dashboard"

--- a/viewer/src/components/explorerNew/ExplorerOverlay.jsx
+++ b/viewer/src/components/explorerNew/ExplorerOverlay.jsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { PiX, PiArrowsClockwise } from 'react-icons/pi';
+import useStore from '../../stores/store';
+import { getTypeColors } from '../new-views/common/objectTypeConfigs';
+import { emitWorkspaceEvent } from '../new-views/workspace/telemetry';
+import { ExplorerRoundTripProvider } from './ExplorerRoundTripContext';
+import ExplorerNewPage from './ExplorerNewPage';
+
+/**
+ * ExplorerOverlay — VIS-778 / J-2.
+ *
+ * Renders the existing Explorer surface as a modal overlay OVER Build mode for
+ * the "+ New Chart" / "+ New Insight" round-trip. Mounted at
+ * `/workspace/dashboard/:dashboardName/explorer?return_to=workspace&slot=<r>:<i>`.
+ *
+ * Framing (the only thing this wave adds — Explorer's surface is unchanged):
+ *   - A dimmed backdrop so the canvas underneath stays visible (origin context).
+ *   - A bordered + shadowed card that reads as "inside Build mode", not a
+ *     navigation away.
+ *   - An origin breadcrumb: "Adding to dashboard <name> · slot <slot>".
+ *   - "Save and place in slot" (via ExplorerRoundTripContext) replaces the
+ *     standard Save; on success the Insight + wrapping Chart are persisted and
+ *     the Chart lands in the originating slot, then the overlay closes.
+ *   - Cancel / the close button / Esc return to Build mode without placing.
+ */
+
+const slotLabel = slot => {
+  if (!slot || slot === 'new') return 'a new row';
+  const [row, item] = String(slot).split(':');
+  if (item === 'end' || item === undefined) return `end of row ${Number(row) + 1}`;
+  return `row ${Number(row) + 1}, position ${Number(item) + 1}`;
+};
+
+const ExplorerOverlay = () => {
+  const navigate = useNavigate();
+  const { dashboardName } = useParams();
+  const [searchParams] = useSearchParams();
+  const slot = searchParams.get('slot') || 'new';
+
+  const saveExplorerObjects = useStore(s => s.saveExplorerObjects);
+  const placeChartInDashboardSlot = useStore(s => s.placeChartInDashboardSlot);
+  const chartName = useStore(s => s.explorerChartName);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const close = useCallback(() => {
+    navigate(`/workspace/dashboard/${encodeURIComponent(dashboardName)}`);
+  }, [navigate, dashboardName]);
+
+  // Esc dismisses (same as Cancel).
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape' && !saving) close();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [close, saving]);
+
+  const handleSaveAndPlace = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await saveExplorerObjects();
+      if (!result.success) {
+        const messages = result.errors.map(e => `${e.type} "${e.name}": ${e.error}`);
+        setError(messages.join('; ') || 'Save failed');
+        setSaving(false);
+        return;
+      }
+      if (!chartName) {
+        setError('No chart to place — build an insight first.');
+        setSaving(false);
+        return;
+      }
+      const placed = await placeChartInDashboardSlot(dashboardName, chartName, slot);
+      if (!placed.success) {
+        setError(placed.error || 'Could not place the chart on the dashboard.');
+        setSaving(false);
+        return;
+      }
+      emitWorkspaceEvent('explorer_roundtrip_placed', { dashboardName, chartName, slot });
+      navigate(
+        `/workspace/dashboard/${encodeURIComponent(dashboardName)}?newItem=${encodeURIComponent(
+          chartName
+        )}`
+      );
+    } catch (err) {
+      setError(err.message || 'An unexpected error occurred');
+      setSaving(false);
+    }
+  }, [
+    saveExplorerObjects,
+    placeChartInDashboardSlot,
+    chartName,
+    dashboardName,
+    slot,
+    navigate,
+  ]);
+
+  const dashColors = getTypeColors('dashboard');
+
+  return (
+    <div
+      data-testid="explorer-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8"
+    >
+      {/* Backdrop — low opacity so the canvas (origin context) shows through. */}
+      <button
+        type="button"
+        aria-label="Close Explorer overlay"
+        data-testid="explorer-overlay-backdrop"
+        className="absolute inset-0 bg-secondary-900/30"
+        onClick={() => !saving && close()}
+      />
+
+      {/* Framed card — border + shadow read as "inside Build mode". */}
+      <div
+        data-testid="explorer-overlay-card"
+        className="relative flex h-full w-full max-w-[1600px] flex-col overflow-hidden rounded-xl border-2 border-primary-200 bg-white shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create a chart for your dashboard"
+      >
+        {/* Origin breadcrumb bar. */}
+        <div className="flex items-center justify-between gap-3 border-b border-secondary-200 bg-primary-50 px-4 py-2">
+          <div className="flex items-center gap-2 text-sm text-secondary-700">
+            <span className="text-secondary-500">Adding to dashboard</span>
+            <span
+              data-testid="explorer-overlay-dashboard"
+              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${dashColors.bg} ${dashColors.text} ${dashColors.border}`}
+            >
+              {dashboardName}
+            </span>
+            <span className="text-secondary-300">·</span>
+            <span data-testid="explorer-overlay-slot" className="text-secondary-500">
+              slot {slotLabel(slot)}
+            </span>
+          </div>
+          <button
+            type="button"
+            data-testid="explorer-overlay-close"
+            disabled={saving}
+            onClick={close}
+            title="Cancel and return to dashboard"
+            aria-label="Cancel and return to dashboard"
+            className="inline-flex h-7 w-7 items-center justify-center rounded text-secondary-500 transition-colors hover:bg-secondary-100 hover:text-secondary-900 disabled:opacity-50"
+          >
+            <PiX size={16} />
+          </button>
+        </div>
+
+        {error && (
+          <div
+            data-testid="explorer-overlay-error"
+            className="border-b border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        {/* The existing Explorer surface — UNCHANGED — inside the frame. The
+            round-trip context swaps its Save button for "Save and place in
+            slot" and disables the surface while placing. */}
+        <div
+          className={`relative min-h-0 flex-1 ${saving ? 'pointer-events-none opacity-60' : ''}`}
+          aria-busy={saving}
+        >
+          <ExplorerRoundTripProvider
+            value={{ dashboardName, slot, saving, onSaveAndPlace: handleSaveAndPlace }}
+          >
+            <ExplorerNewPage />
+          </ExplorerRoundTripProvider>
+          {saving && (
+            <div
+              data-testid="explorer-overlay-saving"
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <span className="inline-flex items-center gap-2 rounded-lg bg-white/90 px-4 py-2 text-sm font-medium text-secondary-700 shadow">
+                <PiArrowsClockwise className="animate-spin" size={16} />
+                Saving and placing on dashboard…
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExplorerOverlay;

--- a/viewer/src/components/explorerNew/ExplorerOverlay.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerOverlay.test.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import ExplorerOverlay from './ExplorerOverlay';
+import useStore from '../../stores/store';
+import { futureFlags } from '../../router-config';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// The real Explorer surface is heavy; stub it. The "Save and place" button it
+// would render comes from the round-trip context, which we exercise via the
+// overlay's own handler in these tests through a stubbed ExplorerNewPage that
+// reads the context.
+jest.mock('./ExplorerNewPage', () => {
+  const { useExplorerRoundTrip } = jest.requireActual('./ExplorerRoundTripContext');
+  return function MockExplorerNewPage() {
+    const rt = useExplorerRoundTrip();
+    return (
+      <div data-testid="explorer-surface">
+        {rt && (
+          <button
+            data-testid="mock-save-and-place"
+            disabled={rt.saving}
+            onClick={() => rt.onSaveAndPlace()}
+          >
+            save-and-place
+          </button>
+        )}
+      </div>
+    );
+  };
+});
+
+const renderOverlay = (entry = '/workspace/dashboard/sales/explorer?return_to=workspace&slot=0:end') =>
+  render(
+    <MemoryRouter initialEntries={[entry]} future={futureFlags}>
+      <Routes>
+        <Route path="/workspace/dashboard/:dashboardName/explorer" element={<ExplorerOverlay />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('ExplorerOverlay (J-2 / VIS-778)', () => {
+  let saveExplorerObjects;
+  let placeChartInDashboardSlot;
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    saveExplorerObjects = jest.fn().mockResolvedValue({ success: true, errors: [] });
+    placeChartInDashboardSlot = jest.fn().mockResolvedValue({ success: true });
+    useStore.setState({
+      saveExplorerObjects,
+      placeChartInDashboardSlot,
+      explorerChartName: 'revenue_chart',
+    });
+  });
+
+  it('renders the framed overlay with the origin breadcrumb', () => {
+    renderOverlay();
+    expect(screen.getByTestId('explorer-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('explorer-overlay-card')).toBeInTheDocument();
+    expect(screen.getByTestId('explorer-overlay-dashboard')).toHaveTextContent('sales');
+    expect(screen.getByTestId('explorer-overlay-slot')).toHaveTextContent('end of row 1');
+  });
+
+  it('renders the Explorer surface inside the overlay', () => {
+    renderOverlay();
+    expect(screen.getByTestId('explorer-surface')).toBeInTheDocument();
+  });
+
+  it('Save and place: saves, wraps+places the chart, then closes to the dashboard', async () => {
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('mock-save-and-place'));
+    await waitFor(() => {
+      expect(saveExplorerObjects).toHaveBeenCalledTimes(1);
+    });
+    expect(placeChartInDashboardSlot).toHaveBeenCalledWith('sales', 'revenue_chart', '0:end');
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/workspace/dashboard/sales?newItem=revenue_chart'
+      );
+    });
+  });
+
+  it('surfaces a save error and does not place', async () => {
+    saveExplorerObjects.mockResolvedValue({
+      success: false,
+      errors: [{ name: 'm', type: 'model', error: 'boom' }],
+    });
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('mock-save-and-place'));
+    await waitFor(() => {
+      expect(screen.getByTestId('explorer-overlay-error')).toHaveTextContent('boom');
+    });
+    expect(placeChartInDashboardSlot).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a placement error', async () => {
+    placeChartInDashboardSlot.mockResolvedValue({ success: false, error: 'no slot' });
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('mock-save-and-place'));
+    await waitFor(() => {
+      expect(screen.getByTestId('explorer-overlay-error')).toHaveTextContent('no slot');
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('close button returns to the dashboard without saving', () => {
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('explorer-overlay-close'));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/dashboard/sales');
+    expect(saveExplorerObjects).not.toHaveBeenCalled();
+  });
+
+  it('Esc returns to the dashboard', () => {
+    renderOverlay();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/dashboard/sales');
+  });
+
+  it('backdrop click returns to the dashboard', () => {
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('explorer-overlay-backdrop'));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/dashboard/sales');
+  });
+
+  it('errors when there is no chart to place', async () => {
+    useStore.setState({ explorerChartName: null });
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('mock-save-and-place'));
+    await waitFor(() => {
+      expect(screen.getByTestId('explorer-overlay-error')).toHaveTextContent(
+        /No chart to place/i
+      );
+    });
+    expect(placeChartInDashboardSlot).not.toHaveBeenCalled();
+  });
+
+  it('defaults the slot label to a new row when slot=new', () => {
+    renderOverlay('/workspace/dashboard/sales/explorer?return_to=workspace&slot=new');
+    expect(screen.getByTestId('explorer-overlay-slot')).toHaveTextContent('a new row');
+  });
+});

--- a/viewer/src/components/explorerNew/ExplorerReturnChip.jsx
+++ b/viewer/src/components/explorerNew/ExplorerReturnChip.jsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { PiArrowLeft } from 'react-icons/pi';
+import { getTypeColors } from '../new-views/common/objectTypeConfigs';
+
+/**
+ * ExplorerReturnChip — VIS-782 / J-3.
+ *
+ * A breadcrumb chip rendered in Explorer's top bar ONLY when the user arrived
+ * from Build mode via "Open in Explorer" (URL carries `?return_to=workspace`).
+ * Clicking it returns to the originating dashboard in Workspace.
+ *
+ * The chip wears the dashboard type colour (rose) from objectTypeConfigs — no
+ * hand-rolled palette — so it visually reads as "back to a dashboard".
+ *
+ * Renders nothing for a normal Explorer entry (no params) so Explorer's chrome
+ * is untouched in the default case.
+ */
+const ExplorerReturnChip = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const returnTo = searchParams.get('return_to');
+  const dashboard = searchParams.get('dashboard');
+
+  const handleClick = useCallback(() => {
+    if (!dashboard) return;
+    navigate(`/workspace/dashboard/${encodeURIComponent(dashboard)}`);
+  }, [navigate, dashboard]);
+
+  if (returnTo !== 'workspace' || !dashboard) return null;
+
+  const { bg, text, border, bgHover } = getTypeColors('dashboard');
+
+  return (
+    <button
+      type="button"
+      data-testid="explorer-return-chip"
+      onClick={handleClick}
+      title={`Back to dashboard '${dashboard}'`}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${bg} ${text} ${border} ${bgHover} cursor-pointer`}
+    >
+      <PiArrowLeft size={14} aria-hidden="true" />
+      <span>
+        Back to dashboard{' '}
+        <span className="font-semibold">&lsquo;{dashboard}&rsquo;</span>
+      </span>
+    </button>
+  );
+};
+
+export default ExplorerReturnChip;

--- a/viewer/src/components/explorerNew/ExplorerReturnChip.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerReturnChip.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import ExplorerReturnChip from './ExplorerReturnChip';
+import { futureFlags } from '../../router-config';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderChip = entry =>
+  render(
+    <MemoryRouter initialEntries={[entry]} future={futureFlags}>
+      <ExplorerReturnChip />
+    </MemoryRouter>
+  );
+
+describe('ExplorerReturnChip (J-3 / VIS-782)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders nothing on a normal Explorer entry (no params)', () => {
+    renderChip('/explorer');
+    expect(screen.queryByTestId('explorer-return-chip')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when return_to is set but dashboard is missing', () => {
+    renderChip('/explorer?return_to=workspace');
+    expect(screen.queryByTestId('explorer-return-chip')).not.toBeInTheDocument();
+  });
+
+  it('shows the chip with the dashboard name when entered from Workspace', () => {
+    renderChip('/explorer?return_to=workspace&dashboard=simple-dashboard');
+    const chip = screen.getByTestId('explorer-return-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('Back to dashboard');
+    expect(chip).toHaveTextContent('simple-dashboard');
+  });
+
+  it('navigates back to the dashboard in Workspace on click', () => {
+    renderChip('/explorer?return_to=workspace&dashboard=simple-dashboard');
+    fireEvent.click(screen.getByTestId('explorer-return-chip'));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/dashboard/simple-dashboard');
+  });
+
+  it('encodes a dashboard name with special characters', () => {
+    renderChip('/explorer?return_to=workspace&dashboard=' + encodeURIComponent('my dash'));
+    fireEvent.click(screen.getByTestId('explorer-return-chip'));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/dashboard/my%20dash');
+  });
+});

--- a/viewer/src/components/explorerNew/ExplorerRightPanel.jsx
+++ b/viewer/src/components/explorerNew/ExplorerRightPanel.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useCallback } from 'react';
-import { PiPlus, PiFloppyDisk } from 'react-icons/pi';
+import { PiPlus, PiFloppyDisk, PiPushPin } from 'react-icons/pi';
 import useStore from '../../stores/store';
 import { selectHasModifications } from '../../stores/explorerNewStore';
 import InsightCRUDSection from './InsightCRUDSection';
 import ChartCRUDSection from './ChartCRUDSection';
 import ExplorerSaveModal from './ExplorerSaveModal';
+import { useExplorerRoundTrip } from './ExplorerRoundTripContext';
 import { recordOnboardingAction } from '../onboarding/onboardingState';
 
 const ExplorerRightPanel = () => {
@@ -13,6 +14,10 @@ const ExplorerRightPanel = () => {
   const setActiveInsight = useStore((s) => s.setActiveInsight);
   const createInsight = useStore((s) => s.createInsight);
   const hasChanges = useStore(selectHasModifications);
+
+  // J-2 round-trip: when present, the Save button becomes "Save and place in
+  // slot" and routes to the overlay's handler instead of the Save modal.
+  const roundTrip = useExplorerRoundTrip();
 
   const [chartExpanded, setChartExpanded] = useState(true);
   const [showSaveModal, setShowSaveModal] = useState(false);
@@ -74,18 +79,32 @@ const ExplorerRightPanel = () => {
 
       {/* Save Button (fixed at bottom) */}
       <div className="flex-shrink-0 p-3 border-t border-gray-200 bg-white">
-        <button
-          data-testid="explorer-save-button"
-          data-onb-target="explorer-save-button"
-          disabled={!hasChanges}
-          onClick={() => setShowSaveModal(true)}
-          className="flex items-center justify-center gap-2 w-full py-2 px-4 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <PiFloppyDisk size={16} />
-          Save to Project
-        </button>
+        {roundTrip ? (
+          <button
+            data-testid="explorer-save-and-place-button"
+            disabled={!hasChanges || roundTrip.saving}
+            onClick={() => roundTrip.onSaveAndPlace && roundTrip.onSaveAndPlace()}
+            className="flex items-center justify-center gap-2 w-full py-2 px-4 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <PiPushPin size={16} />
+            {roundTrip.saving ? 'Placing…' : 'Save and place in slot'}
+          </button>
+        ) : (
+          <button
+            data-testid="explorer-save-button"
+            data-onb-target="explorer-save-button"
+            disabled={!hasChanges}
+            onClick={() => setShowSaveModal(true)}
+            className="flex items-center justify-center gap-2 w-full py-2 px-4 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <PiFloppyDisk size={16} />
+            Save to Project
+          </button>
+        )}
       </div>
-      {showSaveModal && <ExplorerSaveModal onClose={() => setShowSaveModal(false)} />}
+      {showSaveModal && !roundTrip && (
+        <ExplorerSaveModal onClose={() => setShowSaveModal(false)} />
+      )}
     </div>
   );
 };

--- a/viewer/src/components/explorerNew/ExplorerRoundTripContext.jsx
+++ b/viewer/src/components/explorerNew/ExplorerRoundTripContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * ExplorerRoundTripContext — VIS-778 / J-2.
+ *
+ * When Explorer is mounted inside the Build-mode overlay (the round-trip from
+ * "+ New Chart" / "+ New Insight"), this context carries the round-trip
+ * descriptor so the existing Explorer surface can adapt WITHOUT being
+ * redesigned:
+ *
+ *   - `<ExplorerRightPanel>` swaps its "Save to Project" button for
+ *     "Save and place in slot" and routes the click to `onSaveAndPlace`.
+ *
+ * Default `null` → normal Explorer entry, surface unchanged.
+ *
+ * Shape:
+ *   {
+ *     dashboardName: string,   // origin dashboard
+ *     slot: string,            // "<rowIdx>:<itemIdx>" | "<rowIdx>:end" | "new"
+ *     saving: boolean,         // overlay is mid-save (disables the surface)
+ *     onSaveAndPlace: () => Promise<void>,
+ *   }
+ */
+const ExplorerRoundTripContext = createContext(null);
+
+export const ExplorerRoundTripProvider = ExplorerRoundTripContext.Provider;
+
+export const useExplorerRoundTrip = () => useContext(ExplorerRoundTripContext);
+
+export default ExplorerRoundTripContext;

--- a/viewer/src/components/explorerNew/ExplorerSaveModal.jsx
+++ b/viewer/src/components/explorerNew/ExplorerSaveModal.jsx
@@ -1,22 +1,124 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useStore from '../../stores/store';
 import EmbeddedPill from '../new-views/lineage/EmbeddedPill';
+
+/**
+ * Session-scoped key for remembering the last-used "After save" choice (J-1 /
+ * VIS-774). Persists across modal opens until the viewer tab is closed.
+ */
+const AFTER_SAVE_SESSION_KEY = 'visivo.explorer.afterSave';
+
+const AFTER_SAVE_STAY = 'stay';
+const AFTER_SAVE_WORKSPACE = 'workspace';
+const AFTER_SAVE_DASHBOARD = 'dashboard';
+
+const readAfterSavePref = () => {
+  try {
+    const raw = sessionStorage.getItem(AFTER_SAVE_SESSION_KEY);
+    if (raw === AFTER_SAVE_WORKSPACE || raw === AFTER_SAVE_DASHBOARD) return raw;
+  } catch {
+    // sessionStorage may be unavailable (private mode / SSR); fall back to default.
+  }
+  return AFTER_SAVE_STAY;
+};
+
+const writeAfterSavePref = value => {
+  try {
+    sessionStorage.setItem(AFTER_SAVE_SESSION_KEY, value);
+  } catch {
+    // best-effort
+  }
+};
+
+/**
+ * Derive the slot-picker options for a dashboard: one "at end of <row>" per
+ * existing top-level row, plus a final "in a new row at the end". The value is
+ * the engineering `?slot=` descriptor consumed by Build mode:
+ *   - `<rowIndex>:end`  → append to that row
+ *   - `new`             → a fresh row at the end
+ */
+const buildSlotOptions = dashboardConfig => {
+  const rows = Array.isArray(dashboardConfig?.rows) ? dashboardConfig.rows : [];
+  const options = rows.map((row, idx) => ({
+    value: `${idx}:end`,
+    label: `At end of row ${idx + 1}`,
+  }));
+  options.push({ value: 'new', label: 'In a new row at the end' });
+  return options;
+};
 
 /**
  * ExplorerSaveModal - Shows a summary of objects to be saved and handles the save operation.
  *
  * Reads modification status from explorerDiffResult (populated by backend /api/explorer/diff/).
  *
+ * J-1 (VIS-774): an "After save" section lets the user choose what happens once
+ * the save succeeds — stay in Explorer (default), open the new chart in
+ * Workspace, or add it to a chosen dashboard in a chosen slot. The last choice
+ * is remembered per session.
+ *
  * Props:
  * - onClose: (function) called when the modal should close (cancel or successful save)
  */
 const ExplorerSaveModal = ({ onClose }) => {
+  const navigate = useNavigate();
   const diffResult = useStore((s) => s.explorerDiffResult);
   const chartName = useStore((s) => s.explorerChartName);
   const saveExplorerObjects = useStore((s) => s.saveExplorerObjects);
+  const dashboards = useStore((s) => s.dashboards);
+  const fetchDashboards = useStore((s) => s.fetchDashboards);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+
+  // The standalone Explorer page doesn't load the dashboards collection, but
+  // the "Add to dashboard" option (J-1) needs it. Fetch on mount so the picker
+  // populates. No-op cost when the cache is already warm.
+  useEffect(() => {
+    if (fetchDashboards && (dashboards || []).length === 0) {
+      fetchDashboards();
+    }
+    // Only run on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // After-save choice + the dashboard/slot targets for the "Add to dashboard"
+  // option. Initialised from the per-session preference.
+  const initialChoice = useMemo(() => {
+    const pref = readAfterSavePref();
+    // Down-grade a remembered "dashboard" choice to "stay" if no dashboards
+    // exist this session — option 3 would be disabled anyway.
+    if (pref === AFTER_SAVE_DASHBOARD && (dashboards || []).length === 0) {
+      return AFTER_SAVE_STAY;
+    }
+    return pref;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const [afterSave, setAfterSave] = useState(initialChoice);
+  const [targetDashboard, setTargetDashboard] = useState(
+    () => (dashboards || [])[0]?.name || ''
+  );
+  const [targetSlot, setTargetSlot] = useState('new');
+
+  const hasDashboards = (dashboards || []).length > 0;
+
+  // Once dashboards load (async fetch above), seed the picker if it's empty.
+  useEffect(() => {
+    if (!targetDashboard && (dashboards || []).length > 0) {
+      setTargetDashboard(dashboards[0].name);
+    }
+  }, [dashboards, targetDashboard]);
+
+  const slotOptions = useMemo(() => {
+    const dash = (dashboards || []).find((d) => d.name === targetDashboard);
+    return buildSlotOptions(dash?.config || dash);
+  }, [dashboards, targetDashboard]);
+
+  const handleAfterSaveChange = useCallback((value) => {
+    setAfterSave(value);
+    writeAfterSavePref(value);
+  }, []);
 
   const { newItems, modifiedItems, chartStatus } = useMemo(() => {
     const newArr = [];
@@ -49,6 +151,18 @@ const ExplorerSaveModal = ({ onClose }) => {
     try {
       const result = await saveExplorerObjects();
       if (result.success) {
+        // After-save navigation (J-1). The new chart is the wrapping object the
+        // user places on a dashboard.
+        if (afterSave === AFTER_SAVE_WORKSPACE) {
+          navigate('/workspace');
+        } else if (afterSave === AFTER_SAVE_DASHBOARD && targetDashboard) {
+          const params = new URLSearchParams();
+          params.set('slot', targetSlot);
+          if (chartName) params.set('newItem', chartName);
+          navigate(
+            `/workspace/dashboard/${encodeURIComponent(targetDashboard)}?${params.toString()}`
+          );
+        }
         onClose();
       } else {
         const messages = result.errors.map((e) => `${e.type} "${e.name}": ${e.error}`);
@@ -59,7 +173,12 @@ const ExplorerSaveModal = ({ onClose }) => {
     } finally {
       setSaving(false);
     }
-  }, [saveExplorerObjects, onClose]);
+  }, [saveExplorerObjects, onClose, afterSave, targetDashboard, targetSlot, chartName, navigate]);
+
+  const radioBase =
+    'flex items-start gap-2 text-sm text-secondary-700 cursor-pointer select-none';
+  const selectBase =
+    'rounded-md border border-secondary-300 text-sm px-2 py-1 text-secondary-700 focus:outline-none focus:ring-2 focus:ring-primary-200 disabled:opacity-50 disabled:cursor-not-allowed';
 
   return (
     <div
@@ -121,6 +240,98 @@ const ExplorerSaveModal = ({ onClose }) => {
             </div>
           </div>
         )}
+
+        {/* After save (J-1 / VIS-774) */}
+        <div
+          data-testid="after-save-section"
+          className="mt-4 pt-4 border-t border-secondary-100"
+        >
+          <p className="text-xs font-medium text-secondary-500 uppercase tracking-wide mb-2">
+            After save
+          </p>
+          <div className="space-y-2">
+            <label className={radioBase}>
+              <input
+                type="radio"
+                name="after-save"
+                data-testid="after-save-stay"
+                aria-label="Stay in Explorer"
+                className="mt-0.5 accent-primary"
+                checked={afterSave === AFTER_SAVE_STAY}
+                onChange={() => handleAfterSaveChange(AFTER_SAVE_STAY)}
+                disabled={saving}
+              />
+              <span>Stay in Explorer</span>
+            </label>
+
+            <label className={radioBase}>
+              <input
+                type="radio"
+                name="after-save"
+                data-testid="after-save-workspace"
+                aria-label="Open in Workspace"
+                className="mt-0.5 accent-primary"
+                checked={afterSave === AFTER_SAVE_WORKSPACE}
+                onChange={() => handleAfterSaveChange(AFTER_SAVE_WORKSPACE)}
+                disabled={saving}
+              />
+              <span>Open in Workspace</span>
+            </label>
+
+            <label
+              className={`${radioBase} ${!hasDashboards ? 'opacity-50 cursor-not-allowed' : ''}`}
+              title={
+                !hasDashboards
+                  ? 'No dashboards exist yet — create one in Workspace first.'
+                  : undefined
+              }
+            >
+              <input
+                type="radio"
+                name="after-save"
+                data-testid="after-save-dashboard"
+                aria-label="Add to dashboard"
+                className="mt-0.5 accent-primary"
+                checked={afterSave === AFTER_SAVE_DASHBOARD}
+                onChange={() => handleAfterSaveChange(AFTER_SAVE_DASHBOARD)}
+                disabled={saving || !hasDashboards}
+              />
+              <span className="flex flex-wrap items-center gap-1.5">
+                <span>Add to dashboard</span>
+                <select
+                  data-testid="after-save-dashboard-select"
+                  className={selectBase}
+                  value={targetDashboard}
+                  disabled={saving || !hasDashboards || afterSave !== AFTER_SAVE_DASHBOARD}
+                  onChange={(e) => {
+                    setTargetDashboard(e.target.value);
+                    setTargetSlot('new');
+                  }}
+                >
+                  {(dashboards || []).map((d) => (
+                    <option key={d.name} value={d.name}>
+                      {d.name}
+                    </option>
+                  ))}
+                </select>
+                <span>in slot</span>
+                <select
+                  data-testid="after-save-slot-select"
+                  className={selectBase}
+                  value={targetSlot}
+                  disabled={saving || !hasDashboards || afterSave !== AFTER_SAVE_DASHBOARD}
+                  onChange={(e) => setTargetSlot(e.target.value)}
+                >
+                  {slotOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
+          </div>
+        </div>
 
         {/* Error display */}
         {error && (

--- a/viewer/src/components/explorerNew/ExplorerSaveModal.jsx
+++ b/viewer/src/components/explorerNew/ExplorerSaveModal.jsx
@@ -55,8 +55,11 @@ const buildSlotOptions = dashboardConfig => {
  *
  * J-1 (VIS-774): an "After save" section lets the user choose what happens once
  * the save succeeds — stay in Explorer (default), open the new chart in
- * Workspace, or add it to a chosen dashboard in a chosen slot. The last choice
- * is remembered per session.
+ * Workspace, or add it to a chosen dashboard in a chosen slot. The "Add to
+ * dashboard" choice places the saved chart in the slot (via
+ * placeChartInDashboardSlot) and then navigates to Build mode with
+ * `?slot&newItem` so the receiving canvas can highlight the new item. The last
+ * choice is remembered per session.
  *
  * Props:
  * - onClose: (function) called when the modal should close (cancel or successful save)
@@ -64,10 +67,13 @@ const buildSlotOptions = dashboardConfig => {
 const ExplorerSaveModal = ({ onClose }) => {
   const navigate = useNavigate();
   const diffResult = useStore((s) => s.explorerDiffResult);
+  const modelStates = useStore((s) => s.explorerModelStates);
+  const insightStates = useStore((s) => s.explorerInsightStates);
   const chartName = useStore((s) => s.explorerChartName);
   const saveExplorerObjects = useStore((s) => s.saveExplorerObjects);
   const dashboards = useStore((s) => s.dashboards);
   const fetchDashboards = useStore((s) => s.fetchDashboards);
+  const placeChartInDashboardSlot = useStore((s) => s.placeChartInDashboardSlot);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -123,6 +129,7 @@ const ExplorerSaveModal = ({ onClose }) => {
   const { newItems, modifiedItems, chartStatus } = useMemo(() => {
     const newArr = [];
     const modArr = [];
+    const seen = new Set();
 
     if (diffResult) {
       for (const [category, statuses] of Object.entries(diffResult)) {
@@ -130,9 +137,32 @@ const ExplorerSaveModal = ({ onClose }) => {
         // Map category to objectType (e.g., "models" → "model")
         const objectType = category.replace(/s$/, '');
         for (const [name, status] of Object.entries(statuses || {})) {
-          if (status === 'new') newArr.push({ name, objectType });
-          else if (status === 'modified') modArr.push({ name, objectType });
+          if (status === 'new') {
+            newArr.push({ name, objectType });
+            seen.add(`${objectType}:${name}`);
+          } else if (status === 'modified') {
+            modArr.push({ name, objectType });
+            seen.add(`${objectType}:${name}`);
+          }
         }
+      }
+    }
+
+    // Brand-new LOCAL objects (isNew) may not appear in the backend diff yet —
+    // the diff only tracks objects the backend already knows about. Mirror
+    // selectHasModifications here so the modal's "new" list (and totalChanges)
+    // matches the top Save button's enabled state. Without this, a fresh model/
+    // insight shows "No changes to save" with Save disabled — a dead end.
+    for (const [name, ms] of Object.entries(modelStates || {})) {
+      if (ms?.isNew && ms?.sql && !seen.has(`model:${name}`)) {
+        newArr.push({ name, objectType: 'model' });
+        seen.add(`model:${name}`);
+      }
+    }
+    for (const [name, is] of Object.entries(insightStates || {})) {
+      if (is?.isNew && !seen.has(`insight:${name}`)) {
+        newArr.push({ name, objectType: 'insight' });
+        seen.add(`insight:${name}`);
       }
     }
 
@@ -141,7 +171,7 @@ const ExplorerSaveModal = ({ onClose }) => {
       modifiedItems: modArr,
       chartStatus: diffResult?.chart || null,
     };
-  }, [diffResult]);
+  }, [diffResult, modelStates, insightStates]);
 
   const totalChanges = newItems.length + modifiedItems.length + (chartStatus ? 1 : 0);
 
@@ -156,6 +186,21 @@ const ExplorerSaveModal = ({ onClose }) => {
         if (afterSave === AFTER_SAVE_WORKSPACE) {
           navigate('/workspace');
         } else if (afterSave === AFTER_SAVE_DASHBOARD && targetDashboard) {
+          // Actually place the freshly-saved chart in the chosen slot before
+          // navigating — without this the "Add to dashboard … in slot …" choice
+          // only moved the user to Build mode and silently dropped the chart.
+          if (chartName) {
+            const placed = await placeChartInDashboardSlot(
+              targetDashboard,
+              chartName,
+              targetSlot
+            );
+            if (!placed.success) {
+              setError(placed.error || 'Could not place the chart on the dashboard.');
+              setSaving(false);
+              return;
+            }
+          }
           const params = new URLSearchParams();
           params.set('slot', targetSlot);
           if (chartName) params.set('newItem', chartName);
@@ -173,7 +218,16 @@ const ExplorerSaveModal = ({ onClose }) => {
     } finally {
       setSaving(false);
     }
-  }, [saveExplorerObjects, onClose, afterSave, targetDashboard, targetSlot, chartName, navigate]);
+  }, [
+    saveExplorerObjects,
+    onClose,
+    afterSave,
+    targetDashboard,
+    targetSlot,
+    chartName,
+    navigate,
+    placeChartInDashboardSlot,
+  ]);
 
   const radioBase =
     'flex items-start gap-2 text-sm text-secondary-700 cursor-pointer select-none';

--- a/viewer/src/components/explorerNew/ExplorerSaveModal.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerSaveModal.test.jsx
@@ -45,18 +45,21 @@ const baseState = {
 describe('ExplorerSaveModal', () => {
   let mockOnClose;
   let mockSaveExplorerObjects;
+  let mockPlaceChart;
 
   beforeEach(() => {
     mockOnClose = jest.fn();
     mockNavigate.mockClear();
     sessionStorage.clear();
     mockSaveExplorerObjects = jest.fn().mockResolvedValue({ success: true, errors: [] });
+    mockPlaceChart = jest.fn().mockResolvedValue({ success: true });
     useStore.setState({
       ...baseState,
       dashboards: [],
       // Stub so the modal's on-mount dashboards fetch doesn't hit the network.
       fetchDashboards: jest.fn().mockResolvedValue(undefined),
       saveExplorerObjects: mockSaveExplorerObjects,
+      placeChartInDashboardSlot: mockPlaceChart,
     });
   });
 
@@ -204,6 +207,40 @@ describe('ExplorerSaveModal', () => {
     expect(screen.queryByTestId('embedded-pill-metric-existing_met')).not.toBeInTheDocument();
   });
 
+  it('enables Save for a brand-new LOCAL model absent from the backend diff', () => {
+    // Mirrors selectHasModifications: a fresh model (isNew + sql) exists only
+    // locally and is not yet in explorerDiffResult. The modal must still treat
+    // it as a change (no "No changes to save" dead end).
+    useStore.setState({
+      explorerDiffResult: {},
+      explorerModelStates: { model_2: { isNew: true, sql: 'SELECT 1' } },
+    });
+    renderModal({ onClose: mockOnClose });
+    expect(screen.getByTestId('save-modal-confirm')).not.toBeDisabled();
+    expect(screen.getByTestId('embedded-pill-model-model_2')).toBeInTheDocument();
+    expect(screen.queryByText('No changes to save.')).not.toBeInTheDocument();
+  });
+
+  it('enables Save for a brand-new LOCAL insight absent from the backend diff', () => {
+    useStore.setState({
+      explorerDiffResult: null,
+      explorerInsightStates: { my_insight: { isNew: true, type: 'bar', props: {} } },
+    });
+    renderModal({ onClose: mockOnClose });
+    expect(screen.getByTestId('save-modal-confirm')).not.toBeDisabled();
+    expect(screen.getByTestId('embedded-pill-insight-my_insight')).toBeInTheDocument();
+  });
+
+  it('does not double-count a local new model that is also in the diff', () => {
+    useStore.setState({
+      explorerDiffResult: { models: { model_2: 'new' } },
+      explorerModelStates: { model_2: { isNew: true, sql: 'SELECT 1' } },
+    });
+    renderModal({ onClose: mockOnClose });
+    // Exactly one pill for model_2.
+    expect(screen.getAllByTestId('embedded-pill-model-model_2')).toHaveLength(1);
+  });
+
   it('save button is disabled when no changes', () => {
     useStore.setState({
       explorerDiffResult: { models: { m: null }, insights: { i: null } },
@@ -264,7 +301,7 @@ describe('ExplorerSaveModal', () => {
       });
     });
 
-    it('navigates to the dashboard with slot + newItem params on option 3', async () => {
+    it('places the chart in the chosen slot AND navigates with slot + newItem params on option 3', async () => {
       withDashboards();
       renderModal({ onClose: mockOnClose });
       fireEvent.click(screen.getByTestId('after-save-dashboard'));
@@ -276,10 +313,27 @@ describe('ExplorerSaveModal', () => {
       });
       fireEvent.click(screen.getByTestId('save-modal-confirm'));
       await waitFor(() => {
+        expect(mockPlaceChart).toHaveBeenCalledWith('ops', 'revenue_chart', '0:end');
+      });
+      await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(
           '/workspace/dashboard/ops?slot=0%3Aend&newItem=revenue_chart'
         );
       });
+    });
+
+    it('surfaces an error and does NOT navigate when placement fails on option 3', async () => {
+      mockPlaceChart.mockResolvedValue({ success: false, error: 'slot is gone' });
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      fireEvent.click(screen.getByTestId('after-save-dashboard'));
+      fireEvent.click(screen.getByTestId('save-modal-confirm'));
+      await waitFor(() => {
+        expect(screen.getByTestId('save-error')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/slot is gone/)).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockOnClose).not.toHaveBeenCalled();
     });
 
     it('slot picker lists one option per row plus a new-row option', () => {

--- a/viewer/src/components/explorerNew/ExplorerSaveModal.test.jsx
+++ b/viewer/src/components/explorerNew/ExplorerSaveModal.test.jsx
@@ -1,8 +1,24 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import ExplorerSaveModal from './ExplorerSaveModal';
 import useStore from '../../stores/store';
+import { futureFlags } from '../../router-config';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Wrap render so every test has Router context (useNavigate).
+const renderModal = (props) =>
+  render(
+    <MemoryRouter future={futureFlags}>
+      <ExplorerSaveModal {...props} />
+    </MemoryRouter>
+  );
 
 jest.mock('../new-views/lineage/EmbeddedPill', () => {
   return function MockEmbeddedPill({ objectType, label, statusDot }) {
@@ -32,23 +48,28 @@ describe('ExplorerSaveModal', () => {
 
   beforeEach(() => {
     mockOnClose = jest.fn();
+    mockNavigate.mockClear();
+    sessionStorage.clear();
     mockSaveExplorerObjects = jest.fn().mockResolvedValue({ success: true, errors: [] });
     useStore.setState({
       ...baseState,
+      dashboards: [],
+      // Stub so the modal's on-mount dashboards fetch doesn't hit the network.
+      fetchDashboards: jest.fn().mockResolvedValue(undefined),
       saveExplorerObjects: mockSaveExplorerObjects,
     });
   });
 
   it('renders modal with title', () => {
     useStore.setState({ explorerDiffResult: { models: { new_model: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.getByTestId('explorer-save-modal')).toBeInTheDocument();
     expect(screen.getByText('Save to Project')).toBeInTheDocument();
   });
 
   it('shows new models with green status dot', () => {
     useStore.setState({ explorerDiffResult: { models: { new_model: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-model-new_model');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'new');
@@ -56,7 +77,7 @@ describe('ExplorerSaveModal', () => {
 
   it('shows modified models with amber status dot', () => {
     useStore.setState({ explorerDiffResult: { models: { existing_model: 'modified' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-model-existing_model');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'modified');
@@ -69,14 +90,14 @@ describe('ExplorerSaveModal', () => {
         insights: { stable_insight: null },
       },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.queryByTestId('embedded-pill-model-stable_model')).not.toBeInTheDocument();
     expect(screen.queryByTestId('embedded-pill-insight-stable_insight')).not.toBeInTheDocument();
   });
 
   it('shows new insights with green status dot', () => {
     useStore.setState({ explorerDiffResult: { insights: { new_insight: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-insight-new_insight');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'new');
@@ -84,7 +105,7 @@ describe('ExplorerSaveModal', () => {
 
   it('shows modified insights with amber status dot', () => {
     useStore.setState({ explorerDiffResult: { insights: { existing_insight: 'modified' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-insight-existing_insight');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'modified');
@@ -92,14 +113,14 @@ describe('ExplorerSaveModal', () => {
 
   it('cancel button calls onClose', () => {
     useStore.setState({ explorerDiffResult: { models: { m: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     fireEvent.click(screen.getByTestId('save-modal-cancel'));
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('save button calls saveExplorerObjects', async () => {
     useStore.setState({ explorerDiffResult: { models: { m: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     fireEvent.click(screen.getByTestId('save-modal-confirm'));
     await waitFor(() => {
       expect(mockSaveExplorerObjects).toHaveBeenCalledTimes(1);
@@ -111,7 +132,7 @@ describe('ExplorerSaveModal', () => {
     const slowSave = new Promise((resolve) => { resolvePromise = resolve; });
     mockSaveExplorerObjects.mockReturnValue(slowSave);
     useStore.setState({ explorerDiffResult: { models: { m: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     fireEvent.click(screen.getByTestId('save-modal-confirm'));
     await waitFor(() => {
       expect(screen.getByText('Saving...')).toBeInTheDocument();
@@ -127,7 +148,7 @@ describe('ExplorerSaveModal', () => {
       errors: [{ name: 'my_model', type: 'model', error: 'Network error' }],
     });
     useStore.setState({ explorerDiffResult: { models: { my_model: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     fireEvent.click(screen.getByTestId('save-modal-confirm'));
     await waitFor(() => {
       expect(screen.getByTestId('save-error')).toBeInTheDocument();
@@ -138,7 +159,7 @@ describe('ExplorerSaveModal', () => {
 
   it('calls onClose on successful save', async () => {
     useStore.setState({ explorerDiffResult: { models: { m: 'new' } } });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     fireEvent.click(screen.getByTestId('save-modal-confirm'));
     await waitFor(() => { expect(mockOnClose).toHaveBeenCalledTimes(1); });
   });
@@ -148,7 +169,7 @@ describe('ExplorerSaveModal', () => {
       explorerChartName: 'my_chart',
       explorerDiffResult: { chart: 'new' },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-chart-my_chart');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'new');
@@ -159,7 +180,7 @@ describe('ExplorerSaveModal', () => {
       explorerChartName: 'my_chart',
       explorerDiffResult: { chart: 'modified' },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     const pill = screen.getByTestId('embedded-pill-chart-my_chart');
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute('data-status', 'modified');
@@ -170,7 +191,7 @@ describe('ExplorerSaveModal', () => {
       explorerChartName: 'my_chart',
       explorerDiffResult: { chart: null },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.queryByTestId('embedded-pill-chart-my_chart')).not.toBeInTheDocument();
   });
 
@@ -178,7 +199,7 @@ describe('ExplorerSaveModal', () => {
     useStore.setState({
       explorerDiffResult: { metrics: { total_x: 'new', existing_met: null } },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.getByTestId('embedded-pill-metric-total_x')).toBeInTheDocument();
     expect(screen.queryByTestId('embedded-pill-metric-existing_met')).not.toBeInTheDocument();
   });
@@ -187,13 +208,107 @@ describe('ExplorerSaveModal', () => {
     useStore.setState({
       explorerDiffResult: { models: { m: null }, insights: { i: null } },
     });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.getByTestId('save-modal-confirm')).toBeDisabled();
   });
 
   it('save button is disabled when diff result is null', () => {
     useStore.setState({ explorerDiffResult: null });
-    render(<ExplorerSaveModal onClose={mockOnClose} />);
+    renderModal({ onClose: mockOnClose });
     expect(screen.getByTestId('save-modal-confirm')).toBeDisabled();
+  });
+
+  // ------------------------------------------------------------------
+  // J-1 / VIS-774 — "After save" section
+  // ------------------------------------------------------------------
+  describe('After save section (J-1)', () => {
+    const withDashboards = (extra = {}) => {
+      useStore.setState({
+        explorerChartName: 'revenue_chart',
+        explorerDiffResult: { chart: 'new' },
+        dashboards: [
+          { name: 'sales', config: { rows: [{ items: [] }, { items: [] }] } },
+          { name: 'ops', config: { rows: [{ items: [] }] } },
+        ],
+        ...extra,
+      });
+    };
+
+    it('renders the After save section with three radios, Stay default', () => {
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      expect(screen.getByTestId('after-save-section')).toBeInTheDocument();
+      expect(screen.getByTestId('after-save-stay')).toBeChecked();
+      expect(screen.getByTestId('after-save-workspace')).toBeInTheDocument();
+      expect(screen.getByTestId('after-save-dashboard')).toBeInTheDocument();
+    });
+
+    it('disables option 3 when no dashboards exist', () => {
+      useStore.setState({
+        explorerChartName: 'revenue_chart',
+        explorerDiffResult: { chart: 'new' },
+        dashboards: [],
+      });
+      renderModal({ onClose: mockOnClose });
+      expect(screen.getByTestId('after-save-dashboard')).toBeDisabled();
+      expect(screen.getByTestId('after-save-dashboard-select')).toBeDisabled();
+    });
+
+    it('navigates to /workspace when "Open in Workspace" is chosen', async () => {
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      fireEvent.click(screen.getByTestId('after-save-workspace'));
+      fireEvent.click(screen.getByTestId('save-modal-confirm'));
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/workspace');
+      });
+    });
+
+    it('navigates to the dashboard with slot + newItem params on option 3', async () => {
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      fireEvent.click(screen.getByTestId('after-save-dashboard'));
+      fireEvent.change(screen.getByTestId('after-save-dashboard-select'), {
+        target: { value: 'ops' },
+      });
+      fireEvent.change(screen.getByTestId('after-save-slot-select'), {
+        target: { value: '0:end' },
+      });
+      fireEvent.click(screen.getByTestId('save-modal-confirm'));
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/workspace/dashboard/ops?slot=0%3Aend&newItem=revenue_chart'
+        );
+      });
+    });
+
+    it('slot picker lists one option per row plus a new-row option', () => {
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      // 'sales' has 2 rows → 2 "at end of" + 1 "new row".
+      const slotSelect = screen.getByTestId('after-save-slot-select');
+      expect(slotSelect).toContainHTML('At end of row 1');
+      expect(slotSelect).toContainHTML('At end of row 2');
+      expect(slotSelect).toContainHTML('In a new row at the end');
+    });
+
+    it('does not navigate when staying in Explorer (default)', async () => {
+      withDashboards();
+      renderModal({ onClose: mockOnClose });
+      fireEvent.click(screen.getByTestId('save-modal-confirm'));
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('persists the choice across modal opens within a session', async () => {
+      withDashboards();
+      const { unmount } = renderModal({ onClose: mockOnClose });
+      fireEvent.click(screen.getByTestId('after-save-workspace'));
+      unmount();
+      renderModal({ onClose: mockOnClose });
+      expect(screen.getByTestId('after-save-workspace')).toBeChecked();
+    });
   });
 });

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useStore from '../../../../stores/store';
+import { parseRefValue } from '../../../../utils/refString';
 import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
 import {
@@ -67,6 +69,35 @@ const isContainerItem = (config, key) => {
   return !!item && Array.isArray(item.rows) && item.rows.length > 0;
 };
 
+// Walk the config to the leaf item addressed by an item key, then resolve the
+// chart/table subject it carries: `{ type, name }` or null (container / empty /
+// non-chart leaf). Used by "Open in Explorer" (VIS-782 / J-3) — only chart and
+// table leaves have a model+insight worth opening in Explorer.
+const explorerSubjectAtKey = (config, key) => {
+  const segments = parseCanvasPath(key);
+  if (!segments.length || segments[segments.length - 1].kind !== 'item') return null;
+  let rows = Array.isArray(config?.rows) ? config.rows : null;
+  let item = null;
+  for (const seg of segments) {
+    if (seg.kind === 'row') {
+      if (!rows || !rows[seg.index]) return null;
+      rows = Array.isArray(rows[seg.index].items) ? rows[seg.index].items : null;
+    } else {
+      if (!rows || !rows[seg.index]) return null;
+      item = rows[seg.index];
+      rows = Array.isArray(item.rows) ? item.rows : null;
+    }
+  }
+  if (!item || (Array.isArray(item.rows) && item.rows.length > 0)) return null;
+  for (const type of ['chart', 'table']) {
+    const raw = item[type];
+    if (raw == null || raw === '') continue;
+    const name = typeof raw === 'string' ? parseRefValue(raw) : raw.name || raw.path;
+    if (name) return { type, name };
+  }
+  return null;
+};
+
 // The ROW path that owns the item at an item key (for "Add item to row" from an
 // item right-click): drop the trailing `item.<n>` segment.
 const rowPathForItemKey = key => {
@@ -114,6 +145,7 @@ const MenuItem = ({ testid, label, hint, onClick, danger }) => (
 );
 
 const CanvasContextMenu = ({ rootRef, dashboardName }) => {
+  const navigate = useNavigate();
   const dashboards = useStore(s => s.dashboards);
   const setSelectedKey = useStore(s => s.setWorkspaceOutlineSelectedKey);
   const commitCanvasConfig = useWorkspaceCommit();
@@ -187,9 +219,32 @@ const CanvasContextMenu = ({ rootRef, dashboardName }) => {
     [dashboardName, commitCanvasConfig, dashboardConfig]
   );
 
+  const openInExplorer = useCallback(
+    subject => {
+      if (!subject) return;
+      const params = new URLSearchParams();
+      // The deep-load target — Explorer reads `?insight=` / engineering routing
+      // hydrates the chart's model + insight (out of scope for J-3 framing).
+      params.set(subject.type === 'table' ? 'table' : 'insight', subject.name);
+      params.set('return_to', 'workspace');
+      if (dashboardName) params.set('dashboard', dashboardName);
+      emitWorkspaceEvent('open_in_explorer', {
+        dashboardName,
+        subjectType: subject.type,
+        subjectName: subject.name,
+      });
+      setMenu(null);
+      navigate(`/explorer?${params.toString()}`);
+    },
+    [navigate, dashboardName]
+  );
+
   if (!dashboardConfig || !menu) return null;
 
   const isContainer = menu.kind === 'item' && isContainerItem(dashboardConfig, menu.key);
+  // "Open in Explorer" subject — a chart/table leaf carries a model+insight.
+  const explorerSubject =
+    menu.kind === 'item' ? explorerSubjectAtKey(dashboardConfig, menu.key) : null;
   // A leaf can be wrapped. (A container is not a leaf.)
   const isLeaf = menu.kind === 'item' && !isContainer;
   // Container actions target the nearest container ancestor — the clicked key
@@ -214,6 +269,18 @@ const CanvasContextMenu = ({ rootRef, dashboardName }) => {
       <div className="px-2.5 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
         {menu.kind === 'item' ? (isContainer ? 'Container' : 'Item') : 'Row'}
       </div>
+
+      {explorerSubject && (
+        <>
+          <MenuItem
+            testid="canvas-ctx-open-in-explorer"
+            label="Open in Explorer"
+            hint="↗"
+            onClick={() => openInExplorer(explorerSubject)}
+          />
+          <div className="my-1 h-px bg-[#f0ebed]" />
+        </>
+      )}
 
       {isLeaf && (
         <MenuItem

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
@@ -10,15 +10,24 @@
  */
 import React, { useRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import CanvasContextMenu from './CanvasContextMenu';
 import useStore from '../../../../stores/store';
 import { WorkspaceCommitProvider } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { futureFlags } from '../../../../router-config';
 
 // Stub the telemetry emitter (no shell mounted). jest hoists this above the
 // imports, so the mocked module is what the import above resolves to.
 jest.mock('../../workspace/telemetry', () => ({
   emitWorkspaceEvent: jest.fn(),
+}));
+
+// Capture navigation (J-3 "Open in Explorer").
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
 }));
 
 const LEAF_DASH = {
@@ -69,23 +78,32 @@ const Host = ({ commit, structure = 'leaf' }) => {
   );
 };
 
+// Render the Host inside a Router so `useNavigate` resolves.
+const renderHost = props =>
+  render(
+    <MemoryRouter future={futureFlags}>
+      <Host {...props} />
+    </MemoryRouter>
+  );
+
 const rightClick = testid =>
   fireEvent.contextMenu(screen.getByTestId(testid), { clientX: 100, clientY: 100 });
 
 describe('CanvasContextMenu (VIS-781)', () => {
   beforeEach(() => {
     emitWorkspaceEvent.mockClear();
+    mockNavigate.mockClear();
     useStore.setState({ dashboards: [LEAF_DASH], workspaceOutlineSelectedKey: 'dashboard' });
     // jsdom getBoundingClientRect is zeroed; the menu only needs a root rect.
   });
 
   test('no menu until a right-click on a row/item', () => {
-    render(<Host commit={jest.fn()} />);
+    renderHost({ commit: jest.fn() });
     expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
   });
 
   test('right-clicking a LEAF item shows Wrap + Add item to row, not Unwrap/Add row inside', () => {
-    render(<Host commit={jest.fn()} />);
+    renderHost({ commit: jest.fn() });
     rightClick('r0i0');
     expect(screen.getByTestId('canvas-context-menu')).toBeInTheDocument();
     expect(screen.getByTestId('canvas-ctx-wrap')).toBeInTheDocument();
@@ -95,7 +113,7 @@ describe('CanvasContextMenu (VIS-781)', () => {
   });
 
   test('right-clicking a ROW shows only Add item to row', () => {
-    render(<Host commit={jest.fn()} />);
+    renderHost({ commit: jest.fn() });
     rightClick('r0');
     expect(screen.getByTestId('canvas-ctx-add-item')).toBeInTheDocument();
     expect(screen.queryByTestId('canvas-ctx-wrap')).not.toBeInTheDocument();
@@ -103,7 +121,7 @@ describe('CanvasContextMenu (VIS-781)', () => {
 
   test('Wrap in container commits the wrapped config + fires telemetry', () => {
     const commit = jest.fn();
-    render(<Host commit={commit} />);
+    renderHost({ commit });
     rightClick('r0i0');
     fireEvent.click(screen.getByTestId('canvas-ctx-wrap'));
     expect(commit).toHaveBeenCalledTimes(1);
@@ -120,7 +138,7 @@ describe('CanvasContextMenu (VIS-781)', () => {
 
   test('right-clicking a CONTAINER item shows Add row inside + Unwrap (trivial 1×1)', () => {
     useStore.setState({ dashboards: [CONTAINER_DASH] });
-    render(<Host commit={jest.fn()} structure="container" />);
+    renderHost({ commit: jest.fn(), structure: "container" });
     rightClick('r0i0');
     expect(screen.getByTestId('canvas-ctx-add-row-inside')).toBeInTheDocument();
     expect(screen.getByTestId('canvas-ctx-unwrap')).toBeInTheDocument();
@@ -131,7 +149,7 @@ describe('CanvasContextMenu (VIS-781)', () => {
   test('Unwrap commits the collapsed config', () => {
     useStore.setState({ dashboards: [CONTAINER_DASH] });
     const commit = jest.fn();
-    render(<Host commit={commit} structure="container" />);
+    renderHost({ commit, structure: "container" });
     rightClick('r0i0');
     fireEvent.click(screen.getByTestId('canvas-ctx-unwrap'));
     const [, nextConfig] = commit.mock.calls[0];
@@ -144,10 +162,52 @@ describe('CanvasContextMenu (VIS-781)', () => {
   });
 
   test('Escape dismisses the menu', () => {
-    render(<Host commit={jest.fn()} />);
+    renderHost({ commit: jest.fn() });
     rightClick('r0i0');
     expect(screen.getByTestId('canvas-context-menu')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+  });
+
+  // ------------------------------------------------------------------
+  // J-3 / VIS-782 — "Open in Explorer"
+  // ------------------------------------------------------------------
+  describe('Open in Explorer (J-3)', () => {
+    test('chart leaf shows Open in Explorer and navigates with return_to + dashboard', () => {
+      renderHost({ commit: jest.fn() });
+      rightClick('r0i0');
+      const item = screen.getByTestId('canvas-ctx-open-in-explorer');
+      expect(item).toBeInTheDocument();
+      fireEvent.click(item);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/explorer?insight=a&return_to=workspace&dashboard=dash'
+      );
+      expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+        'open_in_explorer',
+        expect.objectContaining({ dashboardName: 'dash', subjectType: 'chart', subjectName: 'a' })
+      );
+    });
+
+    test('table leaf navigates with a table param', () => {
+      renderHost({ commit: jest.fn() });
+      rightClick('r0i1');
+      fireEvent.click(screen.getByTestId('canvas-ctx-open-in-explorer'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/explorer?table=b&return_to=workspace&dashboard=dash'
+      );
+    });
+
+    test('a container item does not offer Open in Explorer', () => {
+      useStore.setState({ dashboards: [CONTAINER_DASH] });
+      renderHost({ commit: jest.fn(), structure: 'container' });
+      rightClick('r0i0');
+      expect(screen.queryByTestId('canvas-ctx-open-in-explorer')).not.toBeInTheDocument();
+    });
+
+    test('a row right-click does not offer Open in Explorer', () => {
+      renderHost({ commit: jest.fn() });
+      rightClick('r0');
+      expect(screen.queryByTestId('canvas-ctx-open-in-explorer')).not.toBeInTheDocument();
+    });
   });
 });

--- a/viewer/src/components/new-views/workspace/library/Library.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.jsx
@@ -1,9 +1,11 @@
 import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PiSidebar } from 'react-icons/pi';
 import LibrarySection from './LibrarySection';
 import useLibraryData from './useLibraryData';
 import { LAYOUT_TYPES, DATA_TYPES } from './LibraryRow';
 import useStore from '../../../../stores/store';
+import { useWorkspaceScope } from '../useWorkspaceScope';
 import { emitWorkspaceEvent } from '../telemetry';
 
 /**
@@ -42,6 +44,8 @@ import { emitWorkspaceEvent } from '../telemetry';
  */
 const Library = () => {
   const data = useLibraryData();
+  const navigate = useNavigate();
+  const scope = useWorkspaceScope();
 
   // Workspace actions — read from the store directly so the Library has no
   // required props (the parent LeftRail mounts it as `<Library />`).
@@ -90,6 +94,20 @@ const Library = () => {
   const handleCreate = useCallback(
     typeKey => {
       emitWorkspaceEvent('inline_create_used', { source: 'library', kind: typeKey });
+      // J-2 (VIS-778): "+ New Chart" inside a scoped dashboard opens the
+      // Explorer round-trip overlay (build the insight there, it gets wrapped
+      // in a chart and placed back on the dashboard). Outside a dashboard
+      // scope there's no slot to return to, so fall back to the create modal.
+      if (typeKey === 'chart' && scope.dashboardName) {
+        navigate(
+          `/workspace/dashboard/${encodeURIComponent(
+            scope.dashboardName
+          )}/explorer?return_to=workspace&dashboard=${encodeURIComponent(
+            scope.dashboardName
+          )}&slot=new`
+        );
+        return;
+      }
       switch (typeKey) {
         case 'chart':
           if (openCreateChartModal) openCreateChartModal();
@@ -107,7 +125,14 @@ const Library = () => {
           break;
       }
     },
-    [openCreateChartModal, openCreateTableModal, openCreateMarkdownModal, openCreateInputModal]
+    [
+      openCreateChartModal,
+      openCreateTableModal,
+      openCreateMarkdownModal,
+      openCreateInputModal,
+      navigate,
+      scope.dashboardName,
+    ]
   );
 
   return (

--- a/viewer/src/components/new-views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.test.jsx
@@ -26,15 +26,26 @@ import Library from './Library';
 import useStore from '../../../../stores/store';
 import { setWorkspaceTelemetryListener } from '../telemetry';
 
+// Renders the current URL so navigation assertions (J-2 overlay) can read it.
+const LocationProbe = () => {
+  const { useLocation } = jest.requireActual('react-router-dom');
+  const loc = useLocation();
+  return <div data-testid="location-probe">{loc.pathname + loc.search}</div>;
+};
+
 const renderLibrary = (entry = '/workspace') => {
   const router = createMemoryRouter(
     createRoutesFromElements(
       <>
-        <Route path="/workspace" element={<DndContext><Library /></DndContext>} />
+        <Route
+          path="/workspace"
+          element={<DndContext><Library /><LocationProbe /></DndContext>}
+        />
         <Route
           path="/workspace/dashboard/:dashboardName"
-          element={<DndContext><Library /></DndContext>}
+          element={<DndContext><Library /><LocationProbe /></DndContext>}
         />
+        <Route path="/workspace/dashboard/:dashboardName/explorer" element={<LocationProbe />} />
       </>
     ),
     { initialEntries: [entry], future: futureFlags }
@@ -259,12 +270,25 @@ describe('Library', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('"+ New Chart" calls the chart create-modal opener', () => {
+  test('"+ New Chart" calls the chart create-modal opener (unscoped)', () => {
     const openCreateChartModal = jest.fn();
     seedStore({ openCreateChartModal });
     renderLibrary();
     fireEvent.click(screen.getByTestId('library-subsection-chart-create'));
     expect(openCreateChartModal).toHaveBeenCalledTimes(1);
+  });
+
+  test('"+ New Chart" opens the Explorer round-trip overlay when scoped to a dashboard (J-2)', () => {
+    const openCreateChartModal = jest.fn();
+    seedStore({ openCreateChartModal });
+    renderLibrary('/workspace/dashboard/overview');
+    fireEvent.click(screen.getByTestId('library-subsection-chart-create'));
+    expect(openCreateChartModal).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location-probe')).toHaveTextContent(
+      '/workspace/dashboard/overview/explorer'
+    );
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('return_to=workspace');
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('slot=new');
   });
 
   test('"+ New Table" calls the table create-modal opener', () => {

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -1,6 +1,36 @@
 import * as dashboardsApi from '../api/dashboards';
 import { recordOnboardingAction } from '../components/onboarding/onboardingState';
 import { getEffectiveLevels } from '../utils/effectiveLevels';
+import { insertItemAtTarget } from '../components/new-views/project/canvas/canvasReorder';
+
+/**
+ * Translate a J-1 / J-2 `slot` descriptor into the `insertItemAtTarget` target
+ * descriptor against a dashboard config:
+ *
+ *   "new"             → a new top-level row at the end.
+ *   "<rowIdx>:end"    → append to that row (or new row if the index is gone).
+ *   "<rowIdx>:<i>"    → insert before item <i> in that row.
+ *
+ * Always falls back to a new row at the end when the descriptor can't be
+ * resolved, so a placement never silently drops the chart.
+ */
+export const slotToInsertTarget = (config, slot) => {
+  const rows = Array.isArray(config?.rows) ? config.rows : [];
+  const newRow = { kind: 'between-rows', index: rows.length };
+  if (!slot || slot === 'new') return newRow;
+  const [rowPart, itemPart] = String(slot).split(':');
+  const rowIdx = Number(rowPart);
+  if (!Number.isInteger(rowIdx) || rowIdx < 0 || rowIdx >= rows.length) return newRow;
+  const rowPath = `row.${rowIdx}`;
+  if (itemPart === 'end' || itemPart === undefined) {
+    return { kind: 'end-of-row', rowPath };
+  }
+  const itemIdx = Number(itemPart);
+  if (!Number.isInteger(itemIdx) || itemIdx < 0) {
+    return { kind: 'end-of-row', rowPath };
+  }
+  return { kind: 'between-items', rowPath, index: itemIdx };
+};
 
 /**
  * Dashboard Store Slice
@@ -72,6 +102,34 @@ const createDashboardSlice = (set, get) => ({
       nextConfig.level = nextLevel;
     }
     return get().saveDashboard(name, nextConfig);
+  },
+
+  /**
+   * Place an existing chart onto a dashboard in a given slot (J-2 / VIS-778
+   * round-trip, and the J-1 add-to-dashboard landing). The chart is wrapped in
+   * an `Item` ({ chart: ref(...) }) and inserted at the slot via the same
+   * canvas reshape helper the DnD router uses, then persisted through the draft
+   * cache (`saveDashboard`).
+   *
+   * Returns `{ success, result|error }`.
+   */
+  placeChartInDashboardSlot: async (dashboardName, chartName, slot) => {
+    if (!dashboardName || !chartName) {
+      return { success: false, error: 'dashboard and chart names are required' };
+    }
+    const dashboard = (get().dashboards || []).find(d => d.name === dashboardName);
+    if (!dashboard) {
+      return { success: false, error: `Dashboard "${dashboardName}" not found` };
+    }
+    const config = dashboard.config || {};
+    const baseConfig = { ...config, rows: Array.isArray(config.rows) ? config.rows : [] };
+    const target = slotToInsertTarget(baseConfig, slot);
+    const newItem = { width: 1, chart: `ref(${chartName})` };
+    const nextConfig = insertItemAtTarget(baseConfig, target, newItem);
+    if (nextConfig === baseConfig) {
+      return { success: false, error: 'Could not place the chart in the requested slot' };
+    }
+    return get().saveDashboard(dashboardName, nextConfig);
   },
 
   // Mark dashboard for deletion

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -7,6 +7,7 @@
  */
 import { act } from '@testing-library/react';
 import useStore from './store';
+import { slotToInsertTarget } from './dashboardStore';
 
 const seed = (dashboards, saveDashboard) => {
   act(() => {
@@ -219,5 +220,100 @@ describe('dashboardStore level CRUD (VIS-807 M-2a)', () => {
     expect(saveDefaults).toHaveBeenCalledWith({ levels: [{ title: 'Team' }] });
     // reassignDashboardLevel(name, null) strips the level key via saveDashboard.
     expect(saveDashboard).toHaveBeenCalledWith('exec', {});
+  });
+});
+
+// ----------------------------------------------------------------------------
+// J-1 / J-2 (VIS-774 / VIS-778) — placeChartInDashboardSlot + slotToInsertTarget
+// ----------------------------------------------------------------------------
+describe('slotToInsertTarget', () => {
+  const config = { rows: [{ items: [{ chart: 'ref(a)' }] }, { items: [] }] };
+
+  test('"new" → a new top-level row at the end', () => {
+    expect(slotToInsertTarget(config, 'new')).toEqual({ kind: 'between-rows', index: 2 });
+  });
+
+  test('undefined slot defaults to a new row', () => {
+    expect(slotToInsertTarget(config, undefined)).toEqual({ kind: 'between-rows', index: 2 });
+  });
+
+  test('"<row>:end" → end-of-row target', () => {
+    expect(slotToInsertTarget(config, '1:end')).toEqual({ kind: 'end-of-row', rowPath: 'row.1' });
+  });
+
+  test('"<row>:<item>" → between-items target', () => {
+    expect(slotToInsertTarget(config, '0:0')).toEqual({
+      kind: 'between-items',
+      rowPath: 'row.0',
+      index: 0,
+    });
+  });
+
+  test('an out-of-range row index falls back to a new row', () => {
+    expect(slotToInsertTarget(config, '9:end')).toEqual({ kind: 'between-rows', index: 2 });
+  });
+});
+
+describe('dashboardStore placeChartInDashboardSlot', () => {
+  const seedPlace = (dashboards, saveDashboard) => {
+    act(() => {
+      useStore.setState({
+        dashboards,
+        saveDashboard: saveDashboard || jest.fn(async () => ({ success: true })),
+      });
+    });
+  };
+
+  test('wraps the chart in an item and appends a new row, then saves', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seedPlace([{ name: 'sales', config: { rows: [{ items: [{ chart: 'ref(x)' }] }] } }], saveDashboard);
+    await act(async () => {
+      await useStore.getState().placeChartInDashboardSlot('sales', 'revenue_chart', 'new');
+    });
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = saveDashboard.mock.calls[0];
+    expect(name).toBe('sales');
+    expect(nextConfig.rows).toHaveLength(2);
+    const placedItem = nextConfig.rows[1].items[0];
+    expect(placedItem.chart).toBe('ref(revenue_chart)');
+  });
+
+  test('appends to an existing row for "<row>:end"', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seedPlace([{ name: 'sales', config: { rows: [{ items: [{ chart: 'ref(x)' }] }] } }], saveDashboard);
+    await act(async () => {
+      await useStore.getState().placeChartInDashboardSlot('sales', 'revenue_chart', '0:end');
+    });
+    const [, nextConfig] = saveDashboard.mock.calls[0];
+    expect(nextConfig.rows).toHaveLength(1);
+    expect(nextConfig.rows[0].items.map(i => i.chart)).toEqual(['ref(x)', 'ref(revenue_chart)']);
+  });
+
+  test('handles a dashboard with no rows', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seedPlace([{ name: 'sales', config: {} }], saveDashboard);
+    await act(async () => {
+      await useStore.getState().placeChartInDashboardSlot('sales', 'revenue_chart', 'new');
+    });
+    const [, nextConfig] = saveDashboard.mock.calls[0];
+    expect(nextConfig.rows[0].items[0].chart).toBe('ref(revenue_chart)');
+  });
+
+  test('returns an error when the dashboard is not found', async () => {
+    seedPlace([], jest.fn());
+    let result;
+    await act(async () => {
+      result = await useStore.getState().placeChartInDashboardSlot('ghost', 'c', 'new');
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('returns an error when chart name is missing', async () => {
+    seedPlace([{ name: 'sales', config: { rows: [] } }], jest.fn());
+    let result;
+    await act(async () => {
+      result = await useStore.getState().placeChartInDashboardSlot('sales', '', 'new');
+    });
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Track J — Explorer integrations (Dashboard Building v1, Wave 1 / Lane 2)

Thin integrations so Workspace and Explorer compose into one workflow. Integration-only (Q17=A) — Explorer's own surface is unchanged. Frontend-only, no Python.

### Issues
- VIS-774 / J-1 — Explorer Save modal "After save" radio (stay / open in Workspace / add to dashboard + slot)
- VIS-778 / J-2 — Explorer modal-overlay round-trip from Build mode ("Save and place in slot")
- VIS-782 / J-3 — canvas "Open in Explorer" context-menu entry + return chip
- VIS-789 / J-5 — Explorer empty-state CTA parameterized when entered from Build mode
- VIS-786 / J-4 — **verification only, no code.** The "parallel save codepath" the brief described was pre-2.0; on this branch `saveExplorerObjects` already routes through the shared per-type save APIs and refreshes the Library collections, so an Explorer-created insight appears in the Library with no reload.

### Tests
- Unit: **2273 pass / 174 suites**, lint clean.
- E2E: J-1 3/3, J-2 5/5, J-3 3/3 — **10/10**.

### Follow-ups deferred (out of integration-only scope — confirm if wanted)
- "+ New Insight" affordance in the Library data-layer section.
- Canvas "Create chart here" empty-slot drop-zone.
- Explorer **auto-hydrate from `?insight=`/`?table=`** — makes the J-2/J-3 round-trips fully seamless rather than just landing on the route.

> ⚠️ **Validation depth:** initial happy-path e2e. Hardening sweep + Playwright MCP visual review planned before merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
