### PR TITLE
feat(viewer): Track O — workspace tab navigation (VIS-810/811/812)

### DIFF
--- a/viewer/e2e/stories/tabbed-navigation.spec.mjs
+++ b/viewer/e2e/stories/tabbed-navigation.spec.mjs
@@ -1,0 +1,119 @@
+/**
+ * Story: Tabbed Workspace navigation — basic open / close / switch (VIS-810 / Track O O-1).
+ *
+ * Drives the REAL cursor through the multi-tab happy path:
+ *   1. /workspace opens with the default project tab.
+ *   2. Clicking Library rows opens tabs (icon + name in the strip, focused).
+ *   3. Clicking a tab switches the workspace context (active styling + middle pane).
+ *   4. Closing via the × removes the tab and focus falls back to the left neighbour.
+ *   5. A dirty tab shows the mulberry ● indicator.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=trackO VISIVO_SANDBOX_BACKEND_PORT=8041 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3041 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3041 npx playwright test tabbed-navigation
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+
+async function openLibraryObject(page, type, name) {
+  const header = page.getByTestId(`library-subsection-${type}-header`);
+  // Subsections are collapsed by default; expand once.
+  const row = page.getByTestId(`library-row-${type}-${name}`);
+  if (!(await row.isVisible().catch(() => false))) {
+    await header.hover();
+    await header.click();
+  }
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.hover();
+  await row.click();
+}
+
+async function gotoWorkspace(page) {
+  await page.goto(`${BASE_URL}/workspace`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-tab-strip')).toBeVisible({ timeout: 15000 });
+}
+
+test.describe('Tabbed navigation — open / close / switch (VIS-810)', () => {
+  test('default project tab is present and active on entry', async ({ page }) => {
+    await gotoWorkspace(page);
+    const projectTab = page.locator('[data-testid^="workspace-tab-project:"]');
+    await expect(projectTab).toHaveCount(1);
+    await expect(projectTab).toHaveAttribute('data-active', 'true');
+  });
+
+  test('opening objects from the Library adds focused tabs; clicking tabs switches context', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    const chartTab = page.getByTestId('workspace-tab-chart:simple-scatter-chart');
+    await expect(chartTab).toBeVisible();
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+
+    await openLibraryObject(page, 'table', 'new_table');
+    const tableTab = page.getByTestId('workspace-tab-table:new_table');
+    await expect(tableTab).toHaveAttribute('data-active', 'true');
+    await expect(chartTab).toHaveAttribute('data-active', 'false');
+
+    // Click the chart tab → context switches back (real cursor).
+    const chartSelect = page.getByTestId('workspace-tab-select-chart:simple-scatter-chart');
+    await chartSelect.hover();
+    await chartSelect.click();
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+    await expect(tableTab).toHaveAttribute('data-active', 'false');
+    // Middle pane follows the active tab — the chart preview mounts.
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('closing the active tab via × falls back to the previous tab', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    await openLibraryObject(page, 'table', 'new_table');
+
+    const closeBtn = page.getByTestId('workspace-tab-close-table:new_table');
+    await closeBtn.hover();
+    await closeBtn.click();
+
+    await expect(page.getByTestId('workspace-tab-table:new_table')).toHaveCount(0);
+    await expect(
+      page.getByTestId('workspace-tab-chart:simple-scatter-chart')
+    ).toHaveAttribute('data-active', 'true');
+  });
+
+  test('a dirty tab shows the unsaved-changes dot', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    // Dirty wiring is Track H's job (auto-save); flip the store flag directly
+    // as state setup — the assertion is about the strip's rendering.
+    await page.evaluate(() => {
+      window.useStore.getState().setWorkspaceTabDirty('chart:simple-scatter-chart', true);
+    });
+    await expect(
+      page.getByTestId('workspace-tab-dirty-chart:simple-scatter-chart')
+    ).toBeVisible();
+  });
+
+  test('the + affordance focuses/opens the project tab', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    await expect(page.locator(`[data-testid^="workspace-tab-project:"]`)).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+    const plus = page.getByTestId('workspace-tab-new');
+    await plus.hover();
+    await plus.click();
+    await expect(page.locator('[data-testid^="workspace-tab-project:"]')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+  });
+});

--- a/viewer/e2e/stories/workspace-tabs-context-menu.spec.mjs
+++ b/viewer/e2e/stories/workspace-tabs-context-menu.spec.mjs
@@ -1,0 +1,166 @@
+/**
+ * Story: Right-click "Open in new tab" across workspace surfaces (VIS-811 / Track O O-2).
+ *
+ * Real-cursor right-clicks (`click({ button: 'right' })`) on each surface:
+ *   1. Library rows        — existing kebab/context menu, now wired to the store.
+ *   2. Project Editor tile — shared OpenObjectContextMenu.
+ *   3. Canvas item (chart leaf, scoped dashboard) — extended CanvasContextMenu.
+ *   4. Lineage node        — shared OpenObjectContextMenu via React Flow.
+ *
+ * Background-open convention: "Open in new tab" adds the tab WITHOUT stealing
+ * focus from the current tab (per the Track O spec — clicking the new tab is
+ * what switches the workspace context).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=trackO VISIVO_SANDBOX_BACKEND_PORT=8041 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3041 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3041 npx playwright test workspace-tabs-context-menu
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+async function gotoWorkspace(page, path = '/workspace') {
+  await page.goto(`${BASE_URL}${path}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-tab-strip')).toBeVisible({ timeout: 15000 });
+}
+
+async function expandSubsection(page, type) {
+  const header = page.getByTestId(`library-subsection-${type}-header`);
+  await expect(header).toBeVisible({ timeout: 10000 });
+  await header.hover();
+  await header.click();
+}
+
+test.describe('Right-click "Open in new tab" (VIS-811)', () => {
+  test('Library row → Open in new tab adds a background tab, focus unchanged', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+    await expandSubsection(page, 'chart');
+    const row = page.getByTestId('library-row-chart-simple-scatter-chart');
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    await row.hover();
+    await row.click({ button: 'right' });
+    const menu = page.getByTestId('library-row-chart-simple-scatter-chart-context-menu');
+    await expect(menu).toBeVisible();
+
+    const item = menu.getByText('Open in new tab');
+    await item.hover();
+    await item.click();
+
+    // The chart tab joins the strip but the project tab keeps focus.
+    const chartTab = page.getByTestId('workspace-tab-chart:simple-scatter-chart');
+    await expect(chartTab).toBeVisible();
+    await expect(chartTab).toHaveAttribute('data-active', 'false');
+    await expect(page.locator('[data-testid^="workspace-tab-project:"]')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // Clicking the new tab is what switches the context.
+    const select = page.getByTestId('workspace-tab-select-chart:simple-scatter-chart');
+    await select.hover();
+    await select.click();
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+  });
+
+  test('Project Editor tile → Open / Open in new tab', async ({ page }) => {
+    await gotoWorkspace(page);
+    const tile = page.getByTestId(`project-tile-${DASHBOARD}`);
+    await expect(tile).toBeVisible({ timeout: WAIT });
+
+    await tile.hover();
+    await tile.click({ button: 'right' });
+    const menu = page.getByTestId(`project-tile-ctx-${DASHBOARD}-menu`);
+    await expect(menu).toBeVisible();
+
+    const openNew = page.getByTestId(`project-tile-ctx-${DASHBOARD}-open-new-tab`);
+    await openNew.hover();
+    await openNew.click();
+
+    const dashTab = page.getByTestId(`workspace-tab-dashboard:${DASHBOARD}`);
+    await expect(dashTab).toBeVisible();
+    await expect(dashTab).toHaveAttribute('data-active', 'false');
+    await expect(page.locator('[data-testid^="workspace-tab-project:"]')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // "Open" (foreground) on a second right-click switches the context.
+    await tile.hover();
+    await tile.click({ button: 'right' });
+    const open = page.getByTestId(`project-tile-ctx-${DASHBOARD}-open`);
+    await open.hover();
+    await open.click();
+    await expect(dashTab).toHaveAttribute('data-active', 'true');
+  });
+
+  test('Canvas chart item → Open in new tab keeps the dashboard tab focused', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page, `/workspace/dashboard/${DASHBOARD}`);
+    await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+    const item = page.locator('[data-canvas-path="row.0.item.0"]').first();
+    await expect(item).toBeVisible({ timeout: WAIT });
+
+    // The canvas item overlays a live Plotly chart — force the real-cursor
+    // right-click past the actionability false-positive.
+    await item.hover({ force: true });
+    await item.click({ button: 'right', force: true });
+    const menu = page.getByTestId('canvas-context-menu');
+    await expect(menu).toBeVisible();
+
+    const openNew = page.getByTestId('canvas-ctx-open-new-tab');
+    await expect(openNew).toBeVisible();
+    await openNew.hover();
+    await openNew.click();
+
+    // The chart tab joined the strip; the dashboard tab keeps focus.
+    const chartTab = page.locator('[data-testid^="workspace-tab-chart:"]');
+    await expect(chartTab).toHaveCount(1);
+    await expect(chartTab).toHaveAttribute('data-active', 'false');
+    await expect(
+      page.getByTestId(`workspace-tab-dashboard:${DASHBOARD}`)
+    ).toHaveAttribute('data-active', 'true');
+  });
+
+  test('Lineage node → Open in new tab background-opens the node object', async ({ page }) => {
+    await gotoWorkspace(page, `/workspace/dashboard/${DASHBOARD}`);
+    // Flip the middle pane to the Lineage lens via the sub-bar segmented control.
+    const lineageSeg = page.getByTestId('workspace-lens-picker-option-lineage');
+    await expect(lineageSeg).toBeVisible({ timeout: WAIT });
+    await lineageSeg.hover();
+    await lineageSeg.click();
+    await expect(page.getByTestId('lineage-canvas')).toBeVisible({ timeout: WAIT });
+
+    // Wait for React Flow to draw nodes, then right-click the first one.
+    const node = page.locator('.react-flow__node').first();
+    await expect(node).toBeVisible({ timeout: WAIT });
+    await node.hover();
+    await node.click({ button: 'right' });
+
+    const menu = page.getByTestId('lineage-node-ctx-menu');
+    await expect(menu).toBeVisible();
+    const openNew = page.getByTestId('lineage-node-ctx-open-new-tab');
+    await openNew.hover();
+    await openNew.click();
+    await expect(menu).not.toBeVisible();
+
+    // A new background tab joined the strip; the dashboard tab keeps focus.
+    const tabCount = await page
+      .getByTestId('workspace-tab-strip')
+      .locator('[role="tab"]')
+      .count();
+    expect(tabCount).toBeGreaterThanOrEqual(3); // project + dashboard + the node's tab
+    await expect(
+      page.getByTestId(`workspace-tab-dashboard:${DASHBOARD}`)
+    ).toHaveAttribute('data-active', 'true');
+  });
+});

--- a/viewer/e2e/stories/workspace-tabs-shortcuts.spec.mjs
+++ b/viewer/e2e/stories/workspace-tabs-shortcuts.spec.mjs
@@ -1,0 +1,190 @@
+/**
+ * Story: Tab power features — shortcuts, drag-reorder, overflow, dirty-close
+ * (VIS-812 / Track O O-3).
+ *
+ *   1. Cmd/Ctrl+T opens the project ("new") tab.
+ *   2. Cmd/Ctrl+1..9 switches by strip position.
+ *   3. Cmd/Ctrl+W closes the active (clean) tab.
+ *   4. Shortcuts are suppressed while typing in an input.
+ *   5. Drag-to-reorder with a REAL cursor (pointer-driven dnd-kit).
+ *   6. >8 tabs → the strip overflows and scrolls horizontally.
+ *   7. Closing a dirty tab raises the confirmation dialog (Keep editing /
+ *      Close without saving).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=trackO VISIVO_SANDBOX_BACKEND_PORT=8041 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3041 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3041 npx playwright test workspace-tabs-shortcuts
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+// Playwright runs on the same host as the browser, so process.platform picks
+// the right modifier for the page's navigator-based detection.
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function gotoWorkspace(page) {
+  await page.goto(`${BASE_URL}/workspace`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-tab-strip')).toBeVisible({ timeout: 15000 });
+}
+
+async function openLibraryObject(page, type, name) {
+  const header = page.getByTestId(`library-subsection-${type}-header`);
+  const row = page.getByTestId(`library-row-${type}-${name}`);
+  if (!(await row.isVisible().catch(() => false))) {
+    await header.hover();
+    await header.click();
+  }
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.hover();
+  await row.click();
+}
+
+test.describe('Tab shortcuts + reorder + overflow + dirty-close (VIS-812)', () => {
+  test('Cmd+1..9 switches by position; Cmd+T focuses the project tab; Cmd+W closes', async ({
+    page,
+  }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    await openLibraryObject(page, 'table', 'new_table');
+    // Strip: [project, chart, table] — table is active.
+
+    const projectTab = page.locator('[data-testid^="workspace-tab-project:"]');
+    const chartTab = page.getByTestId('workspace-tab-chart:simple-scatter-chart');
+    const tableTab = page.getByTestId('workspace-tab-table:new_table');
+    await expect(tableTab).toHaveAttribute('data-active', 'true');
+
+    // Cmd+2 → the chart (position 2).
+    await page.keyboard.press(`${MOD}+2`);
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+
+    // Cmd+1 → the project tab.
+    await page.keyboard.press(`${MOD}+1`);
+    await expect(projectTab).toHaveAttribute('data-active', 'true');
+
+    // Cmd+3 → the table.
+    await page.keyboard.press(`${MOD}+3`);
+    await expect(tableTab).toHaveAttribute('data-active', 'true');
+
+    // Cmd+W closes the active clean tab; focus falls back to the chart.
+    await page.keyboard.press(`${MOD}+w`);
+    await expect(page.getByTestId('workspace-tab-table:new_table')).toHaveCount(0);
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+
+    // Cmd+T re-focuses the project ("new") tab.
+    await page.keyboard.press(`${MOD}+t`);
+    await expect(projectTab).toHaveAttribute('data-active', 'true');
+  });
+
+  test('shortcuts are suppressed while typing in an input', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    const chartTab = page.getByTestId('workspace-tab-chart:simple-scatter-chart');
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+
+    // Focus the Library search input and fire the chord — nothing must change.
+    const search = page.locator('input').first();
+    await search.hover();
+    await search.click();
+    await page.keyboard.press(`${MOD}+1`);
+    await expect(chartTab).toHaveAttribute('data-active', 'true');
+    await expect(page.getByTestId('workspace-tab-chart:simple-scatter-chart')).toHaveCount(1);
+  });
+
+  test('drag-to-reorder tabs with a real cursor', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    await openLibraryObject(page, 'table', 'new_table');
+    // Strip order: [project, chart, table].
+
+    const source = page.getByTestId('workspace-tab-wrapper-table:new_table');
+    const target = page.locator('[data-testid^="workspace-tab-wrapper-project:"]');
+    const src = await source.boundingBox();
+    const tgt = await target.boundingBox();
+    expect(src && tgt).toBeTruthy();
+
+    // Real pointer drag: down on the table tab, glide onto the project tab
+    // (left edge so closest-center resolves to it), release.
+    await page.mouse.move(src.x + src.width / 2, src.y + src.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(tgt.x + tgt.width / 3, tgt.y + tgt.height / 2, { steps: 12 });
+    await page.mouse.move(tgt.x + tgt.width / 3, tgt.y + tgt.height / 2, { steps: 4 });
+    await page.mouse.up();
+
+    // The table tab now occupies the first slot.
+    const ids = await page
+      .getByTestId('workspace-tab-strip')
+      .locator('[role="tab"]')
+      .evaluateAll(els => els.map(el => el.getAttribute('data-testid')));
+    expect(ids[0]).toBe('workspace-tab-table:new_table');
+  });
+
+  test('the strip scrolls horizontally when more than 8 tabs are open', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    // Bulk state setup (NOT the behaviour under test): background-open enough
+    // tabs to overflow the strip — the scroll behaviour is what we assert.
+    await page.evaluate(() => {
+      const open = window.useStore.getState().openWorkspaceTabBackground;
+      for (let i = 1; i <= 9; i += 1) {
+        open({ type: 'model', name: `overflow-model-${i}` });
+      }
+    });
+    const strip = page.getByTestId('workspace-tab-strip');
+    await expect(strip.locator('[role="tab"]')).toHaveCount(11, { timeout: 10000 });
+
+    const scroller = strip.locator('> div').first();
+    const overflows = await scroller.evaluate(el => el.scrollWidth > el.clientWidth);
+    expect(overflows).toBe(true);
+
+    // Switching to the LAST tab keeps it in view (scrollIntoView on activate).
+    const lastSelect = page.getByTestId('workspace-tab-select-model:overflow-model-9');
+    await page.evaluate(() =>
+      window.useStore.getState().switchWorkspaceTab('model:overflow-model-9')
+    );
+    await expect(page.getByTestId('workspace-tab-model:overflow-model-9')).toBeVisible();
+    const inView = await lastSelect.evaluate(el => {
+      const r = el.getBoundingClientRect();
+      return r.right <= window.innerWidth && r.left >= 0;
+    });
+    expect(inView).toBe(true);
+  });
+
+  test('closing a dirty tab raises the confirmation dialog', async ({ page }) => {
+    await gotoWorkspace(page);
+    await openLibraryObject(page, 'chart', 'simple-scatter-chart');
+    const tabId = 'chart:simple-scatter-chart';
+    // Dirty wiring belongs to Track H (auto-save) — flip the flag as setup.
+    await page.evaluate(id => {
+      window.useStore.getState().setWorkspaceTabDirty(id, true);
+    }, tabId);
+    await expect(page.getByTestId(`workspace-tab-dirty-${tabId}`)).toBeVisible();
+
+    // Real-cursor close → the dialog appears instead of closing.
+    const closeBtn = page.getByTestId(`workspace-tab-close-${tabId}`);
+    await closeBtn.hover();
+    await closeBtn.click();
+    const dialog = page.getByTestId('tab-close-confirm-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('simple-scatter-chart');
+
+    // "Keep editing" → tab survives, still dirty.
+    const cancel = page.getByTestId('tab-close-confirm-cancel');
+    await cancel.hover();
+    await cancel.click();
+    await expect(dialog).not.toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-${tabId}`)).toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-dirty-${tabId}`)).toBeVisible();
+
+    // Close again via Cmd+W (the tab is active) → confirm the discard.
+    await page.keyboard.press(`${MOD}+w`);
+    await expect(dialog).toBeVisible();
+    const confirm = page.getByTestId('tab-close-confirm-close');
+    await confirm.hover();
+    await confirm.click();
+    await expect(page.getByTestId(`workspace-tab-${tabId}`)).toHaveCount(0);
+  });
+});

--- a/viewer/src/components/new-views/lineage/LineageCanvas.jsx
+++ b/viewer/src/components/new-views/lineage/LineageCanvas.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PiTreeStructure, PiArrowCounterClockwise } from 'react-icons/pi';
 import LineageNew from './LineageNew';
+import OpenObjectContextMenu from '../workspace/OpenObjectContextMenu';
 import useStore from '../../../stores/store';
 import { useWorkspaceScope } from '../workspace/useWorkspaceScope';
 import { emitWorkspaceEvent } from '../workspace/telemetry';
@@ -31,6 +32,7 @@ import { emitWorkspaceEvent } from '../workspace/telemetry';
 const LineageCanvas = () => {
   const { scope, selector, dashboardName, selectedItem } = useWorkspaceScope();
   const openWorkspaceTab = useStore((s) => s.openWorkspaceTab);
+  const openWorkspaceTabBackground = useStore((s) => s.openWorkspaceTabBackground);
 
   // Local "show full project" override. When active we force `*` regardless of
   // the derived scope — without touching the route. It auto-clears whenever the
@@ -94,6 +96,37 @@ const LineageCanvas = () => {
     [openWorkspaceTab]
   );
 
+  // Right-click a node → "Open / Open in new tab" (VIS-811 / Track O O-2).
+  // `ctxMenu`: null | { x, y, obj: { type, name } } — viewport coordinates for
+  // the portal-rendered shared menu.
+  const [ctxMenu, setCtxMenu] = useState(null);
+  const handleNodeContextMenu = useCallback((event, obj) => {
+    if (!obj || !obj.type || !obj.name) return;
+    setCtxMenu({ x: event.clientX, y: event.clientY, obj });
+  }, []);
+  const dismissCtxMenu = useCallback(() => setCtxMenu(null), []);
+  const handleCtxOpen = useCallback(
+    (obj) => handleNodeSelect(obj),
+    [handleNodeSelect]
+  );
+  const handleCtxOpenInNewTab = useCallback(
+    (obj) => {
+      if (openWorkspaceTabBackground) {
+        openWorkspaceTabBackground({
+          id: `${obj.type}:${obj.name}`,
+          type: obj.type,
+          name: obj.name,
+        });
+      }
+      emitWorkspaceEvent('lineage_node_context_action', {
+        type: obj.type,
+        name: obj.name,
+        action: 'openInNewTab',
+      });
+    },
+    [openWorkspaceTabBackground]
+  );
+
   const chrome = (
     <div
       data-testid="lineage-canvas-scope-bar"
@@ -135,8 +168,20 @@ const LineageCanvas = () => {
       <LineageNew
         scopeSelector={effectiveSelector}
         onNodeSelect={handleNodeSelect}
+        onNodeContextMenu={handleNodeContextMenu}
         headerSlot={chrome}
       />
+      {ctxMenu && (
+        <OpenObjectContextMenu
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          obj={ctxMenu.obj}
+          onOpen={handleCtxOpen}
+          onOpenInNewTab={handleCtxOpenInNewTab}
+          onDismiss={dismissCtxMenu}
+          testIdPrefix="lineage-node-ctx"
+        />
+      )}
     </div>
   );
 };

--- a/viewer/src/components/new-views/lineage/LineageCanvas.test.jsx
+++ b/viewer/src/components/new-views/lineage/LineageCanvas.test.jsx
@@ -28,7 +28,7 @@ jest.mock('../workspace/useWorkspaceScope', () => ({
 // Mock LineageNew with a stub that echoes the props we care about and lets us
 // drive the node-select round-trip + the manual selector input.
 jest.mock('./LineageNew', () => {
-  const MockLineageNew = ({ scopeSelector, onNodeSelect, headerSlot }) => {
+  const MockLineageNew = ({ scopeSelector, onNodeSelect, onNodeContextMenu, headerSlot }) => {
     const React = require('react');
     const [manual, setManual] = React.useState(scopeSelector || '');
     React.useEffect(() => {
@@ -48,6 +48,14 @@ jest.mock('./LineageNew', () => {
           onClick={() => onNodeSelect && onNodeSelect({ type: 'model', name: 'monthly_revenue' })}
         >
           click node
+        </button>
+        <button
+          data-testid="simulate-node-contextmenu"
+          onClick={(e) =>
+            onNodeContextMenu && onNodeContextMenu(e, { type: 'model', name: 'monthly_revenue' })
+          }
+        >
+          right-click node
         </button>
       </div>
     );
@@ -149,6 +157,58 @@ describe('LineageCanvas', () => {
       scope: 'dashboard',
       dashboardName: 'sales',
     });
+  });
+
+  // Right-click context menu (VIS-811 / Track O O-2) -------------------------
+
+  test('right-clicking a node opens the Open / Open in new tab menu', () => {
+    setScope(DASHBOARD);
+    render(<LineageCanvas />);
+    fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+    expect(screen.getByTestId('lineage-node-ctx-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('lineage-node-ctx-open')).toBeInTheDocument();
+    expect(screen.getByTestId('lineage-node-ctx-open-new-tab')).toBeInTheDocument();
+  });
+
+  test('context-menu "Open" focuses the object tab (replaces context) and dismisses', () => {
+    setScope(DASHBOARD);
+    render(<LineageCanvas />);
+    fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+    fireEvent.click(screen.getByTestId('lineage-node-ctx-open'));
+
+    const state = useStore.getState();
+    expect(state.workspaceActiveTabId).toBe('model:monthly_revenue');
+    expect(state.workspaceActiveObject).toEqual({ type: 'model', name: 'monthly_revenue' });
+    expect(screen.queryByTestId('lineage-node-ctx-menu')).not.toBeInTheDocument();
+  });
+
+  test('context-menu "Open in new tab" background-opens without stealing focus', () => {
+    setScope(DASHBOARD);
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'sales' });
+    });
+    render(<LineageCanvas />);
+    fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+    fireEvent.click(screen.getByTestId('lineage-node-ctx-open-new-tab'));
+
+    const state = useStore.getState();
+    expect(state.workspaceTabs.map((t) => t.id)).toEqual([
+      'dashboard:sales',
+      'model:monthly_revenue',
+    ]);
+    // Focus is untouched — the dashboard tab stays active.
+    expect(state.workspaceActiveTabId).toBe('dashboard:sales');
+    expect(screen.queryByTestId('lineage-node-ctx-menu')).not.toBeInTheDocument();
+  });
+
+  test('the node context menu dismisses on Escape without opening anything', () => {
+    setScope(DASHBOARD);
+    render(<LineageCanvas />);
+    fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+    expect(screen.getByTestId('lineage-node-ctx-menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('lineage-node-ctx-menu')).not.toBeInTheDocument();
+    expect(useStore.getState().workspaceTabs).toHaveLength(0);
   });
 
   test('manual selector input inside LineageNew still works as an override', () => {

--- a/viewer/src/components/new-views/lineage/LineageNew.jsx
+++ b/viewer/src/components/new-views/lineage/LineageNew.jsx
@@ -41,8 +41,18 @@ import { formatRefExpression } from '../../../utils/refString';
  *   - `headerSlot`     — optional React node rendered to the left of the
  *                        selector input bar (used by `<LineageCanvas>` to
  *                        mount the scope-indicator chrome).
+ *   - `onNodeContextMenu` — called with `(event, { type, name })` when a node
+ *                        is right-clicked (VIS-811 / Track O O-2) so a host
+ *                        can mount an "Open / Open in new tab" context menu.
+ *                        When provided, the browser's default menu is
+ *                        suppressed for node right-clicks only.
  */
-const LineageNew = ({ scopeSelector = null, onNodeSelect = null, headerSlot = null } = {}) => {
+const LineageNew = ({
+  scopeSelector = null,
+  onNodeSelect = null,
+  headerSlot = null,
+  onNodeContextMenu = null,
+} = {}) => {
   // Sources
   const fetchSources = useStore(state => state.fetchSources);
   const sourcesError = useStore(state => state.sourcesError);
@@ -422,6 +432,19 @@ const LineageNew = ({ scopeSelector = null, onNodeSelect = null, headerSlot = nu
     }
   }, [clearEdit, pushEdit, onNodeSelect]);
 
+  // Right-click on a node (VIS-811 / Track O O-2) — resolve the node to its
+  // `{ type, name }` identity and hand it to the host with the raw event so
+  // the host can position its own context menu. Suppress the browser menu
+  // only when a host is actually listening.
+  const handleNodeContextMenu = useCallback(
+    (event, node) => {
+      if (!onNodeContextMenu) return;
+      event.preventDefault();
+      onNodeContextMenu(event, { type: node.data.objectType, name: node.data.name });
+    },
+    [onNodeContextMenu]
+  );
+
   // Handle new edge connection (drag from source to model)
   const handleConnect = useCallback(
     async params => {
@@ -599,6 +622,7 @@ const LineageNew = ({ scopeSelector = null, onNodeSelect = null, headerSlot = nu
             edges={initialLoadDone ? (edges || []) : []}
             nodeTypes={nodeTypes}
             onNodeClick={handleNodeClick}
+            onNodeContextMenu={handleNodeContextMenu}
             onConnect={handleConnect}
             onEdgesDelete={handleEdgesDelete}
             onInit={instance => {

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.jsx
@@ -148,6 +148,8 @@ const CanvasContextMenu = ({ rootRef, dashboardName }) => {
   const navigate = useNavigate();
   const dashboards = useStore(s => s.dashboards);
   const setSelectedKey = useStore(s => s.setWorkspaceOutlineSelectedKey);
+  const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  const openWorkspaceTabBackground = useStore(s => s.openWorkspaceTabBackground);
   const commitCanvasConfig = useWorkspaceCommit();
   // menu: null | { x, y, key, kind }
   const [menu, setMenu] = useState(null);
@@ -239,6 +241,27 @@ const CanvasContextMenu = ({ rootRef, dashboardName }) => {
     [navigate, dashboardName]
   );
 
+  // VIS-811 / O-2: open the right-clicked leaf's object as a workspace tab.
+  // "Open" replaces the current context (focus moves); "Open in new tab"
+  // background-opens so the dashboard tab keeps focus.
+  const openAsTab = useCallback(
+    (subject, background) => {
+      if (!subject) return;
+      const tab = {
+        id: `${subject.type}:${subject.name}`,
+        type: subject.type,
+        name: subject.name,
+      };
+      if (background) {
+        if (openWorkspaceTabBackground) openWorkspaceTabBackground(tab);
+      } else if (openWorkspaceTab) {
+        openWorkspaceTab(tab);
+      }
+      setMenu(null);
+    },
+    [openWorkspaceTab, openWorkspaceTabBackground]
+  );
+
   if (!dashboardConfig || !menu) return null;
 
   const isContainer = menu.kind === 'item' && isContainerItem(dashboardConfig, menu.key);
@@ -272,6 +295,18 @@ const CanvasContextMenu = ({ rootRef, dashboardName }) => {
 
       {explorerSubject && (
         <>
+          <MenuItem
+            testid="canvas-ctx-open"
+            label="Open"
+            hint="tab"
+            onClick={() => openAsTab(explorerSubject, false)}
+          />
+          <MenuItem
+            testid="canvas-ctx-open-new-tab"
+            label="Open in new tab"
+            hint="⌘↵"
+            onClick={() => openAsTab(explorerSubject, true)}
+          />
           <MenuItem
             testid="canvas-ctx-open-in-explorer"
             label="Open in Explorer"

--- a/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasContextMenu.test.jsx
@@ -210,4 +210,56 @@ describe('CanvasContextMenu (VIS-781)', () => {
       expect(screen.queryByTestId('canvas-ctx-open-in-explorer')).not.toBeInTheDocument();
     });
   });
+
+  // ------------------------------------------------------------------
+  // O-2 / VIS-811 — "Open" / "Open in new tab" (workspace tabs)
+  // ------------------------------------------------------------------
+  describe('Open / Open in new tab (O-2)', () => {
+    beforeEach(() => {
+      useStore.setState({
+        workspaceTabs: [],
+        workspaceActiveTabId: null,
+        workspaceActiveObject: null,
+      });
+    });
+
+    test('chart leaf shows both open actions', () => {
+      renderHost({ commit: jest.fn() });
+      rightClick('r0i0');
+      expect(screen.getByTestId('canvas-ctx-open')).toBeInTheDocument();
+      expect(screen.getByTestId('canvas-ctx-open-new-tab')).toBeInTheDocument();
+    });
+
+    test('"Open" focuses a tab for the chart (replaces current context) and dismisses', () => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'dash' });
+      renderHost({ commit: jest.fn() });
+      rightClick('r0i0');
+      fireEvent.click(screen.getByTestId('canvas-ctx-open'));
+
+      const s = useStore.getState();
+      expect(s.workspaceActiveTabId).toBe('chart:a');
+      expect(s.workspaceActiveObject).toEqual({ type: 'chart', name: 'a' });
+      expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+    });
+
+    test('"Open in new tab" background-opens without stealing focus from the dashboard', () => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'dash' });
+      renderHost({ commit: jest.fn() });
+      rightClick('r0i1'); // the table leaf → subject { type: 'table', name: 'b' }
+      fireEvent.click(screen.getByTestId('canvas-ctx-open-new-tab'));
+
+      const s = useStore.getState();
+      expect(s.workspaceTabs.map(t => t.id)).toEqual(['dashboard:dash', 'table:b']);
+      expect(s.workspaceActiveTabId).toBe('dashboard:dash');
+      expect(screen.queryByTestId('canvas-context-menu')).not.toBeInTheDocument();
+    });
+
+    test('a container item offers neither open action', () => {
+      useStore.setState({ dashboards: [CONTAINER_DASH] });
+      renderHost({ commit: jest.fn(), structure: 'container' });
+      rightClick('r0i0');
+      expect(screen.queryByTestId('canvas-ctx-open')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('canvas-ctx-open-new-tab')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/viewer/src/components/new-views/project/editor/DashboardTile.jsx
+++ b/viewer/src/components/new-views/project/editor/DashboardTile.jsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { PiDotsSix } from 'react-icons/pi';
 import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
+import OpenObjectContextMenu from '../../workspace/OpenObjectContextMenu';
 
 /**
  * DashboardTile — VIS-805 / Track M M-1.
@@ -19,7 +20,7 @@ import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
 const DashboardIcon = getTypeIcon('dashboard');
 const DASH_COLORS = getTypeColors('dashboard');
 
-const DashboardTile = ({ tile, selected = false, onSelect }) => {
+const DashboardTile = ({ tile, selected = false, onSelect, onOpenInNewTab }) => {
   const drag = useDraggable({
     id: `project-tile:${tile.name}`,
     data: { source: 'project-editor', type: 'dashboard', name: tile.name, level: tile.level },
@@ -38,6 +39,16 @@ const DashboardTile = ({ tile, selected = false, onSelect }) => {
     [drag.isDragging, onSelect, tile]
   );
 
+  // Right-click → "Open / Open in new tab" (VIS-811 / Track O O-2).
+  // `ctxMenu`: null | { x, y } in viewport coordinates for the shared menu.
+  const [ctxMenu, setCtxMenu] = useState(null);
+  const handleContextMenu = useCallback(e => {
+    e.preventDefault();
+    e.stopPropagation();
+    setCtxMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+  const dismissCtxMenu = useCallback(() => setCtxMenu(null), []);
+
   const tags = Array.isArray(tile.tags) ? tile.tags : [];
 
   return (
@@ -49,6 +60,7 @@ const DashboardTile = ({ tile, selected = false, onSelect }) => {
       data-selected={selected ? 'true' : 'false'}
       data-dragging={drag.isDragging ? 'true' : 'false'}
       onClick={handleClick}
+      onContextMenu={handleContextMenu}
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -96,6 +108,18 @@ const DashboardTile = ({ tile, selected = false, onSelect }) => {
         <span>{tile.itemCount != null ? `${tile.itemCount} items` : 'dashboard'}</span>
         {tile.updatedAt && <span className="truncate">{tile.updatedAt}</span>}
       </div>
+
+      {ctxMenu && (
+        <OpenObjectContextMenu
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          obj={{ type: 'dashboard', name: tile.name }}
+          onOpen={() => onSelect && onSelect(tile)}
+          onOpenInNewTab={() => onOpenInNewTab && onOpenInNewTab(tile)}
+          onDismiss={dismissCtxMenu}
+          testIdPrefix={`project-tile-ctx-${tile.name}`}
+        />
+      )}
     </div>
   );
 };

--- a/viewer/src/components/new-views/project/editor/DashboardTile.test.jsx
+++ b/viewer/src/components/new-views/project/editor/DashboardTile.test.jsx
@@ -43,6 +43,55 @@ describe('DashboardTile', () => {
     );
   });
 
+  // Right-click context menu (VIS-811 / Track O O-2) -------------------------
+
+  test('right-clicking a tile opens the Open / Open in new tab menu', () => {
+    renderTile();
+    fireEvent.contextMenu(screen.getByTestId('project-tile-revenue-overview'), {
+      clientX: 50,
+      clientY: 60,
+    });
+    expect(screen.getByTestId('project-tile-ctx-revenue-overview-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('project-tile-ctx-revenue-overview-open')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('project-tile-ctx-revenue-overview-open-new-tab')
+    ).toBeInTheDocument();
+  });
+
+  test('context-menu "Open" dispatches onSelect (replace current context) and dismisses', () => {
+    const onSelect = jest.fn();
+    const onOpenInNewTab = jest.fn();
+    renderTile({ onSelect, onOpenInNewTab });
+    fireEvent.contextMenu(screen.getByTestId('project-tile-revenue-overview'));
+    fireEvent.click(screen.getByTestId('project-tile-ctx-revenue-overview-open'));
+    expect(onSelect).toHaveBeenCalledWith(tile);
+    expect(onOpenInNewTab).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId('project-tile-ctx-revenue-overview-menu')
+    ).not.toBeInTheDocument();
+  });
+
+  test('context-menu "Open in new tab" dispatches onOpenInNewTab, NOT onSelect', () => {
+    const onSelect = jest.fn();
+    const onOpenInNewTab = jest.fn();
+    renderTile({ onSelect, onOpenInNewTab });
+    fireEvent.contextMenu(screen.getByTestId('project-tile-revenue-overview'));
+    fireEvent.click(screen.getByTestId('project-tile-ctx-revenue-overview-open-new-tab'));
+    expect(onOpenInNewTab).toHaveBeenCalledWith(tile);
+    // The portal click must not bubble into the tile's own onClick → onSelect.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test('the tile context menu dismisses on Escape', () => {
+    renderTile();
+    fireEvent.contextMenu(screen.getByTestId('project-tile-revenue-overview'));
+    expect(screen.getByTestId('project-tile-ctx-revenue-overview-menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(
+      screen.queryByTestId('project-tile-ctx-revenue-overview-menu')
+    ).not.toBeInTheDocument();
+  });
+
   test('renders a sensible footer label when item count is unknown', () => {
     render(
       <DndContext>

--- a/viewer/src/components/new-views/project/editor/LevelGroup.jsx
+++ b/viewer/src/components/new-views/project/editor/LevelGroup.jsx
@@ -20,6 +20,7 @@ const LevelGroup = ({
   onToggle,
   selectedDashboardName,
   onSelectTile,
+  onOpenTileInNewTab,
   activeDragName,
   isActiveSourceGroup,
   editable = false,
@@ -109,6 +110,7 @@ const LevelGroup = ({
                 tile={tile}
                 selected={selectedDashboardName === tile.name}
                 onSelect={onSelectTile}
+                onOpenInNewTab={onOpenTileInNewTab}
               />
             ))
           )}

--- a/viewer/src/components/new-views/project/editor/ProjectEditor.jsx
+++ b/viewer/src/components/new-views/project/editor/ProjectEditor.jsx
@@ -144,6 +144,7 @@ const ProjectEditor = () => {
   const sources = useStore(s => s.sources);
   const defaults = useStore(s => s.defaults);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  const openWorkspaceTabBackground = useStore(s => s.openWorkspaceTabBackground);
   // M-2a level CRUD (merged from feature). Drag-between-levels reassignment now
   // lives in the shell's shared WorkspaceDndContext handler, so this surface no
   // longer needs `reassignDashboardLevel` — only the level-editing actions.
@@ -238,6 +239,25 @@ const ProjectEditor = () => {
       });
     },
     [openWorkspaceTab]
+  );
+
+  // Right-click "Open in new tab" on a tile (VIS-811 / O-2): background-open —
+  // the tab joins the strip but the Project Editor keeps focus.
+  const dispatchDashboardOpenInNewTab = useCallback(
+    tile => {
+      if (openWorkspaceTabBackground) {
+        openWorkspaceTabBackground({
+          id: `dashboard:${tile.name}`,
+          type: 'dashboard',
+          name: tile.name,
+        });
+      }
+      emitWorkspaceEvent('project_editor_action', {
+        kind: 'open_tile_in_new_tab',
+        name: tile.name,
+      });
+    },
+    [openWorkspaceTabBackground]
   );
 
   const dispatchChromeSelection = useCallback(() => {
@@ -403,6 +423,7 @@ const ProjectEditor = () => {
                       onToggle={() => handleToggle(group.levelKey)}
                       selectedDashboardName={selectedDashboardName}
                       onSelectTile={dispatchDashboardSelection}
+                      onOpenTileInNewTab={dispatchDashboardOpenInNewTab}
                       activeDragName={activeDrag?.name || null}
                       isActiveSourceGroup={isActiveSourceGroup}
                       editable={editable}

--- a/viewer/src/components/new-views/workspace/OpenObjectContextMenu.jsx
+++ b/viewer/src/components/new-views/workspace/OpenObjectContextMenu.jsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { PiArrowSquareOut, PiArrowRight } from 'react-icons/pi';
+import { getTypeIcon } from '../common/objectTypeConfigs';
+
+/**
+ * OpenObjectContextMenu — VIS-811 / Track O O-2.
+ *
+ * The shared right-click menu for "openable" workspace objects. Mounted by
+ * surfaces that don't already own a context menu (lineage nodes, Project
+ * Editor tiles); the canvas and Library menus integrate the same two actions
+ * into their existing menus instead.
+ *
+ *   - Open             → replaces the current workspace context
+ *                        (`openWorkspaceTab` — focuses/creates the tab).
+ *   - Open in new tab  → background-opens (`openWorkspaceTabBackground`) so
+ *                        the user's current tab keeps focus; the new tab
+ *                        joins the strip ready to click. This matches the
+ *                        Track O spec ("creates a new tab; clicking the tab
+ *                        switches the workspace context").
+ *
+ * Rendered through a portal at a fixed viewport position (`x`/`y` are
+ * clientX/clientY) so it escapes any overflow-clipping ancestor (the lineage
+ * pane, the editor's scroll container). Dismisses on outside pointer-down,
+ * Escape, or scroll — same contract as CanvasContextMenu.
+ */
+const MULBERRY = '#713b57';
+
+const MenuItem = ({ testid, icon: Icon, label, onClick }) => (
+  <button
+    type="button"
+    role="menuitem"
+    data-testid={testid}
+    onClick={e => {
+      // React portals bubble through the REACT tree — without this, a menu
+      // click would also fire the host's onClick (e.g. a tile's "select").
+      e.stopPropagation();
+      onClick && onClick(e);
+    }}
+    className="flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-left text-[12.5px] text-gray-700 transition-colors hover:bg-[#f9f6f8] focus:bg-[#f9f6f8] focus:outline-none"
+  >
+    {Icon && <Icon className="shrink-0 text-gray-500" style={{ fontSize: 14 }} />}
+    <span className="font-medium">{label}</span>
+  </button>
+);
+
+const OpenObjectContextMenu = ({ x, y, obj, onOpen, onOpenInNewTab, onDismiss, testIdPrefix }) => {
+  const menuRef = useRef(null);
+  const prefix = testIdPrefix || 'open-object-ctx';
+  const TypeIcon = obj?.type ? getTypeIcon(obj.type) : null;
+
+  useEffect(() => {
+    const onDocPointer = e => {
+      if (menuRef.current && menuRef.current.contains(e.target)) return;
+      onDismiss && onDismiss();
+    };
+    const onKey = e => {
+      if (e.key === 'Escape') onDismiss && onDismiss();
+    };
+    const onScroll = () => onDismiss && onDismiss();
+    document.addEventListener('pointerdown', onDocPointer, true);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointer, true);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [onDismiss]);
+
+  if (!obj) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label={`${obj.name} actions`}
+      data-testid={`${prefix}-menu`}
+      className="fixed z-[80] min-w-[190px] rounded-lg border border-[#e5e0e3] bg-white p-1 shadow-lg"
+      style={{ top: y, left: x }}
+      onPointerDown={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    >
+      <div className="flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        {TypeIcon && <TypeIcon aria-hidden="true" style={{ fontSize: 12 }} />}
+        <span className="truncate">{obj.name}</span>
+      </div>
+      <MenuItem
+        testid={`${prefix}-open`}
+        icon={PiArrowRight}
+        label="Open"
+        onClick={() => {
+          onOpen && onOpen(obj);
+          onDismiss && onDismiss();
+        }}
+      />
+      <MenuItem
+        testid={`${prefix}-open-new-tab`}
+        icon={PiArrowSquareOut}
+        label="Open in new tab"
+        onClick={() => {
+          onOpenInNewTab && onOpenInNewTab(obj);
+          onDismiss && onDismiss();
+        }}
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-px top-2 h-4 w-[3px] rounded-r"
+        style={{ background: MULBERRY }}
+      />
+    </div>,
+    document.body
+  );
+};
+
+export default OpenObjectContextMenu;

--- a/viewer/src/components/new-views/workspace/OpenObjectContextMenu.test.jsx
+++ b/viewer/src/components/new-views/workspace/OpenObjectContextMenu.test.jsx
@@ -1,0 +1,97 @@
+/**
+ * OpenObjectContextMenu (VIS-811 / Track O O-2).
+ *
+ * The shared right-click "Open / Open in new tab" menu used by lineage nodes
+ * and Project Editor tiles. These tests pin the action wiring, the dismiss
+ * contract (outside pointer / Escape / scroll), and the event-bubbling guard
+ * (portal clicks must not reach the host element's onClick).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OpenObjectContextMenu from './OpenObjectContextMenu';
+
+const OBJ = { type: 'chart', name: 'revenue_chart' };
+
+const renderMenu = (props = {}) =>
+  render(
+    <OpenObjectContextMenu
+      x={120}
+      y={80}
+      obj={OBJ}
+      testIdPrefix="test-ctx"
+      {...props}
+    />
+  );
+
+describe('OpenObjectContextMenu', () => {
+  test('renders the object name header and both actions at the given position', () => {
+    renderMenu();
+    const menu = screen.getByTestId('test-ctx-menu');
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveStyle({ top: '80px', left: '120px' });
+    expect(screen.getByText('revenue_chart')).toBeInTheDocument();
+    expect(screen.getByTestId('test-ctx-open')).toHaveTextContent('Open');
+    expect(screen.getByTestId('test-ctx-open-new-tab')).toHaveTextContent('Open in new tab');
+  });
+
+  test('renders nothing without an object', () => {
+    render(<OpenObjectContextMenu x={0} y={0} obj={null} testIdPrefix="test-ctx" />);
+    expect(screen.queryByTestId('test-ctx-menu')).not.toBeInTheDocument();
+  });
+
+  test('"Open" calls onOpen with the object, then dismisses', () => {
+    const onOpen = jest.fn();
+    const onDismiss = jest.fn();
+    renderMenu({ onOpen, onDismiss });
+    fireEvent.click(screen.getByTestId('test-ctx-open'));
+    expect(onOpen).toHaveBeenCalledWith(OBJ);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  test('"Open in new tab" calls onOpenInNewTab with the object, then dismisses', () => {
+    const onOpenInNewTab = jest.fn();
+    const onDismiss = jest.fn();
+    renderMenu({ onOpenInNewTab, onDismiss });
+    fireEvent.click(screen.getByTestId('test-ctx-open-new-tab'));
+    expect(onOpenInNewTab).toHaveBeenCalledWith(OBJ);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  test('dismisses on Escape and on outside pointer-down, but not on inside pointer-down', () => {
+    const onDismiss = jest.fn();
+    renderMenu({ onDismiss });
+
+    fireEvent.pointerDown(screen.getByTestId('test-ctx-open'));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerDown(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+
+  test('dismisses on scroll', () => {
+    const onDismiss = jest.fn();
+    renderMenu({ onDismiss });
+    fireEvent.scroll(window);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  test('menu clicks do not bubble to the host element (portal guard)', () => {
+    const hostClick = jest.fn();
+    render(
+      <div onClick={hostClick}>
+        <OpenObjectContextMenu
+          x={0}
+          y={0}
+          obj={OBJ}
+          onOpen={jest.fn()}
+          testIdPrefix="test-ctx"
+        />
+      </div>
+    );
+    fireEvent.click(screen.getByTestId('test-ctx-open'));
+    expect(hostClick).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/new-views/workspace/TabCloseConfirmDialog.jsx
+++ b/viewer/src/components/new-views/workspace/TabCloseConfirmDialog.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { PiWarningCircle } from 'react-icons/pi';
+import useStore from '../../../stores/store';
+
+/**
+ * TabCloseConfirmDialog — VIS-812 / Track O O-3.
+ *
+ * The dirty-close confirmation. Renders (via portal) whenever the store has
+ * a `workspacePendingCloseTabId` parked by `requestCloseWorkspaceTab` — i.e.
+ * the user tried to close a tab whose `dirty` flag is set (the mulberry ●).
+ *
+ *   - "Keep editing"          → cancelCloseWorkspaceTab (tab stays open).
+ *   - "Close without saving"  → confirmCloseWorkspaceTab (destructive —
+ *                               highlight palette per the design system).
+ *
+ * Escape and a backdrop click both cancel — closing a dirty tab must always
+ * be the explicit choice. Focus starts on the safe action.
+ */
+const TabCloseConfirmDialog = () => {
+  const pendingId = useStore(s => s.workspacePendingCloseTabId);
+  const tabs = useStore(s => s.workspaceTabs);
+  const confirmClose = useStore(s => s.confirmCloseWorkspaceTab);
+  const cancelClose = useStore(s => s.cancelCloseWorkspaceTab);
+
+  const cancelRef = useRef(null);
+  const tab = pendingId ? (tabs || []).find(t => t.id === pendingId) : null;
+
+  useEffect(() => {
+    if (!tab) return undefined;
+    // Focus the safe action so Enter keeps editing rather than discarding.
+    if (cancelRef.current) cancelRef.current.focus();
+    const onKey = e => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        cancelClose && cancelClose();
+      }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [tab, cancelClose]);
+
+  if (!tab) return null;
+
+  return createPortal(
+    <div
+      data-testid="tab-close-confirm-backdrop"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/30"
+      onPointerDown={e => {
+        if (e.target === e.currentTarget) cancelClose && cancelClose();
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="tab-close-confirm-title"
+        data-testid="tab-close-confirm-dialog"
+        className="w-[400px] max-w-[calc(100vw-32px)] rounded-lg bg-white p-5 shadow-xl ring-1 ring-gray-200"
+      >
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-highlight-100 text-highlight">
+            <PiWarningCircle style={{ fontSize: 20 }} />
+          </span>
+          <div className="min-w-0">
+            <h2
+              id="tab-close-confirm-title"
+              className="text-[15px] font-semibold text-gray-900"
+            >
+              Close tab with unsaved changes?
+            </h2>
+            <p className="mt-1 text-[13px] leading-relaxed text-gray-600">
+              <span className="font-medium text-gray-900">“{tab.name}”</span> has unsaved
+              changes. If you close it now, those changes will be discarded.
+            </p>
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            ref={cancelRef}
+            data-testid="tab-close-confirm-cancel"
+            onClick={() => cancelClose && cancelClose()}
+            className="inline-flex h-9 items-center rounded-lg px-4 text-[13px] font-medium text-gray-700 ring-1 ring-gray-300 transition-all duration-200 hover:bg-gray-50 focus:outline-none focus:ring-4 focus:ring-primary-200"
+          >
+            Keep editing
+          </button>
+          <button
+            type="button"
+            data-testid="tab-close-confirm-close"
+            onClick={() => confirmClose && confirmClose()}
+            className="inline-flex h-9 items-center rounded-lg bg-highlight px-4 text-[13px] font-semibold text-white transition-all duration-200 hover:bg-highlight-700 focus:outline-none focus:ring-4 focus:ring-highlight-200"
+          >
+            Close without saving
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default TabCloseConfirmDialog;

--- a/viewer/src/components/new-views/workspace/TabCloseConfirmDialog.test.jsx
+++ b/viewer/src/components/new-views/workspace/TabCloseConfirmDialog.test.jsx
@@ -1,0 +1,85 @@
+/**
+ * TabCloseConfirmDialog (VIS-812 / Track O O-3).
+ *
+ * The dirty-close confirmation. Store-driven: renders only while
+ * `workspacePendingCloseTabId` points at an open tab; "Keep editing" cancels,
+ * "Close without saving" confirms, Escape + backdrop both cancel.
+ */
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TabCloseConfirmDialog from './TabCloseConfirmDialog';
+import useStore from '../../../stores/store';
+
+const TABS = [
+  { id: 'project:p', type: 'project', name: 'p', dirty: false },
+  { id: 'chart:revenue', type: 'chart', name: 'revenue', dirty: true },
+];
+
+const seed = (extra = {}) => {
+  act(() => {
+    useStore.setState({
+      workspaceTabs: TABS,
+      workspacePendingCloseTabId: null,
+      confirmCloseWorkspaceTab: jest.fn(),
+      cancelCloseWorkspaceTab: jest.fn(),
+      ...extra,
+    });
+  });
+};
+
+describe('TabCloseConfirmDialog', () => {
+  test('renders nothing without a pending close', () => {
+    seed();
+    render(<TabCloseConfirmDialog />);
+    expect(screen.queryByTestId('tab-close-confirm-dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders nothing when the pending id does not match an open tab', () => {
+    seed({ workspacePendingCloseTabId: 'chart:gone' });
+    render(<TabCloseConfirmDialog />);
+    expect(screen.queryByTestId('tab-close-confirm-dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders the dialog naming the dirty tab, with focus on the safe action', () => {
+    seed({ workspacePendingCloseTabId: 'chart:revenue' });
+    render(<TabCloseConfirmDialog />);
+    const dialog = screen.getByTestId('tab-close-confirm-dialog');
+    expect(dialog).toHaveTextContent('Close tab with unsaved changes?');
+    expect(dialog).toHaveTextContent('revenue');
+    expect(screen.getByTestId('tab-close-confirm-cancel')).toHaveFocus();
+  });
+
+  test('"Close without saving" confirms the close', () => {
+    const confirmCloseWorkspaceTab = jest.fn();
+    seed({ workspacePendingCloseTabId: 'chart:revenue', confirmCloseWorkspaceTab });
+    render(<TabCloseConfirmDialog />);
+    fireEvent.click(screen.getByTestId('tab-close-confirm-close'));
+    expect(confirmCloseWorkspaceTab).toHaveBeenCalled();
+  });
+
+  test('"Keep editing" cancels the close', () => {
+    const cancelCloseWorkspaceTab = jest.fn();
+    seed({ workspacePendingCloseTabId: 'chart:revenue', cancelCloseWorkspaceTab });
+    render(<TabCloseConfirmDialog />);
+    fireEvent.click(screen.getByTestId('tab-close-confirm-cancel'));
+    expect(cancelCloseWorkspaceTab).toHaveBeenCalled();
+  });
+
+  test('Escape cancels the close', () => {
+    const cancelCloseWorkspaceTab = jest.fn();
+    seed({ workspacePendingCloseTabId: 'chart:revenue', cancelCloseWorkspaceTab });
+    render(<TabCloseConfirmDialog />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(cancelCloseWorkspaceTab).toHaveBeenCalled();
+  });
+
+  test('clicking the backdrop cancels; clicking inside the card does not', () => {
+    const cancelCloseWorkspaceTab = jest.fn();
+    seed({ workspacePendingCloseTabId: 'chart:revenue', cancelCloseWorkspaceTab });
+    render(<TabCloseConfirmDialog />);
+    fireEvent.pointerDown(screen.getByTestId('tab-close-confirm-dialog'));
+    expect(cancelCloseWorkspaceTab).not.toHaveBeenCalled();
+    fireEvent.pointerDown(screen.getByTestId('tab-close-confirm-backdrop'));
+    expect(cancelCloseWorkspaceTab).toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/new-views/workspace/TabStrip.jsx
+++ b/viewer/src/components/new-views/workspace/TabStrip.jsx
@@ -1,13 +1,36 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  closestCenter,
+} from '@dnd-kit/core';
 import { PiX, PiPlus, PiCube } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import { getTypeIcon } from '../common/objectTypeConfigs';
+import TabCloseConfirmDialog from './TabCloseConfirmDialog';
 
 // Tab icons come from the canonical `objectTypeConfigs.js` for the 13 data-
 // object types. `project` is workspace-chrome — not a data object — so it
 // keeps its Phosphor glyph here as a one-line special case.
 const PROJECT_TAB_ICON = PiCube;
 const getTabIcon = type => (type === 'project' ? PROJECT_TAB_ICON : getTypeIcon(type));
+
+/**
+ * Resolve a dnd-kit drag-end event to a `[activeId, overId]` reorder pair,
+ * or null when the drop shouldn't reorder (no target / dropped on itself).
+ * Exported for unit tests — the gesture itself is covered by the Playwright
+ * story (workspace-tabs-shortcuts.spec.mjs).
+ */
+export const tabDragEndToReorder = event => {
+  const activeId = event?.active?.id;
+  const overId = event?.over?.id;
+  if (!activeId || !overId || activeId === overId) return null;
+  return [activeId, overId];
+};
 
 /**
  * WorkspaceTab — a single tab in the strip (presentational).
@@ -83,6 +106,49 @@ const WorkspaceTab = ({ tab, active, onSelect, onClose, isDragging }) => {
 };
 
 /**
+ * DraggableTab — wraps a WorkspaceTab as BOTH a dnd-kit drag source and a
+ * drop target keyed on the tab id (VIS-812 / O-3). The PointerSensor's
+ * distance constraint keeps plain clicks flowing to the select/close
+ * buttons; only an actual horizontal pull starts the reorder. The dragged
+ * tab ghosts in place; the hovered target paints the 2-px mulberry slot
+ * indicator on its left edge (per the B-1 design).
+ */
+const DraggableTab = ({ tab, active, onSelect, onClose, isDragging, isDropTarget, scrollRef }) => {
+  const drag = useDraggable({ id: tab.id });
+  const drop = useDroppable({ id: tab.id });
+  const setRefs = el => {
+    drag.setNodeRef(el);
+    drop.setNodeRef(el);
+    if (scrollRef) scrollRef(el);
+  };
+  return (
+    <div
+      ref={setRefs}
+      {...drag.listeners}
+      {...drag.attributes}
+      data-testid={`workspace-tab-wrapper-${tab.id}`}
+      className="relative"
+      style={{ touchAction: 'none' }}
+    >
+      {isDropTarget && (
+        <span
+          aria-hidden="true"
+          data-testid={`workspace-tab-drop-slot-${tab.id}`}
+          className="pointer-events-none absolute inset-y-1 left-0 z-10 w-0.5 rounded-full bg-primary"
+        />
+      )}
+      <WorkspaceTab
+        tab={tab}
+        active={active}
+        onSelect={onSelect}
+        onClose={onClose}
+        isDragging={isDragging}
+      />
+    </div>
+  );
+};
+
+/**
  * TabStrip — h-9 white bar between the top bar and the middle/right area.
  *
  * Sits OVER the middle + right rail only — the left rail anchors full-height.
@@ -90,30 +156,46 @@ const WorkspaceTab = ({ tab, active, onSelect, onClose, isDragging }) => {
  * right rail), not the project-wide Library.
  *
  * Reads tabs + active id + actions directly from the workspace store — no
- * prop-drilling from the route container. Phase 0 supports: open project
- * tab on mount, click-to-switch, close, AND drag-to-reorder (native HTML5
- * drag, no extra dep — dispatches `reorderWorkspaceTabs` on drop). Per the
- * B-1 design, the dragged tab gets the ghost styling and the drop target
- * gets a 2-px mulberry slot indicator on its left edge.
+ * prop-drilling from the route container. Supports: open project tab on
+ * mount, click-to-switch, close-through-the-dirty-guard (VIS-812 — the ×
+ * routes through `requestCloseWorkspaceTab`, so dirty tabs raise the
+ * confirmation dialog), drag-to-reorder via a strip-local dnd-kit context
+ * (pointer-driven, so it's exercisable with a real cursor), and horizontal
+ * overflow scrolling with the active tab kept in view.
  */
 const TabStrip = () => {
   const tabs = useStore(s => s.workspaceTabs);
   const activeId = useStore(s => s.workspaceActiveTabId);
   const switchWorkspaceTab = useStore(s => s.switchWorkspaceTab);
-  const closeWorkspaceTab = useStore(s => s.closeWorkspaceTab);
+  const requestCloseWorkspaceTab = useStore(s => s.requestCloseWorkspaceTab);
   const reorderWorkspaceTabs = useStore(s => s.reorderWorkspaceTabs);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const project = useStore(s => s.project);
 
+  // Live drag state for the ghost + slot-indicator styling.
   const [draggedId, setDraggedId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
+
+  // Distance constraint: a plain click never starts a drag, so the tab's
+  // select/close buttons keep working without stopPropagation gymnastics.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+
+  // Keep the active tab visible when the strip overflows (>8 tabs scroll).
+  const tabElsRef = useRef(new Map());
+  useEffect(() => {
+    const el = tabElsRef.current.get(activeId);
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+    }
+  }, [activeId]);
 
   if (!tabs || tabs.length === 0) return null;
 
   const projectName = project?.project_json?.name || project?.name || 'project';
 
-  // Defer real "open in new tab" semantics to VIS-O2; the + button is a
-  // visual affordance for now. Focus the project tab as a sane default.
+  // The + affordance (and Cmd/Ctrl+T) opens the Workspace's "empty tab" —
+  // the unscoped project tab. The project is a first-class single-instance
+  // tab per the delivered B-1 design, so repeated presses focus it.
   const handleNewTab = () =>
     openWorkspaceTab({
       id: `project:${projectName}`,
@@ -121,30 +203,20 @@ const TabStrip = () => {
       name: projectName,
     });
 
-  const handleDragStart = (e, tab) => {
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', tab.id);
-    setDraggedId(tab.id);
+  const handleDragStart = event => {
+    setDraggedId(event.active?.id || null);
   };
-  const handleDragOver = (e, tab) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    if (tab.id !== draggedId && dragOverId !== tab.id) {
-      setDragOverId(tab.id);
-    }
+  const handleDragOver = event => {
+    const overId = event.over?.id || null;
+    setDragOverId(overId === event.active?.id ? null : overId);
   };
-  const handleDrop = (e, tab) => {
-    e.preventDefault();
-    const sourceId =
-      (e.dataTransfer && e.dataTransfer.getData && e.dataTransfer.getData('text/plain')) ||
-      draggedId;
-    if (sourceId && sourceId !== tab.id) {
-      reorderWorkspaceTabs(sourceId, tab.id);
-    }
+  const handleDragEnd = event => {
+    const pair = tabDragEndToReorder(event);
+    if (pair) reorderWorkspaceTabs(pair[0], pair[1]);
     setDraggedId(null);
     setDragOverId(null);
   };
-  const handleDragEnd = () => {
+  const handleDragCancel = () => {
     setDraggedId(null);
     setDragOverId(null);
   };
@@ -156,38 +228,31 @@ const TabStrip = () => {
       aria-label="Workspace tabs"
       className="relative flex h-9 shrink-0 items-stretch border-b border-gray-200 bg-gray-50"
     >
-      <div className="flex flex-1 items-stretch overflow-x-auto">
-        {tabs.map(tab => {
-          const isDragging = tab.id === draggedId;
-          const isDropTarget = tab.id === dragOverId && dragOverId !== draggedId;
-          return (
-            <div
+      <div className="flex flex-1 items-stretch overflow-x-auto overflow-y-hidden">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          {tabs.map(tab => (
+            <DraggableTab
               key={tab.id}
-              draggable
-              onDragStart={e => handleDragStart(e, tab)}
-              onDragOver={e => handleDragOver(e, tab)}
-              onDrop={e => handleDrop(e, tab)}
-              onDragEnd={handleDragEnd}
-              data-testid={`workspace-tab-wrapper-${tab.id}`}
-              className="relative"
-            >
-              {isDropTarget && (
-                <span
-                  aria-hidden="true"
-                  data-testid={`workspace-tab-drop-slot-${tab.id}`}
-                  className="pointer-events-none absolute inset-y-1 left-0 z-10 w-0.5 rounded-full bg-primary"
-                />
-              )}
-              <WorkspaceTab
-                tab={tab}
-                active={tab.id === activeId}
-                onSelect={switchWorkspaceTab}
-                onClose={closeWorkspaceTab}
-                isDragging={isDragging}
-              />
-            </div>
-          );
-        })}
+              tab={tab}
+              active={tab.id === activeId}
+              onSelect={switchWorkspaceTab}
+              onClose={requestCloseWorkspaceTab}
+              isDragging={tab.id === draggedId}
+              isDropTarget={tab.id === dragOverId && dragOverId !== draggedId}
+              scrollRef={el => {
+                if (el) tabElsRef.current.set(tab.id, el);
+                else tabElsRef.current.delete(tab.id);
+              }}
+            />
+          ))}
+        </DndContext>
         <button
           type="button"
           onClick={handleNewTab}
@@ -199,6 +264,7 @@ const TabStrip = () => {
           <PiPlus className="h-3.5 w-3.5" />
         </button>
       </div>
+      <TabCloseConfirmDialog />
     </div>
   );
 };

--- a/viewer/src/components/new-views/workspace/TabStrip.test.jsx
+++ b/viewer/src/components/new-views/workspace/TabStrip.test.jsx
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import TabStrip from './TabStrip';
+import TabStrip, { tabDragEndToReorder } from './TabStrip';
 import useStore from '../../../stores/store';
 
 const sampleTabs = [
@@ -26,8 +26,10 @@ const seedStore = (extra = {}) => {
     useStore.setState({
       workspaceTabs: sampleTabs,
       workspaceActiveTabId: null,
+      workspacePendingCloseTabId: null,
       switchWorkspaceTab: jest.fn(),
       closeWorkspaceTab: jest.fn(),
+      requestCloseWorkspaceTab: jest.fn(),
       openWorkspaceTab: jest.fn(),
       project: { id: 'p1', project_json: { name: 'analytics-platform' } },
       ...extra,
@@ -37,16 +39,7 @@ const seedStore = (extra = {}) => {
 
 describe('TabStrip', () => {
   test('renders nothing when there are no tabs', () => {
-    act(() => {
-      useStore.setState({
-        workspaceTabs: [],
-        workspaceActiveTabId: null,
-        switchWorkspaceTab: jest.fn(),
-        closeWorkspaceTab: jest.fn(),
-        openWorkspaceTab: jest.fn(),
-        project: null,
-      });
-    });
+    seedStore({ workspaceTabs: [], project: null });
     const { container } = render(<TabStrip />);
     expect(container).toBeEmptyDOMElement();
   });
@@ -86,45 +79,55 @@ describe('TabStrip', () => {
     expect(switchWorkspaceTab).toHaveBeenCalledWith('chart:revenue_chart');
   });
 
-  test('clicking the close button calls closeWorkspaceTab without firing select', () => {
+  test('clicking the close button routes through requestCloseWorkspaceTab (dirty guard) without firing select', () => {
     const switchWorkspaceTab = jest.fn();
     const closeWorkspaceTab = jest.fn();
-    seedStore({ switchWorkspaceTab, closeWorkspaceTab });
+    const requestCloseWorkspaceTab = jest.fn();
+    seedStore({ switchWorkspaceTab, closeWorkspaceTab, requestCloseWorkspaceTab });
     render(<TabStrip />);
     fireEvent.click(
       screen.getByTestId('workspace-tab-close-dashboard:simple-dashboard')
     );
-    expect(closeWorkspaceTab).toHaveBeenCalledWith('dashboard:simple-dashboard');
-    // stopPropagation in the close handler prevents the underlying select fire.
+    // VIS-812: the × asks the guard (which raises the confirm dialog when
+    // dirty) instead of force-closing.
+    expect(requestCloseWorkspaceTab).toHaveBeenCalledWith('dashboard:simple-dashboard');
+    expect(closeWorkspaceTab).not.toHaveBeenCalled();
     expect(switchWorkspaceTab).not.toHaveBeenCalled();
   });
 
-  test('drag-and-drop dispatches reorderWorkspaceTabs', () => {
-    const reorderWorkspaceTabs = jest.fn();
-    seedStore({ reorderWorkspaceTabs });
+  // Drag-reorder is dnd-kit pointer-driven (VIS-812) — the gesture itself is
+  // covered by the Playwright story; here we pin the drag-end → reorder
+  // resolution and that every tab mounts as a draggable wrapper.
+  test('tabDragEndToReorder resolves a drop to the [active, over] pair', () => {
+    expect(
+      tabDragEndToReorder({ active: { id: 'chart:c' }, over: { id: 'project:p' } })
+    ).toEqual(['chart:c', 'project:p']);
+    // Dropped on itself / nowhere → no reorder.
+    expect(
+      tabDragEndToReorder({ active: { id: 'chart:c' }, over: { id: 'chart:c' } })
+    ).toBeNull();
+    expect(tabDragEndToReorder({ active: { id: 'chart:c' }, over: null })).toBeNull();
+    expect(tabDragEndToReorder(null)).toBeNull();
+  });
+
+  test('every tab renders a draggable wrapper for the strip-local dnd context', () => {
+    seedStore();
     render(<TabStrip />);
-    // dnd-kit isn't used here (native HTML5 drag) — fire the synthetic
-    // events with a hand-rolled dataTransfer.
-    const dataTransfer = {
-      effectAllowed: '',
-      dropEffect: '',
-      _data: '',
-      setData(_, v) {
-        this._data = v;
-      },
-      getData() {
-        return this._data;
-      },
-    };
-    const source = screen.getByTestId('workspace-tab-wrapper-chart:revenue_chart');
-    const target = screen.getByTestId('workspace-tab-wrapper-project:analytics-platform');
-    fireEvent.dragStart(source, { dataTransfer });
-    fireEvent.dragOver(target, { dataTransfer });
-    fireEvent.drop(target, { dataTransfer });
-    expect(reorderWorkspaceTabs).toHaveBeenCalledWith(
-      'chart:revenue_chart',
-      'project:analytics-platform'
-    );
+    sampleTabs.forEach(tab => {
+      expect(screen.getByTestId(`workspace-tab-wrapper-${tab.id}`)).toBeInTheDocument();
+    });
+  });
+
+  test('mounts the dirty-close confirmation dialog when a close is pending', () => {
+    seedStore({
+      workspacePendingCloseTabId: 'dashboard:simple-dashboard',
+      confirmCloseWorkspaceTab: jest.fn(),
+      cancelCloseWorkspaceTab: jest.fn(),
+    });
+    render(<TabStrip />);
+    const dialog = screen.getByTestId('tab-close-confirm-dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent('simple-dashboard');
   });
 
   test('clicking the + button opens the project tab via openWorkspaceTab', () => {

--- a/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
@@ -7,6 +7,7 @@ import MiddlePane from './MiddlePane';
 import DragHandle from './DragHandle';
 import WorkspaceDndContext from './WorkspaceDndContext';
 import ExternalEditBanner from './ExternalEditBanner';
+import useWorkspaceTabShortcuts from './useWorkspaceTabShortcuts';
 import useStore from '../../../stores/store';
 
 /**
@@ -40,6 +41,10 @@ const WorkspaceShell = ({ testId = 'workspace-shell' }) => {
   const rightCollapsed = useStore(s => s.workspaceRightCollapsed);
   const leftWidth = useStore(s => s.workspaceLeftWidth);
   const rightWidth = useStore(s => s.workspaceRightWidth);
+
+  // Tab keyboard shortcuts (VIS-812 / O-3): Cmd/Ctrl+T new tab, Cmd/Ctrl+W
+  // close active (through the dirty guard), Cmd/Ctrl+1..9 switch by position.
+  useWorkspaceTabShortcuts();
 
   return (
     <div

--- a/viewer/src/components/new-views/workspace/library/Library.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.jsx
@@ -50,6 +50,7 @@ const Library = () => {
   // Workspace actions — read from the store directly so the Library has no
   // required props (the parent LeftRail mounts it as `<Library />`).
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  const openWorkspaceTabBackground = useStore(s => s.openWorkspaceTabBackground);
   const toggleLeftCollapsed = useStore(s => s.toggleWorkspaceLeftCollapsed);
 
   // The active workspace tab's id is the selected row's id — both are
@@ -82,14 +83,27 @@ const Library = () => {
     [openWorkspaceTab]
   );
 
-  const handleContextAction = useCallback((action, obj) => {
-    // Track G wires the actual handlers; for C3 we just emit telemetry.
-    emitWorkspaceEvent('library_row_context_action', {
-      type: obj.type,
-      name: obj.name,
-      action,
-    });
-  }, []);
+  const handleContextAction = useCallback(
+    (action, obj) => {
+      emitWorkspaceEvent('library_row_context_action', {
+        type: obj.type,
+        name: obj.name,
+        action,
+      });
+      // VIS-811 / O-2: the open actions are live; the rest (wrapInChart,
+      // showLineage, delete) stay telemetry-only until their tracks wire them.
+      if (action === 'edit' && openWorkspaceTab) {
+        openWorkspaceTab({ id: `${obj.type}:${obj.name}`, type: obj.type, name: obj.name });
+      } else if (action === 'openInNewTab' && openWorkspaceTabBackground) {
+        openWorkspaceTabBackground({
+          id: `${obj.type}:${obj.name}`,
+          type: obj.type,
+          name: obj.name,
+        });
+      }
+    },
+    [openWorkspaceTab, openWorkspaceTabBackground]
+  );
 
   const handleCreate = useCallback(
     typeKey => {

--- a/viewer/src/components/new-views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.test.jsx
@@ -288,6 +288,48 @@ describe('Library', () => {
     expect(openWorkspaceTabBackground).not.toHaveBeenCalled();
   });
 
+  test('a mousedown INSIDE the row menu does not dismiss it (real-cursor click sequence)', () => {
+    const openWorkspaceTabBackground = jest.fn();
+    seedStore({ openWorkspaceTab: jest.fn(), openWorkspaceTabBackground });
+    renderLibrary();
+
+    fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
+    const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
+    const item = within(menu).getByText('Open in new tab');
+
+    // A REAL cursor fires mousedown → mouseup → click. If the mousedown
+    // dismisses (unmounts) the menu, the click never lands and the action is
+    // a silent no-op — exactly the VIS-811 e2e regression this pins.
+    fireEvent.mouseDown(item);
+    expect(
+      screen.getByTestId('library-row-chart-waterfall-context-menu')
+    ).toBeInTheDocument();
+    fireEvent.mouseUp(item);
+    fireEvent.click(item);
+    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
+      id: 'chart:waterfall',
+      type: 'chart',
+      name: 'waterfall',
+    });
+    // The action itself dismisses the menu.
+    expect(
+      screen.queryByTestId('library-row-chart-waterfall-context-menu')
+    ).not.toBeInTheDocument();
+  });
+
+  test('a mousedown OUTSIDE the row menu still dismisses it', () => {
+    seedStore({ openWorkspaceTab: jest.fn(), openWorkspaceTabBackground: jest.fn() });
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
+    expect(
+      screen.getByTestId('library-row-chart-waterfall-context-menu')
+    ).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(
+      screen.queryByTestId('library-row-chart-waterfall-context-menu')
+    ).not.toBeInTheDocument();
+  });
+
   test('row context actions still emit library_row_context_action telemetry', () => {
     const events = [];
     const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));

--- a/viewer/src/components/new-views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/new-views/workspace/library/Library.test.jsx
@@ -13,7 +13,7 @@
  *   - "+ New X" delegates to the corresponding store opener + telemetry.
  */
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import {
   createMemoryRouter,
   Route,
@@ -248,6 +248,60 @@ describe('Library', () => {
       type: 'source',
       name: 'local-duck',
     });
+  });
+
+  // Right-click context actions (VIS-811 / Track O O-2) ----------------------
+
+  test('row context "Open in new tab" background-opens (openWorkspaceTabBackground), not openWorkspaceTab', () => {
+    const openWorkspaceTab = jest.fn();
+    const openWorkspaceTabBackground = jest.fn();
+    seedStore({ openWorkspaceTab, openWorkspaceTabBackground });
+    renderLibrary();
+
+    fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
+    const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
+    fireEvent.click(within(menu).getByText('Open in new tab'));
+
+    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
+      id: 'chart:waterfall',
+      type: 'chart',
+      name: 'waterfall',
+    });
+    expect(openWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('row context "Open in right rail" focuses the tab via openWorkspaceTab', () => {
+    const openWorkspaceTab = jest.fn();
+    const openWorkspaceTabBackground = jest.fn();
+    seedStore({ openWorkspaceTab, openWorkspaceTabBackground });
+    renderLibrary();
+
+    fireEvent.contextMenu(screen.getByTestId('library-row-model-monthly_revenue'));
+    const menu = screen.getByTestId('library-row-model-monthly_revenue-context-menu');
+    fireEvent.click(within(menu).getByText('Open in right rail'));
+
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'model:monthly_revenue',
+      type: 'model',
+      name: 'monthly_revenue',
+    });
+    expect(openWorkspaceTabBackground).not.toHaveBeenCalled();
+  });
+
+  test('row context actions still emit library_row_context_action telemetry', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    seedStore({ openWorkspaceTab: jest.fn(), openWorkspaceTabBackground: jest.fn() });
+    renderLibrary();
+
+    fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
+    const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
+    fireEvent.click(within(menu).getByText('Open in new tab'));
+
+    const ctx = events.find(e => e.eventName === 'library_row_context_action');
+    expect(ctx).toBeTruthy();
+    expect(ctx.payload).toEqual({ type: 'chart', name: 'waterfall', action: 'openInNewTab' });
+    unsubscribe();
   });
 
   test('clicking a dashboard row scopes the workspace to that dashboard (VIS-824)', () => {

--- a/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/new-views/workspace/library/LibraryRow.jsx
@@ -121,6 +121,7 @@ const ContextMenu = ({ obj, onAction, onDismiss }) => {
   return (
     <div
       role="menu"
+      data-library-row-menu="true"
       data-testid={`library-row-${obj.type}-${obj.name}-context-menu`}
       className="absolute right-0 top-full z-30 mt-1 w-56 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-gray-200"
     >
@@ -237,10 +238,16 @@ const LibraryRow = ({ obj, selected = false, draggable = true, onClick, onContex
   const handleMenuDismiss = useCallback(() => setMenuOpen(false), []);
   const handlePopoverClose = useCallback(() => setPopoverOpen(false), []);
 
-  // Dismiss menu on outside click.
+  // Dismiss menu on outside click. Mousedowns INSIDE the menu must not
+  // dismiss it — with a real cursor the native mousedown precedes the click,
+  // and unmounting the item between the two means its onClick never fires
+  // (VIS-811: this made every menu action a silent no-op outside jsdom).
   React.useEffect(() => {
     if (!menuOpen) return undefined;
-    const onDoc = () => setMenuOpen(false);
+    const onDoc = e => {
+      if (e.target?.closest?.('[data-library-row-menu="true"]')) return;
+      setMenuOpen(false);
+    };
     document.addEventListener('mousedown', onDoc);
     return () => document.removeEventListener('mousedown', onDoc);
   }, [menuOpen]);

--- a/viewer/src/components/new-views/workspace/useWorkspaceTabShortcuts.js
+++ b/viewer/src/components/new-views/workspace/useWorkspaceTabShortcuts.js
@@ -1,0 +1,92 @@
+import { useEffect } from 'react';
+import useStore from '../../../stores/store';
+
+/**
+ * useWorkspaceTabShortcuts — VIS-812 / Track O O-3.
+ *
+ * Workspace tab keyboard shortcuts, mounted once by the WorkspaceShell:
+ *
+ *   - Cmd/Ctrl+T     → new tab (the unscoped project tab — the Workspace's
+ *                      "empty tab", matching the strip's + affordance).
+ *   - Cmd/Ctrl+W     → close the active tab THROUGH the dirty guard
+ *                      (`requestCloseWorkspaceTab` → confirm dialog if dirty).
+ *   - Cmd/Ctrl+1..9  → switch to the tab at that strip position.
+ *
+ * Modifier: metaKey on macOS, ctrlKey elsewhere. Shortcuts are suppressed
+ * while focus is in an input / textarea / select / contenteditable so the
+ * browser's own editing shortcuts are never clobbered, and any combo with
+ * Alt or Shift is left alone (those are browser/system chords).
+ */
+
+/** Mac detection — exported for tests. `navigator.platform` is deprecated but
+ *  still the most reliable signal; fall back to the UA string. */
+export const isMacPlatform = () => {
+  if (typeof navigator === 'undefined') return false;
+  const probe = navigator.platform || navigator.userAgent || '';
+  return /Mac|iPhone|iPad|iPod/i.test(probe);
+};
+
+/** Should the shortcut layer ignore this event target? Exported for tests. */
+export const isEditableTarget = (el) => {
+  if (!el || !el.tagName) return false;
+  const tag = el.tagName.toUpperCase();
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || !!el.isContentEditable;
+};
+
+/**
+ * The pure keydown handler — exported so tests can drive it without
+ * mounting a component. `store` is the zustand state (getState()).
+ */
+export const handleTabShortcut = (e, store, { mac = isMacPlatform() } = {}) => {
+  const mod = mac ? e.metaKey : e.ctrlKey;
+  if (!mod || e.altKey || e.shiftKey) return false;
+  if (isEditableTarget(e.target)) return false;
+
+  const key = typeof e.key === 'string' ? e.key.toLowerCase() : '';
+
+  if (key === 't') {
+    e.preventDefault();
+    const project = store.project;
+    const projectName = project?.project_json?.name || project?.name || 'project';
+    if (store.openWorkspaceTab) {
+      store.openWorkspaceTab({
+        id: `project:${projectName}`,
+        type: 'project',
+        name: projectName,
+      });
+    }
+    return true;
+  }
+
+  if (key === 'w') {
+    e.preventDefault();
+    if (store.workspaceActiveTabId && store.requestCloseWorkspaceTab) {
+      store.requestCloseWorkspaceTab(store.workspaceActiveTabId);
+    }
+    return true;
+  }
+
+  if (/^[1-9]$/.test(key)) {
+    const tab = (store.workspaceTabs || [])[Number(key) - 1];
+    if (tab && store.switchWorkspaceTab) {
+      e.preventDefault();
+      store.switchWorkspaceTab(tab.id);
+      return true;
+    }
+    return false;
+  }
+
+  return false;
+};
+
+const useWorkspaceTabShortcuts = () => {
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      handleTabShortcut(e, useStore.getState());
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+};
+
+export default useWorkspaceTabShortcuts;

--- a/viewer/src/components/new-views/workspace/useWorkspaceTabShortcuts.test.jsx
+++ b/viewer/src/components/new-views/workspace/useWorkspaceTabShortcuts.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * useWorkspaceTabShortcuts (VIS-812 / Track O O-3).
+ *
+ * Covers the pure `handleTabShortcut` dispatcher (mod resolution per
+ * platform, editable-target suppression, all three shortcut families) plus a
+ * mounted integration pass driving real window keydown events through the
+ * hook into the store.
+ */
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import useWorkspaceTabShortcuts, {
+  handleTabShortcut,
+  isEditableTarget,
+} from './useWorkspaceTabShortcuts';
+import useStore from '../../../stores/store';
+
+const makeEvent = (overrides = {}) => ({
+  key: 't',
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  target: document.body,
+  preventDefault: jest.fn(),
+  ...overrides,
+});
+
+const makeStore = (overrides = {}) => ({
+  project: { project_json: { name: 'analytics' } },
+  workspaceTabs: [
+    { id: 'project:analytics', type: 'project', name: 'analytics' },
+    { id: 'chart:c1', type: 'chart', name: 'c1' },
+    { id: 'table:t1', type: 'table', name: 't1' },
+  ],
+  workspaceActiveTabId: 'chart:c1',
+  openWorkspaceTab: jest.fn(),
+  requestCloseWorkspaceTab: jest.fn(),
+  switchWorkspaceTab: jest.fn(),
+  ...overrides,
+});
+
+describe('handleTabShortcut (pure dispatcher)', () => {
+  test('Cmd+T on mac opens the project tab (the "new empty tab")', () => {
+    const store = makeStore();
+    const e = makeEvent({ key: 't', metaKey: true });
+    expect(handleTabShortcut(e, store, { mac: true })).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(store.openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'project:analytics',
+      type: 'project',
+      name: 'analytics',
+    });
+  });
+
+  test('Ctrl+T on non-mac is the modifier; Cmd is ignored there', () => {
+    const store = makeStore();
+    expect(
+      handleTabShortcut(makeEvent({ key: 't', ctrlKey: true }), store, { mac: false })
+    ).toBe(true);
+    expect(store.openWorkspaceTab).toHaveBeenCalledTimes(1);
+    // metaKey alone on non-mac → not our shortcut.
+    expect(
+      handleTabShortcut(makeEvent({ key: 't', metaKey: true }), store, { mac: false })
+    ).toBe(false);
+    expect(store.openWorkspaceTab).toHaveBeenCalledTimes(1);
+  });
+
+  test('Cmd+W closes the ACTIVE tab through the dirty guard', () => {
+    const store = makeStore();
+    const e = makeEvent({ key: 'w', metaKey: true });
+    expect(handleTabShortcut(e, store, { mac: true })).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(store.requestCloseWorkspaceTab).toHaveBeenCalledWith('chart:c1');
+  });
+
+  test('Cmd+W with no active tab still claims the shortcut but closes nothing', () => {
+    const store = makeStore({ workspaceActiveTabId: null });
+    expect(handleTabShortcut(makeEvent({ key: 'w', metaKey: true }), store, { mac: true })).toBe(
+      true
+    );
+    expect(store.requestCloseWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('Cmd+1..9 switches by strip position; out-of-range digits are left to the browser', () => {
+    const store = makeStore();
+    const e2 = makeEvent({ key: '2', metaKey: true });
+    expect(handleTabShortcut(e2, store, { mac: true })).toBe(true);
+    expect(e2.preventDefault).toHaveBeenCalled();
+    expect(store.switchWorkspaceTab).toHaveBeenCalledWith('chart:c1');
+
+    const e9 = makeEvent({ key: '9', metaKey: true });
+    expect(handleTabShortcut(e9, store, { mac: true })).toBe(false);
+    expect(e9.preventDefault).not.toHaveBeenCalled();
+    expect(store.switchWorkspaceTab).toHaveBeenCalledTimes(1);
+  });
+
+  test('shortcuts are suppressed while typing in editable targets', () => {
+    const store = makeStore();
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const editable = document.createElement('div');
+    Object.defineProperty(editable, 'isContentEditable', { value: true });
+
+    [input, textarea, editable].forEach(target => {
+      expect(
+        handleTabShortcut(makeEvent({ key: 'w', metaKey: true, target }), store, { mac: true })
+      ).toBe(false);
+    });
+    expect(store.requestCloseWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('chords with Shift or Alt are never claimed (browser/system shortcuts)', () => {
+    const store = makeStore();
+    expect(
+      handleTabShortcut(makeEvent({ key: 't', metaKey: true, shiftKey: true }), store, {
+        mac: true,
+      })
+    ).toBe(false);
+    expect(
+      handleTabShortcut(makeEvent({ key: 'w', metaKey: true, altKey: true }), store, {
+        mac: true,
+      })
+    ).toBe(false);
+    expect(store.openWorkspaceTab).not.toHaveBeenCalled();
+    expect(store.requestCloseWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('plain keys without the modifier are ignored', () => {
+    const store = makeStore();
+    expect(handleTabShortcut(makeEvent({ key: 't' }), store, { mac: true })).toBe(false);
+    expect(store.openWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('isEditableTarget recognises selects and rejects plain divs', () => {
+    expect(isEditableTarget(document.createElement('select'))).toBe(true);
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('useWorkspaceTabShortcuts (mounted)', () => {
+  const Harness = () => {
+    useWorkspaceTabShortcuts();
+    return null;
+  };
+
+  test('window keydown reaches the store through the hook', () => {
+    const switchWorkspaceTab = jest.fn();
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [
+          { id: 'project:p', type: 'project', name: 'p' },
+          { id: 'chart:c1', type: 'chart', name: 'c1' },
+        ],
+        workspaceActiveTabId: 'project:p',
+        switchWorkspaceTab,
+      });
+    });
+    render(<Harness />);
+    // jsdom reports no mac platform → ctrlKey is the modifier.
+    fireEvent.keyDown(window, { key: '2', ctrlKey: true });
+    expect(switchWorkspaceTab).toHaveBeenCalledWith('chart:c1');
+  });
+
+  test('the listener is removed on unmount', () => {
+    const switchWorkspaceTab = jest.fn();
+    act(() => {
+      useStore.setState({
+        workspaceTabs: [{ id: 'chart:c1', type: 'chart', name: 'c1' }],
+        workspaceActiveTabId: 'chart:c1',
+        switchWorkspaceTab,
+      });
+    });
+    const { unmount } = render(<Harness />);
+    unmount();
+    fireEvent.keyDown(window, { key: '1', ctrlKey: true });
+    expect(switchWorkspaceTab).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -116,6 +116,30 @@ const createWorkspaceSlice = (set, get) => ({
     return id;
   },
 
+  /**
+   * Open a tab WITHOUT focusing it (VIS-811 / O-2). The convention for
+   * right-click "Open in new tab": the tab joins the strip in the background
+   * and the current context is untouched (per the Track O spec — "creates a
+   * new tab; clicking the tab switches the workspace context"). If the tab
+   * is already open this is a no-op (it keeps its position and focus stays
+   * where it is). Returns the tab id, or null on bad input.
+   */
+  openWorkspaceTabBackground: (tab) => {
+    if (!tab || !tab.type || !tab.name) return null;
+    const id = tab.id || `${tab.type}:${tab.name}`;
+    const state = get();
+    if (state.workspaceTabs.some((t) => t.id === id)) return id;
+    const next = { id, type: tab.type, name: tab.name, dirty: !!tab.dirty };
+    emitWorkspaceEvent('tab_opened', {
+      id,
+      type: tab.type,
+      name: tab.name,
+      background: true,
+    });
+    set({ workspaceTabs: [...state.workspaceTabs, next] });
+    return id;
+  },
+
   /** Focus a tab by id without opening anything new. No-op if id unknown. */
   switchWorkspaceTab: (tabId) => {
     const state = get();

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -47,6 +47,10 @@ const createWorkspaceSlice = (set, get) => ({
   workspaceActiveTabId: null,
   workspaceActiveObject: null, // `{ type, name }` mirror of the active tab.
 
+  // Dirty-close confirmation (VIS-812 / O-3): the tab id awaiting the user's
+  // confirm/cancel in the close dialog, or null when no close is pending.
+  workspacePendingCloseTabId: null,
+
   // Rails -------------------------------------------------------------------
   workspaceLeftCollapsed: false,
   workspaceRightCollapsed: false,
@@ -187,7 +191,42 @@ const createWorkspaceSlice = (set, get) => ({
       workspaceTabs: remaining,
       workspaceActiveTabId: activeId,
       workspaceActiveObject: activeObject,
+      // A tab closed by any path can't stay parked in the confirm dialog.
+      workspacePendingCloseTabId:
+        state.workspacePendingCloseTabId === tabId ? null : state.workspacePendingCloseTabId,
     });
+  },
+
+  /**
+   * Close a tab THROUGH the dirty guard (VIS-812 / O-3). Clean tabs close
+   * immediately; dirty tabs park their id in `workspacePendingCloseTabId`
+   * so the TabStrip's confirmation dialog can ask first. The × button and
+   * Cmd/Ctrl+W both route through here; `closeWorkspaceTab` stays the
+   * unguarded primitive (the dialog's "Close without saving" calls it).
+   */
+  requestCloseWorkspaceTab: (tabId) => {
+    const state = get();
+    const tab = state.workspaceTabs.find((t) => t.id === tabId);
+    if (!tab) return;
+    if (tab.dirty) {
+      set({ workspacePendingCloseTabId: tabId });
+      return;
+    }
+    state.closeWorkspaceTab(tabId);
+  },
+
+  /** Confirm the pending dirty close — closes the tab and clears the pending id. */
+  confirmCloseWorkspaceTab: () => {
+    const state = get();
+    const tabId = state.workspacePendingCloseTabId;
+    if (!tabId) return;
+    set({ workspacePendingCloseTabId: null });
+    state.closeWorkspaceTab(tabId);
+  },
+
+  /** Cancel the pending dirty close — the tab stays open and dirty. */
+  cancelCloseWorkspaceTab: () => {
+    set({ workspacePendingCloseTabId: null });
   },
 
   /**

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -90,6 +90,9 @@ const createWorkspaceSlice = (set, get) => ({
     const existing = state.workspaceTabs.find((t) => t.id === id);
     const activeObject = { type: tab.type, name: tab.name };
     if (existing) {
+      if (state.workspaceActiveTabId !== id) {
+        emitWorkspaceEvent('tab_switched', { id, type: tab.type, name: tab.name, via: 'open' });
+      }
       set({ workspaceActiveTabId: id, workspaceActiveObject: activeObject });
       return id;
     }
@@ -99,6 +102,12 @@ const createWorkspaceSlice = (set, get) => ({
       name: tab.name,
       dirty: !!tab.dirty,
     };
+    emitWorkspaceEvent('tab_opened', {
+      id,
+      type: tab.type,
+      name: tab.name,
+      background: false,
+    });
     set({
       workspaceTabs: [...state.workspaceTabs, next],
       workspaceActiveTabId: id,
@@ -112,6 +121,9 @@ const createWorkspaceSlice = (set, get) => ({
     const state = get();
     const tab = state.workspaceTabs.find((t) => t.id === tabId);
     if (!tab) return;
+    if (state.workspaceActiveTabId !== tabId) {
+      emitWorkspaceEvent('tab_switched', { id: tabId, type: tab.type, name: tab.name });
+    }
     set({
       workspaceActiveTabId: tabId,
       workspaceActiveObject: { type: tab.type, name: tab.name },
@@ -127,6 +139,13 @@ const createWorkspaceSlice = (set, get) => ({
     const state = get();
     const idx = state.workspaceTabs.findIndex((t) => t.id === tabId);
     if (idx === -1) return;
+    const closing = state.workspaceTabs[idx];
+    emitWorkspaceEvent('tab_closed', {
+      id: tabId,
+      type: closing.type,
+      name: closing.name,
+      dirty: !!closing.dirty,
+    });
     const remaining = state.workspaceTabs.filter((t) => t.id !== tabId);
     let activeId = state.workspaceActiveTabId;
     let activeObject = state.workspaceActiveObject;

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -58,6 +58,61 @@ describe('workspace store slice', () => {
     expect(s.workspaceActiveTabId).toBe('dashboard:simple-dashboard');
   });
 
+  // Background open (VIS-811 / Track O O-2) ---------------------------------
+
+  test('openWorkspaceTabBackground adds a tab WITHOUT focusing it', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTabBackground({ type: 'chart', name: 'c1' });
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs.map((t) => t.id)).toEqual(['dashboard:d1', 'chart:c1']);
+    // Focus and the active-object mirror are untouched.
+    expect(s.workspaceActiveTabId).toBe('dashboard:d1');
+    expect(s.workspaceActiveObject).toEqual({ type: 'dashboard', name: 'd1' });
+  });
+
+  test('openWorkspaceTabBackground works with no tabs open (adds without activating)', () => {
+    let returned;
+    act(() => {
+      returned = useStore.getState().openWorkspaceTabBackground({ type: 'chart', name: 'c1' });
+    });
+    const s = useStore.getState();
+    expect(returned).toBe('chart:c1');
+    expect(s.workspaceTabs).toHaveLength(1);
+    expect(s.workspaceActiveTabId).toBeNull();
+  });
+
+  test('openWorkspaceTabBackground is a no-op when the tab already exists', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+    });
+    let returned;
+    act(() => {
+      returned = useStore.getState().openWorkspaceTabBackground({ type: 'chart', name: 'c1' });
+    });
+    const s = useStore.getState();
+    expect(returned).toBe('chart:c1');
+    expect(s.workspaceTabs).toHaveLength(2);
+    // Existing tab keeps its position; focus untouched.
+    expect(s.workspaceTabs[0].id).toBe('chart:c1');
+    expect(s.workspaceActiveTabId).toBe('dashboard:d1');
+  });
+
+  test('openWorkspaceTabBackground rejects bad input', () => {
+    let returned;
+    act(() => {
+      returned = useStore.getState().openWorkspaceTabBackground({ type: 'chart' });
+    });
+    expect(returned).toBeNull();
+    act(() => {
+      returned = useStore.getState().openWorkspaceTabBackground(null);
+    });
+    expect(returned).toBeNull();
+    expect(useStore.getState().workspaceTabs).toHaveLength(0);
+  });
+
   test('switchWorkspaceTab focuses an existing tab; no-op for unknown ids', () => {
     act(() => {
       useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
@@ -377,6 +432,25 @@ describe('workspace store slice', () => {
     test('closeWorkspaceTab on an unknown id fires nothing', () => {
       act(() => {
         useStore.getState().closeWorkspaceTab('nope:nope');
+      });
+      expect(events).toHaveLength(0);
+    });
+
+    test('openWorkspaceTabBackground fires tab_opened with background: true', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTabBackground({ type: 'chart', name: 'c1' });
+      });
+      expect(events.map(e => e.eventName)).toEqual(['tab_opened']);
+      expect(events[0].payload).toEqual({
+        id: 'chart:c1',
+        type: 'chart',
+        name: 'c1',
+        background: true,
+      });
+      events.length = 0;
+      // Already open → no duplicate event.
+      act(() => {
+        useStore.getState().openWorkspaceTabBackground({ type: 'chart', name: 'c1' });
       });
       expect(events).toHaveLength(0);
     });

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -276,6 +276,112 @@ describe('workspace store slice', () => {
     expect(events.filter(e => e.eventName === 'middle_pane_toggled')).toHaveLength(0);
   });
 
+  // Tab telemetry (VIS-810 / Track O O-1) ------------------------------------
+
+  describe('tab telemetry', () => {
+    let events;
+    let unsubscribe;
+
+    beforeEach(() => {
+      events = [];
+      unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    });
+
+    afterEach(() => {
+      unsubscribe();
+    });
+
+    test('openWorkspaceTab fires tab_opened for a new tab', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      });
+      expect(events.map(e => e.eventName)).toEqual(['tab_opened']);
+      expect(events[0].payload).toEqual({
+        id: 'dashboard:d1',
+        type: 'dashboard',
+        name: 'd1',
+        background: false,
+      });
+    });
+
+    test('openWorkspaceTab on an already-open, non-active tab fires tab_switched (not tab_opened)', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+        useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      });
+      events.length = 0;
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      });
+      expect(events.map(e => e.eventName)).toEqual(['tab_switched']);
+      expect(events[0].payload).toEqual({
+        id: 'dashboard:d1',
+        type: 'dashboard',
+        name: 'd1',
+        via: 'open',
+      });
+    });
+
+    test('openWorkspaceTab on the already-active tab fires nothing', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      });
+      events.length = 0;
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      });
+      expect(events).toHaveLength(0);
+    });
+
+    test('switchWorkspaceTab fires tab_switched only when focus actually changes', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+        useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      });
+      events.length = 0;
+      act(() => {
+        useStore.getState().switchWorkspaceTab('dashboard:d1');
+      });
+      expect(events.map(e => e.eventName)).toEqual(['tab_switched']);
+      events.length = 0;
+      // Already active → no event.
+      act(() => {
+        useStore.getState().switchWorkspaceTab('dashboard:d1');
+      });
+      expect(events).toHaveLength(0);
+      // Unknown id → no event.
+      act(() => {
+        useStore.getState().switchWorkspaceTab('nope:nope');
+      });
+      expect(events).toHaveLength(0);
+    });
+
+    test('closeWorkspaceTab fires tab_closed with the dirty flag', () => {
+      act(() => {
+        useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+        useStore.getState().setWorkspaceTabDirty('dashboard:d1', true);
+      });
+      events.length = 0;
+      act(() => {
+        useStore.getState().closeWorkspaceTab('dashboard:d1');
+      });
+      expect(events.map(e => e.eventName)).toEqual(['tab_closed']);
+      expect(events[0].payload).toEqual({
+        id: 'dashboard:d1',
+        type: 'dashboard',
+        name: 'd1',
+        dirty: true,
+      });
+    });
+
+    test('closeWorkspaceTab on an unknown id fires nothing', () => {
+      act(() => {
+        useStore.getState().closeWorkspaceTab('nope:nope');
+      });
+      expect(events).toHaveLength(0);
+    });
+  });
+
   // Outline tree (VIS-793 / Track F F-3) ------------------------------------
 
   test('setWorkspaceOutlineSelectedKey updates the selection key', () => {

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -14,6 +14,7 @@ const reset = () => {
     useStore.setState({
       workspaceTabs: [],
       workspaceActiveTabId: null,
+      workspacePendingCloseTabId: null,
       workspaceLeftCollapsed: false,
       workspaceRightCollapsed: false,
       workspaceRightTab: 'edit',
@@ -165,6 +166,86 @@ describe('workspace store slice', () => {
     const s = useStore.getState();
     expect(s.workspaceTabs).toHaveLength(0);
     expect(s.workspaceActiveTabId).toBeNull();
+  });
+
+  // Dirty-close guard (VIS-812 / Track O O-3) --------------------------------
+
+  test('requestCloseWorkspaceTab closes a CLEAN tab immediately', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().requestCloseWorkspaceTab('dashboard:d1');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(0);
+    expect(s.workspacePendingCloseTabId).toBeNull();
+  });
+
+  test('requestCloseWorkspaceTab parks a DIRTY tab for confirmation instead of closing', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().setWorkspaceTabDirty('dashboard:d1', true);
+      useStore.getState().requestCloseWorkspaceTab('dashboard:d1');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(1);
+    expect(s.workspacePendingCloseTabId).toBe('dashboard:d1');
+  });
+
+  test('requestCloseWorkspaceTab is a no-op for unknown ids', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().requestCloseWorkspaceTab('nope:nope');
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs).toHaveLength(1);
+    expect(s.workspacePendingCloseTabId).toBeNull();
+  });
+
+  test('confirmCloseWorkspaceTab closes the parked tab and clears the pending id', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().setWorkspaceTabDirty('chart:c1', true);
+      useStore.getState().requestCloseWorkspaceTab('chart:c1');
+      useStore.getState().confirmCloseWorkspaceTab();
+    });
+    const s = useStore.getState();
+    expect(s.workspaceTabs.map((t) => t.id)).toEqual(['dashboard:d1']);
+    expect(s.workspacePendingCloseTabId).toBeNull();
+    // Focus fell back to the surviving tab.
+    expect(s.workspaceActiveTabId).toBe('dashboard:d1');
+  });
+
+  test('confirmCloseWorkspaceTab with nothing pending is a no-op', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().confirmCloseWorkspaceTab();
+    });
+    expect(useStore.getState().workspaceTabs).toHaveLength(1);
+  });
+
+  test('cancelCloseWorkspaceTab keeps the tab open (and still dirty)', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().setWorkspaceTabDirty('chart:c1', true);
+      useStore.getState().requestCloseWorkspaceTab('chart:c1');
+      useStore.getState().cancelCloseWorkspaceTab();
+    });
+    const s = useStore.getState();
+    expect(s.workspacePendingCloseTabId).toBeNull();
+    expect(s.workspaceTabs).toHaveLength(1);
+    expect(s.workspaceTabs[0].dirty).toBe(true);
+  });
+
+  test('closing a parked tab by another path clears the pending id', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().setWorkspaceTabDirty('chart:c1', true);
+      useStore.getState().requestCloseWorkspaceTab('chart:c1');
+      // Force-close (e.g. some other surface) while the dialog is up.
+      useStore.getState().closeWorkspaceTab('chart:c1');
+    });
+    expect(useStore.getState().workspacePendingCloseTabId).toBeNull();
   });
 
   test('setWorkspaceTabDirty toggles the dirty flag without touching others', () => {


### PR DESCRIPTION
## Summary

Track O (Tabbed Workspace navigation) — three issues, one commit each, plus one real-bug fix the new e2e stories caught.

### VIS-810 (O-1) — TabStrip + multi-tab store audit
**Audit result: the delivered B-2 work already covers most of O-1.** The store (`workspaceTabs`, `workspaceActiveTabId`, open/close/switch/reorder/dirty/hydrate) and the mounted TabStrip (type icons via `objectTypeConfigs`, mulberry dirty dot, close ×, active underline, `+` affordance, default project tab on entry) match the B-1 design and the Track O spec. Two real gaps, both fixed:
- **Telemetry**: `tab_opened` / `tab_closed` / `tab_switched` now emit from the store actions (covers every call site). `tab_switched` only fires when focus actually changes; re-opening an existing tab emits `tab_switched (via: open)`, never a duplicate `tab_opened`.
- **Story**: new `tabbed-navigation.spec.mjs` covers the open/close/switch happy path, the dirty dot, and the `+` affordance.

### VIS-811 (O-2) — right-click "Open in new tab" on all four surfaces
- New store action `openWorkspaceTabBackground` — adds the tab WITHOUT stealing focus.
- **Library rows**: the existing menu's "Open in right rail" / "Open in new tab" actions are now live (they were telemetry-only stubs).
- **Canvas items**: `CanvasContextMenu` gains "Open" / "Open in new tab" on chart + table leaves.
- **Lineage nodes**: `LineageNew` gains an `onNodeContextMenu` prop; `LineageCanvas` mounts the new shared `OpenObjectContextMenu`.
- **Project-Editor tiles**: `DashboardTile` right-click mounts the same shared menu.
- **Bug found & fixed by the e2e story**: `LibraryRow`'s document-level mousedown dismiss unmounted the menu before a real cursor's `click` could land — every Library menu action was a silent no-op outside jsdom. Guarded to outside targets only + a unit test pinning the real `mousedown→mouseup→click` sequence.

### VIS-812 (O-3) — tab power features
- **Shortcuts** (`useWorkspaceTabShortcuts`, mounted by the shell): Cmd/Ctrl+T new tab, Cmd/Ctrl+W close-through-the-dirty-guard, Cmd/Ctrl+1..9 switch by position. metaKey on macOS / ctrlKey elsewhere; suppressed in inputs/textareas/contenteditable; Alt/Shift chords never claimed.
- **Drag-to-reorder** converted from native HTML5 drag to a strip-local dnd-kit `DndContext` (PointerSensor, 6px activation) — works with a real cursor and keeps the ghost + mulberry slot indicator.
- **Dirty-close confirmation**: `requestCloseWorkspaceTab` parks dirty tabs in `workspacePendingCloseTabId`; `<TabCloseConfirmDialog>` (highlight palette, focus on the safe action, Escape/backdrop cancel) confirms or cancels. `closeWorkspaceTab` stays the unguarded primitive.
- **Overflow**: strip scrolls horizontally >8 tabs; active tab kept in view via `scrollIntoView`.

## Deviations from ticket wording (with rationale)
- **Background open**: VIS-811's AC says "switches focus to it", but the Track O spec reads "creates a new tab; **clicking the tab** switches the workspace context" — background open is also the browser convention for right-click. Implemented background open per the spec. ("Open" gives the focus-switching variant.)
- **"New empty tab"**: there is no empty-tab concept in the model — `Cmd+T`/`+` open the single-instance unscoped **project tab** (the Workspace's empty surface, per the B-1 "project is a first-class tab" design).
- **Cmd+9** switches to position 9 (spec says "tab N"), not last-tab.

## Test evidence
- **Unit**: 2390 → **2452 passing** (+62 net; 64 added, 2 replaced). Lint 0 errors.
- **e2e (local gate, sandbox :3041)** — all passing:
  - `tabbed-navigation.spec.mjs` (5 tests)
  - `workspace-tabs-context-menu.spec.mjs` (4 tests — Library row, Project-Editor tile, canvas item, lineage node)
  - `workspace-tabs-shortcuts.spec.mjs` (5 tests — shortcuts, input suppression, real-cursor drag-reorder, >8-tab overflow, dirty-close dialog)
- **Adjacent-story regression check** (library, lineage, canvas, previews, flip-expand): green except `lineage-context-scope.spec.mjs` Step 4, which **fails identically on the base branch** (verified by A/B with `git checkout origin/feature/dashboard-building-v1 -- viewer/src`) — pre-existing, not introduced here.
- **Visual validation**: desktop (1440×900) + small (1024×768) screenshots reviewed for the many-tabs/overflow strip, dirty dot, both context menus, and the dirty-close dialog — no contrast or layout issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)