### PR TITLE
feat: Track K — workspace telemetry → PostHog relay + coverage audit + Q22 metrics test (VIS-822/797/799)

### DIFF
--- a/tests/server/views/test_telemetry_views.py
+++ b/tests/server/views/test_telemetry_views.py
@@ -1,0 +1,120 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask
+
+from visivo.server.views.telemetry_views import MAX_PAYLOAD_BYTES, register_telemetry_views
+
+
+class TestTelemetryViews:
+    """Test suite for the workspace-event telemetry forwarding endpoint (VIS-822)."""
+
+    @pytest.fixture
+    def flask_app(self):
+        flask_app = Mock()
+        flask_app.project = Mock()
+        flask_app.project.defaults = None
+        return flask_app
+
+    @pytest.fixture
+    def app(self, flask_app):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        register_telemetry_views(app, flask_app, "/tmp/output")
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    def post_event(self, client, body):
+        return client.post(
+            "/api/telemetry/workspace-event/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    @patch("visivo.telemetry.client.get_telemetry_client")
+    @patch("visivo.server.views.telemetry_views.is_telemetry_enabled", return_value=True)
+    def test_forwards_event_through_telemetry_client(self, _enabled, get_client, client):
+        telemetry_client = Mock()
+        get_client.return_value = telemetry_client
+
+        response = self.post_event(
+            client,
+            {"name": "workspace_mode_entered", "payload": {"dashboardName": "sales"}},
+        )
+
+        assert response.status_code == 204
+        telemetry_client.track.assert_called_once()
+        event = telemetry_client.track.call_args[0][0]
+        assert event.event_type == "workspace_mode_entered"
+        assert event.properties["dashboardName"] == "sales"
+        assert event.properties["source_surface"] == "viewer_workspace"
+
+    @patch("visivo.telemetry.client.get_telemetry_client")
+    @patch("visivo.server.views.telemetry_views.is_telemetry_enabled", return_value=True)
+    def test_payload_defaults_to_empty_object(self, _enabled, get_client, client):
+        telemetry_client = Mock()
+        get_client.return_value = telemetry_client
+
+        response = self.post_event(client, {"name": "canvas_action"})
+
+        assert response.status_code == 204
+        event = telemetry_client.track.call_args[0][0]
+        assert event.event_type == "canvas_action"
+
+    @patch("visivo.telemetry.client.get_telemetry_client")
+    @patch("visivo.server.views.telemetry_views.is_telemetry_enabled", return_value=False)
+    def test_opt_out_accepts_and_drops_event(self, _enabled, get_client, client):
+        response = self.post_event(
+            client, {"name": "workspace_mode_entered", "payload": {"scope": "root"}}
+        )
+
+        assert response.status_code == 204
+        get_client.assert_not_called()
+
+    @patch("visivo.server.views.telemetry_views.is_telemetry_enabled", return_value=True)
+    def test_opt_out_consults_project_defaults(self, enabled, client, flask_app):
+        with patch("visivo.telemetry.client.get_telemetry_client") as get_client:
+            get_client.return_value = Mock()
+            self.post_event(client, {"name": "canvas_action"})
+        enabled.assert_called_once_with(flask_app.project.defaults)
+
+    def test_rejects_non_object_body(self, client):
+        response = client.post(
+            "/api/telemetry/workspace-event/",
+            data=json.dumps(["not", "an", "object"]),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_rejects_missing_name(self, client):
+        response = self.post_event(client, {"payload": {}})
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["", "Has-Caps", "1starts_with_digit", "kebab-case", "a" * 65, 42],
+    )
+    def test_rejects_invalid_event_names(self, client, bad_name):
+        response = self.post_event(client, {"name": bad_name})
+        assert response.status_code == 400
+
+    def test_rejects_non_object_payload(self, client):
+        response = self.post_event(client, {"name": "canvas_action", "payload": [1, 2, 3]})
+        assert response.status_code == 400
+
+    def test_rejects_oversized_payload(self, client):
+        response = self.post_event(
+            client,
+            {"name": "canvas_action", "payload": {"blob": "x" * (MAX_PAYLOAD_BYTES + 1)}},
+        )
+        assert response.status_code == 400
+
+    @patch("visivo.telemetry.client.get_telemetry_client", side_effect=RuntimeError("boom"))
+    @patch("visivo.server.views.telemetry_views.is_telemetry_enabled", return_value=True)
+    def test_telemetry_client_errors_never_surface(self, _enabled, _get_client, client):
+        response = self.post_event(client, {"name": "canvas_action", "payload": {}})
+        assert response.status_code == 204

--- a/viewer/src/api/workspaceTelemetry.js
+++ b/viewer/src/api/workspaceTelemetry.js
@@ -1,0 +1,71 @@
+import { isAvailable, getUrl } from '../contexts/URLContext';
+
+/**
+ * Workspace telemetry sink (VIS-822).
+ *
+ * `emitWorkspaceEvent` forwards each workspace event here; we POST it to the
+ * local Flask server's `/api/telemetry/workspace-event/` endpoint, which
+ * relays it through the CLI's server-side PostHog client. Routing through
+ * the server (instead of shipping posthog-js + an API key in the bundle)
+ * means the CLI telemetry opt-out (`VISIVO_TELEMETRY_DISABLED`,
+ * `~/.visivo/config.yml`, project `defaults.telemetry_enabled`) and its
+ * anonymization (machine-id distinct ids, `$ip: 0.0.0.0`) apply to frontend
+ * events for free.
+ *
+ * Guarantees:
+ *   - NEVER throws into the render path (every failure is swallowed).
+ *   - No-op under jest (`JEST_WORKER_ID`), so unit tests never fire network
+ *     calls — integration tests mock this module instead.
+ *   - No-op in the dist/cloud viewer (the `workspaceTelemetry` URL key is
+ *     `null` there — the standard urls.js local-only pattern) and before the
+ *     URLConfig is initialized.
+ */
+
+const isJest = () =>
+  typeof process !== 'undefined' && !!(process.env && process.env.JEST_WORKER_ID);
+
+/**
+ * Build the fetch request for a workspace event, or `null` when the sink is
+ * unavailable (dist mode, URLConfig not initialized, malformed event).
+ * Pure-ish (reads URL config) and exported so tests can cover the request
+ * shape without dispatching network calls.
+ *
+ * @param {{eventName: string, payload?: object, ts?: number}} event
+ * @returns {{url: string, options: object}|null}
+ */
+export function buildWorkspaceTelemetryRequest(event) {
+  if (!event || typeof event.eventName !== 'string' || !event.eventName) return null;
+  if (!isAvailable('workspaceTelemetry')) return null;
+  return {
+    url: getUrl('workspaceTelemetry'),
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: event.eventName,
+        payload: event.payload || {},
+        ts: event.ts,
+      }),
+      // Let the event survive page unloads (e.g. a publish immediately
+      // followed by navigation).
+      keepalive: true,
+    },
+  };
+}
+
+/**
+ * Fire-and-forget a workspace event to the server-side telemetry relay.
+ * Telemetry must never break the app: all errors are swallowed.
+ *
+ * @param {{eventName: string, payload?: object, ts?: number}} event
+ */
+export function postWorkspaceEvent(event) {
+  if (isJest()) return;
+  try {
+    const request = buildWorkspaceTelemetryRequest(event);
+    if (!request || typeof fetch !== 'function') return;
+    fetch(request.url, request.options).catch(() => {});
+  } catch {
+    // Swallow — telemetry must never throw into the render path.
+  }
+}

--- a/viewer/src/api/workspaceTelemetry.test.js
+++ b/viewer/src/api/workspaceTelemetry.test.js
@@ -1,0 +1,76 @@
+/**
+ * Workspace telemetry sink (VIS-822).
+ *
+ * `buildWorkspaceTelemetryRequest` is the testable core — it resolves the
+ * relay URL through the urls.js null-pattern (local-only endpoint) and shapes
+ * the POST body. `postWorkspaceEvent` is a thin fire-and-forget dispatcher
+ * that is a deliberate no-op under jest (asserted here).
+ */
+import { buildWorkspaceTelemetryRequest, postWorkspaceEvent } from './workspaceTelemetry';
+import { isAvailable, getUrl } from '../contexts/URLContext';
+
+jest.mock('../contexts/URLContext', () => ({
+  isAvailable: jest.fn(),
+  getUrl: jest.fn(),
+}));
+
+describe('buildWorkspaceTelemetryRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isAvailable.mockReturnValue(true);
+    getUrl.mockReturnValue('/api/telemetry/workspace-event/');
+  });
+
+  test('builds a keepalive POST with name + payload + ts', () => {
+    const request = buildWorkspaceTelemetryRequest({
+      eventName: 'canvas_action',
+      payload: { kind: 'resize_item', fluid: true },
+      ts: 1718000000000,
+    });
+
+    expect(request.url).toBe('/api/telemetry/workspace-event/');
+    expect(request.options.method).toBe('POST');
+    expect(request.options.keepalive).toBe(true);
+    expect(request.options.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(request.options.body)).toEqual({
+      name: 'canvas_action',
+      payload: { kind: 'resize_item', fluid: true },
+      ts: 1718000000000,
+    });
+  });
+
+  test('defaults a missing payload to an empty object', () => {
+    const request = buildWorkspaceTelemetryRequest({ eventName: 'workspace_mode_entered' });
+    expect(JSON.parse(request.options.body).payload).toEqual({});
+  });
+
+  test('returns null when the endpoint is unavailable (dist mode / uninitialized)', () => {
+    isAvailable.mockReturnValue(false);
+    expect(
+      buildWorkspaceTelemetryRequest({ eventName: 'canvas_action', payload: {} })
+    ).toBeNull();
+    expect(getUrl).not.toHaveBeenCalled();
+  });
+
+  test('returns null for malformed events', () => {
+    expect(buildWorkspaceTelemetryRequest(null)).toBeNull();
+    expect(buildWorkspaceTelemetryRequest({})).toBeNull();
+    expect(buildWorkspaceTelemetryRequest({ eventName: '' })).toBeNull();
+    expect(buildWorkspaceTelemetryRequest({ eventName: 42 })).toBeNull();
+  });
+});
+
+describe('postWorkspaceEvent', () => {
+  test('is a no-op under jest (never dispatches network calls from unit tests)', () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy;
+    try {
+      expect(() =>
+        postWorkspaceEvent({ eventName: 'canvas_action', payload: { kind: 'add_row' } })
+      ).not.toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      delete global.fetch;
+    }
+  });
+});

--- a/viewer/src/components/new-views/project/canvas/CanvasAddRow.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasAddRow.jsx
@@ -163,7 +163,10 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
 
   const handleInlineCreate = useCallback(
     type => {
-      emitWorkspaceEvent('inline_create_used', { type, dashboardName });
+      // §3.4 payload convention: `source` (where the create was initiated) +
+      // `kind` (the object type), matching the Library / broken-ref /
+      // project-editor inline-create sites.
+      emitWorkspaceEvent('inline_create_used', { source: 'canvas', kind: type, dashboardName });
       setOpenMenu(null);
       // The full Explorer round-trip (author → return to canvas slot) is VIS-J2;
       // for now route to the Explorer so the create flow is reachable.

--- a/viewer/src/components/new-views/project/canvas/CanvasAddRow.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasAddRow.test.jsx
@@ -85,7 +85,12 @@ describe('CanvasAddRow — empty canvas (D-8)', () => {
     render(<Harness dashboardName="empty-dash" />);
     fireEvent.click(screen.getByTestId('canvas-inline-create-chart'));
     unsub();
-    expect(events.find(e => e.eventName === 'inline_create_used')?.payload.type).toBe('chart');
+    // §3.4 payload convention: source (initiating surface) + kind (object type).
+    expect(events.find(e => e.eventName === 'inline_create_used')?.payload).toEqual({
+      source: 'canvas',
+      kind: 'chart',
+      dashboardName: 'empty-dash',
+    });
     expect(mockNavigate).toHaveBeenCalledWith('/explorer?create=chart');
   });
 });

--- a/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.jsx
@@ -50,12 +50,21 @@ const CanvasKeyboardLayer = ({ rootRef, dashboardName }) => {
   );
 
   // Reorder commits go through the shared commitCanvasConfig with a telemetry
-  // shadow (parity with the pointer reorders).
+  // shadow (parity with the pointer reorders). The §3.4 canvas_action kind is
+  // derived from the reorder axis (row → move_row, item → move_item) so
+  // keyboard moves roll up with their pointer/DnD equivalents; `via` keeps the
+  // input modality visible for analytics.
   const commitConfig = useCallback(
     (nextConfig, meta) => {
       if (!dashboardName || typeof commitCanvasConfig !== 'function') return;
       commitCanvasConfig(dashboardName, nextConfig, meta);
-      emitWorkspaceEvent('canvas_action', { kind: meta?.kind || 'reorder_keyboard', dashboardName });
+      const kind =
+        meta?.axis === 'row'
+          ? 'move_row'
+          : meta?.axis === 'item'
+            ? 'move_item'
+            : meta?.kind || 'reorder_keyboard';
+      emitWorkspaceEvent('canvas_action', { kind, via: 'keyboard', dashboardName });
     },
     [dashboardName, commitCanvasConfig]
   );

--- a/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.test.jsx
+++ b/viewer/src/components/new-views/project/canvas/CanvasKeyboardLayer.test.jsx
@@ -101,6 +101,25 @@ describe('CanvasKeyboardLayer (VIS-790)', () => {
     expect(nextConfig.rows.map(r => r.height)).toEqual(['small', 'medium']);
     // The selection follows the moved row to its new index.
     expect(selectedKey()).toBe('row.1');
+    // §3.4 canvas_action kind — keyboard row moves roll up as move_row.
+    const { emitWorkspaceEvent } = require('../../workspace/telemetry');
+    expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'move_row', via: 'keyboard', dashboardName: 'dash' })
+    );
+  });
+
+  test('⌘ArrowDown on a selected ITEM reorders it and emits move_item (§3.4)', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.0' });
+    const commit = jest.fn();
+    render(<Host commit={commit} />);
+    press('ArrowDown', { metaKey: true });
+    expect(commit).toHaveBeenCalledTimes(1);
+    const { emitWorkspaceEvent } = require('../../workspace/telemetry');
+    expect(emitWorkspaceEvent).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'move_item', via: 'keyboard', dashboardName: 'dash' })
+    );
   });
 
   test('Escape deselects to the dashboard root', () => {

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.jsx
@@ -272,9 +272,10 @@ export const routeWorkspaceDragEnd = (
         const next = reorderItemsInRow(config, dragData.rowPath, fromIndex, toIndex);
         if (next === config) return 'noop';
         commitCanvasConfig(dashboardName, next, { kind: 'reorder_items' });
+        // §3.4 canvas_action kind for a DnD item move.
         emit &&
-          emit('canvas_dnd', {
-            kind: 'reorder_items',
+          emit('canvas_action', {
+            kind: 'move_item',
             rowPath: dragData.rowPath,
             from: fromIndex,
           });
@@ -294,9 +295,10 @@ export const routeWorkspaceDragEnd = (
           const next = reorderRowsInContainer(config, dragNested.containerPath, fromIndex, toIndex);
           if (next === config) return 'noop';
           commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
+          // §3.4 canvas_action kind for a DnD row move (nested container rows).
           emit &&
-            emit('canvas_dnd', {
-              kind: 'reorder_rows',
+            emit('canvas_action', {
+              kind: 'move_row',
               containerPath: dragNested.containerPath,
               from: fromIndex,
               to: toIndex,
@@ -315,7 +317,8 @@ export const routeWorkspaceDragEnd = (
           const next = reorderTopLevelRows(config, fromIndex, toIndex);
           if (next === config) return 'noop';
           commitCanvasConfig(dashboardName, next, { kind: 'reorder_rows' });
-          emit && emit('canvas_dnd', { kind: 'reorder_rows', from: fromIndex, to: toIndex });
+          // §3.4 canvas_action kind for a DnD row move (top-level rows).
+          emit && emit('canvas_action', { kind: 'move_row', from: fromIndex, to: toIndex });
           return 'canvas_reorder_rows';
         }
 
@@ -331,9 +334,11 @@ export const routeWorkspaceDragEnd = (
       const next = insertItemAtTarget(config, target, newItem);
       if (next === config) return 'noop';
       commitCanvasConfig(dashboardName, next, { kind: 'library_insert' });
+      // §3.4 canvas_action kind for a Library → canvas item insert.
       emit &&
-        emit('canvas_dnd', {
-          kind: 'library_insert',
+        emit('canvas_action', {
+          kind: 'add_item',
+          source: 'library',
           type: dragData.type,
           name: dragData.name,
           target: target.kind,

--- a/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/new-views/workspace/WorkspaceDndContext.test.jsx
@@ -227,7 +227,10 @@ describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
     expect(name).toBe('dash');
     const order = nextConfig.rows[0].items.map(it => it.chart || it.table);
     expect(order).toEqual(['ref(b)', 'ref(a)']);
-    expect(emit).toHaveBeenCalledWith('canvas_dnd', expect.objectContaining({ kind: 'reorder_items' }));
+    expect(emit).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'move_item', rowPath: 'row.0', from: 0 })
+    );
   });
 
   test('canvas item drag → end-of-row appends the item to the end', () => {
@@ -275,7 +278,10 @@ describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
     expect(result).toBe('canvas_reorder_rows');
     const heights = commitCanvasConfig.mock.calls[0][1].rows.map(r => r.height);
     expect(heights).toEqual(['small', 'medium']);
-    expect(emit).toHaveBeenCalledWith('canvas_dnd', expect.objectContaining({ kind: 'reorder_rows' }));
+    expect(emit).toHaveBeenCalledWith(
+      'canvas_action',
+      expect.objectContaining({ kind: 'move_row', from: 1, to: 0 })
+    );
   });
 
   test('library drag → canvas between-items inserts a new item referencing the object', () => {
@@ -293,8 +299,8 @@ describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
     expect(items).toHaveLength(3);
     expect(items[1].chart).toBe('ref(new-chart)');
     expect(emit).toHaveBeenCalledWith(
-      'canvas_dnd',
-      expect.objectContaining({ kind: 'library_insert', type: 'chart', name: 'new-chart' })
+      'canvas_action',
+      expect.objectContaining({ kind: 'add_item', type: 'chart', name: 'new-chart' })
     );
   });
 
@@ -389,8 +395,8 @@ describe('routeWorkspaceDragEnd — canvas D-3 branches (VIS-771)', () => {
     expect(subRows[1].items[0].markdown).toBe(undefined); // moved
     expect(subRows[0].items[0].markdown).toBe('ref(n2)');
     expect(emit).toHaveBeenCalledWith(
-      'canvas_dnd',
-      expect.objectContaining({ kind: 'reorder_rows', containerPath: 'row.0.item.1' })
+      'canvas_action',
+      expect.objectContaining({ kind: 'move_row', containerPath: 'row.0.item.1' })
     );
   });
 

--- a/viewer/src/components/new-views/workspace/dashboardBuildingMetrics.js
+++ b/viewer/src/components/new-views/workspace/dashboardBuildingMetrics.js
@@ -1,0 +1,91 @@
+/**
+ * Dashboard-building headline metrics (VIS-799 / Track K, Q22).
+ *
+ * Pure aggregation over a workspace telemetry event stream — the four
+ * headline metrics from `specs/dashboard-building/04-open-questions.md` Q22:
+ *
+ *   1. Time-to-first-saved-dashboard (target < 3 min) — from
+ *      `time_to_first_publish_in_build_mode` payloads.
+ *   2. Build-mode adoption % (target > 70%) — `workspace_mode_entered`
+ *      entries ÷ all dashboard edits (build entries + legacy form edits).
+ *   3. Avg canvas actions per Publish (target ≈ 1) — `canvas_action` count
+ *      ÷ publish count.
+ *   4. Outline-tab usage % (informational, no target) — per the Q22 revision
+ *      of 2026-05-16 the obsolete "Outline-lens usage" metric became
+ *      `right_rail_tab_switched` characterization: the share of right-rail
+ *      tab switches that landed on the Outline tab.
+ *
+ * Notes on denominators:
+ *   - Publishes are counted via `time_to_first_publish_in_build_mode` — the
+ *     only publish-shaped event in the §3.4 seven-event taxonomy (it fires on
+ *     the FIRST publish after each Build-mode entry; re-entering re-arms it).
+ *   - "All dashboard edits" needs a marker for legacy form-based edits, which
+ *     the §3.4 taxonomy doesn't carry; `LEGACY_FORM_EDIT_EVENT` names the
+ *     event the legacy surface will emit. Streams without it yield 100%
+ *     adoption — correct for a workspace-only stream.
+ *
+ * Events are `{ eventName, payload, ts }` — the exact shape
+ * `emitWorkspaceEvent` produces (and the `visivo:workspace-telemetry`
+ * CustomEvent `detail` carries), so a captured session stream can be fed in
+ * unmodified. This module is intentionally framework-free so the same
+ * computation can run in tests, notebooks, or a PostHog-export script.
+ */
+
+/** Event name the legacy (form-based) dashboard-edit surface emits. */
+export const LEGACY_FORM_EDIT_EVENT = 'dashboard_form_edit';
+
+const countByName = (events, name) => events.filter(e => e && e.eventName === name).length;
+
+/**
+ * Compute the four Q22 headline metrics from a workspace event stream.
+ *
+ * Every metric is `null` when its denominator is empty (no signal ≠ zero) —
+ * callers must treat `null` as "not measurable from this stream".
+ *
+ * @param {Array<{eventName: string, payload?: object, ts?: number}>} events
+ * @returns {{
+ *   timeToFirstSavedDashboardMs: number|null,
+ *   buildModeAdoptionPct: number|null,
+ *   avgCanvasActionsPerPublish: number|null,
+ *   outlineTabUsagePct: number|null,
+ * }}
+ */
+export function computeDashboardBuildingMetrics(events) {
+  const stream = Array.isArray(events) ? events.filter(Boolean) : [];
+
+  // 1. Time-to-first-saved-dashboard: mean of the recorded elapsed times.
+  // Null payload values (publish without a recorded Build-mode entry, e.g.
+  // from the legacy surface) carry no timing signal and are excluded.
+  const firstPublishDurations = stream
+    .filter(e => e.eventName === 'time_to_first_publish_in_build_mode')
+    .map(e => e.payload && e.payload.msSinceBuildModeEntered)
+    .filter(ms => typeof ms === 'number' && Number.isFinite(ms));
+  const timeToFirstSavedDashboardMs = firstPublishDurations.length
+    ? firstPublishDurations.reduce((sum, ms) => sum + ms, 0) / firstPublishDurations.length
+    : null;
+
+  // 2. Build-mode adoption %: build entries ÷ (build entries + form edits).
+  const buildEntries = countByName(stream, 'workspace_mode_entered');
+  const formEdits = countByName(stream, LEGACY_FORM_EDIT_EVENT);
+  const totalEdits = buildEntries + formEdits;
+  const buildModeAdoptionPct = totalEdits > 0 ? (buildEntries / totalEdits) * 100 : null;
+
+  // 3. Avg canvas actions per Publish.
+  const canvasActions = countByName(stream, 'canvas_action');
+  const publishes = countByName(stream, 'time_to_first_publish_in_build_mode');
+  const avgCanvasActionsPerPublish = publishes > 0 ? canvasActions / publishes : null;
+
+  // 4. Outline-tab usage % (Q22 revision of "Outline-lens usage").
+  const tabSwitches = stream.filter(e => e.eventName === 'right_rail_tab_switched');
+  const outlineSwitches = tabSwitches.filter(e => e.payload && e.payload.tab === 'outline');
+  const outlineTabUsagePct = tabSwitches.length
+    ? (outlineSwitches.length / tabSwitches.length) * 100
+    : null;
+
+  return {
+    timeToFirstSavedDashboardMs,
+    buildModeAdoptionPct,
+    avgCanvasActionsPerPublish,
+    outlineTabUsagePct,
+  };
+}

--- a/viewer/src/components/new-views/workspace/dashboardBuildingMetrics.test.js
+++ b/viewer/src/components/new-views/workspace/dashboardBuildingMetrics.test.js
@@ -1,0 +1,123 @@
+/**
+ * Q22 metrics aggregate test (VIS-799 / Track K).
+ *
+ * Phase 5 gate: proves the four headline metrics from
+ * `specs/dashboard-building/04-open-questions.md` Q22 are computable from the
+ * telemetry events as instrumented (§3.4 taxonomy), before Phase 6 dogfood
+ * runs against real data. The synthetic stream below mimics two users across
+ * three Build-mode sessions plus one legacy form edit, and every expected
+ * value is asserted EXACTLY.
+ */
+import {
+  computeDashboardBuildingMetrics,
+  LEGACY_FORM_EDIT_EVENT,
+} from './dashboardBuildingMetrics';
+
+// Helper mirroring the `emitWorkspaceEvent` event shape.
+const ev = (eventName, payload = {}, ts = 0) => ({ eventName, payload, ts });
+
+/**
+ * Synthetic stream — two users, three Build-mode sessions, one legacy edit:
+ *
+ *   Session A (user 1): enters Build mode, 3 canvas actions, publishes
+ *     after 120s.
+ *   Session B (user 1): re-enters Build mode, 2 canvas actions, publishes
+ *     after 60s. Switches the right rail Outline → Edit → Outline.
+ *   Session C (user 2): enters Build mode, 1 canvas action, abandons
+ *     without publishing. Switches the right rail to Edit once.
+ *   Legacy: one form-based dashboard edit (no Build mode).
+ */
+const STREAM = [
+  // Session A
+  ev('workspace_mode_entered', { dashboardName: 'sales', scope: 'dashboard' }, 1000),
+  ev('canvas_action', { kind: 'add_row', template: 'blank' }, 2000),
+  ev('canvas_action', { kind: 'add_item', type: 'chart', name: 'rev' }, 3000),
+  ev('canvas_action', { kind: 'resize_item', fluid: true, axis: 'height' }, 4000),
+  ev('time_to_first_publish_in_build_mode', { msSinceBuildModeEntered: 120000 }, 121000),
+
+  // Session B
+  ev('workspace_mode_entered', { dashboardName: 'sales', scope: 'dashboard' }, 200000),
+  ev('canvas_action', { kind: 'move_row', from: 1, to: 0 }, 201000),
+  ev('canvas_action', { kind: 'wrap_in_container', path: 'row.0.item.0' }, 202000),
+  ev('right_rail_tab_switched', { tab: 'outline' }, 202500),
+  ev('right_rail_tab_switched', { tab: 'edit' }, 202600),
+  ev('right_rail_tab_switched', { tab: 'outline' }, 202700),
+  ev('time_to_first_publish_in_build_mode', { msSinceBuildModeEntered: 60000 }, 260000),
+
+  // Session C (no publish)
+  ev('workspace_mode_entered', { dashboardName: null, scope: 'root' }, 300000),
+  ev('canvas_action', { kind: 'move_item', rowPath: 'row.0', from: 0 }, 301000),
+  ev('right_rail_tab_switched', { tab: 'edit' }, 302000),
+  ev('middle_pane_toggled', { pane: 'lineage', scope: 'dashboard' }, 303000),
+  ev('middle_pane_toggled', { pane: 'canvas', scope: 'dashboard' }, 304000),
+  ev('item_flipped', { surface: 'build', type: 'chart', name: 'rev' }, 305000),
+  ev('inline_create_used', { source: 'library', kind: 'chart' }, 306000),
+
+  // Legacy form-based dashboard edit
+  ev(LEGACY_FORM_EDIT_EVENT, { dashboardName: 'ops' }, 400000),
+];
+
+describe('computeDashboardBuildingMetrics (Q22)', () => {
+  test('computes all four headline metrics exactly from the synthetic stream', () => {
+    const metrics = computeDashboardBuildingMetrics(STREAM);
+
+    // 1. Time-to-first-saved-dashboard: mean(120000, 60000) = 90000ms (1.5
+    //    min — under the <3 min target).
+    expect(metrics.timeToFirstSavedDashboardMs).toBe(90000);
+
+    // 2. Build-mode adoption: 3 build entries ÷ (3 + 1 form edit) = 75%
+    //    (over the >70% target).
+    expect(metrics.buildModeAdoptionPct).toBe(75);
+
+    // 3. Avg canvas actions per Publish: 6 canvas actions ÷ 2 publishes = 3.
+    expect(metrics.avgCanvasActionsPerPublish).toBe(3);
+
+    // 4. Outline-tab usage: 2 outline switches ÷ 4 switches = 50%
+    //    (informational — no target).
+    expect(metrics.outlineTabUsagePct).toBe(50);
+  });
+
+  test('an empty stream yields null for every metric (no signal ≠ zero)', () => {
+    expect(computeDashboardBuildingMetrics([])).toEqual({
+      timeToFirstSavedDashboardMs: null,
+      buildModeAdoptionPct: null,
+      avgCanvasActionsPerPublish: null,
+      outlineTabUsagePct: null,
+    });
+    expect(computeDashboardBuildingMetrics(undefined)).toEqual({
+      timeToFirstSavedDashboardMs: null,
+      buildModeAdoptionPct: null,
+      avgCanvasActionsPerPublish: null,
+      outlineTabUsagePct: null,
+    });
+  });
+
+  test('null first-publish durations are excluded from the timing mean but still count as publishes', () => {
+    const metrics = computeDashboardBuildingMetrics([
+      ev('workspace_mode_entered', { dashboardName: 'a', scope: 'dashboard' }),
+      ev('canvas_action', { kind: 'add_row' }),
+      ev('canvas_action', { kind: 'add_row' }),
+      // Publish without a recorded Build-mode entry (legacy /editor surface).
+      ev('time_to_first_publish_in_build_mode', { msSinceBuildModeEntered: null }),
+      ev('time_to_first_publish_in_build_mode', { msSinceBuildModeEntered: 30000 }),
+    ]);
+    expect(metrics.timeToFirstSavedDashboardMs).toBe(30000);
+    expect(metrics.avgCanvasActionsPerPublish).toBe(1);
+  });
+
+  test('a workspace-only stream (no legacy form edits) reads as 100% adoption', () => {
+    const metrics = computeDashboardBuildingMetrics([
+      ev('workspace_mode_entered', { dashboardName: 'a', scope: 'dashboard' }),
+      ev('workspace_mode_entered', { dashboardName: 'b', scope: 'dashboard' }),
+    ]);
+    expect(metrics.buildModeAdoptionPct).toBe(100);
+  });
+
+  test('publish-less streams yield null actions-per-publish (not Infinity)', () => {
+    const metrics = computeDashboardBuildingMetrics([
+      ev('canvas_action', { kind: 'add_row' }),
+      ev('canvas_action', { kind: 'move_row' }),
+    ]);
+    expect(metrics.avgCanvasActionsPerPublish).toBeNull();
+  });
+});

--- a/viewer/src/components/new-views/workspace/telemetry.js
+++ b/viewer/src/components/new-views/workspace/telemetry.js
@@ -1,21 +1,25 @@
 /**
- * Workspace telemetry stub (VIS-775 / Track B B2).
+ * Workspace telemetry (VIS-775 / Track B B2, sink wired in VIS-822 / Track K).
  *
- * The viewer has no frontend telemetry framework yet — server-side telemetry
- * lives in `visivo/telemetry/` (Flask middleware + PostHog client). When the
- * frontend gets its own analytics sink (PostHog browser SDK or similar), wire
- * `emitWorkspaceEvent` to forward to it.
+ * `emitWorkspaceEvent(name, payload)` fans each event out to three places:
  *
- * The spec for VIS-775 (`specs/dashboard-building/implementation/01-tracks-and-phasing.md`
- * Track B B2) requires firing `workspace_mode_entered` on shell mount with the
- * scoped dashboard name (or `null` for unscoped). We log the event to the
- * console in dev so the shape is visible during local testing, and we expose
- * a hook so tests can spy on emissions without coupling to a sink.
+ *   1. The in-memory test listener (`setWorkspaceTelemetryListener`) — when
+ *      set, it REPLACES the other sinks so unit tests observe emissions
+ *      without any side effects.
+ *   2. The `visivo:workspace-telemetry` CustomEvent — out-of-process
+ *      observers (Playwright e2e stories) subscribe to this.
+ *   3. The PostHog sink (`postWorkspaceEvent`) — POSTs the event to the local
+ *      Flask server's `/api/telemetry/workspace-event/` relay, which tracks
+ *      it through the CLI's server-side PostHog client (so the CLI telemetry
+ *      opt-out and anonymization apply). A no-op under jest and in the
+ *      dist/cloud viewer (the URL key is `null` there).
  *
- * TODO(VIS-?): replace with real telemetry call once the viewer adopts a
- * browser-side analytics module. Keep the function signature stable so
- * call-sites don't need to change.
+ * Event names + payload shapes follow
+ * `specs/dashboard-building/03-architecture-proposal.md` §3.4; keep the
+ * function signature stable so call-sites don't need to change.
  */
+
+import { postWorkspaceEvent } from '../../../api/workspaceTelemetry';
 
 let listener = null;
 
@@ -49,6 +53,14 @@ export function emitWorkspaceEvent(eventName, payload = {}) {
     } catch {
       // ignore — telemetry must never throw into the render path.
     }
+  }
+  // Forward to the PostHog sink (VIS-822). The sink module guards itself
+  // (jest no-op, dist no-op, all errors swallowed) but we belt-and-suspenders
+  // the call so telemetry can never throw into the render path.
+  try {
+    postWorkspaceEvent(event);
+  } catch {
+    // ignore — telemetry must never break the app.
   }
   // Dev visibility only — keep silent in CI/test to avoid the
   // setupTests.js "unexpected console call" guard. Under Vite `process` is

--- a/viewer/src/components/new-views/workspace/telemetry.test.js
+++ b/viewer/src/components/new-views/workspace/telemetry.test.js
@@ -14,6 +14,13 @@ import {
   markBuildModeEntered,
   emitFirstPublishTelemetry,
 } from './telemetry';
+import { postWorkspaceEvent } from '../../../api/workspaceTelemetry';
+
+// Mock the PostHog sink so the integration tests below can assert the
+// emit → sink contract (VIS-822) without network calls.
+jest.mock('../../../api/workspaceTelemetry', () => ({
+  postWorkspaceEvent: jest.fn(),
+}));
 
 const TEL_EVENT = 'visivo:workspace-telemetry';
 
@@ -74,6 +81,39 @@ describe('emitWorkspaceEvent', () => {
       throw new Error('boom');
     });
     expect(() => emitWorkspaceEvent('middle_pane_toggled', {})).not.toThrow();
+  });
+});
+
+describe('PostHog sink integration (VIS-822)', () => {
+  beforeEach(() => {
+    postWorkspaceEvent.mockClear();
+  });
+
+  afterEach(() => {
+    setWorkspaceTelemetryListener(null);
+  });
+
+  test('emitWorkspaceEvent forwards the event to the sink with name + payload', () => {
+    emitWorkspaceEvent('workspace_mode_entered', { dashboardName: 'sales', scope: 'dashboard' });
+
+    expect(postWorkspaceEvent).toHaveBeenCalledTimes(1);
+    const event = postWorkspaceEvent.mock.calls[0][0];
+    expect(event.eventName).toBe('workspace_mode_entered');
+    expect(event.payload).toEqual({ dashboardName: 'sales', scope: 'dashboard' });
+    expect(typeof event.ts).toBe('number');
+  });
+
+  test('the in-memory test listener short-circuits the sink', () => {
+    setWorkspaceTelemetryListener(() => {});
+    emitWorkspaceEvent('canvas_action', { kind: 'add_row' });
+    expect(postWorkspaceEvent).not.toHaveBeenCalled();
+  });
+
+  test('a throwing sink cannot break the shell', () => {
+    postWorkspaceEvent.mockImplementationOnce(() => {
+      throw new Error('sink boom');
+    });
+    expect(() => emitWorkspaceEvent('canvas_action', { kind: 'add_row' })).not.toThrow();
   });
 });
 

--- a/viewer/src/components/project/ProjectViewFlipLayer.jsx
+++ b/viewer/src/components/project/ProjectViewFlipLayer.jsx
@@ -6,6 +6,7 @@ import { parseCanvasPath } from '../new-views/project/canvas/canvasReorder';
 import ItemFlipCard from './ItemFlipCard';
 import ItemActionMenu from './ItemActionMenu';
 import copyItemLink from './copyItemLink';
+import { emitWorkspaceEvent } from '../new-views/workspace/telemetry';
 
 /**
  * ProjectViewFlipLayer — VIS-788 / I-1 (View-mode flip gesture).
@@ -142,14 +143,31 @@ const ProjectViewFlipLayer = ({ rootRef, dashboardConfig }) => {
     };
   }, [rootRef]);
 
-  const toggleFlip = useCallback(key => {
-    setFlipped(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+  const toggleFlip = useCallback(
+    key => {
+      setFlipped(prev => {
+        const next = new Set(prev);
+        const willFlip = !next.has(key);
+        if (willFlip) next.add(key);
+        else next.delete(key);
+        // `item_flipped` telemetry (§3.4 / Q3b) — the View-mode counterpart of
+        // the Build-mode emission in <CanvasItemFlipLayer>; only the opening
+        // flip emits. Payload shape mirrors the canvas layer exactly.
+        if (willFlip) {
+          const subject = subjectForItem(itemAtKey(dashboardConfig, key));
+          emitWorkspaceEvent('item_flipped', {
+            surface: 'view',
+            selector_edited: false,
+            expanded_to_modal: false,
+            type: subject?.type,
+            name: subject?.name,
+          });
+        }
+        return next;
+      });
+    },
+    [dashboardConfig]
+  );
 
   // Expand = "open full lineage in a tab": deep-link to the Workspace with both
   // the `edit=<type>:<name>` scope (opens a real tab for the subject) and the

--- a/viewer/src/components/project/ProjectViewFlipLayer.test.jsx
+++ b/viewer/src/components/project/ProjectViewFlipLayer.test.jsx
@@ -14,6 +14,7 @@
 import React, { useRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ProjectViewFlipLayer from './ProjectViewFlipLayer';
+import { setWorkspaceTelemetryListener } from '../new-views/workspace/telemetry';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -130,6 +131,31 @@ describe('ProjectViewFlipLayer kebab (VIS-788)', () => {
     fireEvent.click(action('flip', 'row.0.item.0'));
     const card = screen.getByTestId('view-flip-card-row.0.item.0');
     expect(card).toHaveAttribute('data-subject', 'chart:rev_chart');
+  });
+
+  test('flipping fires item_flipped telemetry with surface: view (§3.4 / Q3b)', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    try {
+      render(<Host />);
+      hover('r0i0');
+      openMenu('row.0.item.0');
+      fireEvent.click(action('flip', 'row.0.item.0'));
+      // Closing the flip must NOT emit a second event.
+      openMenu('row.0.item.0');
+      fireEvent.click(action('flip', 'row.0.item.0'));
+    } finally {
+      unsubscribe();
+    }
+    const flips = events.filter(e => e.eventName === 'item_flipped');
+    expect(flips).toHaveLength(1);
+    expect(flips[0].payload).toEqual({
+      surface: 'view',
+      selector_edited: false,
+      expanded_to_modal: false,
+      type: 'chart',
+      name: 'rev_chart',
+    });
   });
 
   test('the flipped card overlays the SLOT box (in-place flip, not a beside popover)', () => {

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -144,6 +144,11 @@ const URL_PATTERNS = {
     // Exploration persistence endpoints
     explorationsList: '/api/explorations/',
     explorationDetail: '/api/explorations/{id}/',
+
+    // Workspace telemetry forwarding endpoint (VIS-822) — the local Flask
+    // server relays workspace events through the CLI's PostHog client so the
+    // CLI telemetry opt-out + anonymization apply to frontend events.
+    workspaceTelemetry: '/api/telemetry/workspace-event/',
   },
 
   dist: {
@@ -280,6 +285,9 @@ const URL_PATTERNS = {
     // Exploration persistence endpoints (not available in dist)
     explorationsList: null,
     explorationDetail: null,
+
+    // Workspace telemetry forwarding (not available in dist — no Flask server)
+    workspaceTelemetry: null,
   },
 };
 

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -39,6 +39,8 @@
  * O3 — this slice only carries the state the shell needs in Phase 0.
  */
 
+import { emitWorkspaceEvent } from '../components/new-views/workspace/telemetry';
+
 const createWorkspaceSlice = (set, get) => ({
   // Tabs --------------------------------------------------------------------
   workspaceTabs: [],
@@ -191,7 +193,28 @@ const createWorkspaceSlice = (set, get) => ({
 
   setWorkspaceLens: (lens) => {
     if (!['preview', 'lineage'].includes(lens)) return;
+    const previous = get().workspaceLens;
     set({ workspaceLens: lens });
+    // `middle_pane_toggled` telemetry (§3.4, VIS-797). Lineage ENTRIES are
+    // emitted by <LineageCanvas> on mount (with the richer scope/selector
+    // payload) — emitting the lineage direction here too would double-count a
+    // single toggle. The canvas/preview direction has no mount site of its
+    // own, so the explicit toggle-back is captured here, tagged with the
+    // scope at toggle time per the spec.
+    if (lens === 'preview' && previous !== 'preview') {
+      const activeObject = get().workspaceActiveObject;
+      const scope =
+        !activeObject || activeObject.type === 'project'
+          ? 'root'
+          : activeObject.type === 'dashboard'
+            ? 'dashboard'
+            : 'item';
+      emitWorkspaceEvent('middle_pane_toggled', {
+        pane: 'canvas',
+        scope,
+        dashboardName: activeObject?.type === 'dashboard' ? activeObject.name : null,
+      });
+    }
   },
 
   // ------------------------------------------------------------------------

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -7,6 +7,7 @@
  */
 import { act } from '@testing-library/react';
 import useStore from './store';
+import { setWorkspaceTelemetryListener } from '../components/new-views/workspace/telemetry';
 
 const reset = () => {
   act(() => {
@@ -210,6 +211,69 @@ describe('workspace store slice', () => {
       useStore.getState().setWorkspaceLens('garbage');
     });
     expect(useStore.getState().workspaceLens).toBe('lineage');
+  });
+
+  // middle_pane_toggled telemetry (§3.4, VIS-797) ----------------------------
+
+  test('toggling back to the canvas lens fires middle_pane_toggled with scope', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    try {
+      act(() => {
+        useStore.setState({
+          workspaceLens: 'lineage',
+          workspaceActiveObject: { type: 'dashboard', name: 'sales' },
+        });
+        useStore.getState().setWorkspaceLens('preview');
+      });
+    } finally {
+      unsubscribe();
+    }
+    const toggled = events.filter(e => e.eventName === 'middle_pane_toggled');
+    expect(toggled).toHaveLength(1);
+    expect(toggled[0].payload).toEqual({
+      pane: 'canvas',
+      scope: 'dashboard',
+      dashboardName: 'sales',
+    });
+  });
+
+  test('middle_pane_toggled scope is root for the project tab and item for objects', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    try {
+      act(() => {
+        useStore.setState({ workspaceLens: 'lineage', workspaceActiveObject: null });
+        useStore.getState().setWorkspaceLens('preview');
+        useStore.setState({
+          workspaceLens: 'lineage',
+          workspaceActiveObject: { type: 'chart', name: 'rev' },
+        });
+        useStore.getState().setWorkspaceLens('preview');
+      });
+    } finally {
+      unsubscribe();
+    }
+    const scopes = events
+      .filter(e => e.eventName === 'middle_pane_toggled')
+      .map(e => e.payload.scope);
+    expect(scopes).toEqual(['root', 'item']);
+  });
+
+  test('the lineage direction does NOT emit from the store (LineageCanvas owns it)', () => {
+    const events = [];
+    const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    try {
+      act(() => {
+        useStore.getState().setWorkspaceLens('lineage');
+        // Re-selecting the current lens is a no-op too.
+        useStore.setState({ workspaceLens: 'preview' });
+        useStore.getState().setWorkspaceLens('preview');
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(events.filter(e => e.eventName === 'middle_pane_toggled')).toHaveLength(0);
   });
 
   // Outline tree (VIS-793 / Track F F-3) ------------------------------------

--- a/visivo/server/views/__init__.py
+++ b/visivo/server/views/__init__.py
@@ -24,6 +24,7 @@ from visivo.server.views.publish_views import register_publish_views
 from visivo.server.views.relations_views import register_relations_views
 from visivo.server.views.sources_views import register_source_views
 from visivo.server.views.source_schema_jobs_views import register_source_schema_jobs_views
+from visivo.server.views.telemetry_views import register_telemetry_views
 from visivo.server.views.explorer_views import register_explorer_views
 from visivo.server.views.expression_views import register_expression_views
 from visivo.server.views.model_data_views import register_model_data_views
@@ -56,6 +57,7 @@ def register_views(app, flask_app, output_dir):
     register_source_schema_jobs_views(app, flask_app, output_dir)
     register_auth_views(app, flask_app, output_dir)
     register_cloud_views(app, flask_app, output_dir)
+    register_telemetry_views(app, flask_app, output_dir)
 
     register_explorer_views(app, flask_app, output_dir)
     register_expression_views(app, flask_app, output_dir)

--- a/visivo/server/views/telemetry_views.py
+++ b/visivo/server/views/telemetry_views.py
@@ -1,0 +1,79 @@
+"""
+Telemetry forwarding endpoint for viewer Workspace events (VIS-822).
+
+The viewer has no PostHog client of its own — `emitWorkspaceEvent` POSTs
+workspace events here and the server forwards them through the shared
+`visivo.telemetry` PostHog client. Routing frontend telemetry through the
+server means the CLI's opt-out rules (`VISIVO_TELEMETRY_DISABLED`,
+`~/.visivo/config.yml`, project `defaults.telemetry_enabled`) and its
+anonymization (machine-id distinct ids, `$ip: 0.0.0.0`) apply to workspace
+events identically to CLI/API events, and no analytics API key ships in the
+JS bundle.
+
+The dist/cloud viewer has no Flask server; its `urls.js` entry for this
+endpoint is `null`, so the viewer-side sink is a no-op there.
+"""
+
+import json
+import re
+
+from flask import jsonify, request
+
+from visivo.telemetry.config import is_telemetry_enabled
+from visivo.telemetry.events import WorkspaceEvent
+
+# Workspace event names are snake_case identifiers (see
+# specs/dashboard-building/03-architecture-proposal.md §3.4).
+EVENT_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+# Workspace payloads are small property bags; anything larger is malformed
+# (or abusive) input rather than a legitimate gesture event.
+MAX_PAYLOAD_BYTES = 8192
+
+
+def register_telemetry_views(app, flask_app, output_dir):
+    """Register telemetry forwarding endpoints."""
+
+    @app.route("/api/telemetry/workspace-event/", methods=["POST"])
+    def post_workspace_event():
+        """Forward a viewer workspace event through the server-side telemetry client."""
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "Expected a JSON object body"}), 400
+
+        name = body.get("name")
+        if not isinstance(name, str) or not EVENT_NAME_PATTERN.match(name):
+            return jsonify({"error": "Invalid event name"}), 400
+
+        payload = body.get("payload", {})
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, dict):
+            return jsonify({"error": "Event payload must be an object"}), 400
+
+        try:
+            payload_size = len(json.dumps(payload))
+        except (TypeError, ValueError):
+            return jsonify({"error": "Event payload must be JSON-serializable"}), 400
+        if payload_size > MAX_PAYLOAD_BYTES:
+            return jsonify({"error": "Event payload too large"}), 400
+
+        # Respect the CLI opt-out — accept-and-drop so the viewer never has to
+        # branch on whether telemetry is enabled.
+        project = getattr(flask_app, "project", None)
+        defaults = getattr(project, "defaults", None) if project is not None else None
+        if not is_telemetry_enabled(defaults):
+            return "", 204
+
+        # Import here (not module level) so tests can patch the client factory
+        # and so disabling telemetry never initializes the PostHog client.
+        from visivo.telemetry.client import get_telemetry_client
+
+        try:
+            client = get_telemetry_client(enabled=True)
+            client.track(WorkspaceEvent.create(name=name, properties=payload))
+        except Exception:
+            # Telemetry must never break the viewer — accept-and-drop.
+            pass
+
+        return "", 204

--- a/visivo/telemetry/events.py
+++ b/visivo/telemetry/events.py
@@ -155,3 +155,44 @@ class NewInstallationEvent(BaseEvent):
             machine_id=machine_id,  # Use the provided machine_id instead of calling _get_machine_id()
             properties=properties,
         )
+
+
+@dataclass
+class WorkspaceEvent(BaseEvent):
+    """
+    Event for a viewer Workspace interaction (dashboard-building telemetry).
+
+    The viewer's `emitWorkspaceEvent` forwards workspace events (e.g.
+    `workspace_mode_entered`, `canvas_action`) to the local Flask server,
+    which wraps them in this event and tracks them through the shared
+    PostHog client — so the CLI's opt-out and anonymization rules apply
+    to frontend events identically to CLI/API events.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        properties: Optional[Dict[str, Any]] = None,
+        project_hash: Optional[str] = None,
+    ) -> "WorkspaceEvent":
+        """Create a workspace event carrying the viewer payload plus system properties."""
+        merged_properties = {
+            **(properties or {}),
+            "visivo_version": VISIVO_VERSION,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "platform": platform.system().lower(),
+            "is_ci": is_ci_environment(),
+            "source_surface": "viewer_workspace",
+        }
+
+        if project_hash:
+            merged_properties["project_hash"] = project_hash
+
+        return cls(
+            event_type=name,
+            timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            session_id=SESSION_ID,
+            machine_id=_get_machine_id(),
+            properties=merged_properties,
+        )


### PR DESCRIPTION
## Track K (stacked on #474 → #473)

> **Stacked PR**: base is `jared/vis-808-external-edit-banner` (PR #474). Merge #473 → #474 → this.

Built by a worktree agent; independently re-verified before push (full suites re-run from scratch: **backend 1678 passed + black clean, viewer 2449 passed + lint clean**).

### VIS-822 — `emitWorkspaceEvent` → PostHog via server relay
Sink decision: **POST to a new local Flask relay** (`POST /api/telemetry/workspace-event/`) which forwards through the existing `visivo/telemetry` PostHog client, rather than posthog-js in the bundle. Why: the CLI's opt-out (`VISIVO_TELEMETRY_DISABLED`, `~/.visivo/config.yml`, project `defaults.telemetry_enabled`) and anonymization (machine-id distinct ids, `$ip: 0.0.0.0`) apply to workspace events for free; no analytics key ships in the JS bundle; dist/cloud viewer no-ops via the standard `urls.js` null pattern. Relay validates names (`^[a-z][a-z0-9_]{0,63}$`) + payload size (≤8KB), accept-and-drops on opt-out (204), and never throws into the render path. The `setWorkspaceTelemetryListener` test hook and the `visivo:workspace-telemetry` CustomEvent fan-out are preserved unchanged.

### VIS-797 — seven-event coverage audit (§3.4)
| Event | Status | Site(s) |
|---|---|---|
| `workspace_mode_entered` | ✅ was wired (Track B) | Workspace.jsx |
| `canvas_action` | 🔧 instrumented here | CanvasAddRow (add_row), WorkspaceDndContext (add_item/move_row/move_item), CanvasKeyboardLayer (keyboard moves), CanvasResizeLayer (resize_item + `fluid`), CanvasContextMenu (wrap/unwrap/add), ProjectCanvas (broken_ref_fix/delete) |
| `middle_pane_toggled` | 🔧 instrumented here | LineageCanvas (lineage entry) + workspaceStore.setWorkspaceLens (canvas return) — split so a toggle never double-counts |
| `outline_lens_entered` | ⚠️ superseded → `right_rail_tab_switched` | RightRail.jsx (Outline moved from middle-pane lens to right-rail tab in the Q22 revision) |
| `item_flipped` | 🔧 instrumented here | CanvasItemFlipLayer (build), ProjectViewFlipLayer (view) |
| `inline_create_used` | ✅ was wired (C/D/J) | Library / CanvasAddRow / ProjectCanvas / ProjectEditor |
| `time_to_first_publish_in_build_mode` | ✅ wired in Track H | telemetry.js + publishStore |

Documented gaps (deliberate, not guessed): `canvas_action` delete_* kinds await a general delete affordance (only broken_ref_delete exists); `item_flipped.selector_edited`/`expanded_to_modal` emit `false` at flip time. Per-event payload-shape unit tests added.
**Note:** the audit comment for the VIS-797 AC was NOT posted to Linear (permission boundary) — this table is the audit; paste it there if you want it on the issue.

### VIS-799 — Q22 metrics aggregate test
`dashboardBuildingMetrics.js` + jest suite: synthetic event stream → the four headline metrics (time-to-first-saved-dashboard, build-mode adoption %, avg canvas actions per publish, outline-tab usage share). Empty denominators yield `null`, never 0/Infinity. Runs in the normal jest suite (CI-covered).

### Docs
Specs repo got `dashboard-building/05-telemetry-conventions.md` (naming/payload conventions + sink architecture + emission map) and a §9 note in `implementation/02-test-strategy.md` (committed locally in the specs repo as `4d528e2`, not pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)