### PR TITLE
feat(docs): docs_gen.sh + docs_sandbox.sh (:8003) + Playwright docs e2e harness (VIS-966)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ test-results/
 .sandbox/
 .sandbox-publish/
 .sandbox-onb-empty/
+.sandbox-docs/
 viewer/e2e/screenshots/
 viewer/test-results/
 

--- a/scripts/docs_gen.sh
+++ b/scripts/docs_gen.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# One-shot docs generation + build pipeline for the MkDocs site.
+#
+# Pipeline:
+#   1. Preflight  — verify the poetry env can import visivo + mkdocs-material
+#   2. Schema     — write generate_schema() straight to mkdocs/assets/visivo_schema.json
+#                   (fast, ~2s). --ci-parity instead runs the schema pytest and copies
+#                   the NEWEST tmp/**/visivo_schema.json, matching .rwx/test_docs.yml.
+#   3. Markdown   — poetry run python mkdocs/src/write_mkdocs_markdown_files.py
+#                   (NOTE: this rewrites the committed mkdocs.yml nav in place)
+#   4. Build      — PYTHONPATH=$PWD poetry run mkdocs build, teed to tmp/docs/build_stdout.txt
+#   5. Spellcheck — fail on any "WARNING -  mkdocs_spellcheck" line in the build output
+#
+# Usage:
+#   bash scripts/docs_gen.sh                 — full pipeline (fast schema path)
+#   bash scripts/docs_gen.sh --ci-parity     — schema via pytest + tmp copy (CI parity)
+#   bash scripts/docs_gen.sh --strict        — pass -s to mkdocs build (warnings fatal)
+#   bash scripts/docs_gen.sh --skip-build    — steps 1-3 only (no build, no spellcheck)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+CI_PARITY=false
+STRICT=false
+SKIP_BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --ci-parity)  CI_PARITY=true ;;
+        --strict)     STRICT=true ;;
+        --skip-build) SKIP_BUILD=true ;;
+        *)
+            echo "Unknown flag: $arg"
+            echo "Usage: bash scripts/docs_gen.sh [--ci-parity] [--strict] [--skip-build]"
+            exit 1
+            ;;
+    esac
+done
+
+# --- 1. Preflight -----------------------------------------------------------
+if ! poetry run python -c "import visivo, material" >/dev/null 2>&1; then
+    echo "ERROR: the poetry env cannot import visivo and/or mkdocs-material."
+    echo "Remediation:"
+    echo "  poetry env use /opt/homebrew/bin/python3.12 && poetry install --with dev"
+    exit 1
+fi
+
+# --- 2. Schema --------------------------------------------------------------
+if [ "$CI_PARITY" = true ]; then
+    echo "==> Schema (--ci-parity): running tests/parsers/test_schema_generator.py..."
+    poetry run pytest tests/parsers/test_schema_generator.py
+    # CI uses `find tmp -name visivo_schema.json -exec cp {}` which grabs ANY match;
+    # locally tmp/ can hold stale schemas from old runs, so copy only the NEWEST.
+    newest_schema=$(find tmp -name visivo_schema.json -print0 2>/dev/null \
+        | xargs -0 ls -t 2>/dev/null | head -n 1)
+    if [ -z "$newest_schema" ]; then
+        echo "ERROR: schema test passed but produced no tmp/**/visivo_schema.json"
+        exit 1
+    fi
+    cp "$newest_schema" mkdocs/assets/visivo_schema.json
+    echo "Copied $newest_schema -> mkdocs/assets/visivo_schema.json"
+else
+    echo "==> Schema (fast path): writing mkdocs/assets/visivo_schema.json..."
+    poetry run python -c "from visivo.parsers.schema_generator import generate_schema; from pathlib import Path; Path('mkdocs/assets/visivo_schema.json').write_text(generate_schema())"
+fi
+
+# --- 3. Markdown generation -------------------------------------------------
+echo "==> Generating reference markdown (rewrites mkdocs.yml nav in place)..."
+poetry run python mkdocs/src/write_mkdocs_markdown_files.py
+if ! git diff --quiet mkdocs.yml; then
+    echo ""
+    echo "#####################################################################"
+    echo "# mkdocs.yml nav was rewritten by write_mkdocs_markdown_files.py.   #"
+    echo "# If your change intends nav updates, COMMIT the mkdocs.yml diff.   #"
+    echo "# Otherwise restore the committed nav:  git checkout -- mkdocs.yml  #"
+    echo "#####################################################################"
+    echo ""
+fi
+
+if [ "$SKIP_BUILD" = true ]; then
+    echo "==> Skipping mkdocs build + spellcheck (--skip-build)"
+    echo "docs_gen complete (steps 1-3)"
+    exit 0
+fi
+
+# --- 4. Build ---------------------------------------------------------------
+mkdir -p tmp/docs
+build_args=()
+if [ "$STRICT" = true ]; then
+    build_args+=(-s)
+fi
+echo "==> Building docs (mkdocs build ${build_args[*]})..."
+PYTHONPATH="$PROJECT_DIR" poetry run mkdocs build "${build_args[@]}" 2>&1 \
+    | tee tmp/docs/build_stdout.txt
+build_status=${PIPESTATUS[0]}
+if [ "$build_status" -ne 0 ]; then
+    echo "ERROR: mkdocs build failed (exit $build_status) — see tmp/docs/build_stdout.txt"
+    exit "$build_status"
+fi
+
+# --- 5. Spellcheck gate -----------------------------------------------------
+if grep -q "WARNING -  mkdocs_spellcheck" tmp/docs/build_stdout.txt; then
+    echo ""
+    echo "ERROR: spelling errors were found in the docs build:"
+    grep "WARNING -  mkdocs_spellcheck" tmp/docs/build_stdout.txt | head -n 20
+    echo "Fix the misspellings, or add legitimately-introduced words to mkdocs/known_words.txt"
+    exit 1
+fi
+
+echo "docs_gen complete — build green, spellcheck clean (output: mkdocs_build/)"

--- a/scripts/docs_sandbox.sh
+++ b/scripts/docs_sandbox.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Manage the isolated docs sandbox (MkDocs site) for Claude Code testing.
+# Defaults to port 8003 to avoid conflicting with the user's dev servers
+# (8000/3000) and the other sandboxes (8001/3001, 8002/3002).
+#
+# Env-var overrides (all optional):
+#   VISIVO_DOCS_PORT   default 8003
+#
+# Usage:
+#   bash scripts/docs_sandbox.sh start             — gen (docs_gen.sh steps 1-3) + mkdocs serve
+#   bash scripts/docs_sandbox.sh start --no-gen    — skip generation, just serve
+#   bash scripts/docs_sandbox.sh start --static    — full docs_gen.sh, then http.server on mkdocs_build
+#   bash scripts/docs_sandbox.sh stop              — stop the docs server
+#   bash scripts/docs_sandbox.sh status            — check if the docs server is running
+#   bash scripts/docs_sandbox.sh test              — start, link-crawl + Playwright docs suite, stop
+#   bash scripts/docs_sandbox.sh restart           — stop then start
+
+set -e
+
+DOCS_PORT="${VISIVO_DOCS_PORT:-8003}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VIEWER_DIR="$PROJECT_DIR/viewer"
+PID_DIR="$PROJECT_DIR/.sandbox-docs"
+
+docs_pid_file="$PID_DIR/docs.pid"
+
+mkdir -p "$PID_DIR"
+
+# Optional flags for `start` / `restart` / `test`
+NO_GEN=false
+STATIC=false
+for arg in "${@:2}"; do
+    case "$arg" in
+        --no-gen) NO_GEN=true ;;
+        --static) STATIC=true ;;
+        *)
+            echo "Unknown flag: $arg"
+            echo "Usage: bash scripts/docs_sandbox.sh {start|stop|status|test|restart} [--no-gen] [--static]"
+            exit 1
+            ;;
+    esac
+done
+
+is_port_in_use() {
+    lsof -i ":$1" -sTCP:LISTEN -t >/dev/null 2>&1
+}
+
+get_pid() {
+    local pid_file="$1"
+    if [ -f "$pid_file" ]; then
+        local pid
+        pid=$(cat "$pid_file")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "$pid"
+            return 0
+        fi
+        rm -f "$pid_file"
+    fi
+    return 1
+}
+
+run_gen() {
+    if [ "$NO_GEN" = true ]; then
+        echo "Skipping docs generation (--no-gen)"
+        return 0
+    fi
+    if [ "$STATIC" = true ]; then
+        # Static mode serves mkdocs_build/, so run the FULL pipeline (incl. build).
+        bash "$SCRIPT_DIR/docs_gen.sh"
+    else
+        # mkdocs serve builds on startup, so only run gen steps 1-3.
+        bash "$SCRIPT_DIR/docs_gen.sh" --skip-build
+    fi
+}
+
+start_docs() {
+    if is_port_in_use "$DOCS_PORT"; then
+        echo "Docs server already running on :$DOCS_PORT"
+        return 0
+    fi
+
+    run_gen
+
+    if [ "$STATIC" = true ]; then
+        if [ ! -d "$PROJECT_DIR/mkdocs_build" ]; then
+            echo "ERROR: mkdocs_build/ not found — run bash scripts/docs_gen.sh first"
+            exit 1
+        fi
+        echo "Starting static docs server on :$DOCS_PORT..."
+        # Redirect the WHOLE subshell (not just the server command) and detach
+        # stdin, so the background server holds no reference to the caller's
+        # stdout pipe — otherwise `docs_sandbox.sh start | tee/tail` never
+        # sees EOF and hangs after the script exits.
+        (
+            cd "$PROJECT_DIR"
+            exec python3 -m http.server "$DOCS_PORT" --directory mkdocs_build
+        ) > "$PID_DIR/mkdocs.log" 2>&1 < /dev/null &
+        echo $! > "$docs_pid_file"
+    else
+        echo "Starting mkdocs serve on :$DOCS_PORT..."
+        (
+            cd "$PROJECT_DIR"
+            export PYTHONPATH="$PROJECT_DIR"
+            exec poetry run mkdocs serve -a "127.0.0.1:$DOCS_PORT"
+        ) > "$PID_DIR/mkdocs.log" 2>&1 < /dev/null &
+        echo $! > "$docs_pid_file"
+    fi
+
+    # Wait for ready — mkdocs serve rebuilds the whole site before listening,
+    # so allow up to 90s (the reference build runs ~30-60s on a laptop).
+    for i in $(seq 1 90); do
+        if curl --head --silent --fail "http://127.0.0.1:$DOCS_PORT" >/dev/null 2>&1; then
+            echo "Docs server ready on :$DOCS_PORT"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "ERROR: docs server did not become ready within 90s — see $PID_DIR/mkdocs.log"
+    return 1
+}
+
+stop_process() {
+    local pid_file="$1"
+    local name="$2"
+    local pid
+    if pid=$(get_pid "$pid_file"); then
+        echo "Stopping $name (PID $pid)..."
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        rm -f "$pid_file"
+    else
+        echo "$name not running"
+    fi
+}
+
+stop_by_port() {
+    local port="$1"
+    local name="$2"
+    local pids
+    pids=$(lsof -i ":$port" -sTCP:LISTEN -t 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "Stopping $name on :$port (PIDs: $pids)..."
+        echo "$pids" | xargs kill 2>/dev/null || true
+    fi
+}
+
+run_link_crawl() {
+    if ! command -v wget >/dev/null 2>&1; then
+        echo "ERROR: wget is required for the link crawl — brew install wget"
+        return 1
+    fi
+    echo "==> Link crawl: wget --recursive --spider http://127.0.0.1:$DOCS_PORT/ ..."
+    local crawl_log="$PID_DIR/crawl.log"
+    local crawl_status=0
+    # --spider downloads nothing; mirror .rwx/test_docs.yml's grep filtering
+    # (drop the per-URL "... 200 OK", unlink, and .tmp.tmp noise lines).
+    (cd "$PID_DIR" && wget --recursive --no-verbose --spider "http://127.0.0.1:$DOCS_PORT/" > crawl.log 2>&1) \
+        || crawl_status=$?
+    grep -v -E 'OK$|^unlink|\.tmp\.tmp' "$crawl_log" || true
+    if [ "$crawl_status" -ne 0 ]; then
+        echo "ERROR: link crawl failed (wget exit $crawl_status) — broken links above (full log: $crawl_log)"
+        return 1
+    fi
+    echo "Link crawl passed"
+}
+
+run_playwright() {
+    local config="$VIEWER_DIR/playwright.docs.config.mjs"
+    if [ ! -f "$config" ]; then
+        echo "No viewer/playwright.docs.config.mjs found — skipping Playwright docs suite"
+        return 0
+    fi
+    echo "==> Playwright docs suite..."
+    (
+        cd "$VIEWER_DIR"
+        source ~/.nvm/nvm.sh
+        nvm use
+        VISIVO_DOCS_PORT="$DOCS_PORT" npx playwright test --config playwright.docs.config.mjs --reporter=list
+    )
+}
+
+cmd_start() {
+    start_docs
+    echo ""
+    echo "Docs sandbox ready:"
+    echo "  Docs: http://127.0.0.1:$DOCS_PORT"
+}
+
+cmd_stop() {
+    stop_process "$docs_pid_file" "docs server"
+    # Also kill by port in case PIDs are stale
+    stop_by_port "$DOCS_PORT" "docs server"
+    echo "Docs sandbox stopped"
+}
+
+cmd_status() {
+    echo "Docs sandbox status:"
+    if is_port_in_use "$DOCS_PORT"; then
+        echo "  Docs: RUNNING on :$DOCS_PORT"
+    else
+        echo "  Docs: STOPPED"
+    fi
+}
+
+cmd_test() {
+    local exit_code=0
+    start_docs || exit_code=1
+    if [ "$exit_code" -eq 0 ]; then
+        run_link_crawl || exit_code=1
+        run_playwright || exit_code=1
+    fi
+    cmd_stop
+    if [ "$exit_code" -eq 0 ]; then
+        echo "Docs sandbox test PASSED"
+    else
+        echo "Docs sandbox test FAILED"
+    fi
+    exit "$exit_code"
+}
+
+cmd_restart() {
+    cmd_stop
+    sleep 1
+    cmd_start
+}
+
+case "${1:-status}" in
+    start)   cmd_start ;;
+    stop)    cmd_stop ;;
+    status)  cmd_status ;;
+    test)    cmd_test ;;
+    restart) cmd_restart ;;
+    *)
+        echo "Usage: bash scripts/docs_sandbox.sh {start|stop|status|test|restart} [--no-gen] [--static]"
+        exit 1
+        ;;
+esac

--- a/viewer/e2e/docs/docs-design.spec.mjs
+++ b/viewer/e2e/docs/docs-design.spec.mjs
@@ -1,0 +1,96 @@
+/**
+ * Docs design-compliance suite (ported from www/e2e/design-compliance.spec.ts).
+ *
+ * Gates on both desktop + mobile projects (see playwright.docs.config.mjs):
+ *   - no horizontal overflow (mobile regressions are the usual culprit)
+ *   - no near-invisible text (dark-on-dark / light-on-light) on the
+ *     hero/heading and Material nav chrome
+ *
+ * Precondition: docs sandbox running on :8003 (or $VISIVO_DOCS_PORT)
+ *   bash scripts/docs_sandbox.sh start
+ */
+
+import { test, expect } from '@playwright/test';
+
+const PAGES = [
+  '/',
+  '/installation/',
+  '/topics/sources/',
+  '/reference/configuration/Dashboards/Dashboard/',
+];
+
+for (const route of PAGES) {
+  test(`no horizontal overflow on ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.waitForLoadState('domcontentloaded');
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    );
+    // small tolerance for sub-pixel rounding / scrollbars
+    expect(overflow, `${overflow}px of horizontal overflow on ${route}`).toBeLessThanOrEqual(2);
+  });
+
+  test(`no near-invisible text on hero/nav of ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.waitForLoadState('domcontentloaded');
+    const offenders = await page.evaluate(() => {
+      const parseRGB = s => {
+        const m = s.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const p = m[1].split(',').map(x => parseFloat(x.trim()));
+        return [p[0], p[1], p[2], p[3] ?? 1];
+      };
+      const lum = (r, g, b) => {
+        const a = [r, g, b].map(v => {
+          v /= 255;
+          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+      };
+      const effectiveBg = el => {
+        let node = el;
+        while (node) {
+          const bg = parseRGB(getComputedStyle(node).backgroundColor);
+          if (bg && bg[3] > 0) return bg;
+          node = node.parentElement;
+        }
+        return null;
+      };
+      const bad = [];
+      // Hero/heading + Material nav chrome — the elements users must always
+      // be able to read, regardless of palette tweaks.
+      const els = Array.from(
+        document.querySelectorAll(
+          [
+            '.md-content h1',
+            '.md-content h2',
+            'header.md-header a',
+            'header.md-header span',
+            '.md-tabs a',
+            'nav.md-nav--primary a',
+          ].join(',')
+        )
+      ).slice(0, 500);
+      for (const el of els) {
+        const text = el.innerText?.trim();
+        if (!text) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
+        const style = getComputedStyle(el);
+        if (style.visibility === 'hidden' || style.display === 'none') continue;
+        const fg = parseRGB(style.color);
+        const bg = effectiveBg(el);
+        if (!fg || !bg) continue;
+        const ratio =
+          (Math.max(lum(fg[0], fg[1], fg[2]), lum(bg[0], bg[1], bg[2])) + 0.05) /
+          (Math.min(lum(fg[0], fg[1], fg[2]), lum(bg[0], bg[1], bg[2])) + 0.05);
+        // ratio < 1.5 ≈ near-invisible same-on-same color (the bug we care about)
+        if (ratio < 1.5) {
+          bad.push(`<${el.tagName.toLowerCase()}> "${text.slice(0, 40)}" ratio=${ratio.toFixed(2)}`);
+        }
+      }
+      return bad;
+    });
+    expect(offenders, `near-invisible text on ${route}:\n${offenders.join('\n')}`).toEqual([]);
+  });
+}

--- a/viewer/e2e/docs/docs-routes.spec.mjs
+++ b/viewer/e2e/docs/docs-routes.spec.mjs
@@ -1,0 +1,68 @@
+/**
+ * Docs routes smoke suite.
+ *
+ * Validates that the core docs page types render correctly:
+ *   - the home / quick-start page (hand-written)
+ *   - a generated configuration-reference page (from write_mkdocs_markdown_files.py)
+ *   - a topics page (hand-written prose)
+ *   - the installation page
+ *
+ * Each page must render an h1, expose the Material header nav + search,
+ * and produce ZERO console errors (third-party analytics noise excluded).
+ *
+ * Precondition: docs sandbox running on :8003 (or $VISIVO_DOCS_PORT)
+ *   bash scripts/docs_sandbox.sh start
+ */
+
+import { test, expect } from '@playwright/test';
+
+const ROUTES = [
+  { name: 'home (quick start)', path: '/' },
+  { name: 'generated reference (Dashboard)', path: '/reference/configuration/Dashboards/Dashboard/' },
+  { name: 'topics (sources)', path: '/topics/sources/' },
+  { name: 'installation', path: '/installation/' },
+];
+
+// Errors from third-party analytics (gtag/GA) are environmental, not docs bugs.
+const isThirdPartyNoise = text =>
+  /googletagmanager|google-analytics|gtag|doubleclick/i.test(text);
+
+for (const route of ROUTES) {
+  test.describe(`docs route: ${route.name}`, () => {
+    test(`${route.path} renders with h1, Material nav + search, no console errors`, async ({
+      page,
+    }) => {
+      const consoleErrors = [];
+      page.on('console', msg => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+      });
+      page.on('pageerror', err => consoleErrors.push(String(err)));
+
+      const response = await page.goto(route.path);
+      expect(response.status(), `${route.path} should respond 200`).toBe(200);
+      await page.waitForLoadState('domcontentloaded');
+
+      // A single h1 with real content
+      const h1 = page.locator('article h1, .md-content h1').first();
+      await expect(h1).toBeVisible();
+      expect((await h1.innerText()).trim().length).toBeGreaterThan(0);
+
+      // Material chrome: header, primary nav, and search are present.
+      // (On mobile the nav/search live behind toggles, so assert attachment,
+      // not visibility.)
+      await expect(page.locator('header.md-header')).toBeAttached();
+      await expect(page.locator('nav.md-nav--primary')).toBeAttached();
+      await expect(page.locator('[data-md-component="search"]')).toBeAttached();
+
+      const realErrors = consoleErrors.filter(e => !isThirdPartyNoise(e));
+      expect(realErrors, `console errors on ${route.path}:\n${realErrors.join('\n')}`).toEqual(
+        []
+      );
+    });
+  });
+}
+
+test('unknown docs path serves the 404 page', async ({ page }) => {
+  const response = await page.goto('/this/page/does/not/exist/');
+  expect(response.status()).toBe(404);
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -25,6 +25,9 @@ export default defineConfig({
       testIgnore: [
         '**/explorer-crud-save.spec.mjs',
         '**/explorer-publish-to-files.spec.mjs',
+        // Docs specs run against the docs sandbox (:8003) via
+        // playwright.docs.config.mjs — never against the viewer sandbox.
+        '**/e2e/docs/**',
       ],
     },
     {

--- a/viewer/playwright.docs.config.mjs
+++ b/viewer/playwright.docs.config.mjs
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Docs sandbox port — keep in sync with scripts/docs_sandbox.sh (default 8003).
+const DOCS_PORT = process.env.VISIVO_DOCS_PORT || '8003';
+
+export default defineConfig({
+  testDir: './e2e/docs',
+  timeout: 30000,
+  retries: 2,
+  workers: '75%',
+  use: {
+    baseURL: `http://localhost:${DOCS_PORT}`,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  // Two projects so docs regressions that only show on small screens
+  // (overflow, hidden nav) are caught — mirrors www's desktop+mobile gating.
+  projects: [
+    {
+      name: 'desktop',
+      use: { viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+  // No webServer config — the docs sandbox must be started separately via
+  // `bash scripts/docs_sandbox.sh start` (same philosophy as playwright.config.mjs:
+  // keeps Claude's tests isolated from the user's dev servers).
+});


### PR DESCRIPTION
## What

P4 M0 docs tooling (VIS-966):

- **`scripts/docs_gen.sh`** — one-shot docs pipeline: preflight (poetry env imports `visivo` + `material`, with remediation hint on failure) → schema → reference markdown → `mkdocs build` (teed to `tmp/docs/build_stdout.txt`) → spellcheck gate (fails on `mkdocs_spellcheck` warnings, points at `mkdocs/known_words.txt`).
  - Fast schema path writes `generate_schema()` straight to `mkdocs/assets/visivo_schema.json` (~2s); `--ci-parity` mirrors `.rwx/test_docs.yml` (runs `tests/parsers/test_schema_generator.py`, copies the **newest** `tmp/**/visivo_schema.json` — CI's find-any-match is hazardous locally).
  - Flags: `--ci-parity`, `--strict` (passes `-s` to mkdocs build), `--skip-build`.
  - Prints a loud reminder when `write_mkdocs_markdown_files.py` leaves an uncommitted `mkdocs.yml` nav diff.
- **`scripts/docs_sandbox.sh`** — isolated docs server on **:8003** (`VISIVO_DOCS_PORT`), mirroring `scripts/sandbox.sh` conventions (lsof `is_port_in_use`, PID file with `kill -0` validation, background subshell + `$!` pidfile, kill-by-pid then kill-by-port, `start|stop|status|test|restart`, default `status`).
  - `start` runs gen steps 1-3 first (`--no-gen` skips); `start --static` runs the full pipeline and serves `mkdocs_build/` via `python3 -m http.server`.
  - `test` = wget recursive link crawl (CI-parity grep filtering) + Playwright docs suite (if `viewer/playwright.docs.config.mjs` exists) → stop → exit with check status.
  - Server subshells are fully detached from caller stdio (`> log 2>&1 < /dev/null` on the subshell + `exec`), so piped invocations (`start | tail`) get EOF instead of hanging — found and fixed during verification.
- **Playwright docs harness** — `viewer/playwright.docs.config.mjs` (testDir `./e2e/docs`, baseURL honors `VISIVO_DOCS_PORT`, desktop 1440×900 + mobile Pixel 7, no webServer — sandbox started separately, same philosophy as the main viewer config) with two specs:
  - `docs-routes.spec.mjs` — home, generated reference (`/reference/configuration/Dashboards/Dashboard/`), topics (`/topics/sources/`), installation: each renders an h1, Material nav + search present, **zero** console errors (third-party analytics noise excluded); unknown path 404s.
  - `docs-design.spec.mjs` — no horizontal overflow, no near-invisible (same-on-same) text on hero/nav chrome — ported from www's design-compliance gates.
- `viewer/playwright.config.mjs`: main suite now ignores `e2e/docs/**` (those specs must never run against the viewer sandbox on :3001).
- `.gitignore`: `.sandbox-docs/`.

## Why

Gives docs work the same gated, isolated, e2e-verified workflow the viewer already has — one command to regenerate/build with the spellcheck gate, and one command to smoke the rendered site on an isolated port (:8003) without touching the user's :8000/:3000 or other sandboxes.

## Verification

- `bash scripts/docs_gen.sh` → green (~22s total; mkdocs build 9.4s; spellcheck clean; `mkdocs.yml` untouched)
- `bash scripts/docs_gen.sh --ci-parity --skip-build` → schema test + newest-tmp copy verified
- `bash scripts/docs_sandbox.sh test` → 115-file link crawl passed + **26/26** Playwright tests passed (desktop + mobile), server stopped, **:8003 free** afterwards
- `start`/`start --static`/`status`/`restart`/`stop` lifecycle verified through pipes (no hangs)
- `poetry run black --check --target-version py312 .` clean (no `.py` changes)

Note: the readiness poll is 90×1s (vs 30 in the original sketch) — `mkdocs serve` rebuilds the whole site before listening and CI's own `check-connection.sh` allows 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)