### PR TITLE
fix(docs): critical clarity fixes — /background 404, install reconcile, Slack links, truthful serve log (VIS-870)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,13 +320,13 @@ Releases are created through GitHub Actions:
 
 - Be respectful and inclusive
 - Follow the code of conduct
-- Ask questions in our [Slack community](https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ)
+- Ask questions in [GitHub Discussions](https://github.com/visivo-io/visivo/discussions)
 - Report bugs with clear reproduction steps
 - Suggest features with use cases
 
 ## 📞 Getting Help
 
-- 💬 [Join our Slack](https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ) for real-time help
+- 💬 [Start a discussion](https://github.com/visivo-io/visivo/discussions) for questions and help
 - 📚 Check the [documentation](https://docs.visivo.io)
 - 🐛 Search [existing issues](https://github.com/visivo-io/visivo/issues) before creating new ones
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://visivo.io">Website</a> •
   <a href="https://docs.visivo.io">Documentation</a> •
   <a href="https://visivo.io/examples">Live Examples</a> •
-  <a href="https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ">Join Slack</a> •
+  <a href="https://github.com/visivo-io/visivo/discussions">Discussions</a> •
   <a href="https://www.linkedin.com/company/visivo-io">LinkedIn</a>
 </p>
 
@@ -112,7 +112,7 @@ python -m pip install git+https://github.com/visivo-io/visivo.git@v1.1.0-beta-1
   <strong>Join our growing community of data practitioners!</strong>
 </p>
 
-- 💬 **[Join our Slack](https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ)** – Get help, share dashboards, and chat with the team
+- 💬 **[GitHub Discussions](https://github.com/visivo-io/visivo/discussions)** – Get help, share dashboards, and chat with the team
 - 📚 **[Browse Documentation](https://docs.visivo.io)** – Comprehensive guides and API reference
 - 🐛 **[Report Issues](https://github.com/visivo-io/visivo/issues)** – Found a bug or have a feature request? Let us know!
 - 💼 **[Follow on LinkedIn](https://www.linkedin.com/company/visivo-io)** – Stay updated with the latest news

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -288,5 +288,6 @@ nav:
           - Run Time:
               - reference/functions/runtime_functions/index.md
   - Background:
+      - background/index.md
       - Viewpoint: viewpoint.md
       - How It Works: how_it_works.md

--- a/mkdocs/background/index.md
+++ b/mkdocs/background/index.md
@@ -1,0 +1,25 @@
+# Background
+
+Why Visivo exists and how it works under the hood.
+
+<div class="grid cards" markdown>
+
+-   :material-eye:{ .lg .middle } **Viewpoint**
+
+    ---
+
+    The opinions behind Visivo: why BI-as-code, why YAML, and why
+    your dashboards belong in version control.
+
+    [:octicons-arrow-right-24: Read the viewpoint](../viewpoint.md)
+
+-   :material-cog:{ .lg .middle } **How It Works**
+
+    ---
+
+    The compile → run → serve lifecycle that turns your project
+    configuration into interactive dashboards.
+
+    [:octicons-arrow-right-24: See how it works](../how_it_works.md)
+
+</div>

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -165,7 +165,7 @@ Now that you have a running dashboard, explore what's possible:
 ---
 
 <div style="text-align: center; margin-top: 2rem;">
-  <a href="https://github.com/visivo/visivo" class="md-button md-button--primary">
+  <a href="https://github.com/visivo-io/visivo" class="md-button md-button--primary">
     :octicons-star-16: Star us on GitHub
   </a>
   <a href="https://app.visivo.io" class="md-button">

--- a/mkdocs/installation.md
+++ b/mkdocs/installation.md
@@ -6,22 +6,16 @@ Visivo offers multiple installation methods to suit different needs and environm
 
 The fastest way to get started with Visivo is using our installation script:
 
-=== "macOS/Linux/Windows (WSL)"
+```bash
+curl -fsSL https://visivo.sh | bash
+```
 
-    ```bash
-    curl -fsSL https://visivo.sh | bash
-    ```
-
-=== "Windows (PowerShell)"
-
-    ```powershell
-    irm https://visivo.sh/install.ps1 | iex
-    ```
+The script installs the `visivo` binary to `~/.visivo/bin` and adds it to your `PATH`. On Windows, run it inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), or use the [pip installation](#python-package-pip) instead.
 
 !!! success "What you get"
     - ✅ Single binary, no dependencies
-    - ✅ Works on Mac, Linux, and Windows
-    - ✅ Automatic updates available
+    - ✅ Works on Mac, Linux, and Windows (WSL)
+    - ✅ No `sudo` required — installs to your home directory
     - ✅ Instant hot-reload development
 
 ## Python Package (pip)
@@ -106,8 +100,8 @@ visivo serve
 
 ### Windows
 - Windows 10/11 recommended
-- PowerShell 5.1+ required for install script
-- WSL2 recommended for best experience
+- WSL2 recommended for the install script
+- Native Windows users should install via [pip](#python-package-pip)
 
 ## Environment Variables
 
@@ -126,16 +120,25 @@ export VISIVO_LOG_LEVEL=DEBUG
 
 ## Troubleshooting
 
-### Permission Denied
+### Command Not Found After Install
 
-If you get a permission error during installation:
+The install script places the binary in `~/.visivo/bin` and appends that
+directory to your shell profile. If `visivo` isn't found right after
+installing, reload your shell:
 
 ```bash
-# macOS/Linux
-sudo curl -fsSL https://visivo.sh | bash
+# Restart your terminal, or:
+source ~/.bashrc   # bash
+source ~/.zshrc    # zsh
 
-# Or install to user directory
-curl -fsSL https://visivo.sh | bash -s -- --prefix=$HOME/.local
+# Or add it to your PATH manually
+export PATH="$HOME/.visivo/bin:$PATH"
+```
+
+### Installing a Specific Version
+
+```bash
+curl -fsSL https://visivo.sh | bash -s -- --version 2.0.3
 ```
 
 ### Python Version Issues
@@ -168,11 +171,11 @@ pip install visivo
 ### Binary Installation
 
 ```bash
-# Remove binary
-rm /usr/local/bin/visivo
+# Remove the install directory
+rm -rf ~/.visivo
 
-# Or if installed with --prefix
-rm $HOME/.local/bin/visivo
+# Then remove the PATH line the installer added to your
+# shell profile (~/.bashrc, ~/.zshrc, or ~/.profile)
 ```
 
 ### Python Package

--- a/mkdocs/topics/deployments.md
+++ b/mkdocs/topics/deployments.md
@@ -385,7 +385,7 @@ With [Mint Cron Schedules](https://www.rwx.com/docs/mint/cron-schedules) you can
     ```
 
     1. Mint [automatically configures a clone token](https://www.rwx.com/docs/mint/getting-started/github#cloning-repositories) when you connect it to github. You should be able to find it in your mint vault.
-    2. Specifying a [version of visivo](https://github.com/visivo-io/visivo/releases) can be a good idea. For example- `pip install visivo==1.0.26`
+    2. Specifying a [version of visivo](https://github.com/visivo-io/visivo/releases) can be a good idea. For example- `pip install visivo==2.0.3`
     3. You can get your visivo token from [app.visivo.io](https://app.visivo.io). 
     4. This assumes that you have a target set up in your project that depends on these env variables for connection. 
 
@@ -447,7 +447,7 @@ With [Mint Cron Schedules](https://www.rwx.com/docs/mint/cron-schedules) you can
     ```
 
     1. Mint [automatically configures a clone token](https://www.rwx.com/docs/mint/getting-started/github#cloning-repositories) when you connect it to github. You should be able to find it in your mint vault.
-    2. Specifying a [version of visivo](https://github.com/visivo-io/visivo/releases) can be a good idea. For example- `pip install visivo==1.0.26`
+    2. Specifying a [version of visivo](https://github.com/visivo-io/visivo/releases) can be a good idea. For example- `pip install visivo==2.0.3`
     3. You can get your visivo token from [app.visivo.io](https://app.visivo.io). 
     4. This assumes that you have a target set up in your project that depends on these env variables for connection. 
 {% endraw %}

--- a/tests/commands/test_serve.py
+++ b/tests/commands/test_serve.py
@@ -123,3 +123,35 @@ def test_serve_command_raises_when_parse_fails(output_dir, tmp_path):
 
         assert result.exit_code != 0
         assert "mock parse failure" in result.output.lower()
+
+
+def test_serve_command_does_not_claim_build_complete_before_data_ready(output_dir, tmp_path):
+    """Regression (VIS-870): `visivo serve` used to log "Initial build completed"
+    right after serve_phase() returned — before the server had started and before
+    the initial run_phase (triggered by the on_server_ready callback) had built
+    any data. The pre-serve log lines must not claim the build is done; the
+    truthful completion message ("Initial Data Refresh Complete.") is emitted by
+    serve_phase once the data is actually ready.
+    """
+    from unittest.mock import MagicMock
+
+    port = get_test_port()
+    mock_server = MagicMock()
+
+    with (
+        patch("visivo.commands.serve.parse_project_phase") as mock_parse,
+        patch("visivo.commands.serve.serve_phase") as mock_serve_phase,
+    ):
+        mock_parse.return_value = ProjectFactory()
+        mock_serve_phase.return_value = (mock_server, MagicMock(), MagicMock())
+
+        result = runner.invoke(
+            serve,
+            ["--output-dir", str(output_dir), "--working-dir", str(tmp_path), "--port", str(port)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Initial build completed" not in result.output
+        assert "Project loaded in" in result.output
+        assert f"Starting server at http://localhost:{port}" in result.output
+        mock_server.serve.assert_called_once()

--- a/viewer/src/components/common/TopNav.jsx
+++ b/viewer/src/components/common/TopNav.jsx
@@ -5,7 +5,7 @@ import Dropdown from './Dropdown';
 import { FiChevronDown, FiFolder, FiCheck, FiX, FiSearch, FiClock, FiUser, FiUsers, FiLogOut, FiLayers, FiArrowRight } from 'react-icons/fi';
 import { FaStar, FaRocket } from 'react-icons/fa';
 import { VscGitCommit } from 'react-icons/vsc';
-import { SiSlack } from 'react-icons/si';
+import { SiGithub } from 'react-icons/si';
 import { MdMenuBook } from 'react-icons/md';
 import { PiMagnifyingGlass, PiTreeStructure, PiPencil } from 'react-icons/pi';
 import { HiTemplate } from 'react-icons/hi';
@@ -361,13 +361,13 @@ function localMenu(close) {
         <MdMenuBook size={16} color="#6b7280" /> Documentation
       </a>
       <a
-        href="https://join.slack.com/t/visivo-community/shared_invite/zt-38shh3jmq-1Vl3YkxHlGpD~GlalfiKsQ"
+        href="https://github.com/visivo-io/visivo/discussions"
         target="_blank"
         rel="noopener noreferrer"
         onClick={close}
         style={{ ...linkStyle, display: 'flex', alignItems: 'center', gap: 8 }}
       >
-        <SiSlack size={15} color="#6b7280" /> Join the Community
+        <SiGithub size={15} color="#6b7280" /> Join the Community
       </a>
       <a href="https://github.com/visivo-io/visivo/issues/new/choose" target="_blank" rel="noopener noreferrer" onClick={close} style={linkStyle}>
         Log an Issue

--- a/visivo/commands/serve.py
+++ b/visivo/commands/serve.py
@@ -108,8 +108,11 @@ def serve(
         no_deprecation_warnings=no_deprecation_warnings,
     )
 
-    logger.info(f"Initial build completed in {round(time() - start_time, 2)}s")
-    logger.info(f"Server running at {server_url}")
+    # The initial data build runs via the on_server_ready callback after the
+    # server starts, so don't claim the build is done here — serve_phase logs
+    # "Initial Data Refresh Complete." when the data is actually ready.
+    logger.info(f"Project loaded in {round(time() - start_time, 2)}s")
+    logger.info(f"Starting server at {server_url} (initial data refresh runs once it's up)")
 
     server.serve(
         host="0.0.0.0",


### PR DESCRIPTION
## What / Why

Works through each item of VIS-870 (docs critical clarity fixes). Per-item disposition:

| # | Item | Disposition |
|---|------|-------------|
| 1 | Deprecation banners on Trace/Selector content | **Not found — already clean.** `grep -rni 'trace\|selector' mkdocs/` finds only "stack traces" in topics/telemetry.md and generated Plotly prop text under props-docs. topics/interactivity.md already leads with Inputs + Insights + the semantic layer; no Trace/Selector pages or nav entries remain, so no banners were needed. |
| 2 | /background 404 | **Fixed.** The nav had a `Background:` section (Viewpoint, How It Works) with no index page, so `/background/` 404'd. Added `mkdocs/background/index.md` as the section landing page (Material `navigation.indexes` is already enabled) and wired it into the nav — `/background/` now renders and links both child pages. No in-repo links pointed at /background, so nothing else to retarget. |
| 3 | Reconcile install commands | **Fixed.** Canonical story (curl primary, pip secondary w/ Python 3.10+) was already right in index.md + installation.md, but installation.md advertised a PowerShell installer (`visivo.sh/install.ps1` → **404**, verified) and a `--prefix` flag + `sudo` troubleshooting the script doesn't support (it installs to `~/.visivo/bin`, no sudo). Replaced with accurate WSL/pip guidance for Windows, PATH troubleshooting, the installer's real `--version` flag, and correct uninstall paths. Also bumped `pip install visivo==1.0.26` CI examples in topics/deployments.md to `2.0.3`, and fixed the home page GitHub star link org (`visivo/visivo` → `visivo-io/visivo`). |
| 4 | Remove Slack invite links (D10) | **Fixed (none were in mkdocs/).** The docs themselves had zero Slack invite links; the dead-community links lived in README.md (2), CONTRIBUTING.md (2), and the viewer TopNav "Join the Community" menu item. All now point at GitHub Discussions. SlackDestination feature docs are untouched. |
| 5 | "Initial build completed" logs before data ready | **Fixed.** `visivo/commands/serve.py` logged it right after `serve_phase()` returned — but serve_phase only constructs the Flask app/hot-reload server; the initial `run_phase` build runs later via the `on_server_ready` callback. Reworded to `Project loaded in Xs` + `Starting server at <url> (initial data refresh runs once it's up)`; the truthful completion message remains serve_phase's "Initial Data Refresh Complete.". Added a CLI-level regression test. |
| 6 | Docs verification pipeline | **Run end-to-end** (see below). |

## Verification

- Schema gen + `mkdocs/src/write_mkdocs_markdown_files.py` run — generator produced **zero** nav/reference churn; the only mkdocs.yml diff is the intended Background index line (generated `visivo_schema.json` not committed per convention)
- `mkdocs build`: success, **spellcheck gate clean** (no `mkdocs_spellcheck` warnings)
- Built HTML spot-checks: `mkdocs_build/background/index.html` exists & links viewpoint/how_it_works; no `install.ps1`/`--prefix`/`sudo curl` remnants; no `join.slack.com` anywhere in the build; deployments page shows `visivo==2.0.3`
- `poetry run black --check --target-version py312 .` clean
- Full `poetry run pytest tests/ -x`: **1707 passed, 2 skipped, 5 xfailed, 1 xpassed in 53.46s**
- Viewer (TopNav.jsx change): `yarn test --testPathPattern=TopNav` 10/10 passed; `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)