### PR TITLE
feat: H-1 Save/Publish cluster — draft cache → Publish/Discard + live count (VIS-806)

### DIFF
--- a/tests/commands/test_serve_phase.py
+++ b/tests/commands/test_serve_phase.py
@@ -1,7 +1,9 @@
 import os
 import pytest
 from tests.factories.model_factories import (
+    ItemFactory,
     ProjectFactory,
+    RowFactory,
 )
 from tests.support.utils import temp_folder
 from visivo.commands.serve_phase import serve_phase
@@ -79,3 +81,46 @@ def test_serve_phase_handles_dbt_ignore_patterns(test_project, output_dir, serve
     )
 
     assert "mock_dbt_file" in server.ignore_patterns
+
+
+def test_on_project_change_layout_only_edit_refreshes_served_project(
+    test_project, output_dir, server_url, mocker
+):
+    """A layout-only edit produces no runnable DAG diff, but the served project
+    must still refresh (VIS-806). Without it, publishing a dashboard reshape
+    leaves the object managers on the stale published config once the draft
+    cache clears — the canvas silently loses the just-published edit."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    server, on_project_change, _ = serve_phase(
+        output_dir=output_dir,
+        working_dir=".",
+        default_source=None,
+        dag_filter=None,
+        threads=1,
+        skip_compile=True,
+        project=test_project,
+        server_url=server_url,
+    )
+
+    dashboard_name = test_project.dashboards[0].name
+    baseline_rows = len(test_project.dashboards[0].rows)
+
+    # The recompiled project differs only by an empty layout row — exactly the
+    # shape the Build-mode "+ Add row" → Publish flow writes to YAML. The row
+    # and its slots are UNNAMED (like canvas-created empty slots), so they add
+    # no named DAG node and the runnable diff stays empty. Built fresh (not
+    # model_copy) because Project memoizes its dag in a private attr that a
+    # deep copy would carry over, hiding the added row.
+    modified_project = ProjectFactory()
+    modified_project.dashboards[0].rows = list(modified_project.dashboards[0].rows) + [
+        RowFactory(name=None, items=[ItemFactory(name=None, chart=None)])
+    ]
+    mocker.patch("visivo.commands.serve_phase.compile_phase", return_value=modified_project)
+
+    on_project_change()
+
+    client = server.app.test_client()
+    data = client.get("/api/dashboards/").get_json()
+    served = next(d for d in data["dashboards"] if d["name"] == dashboard_name)
+    assert len(served["config"]["rows"]) == baseline_rows + 1

--- a/tests/server/views/test_publish_views.py
+++ b/tests/server/views/test_publish_views.py
@@ -223,3 +223,104 @@ class TestPublishViews:
         # Verify caches were cleared
         app.flask_app.source_manager.clear_cache.assert_called_once()
         app.flask_app.model_manager.clear_cache.assert_called_once()
+
+    @patch("visivo.server.views.publish_views.ProjectWriter")
+    def test_publish_pauses_watcher_around_write_and_refresh(self, mock_writer_class, client, app):
+        """The YAML write + synchronous project refresh must be serialized
+        with the file watcher — a concurrent watcher recompile races the git
+        include cache and leaves the served project stale (VIS-806)."""
+        mock_source = Mock()
+        mock_source.model_dump.return_value = {"name": "new_source", "type": "sqlite"}
+        app.flask_app.source_manager.cached_objects = {"new_source": mock_source}
+        app.flask_app.source_manager.published_objects = {}
+        app.flask_app.source_manager.get_status.return_value = ObjectStatus.NEW
+        app.flask_app.model_manager.cached_objects = {}
+        app.flask_app.model_manager.get_status.return_value = ObjectStatus.PUBLISHED
+        mock_writer_class.return_value = Mock()
+
+        hot_reload = Mock()
+        app.flask_app.hot_reload_server = hot_reload
+
+        response = client.post("/api/publish/")
+
+        assert response.status_code == 200
+        ordered = [
+            c[0]
+            for c in hot_reload.method_calls
+            if c[0] in ("pause_file_watcher", "on_project_change", "resume_file_watcher")
+        ]
+        assert ordered == ["pause_file_watcher", "on_project_change", "resume_file_watcher"]
+
+    @patch("visivo.server.views.publish_views.ProjectWriter")
+    def test_publish_resumes_watcher_when_refresh_throws(self, mock_writer_class, client, app):
+        """resume_file_watcher must run even when the refresh fails — a stuck
+        pause would silently disable hot reload for the rest of the session."""
+        mock_source = Mock()
+        mock_source.model_dump.return_value = {"name": "new_source", "type": "sqlite"}
+        app.flask_app.source_manager.cached_objects = {"new_source": mock_source}
+        app.flask_app.source_manager.published_objects = {}
+        app.flask_app.source_manager.get_status.return_value = ObjectStatus.NEW
+        app.flask_app.model_manager.cached_objects = {}
+        app.flask_app.model_manager.get_status.return_value = ObjectStatus.PUBLISHED
+        mock_writer_class.return_value = Mock()
+
+        hot_reload = Mock()
+        hot_reload.on_project_change.side_effect = RuntimeError("compile blew up")
+        app.flask_app.hot_reload_server = hot_reload
+
+        response = client.post("/api/publish/")
+
+        assert response.status_code == 500
+        hot_reload.resume_file_watcher.assert_called_once()
+
+    def test_discard_no_changes(self, client, app):
+        """Discard with an empty draft cache reports zero discards."""
+        response = client.post("/api/publish/discard/")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["discarded_count"] == 0
+        assert "discarded" in data["message"].lower()
+        app.flask_app.source_manager.clear_cache.assert_called_once()
+
+    def test_discard_with_changes(self, client, app):
+        """Discard counts every unpublished draft and clears all caches."""
+        mock_source = Mock()
+        mock_source.type = "sqlite"
+        app.flask_app.source_manager.cached_objects = {"new_source": mock_source}
+        app.flask_app.source_manager.get_status.return_value = ObjectStatus.NEW
+        app.flask_app.model_manager.cached_objects = {"edited_model": Mock()}
+        app.flask_app.model_manager.get_status.return_value = ObjectStatus.MODIFIED
+        app.flask_app._cached_defaults = Mock()
+
+        response = client.post("/api/publish/discard/")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["discarded_count"] == 3
+        app.flask_app.source_manager.clear_cache.assert_called_once()
+        app.flask_app.model_manager.clear_cache.assert_called_once()
+        app.flask_app.dashboard_manager.clear_cache.assert_called_once()
+        assert app.flask_app._cached_defaults is None
+
+    def test_discard_excludes_published(self, client, app):
+        """Cached objects already in the published state don't inflate the count."""
+        app.flask_app.source_manager.cached_objects = {"published_source": Mock()}
+        app.flask_app.source_manager.get_status.return_value = ObjectStatus.PUBLISHED
+
+        response = client.post("/api/publish/discard/")
+
+        assert response.status_code == 200
+        assert response.get_json()["discarded_count"] == 0
+        app.flask_app.source_manager.clear_cache.assert_called_once()
+
+    def test_discard_counts_deletions(self, client, app):
+        """A draft deletion (None entry) counts as a discarded change."""
+        app.flask_app.dashboard_manager.cached_objects = {"doomed_dashboard": None}
+        app.flask_app.dashboard_manager.get_status.return_value = ObjectStatus.DELETED
+
+        response = client.post("/api/publish/discard/")
+
+        assert response.status_code == 200
+        assert response.get_json()["discarded_count"] == 1
+        app.flask_app.dashboard_manager.clear_cache.assert_called_once()

--- a/viewer/e2e/stories/build-mode-publish.spec.mjs
+++ b/viewer/e2e/stories/build-mode-publish.spec.mjs
@@ -1,0 +1,273 @@
+/**
+ * Story: Build-mode Save/Publish cluster (VIS-806 / Track H H-1).
+ *
+ * The Workspace TopBar mounts <PublishCluster> — the status pill + Discard +
+ * Publish·N group. Every canvas action auto-saves to the backend draft cache;
+ * the cluster's pending count updates live; Publish opens the confirm modal
+ * and flushes the cache to YAML; Discard drops the cache and the canvas
+ * reverts to last-published state.
+ *
+ * The publish step REALLY writes test-projects/integration/project.visivo.yml.
+ * The suite snapshots the file in beforeAll and restores it byte-for-byte in
+ * afterAll (which also re-triggers the watcher so the sandbox recompiles back
+ * to baseline), plus discards any leftover drafts on both ends.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8051 VISIVO_SANDBOX_FRONTEND_PORT=3051 \
+ *   VISIVO_SANDBOX_NAME=vis806 bash scripts/sandbox.sh start
+ *   # then: VIS_PUBLISH_BASE=http://localhost:3051 npx playwright test build-mode-publish
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const BASE = process.env.VIS_PUBLISH_BASE || 'http://localhost:3051';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+const PROJECT_YML = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../test-projects/integration/project.visivo.yml'
+);
+
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(dash.locator('[data-row-index]').first()).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-add-row')).toBeAttached({ timeout: WAIT });
+};
+
+// Append a 3-up row through the real "+ Add row" affordance — the canvas
+// action whose auto-save the cluster must surface.
+const addRowViaCanvas = async page => {
+  const before = (await readRows(page)).length;
+  await page.getByTestId('canvas-add-row-end-button').click();
+  await expect(page.getByTestId('row-template-menu')).toBeVisible({ timeout: WAIT });
+  await page.getByTestId('row-template-3up').click();
+  await expect
+    .poll(async () => (await readRows(page)).length, { timeout: WAIT })
+    .toBe(before + 1);
+  return before;
+};
+
+const discardViaApi = async request => {
+  await request.post(`${BASE}/api/publish/discard/`).catch(() => {});
+};
+
+// Self-contained test setup: drop any leftover drafts on the backend, wait
+// until it reports clean, then open a fresh canvas so the store re-hydrates
+// from the clean state. Keeps every test independent of its predecessors.
+const startClean = async (page, request) => {
+  await discardViaApi(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(`${BASE}/api/publish/pending/`);
+        return (await res.json()).count;
+      },
+      { timeout: WAIT }
+    )
+    .toBe(0);
+  await openCanvas(page);
+  await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+};
+
+test.describe('Build-mode Save/Publish cluster (VIS-806 / H-1)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(180000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  let originalYaml;
+
+  test.beforeAll(async ({ browser, request }) => {
+    originalYaml = fs.readFileSync(PROJECT_YML, 'utf8');
+    await discardViaApi(request);
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Byte-for-byte YAML restore + draft drop, then give the watcher a beat
+    // to recompile back to baseline so the next suite sees a clean sandbox.
+    await discardViaApi(request);
+    if (originalYaml !== undefined && fs.readFileSync(PROJECT_YML, 'utf8') !== originalYaml) {
+      fs.writeFileSync(PROJECT_YML, originalYaml);
+      await new Promise(resolve => setTimeout(resolve, 4000));
+    }
+    await page.close();
+  });
+
+  test('clean baseline: "Saved" pill, Publish disabled, no Discard', async ({ request }) => {
+    await startClean(page, request);
+    await expect(page.getByTestId('workspace-save-pill-clean')).toHaveText(/Saved/, {
+      timeout: WAIT,
+    });
+    await expect(page.getByTestId('workspace-top-bar-publish')).toBeDisabled();
+    await expect(page.getByTestId('workspace-top-bar-discard')).toHaveCount(0);
+
+    // Regression guard: the Workspace overlay must stack ABOVE Home's fixed
+    // TopNav (z-[60] > z-50). At the old z-40 the outer nav covered this bar,
+    // making every cluster button visible-but-unclickable.
+    const coveredByOuterNav = await page.evaluate(() => {
+      const bar = document.querySelector('[data-testid="workspace-top-bar"]');
+      const hit = document.elementFromPoint(Math.floor(window.innerWidth / 2), 24);
+      return !(bar && hit && bar.contains(hit));
+    });
+    expect(coveredByOuterNav, 'workspace top bar is the interactive surface').toBe(false);
+
+    // The bar's Deploy opens the real DeployModal (the outer nav's Deploy is
+    // unreachable in Build mode now).
+    await page.getByTestId('workspace-top-bar-deploy').hover();
+    await page.getByTestId('workspace-top-bar-deploy').click();
+    await expect(page.getByText('Project Deployment')).toBeVisible({ timeout: WAIT });
+    await page.getByRole('button', { name: '×' }).click();
+    await expect(page.getByText('Project Deployment')).toHaveCount(0);
+
+    await page.screenshot({ path: `${SCREENS}/vis806-01-clean-cluster.png` });
+  });
+
+  test('a canvas action lights the cluster: live count + enabled Publish + Discard', async ({
+    request,
+  }) => {
+    await startClean(page, request);
+    await addRowViaCanvas(page);
+
+    await expect(page.getByTestId('workspace-save-pill-dirty')).toHaveText(/1 change/, {
+      timeout: WAIT,
+    });
+    const publish = page.getByTestId('workspace-top-bar-publish');
+    await expect(publish).toBeEnabled();
+    await expect(publish).toHaveText(/Publish/);
+    await expect(publish).toHaveText(/1/);
+    await expect(page.getByTestId('workspace-top-bar-discard')).toBeVisible();
+    await page.screenshot({ path: `${SCREENS}/vis806-02-dirty-cluster.png` });
+  });
+
+  test('Discard: confirm dialog → draft cache dropped → canvas reverts', async ({ request }) => {
+    await startClean(page, request);
+    const baselineRows = (await readRows(page)).length;
+    await addRowViaCanvas(page);
+    expect((await readRows(page)).length).toBe(baselineRows + 1);
+    await expect(page.getByTestId('workspace-save-pill-dirty')).toBeVisible({ timeout: WAIT });
+
+    await page.getByTestId('workspace-top-bar-discard').hover();
+    await page.getByTestId('workspace-top-bar-discard').click();
+    await expect(page.getByTestId('workspace-discard-confirm')).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('workspace-discard-confirm')).toHaveText(/Discard 1 change\?/);
+    await page.screenshot({ path: `${SCREENS}/vis806-03-discard-confirm.png` });
+
+    await page.getByTestId('workspace-discard-confirm-button').click();
+    await expect(page.getByTestId('workspace-discard-confirm')).toHaveCount(0, {
+      timeout: WAIT,
+    });
+
+    // Count returns to 0 and the canvas re-renders from last-published state.
+    await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+    await expect
+      .poll(async () => (await readRows(page)).length, { timeout: WAIT })
+      .toBe(baselineRows); // reverted — the discarded row is gone
+    await expect(page.getByTestId('workspace-top-bar-publish')).toBeDisabled();
+    await page.screenshot({ path: `${SCREENS}/vis806-04-after-discard.png` });
+  });
+
+  test('Publish: modal lists the pending change → YAML written → "Published ✓" flash → clean', async ({
+    request,
+  }) => {
+    await startClean(page, request);
+    const yamlBefore = fs.readFileSync(PROJECT_YML, 'utf8');
+    const rowsAfterAdd = (await addRowViaCanvas(page)) + 1;
+
+    await expect(page.getByTestId('workspace-save-pill-dirty')).toBeVisible({ timeout: WAIT });
+    await page.getByTestId('workspace-top-bar-publish').hover();
+    await page.getByTestId('workspace-top-bar-publish').click();
+
+    // The PublishModal confirm step lists the dashboard's pending change.
+    const modalPublish = page.getByRole('button', { name: 'Publish Changes' });
+    await expect(modalPublish).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('publish-modal-pending-list')).toContainText(DASHBOARD);
+    await page.screenshot({ path: `${SCREENS}/vis806-05-publish-modal.png` });
+
+    await modalPublish.click();
+
+    // Transient success flash (≤2s) then the cluster settles clean.
+    await expect(page.getByTestId('workspace-save-pill-published')).toBeVisible({
+      timeout: WAIT,
+    });
+    await page.screenshot({ path: `${SCREENS}/vis806-06-published-flash.png` });
+    await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('workspace-top-bar-publish')).toBeDisabled({ timeout: WAIT });
+
+    // YAML round-trip: the file actually changed on disk and the backend
+    // reports a clean draft cache.
+    const yamlAfter = fs.readFileSync(PROJECT_YML, 'utf8');
+    expect(yamlAfter).not.toBe(yamlBefore);
+    const pending = await (await request.get(`${BASE}/api/publish/pending/`)).json();
+    expect(pending.count).toBe(0);
+
+    // The published row survives a re-fetch (it's in YAML now, not the cache).
+    await expect
+      .poll(async () => (await readRows(page)).length, { timeout: WAIT })
+      .toBe(rowsAfterAdd);
+  });
+
+  test('cluster fits a 1280px top bar without pushing Deploy/utilities off-screen', async ({
+    request,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await startClean(page, request);
+    await addRowViaCanvas(page); // dirty state = widest cluster (pill+Discard+Publish·N)
+
+    await expect(page.getByTestId('workspace-save-pill-dirty')).toBeVisible({ timeout: WAIT });
+    for (const id of [
+      'workspace-top-bar-publish',
+      'workspace-top-bar-discard',
+      'workspace-top-bar-deploy',
+      'workspace-top-bar-slack',
+      'workspace-top-bar-docs',
+      'workspace-top-bar-account',
+    ]) {
+      const box = await page.getByTestId(id).boundingBox();
+      expect(box, `${id} is rendered`).toBeTruthy();
+      expect(box.x + box.width, `${id} fits inside 1280px`).toBeLessThanOrEqual(1280);
+    }
+    await page.screenshot({ path: `${SCREENS}/vis806-07-1280-top-bar.png` });
+
+    // Clean up the extra draft so afterAll's restore starts from a known state.
+    await page.getByTestId('workspace-top-bar-discard').click();
+    await expect(page.getByTestId('workspace-discard-confirm')).toBeVisible({ timeout: WAIT });
+    await page.getByTestId('workspace-discard-confirm-button').click();
+    await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+  });
+
+  test('no console errors across the publish/discard gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    expect(real, `console errors:\n${real.join('\n')}`).toHaveLength(0);
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
         '**/explorer-crud-save.spec.mjs',
         '**/explorer-library-reactivity.spec.mjs',
         '**/explorer-publish-to-files.spec.mjs',
+        '**/build-mode-publish.spec.mjs',
       ],
     },
     {
@@ -48,6 +49,18 @@ export default defineConfig({
       workers: 1,
       // Retries would run against polluted backend cache from the failed
       // attempt, so they give no useful signal. Fail fast instead.
+      retries: 0,
+    },
+    {
+      // H-1 Save/Publish cluster (VIS-806) — publishes REAL YAML writes to the
+      // integration project, so it gets the same isolation as 'publish':
+      // serial, no retries (a retry would race the file-watcher recompile
+      // triggered by the previous attempt's YAML restore and see phantom
+      // pending changes). Targets its own sandbox via VIS_PUBLISH_BASE.
+      name: 'workspace-publish',
+      testMatch: ['**/build-mode-publish.spec.mjs'],
+      fullyParallel: false,
+      workers: 1,
       retries: 0,
     },
   ],

--- a/viewer/src/api/publish.js
+++ b/viewer/src/api/publish.js
@@ -38,3 +38,20 @@ export const publishChanges = async () => {
   const errorData = await response.json().catch(() => ({}));
   throw new Error(errorData.error || 'Failed to publish changes');
 };
+
+/**
+ * Discard all cached changes without writing YAML (the v1 rollback, Q14)
+ */
+export const discardChanges = async () => {
+  const response = await fetch(getUrl('publishDiscard'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (response.status === 200) {
+    return await response.json();
+  }
+  const errorData = await response.json().catch(() => ({}));
+  throw new Error(errorData.error || 'Failed to discard changes');
+};

--- a/viewer/src/components/new-views/workspace/PublishCluster.jsx
+++ b/viewer/src/components/new-views/workspace/PublishCluster.jsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  PiCheckCircle,
+  PiCircleNotch,
+  PiClock,
+  PiWarningCircle,
+} from 'react-icons/pi';
+import useStore from '../../../stores/store';
+
+/**
+ * PublishCluster — VIS-806 (Track H H-1).
+ *
+ * The TopBar right-group cluster that surfaces save/publish state in Build
+ * mode, per the H-1 design brief (`design/04-phase-3-save-semantics.md`):
+ *
+ *   [ status pill ]  [ Discard ]  [ Publish · N ]
+ *
+ * Status pill precedence (highest first):
+ *   Saving…      — any draft write in flight (`saveActivityCount > 0`)
+ *   Save failed  — the last draft write errored
+ *   Published ✓  — ≤2s after a successful publish (transient flash)
+ *   N change(s)  — unpublished drafts pending
+ *   Saved        — clean
+ *
+ * Publish opens the existing PublishModal (pending-change list + confirm);
+ * a publish failure surfaces here as "Publish failed" + Retry (which
+ * re-publishes directly, skipping the modal). Discard asks for confirmation
+ * (it's the v1 rollback — no undo per Q14) then drops the entire draft
+ * cache; the canvas reverts via the store's named-child refetch.
+ */
+
+const PUBLISH_FLASH_MS = 2000;
+
+const StatusPill = ({ icon: Icon, label, tone, spin = false, testId }) => (
+  <span
+    data-testid={testId}
+    className={`inline-flex h-7 items-center gap-1.5 rounded-full px-2.5 text-[12px] font-medium tabular-nums ${tone}`}
+  >
+    <Icon
+      aria-hidden="true"
+      className={`h-3.5 w-3.5 shrink-0 ${spin ? 'animate-spin' : ''}`}
+    />
+    {label}
+  </span>
+);
+
+const ConfirmDiscardDialog = ({ count, busy, onCancel, onConfirm }) => (
+  <div
+    className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40"
+    data-testid="workspace-discard-confirm"
+  >
+    <div className="w-[360px] rounded-lg bg-white p-6 shadow-xl">
+      <h3 className="text-lg font-medium text-gray-900">
+        Discard {count} {count === 1 ? 'change' : 'changes'}?
+      </h3>
+      <p className="mt-2 text-sm text-gray-600">
+        This clears every unsaved draft and reverts the canvas to the last
+        published state. There is no undo.
+      </p>
+      <div className="mt-5 flex justify-end gap-3">
+        <button
+          type="button"
+          autoFocus
+          onClick={onCancel}
+          disabled={busy}
+          data-testid="workspace-discard-cancel"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-700"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={busy}
+          data-testid="workspace-discard-confirm-button"
+          className="rounded-lg bg-highlight px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-highlight-700 disabled:opacity-60"
+        >
+          {busy ? 'Discarding…' : 'Discard'}
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+const PublishCluster = () => {
+  const pendingCount = useStore(s => s.pendingCount);
+  const saveActivityCount = useStore(s => s.saveActivityCount);
+  const lastSaveFailed = useStore(s => s.lastSaveFailed);
+  const publishLoading = useStore(s => s.publishLoading);
+  const publishError = useStore(s => s.publishError);
+  const publishModalOpen = useStore(s => s.publishModalOpen);
+  const lastPublishedAt = useStore(s => s.lastPublishedAt);
+  const discardLoading = useStore(s => s.discardLoading);
+  const openPublishModal = useStore(s => s.openPublishModal);
+  const publishChanges = useStore(s => s.publishChanges);
+  const discardChanges = useStore(s => s.discardChanges);
+
+  const [justPublished, setJustPublished] = useState(false);
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+  // Skip the flash for a `lastPublishedAt` that predates this mount (e.g.
+  // re-entering the Workspace after publishing elsewhere).
+  const mountedAtRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (!lastPublishedAt || lastPublishedAt < mountedAtRef.current) return undefined;
+    setJustPublished(true);
+    const timer = setTimeout(() => setJustPublished(false), PUBLISH_FLASH_MS);
+    return () => clearTimeout(timer);
+  }, [lastPublishedAt]);
+
+  const handleConfirmDiscard = async () => {
+    const result = await discardChanges();
+    if (result?.success) setConfirmDiscardOpen(false);
+  };
+
+  // "Publish failed" surfaces in the cluster only while the modal is closed
+  // (the modal shows the same error inline when it's open).
+  const publishFailed = Boolean(publishError) && !publishModalOpen;
+
+  let pill;
+  if (saveActivityCount > 0) {
+    pill = (
+      <StatusPill
+        icon={PiCircleNotch}
+        spin
+        label="Saving…"
+        tone="bg-white/10 text-white/80"
+        testId="workspace-save-pill-saving"
+      />
+    );
+  } else if (lastSaveFailed) {
+    pill = (
+      <StatusPill
+        icon={PiWarningCircle}
+        label="Save failed"
+        tone="bg-highlight-700/60 text-white"
+        testId="workspace-save-pill-error"
+      />
+    );
+  } else if (justPublished) {
+    pill = (
+      <StatusPill
+        icon={PiCheckCircle}
+        label="Published ✓"
+        tone="bg-green-600/30 text-green-100"
+        testId="workspace-save-pill-published"
+      />
+    );
+  } else if (pendingCount > 0) {
+    pill = (
+      <StatusPill
+        icon={PiClock}
+        label={`${pendingCount} ${pendingCount === 1 ? 'change' : 'changes'}`}
+        tone="bg-white/10 text-white/80"
+        testId="workspace-save-pill-dirty"
+      />
+    );
+  } else {
+    pill = (
+      <StatusPill
+        icon={PiCheckCircle}
+        label="Saved"
+        tone="text-white/45"
+        testId="workspace-save-pill-clean"
+      />
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2" data-testid="workspace-publish-cluster">
+      {pill}
+      {publishFailed && (
+        <button
+          type="button"
+          onClick={publishChanges}
+          data-testid="workspace-top-bar-publish-retry"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-highlight px-3 text-[13px] font-semibold text-white shadow-sm transition-colors hover:bg-highlight-700"
+        >
+          Publish failed — Retry
+        </button>
+      )}
+      {pendingCount > 0 && !publishLoading && (
+        <button
+          type="button"
+          onClick={() => setConfirmDiscardOpen(true)}
+          data-testid="workspace-top-bar-discard"
+          className="inline-flex h-8 items-center rounded-md border border-white/20 px-3 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+        >
+          Discard
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={openPublishModal}
+        disabled={pendingCount === 0 || publishLoading}
+        data-testid="workspace-top-bar-publish"
+        className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[13px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {publishLoading ? (
+          <>
+            <PiCircleNotch aria-hidden="true" className="h-4 w-4 animate-spin" />
+            Publishing…
+          </>
+        ) : (
+          <>
+            Publish
+            {pendingCount > 0 && (
+              <span className="rounded-sm bg-white/20 px-1.5 py-px text-[11px] font-bold tabular-nums">
+                {pendingCount}
+              </span>
+            )}
+          </>
+        )}
+      </button>
+      {confirmDiscardOpen && (
+        <ConfirmDiscardDialog
+          count={pendingCount}
+          busy={discardLoading}
+          onCancel={() => setConfirmDiscardOpen(false)}
+          onConfirm={handleConfirmDiscard}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PublishCluster;

--- a/viewer/src/components/new-views/workspace/PublishCluster.test.jsx
+++ b/viewer/src/components/new-views/workspace/PublishCluster.test.jsx
@@ -1,0 +1,185 @@
+/**
+ * PublishCluster tests (VIS-806 / Track H H-1).
+ *
+ * The TopBar save/publish cluster: status pill precedence, Publish button
+ * states, Discard + confirm dialog, publish-failed Retry, and the transient
+ * "Published ✓" flash.
+ */
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useStore from '../../../stores/store';
+import PublishCluster from './PublishCluster';
+
+const setPublishState = overrides =>
+  useStore.setState({
+    pendingCount: 0,
+    saveActivityCount: 0,
+    lastSaveFailed: false,
+    publishLoading: false,
+    publishError: null,
+    publishModalOpen: false,
+    lastPublishedAt: null,
+    discardLoading: false,
+    openPublishModal: jest.fn(),
+    publishChanges: jest.fn().mockResolvedValue({ success: true }),
+    discardChanges: jest.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  });
+
+describe('PublishCluster (VIS-806)', () => {
+  beforeEach(() => {
+    setPublishState();
+  });
+
+  test('clean state: "Saved" pill, Publish disabled, no Discard', () => {
+    render(<PublishCluster />);
+
+    expect(screen.getByTestId('workspace-save-pill-clean')).toHaveTextContent('Saved');
+    expect(screen.getByTestId('workspace-top-bar-publish')).toBeDisabled();
+    expect(screen.queryByTestId('workspace-top-bar-discard')).not.toBeInTheDocument();
+  });
+
+  test('dirty state: count pill (plural), Publish enabled with badge, Discard visible', () => {
+    setPublishState({ pendingCount: 3 });
+    render(<PublishCluster />);
+
+    expect(screen.getByTestId('workspace-save-pill-dirty')).toHaveTextContent('3 changes');
+    const publish = screen.getByTestId('workspace-top-bar-publish');
+    expect(publish).toBeEnabled();
+    expect(publish).toHaveTextContent('3');
+    expect(screen.getByTestId('workspace-top-bar-discard')).toBeInTheDocument();
+  });
+
+  test('singular count reads "1 change"', () => {
+    setPublishState({ pendingCount: 1 });
+    render(<PublishCluster />);
+
+    expect(screen.getByTestId('workspace-save-pill-dirty')).toHaveTextContent('1 change');
+  });
+
+  test('a save in flight wins the pill: "Saving…"', () => {
+    setPublishState({ pendingCount: 2, saveActivityCount: 1 });
+    render(<PublishCluster />);
+
+    expect(screen.getByTestId('workspace-save-pill-saving')).toHaveTextContent('Saving…');
+    expect(screen.queryByTestId('workspace-save-pill-dirty')).not.toBeInTheDocument();
+  });
+
+  test('a failed save shows "Save failed"', () => {
+    setPublishState({ pendingCount: 2, lastSaveFailed: true });
+    render(<PublishCluster />);
+
+    expect(screen.getByTestId('workspace-save-pill-error')).toHaveTextContent('Save failed');
+  });
+
+  test('publishing: button shows "Publishing…" and is disabled; Discard hides', () => {
+    setPublishState({ pendingCount: 2, publishLoading: true });
+    render(<PublishCluster />);
+
+    const publish = screen.getByTestId('workspace-top-bar-publish');
+    expect(publish).toHaveTextContent('Publishing…');
+    expect(publish).toBeDisabled();
+    expect(screen.queryByTestId('workspace-top-bar-discard')).not.toBeInTheDocument();
+  });
+
+  test('clicking Publish opens the publish modal', async () => {
+    const openPublishModal = jest.fn();
+    setPublishState({ pendingCount: 2, openPublishModal });
+    render(<PublishCluster />);
+
+    await userEvent.click(screen.getByTestId('workspace-top-bar-publish'));
+
+    expect(openPublishModal).toHaveBeenCalledTimes(1);
+  });
+
+  test('a publish error (modal closed) surfaces Retry, which re-publishes directly', async () => {
+    const publishChanges = jest.fn().mockResolvedValue({ success: true });
+    setPublishState({ pendingCount: 2, publishError: 'disk full', publishChanges });
+    render(<PublishCluster />);
+
+    const retry = screen.getByTestId('workspace-top-bar-publish-retry');
+    expect(retry).toHaveTextContent('Publish failed — Retry');
+    await userEvent.click(retry);
+    expect(publishChanges).toHaveBeenCalledTimes(1);
+  });
+
+  test('a publish error stays inside the modal while it is open', () => {
+    setPublishState({ pendingCount: 2, publishError: 'disk full', publishModalOpen: true });
+    render(<PublishCluster />);
+
+    expect(screen.queryByTestId('workspace-top-bar-publish-retry')).not.toBeInTheDocument();
+  });
+
+  test('Discard opens the confirm dialog; Cancel closes it without discarding', async () => {
+    const discardChanges = jest.fn();
+    setPublishState({ pendingCount: 3, discardChanges });
+    render(<PublishCluster />);
+
+    await userEvent.click(screen.getByTestId('workspace-top-bar-discard'));
+    expect(screen.getByTestId('workspace-discard-confirm')).toHaveTextContent(
+      'Discard 3 changes?'
+    );
+
+    await userEvent.click(screen.getByTestId('workspace-discard-cancel'));
+    expect(screen.queryByTestId('workspace-discard-confirm')).not.toBeInTheDocument();
+    expect(discardChanges).not.toHaveBeenCalled();
+  });
+
+  test('confirming Discard calls discardChanges and closes the dialog on success', async () => {
+    const discardChanges = jest.fn().mockResolvedValue({ success: true });
+    setPublishState({ pendingCount: 3, discardChanges });
+    render(<PublishCluster />);
+
+    await userEvent.click(screen.getByTestId('workspace-top-bar-discard'));
+    await userEvent.click(screen.getByTestId('workspace-discard-confirm-button'));
+
+    expect(discardChanges).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByTestId('workspace-discard-confirm')).not.toBeInTheDocument()
+    );
+  });
+
+  test('a failed discard keeps the dialog open', async () => {
+    const discardChanges = jest.fn().mockResolvedValue({ success: false, error: 'boom' });
+    setPublishState({ pendingCount: 3, discardChanges });
+    render(<PublishCluster />);
+
+    await userEvent.click(screen.getByTestId('workspace-top-bar-discard'));
+    await userEvent.click(screen.getByTestId('workspace-discard-confirm-button'));
+
+    expect(discardChanges).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('workspace-discard-confirm')).toBeInTheDocument();
+  });
+
+  test('a publish success after mount flashes "Published ✓" then settles back', () => {
+    jest.useFakeTimers();
+    try {
+      render(<PublishCluster />);
+      expect(screen.getByTestId('workspace-save-pill-clean')).toBeInTheDocument();
+
+      act(() => {
+        useStore.setState({ lastPublishedAt: Date.now() });
+      });
+      expect(screen.getByTestId('workspace-save-pill-published')).toHaveTextContent(
+        'Published ✓'
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(2100);
+      });
+      expect(screen.queryByTestId('workspace-save-pill-published')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workspace-save-pill-clean')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a lastPublishedAt that predates the mount does not flash', () => {
+    setPublishState({ lastPublishedAt: Date.now() - 60_000 });
+    render(<PublishCluster />);
+
+    expect(screen.queryByTestId('workspace-save-pill-published')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-save-pill-clean')).toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/new-views/workspace/TopBar.jsx
+++ b/viewer/src/components/new-views/workspace/TopBar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { SiSlack } from 'react-icons/si';
 import { MdMenuBook } from 'react-icons/md';
 import { FaUserCircle } from 'react-icons/fa';
@@ -6,19 +6,20 @@ import { HiOutlineCloudUpload } from 'react-icons/hi';
 import { PiCaretRight } from 'react-icons/pi';
 import logo from '../../../images/logo.png';
 import useStore from '../../../stores/store';
+import PublishCluster from './PublishCluster';
+import DeployModal from '../../deploy/DeployModal';
 
 /**
  * TopBar — h-12 navy top bar for the Workspace shell (VIS-775 / Track B B2).
  *
  * Per the delivered B-1 design (`design/cofounder-mockups/`):
  *   LEFT  — brand mark + breadcrumb (`Workspace › <projectName>`).
- *   RIGHT — `Publish · N` (visible only when `dirty > 0 && canBuild`) →
- *           `Deploy` → utility icons (Slack, Docs, Account).
+ *   RIGHT — save/publish cluster (H-1: status pill + Discard + `Publish · N`)
+ *           → `Deploy` → utility icons (Slack, Docs, Account).
  *
- * No mode toggle, no lens picker, no save-state pill. The Publish button's
- * presence IS the save state (saved ⇒ no Publish; unsaved ⇒ `Publish · N`).
- * The route split (`/workspace` = editing, `/project` = consumer) is the
- * mode toggle.
+ * No mode toggle, no lens picker. The route split (`/workspace` = editing,
+ * `/project` = consumer) is the mode toggle. The save-state pill + Publish +
+ * Discard cluster is `PublishCluster` (VIS-806 / Track H H-1).
  */
 const IconButton = ({ children, title, href, onClick, testId }) => {
   const cls =
@@ -55,16 +56,15 @@ const IconButton = ({ children, title, href, onClick, testId }) => {
 const TopBar = () => {
   // Reads directly from the store — no prop-drilling from the route container.
   const project = useStore(s => s.project);
-  const hasUnpublishedChanges = useStore(s => s.hasUnpublishedChanges);
-  const openPublishModal = useStore(s => s.openPublishModal);
 
   const projectName = project?.project_json?.name || project?.name || 'project';
-  const dirty = hasUnpublishedChanges ? 1 : 0;
   const canBuild = true; // Phase 0 — every Workspace user can build.
 
-  // Phase 0 stub — the full deploy modal lives in Home.jsx today. Track O /
-  // Track G will wire the deploy CTA from the Workspace TopBar.
-  const handleDeployClick = () => {};
+  // The Workspace overlay sits above Home's TopNav (z-[60] > z-50), so this
+  // bar's Deploy is the only reachable one in Build mode — it opens the same
+  // DeployModal Home uses, just with bar-local open state.
+  const [isDeployOpen, setIsDeployOpen] = useState(false);
+  const handleDeployClick = () => setIsDeployOpen(true);
 
   return (
     <header
@@ -97,19 +97,7 @@ const TopBar = () => {
       </div>
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
-        {dirty > 0 && canBuild && (
-          <button
-            type="button"
-            onClick={openPublishModal}
-            data-testid="workspace-top-bar-publish"
-            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[13px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600"
-          >
-            Publish
-            <span className="rounded-sm bg-white/20 px-1.5 py-px text-[11px] font-bold tabular-nums">
-              {dirty}
-            </span>
-          </button>
-        )}
+        {canBuild && <PublishCluster />}
         <button
           type="button"
           onClick={handleDeployClick}
@@ -138,6 +126,7 @@ const TopBar = () => {
           <FaUserCircle className="h-5 w-5" />
         </IconButton>
       </div>
+      <DeployModal isOpen={isDeployOpen} setIsOpen={setIsDeployOpen} />
     </header>
   );
 };

--- a/viewer/src/components/new-views/workspace/Workspace.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useStore from '../../../stores/store';
 import WorkspaceShell from './WorkspaceShell';
-import { emitWorkspaceEvent } from './telemetry';
+import { emitWorkspaceEvent, markBuildModeEntered } from './telemetry';
 import { useWorkspaceScope } from './useWorkspaceScope';
 
 /**
@@ -133,6 +133,8 @@ const Workspace = () => {
       dashboardName: dashboardName || null,
       scope: scope.scope,
     });
+    // Arm the time_to_first_publish_in_build_mode metric (H-1 / Q22).
+    markBuildModeEntered();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboardName]);
 
@@ -140,10 +142,13 @@ const Workspace = () => {
   // container to reserve space for its fixed `<TopNav>`. The Workspace
   // shell renders its own TopBar (per the delivered B-1 design), so we
   // anchor the shell to `top-0 bottom-0` to occupy the full viewport
-  // height and visually replace the outer nav.
+  // height and visually replace the outer nav. The overlay must sit ABOVE
+  // TopNav's `z-50` — at the old `z-40` the outer nav covered the shell's
+  // TopBar, leaving the Publish cluster visible-but-unclickable (H-1 e2e
+  // caught this: every pointer action on the top bar hit TopNav instead).
   return (
     <div
-      className="fixed inset-0 z-40 bg-white"
+      className="fixed inset-0 z-[60] bg-white"
       data-testid="workspace-route-root"
     >
       <WorkspaceShell />

--- a/viewer/src/components/new-views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.test.jsx
@@ -64,6 +64,14 @@ const resetWorkspaceStore = () => {
       workspaceRightTab: 'edit',
       workspaceLens: 'preview',
       hasUnpublishedChanges: false,
+      // Publish-cluster state (H-1) — reset so tests are isolated.
+      pendingCount: 0,
+      saveActivityCount: 0,
+      lastSaveFailed: false,
+      publishLoading: false,
+      publishError: null,
+      publishModalOpen: false,
+      lastPublishedAt: null,
       // Stub project that the loader normally hydrates.
       project: {
         id: 'p1',
@@ -191,20 +199,21 @@ describe('VIS-775 Workspace shell', () => {
     expect(chip).toHaveAttribute('data-object-type', 'dashboard');
   });
 
-  test('Publish · N button only renders when dirty > 0', () => {
-    // Clean state.
+  test('Publish cluster: disabled + "Saved" when clean, count badge when dirty (H-1)', () => {
+    // Clean state — the cluster renders, Publish is disabled, pill says Saved.
     renderAt('/workspace');
-    expect(
-      screen.queryByTestId('workspace-top-bar-publish')
-    ).not.toBeInTheDocument();
-    // Mark dirty.
+    expect(screen.getByTestId('workspace-top-bar-publish')).toBeDisabled();
+    expect(screen.getByTestId('workspace-save-pill-clean')).toHaveTextContent('Saved');
+    // Mark dirty with a live pending count.
     act(() => {
-      useStore.setState({ hasUnpublishedChanges: true });
+      useStore.setState({ hasUnpublishedChanges: true, pendingCount: 3 });
     });
-    expect(screen.getByTestId('workspace-top-bar-publish')).toHaveTextContent(
-      'Publish'
-    );
-    expect(screen.getByTestId('workspace-top-bar-publish')).toHaveTextContent('1');
+    const publish = screen.getByTestId('workspace-top-bar-publish');
+    expect(publish).toBeEnabled();
+    expect(publish).toHaveTextContent('Publish');
+    expect(publish).toHaveTextContent('3');
+    expect(screen.getByTestId('workspace-save-pill-dirty')).toHaveTextContent('3 changes');
+    expect(screen.getByTestId('workspace-top-bar-discard')).toBeInTheDocument();
   });
 
   test('fires workspace_mode_entered telemetry on mount with dashboard scope', () => {

--- a/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
@@ -89,6 +89,9 @@ const WorkspaceShell = ({ testId = 'workspace-shell' }) => {
           </div>
         </div>
       </WorkspaceDndContext>
+      {/* The publish confirm flow (H-1) is Home's layout-level <PublishModal>;
+          its ModalOverlay stacks at z-[70], above this shell's z-[60] route
+          overlay, so the Workspace deliberately does NOT mount a second one. */}
     </div>
   );
 };

--- a/viewer/src/components/new-views/workspace/telemetry.js
+++ b/viewer/src/components/new-views/workspace/telemetry.js
@@ -72,3 +72,28 @@ export function setWorkspaceTelemetryListener(fn) {
     if (listener === fn) listener = null;
   };
 }
+
+/**
+ * `time_to_first_publish_in_build_mode` (VIS-806 / Track H H-1, Q22 metric).
+ *
+ * The Workspace marks Build-mode entry on mount; the publish flow calls
+ * `emitFirstPublishTelemetry()` on every successful publish, but only the
+ * FIRST publish after a Build-mode entry emits — re-entering the Workspace
+ * re-arms the metric. Elapsed time is `null` when a publish happens without
+ * a recorded entry (e.g. publish from the legacy /editor surface).
+ */
+let buildModeEnteredAt = null;
+let firstPublishEmitted = false;
+
+export function markBuildModeEntered() {
+  buildModeEnteredAt = Date.now();
+  firstPublishEmitted = false;
+}
+
+export function emitFirstPublishTelemetry() {
+  if (firstPublishEmitted) return;
+  firstPublishEmitted = true;
+  emitWorkspaceEvent('time_to_first_publish_in_build_mode', {
+    msSinceBuildModeEntered: buildModeEnteredAt ? Date.now() - buildModeEnteredAt : null,
+  });
+}

--- a/viewer/src/components/new-views/workspace/telemetry.test.js
+++ b/viewer/src/components/new-views/workspace/telemetry.test.js
@@ -11,6 +11,8 @@
 import {
   emitWorkspaceEvent,
   setWorkspaceTelemetryListener,
+  markBuildModeEntered,
+  emitFirstPublishTelemetry,
 } from './telemetry';
 
 const TEL_EVENT = 'visivo:workspace-telemetry';
@@ -72,5 +74,44 @@ describe('emitWorkspaceEvent', () => {
       throw new Error('boom');
     });
     expect(() => emitWorkspaceEvent('middle_pane_toggled', {})).not.toThrow();
+  });
+});
+
+describe('time_to_first_publish_in_build_mode (VIS-806 / H-1)', () => {
+  let events;
+  let unsubscribe;
+
+  beforeEach(() => {
+    events = [];
+    unsubscribe = setWorkspaceTelemetryListener(evt => events.push(evt));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  test('emits once per Build-mode entry, with elapsed ms', () => {
+    markBuildModeEntered();
+    emitFirstPublishTelemetry();
+    emitFirstPublishTelemetry(); // second publish in the same session — no event
+
+    const publishEvents = events.filter(
+      e => e.eventName === 'time_to_first_publish_in_build_mode'
+    );
+    expect(publishEvents).toHaveLength(1);
+    expect(publishEvents[0].payload.msSinceBuildModeEntered).toEqual(expect.any(Number));
+    expect(publishEvents[0].payload.msSinceBuildModeEntered).toBeGreaterThanOrEqual(0);
+  });
+
+  test('re-entering Build mode re-arms the metric', () => {
+    markBuildModeEntered();
+    emitFirstPublishTelemetry();
+    markBuildModeEntered();
+    emitFirstPublishTelemetry();
+
+    const publishEvents = events.filter(
+      e => e.eventName === 'time_to_first_publish_in_build_mode'
+    );
+    expect(publishEvents).toHaveLength(2);
   });
 });

--- a/viewer/src/components/new-views/workspace/useDebouncedSave.js
+++ b/viewer/src/components/new-views/workspace/useDebouncedSave.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import useStore from '../../../stores/store';
 
 /**
  * useDebouncedSave — VIS-802 / Track G G-1.
@@ -49,11 +50,19 @@ export default function useDebouncedSave(saveFn, opts = {}) {
 
   const runSave = useCallback(async payload => {
     if (mountedRef.current) setStatus('saving');
+    // Report into the global save-activity counter (H-1) so the TopBar
+    // cluster shows "Saving…" while this form's write is in flight. The
+    // counter must balance even if this hook unmounts mid-save, so the
+    // end call lives in `finally` and ignores `mountedRef`.
+    const { beginSaveActivity, endSaveActivity } = useStore.getState();
+    beginSaveActivity?.();
+    let ok = false;
     try {
       const result = await saveFnRef.current(payload);
-      if (!mountedRef.current) return;
       // saveFn may return `{ success }` (the store actions do) or nothing.
-      if (result && result.success === false) {
+      ok = !(result && result.success === false);
+      if (!mountedRef.current) return;
+      if (!ok) {
         setStatus('error');
         return;
       }
@@ -65,6 +74,8 @@ export default function useDebouncedSave(saveFn, opts = {}) {
       }, 2000);
     } catch {
       if (mountedRef.current) setStatus('error');
+    } finally {
+      endSaveActivity?.(ok);
     }
   }, []);
 

--- a/viewer/src/components/new-views/workspace/useDebouncedSave.test.js
+++ b/viewer/src/components/new-views/workspace/useDebouncedSave.test.js
@@ -6,6 +6,7 @@
  */
 import { renderHook, act } from '@testing-library/react';
 import useDebouncedSave from './useDebouncedSave';
+import useStore from '../../../stores/store';
 
 describe('useDebouncedSave (VIS-802)', () => {
   beforeEach(() => {
@@ -97,5 +98,55 @@ describe('useDebouncedSave (VIS-802)', () => {
       jest.advanceTimersByTime(1000);
     });
     expect(saveFn).not.toHaveBeenCalled();
+  });
+
+  test('reports into the global save-activity counter while a save is in flight (H-1)', async () => {
+    useStore.setState({ saveActivityCount: 0, lastSaveFailed: false });
+    let resolveSave;
+    const saveFn = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    const { result } = renderHook(() => useDebouncedSave(saveFn, { delay: 500 }));
+
+    act(() => result.current.scheduleSave({ a: 1 }));
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(useStore.getState().saveActivityCount).toBe(1);
+
+    await act(async () => {
+      resolveSave({ success: true });
+    });
+    expect(useStore.getState().saveActivityCount).toBe(0);
+    expect(useStore.getState().lastSaveFailed).toBe(false);
+  });
+
+  test('a failed save latches lastSaveFailed on the global counter (H-1)', async () => {
+    useStore.setState({ saveActivityCount: 0, lastSaveFailed: false });
+    const saveFn = jest.fn(() => Promise.resolve({ success: false, error: 'nope' }));
+    const { result } = renderHook(() => useDebouncedSave(saveFn, { delay: 500 }));
+
+    await act(async () => {
+      await result.current.saveNow({ a: 1 });
+    });
+
+    expect(useStore.getState().saveActivityCount).toBe(0);
+    expect(useStore.getState().lastSaveFailed).toBe(true);
+  });
+
+  test('a throwing save still balances the global counter (H-1)', async () => {
+    useStore.setState({ saveActivityCount: 0, lastSaveFailed: false });
+    const saveFn = jest.fn(() => Promise.reject(new Error('network')));
+    const { result } = renderHook(() => useDebouncedSave(saveFn, { delay: 500 }));
+
+    await act(async () => {
+      await result.current.saveNow({ a: 1 });
+    });
+
+    expect(useStore.getState().saveActivityCount).toBe(0);
+    expect(useStore.getState().lastSaveFailed).toBe(true);
   });
 });

--- a/viewer/src/components/publish/PublishModal.jsx
+++ b/viewer/src/components/publish/PublishModal.jsx
@@ -76,7 +76,7 @@ const PublishModal = () => {
           <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md">{publishError}</div>
         )}
 
-        <div className="max-h-64 overflow-y-auto mb-6">
+        <div className="max-h-64 overflow-y-auto mb-6" data-testid="publish-modal-pending-list">
           {pendingChanges.length === 0 ? (
             <p className="text-gray-500 text-center py-4">No pending changes to publish.</p>
           ) : (

--- a/viewer/src/components/styled/Modal.js
+++ b/viewer/src/components/styled/Modal.js
@@ -1,13 +1,17 @@
 import tw from 'tailwind-styled-components';
 
+// z-[70]: modals must stack above everything, including the Workspace route
+// overlay (z-[60], which itself sits above Home's z-50 TopNav). Home mounts
+// PublishModal/DeployModal once at the layout level; without this they would
+// render invisibly UNDER the Workspace overlay.
 export const ModalOverlay = tw.div`
-  fixed 
-  inset-0 
-  flex 
-  items-center 
-  justify-center 
-  z-50 
-  bg-opacity-50 
+  fixed
+  inset-0
+  flex
+  items-center
+  justify-center
+  z-[70]
+  bg-opacity-50
   backdrop-blur-sm
 `;
 

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -121,6 +121,7 @@ const URL_PATTERNS = {
     publishStatus: '/api/publish/status/',
     publishPending: '/api/publish/pending/',
     publish: '/api/publish/',
+    publishDiscard: '/api/publish/discard/',
 
     // Source schema jobs endpoints
     sourceSchemaJobsList: '/api/source-schema-jobs/',
@@ -259,6 +260,7 @@ const URL_PATTERNS = {
     publishStatus: null,
     publishPending: null,
     publish: null,
+    publishDiscard: null,
 
     // Source schema jobs endpoints (not available in dist)
     sourceSchemaJobsList: null,

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -56,10 +56,15 @@ const createDashboardSlice = (set, get) => ({
     }
   },
 
-  // Save dashboard to cache
+  // Save dashboard to cache. Reports into the global save-activity counter
+  // (H-1) so canvas actions — which call this directly, without the
+  // debounced-save hook — light up the TopBar "Saving…" pill too.
   saveDashboard: async (name, config) => {
+    get().beginSaveActivity?.();
+    let ok = false;
     try {
       const result = await dashboardsApi.saveDashboard(name, config);
+      ok = true;
       await get().fetchDashboards();
       if (get().checkPublishStatus) {
         await get().checkPublishStatus();
@@ -69,6 +74,8 @@ const createDashboardSlice = (set, get) => ({
       return { success: true, result };
     } catch (error) {
       return { success: false, error: error.message };
+    } finally {
+      get().endSaveActivity?.(ok);
     }
   },
 

--- a/viewer/src/stores/defaultsStore.js
+++ b/viewer/src/stores/defaultsStore.js
@@ -23,10 +23,14 @@ const createDefaultsSlice = (set, get) => ({
     }
   },
 
-  // Save defaults to cache
+  // Save defaults to cache. Reports into the global save-activity counter
+  // (H-1) — level CRUD persists through this path without the debounced hook.
   saveDefaults: async config => {
+    get().beginSaveActivity?.();
+    let ok = false;
     try {
       const result = await defaultsApi.saveDefaults(config);
+      ok = true;
       // Refresh defaults
       await get().fetchDefaults();
       // Trigger publish status check
@@ -36,6 +40,8 @@ const createDefaultsSlice = (set, get) => ({
       return { success: true, result };
     } catch (error) {
       return { success: false, error: error.message };
+    } finally {
+      get().endSaveActivity?.(ok);
     }
   },
 });

--- a/viewer/src/stores/publishStore.js
+++ b/viewer/src/stores/publishStore.js
@@ -1,27 +1,86 @@
 import * as publishApi from '../api/publish';
+import { emitFirstPublishTelemetry } from '../components/new-views/workspace/telemetry';
 
 /**
  * Publish Store Slice
  *
- * Manages the publish workflow for writing cached changes to YAML files.
- * Tracks unpublished changes across sources and models.
+ * Manages the publish workflow for writing cached changes to YAML files
+ * (Track H / VIS-806). Tracks unpublished changes across every named-child
+ * type, the live pending-changes count for the TopBar cluster, and a global
+ * save-activity counter so the cluster can show "Saving…" while any draft
+ * write is in flight (canvas actions, right-rail forms, level CRUD).
  */
+
+/**
+ * Every named-child fetch action that must re-run after a publish or a
+ * discard so the UI reflects the backend's post-flush state. Discard is the
+ * critical consumer: the canvas re-renders from these refetches (Q14
+ * rollback). Each key is called via `get()[key]?.()` so a missing slice
+ * (e.g. in a trimmed test store) is a no-op rather than a crash.
+ */
+const NAMED_CHILD_FETCHERS = [
+  'fetchSources',
+  'fetchModels',
+  'fetchCsvScriptModels',
+  'fetchLocalMergeModels',
+  'fetchDimensions',
+  'fetchMetrics',
+  'fetchRelations',
+  'fetchInsights',
+  'fetchMarkdowns',
+  'fetchCharts',
+  'fetchTables',
+  'fetchDashboards',
+  'fetchInputs',
+  'fetchDefaults',
+];
+
 const createPublishSlice = (set, get) => ({
   // State
   hasUnpublishedChanges: false,
   pendingChanges: [], // List of objects with pending changes
+  pendingCount: 0,
   publishLoading: false,
   publishError: null,
   publishModalOpen: false,
+  discardLoading: false,
+  // Timestamp of the last successful publish — the TopBar cluster derives
+  // its transient "Published ✓" flash from changes to this value.
+  lastPublishedAt: null,
+  // Global save-activity tracking (H-1). `saveActivityCount` counts draft
+  // writes currently in flight; `lastSaveFailed` latches on a failed write
+  // and resets when the next write begins.
+  saveActivityCount: 0,
+  lastSaveFailed: false,
 
-  // Check if there are any unpublished changes
+  beginSaveActivity: () =>
+    set(state => ({
+      saveActivityCount: state.saveActivityCount + 1,
+      lastSaveFailed: false,
+    })),
+
+  endSaveActivity: (ok = true) =>
+    set(state => ({
+      saveActivityCount: Math.max(0, state.saveActivityCount - 1),
+      lastSaveFailed: ok ? state.lastSaveFailed : true,
+    })),
+
+  // Refresh pending-change state (count + list + boolean) in one round trip.
+  // Save actions call this after every draft write, so the TopBar count
+  // updates live.
   checkPublishStatus: async () => {
     try {
-      const data = await publishApi.getPublishStatus();
-      set({ hasUnpublishedChanges: data.has_unpublished_changes });
+      const data = await publishApi.getPendingChanges();
+      const pending = data.pending || [];
+      const count = typeof data.count === 'number' ? data.count : pending.length;
+      set({
+        pendingChanges: pending,
+        pendingCount: count,
+        hasUnpublishedChanges: count > 0,
+      });
     } catch (error) {
       // Silently fail - endpoint may not be available in dist mode
-      set({ hasUnpublishedChanges: false });
+      set({ hasUnpublishedChanges: false, pendingChanges: [], pendingCount: 0 });
     }
   },
 
@@ -29,12 +88,22 @@ const createPublishSlice = (set, get) => ({
   fetchPendingChanges: async () => {
     try {
       const data = await publishApi.getPendingChanges();
-      set({ pendingChanges: data.pending || [] });
-      return data.pending || [];
+      const pending = data.pending || [];
+      const count = typeof data.count === 'number' ? data.count : pending.length;
+      set({
+        pendingChanges: pending,
+        pendingCount: count,
+        hasUnpublishedChanges: count > 0,
+      });
+      return pending;
     } catch (error) {
-      set({ pendingChanges: [] });
+      set({ pendingChanges: [], pendingCount: 0, hasUnpublishedChanges: false });
       return [];
     }
+  },
+
+  _refreshNamedChildren: async () => {
+    await Promise.all(NAMED_CHILD_FETCHERS.map(key => get()[key]?.()));
   },
 
   // Publish all cached changes to YAML files
@@ -46,14 +115,37 @@ const createPublishSlice = (set, get) => ({
         publishLoading: false,
         hasUnpublishedChanges: false,
         pendingChanges: [],
+        pendingCount: 0,
         publishModalOpen: false,
+        lastPublishedAt: Date.now(),
       });
-      // Refresh sources and models to reflect published state
-      await get().fetchSources?.();
-      await get().fetchModels?.();
+      emitFirstPublishTelemetry();
+      // Refresh every named-child collection to reflect published state
+      await get()._refreshNamedChildren();
       return { success: true, result };
     } catch (error) {
       set({ publishLoading: false, publishError: error.message });
+      return { success: false, error: error.message };
+    }
+  },
+
+  // Discard all cached changes without writing YAML (Q14 rollback). The
+  // named-child refetch is what makes the canvas revert to last-published.
+  discardChanges: async () => {
+    set({ discardLoading: true });
+    try {
+      const result = await publishApi.discardChanges();
+      set({
+        discardLoading: false,
+        hasUnpublishedChanges: false,
+        pendingChanges: [],
+        pendingCount: 0,
+        publishError: null,
+      });
+      await get()._refreshNamedChildren();
+      return { success: true, result };
+    } catch (error) {
+      set({ discardLoading: false });
       return { success: false, error: error.message };
     }
   },

--- a/viewer/src/stores/publishStore.test.js
+++ b/viewer/src/stores/publishStore.test.js
@@ -1,0 +1,199 @@
+/**
+ * publishStore tests (VIS-806 / Track H H-1).
+ *
+ * The publish slice drives the TopBar PublishCluster: live pending-change
+ * count, the global save-activity counter, Publish (flush draft cache to
+ * YAML) and Discard (drop the draft cache, Q14 rollback).
+ */
+import useStore from './store';
+import * as publishApi from '../api/publish';
+import { emitFirstPublishTelemetry } from '../components/new-views/workspace/telemetry';
+
+jest.mock('../api/publish', () => ({
+  getPublishStatus: jest.fn(),
+  getPendingChanges: jest.fn(),
+  publishChanges: jest.fn(),
+  discardChanges: jest.fn(),
+}));
+
+jest.mock('../components/new-views/workspace/telemetry', () => ({
+  emitFirstPublishTelemetry: jest.fn(),
+  emitWorkspaceEvent: jest.fn(),
+  markBuildModeEntered: jest.fn(),
+  setWorkspaceTelemetryListener: jest.fn(),
+}));
+
+// Every named-child fetcher the publish/discard flows refresh — stubbed so
+// the post-flush Promise.all never hits the network from jsdom.
+const FETCHER_KEYS = [
+  'fetchSources',
+  'fetchModels',
+  'fetchCsvScriptModels',
+  'fetchLocalMergeModels',
+  'fetchDimensions',
+  'fetchMetrics',
+  'fetchRelations',
+  'fetchInsights',
+  'fetchMarkdowns',
+  'fetchCharts',
+  'fetchTables',
+  'fetchDashboards',
+  'fetchInputs',
+  'fetchDefaults',
+];
+
+describe('publishStore (VIS-806)', () => {
+  let fetcherStubs;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetcherStubs = Object.fromEntries(
+      FETCHER_KEYS.map(key => [key, jest.fn().mockResolvedValue(undefined)])
+    );
+    useStore.setState({
+      ...fetcherStubs,
+      hasUnpublishedChanges: false,
+      pendingChanges: [],
+      pendingCount: 0,
+      publishLoading: false,
+      publishError: null,
+      publishModalOpen: false,
+      discardLoading: false,
+      lastPublishedAt: null,
+      saveActivityCount: 0,
+      lastSaveFailed: false,
+    });
+  });
+
+  describe('checkPublishStatus', () => {
+    test('sets count, list, and boolean from the pending endpoint', async () => {
+      publishApi.getPendingChanges.mockResolvedValue({
+        pending: [
+          { name: 'a', type: 'chart', status: 'new' },
+          { name: 'b', type: 'dashboard', status: 'modified' },
+        ],
+        count: 2,
+      });
+
+      await useStore.getState().checkPublishStatus();
+
+      const state = useStore.getState();
+      expect(state.pendingCount).toBe(2);
+      expect(state.hasUnpublishedChanges).toBe(true);
+      expect(state.pendingChanges).toHaveLength(2);
+    });
+
+    test('falls back to clean state when the endpoint is unavailable', async () => {
+      useStore.setState({ pendingCount: 5, hasUnpublishedChanges: true });
+      publishApi.getPendingChanges.mockRejectedValue(new Error('404'));
+
+      await useStore.getState().checkPublishStatus();
+
+      const state = useStore.getState();
+      expect(state.pendingCount).toBe(0);
+      expect(state.hasUnpublishedChanges).toBe(false);
+      expect(state.pendingChanges).toEqual([]);
+    });
+
+    test('derives the count from the list when the endpoint omits it', async () => {
+      publishApi.getPendingChanges.mockResolvedValue({
+        pending: [{ name: 'a', type: 'chart', status: 'new' }],
+      });
+
+      await useStore.getState().checkPublishStatus();
+
+      expect(useStore.getState().pendingCount).toBe(1);
+    });
+  });
+
+  describe('save activity tracking', () => {
+    test('begin/end balance the counter', () => {
+      const { beginSaveActivity, endSaveActivity } = useStore.getState();
+      beginSaveActivity();
+      beginSaveActivity();
+      expect(useStore.getState().saveActivityCount).toBe(2);
+      endSaveActivity(true);
+      endSaveActivity(true);
+      expect(useStore.getState().saveActivityCount).toBe(0);
+    });
+
+    test('a failed save latches lastSaveFailed until the next save begins', () => {
+      const { beginSaveActivity, endSaveActivity } = useStore.getState();
+      beginSaveActivity();
+      endSaveActivity(false);
+      expect(useStore.getState().lastSaveFailed).toBe(true);
+      beginSaveActivity();
+      expect(useStore.getState().lastSaveFailed).toBe(false);
+    });
+
+    test('the counter never goes negative', () => {
+      useStore.getState().endSaveActivity(true);
+      expect(useStore.getState().saveActivityCount).toBe(0);
+    });
+  });
+
+  describe('publishChanges', () => {
+    test('clears pending state, stamps lastPublishedAt, emits first-publish telemetry, and refreshes collections', async () => {
+      useStore.setState({
+        pendingCount: 3,
+        hasUnpublishedChanges: true,
+        publishModalOpen: true,
+      });
+      publishApi.publishChanges.mockResolvedValue({ published_count: 3 });
+
+      const result = await useStore.getState().publishChanges();
+
+      expect(result.success).toBe(true);
+      const state = useStore.getState();
+      expect(state.pendingCount).toBe(0);
+      expect(state.hasUnpublishedChanges).toBe(false);
+      expect(state.publishModalOpen).toBe(false);
+      expect(state.lastPublishedAt).toEqual(expect.any(Number));
+      expect(emitFirstPublishTelemetry).toHaveBeenCalledTimes(1);
+      FETCHER_KEYS.forEach(key => expect(fetcherStubs[key]).toHaveBeenCalled());
+    });
+
+    test('surfaces the error and keeps pending state on failure', async () => {
+      useStore.setState({ pendingCount: 2, hasUnpublishedChanges: true });
+      publishApi.publishChanges.mockRejectedValue(new Error('YAML write failed'));
+
+      const result = await useStore.getState().publishChanges();
+
+      expect(result.success).toBe(false);
+      const state = useStore.getState();
+      expect(state.publishError).toBe('YAML write failed');
+      expect(state.publishLoading).toBe(false);
+      expect(state.pendingCount).toBe(2);
+      expect(emitFirstPublishTelemetry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('discardChanges', () => {
+    test('drops pending state and refreshes every collection (canvas revert)', async () => {
+      useStore.setState({ pendingCount: 4, hasUnpublishedChanges: true });
+      publishApi.discardChanges.mockResolvedValue({ discarded_count: 4 });
+
+      const result = await useStore.getState().discardChanges();
+
+      expect(result.success).toBe(true);
+      const state = useStore.getState();
+      expect(state.pendingCount).toBe(0);
+      expect(state.hasUnpublishedChanges).toBe(false);
+      expect(state.discardLoading).toBe(false);
+      FETCHER_KEYS.forEach(key => expect(fetcherStubs[key]).toHaveBeenCalled());
+    });
+
+    test('reports failure without clearing pending state', async () => {
+      useStore.setState({ pendingCount: 4, hasUnpublishedChanges: true });
+      publishApi.discardChanges.mockRejectedValue(new Error('boom'));
+
+      const result = await useStore.getState().discardChanges();
+
+      expect(result.success).toBe(false);
+      const state = useStore.getState();
+      expect(state.pendingCount).toBe(4);
+      expect(state.discardLoading).toBe(false);
+      expect(fetcherStubs.fetchDashboards).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -43,7 +43,14 @@ def serve_phase(
                 existing_project=app.project, existing_dag_filter=dag_filter
             )
             if not changed_dag_filter and not new:
-                Logger.instance().info("No changes to the project.")
+                # No runnable jobs changed, but the compiled project may still
+                # differ (e.g. a layout-only dashboard edit published to YAML).
+                # Refresh the app project so the object managers rehydrate from
+                # the new YAML — otherwise a publish that only reshapes a
+                # dashboard serves stale published objects until the next data
+                # change (the canvas would silently lose the published edit).
+                app.project = project
+                Logger.instance().info("No data changes to the project. Refreshed metadata.")
                 return
 
             runner = run_phase(

--- a/visivo/server/views/publish_views.py
+++ b/visivo/server/views/publish_views.py
@@ -437,33 +437,49 @@ def register_publish_views(app, flask_app, output_dir):
             if not named_children:
                 return jsonify({"message": "No changes to publish", "published_count": 0})
 
-            # Use ProjectWriter to write changes
-            writer = ProjectWriter(named_children)
-            writer.update_file_contents()
-            writer.write()
+            # Serialize with the file watcher for the whole write→refresh
+            # window. Without this, the YAML writes below fire a debounced
+            # watcher recompile that races the synchronous one — both clone
+            # git includes into the same cache, one dies on the git lock,
+            # `on_project_change` swallows the error, and this endpoint then
+            # returns success while the served project is still stale (the
+            # canvas silently "loses" the just-published edit). Pausing
+            # blocks until any in-flight watcher compile finishes and drops
+            # the watcher events our own writes would otherwise queue.
+            hot_reload_server = flask_app.hot_reload_server
+            if hot_reload_server:
+                hot_reload_server.pause_file_watcher()
+            try:
+                # Use ProjectWriter to write changes
+                writer = ProjectWriter(named_children)
+                writer.update_file_contents()
+                writer.write()
 
-            # Clear caches after successful write
-            flask_app.source_manager.clear_cache()
-            flask_app.model_manager.clear_cache()
-            flask_app.dimension_manager.clear_cache()
-            flask_app.metric_manager.clear_cache()
-            flask_app.relation_manager.clear_cache()
-            flask_app.insight_manager.clear_cache()
-            flask_app.markdown_manager.clear_cache()
-            flask_app.chart_manager.clear_cache()
-            flask_app.table_manager.clear_cache()
-            flask_app.dashboard_manager.clear_cache()
-            flask_app.csv_script_model_manager.clear_cache()
-            flask_app.local_merge_model_manager.clear_cache()
-            flask_app.input_manager.clear_cache()
-            flask_app._cached_defaults = None
+                # Clear caches after successful write
+                flask_app.source_manager.clear_cache()
+                flask_app.model_manager.clear_cache()
+                flask_app.dimension_manager.clear_cache()
+                flask_app.metric_manager.clear_cache()
+                flask_app.relation_manager.clear_cache()
+                flask_app.insight_manager.clear_cache()
+                flask_app.markdown_manager.clear_cache()
+                flask_app.chart_manager.clear_cache()
+                flask_app.table_manager.clear_cache()
+                flask_app.dashboard_manager.clear_cache()
+                flask_app.csv_script_model_manager.clear_cache()
+                flask_app.local_merge_model_manager.clear_cache()
+                flask_app.input_manager.clear_cache()
+                flask_app._cached_defaults = None
 
-            # Trigger project reload via hot reload server if available
-            if flask_app.hot_reload_server:
-                # Reload the project
-                flask_app.hot_reload_server.on_project_change(one_shot=False)
-                # Notify clients to refresh
-                flask_app.hot_reload_server.socketio.emit("reload")
+                # Trigger project reload via hot reload server if available
+                if hot_reload_server:
+                    # Reload the project
+                    hot_reload_server.on_project_change(one_shot=False)
+                    # Notify clients to refresh
+                    hot_reload_server.socketio.emit("reload")
+            finally:
+                if hot_reload_server:
+                    hot_reload_server.resume_file_watcher()
 
             return jsonify(
                 {
@@ -473,6 +489,46 @@ def register_publish_views(app, flask_app, output_dir):
             )
         except Exception as e:
             Logger.instance().error(f"Error publishing changes: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/publish/discard/", methods=["POST"])
+    def discard_changes():
+        """Drop every cached draft without writing YAML (the Discard rollback, Q14)."""
+        try:
+            managers = [
+                flask_app.source_manager,
+                flask_app.model_manager,
+                flask_app.dimension_manager,
+                flask_app.metric_manager,
+                flask_app.relation_manager,
+                flask_app.insight_manager,
+                flask_app.markdown_manager,
+                flask_app.chart_manager,
+                flask_app.table_manager,
+                flask_app.dashboard_manager,
+                flask_app.csv_script_model_manager,
+                flask_app.local_merge_model_manager,
+                flask_app.input_manager,
+            ]
+            discarded_count = 0
+            for manager in managers:
+                for name in list(manager.cached_objects.keys()):
+                    status = manager.get_status(name)
+                    if status and status != ObjectStatus.PUBLISHED:
+                        discarded_count += 1
+                manager.clear_cache()
+            if flask_app._cached_defaults is not None:
+                discarded_count += 1
+                flask_app._cached_defaults = None
+
+            return jsonify(
+                {
+                    "message": "Changes discarded",
+                    "discarded_count": discarded_count,
+                }
+            )
+        except Exception as e:
+            Logger.instance().error(f"Error discarding changes: {str(e)}")
             return jsonify({"error": str(e)}), 500
 
 


### PR DESCRIPTION
## Track H / VIS-806 — Build-mode Save/Publish

Implements the H-1 design brief: every canvas action and right-rail form change auto-saves to the backend draft cache (this already worked); the TopBar now surfaces it with a live cluster and gates YAML writes behind **Publish**, with **Discard** as the v1 rollback (Q13/Q14).

### What shipped
**Backend**
- `POST /api/publish/discard/` — drops all draft caches without writing YAML, returns `discarded_count`.
- **Post-publish staleness fixes** (found by the e2e):
  - `on_project_change` now refreshes `app.project` on layout-only recompiles (empty runnable diff previously early-returned → after publish the managers served the **pre-publish** config and the canvas silently lost the published edit).
  - Publish pauses the file watcher across write→refresh (a debounced watcher recompile raced the synchronous one; both cloned git includes concurrently and the loser's failure was swallowed, returning success while serving stale state).

**Viewer**
- `PublishCluster` in the TopBar: status pill (Saving… / Save failed / Published ✓ flash / N changes / Saved), `Publish · N` → existing PublishModal confirm flow, `Publish failed — Retry`, Discard → confirm dialog (Cancel is the safe primary) → canvas reverts via full named-child refetch.
- Live pending count: `checkPublishStatus` reads `/api/publish/pending/` (count + list in one trip); every save path already calls it.
- Global save-activity counter feeding the pill: canvas `saveDashboard`, `saveDefaults` (level CRUD), and `useDebouncedSave` (all right-rail forms).
- `time_to_first_publish_in_build_mode` telemetry — armed on Workspace mount, fired once per Build-mode entry.

**Pre-existing bug fixed: the Workspace top bar was never clickable.** Home's fixed `z-50` TopNav covered the `z-40` Workspace overlay — every prior screenshot of the workspace 'top bar' was actually Home's TopNav (green Publish). The overlay moves to `z-[60]`, shared `ModalOverlay` to `z-[70]` (so Home's layout-level Publish/Deploy modals show above it; no duplicate modal mounts), and the TopBar Deploy stub now opens the real DeployModal. The e2e guards this with an `elementFromPoint` assertion.

### Test evidence
- Backend: **1661 passed** (+7: 4 discard, 2 watcher-pause ordering, 1 layout-only-refresh regression w/ mutation check), black clean.
- Viewer: **2390 → 2419 passed**, lint 0 errors.
- e2e: new `build-mode-publish.spec.mjs` — **6/6 green** against a live sandbox, including a real YAML round-trip on disk (file snapshot/byte-restore in the suite). Runs in a new isolated `workspace-publish` playwright project (`workers: 1, retries: 0`) since it mutates project files.
- Visual QA: 1600px + 1280px captures of clean/dirty/confirm/flash states reviewed; cluster fits 1280 without pushing Deploy/utilities off-screen.

### Notes for review
- `hasUnpublishedChanges` is kept (other consumers) but the cluster keys off `pendingCount`.
- H-2 (external-edit banner) comes next on top of this branch — it will also close the remaining 'frontend refetch races the watcher recompile' window via a socket listener instead of a blind page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)