### PR TITLE
docs: SEO + AIO — sitemap/meta/JSON-LD + docs llms.txt + AI-crawler robots (VIS-999)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,10 @@
 site_name: Visivo Docs
 site_url: https://docs.visivo.io
+site_description: Documentation for Visivo, the AI-native open-source BI-as-code platform.
+  Define data sources, a semantic layer of metrics, dimensions, and relations, and
+  dashboards as version-controlled YAML, then explore them interactively with Insights.
+  Develop locally with visivo serve and deploy to Visivo Cloud.
+site_author: Visivo
 plugins:
   - mkdocs-video
   - autolinks

--- a/mkdocs/llms.txt
+++ b/mkdocs/llms.txt
@@ -1,0 +1,49 @@
+# Visivo Docs
+
+> Documentation for Visivo, the AI-native, open-source business intelligence platform that brings software-engineering best practices to data work. Define data sources, a semantic layer (metrics, dimensions, and relations), and dashboards as version-controlled YAML, then explore them interactively with Insights. Develop locally with instant feedback and deploy to Visivo Cloud without breaking production.
+
+Install the open-source CLI with `pip install visivo` or `curl -fsSL https://visivo.sh | bash`, then run `visivo serve` to develop dashboards locally. The hosted cloud platform lives at https://app.visivo.io and the marketing site at https://visivo.io. Visivo connects to data sources including PostgreSQL, MySQL, SQLite, Snowflake, BigQuery, Redshift, ClickHouse, and DuckDB, and renders charts with Plotly.js.
+
+Key facts for accurate citation:
+- Charts are produced by Insights backed by a semantic layer of Metrics, Dimensions, and Relations. (Visivo 2.0 builds charts only through Insights and the semantic layer.)
+- Everything is defined in YAML config and is Git-friendly: version control, code review, and CI/CD apply to your BI.
+- A Model wraps a SQL query against a Source; the semantic layer (metrics, dimensions, relations) sits on top; Insights and Inputs make dashboards interactive.
+- Embedding is in private beta. There is no public embedding SDK, no npm package, and no Python tracking SDK.
+- dbt(TM) users can layer Visivo on top of their existing models.
+
+## Get Started
+
+- [Quick Start](https://docs.visivo.io/): Data to dashboard in 90 seconds. Install the CLI, run visivo serve, and build your first project.
+- [Installation](https://docs.visivo.io/installation/): Install Visivo via the install script or pip (Python 3.10+); covers macOS, Linux, and Windows.
+- [Build with AI](https://docs.visivo.io/ai-usage/): Use AI and agentic workflows to scaffold and edit Visivo projects against the semantic layer.
+
+## Concepts
+
+- [Concepts Overview](https://docs.visivo.io/concepts/): How the core objects fit together: Sources, Models, the semantic layer, Insights, Inputs, and Dashboards.
+- [Source](https://docs.visivo.io/concepts/source/): Connections to your data warehouse or database (PostgreSQL, MySQL, SQLite, Snowflake, BigQuery, Redshift, ClickHouse, DuckDB).
+- [Model](https://docs.visivo.io/concepts/model/): A named SQL query against a Source that becomes the queryable table for metrics and dimensions.
+- [Semantic Layer](https://docs.visivo.io/concepts/semantic-layer/): Define Metrics, Dimensions, and Relations once as version-controlled definitions the whole org and AI share.
+- [Insight](https://docs.visivo.io/concepts/insight/): The 2.0 way to build charts. Interactive visualizations driven by the semantic layer (filters, splits, sorts) and rendered with Plotly.js.
+- [Input](https://docs.visivo.io/concepts/input/): Dynamic dashboard controls (single-select, multi-select, ranges) including query-based dropdown options.
+- [Dashboard](https://docs.visivo.io/concepts/dashboard/): Compose Insights, tables, and markdown into rows and items to build a shareable dashboard.
+
+## Cloud
+
+- [Cloud Overview](https://docs.visivo.io/cloud/): What Visivo Cloud adds on top of the open-source CLI: hosting, sharing, teams, and authentication.
+- [Deploy & Stages](https://docs.visivo.io/cloud/deploy-and-stages/): Deploy projects to named stages with visivo deploy so environments stay isolated.
+- [Hosting & Sharing](https://docs.visivo.io/cloud/hosting-and-sharing/): Host dashboards on Visivo Cloud and share them with your team or stakeholders.
+- [Teams & Roles](https://docs.visivo.io/cloud/teams-and-roles/): Manage members, teams, and role-based access to projects and dashboards.
+- [Authentication](https://docs.visivo.io/cloud/authentication/): Sign in and authenticate the CLI against Visivo Cloud.
+
+## Reference
+
+- [CLI Reference](https://docs.visivo.io/reference/cli/): Every visivo command and flag, including init, run, serve, deploy, and test.
+- [Configuration Reference](https://docs.visivo.io/reference/configuration/Insight/): Full YAML schema for every object: Sources, Models, Metric, Dimension, Relation, Insight, Input, Dashboard, Table, and Alert.
+
+## Tutorials
+
+- [Tutorials Overview](https://docs.visivo.io/how_tos/): Step-by-step guides for common Visivo workflows.
+- [Sources](https://docs.visivo.io/topics/sources/): Connect and configure each supported data source.
+- [Interactivity](https://docs.visivo.io/topics/interactivity/): Add Inputs and Insight interactions so viewers can filter and explore.
+- [Testing](https://docs.visivo.io/topics/testing/): Write data-quality tests that run in CI alongside your dashboards.
+- [Deployment](https://docs.visivo.io/topics/deployments/): Ship projects to Visivo Cloud stages from your CI/CD pipeline.

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,0 +1,143 @@
+{#-
+  Visivo docs SEO + AIO head override (VIS-999).
+
+  Extends Material's base.html and fills the `extrahead` block (Material leaves
+  it empty). We add, per page:
+    - Open Graph + Twitter Card tags (built from page meta with brand defaults)
+    - explicit canonical (base.html already emits one; this re-asserts it on og:url)
+    - site-level JSON-LD: Organization + SoftwareApplication (mirrors the www
+      index.html schema so search + answer engines see one consistent entity)
+    - per-article JSON-LD: TechArticle for content pages (skips the homepage)
+
+  Truth guardrails (keep in sync with www/CLAUDE.md "What Visivo IS / IS NOT"):
+  charts come from Insights backed by a semantic layer of Metrics, Dimensions,
+  and Relations (the 2.0 model). Embedding is private beta (no public SDK).
+
+  Material already emits <meta name="description"> and <link rel="canonical">
+  from base.html's site_meta block, so we do NOT duplicate those here.
+-#}
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {#-
+    Robust homepage detection. page.is_homepage is unreliable here because the
+    root index.md is nested under the "Get Started" nav section, so we also treat
+    the page that builds to the site root as the homepage.
+  -#}
+  {% set is_home = (page and (page.is_homepage or page.url in ("", ".", "/", "index.html"))) %}
+
+  {#- Resolve a title/description/canonical for this page with brand fallbacks. -#}
+  {% if page and page.meta and page.meta.title %}
+    {% set og_title = page.meta.title ~ " - " ~ config.site_name %}
+  {% elif page and page.title and not is_home %}
+    {% set og_title = (page.title | striptags) ~ " - " ~ config.site_name %}
+  {% else %}
+    {% set og_title = config.site_name %}
+  {% endif %}
+
+  {% if page and page.meta and page.meta.description %}
+    {% set og_desc = page.meta.description %}
+  {% else %}
+    {% set og_desc = config.site_description %}
+  {% endif %}
+
+  {% set og_url = page.canonical_url if page and page.canonical_url else config.site_url %}
+  {% set og_image = "https://visivo.io/og-image.png" %}
+
+  {#- Open Graph -#}
+  <meta property="og:site_name" content="Visivo Docs">
+  <meta property="og:type" content="{{ 'website' if is_home else 'article' }}">
+  <meta property="og:title" content="{{ og_title }}">
+  {% if og_desc %}<meta property="og:description" content="{{ og_desc }}">{% endif %}
+  <meta property="og:url" content="{{ og_url }}">
+  <meta property="og:image" content="{{ og_image }}">
+
+  {#- Twitter Card -#}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ og_title }}">
+  {% if og_desc %}<meta name="twitter:description" content="{{ og_desc }}">{% endif %}
+  <meta name="twitter:image" content="{{ og_image }}">
+
+  {#- llms.txt discovery hint for answer engines. -#}
+  <link rel="alternate" type="text/plain" title="llms.txt" href="{{ '/llms.txt' | url }}">
+
+  {#- Site-level Organization entity (mirrors www index.html). -#}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Visivo",
+    "url": "https://visivo.io/",
+    "logo": "https://visivo.io/images/logo.webp",
+    "description": "Visivo is an AI-native, open-source BI-as-code platform. Define a semantic layer of metrics, dimensions, and relations and dashboards as version-controlled code, explore them with Insights, develop locally with instant feedback, and deploy without breaking production.",
+    "sameAs": [
+      "https://github.com/visivo-io"
+    ]
+  }
+  </script>
+
+  {#- Site-level SoftwareApplication entity (mirrors www index.html). -#}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Visivo",
+    "url": "https://visivo.io/",
+    "applicationCategory": "BusinessApplication",
+    "applicationSubCategory": "Business Intelligence",
+    "operatingSystem": "macOS, Linux, Windows",
+    "description": "AI-native, open-source business intelligence as code. Define data sources, a semantic layer of metrics, dimensions, and relations, and dashboards as version-controlled YAML, then explore interactively with Insights. Install the CLI with pip install visivo or curl -fsSL https://visivo.sh | bash, develop locally with visivo serve, and deploy with a hosted cloud platform at app.visivo.io.",
+    "softwareHelp": "https://docs.visivo.io",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Visivo",
+      "url": "https://visivo.io/"
+    },
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "Open Source",
+        "price": "0",
+        "priceCurrency": "USD",
+        "description": "Free, open-source CLI. Install with pip install visivo or curl -fsSL https://visivo.sh | bash.",
+        "url": "https://visivo.io/get-started"
+      },
+      {
+        "@type": "Offer",
+        "name": "Cloud",
+        "price": "15",
+        "priceCurrency": "USD",
+        "description": "Hosted cloud platform with a 14-day free trial.",
+        "url": "https://visivo.io/pricing"
+      }
+    ],
+    "keywords": "BI-as-code, AI-native BI, semantic layer, metrics, dimensions, relations, Insights, dashboards, version control, CI/CD, open source"
+  }
+  </script>
+
+  {#- Per-page TechArticle for documentation content (skip the homepage). -#}
+  {% if page and not is_home and og_desc %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": {{ (page.title | striptags) | tojson }},
+    "description": {{ og_desc | tojson }},
+    "url": "{{ og_url }}",
+    "image": "{{ og_image }}",
+    "inLanguage": "en",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "Visivo Docs",
+      "url": "https://docs.visivo.io/"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Visivo",
+      "url": "https://visivo.io/",
+      "logo": "https://visivo.io/images/logo.webp"
+    }
+  }
+  </script>
+  {% endif %}
+{% endblock %}

--- a/mkdocs/overrides/robots.txt
+++ b/mkdocs/overrides/robots.txt
@@ -1,3 +1,63 @@
+# Visivo Docs robots.txt (VIS-999)
+# Search engines and answer-engine (AI) crawlers are explicitly welcome.
+# llms.txt at the site root gives AI crawlers a curated, 2.0-accurate index.
+
+# Default: allow everything for all user agents.
 User-agent: *
 Allow: /
-Sitemap: https://docs.visivo.io/sitemap.xml 
+
+# Answer-engine / AI crawlers: allow indexing and on-demand fetching so that
+# ChatGPT, Perplexity, Claude, Gemini, and friends cite Visivo 2.0 facts
+# (Insights + the semantic layer) correctly.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+Sitemap: https://docs.visivo.io/sitemap.xml


### PR DESCRIPTION
Makes **docs.visivo.io** discoverable by both search engines and answer engines (ChatGPT, Perplexity, Claude, Gemini) for the Material for MkDocs site. **No `mkdocs.yml` nav edits** — VIS-872 owns the nav concurrently, so this is implemented via `overrides/` + static files, with only a +5-line `mkdocs.yml` change outside the nav block for a trivial 3-way merge.

## SEO
- **Per-page meta** — new `mkdocs/overrides/main.html` extends Material's `base.html` and fills the previously-empty `extrahead` block with Open Graph + Twitter Card tags (`og:title/description/url/image/type`, `twitter:card`, etc.), built from page meta with brand defaults. `og:type` is `website` on the docs root and `article` on content pages (robust homepage detection by URL, because the root `index.md` is nested under a nav section so `page.is_homepage` is unreliable).
- **Default description** — added `site_description` + `site_author` to `mkdocs.yml` so every page emits a `<meta name="description">` (via Material's `site_meta` block) and a sensible OG/Twitter fallback.
- **Canonical** — Material already emits `<link rel="canonical">`; the override re-asserts it via `og:url`.
- **JSON-LD** — site-level `Organization` + `SoftwareApplication` on every page (mirrors the `www` `index.html` entity so engines see one consistent Visivo entity), plus a per-page `TechArticle` on content pages. All blocks validated as parseable JSON (escaped with `tojson`).
- **Sitemap** — Material already auto-generates a complete `sitemap.xml` (175 URLs, correct `https://docs.visivo.io` base) from the existing `site_url`; confirmed present in the build. No change needed.

## AIO (answer-engine optimization)
- **`mkdocs/llms.txt`** served at the site root (mirrors `www/public/llms.txt`) — curated, 2.0-accurate one-line summaries of Get Started, Concepts, Cloud, and Reference pages so answer engines cite **Insights + the semantic layer** (Metrics/Dimensions/Relations) and **dbt™** correctly, never the legacy config. A `<link rel="alternate" type="text/plain">` hint in the head points crawlers at it.
- **`robots.txt`** now explicitly allows the major AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, ClaudeBot, anthropic-ai, Google-Extended, Applebot, Amazonbot, Bytespider, CCBot, cohere-ai, Meta-ExternalAgent, DuckAssistBot) and keeps the `Sitemap:` pointer.

## Guardrails
2.0-truthful (no "trace"/"trace types"), dbt™, no em dashes, entity-rich.

## Gates
- `bash scripts/docs_gen.sh` — GREEN (build + spellcheck clean)
- `bash scripts/docs_sandbox.sh test` — GREEN (link crawl: no broken links; 42 Playwright specs pass on desktop + mobile, zero console errors)
- Verified in a live browser (Playwright MCP): meta / OG / Twitter / 3 valid JSON-LD blocks / `llms.txt` link all render; `sitemap.xml`, `robots.txt`, `llms.txt` all present at the built site root.

## Files
- `mkdocs/overrides/main.html` (new — `extrahead`: OG/Twitter/JSON-LD/llms link)
- `mkdocs/llms.txt` (new — docs AIO index)
- `mkdocs/overrides/robots.txt` (AI crawler allow-list + sitemap)
- `mkdocs.yml` (+5 lines, **outside the nav block**: `site_description` + `site_author`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)