### PR TITLE
fix(docs): QA pass — fix unrendered-emoji buttons + design defects (VIS-995)

### DIFF
--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -164,11 +164,7 @@ Now that you have a running dashboard, explore what's possible:
 
 ---
 
-<div style="text-align: center; margin-top: 2rem;">
-  <a href="https://github.com/visivo-io/visivo" class="md-button md-button--primary">
-    :octicons-star-16: Star us on GitHub
-  </a>
-  <a href="https://app.visivo.io" class="md-button">
-    :material-cloud: Try Visivo Cloud
-  </a>
+<div class="vz-button-row" markdown>
+[:octicons-star-16: Star us on GitHub](https://github.com/visivo-io/visivo){ .md-button .md-button--primary }
+[:material-cloud: Try Visivo Cloud](https://app.visivo.io){ .md-button }
 </div>

--- a/mkdocs/stylesheets/brand_colors.css
+++ b/mkdocs/stylesheets/brand_colors.css
@@ -309,6 +309,43 @@
   background: var(--vz-mulberry-600);
   border-color: var(--vz-mulberry-600);
 }
+/* Dark mode: the outlined (non-primary) button used mulberry-600 text on the
+   navy page background (~1.5:1 contrast — effectively dark-on-dark). Lift the
+   text + border to mulberry-300 so it reads, and keep the filled-on-hover
+   state legible with white text. */
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button {
+  border-color: var(--vz-mulberry-300);
+  color: var(--vz-mulberry-300);
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button:hover,
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button:focus {
+  background: var(--vz-mulberry-400);
+  border-color: var(--vz-mulberry-400);
+  color: #ffffff;
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button--primary {
+  background: var(--vz-mulberry-400);
+  border-color: var(--vz-mulberry-400);
+  color: #ffffff;
+}
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button--primary:hover,
+[data-md-color-scheme="visivo_dark"] .md-typeset .md-button--primary:focus {
+  background: var(--vz-mulberry-300);
+  border-color: var(--vz-mulberry-300);
+  color: var(--vz-navy);
+}
+
+/* Centered button row (e.g. home page CTAs). The buttons live in a
+   `markdown`-enabled <div> so pymdownx.emoji renders the leading icon
+   shortcodes — a raw-HTML wrapper would leave them as literal text. */
+.md-typeset .vz-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2rem;
+}
 
 /* Table header tint. */
 .md-typeset table:not([class]) th {


### PR DESCRIPTION
Adversarial design QA pass on **docs.visivo.io** (Material for MkDocs) after the styling overhaul. VIS-995.

## Unrendered-emoji buttons (the founder's report) — FIXED
The home page (`mkdocs/index.md`) had two CTA buttons built as **raw-HTML `<a>` tags inside a plain `<div>`** (no `markdown` attribute). `pymdownx.emoji` only converts shortcodes in page *content*, not raw-HTML blocks, so the icon shortcodes rendered as **literal text** in the built HTML:

- `:octicons-star-16: Star us on GitHub`
- `:material-cloud: Try Visivo Cloud`

**Fix:** rewrote them as Markdown `.md-button` links inside a `markdown`-enabled `.vz-button-row` div, so the shortcodes resolve to real SVG glyphs (added a small flex `.vz-button-row` rule for the centered layout). Verified: literal shortcodes are gone site-wide in the built HTML, and both buttons now render an `<svg>` icon (light + dark). This was the only place site-wide with unrendered shortcodes.

## Design defects

**Dark-mode button contrast — FIXED.** The outlined (non-primary) `.md-button` used mulberry-600 text on the navy dark-mode page background = **~1.5:1 contrast** (effectively dark-on-dark — the founder's pet peeve). Added a `visivo_dark` override:
- outlined button → mulberry-300 text/border: **5.18:1**
- primary button → mulberry-400 bg + white text: **5.06:1**

Both now exceed WCAG AA (4.5:1). Also covers the "AI-powered dashboard creation" `.md-button`.

**Verified clean (no fix needed):** home/Concepts/Reference(Bar)/Viewpoint on desktop (1440×900) + mobile (Pixel 7) in light + dark — no horizontal overflow (document scrollWidth ≤ viewport; off-canvas drawer nav is expected), no other dark-on-dark / light-on-light text, tabbed nav + dense sidebar legible, card grids + admonitions + code blocks (with copy/annotate) render, header "Start free" CTA renders as text and is correctly hidden on mobile, footer + mobile drawer good.

**Deferred / not applicable:**
- The "Mermaid diagram" noted in the brief does not exist in the current docs — there is no `mermaid` superfence config in `mkdocs.yml` and no `mermaid` fences in any page. The "How they fit together" diagram on `/concepts/` is plain ASCII art in a code block (legible in both schemes). Nothing to retheme.
- No `:visivo-*:` custom icons, re-pointed `theme.icon.*` chrome, brand admonitions, or `theme.font: false` are present in this `mkdocs.yml`, so none of those failure modes applied.
- The reference-page `INFO` build messages about relative/absolute links are pre-existing and non-fatal (build is green).

## Gates
- `bash scripts/docs_gen.sh` — **GREEN** (build + spellcheck clean; no new known_words needed; `mkdocs.yml` nav unchanged)
- `bash scripts/docs_sandbox.sh test` — **GREEN** (link crawl: 0 broken links / 129 files; **42 Playwright docs e2e passed** on desktop + mobile, incl. no-overflow + no-near-invisible-text specs)
- No `.py` changed → black/pytest N/A.

Screenshots (home, Concepts, Reference, Viewpoint, footer, mobile drawer; light + dark) saved to `.design-review/` (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)