### PR TITLE
feat: H-2 external-edit banner + soft-refresh on hot reload (VIS-808)

### DIFF
--- a/tests/commands/test_serve_phase.py
+++ b/tests/commands/test_serve_phase.py
@@ -124,3 +124,64 @@ def test_on_project_change_layout_only_edit_refreshes_served_project(
     data = client.get("/api/dashboards/").get_json()
     served = next(d for d in data["dashboards"] if d["name"] == dashboard_name)
     assert len(served["config"]["rows"]) == baseline_rows + 1
+
+
+def test_on_project_change_drops_drafts_and_emits_project_changed(
+    test_project, output_dir, server_url, mocker
+):
+    """Q15 last-write-wins (VIS-808): an external YAML change during a dirty
+    Build session drops every draft and notifies the SPA via the
+    `project_changed` socket event with drafts_dropped=True."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    server, on_project_change, _ = serve_phase(
+        output_dir=output_dir,
+        working_dir=".",
+        default_source=None,
+        dag_filter=None,
+        threads=1,
+        skip_compile=True,
+        project=test_project,
+        server_url=server_url,
+    )
+    emit_spy = mocker.patch.object(server.socketio, "emit")
+    client = server.app.test_client()
+
+    # Dirty the session through the real save endpoint (draft cache only).
+    dashboard_name = test_project.dashboards[0].name
+    config = client.get(f"/api/dashboards/{dashboard_name}/").get_json()["config"]
+    config["rows"] = list(config["rows"]) + [{"height": "medium", "items": [{"width": 4}]}]
+    assert client.post(f"/api/dashboards/{dashboard_name}/save/", json=config).status_code == 200
+    assert client.get("/api/publish/pending/").get_json()["count"] == 1
+
+    mocker.patch("visivo.commands.serve_phase.compile_phase", return_value=ProjectFactory())
+
+    on_project_change()
+
+    assert client.get("/api/publish/pending/").get_json()["count"] == 0
+    emit_spy.assert_called_with("project_changed", {"drafts_dropped": True})
+
+
+def test_on_project_change_clean_session_emits_without_dropping(
+    test_project, output_dir, server_url, mocker
+):
+    """A recompile with no drafts in flight (e.g. right after a publish, which
+    clears the caches itself) reports drafts_dropped=False — no banner."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    server, on_project_change, _ = serve_phase(
+        output_dir=output_dir,
+        working_dir=".",
+        default_source=None,
+        dag_filter=None,
+        threads=1,
+        skip_compile=True,
+        project=test_project,
+        server_url=server_url,
+    )
+    emit_spy = mocker.patch.object(server.socketio, "emit")
+    mocker.patch("visivo.commands.serve_phase.compile_phase", return_value=ProjectFactory())
+
+    on_project_change()
+
+    emit_spy.assert_called_with("project_changed", {"drafts_dropped": False})

--- a/viewer/e2e/stories/external-edit-banner.spec.mjs
+++ b/viewer/e2e/stories/external-edit-banner.spec.mjs
@@ -1,0 +1,158 @@
+/**
+ * Story: External-edit banner during a dirty Build session (VIS-808 / Track H H-2).
+ *
+ * With unsaved drafts in the Build session, an external edit to the project
+ * YAML triggers the hot-reload pipeline: the backend drops the drafts
+ * (Q15 last-write-wins), emits `project_changed {drafts_dropped: true}`,
+ * and the Workspace soft-refreshes — canvas re-renders from the file's
+ * state, the cluster returns to "Saved", and the warning banner appears at
+ * the top of the canvas area (dismissible, non-blocking).
+ *
+ * Mutates test-projects/integration/project.visivo.yml from the OUTSIDE
+ * (fs append of a comment — parse-identical, but a real watcher event), so
+ * it runs in the isolated 'workspace-publish' playwright project (serial,
+ * no retries). The suite snapshots and byte-restores the YAML.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8051 VISIVO_SANDBOX_FRONTEND_PORT=3051 \
+ *   VISIVO_SANDBOX_NAME=vis806 bash scripts/sandbox.sh start
+ *   # then: VIS_PUBLISH_BASE=http://localhost:3051 npx playwright test external-edit-banner
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const BASE = process.env.VIS_PUBLISH_BASE || 'http://localhost:3051';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+// The watcher debounces 500ms, then recompiles + reruns — give the banner
+// the full pipeline's worth of time.
+const RELOAD_WAIT = 45000;
+
+const PROJECT_YML = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../test-projects/integration/project.visivo.yml'
+);
+
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId('canvas-add-row')).toBeAttached({ timeout: WAIT });
+};
+
+const addRowViaCanvas = async page => {
+  const before = (await readRows(page)).length;
+  await page.getByTestId('canvas-add-row-end-button').click();
+  await expect(page.getByTestId('row-template-menu')).toBeVisible({ timeout: WAIT });
+  await page.getByTestId('row-template-3up').click();
+  await expect
+    .poll(async () => (await readRows(page)).length, { timeout: WAIT })
+    .toBe(before + 1);
+  return before;
+};
+
+test.describe('External-edit banner (VIS-808 / H-2)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(180000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  let originalYaml;
+
+  test.beforeAll(async ({ browser, request }) => {
+    originalYaml = fs.readFileSync(PROJECT_YML, 'utf8');
+    await request.post(`${BASE}/api/publish/discard/`).catch(() => {});
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.post(`${BASE}/api/publish/discard/`).catch(() => {});
+    if (originalYaml !== undefined && fs.readFileSync(PROJECT_YML, 'utf8') !== originalYaml) {
+      fs.writeFileSync(PROJECT_YML, originalYaml);
+      await new Promise(resolve => setTimeout(resolve, 4000));
+    }
+    await page.close();
+  });
+
+  test('an external YAML edit during a dirty session drops drafts and shows the banner', async () => {
+    await openCanvas(page);
+    await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+    const baselineRows = (await readRows(page)).length;
+
+    // Dirty the session through a real canvas action.
+    await addRowViaCanvas(page);
+    await expect(page.getByTestId('workspace-save-pill-dirty')).toBeVisible({ timeout: WAIT });
+    expect((await readRows(page)).length).toBe(baselineRows + 1);
+
+    // External edit: touch the YAML outside Visivo (comment append — a real
+    // file change for the watcher, parse-identical for the compiler).
+    fs.writeFileSync(PROJECT_YML, `${originalYaml}\n# external edit ${process.pid}\n`);
+
+    // The banner appears once the hot-reload pipeline lands...
+    await expect(page.getByTestId('external-edit-banner')).toBeVisible({
+      timeout: RELOAD_WAIT,
+    });
+    await expect(page.getByTestId('external-edit-banner')).toHaveText(
+      /File changed externally/
+    );
+    await page.screenshot({ path: `${SCREENS}/vis808-01-banner.png` });
+
+    // ...the draft row is gone (canvas re-rendered from the file's state,
+    // Q15 last-write-wins) and the cluster reads clean again.
+    await expect
+      .poll(async () => (await readRows(page)).length, { timeout: WAIT })
+      .toBe(baselineRows);
+    await expect(page.getByTestId('workspace-save-pill-clean')).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('workspace-top-bar-publish')).toBeDisabled();
+  });
+
+  test('the banner does not block canvas interaction and dismisses on X', async () => {
+    // Still visible from the previous test (30s auto-dismiss window).
+    await expect(page.getByTestId('external-edit-banner')).toBeVisible({ timeout: WAIT });
+
+    // Canvas stays interactive underneath: the add-row affordance still works.
+    await page.getByTestId('canvas-add-row-end-button').click();
+    await expect(page.getByTestId('row-template-menu')).toBeVisible({ timeout: WAIT });
+    await page.keyboard.press('Escape');
+
+    await page.getByTestId('external-edit-banner-dismiss').hover();
+    await page.getByTestId('external-edit-banner-dismiss').click();
+    await expect(page.getByTestId('external-edit-banner')).toHaveCount(0);
+    await page.screenshot({ path: `${SCREENS}/vis808-02-dismissed.png` });
+  });
+
+  test('no console errors across the external-edit flow', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+      // socket.io reconnect chatter during the sandbox's recompile window
+      'WebSocket',
+      'websocket error',
+      'xhr poll error',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    expect(real, `console errors:\n${real.join('\n')}`).toHaveLength(0);
+  });
+});

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -52,6 +52,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "socket.io-client": "^4.8.3",
     "tailwind-styled-components": "^2.2.0",
     "tailwindcss": "^4.1.18",
     "vite": "^6.4.1",

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
         '**/explorer-library-reactivity.spec.mjs',
         '**/explorer-publish-to-files.spec.mjs',
         '**/build-mode-publish.spec.mjs',
+        '**/external-edit-banner.spec.mjs',
       ],
     },
     {
@@ -52,13 +53,14 @@ export default defineConfig({
       retries: 0,
     },
     {
-      // H-1 Save/Publish cluster (VIS-806) — publishes REAL YAML writes to the
-      // integration project, so it gets the same isolation as 'publish':
-      // serial, no retries (a retry would race the file-watcher recompile
-      // triggered by the previous attempt's YAML restore and see phantom
-      // pending changes). Targets its own sandbox via VIS_PUBLISH_BASE.
+      // Track H stories (VIS-806/808) — both mutate the integration project's
+      // YAML on disk (publish writes / external-edit simulation), so they get
+      // the same isolation as 'publish': serial, no retries (a retry would
+      // race the file-watcher recompile triggered by the previous attempt's
+      // YAML restore and see phantom pending changes). Targets its own
+      // sandbox via VIS_PUBLISH_BASE.
       name: 'workspace-publish',
-      testMatch: ['**/build-mode-publish.spec.mjs'],
+      testMatch: ['**/build-mode-publish.spec.mjs', '**/external-edit-banner.spec.mjs'],
       fullyParallel: false,
       workers: 1,
       retries: 0,

--- a/viewer/src/components/new-views/workspace/ExternalEditBanner.jsx
+++ b/viewer/src/components/new-views/workspace/ExternalEditBanner.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { PiWarningCircle, PiX } from 'react-icons/pi';
+import useStore from '../../../stores/store';
+
+/**
+ * ExternalEditBanner — VIS-808 (Track H H-2, design brief H-2).
+ *
+ * Dismissible warning shown at the top of the canvas area when an external
+ * YAML edit overwrote unsaved canvas changes (Q15 last-write-wins). Sits
+ * below the Workspace top bar, full-width within the middle pane, in the
+ * muted highlight palette — visible but not alarming — and never blocks
+ * canvas interaction. Auto-dismisses after ~30s; dismissing only hides the
+ * warning (the overwrite already happened).
+ */
+
+const AUTO_DISMISS_MS = 30000;
+
+const ExternalEditBanner = () => {
+  const visible = useStore(s => s.externalEditBannerVisible);
+  const dismiss = useStore(s => s.dismissExternalEditBanner);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    const timer = setTimeout(() => dismiss(), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [visible, dismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      data-testid="external-edit-banner"
+      className="flex w-full shrink-0 items-start gap-3 border-b border-highlight-200 bg-highlight-50 px-4 py-3"
+    >
+      <PiWarningCircle
+        aria-hidden="true"
+        className="mt-0.5 h-5 w-5 shrink-0 text-highlight-600"
+      />
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="font-medium text-highlight-900">File changed externally.</p>
+        <p className="mt-0.5 text-highlight-800">
+          Your unsaved canvas changes were dropped because the YAML file was edited outside
+          Visivo. The canvas now reflects the file&apos;s current state.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        data-testid="external-edit-banner-dismiss"
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-highlight-700 transition-colors hover:bg-highlight-100 hover:text-highlight-900"
+      >
+        <PiX className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+export default ExternalEditBanner;

--- a/viewer/src/components/new-views/workspace/ExternalEditBanner.test.jsx
+++ b/viewer/src/components/new-views/workspace/ExternalEditBanner.test.jsx
@@ -1,0 +1,77 @@
+/**
+ * ExternalEditBanner tests (VIS-808 / Track H H-2).
+ *
+ * The Q15 last-write-wins warning: hidden by default, shown via the store
+ * flag, dismissible, auto-dismisses after ~30s, and never blocks the canvas
+ * (it renders as a static banner, not an overlay).
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useStore from '../../../stores/store';
+import ExternalEditBanner from './ExternalEditBanner';
+
+describe('ExternalEditBanner (VIS-808)', () => {
+  beforeEach(() => {
+    useStore.setState({ externalEditBannerVisible: false });
+  });
+
+  test('renders nothing while the flag is off', () => {
+    render(<ExternalEditBanner />);
+    expect(screen.queryByTestId('external-edit-banner')).not.toBeInTheDocument();
+  });
+
+  test('shows the warning copy when an external edit dropped drafts', () => {
+    useStore.setState({ externalEditBannerVisible: true });
+    render(<ExternalEditBanner />);
+
+    const banner = screen.getByTestId('external-edit-banner');
+    expect(banner).toHaveTextContent('File changed externally.');
+    expect(banner).toHaveTextContent('unsaved canvas changes were dropped');
+  });
+
+  test('the X dismisses it', async () => {
+    useStore.setState({ externalEditBannerVisible: true });
+    render(<ExternalEditBanner />);
+
+    await userEvent.click(screen.getByTestId('external-edit-banner-dismiss'));
+
+    expect(screen.queryByTestId('external-edit-banner')).not.toBeInTheDocument();
+    expect(useStore.getState().externalEditBannerVisible).toBe(false);
+  });
+
+  test('auto-dismisses after ~30 seconds', () => {
+    jest.useFakeTimers();
+    try {
+      useStore.setState({ externalEditBannerVisible: true });
+      render(<ExternalEditBanner />);
+      expect(screen.getByTestId('external-edit-banner')).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(30100);
+      });
+      expect(screen.queryByTestId('external-edit-banner')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('re-appears for a subsequent external edit after auto-dismiss', () => {
+    jest.useFakeTimers();
+    try {
+      useStore.setState({ externalEditBannerVisible: true });
+      render(<ExternalEditBanner />);
+      act(() => {
+        jest.advanceTimersByTime(30100);
+      });
+      expect(screen.queryByTestId('external-edit-banner')).not.toBeInTheDocument();
+
+      act(() => {
+        useStore.setState({ externalEditBannerVisible: true });
+      });
+      expect(screen.getByTestId('external-edit-banner')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/viewer/src/components/new-views/workspace/Workspace.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.jsx
@@ -4,6 +4,7 @@ import useStore from '../../../stores/store';
 import WorkspaceShell from './WorkspaceShell';
 import { emitWorkspaceEvent, markBuildModeEntered } from './telemetry';
 import { useWorkspaceScope } from './useWorkspaceScope';
+import useProjectChangeListener from './useProjectChangeListener';
 
 /**
  * Workspace — route container for `/workspace` and
@@ -27,6 +28,10 @@ const Workspace = () => {
   const setWorkspaceLens = useStore(s => s.setWorkspaceLens);
   const checkPublishStatus = useStore(s => s.checkPublishStatus);
   const scope = useWorkspaceScope();
+
+  // H-2: soft-refresh on backend `project_changed` events (and show the
+  // external-edit banner when a hot reload dropped unsaved drafts).
+  useProjectChangeListener();
 
   // Collection loaders — hoisted here from the Library so the rail is a
   // pure consumer and other workspace surfaces (canvas, outline, project

--- a/viewer/src/components/new-views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/new-views/workspace/Workspace.test.jsx
@@ -22,6 +22,12 @@ import { setWorkspaceTelemetryListener } from './telemetry';
 
 // Dashboard has heavy dependencies (insights data, plotly, etc.) — stub
 // it out so the Workspace shell render stays focused on shell behaviour.
+// The route container mounts the H-2 project-change socket listener — stub
+// the socket client so jsdom never attempts a real polling connection.
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => ({ on: jest.fn(), close: jest.fn() })),
+}));
+
 jest.mock('../../project/Dashboard', () => ({
   __esModule: true,
   default: ({ projectId, dashboardName }) => (

--- a/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceShell.jsx
@@ -6,6 +6,7 @@ import RightRail from './RightRail';
 import MiddlePane from './MiddlePane';
 import DragHandle from './DragHandle';
 import WorkspaceDndContext from './WorkspaceDndContext';
+import ExternalEditBanner from './ExternalEditBanner';
 import useStore from '../../../stores/store';
 
 /**
@@ -75,6 +76,9 @@ const WorkspaceShell = ({ testId = 'workspace-shell' }) => {
                 className="flex min-w-0 flex-1 flex-col"
                 data-testid="workspace-middle-container"
               >
+                {/* H-2: external-edit warning — top of the canvas area,
+                    full-width within the middle pane, non-blocking. */}
+                <ExternalEditBanner />
                 <MiddlePane />
               </main>
               <DragHandle side="right" />

--- a/viewer/src/components/new-views/workspace/useProjectChangeListener.js
+++ b/viewer/src/components/new-views/workspace/useProjectChangeListener.js
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { io } from 'socket.io-client';
+import useStore from '../../../stores/store';
+import { emitWorkspaceEvent } from './telemetry';
+
+/**
+ * useProjectChangeListener — VIS-808 (Track H H-2).
+ *
+ * While the Workspace is mounted, listen for the backend's `project_changed`
+ * Socket.IO event (fired after every successful recompile — external YAML
+ * edits AND post-publish refreshes) and soft-refresh the store instead of
+ * letting the page hard-reload:
+ *
+ *   - `drafts_dropped: true` means the recompile happened during a dirty
+ *     Build session and the backend dropped the drafts (Q15
+ *     last-write-wins) — the store shows the external-edit banner and the
+ *     canvas re-renders from the file's state via the refetch.
+ *   - The hook also sets `window.__VISIVO_SOFT_RELOAD__` so the legacy
+ *     `/hot-reload.js` script (injected when Flask serves the bundle) skips
+ *     its `window.location.reload()` while the Workspace handles updates.
+ *
+ * The socket connects to the page origin; the vite dev server proxies
+ * `/socket.io` to the Flask backend (see vite.config.mjs).
+ */
+export default function useProjectChangeListener() {
+  useEffect(() => {
+    window.__VISIVO_SOFT_RELOAD__ = true;
+    const socket = io({
+      // The Flask-SocketIO server runs in threading mode — polling is its
+      // native transport; websocket upgrade is attempted automatically.
+      transports: ['polling', 'websocket'],
+      reconnectionAttempts: 5,
+    });
+
+    socket.on('project_changed', payload => {
+      const draftsDropped = Boolean(payload?.drafts_dropped);
+      const refresh = useStore.getState().refreshFromProjectChange;
+      if (typeof refresh === 'function') {
+        refresh({ draftsDropped });
+      }
+      if (draftsDropped) {
+        emitWorkspaceEvent('external_edit_overwrite', {});
+      }
+    });
+
+    return () => {
+      window.__VISIVO_SOFT_RELOAD__ = false;
+      socket.close();
+    };
+  }, []);
+}

--- a/viewer/src/components/new-views/workspace/useProjectChangeListener.test.js
+++ b/viewer/src/components/new-views/workspace/useProjectChangeListener.test.js
@@ -1,0 +1,88 @@
+/**
+ * useProjectChangeListener tests (VIS-808 / Track H H-2).
+ *
+ * The Workspace's socket bridge: `project_changed` → store soft-refresh
+ * (+ external_edit_overwrite telemetry when drafts were dropped), and the
+ * window soft-reload flag that suppresses the legacy hot-reload script's
+ * hard refresh while the Workspace is mounted.
+ */
+import { renderHook } from '@testing-library/react';
+import { io } from 'socket.io-client';
+import useStore from '../../../stores/store';
+import useProjectChangeListener from './useProjectChangeListener';
+import { setWorkspaceTelemetryListener } from './telemetry';
+
+jest.mock('socket.io-client', () => {
+  const handlers = {};
+  const socket = {
+    on: jest.fn((event, fn) => {
+      handlers[event] = fn;
+    }),
+    close: jest.fn(),
+    _handlers: handlers,
+  };
+  return { io: jest.fn(() => socket) };
+});
+
+const getSocket = () => io.mock.results[io.mock.results.length - 1].value;
+
+describe('useProjectChangeListener (VIS-808)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete window.__VISIVO_SOFT_RELOAD__;
+    useStore.setState({
+      refreshFromProjectChange: jest.fn().mockResolvedValue(undefined),
+      externalEditBannerVisible: false,
+    });
+  });
+
+  test('sets the soft-reload flag while mounted and clears it on unmount', () => {
+    const { unmount } = renderHook(() => useProjectChangeListener());
+
+    expect(window.__VISIVO_SOFT_RELOAD__).toBe(true);
+    unmount();
+    expect(window.__VISIVO_SOFT_RELOAD__).toBe(false);
+    expect(getSocket().close).toHaveBeenCalled();
+  });
+
+  test('project_changed triggers the store soft-refresh', () => {
+    renderHook(() => useProjectChangeListener());
+
+    getSocket()._handlers.project_changed({ drafts_dropped: false });
+
+    expect(useStore.getState().refreshFromProjectChange).toHaveBeenCalledWith({
+      draftsDropped: false,
+    });
+  });
+
+  test('drafts_dropped emits external_edit_overwrite telemetry', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(evt => events.push(evt));
+    try {
+      renderHook(() => useProjectChangeListener());
+
+      getSocket()._handlers.project_changed({ drafts_dropped: true });
+
+      expect(useStore.getState().refreshFromProjectChange).toHaveBeenCalledWith({
+        draftsDropped: true,
+      });
+      expect(events.map(e => e.eventName)).toContain('external_edit_overwrite');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  test('a clean recompile does not emit the overwrite event', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(evt => events.push(evt));
+    try {
+      renderHook(() => useProjectChangeListener());
+
+      getSocket()._handlers.project_changed({ drafts_dropped: false });
+
+      expect(events.map(e => e.eventName)).not.toContain('external_edit_overwrite');
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/viewer/src/index.css
+++ b/viewer/src/index.css
@@ -25,6 +25,7 @@
   --color-secondary-900: #0f0e0f;
   --color-secondary: #4f494c;
 
+  --color-highlight-50: #fdf5f3;
   --color-highlight-100: #f6ddda;
   --color-highlight-200: #edbcb5;
   --color-highlight-300: #e49b90;

--- a/viewer/src/stores/publishStore.js
+++ b/viewer/src/stores/publishStore.js
@@ -150,6 +150,31 @@ const createPublishSlice = (set, get) => ({
     }
   },
 
+  // External-edit banner (VIS-808 / Q15). Shown when a hot-reload fires
+  // during a dirty Build session — the backend dropped the drafts
+  // (last-write-wins) and the canvas re-rendered from the file's state.
+  externalEditBannerVisible: false,
+
+  showExternalEditBanner: () => set({ externalEditBannerVisible: true }),
+
+  dismissExternalEditBanner: () => set({ externalEditBannerVisible: false }),
+
+  /**
+   * Soft refresh after a backend `project_changed` event: re-pull the
+   * project, every named-child collection, and the pending-change state so
+   * the Workspace reflects the recompiled YAML without a page reload.
+   */
+  refreshFromProjectChange: async ({ draftsDropped = false } = {}) => {
+    if (draftsDropped) {
+      set({ externalEditBannerVisible: true });
+    }
+    await Promise.all([
+      get().fetchProject?.(),
+      get()._refreshNamedChildren(),
+      get().checkPublishStatus(),
+    ]);
+  },
+
   // Open publish modal (fetches pending changes)
   openPublishModal: async () => {
     set({ publishModalOpen: true, publishError: null });

--- a/viewer/src/stores/publishStore.test.js
+++ b/viewer/src/stores/publishStore.test.js
@@ -168,6 +168,37 @@ describe('publishStore (VIS-806)', () => {
     });
   });
 
+  describe('refreshFromProjectChange (VIS-808)', () => {
+    test('shows the external-edit banner and refetches when drafts were dropped', async () => {
+      const fetchProject = jest.fn().mockResolvedValue(undefined);
+      useStore.setState({ fetchProject, externalEditBannerVisible: false });
+      publishApi.getPendingChanges.mockResolvedValue({ pending: [], count: 0 });
+
+      await useStore.getState().refreshFromProjectChange({ draftsDropped: true });
+
+      expect(useStore.getState().externalEditBannerVisible).toBe(true);
+      expect(fetchProject).toHaveBeenCalled();
+      expect(fetcherStubs.fetchDashboards).toHaveBeenCalled();
+    });
+
+    test('a clean recompile refetches without showing the banner', async () => {
+      const fetchProject = jest.fn().mockResolvedValue(undefined);
+      useStore.setState({ fetchProject, externalEditBannerVisible: false });
+      publishApi.getPendingChanges.mockResolvedValue({ pending: [], count: 0 });
+
+      await useStore.getState().refreshFromProjectChange({ draftsDropped: false });
+
+      expect(useStore.getState().externalEditBannerVisible).toBe(false);
+      expect(fetchProject).toHaveBeenCalled();
+    });
+
+    test('dismissExternalEditBanner hides the banner', () => {
+      useStore.setState({ externalEditBannerVisible: true });
+      useStore.getState().dismissExternalEditBanner();
+      expect(useStore.getState().externalEditBannerVisible).toBe(false);
+    });
+  });
+
   describe('discardChanges', () => {
     test('drops pending state and refreshes every collection (canvas revert)', async () => {
       useStore.setState({ pendingCount: 4, hasUnpublishedChanges: true });

--- a/viewer/vite.config.mjs
+++ b/viewer/vite.config.mjs
@@ -15,6 +15,12 @@ export default defineConfig({
     proxy: {
       '/data': `http://127.0.0.1:${backendPort}`,
       '/api': `http://127.0.0.1:${backendPort}`,
+      // Socket.IO (hot-reload `project_changed` events, VIS-808) — websocket
+      // upgrade enabled so the dev server behaves like the Flask-served app.
+      '/socket.io': {
+        target: `http://127.0.0.1:${backendPort}`,
+        ws: true,
+      },
     },
   },
   build: {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -2397,6 +2397,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
+  integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
+
 "@swc/helpers@^0.5.11":
   version "0.5.18"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.18.tgz#feeeabea0d10106ee25aaf900165df911ab6d3b1"
@@ -4617,7 +4622,7 @@ debug@2:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@~4.4.1:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -4861,6 +4866,22 @@ end-of-stream@^1.0.0:
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
+
+engine.io-client@~6.6.1:
+  version "6.6.5"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.6.5.tgz#9baebe6358dc432fb174bb42ed74cfd17626d051"
+  integrity sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.20.1"
+    xmlhttprequest-ssl "~2.1.1"
+
+engine.io-parser@~5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.3.tgz#00dc5b97b1f233a23c9398d0209504cf5f94d92f"
+  integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
 
 enhanced-resolve@^5.18.3:
   version "5.18.4"
@@ -9459,6 +9480,24 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+socket.io-client@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.8.3.tgz#62717edd46a318c918125b57e92dc7f8bb71c34c"
+  integrity sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-client "~6.6.1"
+    socket.io-parser "~4.2.4"
+
+socket.io-parser@~4.2.4:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.6.tgz#19156bf179af3931abd05260cfb1491822578a6f"
+  integrity sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -10555,6 +10594,11 @@ ws@^8.11.0, ws@^8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
+ws@~8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
@@ -10569,6 +10613,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ssl@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz#e9e8023b3f29ef34b97a859f584c5e6c61418e23"
+  integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -28,6 +28,17 @@ def serve_phase(
     server = None  # Will be set later
 
     def on_project_change(one_shot=False):
+        def emit_project_changed(drafts_dropped):
+            # Soft-refresh signal for the Workspace SPA (VIS-808 / Q15): the
+            # viewer refetches instead of hard-reloading, and shows the
+            # external-edit banner when drafts were dropped. The legacy
+            # "reload" event (full page refresh) is emitted separately by the
+            # watcher wrapper / publish endpoint.
+            if app.hot_reload_server:
+                app.hot_reload_server.socketio.emit(
+                    "project_changed", {"drafts_dropped": drafts_dropped}
+                )
+
         try:
             Logger.instance().info(
                 "Server has detected changes to the project. Re-running project..."
@@ -38,6 +49,18 @@ def serve_phase(
                 output_dir=output_dir,
                 no_deprecation_warnings=no_deprecation_warnings,
             )
+
+            # Q15 last-write-wins: the YAML on disk just changed, so any
+            # in-flight draft edits are stale — drop them BEFORE serving the
+            # recompiled project. A publish clears the caches before calling
+            # this, so drafts_dropped is only True for genuinely external
+            # edits during a dirty Build session.
+            drafts_dropped = app.has_draft_changes()
+            if drafts_dropped:
+                app.clear_draft_caches()
+                Logger.instance().info(
+                    "External project change with unsaved drafts — drafts dropped (last-write-wins)."
+                )
 
             changed_dag_filter = project.dag().get_diff_dag_filter(
                 existing_project=app.project, existing_dag_filter=dag_filter
@@ -51,6 +74,7 @@ def serve_phase(
                 # change (the canvas would silently lose the published edit).
                 app.project = project
                 Logger.instance().info("No data changes to the project. Refreshed metadata.")
+                emit_project_changed(drafts_dropped)
                 return
 
             runner = run_phase(
@@ -66,6 +90,7 @@ def serve_phase(
                 no_deprecation_warnings=no_deprecation_warnings,
             )
             app.project = runner.project
+            emit_project_changed(drafts_dropped)
             if one_shot:
                 Logger.instance().success("Closing server...")
             else:

--- a/visivo/server/flask_app.py
+++ b/visivo/server/flask_app.py
@@ -88,6 +88,36 @@ class FlaskApp:
 
         register_views(self.app, self, output_dir)
 
+    def _all_object_managers(self):
+        return [
+            self.source_manager,
+            self.model_manager,
+            self.dimension_manager,
+            self.metric_manager,
+            self.relation_manager,
+            self.insight_manager,
+            self.input_manager,
+            self.markdown_manager,
+            self.chart_manager,
+            self.table_manager,
+            self.dashboard_manager,
+            self.csv_script_model_manager,
+            self.local_merge_model_manager,
+        ]
+
+    def has_draft_changes(self) -> bool:
+        """True when any manager holds an unpublished draft (or defaults are cached)."""
+        return (
+            any(m.has_unpublished_changes() for m in self._all_object_managers())
+            or self._cached_defaults is not None
+        )
+
+    def clear_draft_caches(self) -> None:
+        """Drop every draft cache (Q15 last-write-wins on external YAML edits)."""
+        for manager in self._all_object_managers():
+            manager.clear_cache()
+        self._cached_defaults = None
+
     @property
     def project(self):
         return self._project

--- a/visivo/server/hot_reload_server.py
+++ b/visivo/server/hot_reload_server.py
@@ -150,9 +150,17 @@ class HotReloadServer:
             # Add route for client-side reload script
             @self.app.route("/hot-reload.js")
             def hot_reload_script():
+                # The Workspace SPA sets window.__VISIVO_SOFT_RELOAD__ while
+                # mounted and handles the `project_changed` event itself
+                # (refetch + external-edit banner, VIS-808) — a hard reload
+                # here would wipe that UI state.
                 return """
                     const socket = io();
                     socket.on('reload', () => {
+                        if (window.__VISIVO_SOFT_RELOAD__) {
+                            console.log('Soft reload handled by app — skipping page reload.');
+                            return;
+                        }
                         console.log('Reloading page...');
                         window.location.reload();
                     });


### PR DESCRIPTION
## Track H / VIS-808 — External-edit banner (stacked on #473)

> **Stacked PR**: base is `jared/vis-806-publish-save-cluster` (PR #473). Merge #473 first, then retarget/merge this one.

When `hot_reload_server.py` fires during a dirty Build session, the YAML on disk wins (Q15 last-write-wins): the backend drops all drafts, the Workspace re-renders from the file's state **without a page reload**, and a dismissible banner explains what happened.

### What shipped
**Backend**
- `FlaskApp.has_draft_changes()` / `clear_draft_caches()`; `on_project_change` drops drafts before serving the recompiled project (publish clears its own caches first, so `drafts_dropped` is only true for genuinely external edits).
- New `project_changed` Socket.IO event (`{drafts_dropped}`) on both success branches — the SPA's soft-refresh signal. This also closes the last post-publish staleness window from #473 (a later watcher recompile now pushes a refetch).
- The legacy `/hot-reload.js` hard reload defers to the SPA via `window.__VISIVO_SOFT_RELOAD__` (set only while the Workspace is mounted; all other routes keep the full-reload behavior).

**Viewer**
- `useProjectChangeListener` in the Workspace route container (socket.io-client; vite proxies `/socket.io` with ws upgrade) → `refreshFromProjectChange` refetches project + all named children + pending state.
- `<ExternalEditBanner>` per design brief H-2: top of the middle pane, muted highlight palette (added the documented `highlight-50` shade to the shared scale), dismiss X, ~30s auto-dismiss, non-blocking. Fires `external_edit_overwrite` telemetry.

### Test evidence
- Backend: **1663 passed** (+2: drafts-dropped emission, clean-session emission), black clean.
- Viewer: **2419 → 2431 passed**, lint 0 errors.
- e2e: `external-edit-banner.spec.mjs` **3/3 green** (real fs edit to the project YAML mid-session → banner + draft row dropped + cluster 'Saved'; banner non-blocking + dismissible; console sweep). Both Track H stories together: **9/9**.
- Visual QA: banner screenshot reviewed at 1600px — palette/copy/placement match the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)