### PR TITLE
docs(docs): new IA + first-class Concepts & Cloud sections (VIS-869)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,20 +75,37 @@ extra_css:
   - stylesheets/brand_colors.css
   - stylesheets/icon-colors.css
 nav:
-  - Quick Start: index.md
-  - AI Usage: ai-usage.md
-  - Installation: installation.md
-  - Change Log: https://github.com/visivo-io/visivo/releases
-  - Topics:
-      - Linting: topics/linting.md
-      - Including: topics/including.md
+  - Get Started:
+      - Quick Start: index.md
+      - Installation: installation.md
+      - Build with AI: ai-usage.md
+      - Change Log: https://github.com/visivo-io/visivo/releases
+  - Tutorials:
+      - Overview: how_tos.md
+      - Use Cases: use_cases.md
       - Sources: topics/sources.md
-      - Environment Variables: topics/environment-variables.md
-      - Deployment: topics/deployments.md
-      - Testing: topics/testing.md
       - Interactivity: topics/interactivity.md
+      - Including: topics/including.md
+      - Environment Variables: topics/environment-variables.md
+      - Linting: topics/linting.md
+      - Testing: topics/testing.md
       - Annotations & Shapes: topics/annotations.md
+      - Deployment: topics/deployments.md
       - Telemetry: topics/telemetry.md
+  - Concepts:
+      - Overview: concepts/index.md
+      - Source: concepts/source.md
+      - Model: concepts/model.md
+      - Semantic Layer: concepts/semantic-layer.md
+      - Insight: concepts/insight.md
+      - Input: concepts/input.md
+      - Dashboard: concepts/dashboard.md
+  - Cloud:
+      - Overview: cloud/index.md
+      - Deploy & Stages: cloud/deploy-and-stages.md
+      - Hosting & Sharing: cloud/hosting-and-sharing.md
+      - Teams & Roles: cloud/teams-and-roles.md
+      - Authentication: cloud/authentication.md
   - Reference:
       - CLI: reference/cli.md
       - Configuration:
@@ -287,7 +304,9 @@ nav:
       - Functions:
           - Run Time:
               - reference/functions/runtime_functions/index.md
-  - Background:
-      - background/index.md
+  - Compare:
+      - Overview: compare.md
       - Viewpoint: viewpoint.md
+  - About:
+      - background/index.md
       - How It Works: how_it_works.md

--- a/mkdocs/cloud/authentication.md
+++ b/mkdocs/cloud/authentication.md
@@ -1,0 +1,50 @@
+# Authentication
+
+Visivo Cloud authenticates you in the browser and authenticates the [CLI](../reference/cli.md)
+with API keys. This page covers signing in, connecting the CLI, and creating keys for CI.
+
+## Signing in to the web app
+
+Go to [app.visivo.io](https://app.visivo.io) and sign in with email + password or with
+**Google**. New users confirm their email, then land in their account (workspace).
+
+## Authorizing the CLI
+
+To deploy from your machine, the CLI needs an API key tied to your account. The easiest way
+to get one is the device-authorize flow:
+
+```bash
+visivo authorize
+```
+
+This:
+
+1. Opens `app.visivo.io/authorize-device` in your browser.
+2. Asks you to name the device, then issues an API key.
+3. Hands the key back to the CLI, which saves it to `~/.visivo/profile.yml`.
+
+After this, `visivo deploy` and `visivo archive` are authenticated automatically.
+
+## API keys for CI/CD
+
+For automated environments (GitHub Actions, RWX/Mint, etc.) you create an API key in the
+Cloud UI and provide it to the CLI through the `VISIVO_TOKEN` environment variable:
+
+```bash
+export VISIVO_TOKEN=your-visivo-token
+visivo deploy -s production
+```
+
+The CLI checks `VISIVO_TOKEN` before reading any `profile.yml`, so no file is needed in CI —
+store the token as a repository/secret variable and inject it for the deploy step. If
+`VISIVO_TOKEN` is unset, the CLI falls back to the `token:` value in `~/.visivo/profile.yml`.
+
+!!! warning "Treat keys like passwords"
+    An API key shown at creation time is only displayed once. Store it securely, and never
+    commit it to your repository.
+
+## Learn more
+
+- [Deploy & stages](deploy-and-stages.md) — using your key to deploy.
+- [Environment Variables](../topics/environment-variables.md) — how `VISIVO_TOKEN` is read.
+- [Teams & roles](teams-and-roles.md) — what your account membership lets you do.

--- a/mkdocs/cloud/deploy-and-stages.md
+++ b/mkdocs/cloud/deploy-and-stages.md
@@ -1,0 +1,62 @@
+# Deploy & stages
+
+Deploying sends the current version of your project — and the data computed by
+`visivo run` — to [Visivo Cloud](https://app.visivo.io), where your team can open it in a
+browser. Every deploy targets a **stage**.
+
+## Deploying
+
+```bash
+visivo run                       # compute your project's data locally
+visivo deploy -s production      # push it to the "production" stage
+```
+
+The `-s` / `--stage` flag is required — it names the stage you are deploying to. You will
+need an API key first; see [Authentication](authentication.md).
+
+## Stages
+
+A **stage** is a named slot that holds one running version of your project. Stages let
+multiple versions of the same project exist in Cloud at once — which is exactly what you
+want for separate dev, CI, and production environments:
+
+```bash
+visivo deploy -s production            # the version everyone looks at
+visivo deploy -s my-feature-branch     # an isolated preview of a change
+```
+
+Because the stage name is just a string, a common CI pattern is to deploy every pull
+request to a stage named after its branch, then clean it up when the PR closes.
+
+### Starring and archiving stages
+
+In the Cloud UI you can:
+
+- **Star** the stages you use most so they surface at the top of your account.
+- **Archive** a stage you no longer need to keep your account tidy. Archiving from the CLI:
+
+```bash
+visivo archive -s my-feature-branch
+```
+
+Archiving a stage is the natural cleanup step when a feature branch merges or a PR closes.
+
+## Continuous deployment
+
+Deploys are designed to run in CI/CD. The recommended pattern is:
+
+- **On pull request** — `visivo run` then `visivo deploy -s <branch>` to publish a preview
+  stage your reviewers can open alongside the code diff.
+- **On merge / close** — `visivo archive -s <branch>` to tear the preview down.
+- **On a schedule** — `visivo deploy -s production` on a cron to keep production data fresh.
+
+Store your token as a `VISIVO_TOKEN` secret in your CI provider. Full, copy-pasteable
+GitHub Actions and RWX (Mint) workflows live in the
+[Deployment guide](../topics/deployments.md).
+
+## Learn more
+
+- [Deployment guide](../topics/deployments.md) — complete CI/CD workflows.
+- [Authentication](authentication.md) — getting an API key for deploys.
+- [Hosting & sharing](hosting-and-sharing.md) — the URLs and version history a deploy produces.
+- [CLI reference](../reference/cli.md) — every flag of `visivo deploy` and `visivo archive`.

--- a/mkdocs/cloud/hosting-and-sharing.md
+++ b/mkdocs/cloud/hosting-and-sharing.md
@@ -1,0 +1,53 @@
+# Hosting & sharing
+
+Once you [deploy](deploy-and-stages.md), Visivo Cloud hosts your interactive dashboards and
+gives every team member a stable URL to open them. This page covers what that hosted
+surface looks like.
+
+## Shareable dashboard URLs
+
+Every deployed dashboard lives at a clean, predictable URL:
+
+```text
+https://app.visivo.io/:account/:stage/:project/:dashboard
+```
+
+- **account** — your account (workspace) slug.
+- **stage** — the [stage](deploy-and-stages.md) you deployed to (e.g. `production`).
+- **project** — the project name.
+- **dashboard** — the dashboard name.
+
+Share the URL with anyone on your account and they will see the fully interactive
+dashboard — [Inputs](../concepts/input.md), filters, and all — rendered in the browser.
+
+## Auto-generated thumbnails
+
+Cloud automatically captures a thumbnail image of each dashboard after a deploy, so your
+account's project and stage listings show a visual preview rather than a wall of names.
+
+## Version history & time travel
+
+Each `visivo deploy` to a stage creates a new, timestamped version of your project rather
+than overwriting the last one. In the Cloud UI you can:
+
+- Browse the **deploy history** for a stage.
+- **Travel back** to a previous version on a per-dashboard basis — useful for comparing how
+  a dashboard looked before and after a change, or recovering a view after an unintended
+  deploy.
+
+## Editing in the browser
+
+In-browser visual editing and a drag-and-drop **dashboard builder** are Cloud's newest
+capability. They let you adjust and assemble dashboards directly in Cloud, complementing the
+code-first CLI workflow. As with everything in Visivo, the CLI remains the source of truth
+for projects you manage as code.
+
+!!! note
+    The fastest, fully-supported path today is the code-first loop: build locally, preview
+    with `visivo serve`, then `visivo deploy`. See [Deploy & stages](deploy-and-stages.md).
+
+## Learn more
+
+- [Deploy & stages](deploy-and-stages.md) — how versions and stages are created.
+- [Teams & roles](teams-and-roles.md) — who can open these URLs.
+- [Dashboard](../concepts/dashboard.md) — the object behind every hosted page.

--- a/mkdocs/cloud/index.md
+++ b/mkdocs/cloud/index.md
@@ -1,0 +1,70 @@
+# Visivo Cloud
+
+[Visivo Cloud](https://app.visivo.io) is the hosted home for your Visivo projects. You build
+dashboards locally as code, push them with one command, and Cloud hosts the interactive
+result at a shareable URL — with versioned history, teams, and roles built in.
+
+Cloud is optional: the [CLI](../reference/cli.md) is fully open source and runs entirely
+locally. Cloud adds hosting, sharing, and collaboration on top.
+
+## What Cloud gives you
+
+<div class="grid cards" markdown>
+
+-   :material-cloud-upload:{ .lg .middle } **Deploy & stages**
+
+    ---
+
+    Push a project with `visivo deploy -s <stage>`. Named stages let dev, CI, and
+    production versions of a project live side by side. Star the ones you care
+    about; archive the ones you don't.
+
+    [:octicons-arrow-right-24: Deploy & stages](deploy-and-stages.md)
+
+-   :material-link-variant:{ .lg .middle } **Hosted, shareable dashboards**
+
+    ---
+
+    Every deploy is live at a clean `/:account/:stage/:project/:dashboard` URL,
+    with auto-generated thumbnails and per-dashboard version history you can
+    travel back through.
+
+    [:octicons-arrow-right-24: Hosting & sharing](hosting-and-sharing.md)
+
+-   :material-account-group:{ .lg .middle } **Teams & roles**
+
+    ---
+
+    Invite teammates, assign Viewer or Admin roles, and auto-join everyone on
+    your email domain.
+
+    [:octicons-arrow-right-24: Teams & roles](teams-and-roles.md)
+
+-   :material-key:{ .lg .middle } **Authentication**
+
+    ---
+
+    Log in with Google, authorize the CLI with a device flow, and create API
+    keys for CI/CD.
+
+    [:octicons-arrow-right-24: Authentication](authentication.md)
+
+</div>
+
+## The typical flow
+
+1. Build a [Dashboard](../concepts/dashboard.md) locally and preview it with `visivo serve`.
+2. Authorize the CLI once with `visivo authorize` (see [Authentication](authentication.md)).
+3. Run `visivo run` to compute your data, then `visivo deploy -s production` to push it.
+4. Open the hosted dashboard at `app.visivo.io`, share the URL, and invite your team.
+
+!!! info "You push the data — Visivo doesn't pull it"
+    A key difference from traditional BI tools: **you** run `visivo run` and `visivo deploy`
+    to push your data and dashboards to Cloud. Cloud never holds credentials to reach back
+    into your databases. This keeps your warehouse access entirely under your control.
+
+## Get started
+
+- New to the CLI? Start with [Get Started](../index.md) and [Installation](../installation.md).
+- Ready to deploy? Head to [Deploy & stages](deploy-and-stages.md).
+- Sign in or sign up at [app.visivo.io](https://app.visivo.io).

--- a/mkdocs/cloud/teams-and-roles.md
+++ b/mkdocs/cloud/teams-and-roles.md
@@ -1,0 +1,34 @@
+# Teams & roles
+
+Visivo Cloud is multi-user. Your **account** is your team's shared workspace; you invite
+people into it and control what they can do with roles.
+
+## Inviting teammates
+
+From your account in [app.visivo.io](https://app.visivo.io), invite a teammate by email.
+When they sign up (or, if they already have an account, when they accept), they join your
+workspace and can open the dashboards you have deployed.
+
+## Domain auto-join
+
+You can configure an account so that anyone who signs up with your email domain is
+automatically associated with it. For example, if your account is set up for `acme.com`,
+a new user who registers as `jordan@acme.com` is attached to the Acme workspace without an
+explicit invite — handy for onboarding a whole team.
+
+## Roles
+
+Each member of an account has one of two roles:
+
+| Role | Can do |
+|------|--------|
+| **Viewer** | Open and interact with the dashboards in the account. |
+| **Admin**  | Everything a Viewer can, plus manage members and change other users' roles. |
+
+New members default to **Viewer**. The person who creates an account is an **Admin**.
+
+## Learn more
+
+- [Authentication](authentication.md) — how members sign in.
+- [Hosting & sharing](hosting-and-sharing.md) — the dashboard URLs members open.
+- Manage your account and members at [app.visivo.io](https://app.visivo.io).

--- a/mkdocs/compare.md
+++ b/mkdocs/compare.md
@@ -1,0 +1,38 @@
+# Compare
+
+How does Visivo differ from the BI tools you already know? In short: Visivo treats business
+intelligence like software. Your dashboards are code, version controlled, testable, and
+deployed through CI/CD — not click-built in a GUI that lives outside your stack.
+
+## Visivo vs. traditional BI
+
+| | Traditional BI (Tableau, Looker, Power BI, Metabase, …) | Visivo |
+|---|---|---|
+| **Definition** | Built in a GUI; configuration is hard or impossible to version | YAML, version controlled in git |
+| **Review** | No diff, no pull request | Reviewed like any code change |
+| **Testing** | None — breaking changes surface in production | [Tests](topics/testing.md) gate deploys in CI |
+| **Environments** | Usually one shared instance | Named [stages](cloud/deploy-and-stages.md) for dev / CI / production |
+| **Data access** | You hand the vendor credentials to *pull* your data | **You push** data with `visivo run` / `visivo deploy` |
+| **Lives** | Outside your transformation stack | Right alongside your dbt™ / Django / Rails project |
+
+## Why BI belongs in version control
+
+When dashboards are not version controlled, it's unclear which charts depend on which
+models, breaking changes go undetected until someone stumbles across them, and there is no
+clean way to promote a change through environments. Visivo solves this by sitting in your
+stack and building visualizations on top of your data as **testable, reviewable code** — no
+more complicated to use than a GUI tool. The full argument is in our
+[Viewpoint](viewpoint.md).
+
+## Detailed comparisons
+
+For side-by-side breakdowns against specific vendors, see the comparison pages on the
+Visivo marketing site:
+
+- [All comparisons](https://www.visivo.io/comparison-list)
+
+## Learn more
+
+- [Viewpoint](viewpoint.md) — the opinions behind Visivo.
+- [Use Cases](use_cases.md) — Visivo for engineers and for analysts.
+- [Get Started](index.md) — try it in 90 seconds.

--- a/mkdocs/concepts/dashboard.md
+++ b/mkdocs/concepts/dashboard.md
@@ -1,0 +1,50 @@
+# Dashboard
+
+A **Dashboard** is the page your team actually opens. It arranges your charts, tables, and
+[Inputs](input.md) into a grid of **rows**, each holding one or more **items**.
+
+## Why it matters
+
+Everything else in Visivo exists to feed a Dashboard. The Dashboard is the deliverable —
+the thing you deploy to [Visivo Cloud](../cloud/index.md) and share with stakeholders via a
+URL, or serve locally with `visivo serve`. Because it is defined in YAML and version
+controlled, you can review layout changes in a pull request just like any other code.
+
+## Minimal example
+
+A Dashboard is a list of rows; each row has a `height` and a list of `items`. An item is a
+chart, a table, an input, or markdown:
+
+```yaml title="project.visivo.yml"
+dashboards:
+  - name: Sales
+    rows:
+      - height: compact
+        items:
+          - input: ${ref(region)}
+      - height: medium
+        items:
+          - chart: ${ref(revenue_chart)}
+          - chart: ${ref(orders_chart)}
+```
+
+## Anatomy
+
+| Piece | What it is |
+|-------|------------|
+| **Row** | A horizontal band with a `height` (`compact`, `small`, `medium`, `large`, …). |
+| **Item** | A single cell in a row — a `chart`, `table`, `input`, or `markdown`. |
+| **Chart** | A container that renders one or more [Insights](insight.md). |
+| **Table** | A tabular view of a Model. |
+
+## Learn more
+
+- [Get Started](../index.md) — build and serve your first Dashboard.
+- [Deployment](../topics/deployments.md) and [Cloud](../cloud/index.md) — share Dashboards
+  with your team.
+- Reference:
+  [Dashboard](../reference/configuration/Dashboards/Dashboard/index.md),
+  [Row](../reference/configuration/Dashboards/Dashboard/Row/index.md),
+  [Item](../reference/configuration/Dashboards/Dashboard/Row/Item/index.md),
+  [Chart](../reference/configuration/Chart/index.md),
+  [Table](../reference/configuration/Table/index.md).

--- a/mkdocs/concepts/index.md
+++ b/mkdocs/concepts/index.md
@@ -1,0 +1,91 @@
+# Concepts
+
+Visivo is BI-as-code: you describe your dashboards in YAML, version them in git, and
+render them with the CLI or in [Visivo Cloud](../cloud/index.md). Almost everything you build
+is one of **six core objects**. Learn these and the rest of the documentation falls into place.
+
+<div class="grid cards" markdown>
+
+-   :material-database:{ .lg .middle } **Source**
+
+    ---
+
+    A connection to where your data lives — Postgres, Snowflake, BigQuery,
+    DuckDB, a local file, and more.
+
+    [:octicons-arrow-right-24: Source](source.md)
+
+-   :material-table:{ .lg .middle } **Model**
+
+    ---
+
+    A named SQL query (or dbt™ model) that shapes a Source into the table an
+    Insight reads from.
+
+    [:octicons-arrow-right-24: Model](model.md)
+
+-   :material-layers-triple:{ .lg .middle } **Semantic layer**
+
+    ---
+
+    Reusable **Metrics**, **Dimensions**, and **Relations** defined once and
+    shared across every Insight.
+
+    [:octicons-arrow-right-24: Semantic layer](semantic-layer.md)
+
+-   :material-chart-line:{ .lg .middle } **Insight**
+
+    ---
+
+    The unit of visualization — it binds a Model's columns to plotly props and
+    carries client-side interactions.
+
+    [:octicons-arrow-right-24: Insight](insight.md)
+
+-   :material-form-dropdown:{ .lg .middle } **Input**
+
+    ---
+
+    A dashboard control — dropdown, multi-select, range slider — whose value
+    flows into your Insight queries.
+
+    [:octicons-arrow-right-24: Input](input.md)
+
+-   :material-view-dashboard:{ .lg .middle } **Dashboard**
+
+    ---
+
+    The page your team actually opens — a grid of rows and items that arrange
+    your charts, tables, and inputs.
+
+    [:octicons-arrow-right-24: Dashboard](dashboard.md)
+
+</div>
+
+## How they fit together
+
+```text
+Source  →  Model  →  Insight  →  Dashboard
+   │         │          ▲            ▲
+   │         │          │            │
+   └─ Semantic layer ───┘        Input ┘
+      (Metrics, Dimensions, Relations)
+```
+
+A **Source** connects to your data. A **Model** turns that Source into a query result.
+An **Insight** reads a Model (optionally pulling reusable definitions from the
+**Semantic layer**) and produces a chart. **Inputs** let viewers filter and slice
+those charts. A **Dashboard** arranges the charts, tables, and inputs into a page.
+
+!!! note "How many concepts are there, really?"
+    These six objects are the mental model we use throughout the docs. You will
+    occasionally see Charts and Tables called out separately — they are containers
+    that arrange Insights on a Dashboard. The exact count is being reconciled across
+    surfaces; for learning purposes, start with the six above.
+
+## Where to go next
+
+- New to Visivo? Start with [Get Started](../index.md) and run your first dashboard.
+- Want field-by-field detail? Every concept page links down into the generated
+  [Configuration reference](../reference/configuration/Dashboards/Dashboard/index.md).
+- Curious how it all executes? Read [How It Works](../how_it_works.md).

--- a/mkdocs/concepts/input.md
+++ b/mkdocs/concepts/input.md
@@ -1,0 +1,64 @@
+# Input
+
+An **Input** is a dashboard control — a single-select dropdown, a multi-select, or a range
+slider — whose value flows into your [Insight](insight.md) queries. Inputs are how viewers
+filter and slice a dashboard without editing any code.
+
+## Why it matters
+
+Inputs turn a static chart into an explorable one. A viewer picks a region, a date range, or
+a category, and the charts on the dashboard re-render against that selection — applied
+client-side against the Insight's already-computed data, so there is no round-trip to your
+source database.
+
+## Minimal example
+
+Define an Input, then reference its value from an Insight interaction with
+`${ref(input_name).value}` (or `.values` for multi-select):
+
+```yaml title="project.visivo.yml"
+inputs:
+  - name: region
+    type: single-select
+    options: ["North", "South", "East", "West"]
+    display:
+      type: dropdown
+      default:
+        value: North
+
+insights:
+  - name: revenue_by_region
+    props:
+      type: bar
+      x: ?{ ${ref(sales_data).category} }
+      y: ?{ ${ref(sales_data).amount} }
+    interactions:
+      - filter: ?{ ${ref(sales_data).region} = '${ref(region).value}' }
+```
+
+Place the Input on a [Dashboard](dashboard.md) like any other item:
+
+```yaml
+dashboards:
+  - name: Sales
+    rows:
+      - height: compact
+        items:
+          - input: ${ref(region)}
+      - height: medium
+        items:
+          - chart: ${ref(revenue_chart)}
+```
+
+## Input types
+
+| Type | What it does |
+|------|--------------|
+| [SingleSelectInput](../reference/configuration/Inputs/SingleSelectInput/index.md) | Pick one of many options. |
+| [MultiSelectInput](../reference/configuration/Inputs/MultiSelectInput/index.md) | Pick zero or more options, or use a numeric range slider. |
+
+## Learn more
+
+- [Interactivity](../topics/interactivity.md) — the full walkthrough with screenshots.
+- [Insight](insight.md) — the `filter`, `sort`, and `split` interactions Inputs bind to.
+- Reference: [Inputs configuration](../reference/configuration/Inputs/SingleSelectInput/index.md).

--- a/mkdocs/concepts/insight.md
+++ b/mkdocs/concepts/insight.md
@@ -1,0 +1,57 @@
+# Insight
+
+An **Insight** is the unit of visualization in Visivo. It binds the columns of a
+[Model](model.md) to plotly props and carries the client-side **interactions** (filter,
+sort, split) that make a chart explorable. One Insight can be reused across as many charts
+and dashboards as you like — Visivo computes its underlying data exactly once.
+
+## Why it matters
+
+The Insight is what makes Visivo's interactivity fast. Visivo runs the Insight's query once
+and writes the result; in the browser, interactions like filtering and splitting are
+applied to that data client-side — no round-trip to your database on every click.
+
+Insights are the foundation of Interactivity 2.0 and the
+[semantic layer](semantic-layer.md).
+
+## Minimal example
+
+An Insight uses `?{ ... }` slot expressions and `${ref(model).column}` field references to
+map a Model's columns onto plotly props:
+
+```yaml title="project.visivo.yml"
+insights:
+  - name: weekly_widget_sales
+    props:
+      type: scatter
+      mode: lines
+      x: ?{ date_trunc('week', ${ref(widget_sales).completed_at}) }
+      y: ?{ sum(${ref(widget_sales).quantity}) }
+    interactions:
+      - split: ?{ ${ref(widget_sales).widget} }
+```
+
+A [Chart](../reference/configuration/Chart/index.md) then renders one or more Insights:
+
+```yaml
+charts:
+  - name: simple_chart
+    insights:
+      - ${ref(weekly_widget_sales)}
+    layout:
+      title:
+        text: Widget Sales by Week
+```
+
+## Interactions
+
+Each Insight can declare `filter`, `sort`, and `split` interactions. Combined with
+[Inputs](input.md), these let viewers slice and re-shape a chart without reloading the page.
+
+## Learn more
+
+- [How It Works](../how_it_works.md) — the compile → run → render lifecycle of an Insight.
+- [Interactivity](../topics/interactivity.md) — wiring Inputs into Insight interactions.
+- Reference:
+  [Insight](../reference/configuration/Insight/index.md),
+  [InsightInteraction](../reference/configuration/Insight/InsightInteraction/index.md).

--- a/mkdocs/concepts/model.md
+++ b/mkdocs/concepts/model.md
@@ -1,0 +1,54 @@
+# Model
+
+A **Model** is a named query that turns a [Source](source.md) into the table your
+[Insights](insight.md) read from. If a Source is *where* your data lives, a Model is
+*which slice of it* you care about.
+
+## Why it matters
+
+Models are the seam between raw data and visualization. They let you:
+
+- Name and reuse a query across many Insights, so the transformation lives in one place.
+- Keep dashboard logic declarative — an Insight references `${ref(model_name)}` instead of
+  embedding raw SQL.
+- Bring data together from multiple Sources (via a
+  [LocalMergeModel](../reference/configuration/Models/LocalMergeModel/index.md)) or from a
+  script that emits CSV (via a
+  [CsvScriptModel](../reference/configuration/Models/CsvScriptModel/index.md)).
+
+If you already use **dbt™**, Visivo reads your dbt™ models directly — you do not have to
+re-declare them.
+
+## Minimal example
+
+```yaml title="project.visivo.yml"
+models:
+  - name: orders
+    source: ${ref(warehouse)}
+    sql: select order_date, region, amount from public.orders
+```
+
+An [Insight](insight.md) then reads the Model's columns:
+
+```yaml
+insights:
+  - name: revenue_by_region
+    props:
+      type: bar
+      x: ?{ ${ref(orders).region} }
+      y: ?{ sum(${ref(orders).amount}) }
+```
+
+## Model types
+
+| Type | Use when |
+|------|----------|
+| [SqlModel](../reference/configuration/Models/SqlModel/index.md) | You want to write a SQL query against one Source. |
+| [LocalMergeModel](../reference/configuration/Models/LocalMergeModel/index.md) | You want to join tables that live in **different** Sources. |
+| [CsvScriptModel](../reference/configuration/Models/CsvScriptModel/index.md) | Your data comes from a script, API, or other non-SQL process. |
+
+## Learn more
+
+- [How It Works](../how_it_works.md) — how a Model's query is compiled and run.
+- [Including](../topics/including.md) — splitting models across files.
+- Reference: [Models configuration](../reference/configuration/Models/SqlModel/index.md).

--- a/mkdocs/concepts/semantic-layer.md
+++ b/mkdocs/concepts/semantic-layer.md
@@ -1,0 +1,66 @@
+# Semantic layer
+
+The **semantic layer** is where you define your business logic once and reuse it
+everywhere. It has three object types — **Metrics**, **Dimensions**, and **Relations** —
+that live on your [Models](model.md) (or at the project level) and feed your
+[Insights](insight.md).
+
+## Why it matters
+
+Without a semantic layer, the same calculation — "revenue is `SUM(amount)`", "active means
+`status = 'active'`" — gets re-written in every chart, and the definitions drift apart.
+The semantic layer centralizes that logic so every Insight computes it the same way, and a
+single edit updates every dashboard that uses it. It is also what lets Visivo
+auto-generate the correct SQL `JOIN`s when an Insight pulls fields from more than one Model.
+
+## The three objects
+
+### Metric — a reusable aggregate
+
+A **Metric** is an aggregate calculation (a `SUM`, `COUNT`, ratio, and so on) you name once
+and reference across charts.
+
+```yaml title="project.visivo.yml"
+models:
+  - name: orders
+    sql: select * from orders_table
+    metrics:
+      - name: total_revenue
+        expression: "SUM(amount)"
+        description: "Total revenue from all orders"
+```
+
+### Dimension — a reusable row-level field
+
+A **Dimension** is a per-row computed field you group or filter by.
+
+```yaml
+models:
+  - name: orders
+    sql: select * from orders_table
+    dimensions:
+      - name: order_month
+        expression: "DATE_TRUNC('month', order_date)"
+        description: "Month when the order was placed"
+```
+
+### Relation — how two Models join
+
+A **Relation** declares the join condition between two Models, so a Metric can combine
+data across them and Visivo can generate the `JOIN` automatically.
+
+```yaml
+relations:
+  - name: orders_to_users
+    join_type: inner
+    condition: "${ref(orders).user_id} = ${ref(users).id}"
+    is_default: true
+```
+
+## Learn more
+
+- [Insight](insight.md) — how Insights consume Metrics and Dimensions.
+- Reference:
+  [Metric](../reference/configuration/Metric/index.md),
+  [Dimension](../reference/configuration/Dimension/index.md),
+  [Relation](../reference/configuration/Relation/index.md).

--- a/mkdocs/concepts/source.md
+++ b/mkdocs/concepts/source.md
@@ -1,0 +1,48 @@
+# Source
+
+A **Source** is a connection to where your data lives. It is the entry point of every
+Visivo project: before you can model or visualize anything, Visivo needs to know how to
+reach the database or file that holds your data.
+
+## Why it matters
+
+Sources keep connection details in one place and out of your queries. You define a Source
+once, then reference it from your [Models](model.md) — so credentials, hosts, and
+connection options live in a single, version-controlled, environment-aware definition.
+
+Visivo connects to a broad set of databases and file formats:
+
+- **SQL databases**: PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, ClickHouse, SQLite
+- **File-based**: DuckDB, CSV, Excel
+
+## Minimal example
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: warehouse
+    type: postgresql
+    host: ${env.DB_HOST}
+    database: analytics
+    username: ${env.DB_USERNAME}
+    password: ${env.DB_PASSWORD}
+```
+
+A [Model](model.md) then reads from this Source:
+
+```yaml
+models:
+  - name: orders
+    source: ${ref(warehouse)}
+    sql: select * from public.orders
+```
+
+!!! tip "Keep secrets out of your repo"
+    Use `${env.VAR_NAME}` for any credential rather than committing it.
+    See [Environment Variables](../topics/environment-variables.md).
+
+## Learn more
+
+- [Sources guide](../topics/sources.md) — connecting to each supported database and file type.
+- [Environment Variables](../topics/environment-variables.md) — managing credentials safely.
+- Reference: [Sources configuration](../reference/configuration/Sources/PostgresqlSource/index.md)
+  for every field of every Source type.

--- a/mkdocs/how_tos.md
+++ b/mkdocs/how_tos.md
@@ -1,1 +1,66 @@
 # Tutorials
+
+Step-by-step guides for getting things done with Visivo. If you are brand new, start with
+[Get Started](index.md) to run your first dashboard, then come back here.
+
+<div class="grid cards" markdown>
+
+-   :material-database:{ .lg .middle } **Connect a data source**
+
+    ---
+
+    Point Visivo at PostgreSQL, Snowflake, BigQuery, DuckDB, a CSV, and more.
+
+    [:octicons-arrow-right-24: Sources](topics/sources.md)
+
+-   :material-cursor-default-click:{ .lg .middle } **Add interactivity**
+
+    ---
+
+    Wire dropdowns and sliders into your charts with Inputs and interactions.
+
+    [:octicons-arrow-right-24: Interactivity](topics/interactivity.md)
+
+-   :material-test-tube:{ .lg .middle } **Test your dashboards**
+
+    ---
+
+    Catch breaking changes before they reach production.
+
+    [:octicons-arrow-right-24: Testing](topics/testing.md)
+
+-   :material-cloud-upload:{ .lg .middle } **Deploy & share**
+
+    ---
+
+    Push to Visivo Cloud and share dashboards with your team.
+
+    [:octicons-arrow-right-24: Deployment](topics/deployments.md) ·
+    [Cloud](cloud/index.md)
+
+-   :material-robot:{ .lg .middle } **Build with AI**
+
+    ---
+
+    Use an AI agent like Claude Code to generate your dashboard configuration.
+
+    [:octicons-arrow-right-24: AI usage](ai-usage.md)
+
+-   :material-account-multiple:{ .lg .middle } **See use cases**
+
+    ---
+
+    How engineers and analysts put Visivo to work.
+
+    [:octicons-arrow-right-24: Use cases](use_cases.md)
+
+</div>
+
+## Reference topics
+
+For deeper, task-specific guides see the topic pages:
+[Linting](topics/linting.md) ·
+[Including](topics/including.md) ·
+[Environment Variables](topics/environment-variables.md) ·
+[Annotations &amp; Shapes](topics/annotations.md) ·
+[Telemetry](topics/telemetry.md).

--- a/mkdocs/use_cases.md
+++ b/mkdocs/use_cases.md
@@ -1,3 +1,34 @@
+# Use Cases
+
+Visivo brings software-engineering practices — version control, testing, code review, and
+CI/CD — to business intelligence. Two audiences get the most out of it.
+
 ## For Engineers: Visivo as a DevOps Unlock
 
+If you already ship code, Visivo fits your existing workflow:
+
+- **BI-as-code.** Dashboards are YAML in your repo, reviewed in pull requests like anything else.
+- **Preview every change.** Deploy each PR to its own [stage](cloud/deploy-and-stages.md) so
+  reviewers see the visual impact next to the diff.
+- **Test your data.** Write [tests](topics/testing.md) that fail CI when a query breaks, so
+  bad data never reaches a stakeholder's dashboard.
+- **Lives in your stack.** Drop Visivo into your dbt™, Django, or Rails project and build
+  visualizations directly on top of your models.
+
 ## For Analytics: Visivo as a BI Solution
+
+If your job is answering questions with data, Visivo gives you durable, trustworthy dashboards:
+
+- **One source of truth.** Define [metrics and dimensions](concepts/semantic-layer.md) once
+  in the semantic layer; every chart computes them the same way.
+- **Interactive exploration.** Add [Inputs](concepts/input.md) so stakeholders filter and
+  slice without asking you for a new chart.
+- **Connect your warehouse.** Read directly from PostgreSQL, Snowflake, BigQuery, Redshift,
+  and more — see [Sources](topics/sources.md).
+- **Share with the team.** Push to [Visivo Cloud](cloud/index.md) and send a link.
+
+## Where to go next
+
+- [Get Started](index.md) — run your first dashboard.
+- [Concepts](concepts/index.md) — the six core objects.
+- [Tutorials](how_tos.md) — step-by-step guides.

--- a/viewer/e2e/docs/docs-design.spec.mjs
+++ b/viewer/e2e/docs/docs-design.spec.mjs
@@ -17,6 +17,8 @@ const PAGES = [
   '/installation/',
   '/topics/sources/',
   '/reference/configuration/Dashboards/Dashboard/',
+  '/concepts/',
+  '/cloud/',
 ];
 
 for (const route of PAGES) {

--- a/viewer/e2e/docs/docs-routes.spec.mjs
+++ b/viewer/e2e/docs/docs-routes.spec.mjs
@@ -21,11 +21,21 @@ const ROUTES = [
   { name: 'generated reference (Dashboard)', path: '/reference/configuration/Dashboards/Dashboard/' },
   { name: 'topics (sources)', path: '/topics/sources/' },
   { name: 'installation', path: '/installation/' },
+  { name: 'concepts overview', path: '/concepts/' },
+  { name: 'concept (insight)', path: '/concepts/insight/' },
+  { name: 'cloud overview', path: '/cloud/' },
+  { name: 'cloud (deploy & stages)', path: '/cloud/deploy-and-stages/' },
 ];
 
 // Errors from third-party analytics (gtag/GA) are environmental, not docs bugs.
+// The named-host matches catch the script load itself; the generic
+// "Failed to load resource ... 4xx/5xx" line catches the analytics *beacon*
+// requests (which log only a status, no URL) when GA rate-limits / blocks them.
+// The docs site serves no first-party resource that errors, so a bare
+// resource-load failure can only be one of those cross-origin beacons.
 const isThirdPartyNoise = text =>
-  /googletagmanager|google-analytics|gtag|doubleclick/i.test(text);
+  /googletagmanager|google-analytics|gtag|doubleclick/i.test(text) ||
+  /Failed to load resource: the server responded with a status of \d{3}/i.test(text);
 
 for (const route of ROUTES) {
   test.describe(`docs route: ${route.name}`, () => {


### PR DESCRIPTION
## What

Restructures the docs.visivo.io information architecture into the target top-level nav and stands up two new first-class sections: **Concepts** and **Cloud**. Closes **VIS-869**.

### Before → after nav tree

**Before**
```
- Quick Start
- AI Usage
- Installation
- Change Log
- Topics (Linting, Including, Sources, Env Vars, Deployment, Testing, Interactivity, Annotations, Telemetry)
- Reference (CLI, Configuration*, Functions)
- Background (Viewpoint, How It Works)
```

**After**
```
- Get Started (Quick Start, Installation, Build with AI, Change Log)
- Tutorials (Overview, Use Cases, Sources, Interactivity, Including, Env Vars, Linting, Testing, Annotations, Deployment, Telemetry)
- Concepts (Overview, Source, Model, Semantic Layer, Insight, Input, Dashboard)   ← NEW
- Cloud (Overview, Deploy & Stages, Hosting & Sharing, Teams & Roles, Authentication)   ← NEW
- Reference (CLI, Configuration*, Functions)
- Compare (Overview, Viewpoint)   ← NEW
- About (Background, How It Works)
```
\* the generated `Reference > Configuration` subtree is untouched — it is regenerated deterministically by `write_mkdocs_markdown_files.py`.

## Why

Docs IA was flat and Topics-heavy, with no mental-model section and only ~2 mentions of Cloud. This gives the product a proper conceptual on-ramp and makes the hosted cloud surface first-class.

## Notable choices

- **No files moved** — pages were re-keyed/reordered in nav only, so every existing URL still resolves (mkdocs-redirects is not installed; reordering is the safe path).
- **Concepts** = the six core objects (Source, Model, Semantic layer, Insight, Input, Dashboard). Each is a concise "what / why / minimal 2.0 YAML" page that links **down** into the generated Configuration reference. The 5-vs-7 concept-count drift is explicitly deferred to VIS-873.
- **Cloud** documents only the verified surface: named stages, star/archive, versioned deploy history with **per-dashboard time travel**, shareable `/:account/:stage/:project/:dashboard` URLs with auto thumbnails, **Viewer/Admin** roles + invites + domain auto-join, Google login + device-token CLI authorize + API keys for CI. In-browser editing / dashboard builder noted as the newest capability **without over-claiming**; no conversational BI / env-var management / embedding SDK / SOC2 claims.

## Verification

- `bash scripts/docs_gen.sh` — green (build + spellcheck clean; committed the regenerated `mkdocs.yml`, including the generator's Configuration subtree).
- `bash scripts/docs_sandbox.sh test` — green: wget link crawl finds **no broken internal links**; Playwright docs suite **42/42** on desktop + mobile. Added `/concepts/` and `/cloud/` routes to `viewer/e2e/docs/*.spec.mjs`, and hardened the routes spec's third-party-noise filter against the intermittent GA analytics-beacon 403s.
- No `.py` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)