### PR TITLE
ci(docs): per-PR docs preview apps on RWX (VIS-967)

### DIFF
--- a/.rwx/test_docs.yml
+++ b/.rwx/test_docs.yml
@@ -4,6 +4,7 @@ on:
       actions: [opened, reopened, synchronize]
       init:
         commit-sha: ${{ event.git.sha }}
+        pr-num: ${{ event.github.pull_request.pull_request.number }}
 
 base:
   image: ubuntu:22.04
@@ -53,3 +54,31 @@ tasks:
     filter:
       - build_stdout.txt
       - validate_mkdocs_build.sh
+
+  - key: github-cli
+    call: github/install-cli 1.0.5
+
+  # Per-PR docs preview app. Serves the built site (site_dir: mkdocs_build) on an
+  # on-demand rwx.run URL; spins down after 10 min idle and re-materializes from
+  # the task cache when the URL is hit again.
+  - key: docs-preview
+    use: [mkdocs]
+    app:
+      endpoint: docs-pr-${{ init.pr-num }}
+      port: 8000
+      timeout: 2m
+    run: python3 -m http.server $PORT --directory mkdocs_build
+
+  - key: comment-preview-link
+    use: [code, github-cli]
+    run: |
+      BODY="📚 Docs preview: $DOCS_PREVIEW_URL"
+      COMMENT_ID=$(gh api "repos/visivo-io/visivo/issues/${{ init.pr-num }}/comments" --jq '[.[] | select(.body | startswith("📚 Docs preview:"))][0].id // empty')
+      if [ -n "$COMMENT_ID" ]; then
+        gh api -X PATCH "repos/visivo-io/visivo/issues/comments/$COMMENT_ID" -f body="$BODY" > /dev/null
+      else
+        gh pr comment ${{ init.pr-num }} --body "$BODY"
+      fi
+    env:
+      DOCS_PREVIEW_URL: ${{ tasks.docs-preview.app.url.friendly }}
+      GH_TOKEN: ${{ vaults.default.github-apps.mint-automation-visivo.token }}


### PR DESCRIPTION
## What

Adds a per-PR docs preview to the existing RWX docs CI (`.rwx/test_docs.yml`), so every docs PR gets a live, browsable build of the mkdocs site:

- `init` now receives `pr-num` from the `pull_request` event (same expression as `deploy_dashboard.yml`).
- New **`docs-preview`** app task (`use: [mkdocs]`) serves the built site with `python3 -m http.server $PORT --directory mkdocs_build` behind an RWX web app: `endpoint: docs-pr-${{ init.pr-num }}`, `port: 8000`, startup `timeout: 2m`. Apps are on-demand: ~10-min idle spin-down, re-materialized from the task cache when the URL is hit.
- New **`comment-preview-link`** task posts a sticky `📚 Docs preview: <url>` PR comment using `${{ tasks.docs-preview.app.url.friendly }}` — the friendly URL (`https://docs-pr-<num>--{org-slug}.{region}.rwx.run`) tracks the latest build for the endpoint, so the link stays valid across pushes. Auth via `vaults.default.github-apps.mint-automation-visivo.token` + `github/install-cli`, matching `deploy_dashboard.yml`.

## Why

Reviewers (human or agent) can click through the rendered docs for a PR instead of reading raw markdown diffs or rebuilding locally. This PR demos itself — its own RWX run should post the first preview comment.

## Verification

- Syntax verified against the live RWX apps docs (`rwx docs pull /docs/apps`, 2026-06-12): `app: {endpoint, port (1024–49151, exposed as `$PORT`), timeout}`; friendly-URL expression `tasks.<key>.app.url.friendly` is documented, so no org-slug/region guessing is needed.
- `site_dir: mkdocs_build` confirmed in `mkdocs.yml` (line 69); the `mkdocs` task is the one that runs `mkdocs build`, and the app task inherits its filesystem via `use: [mkdocs]`.
- `python3 -c "import yaml; yaml.safe_load(...)"` passes.
- `rwx lint .rwx/test_docs.yml` currently fails with an internal parser error (`n.values(...).filter is not a function`) on local CLI v3.13.1 — it fails identically on the **unmodified** file, so it's a pre-existing CLI lint bug, not this change.
- The real demo is this PR's own RWX run (see comments/checks).

## Deviation from the deploy_dashboard comment pattern

`deploy_dashboard.yml` uses `gh pr comment --edit-last`, but `--edit-last` edits the bot's most recent comment regardless of which workflow wrote it — and both workflows comment via the same `mint-automation-visivo` bot on the same PRs, so they would clobber each other. Instead this task finds its own comment by the `📚 Docs preview:` marker via `gh api` and PATCHes it (or creates it if absent).

## Caveats / open questions

- **mkdocs `site_url` is not set** in `mkdocs.yml`, so internal links in the build are relative and work fine on the preview host. If a `site_url` (docs.visivo.io) is ever added, absolute links/canonicals in previews would point at production — acceptable for previews, just noting it.
- **Does the org plan include RWX web apps?** Unconfirmed until this PR's run executes the app task.
- **Public, guessable URLs**: `docs-pr-<n>--visivo.<region>.rwx.run` is unauthenticated. Docs are OSS so this seems fine, but flagging it.
- **Endpoint cleanup**: nothing tears down `docs-pr-<n>` on PR close; apps idle-stop after 10 min and only re-materialize on traffic, so the cost should be ~nil, but stale URLs keep resolving while the task cache lives. Could add a `closed` action later if we care.

VIS-967

🤖 Generated with [Claude Code](https://claude.com/claude-code)