### PR TITLE
feat(docs): brand-parity MkDocs theme — mulberry + deep-teal + object-type rainbow (VIS-949)

### DIFF
--- a/mkdocs/overrides/partials/header.html
+++ b/mkdocs/overrides/partials/header.html
@@ -1,0 +1,77 @@
+{#-
+  Visivo docs header override (VIS-949) — mirrors the upstream Material
+  header.html and adds a brand "Start free" CTA to app.visivo.io so the docs
+  header echoes the www top bar (one primary conversion CTA). Keep this in sync
+  with upstream Material if the base partial changes; the only addition is the
+  `.vz-header-cta` link below (styled in stylesheets/brand_colors.css).
+-#}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    {# Visivo brand CTA — single primary conversion path, matches www nav. #}
+    <a class="vz-header-cta" href="https://app.visivo.io/register" title="Create a free Visivo Cloud account">
+      Start free
+    </a>
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/mkdocs/stylesheets/brand_colors.css
+++ b/mkdocs/stylesheets/brand_colors.css
@@ -1,39 +1,359 @@
+/* ==========================================================================
+   Visivo docs — brand-parity theme (VIS-949)
+   --------------------------------------------------------------------------
+   Makes docs.visivo.io read as the same product as visivo.io (www),
+   app.visivo.io, and the `visivo serve` viewer. Single tokens stylesheet —
+   no per-page hand-tuning. Canonical tokens (viewer is source of truth;
+   full ramps mirror www/tailwind.config.js):
+     - primary  mulberry  #713b57  (ramp 50 #f9f6f8 … 900 #160b11)
+     - accent   deep-teal #2d6a6f  (ramp 50 #eef4f4 … 900 #091517)
+     - charcoal (secondary/tertiary) #4f494c
+     - highlight terracotta #d25946 (destructive / sparing accent)
+     - anchors  dark navy #191d33, light #ecefcb
+   Object-type rainbow utility classes live in icon-colors.css.
+   ========================================================================== */
+
+:root {
+  /* ---- mulberry primary ramp ---- */
+  --vz-mulberry-50:  #f9f6f8;
+  --vz-mulberry-100: #e2d7dd;
+  --vz-mulberry-200: #c6b0bb;
+  --vz-mulberry-300: #a9899a;
+  --vz-mulberry-400: #8d6278;
+  --vz-mulberry-500: #713b57;
+  --vz-mulberry-600: #5a2f45;
+  --vz-mulberry-700: #432334;
+  --vz-mulberry-800: #2d1722;
+  --vz-mulberry-900: #160b11;
+
+  /* ---- deep-teal accent ramp ---- */
+  --vz-teal-50:  #eef4f4;
+  --vz-teal-100: #d4e1e2;
+  --vz-teal-200: #a9c3c5;
+  --vz-teal-300: #7fa6a9;
+  --vz-teal-400: #54888c;
+  --vz-teal-500: #2d6a6f;
+  --vz-teal-600: #245558;
+  --vz-teal-700: #1b4042;
+  --vz-teal-800: #122a2d;
+  --vz-teal-900: #091517;
+
+  /* ---- anchors / neutrals ---- */
+  --vz-navy:     #191d33;
+  --vz-charcoal: #4f494c;
+  --vz-terracotta: #d25946;
+}
+
+/* ==========================================================================
+   LIGHT SCHEME
+   ========================================================================== */
 [data-md-color-scheme="visivo_light"] {
-    --md-typeset-a-color: #D25946;
-    --md-default-fg-color--light: #713B57;
-    --md-primary-fg-color: #EEEEEE;
-    --md-primary-fg-color--light: #713B57;
-    --md-primary-fg-color--dark: #191D33;
-    --md-primary-bg-color: #4F494C;
-    --md-primary-bg-color--light: #4F494C;
-    --md-accent-fg-color: #D25946;
-    --md-accent-fg-color--transparent: #526cfe1a;
-    --md-accent-bg-color: #fff;
-    --md-accent-bg-color--light: #ECEFCB;
+  /* Primary (header / nav / brand). Material derives many surfaces from this. */
+  --md-primary-fg-color:        var(--vz-mulberry-500);
+  --md-primary-fg-color--light: var(--vz-mulberry-400);
+  --md-primary-fg-color--dark:  var(--vz-mulberry-700);
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.75);
+
+  /* Accent (hover / active / interactive) → deep teal. */
+  --md-accent-fg-color:             var(--vz-teal-500);
+  --md-accent-fg-color--transparent: rgba(45, 106, 111, 0.10);
+  --md-accent-bg-color:             #ffffff;
+  --md-accent-bg-color--light:      var(--vz-teal-50);
+
+  /* Body links → mulberry (matches www inline links / CTAs). */
+  --md-typeset-a-color: var(--vz-mulberry-600);
+
+  /* Foreground tints. */
+  --md-default-fg-color--light: var(--vz-mulberry-500);
+
+  /* Inline + block code accents. */
+  --md-code-hl-string-color:   var(--vz-teal-600);
+  --md-code-hl-keyword-color:  var(--vz-mulberry-600);
 }
 
+/* ==========================================================================
+   DARK SCHEME
+   ========================================================================== */
 [data-md-color-scheme="visivo_dark"] {
-    --md-typeset-a-color: #D25946;
-    --md-typeset-color: #fff;
-    --md-default-fg-color: #fff;
-    --md-default-fg-color--light: #ECEFCB;
-    --md-primary-fg-color: #191D33;
-    --md-primary-fg-color--dark: #191D33;
-    --md-primary-bg-color: #fff;
-    --md-default-bg-color: #333;
-    --md-primary-bg-color--light: #ECEFCB;
-    --md-accent-fg-color: #D25946;
-    --md-accent-fg-color--transparent: #526cfe1a;
-    --md-accent-bg-color: #4F494C;
-    --md-accent-bg-color--light: #ECEFCB;
+  /* Deep navy chrome — the product top-nav color across viewer/core/www. */
+  --md-primary-fg-color:        var(--vz-navy);
+  --md-primary-fg-color--light: var(--vz-mulberry-300);
+  --md-primary-fg-color--dark:  #0f1120;
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.75);
+
+  /* Slightly desaturated body so it doesn't read as flat #333. */
+  --md-default-bg-color:        #1c2030;
+  --md-default-fg-color:        rgba(255, 255, 255, 0.95);
+  --md-default-fg-color--light: rgba(255, 255, 255, 0.78);
+  --md-default-fg-color--lighter: rgba(255, 255, 255, 0.42);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.12);
+  --md-typeset-color:           rgba(255, 255, 255, 0.92);
+
+  /* Accent → brighter teal so it pops on the dark surface. */
+  --md-accent-fg-color:             var(--vz-teal-300);
+  --md-accent-fg-color--transparent: rgba(127, 166, 169, 0.14);
+  --md-accent-bg-color:             var(--vz-navy);
+  --md-accent-bg-color--light:      var(--vz-teal-800);
+
+  /* Links → light mulberry tint (readable on dark, still on-brand). */
+  --md-typeset-a-color: var(--vz-mulberry-300);
+
+  /* Code surface darker than body for separation. */
+  --md-code-bg-color:   #12152133;
+  --md-code-fg-color:   rgba(255, 255, 255, 0.90);
+  --md-code-hl-string-color:  #7fc7cb;
+  --md-code-hl-keyword-color: var(--vz-mulberry-300);
+
+  /* Admonition / note surfaces — the upstream palette hardcodes these to
+     white, which renders a glaring light box in dark mode. Tie them to a
+     dark surface so callouts read correctly in the dark scheme. */
+  --md-admonition-bg-color: #232838;
+  --md-admonition-fg-color: rgba(255, 255, 255, 0.92);
+
+  /* Footer + table surfaces in the dark scheme. */
+  --md-footer-bg-color:       var(--vz-navy);
+  --md-footer-bg-color--dark: #14172a;
 }
 
-@media screen and (min-width: 60em) {
-    .md-search__form {
-        background-color: #00000010;
-    }
+/* Admonition body/title inherit the dark foreground (the upstream success/
+   note/quote variants otherwise fall back to near-black text). */
+[data-md-color-scheme="visivo_dark"] .md-typeset .admonition,
+[data-md-color-scheme="visivo_dark"] .md-typeset details {
+  background: var(--md-admonition-bg-color);
+  color: var(--md-admonition-fg-color);
+  border-color: rgba(255, 255, 255, 0.10);
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset .admonition > *:not(.admonition-title):not(details),
+[data-md-color-scheme="visivo_dark"] .md-typeset details > *:not(summary) {
+  color: var(--md-admonition-fg-color);
+}
 
-    .md-search__form:hover {
-        background-color: #ffffff1f
-    }
+/* ==========================================================================
+   HEADER / NAV — echo the www top bar
+   ========================================================================== */
+.md-header {
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.06), 0 2px 6px -2px rgba(0, 0, 0, 0.10);
+}
+[data-md-color-scheme="visivo_dark"] .md-header {
+  box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.06);
+}
+
+/* Brand mark in the header — rounded square like the www logo treatment. */
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg {
+  border-radius: 7px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+/* Header tabs (when present) + active states. */
+.md-tabs__link {
+  opacity: 0.82;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.md-tabs__link:hover,
+.md-tabs__link--active {
+  opacity: 1;
+}
+
+/* ---- header CTA button (injected by overrides/partials/header.html) ---- */
+.vz-header-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0.3rem;
+  padding: 0.42rem 0.95rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  white-space: nowrap;
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--vz-mulberry-600);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.10);
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+.vz-header-cta:hover {
+  background: var(--vz-mulberry-50);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.18);
+  color: var(--vz-mulberry-700);
+}
+.vz-header-cta:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+/* Hide the CTA on small screens where the header is space-constrained;
+   the install command and signup CTAs still live in the page body. */
+@media screen and (max-width: 76.1875em) {
+  .vz-header-cta { display: none; }
+}
+
+/* ==========================================================================
+   SIDEBAR NAV — brand active state to match www nav links
+   ========================================================================== */
+.md-nav__link--active,
+.md-nav__link--active > .md-ellipsis,
+.md-nav__item--active > .md-nav__link {
+  color: var(--vz-mulberry-600);
+  font-weight: 700;
+}
+[data-md-color-scheme="visivo_dark"] .md-nav__link--active,
+[data-md-color-scheme="visivo_dark"] .md-nav__item--active > .md-nav__link {
+  color: var(--vz-mulberry-300);
+}
+.md-nav__link:focus,
+.md-nav__link:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* Section labels (navigation.sections) in the brand color. */
+.md-nav__item--section > .md-nav__link {
+  color: var(--vz-mulberry-500);
+  font-weight: 700;
+}
+[data-md-color-scheme="visivo_dark"] .md-nav__item--section > .md-nav__link {
+  color: var(--vz-mulberry-300);
+}
+
+/* ==========================================================================
+   TYPOGRAPHY — align with the www design system
+   ========================================================================== */
+.md-typeset h1 {
+  color: var(--vz-mulberry-600);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset h1 {
+  color: #ffffff;
+}
+.md-typeset h2 {
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+.md-typeset h2,
+.md-typeset h3 {
+  color: var(--md-default-fg-color);
+}
+
+/* Headerlink anchor (¶) on hover → teal. */
+.md-typeset .headerlink:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* ==========================================================================
+   CODE BLOCKS — readable in BOTH schemes (was light-on-light in dark before)
+   ========================================================================== */
+.md-typeset code,
+.md-typeset pre > code {
+  border-radius: 6px;
+}
+/* Inline code — subtle mulberry tint in light, restrained in dark. */
+[data-md-color-scheme="visivo_light"] .md-typeset :not(pre) > code {
+  background: var(--vz-mulberry-50);
+  color: var(--vz-mulberry-700);
+}
+/* Fenced code block surface — distinct from the page background. */
+[data-md-color-scheme="visivo_light"] .md-typeset pre > code,
+[data-md-color-scheme="visivo_light"] .highlight {
+  background: #f6f6f7;
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset pre > code,
+[data-md-color-scheme="visivo_dark"] .highlight {
+  background: #11141f;
+  color: rgba(255, 255, 255, 0.90);
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset :not(pre) > code {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e9d9e1;
+}
+/* Copy button → teal on hover. */
+.md-clipboard:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* ==========================================================================
+   LINKS / BUTTONS / TABLES
+   ========================================================================== */
+.md-typeset a {
+  text-decoration-color: rgba(113, 59, 87, 0.35);
+  text-underline-offset: 2px;
+}
+.md-typeset a:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* Material button utility ([Text](url){ .md-button }) → brand primary. */
+.md-typeset .md-button {
+  border-radius: 8px;
+  border-color: var(--vz-mulberry-500);
+  color: var(--vz-mulberry-600);
+  font-weight: 700;
+  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.md-typeset .md-button:hover,
+.md-typeset .md-button:focus {
+  background: var(--vz-mulberry-500);
+  border-color: var(--vz-mulberry-500);
+  color: #ffffff;
+}
+.md-typeset .md-button--primary {
+  background: var(--vz-mulberry-500);
+  border-color: var(--vz-mulberry-500);
+  color: #ffffff;
+}
+.md-typeset .md-button--primary:hover,
+.md-typeset .md-button--primary:focus {
+  background: var(--vz-mulberry-600);
+  border-color: var(--vz-mulberry-600);
+}
+
+/* Table header tint. */
+.md-typeset table:not([class]) th {
+  background: var(--vz-mulberry-50);
+  color: var(--vz-mulberry-700);
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset table:not([class]) th {
+  background: rgba(113, 59, 87, 0.22);
+  color: #e9d9e1;
+}
+
+/* Admonition / tab accent → teal so callouts read on-brand. */
+.md-typeset .tabbed-labels > label:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* Search field (desktop) — subtle on the brand header. */
+@media screen and (min-width: 60em) {
+  .md-search__form {
+    background-color: rgba(0, 0, 0, 0.10);
+    border-radius: 8px;
+  }
+  .md-search__form:hover {
+    background-color: rgba(255, 255, 255, 0.20);
+  }
+}
+
+/* ==========================================================================
+   FOOTER — deep navy to match the www footer
+   ========================================================================== */
+.md-footer {
+  background-color: var(--vz-navy);
+}
+.md-footer-meta {
+  background-color: #14172a;
+}
+.md-footer__link:hover .md-footer__title,
+.md-footer__link:focus .md-footer__title {
+  opacity: 1;
+}
+.md-footer-meta__inner a:hover {
+  color: var(--vz-teal-300);
+}
+
+/* Selection highlight → soft mulberry. */
+::selection {
+  background: rgba(113, 59, 87, 0.22);
 }

--- a/mkdocs/stylesheets/icon-colors.css
+++ b/mkdocs/stylesheets/icon-colors.css
@@ -1,7 +1,74 @@
-.visivo-purple {
-    color: #713B57;
-  }
+/* ==========================================================================
+   Visivo docs — icon + object-type accent utilities (VIS-949)
+   --------------------------------------------------------------------------
+   The object-type rainbow below mirrors the viewer's source of truth
+   (visivo/viewer/.../objectTypeConfigs.js) and the www homepage Pipeline
+   (src/constants/objectTypeColors.js), so an object reads in the SAME color
+   across docs, the marketing site, app.visivo.io, and the `visivo serve`
+   viewer. Apply on the Concepts/Topics pages, e.g.:
 
-.visivo-orange {
-    color: #D25946;
-    }
+     :material-database:{ .vz-source }  Source
+     ## Models { .vz-model }
+
+   The classes color text/SVG-icon fills; the matching `--vz-bg` / accent
+   border helpers tint a callout or badge.
+   ========================================================================== */
+
+/* Legacy brand-icon helpers (kept — referenced in existing pages). */
+.visivo-purple { color: #713b57; }
+.visivo-orange { color: #d25946; }
+
+/* ---- object-type rainbow (source → dashboard spectrum) ---- */
+.vz-source    { color: #f97316; }  /* orange  — Sources */
+.vz-model     { color: #f59e0b; }  /* amber   — Models */
+.vz-csvmodel  { color: #84cc16; }  /* lime    — CSV Script Models */
+.vz-mergemodel{ color: #22c55e; }  /* green   — Local Merge Models */
+.vz-dimension { color: #14b8a6; }  /* teal    — Dimensions */
+.vz-metric    { color: #06b6d4; }  /* cyan    — Metrics */
+.vz-relation  { color: #3b82f6; }  /* blue    — Relations */
+.vz-input     { color: #6366f1; }  /* indigo  — Inputs */
+.vz-insight   { color: #a855f7; }  /* purple  — Insights */
+.vz-markdown  { color: #8b5cf6; }  /* violet  — Markdowns */
+.vz-table     { color: #d946ef; }  /* fuchsia — Tables */
+.vz-chart     { color: #ec4899; }  /* pink    — Charts */
+.vz-dashboard { color: #f43f5e; }  /* rose    — Dashboards */
+
+/* ---- soft-background badge helpers (object-type chips) ---- */
+.vz-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.12em 0.6em;
+  border-radius: 9999px;
+  font-size: 0.78em;
+  font-weight: 700;
+  line-height: 1.5;
+}
+.vz-chip-source    { color: #9a4a0d; background: rgba(249, 115, 22, 0.14); }
+.vz-chip-model     { color: #92560a; background: rgba(245, 158, 11, 0.14); }
+.vz-chip-csvmodel  { color: #4d7c0f; background: rgba(132, 204, 22, 0.16); }
+.vz-chip-mergemodel{ color: #15803d; background: rgba(34, 197, 94, 0.16); }
+.vz-chip-dimension { color: #0f766e; background: rgba(20, 184, 166, 0.16); }
+.vz-chip-metric    { color: #0e7490; background: rgba(6, 182, 212, 0.16); }
+.vz-chip-relation  { color: #1d4ed8; background: rgba(59, 130, 246, 0.14); }
+.vz-chip-input     { color: #4338ca; background: rgba(99, 102, 241, 0.14); }
+.vz-chip-insight   { color: #7e22ce; background: rgba(168, 85, 247, 0.14); }
+.vz-chip-markdown  { color: #6d28d9; background: rgba(139, 92, 246, 0.14); }
+.vz-chip-table     { color: #a21caf; background: rgba(217, 70, 239, 0.14); }
+.vz-chip-chart     { color: #be185d; background: rgba(236, 72, 153, 0.14); }
+.vz-chip-dashboard { color: #be123c; background: rgba(244, 63, 94, 0.14); }
+
+/* Dark-scheme chips: brighten text, keep the same hue family. */
+[data-md-color-scheme="visivo_dark"] .vz-chip-source    { color: #fdba74; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-model     { color: #fcd34d; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-csvmodel  { color: #bef264; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-mergemodel{ color: #86efac; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-dimension { color: #5eead4; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-metric    { color: #67e8f9; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-relation  { color: #93c5fd; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-input     { color: #a5b4fc; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-insight   { color: #d8b4fe; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-markdown  { color: #c4b5fd; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-table     { color: #f0abfc; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-chart     { color: #f9a8d4; }
+[data-md-color-scheme="visivo_dark"] .vz-chip-dashboard { color: #fda4af; }


### PR DESCRIPTION
## What

Makes **docs.visivo.io** read as the same product as visivo.io (www), app.visivo.io, and the `visivo serve` viewer. Almost entirely a tokens/CSS + one header-partial change — **no `mkdocs.yml` edit**, **no `.py` changes**.

- **`mkdocs/stylesheets/brand_colors.css`** — rewrites the `visivo_light` / `visivo_dark` Material palettes to the canonical brand tokens (viewer = source of truth; full ramps mirror `www/tailwind.config.js`):
  - primary **mulberry `#713b57`**, accent **deep-teal `#2d6a6f`**, dark chrome **deep-navy `#191d33`**.
  - header CTA + brand mark treatment, sidebar/section active states, www-aligned typography, **code blocks readable in BOTH schemes**, a brand `.md-button` utility, table/admonition tints, and a **deep-navy footer**.
  - fixes a pre-existing dark-scheme defect where admonitions/`details` rendered as a glaring **white box** (upstream hardcodes `--md-admonition-bg-color: #fff`) — now a dark surface with light text.
- **`mkdocs/stylesheets/icon-colors.css`** — adds the locked **object-type rainbow** as utility classes (`.vz-source … .vz-dashboard` + `.vz-chip-*` badges) for the Concepts/Topics pages. Hexes mirrored from the viewer config / `www/src/constants/objectTypeColors.js` so an object reads the same color across every surface.
- **`mkdocs/overrides/partials/header.html`** — overrides the Material header to add a single **"Start free"** CTA → app.visivo.io (echoes the www top bar); hidden on mobile where the header is space-constrained.

## Why

Cross-surface brand parity (VIS-949). The docs previously used a near-white header and a generic Material look that did not read as Visivo.

## Before → After

- **Light:** near-white `#EEEEEE` header + generic Material → **mulberry header** with "Start free" CTA, mulberry H1/section labels, teal interactive accents, mulberry inline code, deep-navy footer.
- **Dark:** flat `#333` body + **white admonition boxes** + light code blocks → cohesive **deep-navy** chrome + body, dark admonitions with light text, dark readable code blocks, white H1.

## Scope

- **No `mkdocs.yml` change** — both stylesheets were already registered; the generated nav subtree is untouched.
- **No `.py` changes.**

## Verification

- `bash scripts/docs_gen.sh` — green (schema → generated reference → mkdocs build → spellcheck clean).
- Playwright docs design-compliance suite (`viewer/e2e/docs/docs-design.spec.mjs`): **16/16 pass** — no horizontal overflow and no near-invisible (dark-on-dark / light-on-light) text on home + reference + topics, **desktop (1440×900) AND mobile (Pixel 7)**, **light AND dark** schemes.
- Visual review of home / reference / topics + mobile drawer + footer in both schemes: mulberry/teal branding, readable code blocks, usable mobile nav.
- Note: the `docs-routes.spec.mjs` "no console errors" checks fail in this local sandbox due to **api.github.com 403 rate-limiting** of the Material repo-stars widget — confirmed identical on `main` (pre-existing, environmental; not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)