### PR TITLE
docs: 10-source matrix + semantic layer + Inputs at code parity (VIS-872)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,10 @@ nav:
       - Overview: how_tos.md
       - Use Cases: use_cases.md
       - Sources: topics/sources.md
+      - Source Types: topics/source-types.md
+      - Semantic Layer: topics/semantic-layer.md
       - Interactivity: topics/interactivity.md
+      - Inputs: topics/inputs.md
       - Including: topics/including.md
       - Environment Variables: topics/environment-variables.md
       - Linting: topics/linting.md

--- a/mkdocs/topics/inputs.md
+++ b/mkdocs/topics/inputs.md
@@ -1,0 +1,143 @@
+# Inputs
+
+Visivo has exactly two [Input](../concepts/input.md) types, **single-select** and **multi-select**, and a viewer picks values from them to filter and slice a dashboard without editing code. Their selected values flow into [Insight](../concepts/insight.md) interactions through `${ref(input_name).value}` (and related accessors), applied client-side with no round-trip to your source database.
+
+!!! visivo "Two types, several display modes"
+    `single-select` and `multi-select` are the only two Input types. Each renders through one
+    of several UI components (dropdown, radio, checkboxes, range-slider, and more), and
+    `multi-select` can be backed either by a list of options or by a numeric/date **range**.
+    Options can be a static list or a query against one Model.
+
+## The two types
+
+| :visivo-input:{ .vz-input } Type | Selects | Options source | Accessors |
+|------|---------|----------------|-----------|
+| `single-select` | One value | Static list **or** query | `.value` |
+| `multi-select` | Many values, **or** a range | Static list / query, **or** a `range` block | `.values`, `.min`, `.max`, `.first`, `.last` |
+
+## Single-select
+
+Pick one value from a set of options. Options are a static list **or** a query string that
+references exactly one Model. The optional `display` block chooses the UI component and the
+default selection; if omitted, it renders as a dropdown with the first option selected.
+
+```yaml title="project.visivo.yml"
+inputs:
+  - name: region
+    type: single-select
+    options: ["North", "South", "East", "West"]
+    display:
+      type: dropdown
+      default:
+        value: North
+```
+
+**Display types:** `dropdown`, `radio`, `toggle`, `tabs`, `autocomplete`, `slider`. A
+`toggle` display requires exactly two options.
+
+### Query-backed options
+
+Instead of a static list, drive options from your data with a `?{ ... }` query that
+references one Model. Visivo runs it during the build so the dropdown is populated from live
+values.
+
+```yaml title="project.visivo.yml"
+inputs:
+  - name: category
+    type: single-select
+    options: ?{ SELECT DISTINCT category FROM ${ref(products)} }
+```
+
+## Multi-select
+
+Pick several values, or define a numeric/date range. A `multi-select` uses **either**
+`options` (list-based) **or** `range` (range-based); the two are mutually exclusive.
+
+### List-based
+
+```yaml title="project.visivo.yml"
+inputs:
+  - name: categories
+    type: multi-select
+    options: ["Electronics", "Clothing", "Food"]
+    display:
+      type: checkboxes
+      default:
+        values: all
+```
+
+`default.values` accepts a static list, a query, or the keywords `all` (the default) or
+`none`. **Display types:** `dropdown`, `checkboxes`, `chips`, `tags`, `range-slider`,
+`date-range`.
+
+### Range-based
+
+Use a `range` block (`start`, `end`, `step`, all required) for continuous or stepped values.
+The stepped values are computed in the viewer at runtime. A range-based input uses
+`default.start` / `default.end` and pairs naturally with the `range-slider` or `date-range`
+display.
+
+```yaml title="project.visivo.yml"
+inputs:
+  - name: price_range
+    type: multi-select
+    range:
+      start: 0
+      end: 1000
+      step: 50
+    display:
+      type: range-slider
+      default:
+        start: 100
+        end: 500
+```
+
+## Wiring inputs into Insights
+
+Reference an Input's value from an Insight `filter`, `split`, or `sort` interaction. Use the
+accessor that matches the Input type.
+
+```yaml title="project.visivo.yml"
+insights:
+  - name: filtered_sales
+    props:
+      type: bar
+      x: ?{ ${ref(sales).category} }
+      y: ?{ sum(${ref(sales).amount}) }
+    interactions:
+      # single-select → .value
+      - filter: ?{ ${ref(sales).region} = '${ref(region).value}' }
+      # multi-select (list) → .values
+      - filter: ?{ ${ref(sales).category} IN (${ref(categories).values}) }
+      # multi-select (range) → .min / .max
+      - filter: ?{ ${ref(sales).price} BETWEEN ${ref(price_range).min} AND ${ref(price_range).max} }
+```
+
+| Input | Accessor | Returns |
+|-------|----------|---------|
+| `single-select` | `.value` | The selected value |
+| `multi-select` | `.values` | Array of selected values |
+| `multi-select` | `.min` / `.max` | Min / max of the selected values |
+| `multi-select` | `.first` / `.last` | First / last selected value |
+
+Place the Input on a [Dashboard](../concepts/dashboard.md) like any other item:
+
+```yaml title="project.visivo.yml"
+dashboards:
+  - name: Sales
+    rows:
+      - height: compact
+        items:
+          - input: ${ref(region)}
+      - height: medium
+        items:
+          - chart: ${ref(revenue_chart)}
+```
+
+## Learn more
+
+- [Input concept](../concepts/input.md): the short overview.
+- [Interactivity](interactivity.md): the full walkthrough with screenshots.
+- Reference:
+  [SingleSelectInput](../reference/configuration/Inputs/SingleSelectInput/index.md),
+  [MultiSelectInput](../reference/configuration/Inputs/MultiSelectInput/index.md).

--- a/mkdocs/topics/semantic-layer.md
+++ b/mkdocs/topics/semantic-layer.md
@@ -1,0 +1,154 @@
+# Semantic layer
+
+The semantic layer is where you define business logic once, as **Metrics**, **Dimensions**, and **Relations**, then reuse it across every [Insight](../concepts/insight.md). Metrics are reusable aggregates, Dimensions are reusable row-level fields, and Relations declare how Models join so Visivo can auto-generate cross-model SQL.
+
+!!! visivo "Define once, compute everywhere"
+    Without a semantic layer the same calculation gets re-written in every chart and the
+    definitions drift. Defining a Metric, Dimension, or Relation once means every Insight
+    computes it identically, and a single edit updates every dashboard that uses it.
+
+<div class="grid cards" markdown>
+
+-   :visivo-metric:{ .lg .middle .vz-metric } **Metric**
+
+    ---
+
+    A reusable aggregate (`SUM`, `COUNT`, a ratio). Model-scoped metrics use direct SQL
+    aggregates; global metrics compose other metrics.
+
+-   :visivo-dimension:{ .lg .middle .vz-dimension } **Dimension**
+
+    ---
+
+    A reusable, per-row computed field you group or filter by. Model columns also become
+    implicit dimensions automatically.
+
+-   :visivo-relation:{ .lg .middle .vz-relation } **Relation**
+
+    ---
+
+    A declared join condition between two Models, so Visivo generates the correct `JOIN`
+    when an Insight pulls fields from both.
+
+</div>
+
+## Metric: a reusable aggregate
+
+A **Metric** names an aggregate calculation so charts share one definition. Metrics come in two flavors.
+
+### Model-scoped metrics
+
+Defined under a Model's `metrics:` list, these use direct SQL aggregate expressions. The
+`expression` must be a valid aggregate and cannot reference raw columns outside an aggregate
+function.
+
+```yaml title="project.visivo.yml"
+models:
+  - name: orders
+    sql: SELECT * FROM orders_table
+    metrics:
+      - name: total_revenue
+        expression: "SUM(amount)"
+        description: "Total revenue from all orders"
+      - name: order_count
+        expression: "COUNT(DISTINCT id)"
+```
+
+### Global metrics
+
+Defined at the project level under a top-level `metrics:` list, global metrics compose other
+metrics or fields across Models using `${ref(model).field}` or `${ref(metric_name)}` syntax.
+Visivo resolves the dependencies and joins automatically.
+
+```yaml title="project.visivo.yml"
+metrics:
+  - name: revenue_per_user
+    expression: "${ref(orders).total_revenue} / ${ref(users).total_users}"
+    description: "Average revenue per user"
+```
+
+!!! note "Metric naming"
+    A Metric `name` must be a valid SQL identifier (letters, numbers, and underscores only),
+    and it cannot start with a number.
+
+## Dimension: a reusable row-level field
+
+A **Dimension** is a calculated field evaluated for each row, used in `GROUP BY` or as a
+filter. Unlike a Metric, it is not aggregated. Define them under a Model's `dimensions:` list.
+
+```yaml title="project.visivo.yml"
+models:
+  - name: orders
+    sql: SELECT * FROM orders_table
+    dimensions:
+      - name: order_month
+        expression: "DATE_TRUNC('month', order_date)"
+        description: "Month when the order was placed"
+      - name: is_high_value
+        expression: "CASE WHEN amount > 1000 THEN true ELSE false END"
+        data_type: BOOLEAN
+```
+
+### Implicit dimensions
+
+You do not have to declare a Dimension for every column. Visivo automatically exposes each of
+a Model's columns as an **implicit dimension**, with its `data_type` auto-detected from the
+source schema. Declare an explicit Dimension only when you need a computed expression. An
+Insight can reference either a declared Dimension or a raw column with the same
+`${ref(model).field}` syntax.
+
+## Relation: how two Models join
+
+A **Relation** declares the join condition between two Models so a Metric can combine data
+across them and Visivo can generate the `JOIN` automatically. The Models involved are
+inferred from the `condition`, which must reference at least two different Models with
+`${ref(model).field}` syntax. You cannot join on a Metric (an aggregated value).
+
+```yaml title="project.visivo.yml"
+relations:
+  - name: orders_to_users
+    join_type: inner
+    condition: "${ref(orders).user_id} = ${ref(users).id}"
+    is_default: true
+```
+
+| Field | Values | Purpose |
+|-------|--------|---------|
+| `join_type` | `inner`, `left`, `right`, `full` | The SQL join to use. Defaults to `inner`. |
+| `condition` | `${ref(a).x} = ${ref(b).y}` | The join predicate; must reference two Models. |
+| `is_default` | `true` / `false` | Disambiguates which Relation to use when multiple exist between the same pair of Models. |
+
+!!! note "Relations join within a single source"
+    Both Models in a Relation must use the same [Source](../concepts/source.md), because a SQL
+    join requires all tables to be reachable from one database connection. To combine data
+    from different Sources, use a
+    [LocalMergeModel](../reference/configuration/Models/LocalMergeModel/index.md).
+
+## How it fits together
+
+```mermaid
+flowchart LR
+    MA[Model: orders]:::model --> R[Relation]:::relation
+    MB[Model: users]:::model --> R
+    MA --> MET[Metric: total_revenue]:::metric
+    MA --> DIM[Dimension: order_month]:::dimension
+    R --> GM[Global metric:<br/>revenue_per_user]:::metric
+    MET --> GM
+    GM --> I[Insight]:::insight
+    DIM --> I
+
+    classDef model fill:#fffbeb,stroke:#f59e0b,color:#92400e;
+    classDef metric fill:#ecfeff,stroke:#06b6d4,color:#155e75;
+    classDef dimension fill:#f0fdfa,stroke:#14b8a6,color:#115e59;
+    classDef relation fill:#eff6ff,stroke:#3b82f6,color:#1e40af;
+    classDef insight fill:#faf5ff,stroke:#a855f7,color:#6b21a8;
+```
+
+## Learn more
+
+- [Semantic layer concept](../concepts/semantic-layer.md): the short overview.
+- [Insight](../concepts/insight.md): how Insights consume Metrics and Dimensions.
+- Reference:
+  [Metric](../reference/configuration/Metric/index.md),
+  [Dimension](../reference/configuration/Dimension/index.md),
+  [Relation](../reference/configuration/Relation/index.md).

--- a/mkdocs/topics/source-types.md
+++ b/mkdocs/topics/source-types.md
@@ -1,0 +1,267 @@
+# Source types
+
+Visivo ships ten built-in [Source](../concepts/source.md) types: seven that use a SQLAlchemy driver (six networked warehouses and databases plus local SQLite), and three file-based sources you query locally with DuckDB. This page is the at-a-glance matrix plus a minimal, copy-pasteable connection example for each.
+
+!!! visivo "Two engine families"
+    Under the hood every Source resolves to one of two engines. **SQLAlchemy** sources
+    (`postgresql`, `mysql`, `sqlite`, `snowflake`, `bigquery`, `clickhouse`) connect through a
+    SQLAlchemy driver; **Redshift** uses the native `redshift-connector`; and **DuckDB**
+    sources (`duckdb`, `csv`, `xls`) run queries through an embedded DuckDB engine. You write
+    the same SQL either way; Visivo translates dialects with [SQLGlot](https://sqlglot.com).
+
+## The matrix
+
+| :visivo-source:{ .vz-source } Type | Engine | Where the data lives | Key fields |
+|------|--------|----------------------|------------|
+| `postgresql` | SQLAlchemy (`psycopg2`) | PostgreSQL server | `host`, `port`, `database`, `username`, `password`, `db_schema` |
+| `mysql` | SQLAlchemy (`pymysql`) | MySQL server | `host`, `port`, `database`, `username`, `password`, `db_schema` |
+| `sqlite` | SQLAlchemy (`pysqlite`) | Local `.db` file | `database` (file path), `attach` |
+| `snowflake` | SQLAlchemy (`snowflake`) | Snowflake account | `account`, `warehouse`, `database`, `db_schema`, `role`, `username`, `password` (or key pair) |
+| `bigquery` | SQLAlchemy (`bigquery`) | Google BigQuery | `project`, `database` (dataset), `credentials_base64` |
+| `redshift` | `redshift-connector` | Amazon Redshift | `host`, `port`, `database`, `username`, `password` (or IAM) |
+| `clickhouse` | SQLAlchemy (`clickhouse`) | ClickHouse server / Cloud | `host`, `port`, `database`, `username`, `password`, `protocol`, `secure` |
+| `duckdb` | DuckDB | Local `.db` file | `database` (file path), `attach` |
+| `csv` | DuckDB | Local `.csv` file | `file` (file path), `delimiter`, `encoding`, `has_header` |
+| `xls` | DuckDB | Local spreadsheet file | `file` (file path), `delimiter`, `encoding`, `has_header` |
+
+!!! tip "Credentials belong in environment variables"
+    Every credential field accepts the `${env.VAR_NAME}` reference, resolved at run time.
+    Keep secrets out of your committed YAML and out of version control. See
+    [Environment Variables](environment-variables.md) for how Visivo loads `.env` files and
+    where the syntax works.
+
+## SQLAlchemy databases
+
+These connect through a SQLAlchemy driver (Redshift uses the native `redshift-connector`).
+Most run on a server you reach over the network; SQLite is the exception, a local `.db` file
+that still uses the SQLAlchemy `pysqlite` driver rather than DuckDB. The credential fields
+below all accept `${env.VAR_NAME}`.
+
+### PostgreSQL
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: warehouse
+    type: postgresql
+    host: ${env.PG_HOST}
+    port: 5432
+    database: app_db
+    username: ${env.PG_USER}
+    password: ${env.PG_PASSWORD}
+    db_schema: public
+```
+
+### MySQL
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: warehouse
+    type: mysql
+    host: ${env.MYSQL_HOST}
+    port: 3306
+    database: app_db
+    username: ${env.MYSQL_USER}
+    password: ${env.MYSQL_PASSWORD}
+```
+
+### Snowflake
+
+`account`, `warehouse`, `role`, and `timezone` all resolve `${env.VAR_NAME}`, so the whole
+connection can be environment-driven. Use `password` for basic auth, or `private_key_path`
+plus `private_key_passphrase` for key-pair auth (when a key path is set, the password is
+ignored).
+
+=== "Password auth"
+
+    ```yaml title="project.visivo.yml"
+    sources:
+      - name: warehouse
+        type: snowflake
+        account: ${env.SNOWFLAKE_ACCOUNT}
+        warehouse: ${env.SNOWFLAKE_WAREHOUSE}
+        database: DEV
+        db_schema: PUBLIC
+        role: ${env.SNOWFLAKE_ROLE}
+        username: ${env.SNOWFLAKE_USER}
+        password: ${env.SNOWFLAKE_PASSWORD}
+    ```
+
+=== "Key-pair auth"
+
+    ```yaml title="project.visivo.yml"
+    sources:
+      - name: warehouse
+        type: snowflake
+        account: ${env.SNOWFLAKE_ACCOUNT}
+        warehouse: ${env.SNOWFLAKE_WAREHOUSE}
+        database: DEV
+        db_schema: PUBLIC
+        username: ${env.SNOWFLAKE_USER}
+        private_key_path: /path/to/rsa_key.p8
+        private_key_passphrase: ${env.SNOWFLAKE_KEY_PASSPHRASE}
+    ```
+
+### BigQuery
+
+Datasets are BigQuery's databases, so `database` holds the dataset name. Authenticate with a
+base64-encoded service-account key in `credentials_base64`, or set the
+`GOOGLE_APPLICATION_CREDENTIALS` environment variable and omit the field.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: warehouse
+    type: bigquery
+    project: my-gcp-project-id
+    database: my_dataset
+    credentials_base64: ${env.BIGQUERY_BASE64_CREDENTIALS}
+```
+
+### Redshift
+
+Redshift uses the native `redshift-connector`. Use `username` + `password` for basic auth,
+or set `iam: true` with `cluster_identifier` and `region` for IAM auth.
+
+=== "Username / password"
+
+    ```yaml title="project.visivo.yml"
+    sources:
+      - name: warehouse
+        type: redshift
+        host: my-cluster.abcdefghij.us-east-1.redshift.amazonaws.com
+        port: 5439
+        database: dev
+        username: ${env.REDSHIFT_USER}
+        password: ${env.REDSHIFT_PASSWORD}
+        db_schema: public
+    ```
+
+=== "IAM auth"
+
+    ```yaml title="project.visivo.yml"
+    sources:
+      - name: warehouse
+        type: redshift
+        host: my-cluster.abcdefghij.us-east-1.redshift.amazonaws.com
+        port: 5439
+        database: dev
+        username: ${env.REDSHIFT_USER}
+        iam: true
+        cluster_identifier: my-cluster
+        region: us-east-1
+        db_schema: public
+    ```
+
+### ClickHouse
+
+Supports self-hosted ClickHouse and ClickHouse Cloud. The `protocol` field selects `native`
+(TCP, the default, port 9000) or `http` (port 8123); set `secure: true` for TLS, which
+ClickHouse Cloud requires.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: warehouse
+    type: clickhouse
+    host: your-instance.clickhouse.cloud
+    port: 8443
+    database: default
+    username: default
+    password: ${env.CLICKHOUSE_PASSWORD}
+    protocol: http
+    secure: true
+```
+
+### SQLite
+
+A local `.db` file queried through the SQLAlchemy `pysqlite` driver, so no server is needed.
+`database` is the path to the file. Use `attach` to make additional SQLite databases
+available in the same connection so one Model query can join across them; each attachment
+nests a full source under `source`.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: local_db
+    type: sqlite
+    database: local/file/local.db
+    attach:
+      - schema_name: static
+        source:
+          name: static_source
+          type: sqlite
+          database: local/static/local.db
+```
+
+## File-based sources (DuckDB)
+
+These need no server. Visivo loads the file into an embedded DuckDB engine and queries it
+with SQL like any other table.
+
+### DuckDB
+
+`database` is the path to a local DuckDB file. Use `attach` to make additional DuckDB
+databases joinable in a single query; each attachment nests a full source under `source`.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: local_duck
+    type: duckdb
+    database: local/file/database.db
+    attach:
+      - schema_name: static
+        source:
+          name: static_duck
+          type: duckdb
+          database: local/static/static.db
+```
+
+### CSV
+
+Query a local CSV file directly. The file is exposed as a view named after the Source, so a
+[Model](../concepts/model.md) can `SELECT` from it. Use this for small, version-controlled
+datasets; for CSVs produced by a command, use a
+[CsvScriptModel](../reference/configuration/Models/CsvScriptModel/index.md) instead.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: products_csv
+    type: csv
+    file: data/products.csv
+    delimiter: ","
+    has_header: true
+
+models:
+  - name: products
+    source: ${ref(products_csv)}
+    sql: SELECT * FROM products_csv
+```
+
+### Excel
+
+Query a local spreadsheet file. Note the type is `xls` (not `xlsx`).
+
+!!! warning "Excel reading is delimited-text, not native `.xlsx`"
+    The Excel source currently loads the file through DuckDB's `read_csv_auto`, the same path
+    as the CSV source, so it does **not** yet parse the native `.xlsx` binary format
+    ([VIS-971](https://github.com/visivo-io/visivo/issues)). In practice it reads
+    delimited-text spreadsheets reliably. For true binary `.xlsx` files, export to CSV first
+    and use a `csv` source.
+
+```yaml title="project.visivo.yml"
+sources:
+  - name: budget_xls
+    type: xls
+    file: data/budget.csv
+    has_header: true
+
+models:
+  - name: budget
+    source: ${ref(budget_xls)}
+    sql: SELECT * FROM budget_xls
+```
+
+## Learn more
+
+- [Source](../concepts/source.md): the concept and how Sources fit the object model.
+- [Sources overview](sources.md): best practices for one project across many environments.
+- [Environment Variables](environment-variables.md): the `${env.VAR_NAME}` syntax in full.
+- Reference: every field for every type lives under
+  [Sources configuration](../reference/configuration/Sources/PostgresqlSource/index.md).


### PR DESCRIPTION
## What

Adds three Topics pages to docs.visivo.io, each verified against `visivo/models/` (docs follow the code):

- **`topics/source-types.md`** — at-a-glance matrix of all ten Source types (PostgreSQL, MySQL, SQLite, Snowflake, BigQuery, Redshift, ClickHouse, DuckDB, CSV, Excel) with a minimal `${env.VAR}` connection example each. Groups them correctly by engine: seven SQLAlchemy-driver sources (six networked plus **local SQLite, which uses the `pysqlite` driver, not DuckDB**) and three file-based DuckDB sources (`duckdb`, `csv`, `xls`). Notes truthfully that the `xls` source still reads via DuckDB `read_csv_auto` (VIS-971), not native `.xlsx`.
- **`topics/semantic-layer.md`** — Metric (model-scoped SQL aggregates + global composition via `${ref(...)}`), Dimension (explicit + auto-detected implicit), Relation (`condition`, `join_type`, `is_default`, same-source constraint), matching `metric.py` / `dimension.py` / `relation.py`. Includes a Mermaid flowchart of how the pieces fit.
- **`topics/inputs.md`** — Inputs documented **at code parity**. The models (`visivo/models/inputs/`) define exactly **two input types: `single-select` and `multi-select`** (no separate range-slider/date-picker/toggle/free-text *types*). `multi-select` additionally supports a `range` block and the `range-slider` / `date-range` *displays*; accessors `.value` (single) and `.values` / `.min` / `.max` / `.first` / `.last` (multi) wire into Insight interactions via `${ref(input).value}`.

Uses the brand visual system (object-type icons, `.grid.cards`, the `visivo` admonition, Mermaid) consistent with the Concepts pages. `mkdocs.yml` nav updated for the three pages. No `.py` changes; the regenerated `mkdocs/assets/visivo_schema.json` is intentionally left uncommitted (build artifact).

## Recovery note

This **recovers a prior agent's incomplete run** — the three draft pages existed but were uncommitted and unverified. Verifying against the code surfaced and fixed two inaccuracies in the draft: SQLite was mis-grouped under the DuckDB/file-based engine (it is SQLAlchemy `pysqlite`), and the intro source count described SQLite as a networked source. Also removed em dashes per task guardrails and corrected the `attach` examples to the schema-accurate nested `source:` form.

## Gates

- `bash scripts/docs_gen.sh` — **green** (build + spellcheck clean)
- `bash scripts/docs_sandbox.sh test` — **green** (link crawl: 0 broken links across 133 files; Playwright docs suite: 42/42 desktop + mobile)
- Playwright spot-check of all three pages light/dark, desktop + mobile — no overflow, no dark-on-dark/light-on-light, Mermaid + tables + tabbed code render correctly (screenshots saved to `.design-review/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)