### PR TITLE
docs: CI/CD-for-BI guide + 2.0-only editorial rule + concept-count reconciliation (VIS-873)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Linting: topics/linting.md
       - Testing: topics/testing.md
       - Annotations & Shapes: topics/annotations.md
+      - CI/CD for BI: topics/ci-cd.md
       - Deployment: topics/deployments.md
       - Telemetry: topics/telemetry.md
   - Concepts:
@@ -334,3 +335,4 @@ nav:
   - About:
       - background/index.md
       - How It Works: how_it_works.md
+      - Editorial Guidelines: contributing/editorial-guidelines.md

--- a/mkdocs/concepts/index.md
+++ b/mkdocs/concepts/index.md
@@ -97,10 +97,10 @@ An **Insight** reads a Model (optionally pulling reusable definitions from the
 those charts. A **Dashboard** arranges the charts, tables, and inputs into a page.
 
 !!! note "How many concepts are there, really?"
-    These six objects are the mental model we use throughout the docs. You will
-    occasionally see Charts and Tables called out separately — they are containers
-    that arrange Insights on a Dashboard. The exact count is being reconciled across
-    surfaces; for learning purposes, start with the six above.
+    Six. These six objects are the canonical concept set across the docs, and
+    every page uses them consistently. Charts and Tables are not a seventh and
+    eighth concept; they are containers that arrange Insights on a Dashboard, so
+    they live inside the Dashboard concept rather than alongside it.
 
 ## Where to go next
 

--- a/mkdocs/contributing/editorial-guidelines.md
+++ b/mkdocs/contributing/editorial-guidelines.md
@@ -1,0 +1,65 @@
+# Editorial guidelines
+
+These docs describe Visivo 2.0, and they must explain 2.0 on its own terms. This page is the short, enforceable rule set every contributor follows when writing or editing a page. It exists so the docs stay truthful as the product moves, and so the automated guards below have a written standard to point at.
+
+!!! visivo "The one rule"
+    Never explain a 2.0 concept by reaching for a 1.0 primitive. Describe what Visivo does today, with today's objects, in today's commands.
+
+## Explain 2.0 with 2.0 objects
+
+Visivo's mental model is the [six core objects](../concepts/index.md): Source, Model, Semantic layer (Metric, Dimension, Relation), Insight, Input, and Dashboard. Write every explanation in those terms.
+
+- **Charts come from Insights.** An [Insight](../concepts/insight.md) binds a Model's columns to plotly props and carries client-side interactions. The [semantic layer](../concepts/semantic-layer.md), made of Metrics, Dimensions, and Relations, feeds reusable definitions into Insights. That pairing is how a chart gets made.
+- **Do not reintroduce the removed chart primitive.** The standalone 1.0 chart object was removed in 2.0. Do not document it, and do not use its YAML key (`insights:` is the 2.0 key). The phrase that paired the words "trace" and "types" is likewise out: there is no such taxonomy in 2.0, since charts are produced by Insights plus the semantic layer.
+- **Prefer the real command.** Ground instructions in the actual [CLI](../reference/cli.md): `visivo run`, `visivo test`, `visivo serve`, `visivo deploy -s <stage>`. Do not invent flags or workflows.
+
+!!! note "Why the old vocabulary is banned"
+    The removed objects do not exist in the running product. A reader who follows 1.0 vocabulary writes YAML that will not compile. Accuracy here is not stylistic; it is the difference between a working project and a confusing error.
+
+## Banned phrases
+
+The following must never appear in **new** hand-authored docs prose. The first is the removed chart object's YAML key; the others name a chart taxonomy that 2.0 does not have.
+
+<div class="grid cards" markdown>
+
+-   :material-close-octagon:{ .lg .middle } **The removed chart key**
+
+    ---
+
+    Do not use the removed chart object's YAML key at the start of a line. The 2.0 key is `insights:`.
+
+-   :material-close-octagon:{ .lg .middle } **A chart-type taxonomy**
+
+    ---
+
+    Do not write the two-word phrase pairing "trace" with "types", nor any "N+" count of them. Charts come from Insights and the semantic layer.
+
+</div>
+
+!!! tip "Legitimate uses are fine"
+    Words like *stack trace*, *stacktrace*, *tracing*, and *backtrace* are normal engineering vocabulary and are allowed. The generated [props reference](../reference/configuration/Insight/Props/Scatter/index.md) is built from Plotly itself and is not hand-authored prose, so it is excluded from the scan.
+
+## Always write dbt™
+
+When you mention dbt in any hand-authored page, write **dbt™** with the trademark symbol. This keeps the docs consistent with the rest of Visivo's surfaces.
+
+## How this is enforced
+
+You do not have to remember every rule by heart. Two guards catch the common slips, and both reference this page as the standard.
+
+- **Docs-vs-code parity CI (VIS-874).** `tests/docs/test_docs_parity.py` runs in the docs pipeline (`.rwx/test_docs.yml`). It verifies the committed schema JSON matches a freshly generated schema, that every generated reference page has a non-empty description, and that no banned 2.0 phrase appears in hand-authored docs prose. A violation fails the build.
+- **The content guard.** The same banned-phrase list is mirrored in the marketing site's `scripts/check-content-accuracy.cjs`, so the two surfaces stay in lockstep. When you add a banned phrase here, add it in both places.
+
+!!! visivo "When you ship a product change"
+    If you remove or rename an object in the CLI, update the docs vocabulary in the same change. The parity CI checks the reference against the code, but the prose is yours to keep honest.
+
+## Quick checklist
+
+Before you open a docs pull request:
+
+1. Every concept is explained with the [six core objects](../concepts/index.md), not a removed 1.0 primitive.
+2. No banned phrase appears (no removed chart key, no chart-type taxonomy).
+3. Commands match the real [CLI](../reference/cli.md).
+4. dbt is written as **dbt™**.
+5. `bash scripts/docs_gen.sh` builds and the spellcheck is clean.
+</content>

--- a/mkdocs/topics/ci-cd.md
+++ b/mkdocs/topics/ci-cd.md
@@ -1,0 +1,178 @@
+# CI/CD for BI
+
+Visivo lets you treat business intelligence like software: every dashboard change goes through a git branch, gets verified by `visivo test`, and ships to a named stage with `visivo deploy -s <stage>`. This page walks the Git-review and staged-deploy workflow, then turns it into a real CI/CD pipeline.
+
+!!! visivo "BI-as-code in one line"
+    Because your project is YAML in git, the same review and release discipline you use for application code applies to your charts: branch, test computed values, and promote a build through dev, CI, and production stages side by side.
+
+## The four commands
+
+The whole workflow rests on four real CLI commands. Each links to its full reference.
+
+<div class="grid cards" markdown>
+
+-   :material-source-branch:{ .lg .middle .vz-source } **`visivo run`**
+
+    ---
+
+    Compiles the project and runs the model and insight queries to fetch the data that powers your dashboards, writing the results to the output directory.
+
+    [:octicons-arrow-right-24: run](../reference/cli.md#run)
+
+-   :material-test-tube:{ .lg .middle .vz-insight } **`visivo test`**
+
+    ---
+
+    Runs the project's tests, asserting on the computed insight values so the charts you ship have the characteristics you expect.
+
+    [:octicons-arrow-right-24: test](../reference/cli.md#test)
+
+-   :material-rocket-launch:{ .lg .middle .vz-metric } **`visivo deploy -s <stage>`**
+
+    ---
+
+    Pushes the current project and its computed data to [app.visivo.io](https://app.visivo.io) under a named stage. The `-s` / `--stage` flag is required.
+
+    [:octicons-arrow-right-24: deploy](../reference/cli.md#deploy)
+
+-   :material-archive:{ .lg .middle .vz-dashboard } **`visivo archive -s <stage>`**
+
+    ---
+
+    Tears down a stage you no longer need. This is the natural cleanup step when a pull request closes or a feature branch merges.
+
+    [:octicons-arrow-right-24: archive](../reference/cli.md#archive)
+
+</div>
+
+## The Git-review workflow
+
+A change to a dashboard follows the same shape as a code change.
+
+1. **Branch.** Cut a branch off main for your change, exactly as you would for application code.
+2. **`visivo run`.** Compile the project and compute the data behind every insight locally.
+3. **`visivo test`.** Assert on the computed insight values. A test is a boolean Python expression that reads insight data through `${ref(...)}`, so you can assert that a total matches across two grains or that a value lands where you expect. See [Testing](testing.md).
+4. **`visivo deploy -s <branch>`.** Publish a preview to a stage named after the branch, so a reviewer can open the rendered dashboard right next to the code diff.
+5. **Review and merge.** Approve the diff and the preview together, merge, then `visivo archive -s <branch>` to clean the preview up.
+
+```mermaid
+flowchart LR
+    B[git branch]:::source --> R["visivo run"]:::model
+    R --> T["visivo test"]:::insight
+    T -->|pass| D["visivo deploy<br/>-s &lt;branch&gt;"]:::metric
+    T -->|fail| F[fix the branch]:::dashboard
+    F --> R
+    D --> RV[review diff + preview]:::input
+    RV -->|merge| P["visivo deploy<br/>-s production"]:::metric
+    RV -->|close| A["visivo archive<br/>-s &lt;branch&gt;"]:::dashboard
+
+    classDef source fill:#fff7ed,stroke:#f97316,color:#9a3412;
+    classDef model fill:#fffbeb,stroke:#f59e0b,color:#92400e;
+    classDef metric fill:#ecfeff,stroke:#06b6d4,color:#155e75;
+    classDef insight fill:#faf5ff,stroke:#a855f7,color:#6b21a8;
+    classDef input fill:#eef2ff,stroke:#6366f1,color:#3730a3;
+    classDef dashboard fill:#fff1f2,stroke:#f43f5e,color:#9f1239;
+```
+
+## Stages are dev, CI, and production side by side
+
+A **stage** is a named slot in [Visivo Cloud](../cloud/deploy-and-stages.md) that holds one running version of your project. Because the stage name is just a string, the same project can have many versions live at once.
+
+```bash
+visivo deploy -s production          # the version everyone looks at
+visivo deploy -s my-feature-branch   # an isolated preview of one change
+visivo deploy -s ci                  # a shared CI environment
+```
+
+!!! note "Deploys are stage-based, not git-triggered"
+    Visivo does not watch your repository and deploy on its own. **You** decide when to push, and which stage to push to, by running `visivo deploy -s <stage>`. CI/CD just means running that command (and `run` + `test` before it) from a pipeline on the events you choose.
+
+## CI/CD is the three commands in a pipeline
+
+A CI/CD pipeline for BI is `visivo run`, then `visivo test`, then `visivo deploy -s <stage>`, wired to the events you care about. A common shape:
+
+- **On pull request:** run, test, then `deploy -s <branch>` to publish a preview reviewers open alongside the diff.
+- **On merge or close:** `archive -s <branch>` to tear the preview down.
+- **On a schedule:** `deploy -s production` on a cron to keep production data fresh.
+
+### Authenticating in CI
+
+Deploys to [app.visivo.io](https://app.visivo.io) need an API key. Locally, run `visivo authorize`, which starts a device-token flow: it opens the `authorize-device` page in your logged-in browser, you approve the device, and the token is written to `~/.visivo/profile.yml`.
+
+In CI there is no browser, so use the token directly. The CLI reads the `VISIVO_TOKEN` environment variable before any `profile.yml`, so generate a token from your profile at [app.visivo.io](https://app.visivo.io), store it as a CI secret, and inject it as `VISIVO_TOKEN` on the deploy step.
+
+!!! tip
+    Treat `VISIVO_TOKEN` like any deploy credential: a repository or organization secret, never committed to the project.
+
+### A GitHub Actions example
+
+This workflow runs, tests, and deploys a per-branch preview stage on every pull request, and archives that stage when the PR closes. It is the three commands, gated by the pull-request event.
+
+{% raw %}
+``` yaml title=".github/workflows/visivo_ci.yml"
+name: Visivo CI
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+env:
+  stage_name: ${{ github.head_ref }}
+  is_open: ${{ github.event.pull_request.state == 'open' }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Visivo
+        run: pip install visivo #(1)!
+
+      - name: Run
+        if: ${{ env.is_open == 'true' }}
+        run: visivo run
+        env:
+          DB_USERNAME: ${{ secrets.DB_USERNAME }} #(2)!
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+      - name: Test
+        if: ${{ env.is_open == 'true' }}
+        run: visivo test #(3)!
+
+      - name: Deploy preview stage
+        if: ${{ env.is_open == 'true' }}
+        run: visivo deploy -s ${{ env.stage_name }}
+        env:
+          VISIVO_TOKEN: ${{ secrets.VISIVO_TOKEN }} #(4)!
+
+      - name: Archive preview stage on close
+        if: ${{ env.is_open == 'false' }}
+        run: visivo archive -s ${{ env.stage_name }}
+        env:
+          VISIVO_TOKEN: ${{ secrets.VISIVO_TOKEN }}
+```
+
+1. Pin a version for reproducible builds, e.g. `pip install visivo==2.0.3`.
+2. `visivo run` needs to reach your data, so pass whatever connection secrets your sources expect.
+3. `visivo test` asserts on the values that `visivo run` just computed; a failed assertion fails the job before anything deploys.
+4. The deploy and archive steps authenticate with `VISIVO_TOKEN`, stored as a repository secret.
+{% endraw %}
+
+To keep production fresh, add a second scheduled workflow that runs the same `run` then `deploy -s production` on a cron. The [Deployment guide](deployments.md) has full, copy-pasteable GitHub Actions and RWX (Mint) workflows, including database-proxy patterns and a step that comments the preview URL back on the PR.
+
+## Learn more
+
+- [Deployment guide](deployments.md): complete CI/CD workflows for GitHub Actions and RWX.
+- [Testing](testing.md): how to assert on computed insight values.
+- [Deploy & stages](../cloud/deploy-and-stages.md): how stages work in Visivo Cloud.
+- [Authentication](../cloud/authentication.md): getting and storing an API key.
+- [CLI reference](../reference/cli.md): every flag of `run`, `test`, `deploy`, and `archive`.
+</content>
+</invoke>

--- a/viewer/e2e/docs/docs-design.spec.mjs
+++ b/viewer/e2e/docs/docs-design.spec.mjs
@@ -16,6 +16,8 @@ const PAGES = [
   '/',
   '/installation/',
   '/topics/sources/',
+  '/topics/ci-cd/',
+  '/contributing/editorial-guidelines/',
   '/reference/configuration/Dashboards/Dashboard/',
   '/concepts/',
   '/cloud/',

--- a/viewer/e2e/docs/docs-routes.spec.mjs
+++ b/viewer/e2e/docs/docs-routes.spec.mjs
@@ -20,6 +20,8 @@ const ROUTES = [
   { name: 'home (quick start)', path: '/' },
   { name: 'generated reference (Dashboard)', path: '/reference/configuration/Dashboards/Dashboard/' },
   { name: 'topics (sources)', path: '/topics/sources/' },
+  { name: 'topics (CI/CD for BI)', path: '/topics/ci-cd/' },
+  { name: 'editorial guidelines', path: '/contributing/editorial-guidelines/' },
   { name: 'installation', path: '/installation/' },
   { name: 'concepts overview', path: '/concepts/' },
   { name: 'concept (insight)', path: '/concepts/insight/' },


### PR DESCRIPTION
Implements VIS-873 for docs.visivo.io (Material for MkDocs).

## What this adds

**1. CI/CD-for-BI guide** (`mkdocs/topics/ci-cd.md`, nav: Tutorials -> CI/CD for BI)
The Git-review then staged-deploy workflow: branch, `visivo run`, `visivo test` (asserts on computed insight values), `visivo deploy -s <stage>` to app.visivo.io, where named stages give dev / CI / prod side by side. Uses the brand visual aids on main: a Mermaid CI/CD pipeline diagram with object-type node colors, object-type `.grid.cards`, brand-tinted admonitions, and a real GitHub Actions YAML (run/test/deploy/archive per stage, `VISIVO_TOKEN` auth via the device-token/`visivo authorize` flow). Every command is grounded in the real CLI (`visivo/command_line.py` + `commands/`). 2.0-truthful: deploys are stage-based (`visivo deploy -s`), not git-triggered continuous deployment. Complements (does not duplicate) the existing `topics/deployments.md` reference and links to it.

**2. 2.0-only editorial rule** (`mkdocs/contributing/editorial-guidelines.md`, nav: About -> Editorial Guidelines)
Codifies: never explain a 2.0 concept via a 1.0 primitive; never use the removed chart YAML key or the chart-type taxonomy (charts come from Insights + the semantic layer); always **dbt™**. References that the parity CI (VIS-874, `tests/docs/test_docs_parity.py` in `.rwx/test_docs.yml`) and the marketing content guard (`www/scripts/check-content-accuracy.cjs`) enforce it. Written to pass the parity ban-list itself.

**3. Concept-count reconciliation** (`mkdocs/concepts/index.md`)
The docs already used "six core objects" everywhere; the only drift was a hedging note ("the exact count is being reconciled across surfaces"). Firmed it up to adopt the canonical 6 from VIS-869 (Source, Model, Semantic layer, Insight, Input, Dashboard); Charts and Tables are containers inside Dashboard, not separate concepts. Verified no other docs page implies a different count and no banned 2.0 vocabulary in hand-authored prose.

Also wired both new pages into the docs e2e specs (`viewer/e2e/docs/docs-routes.spec.mjs` + `docs-design.spec.mjs`) so they are gated on desktop + mobile.

## Cross-repo concept-count divergences (founder follow-up, NOT changed here)

The docs now treat 6 as canonical. Two other surfaces diverge and need founder sign-off before alignment:

- **Viewer onboarding** (`visivo/viewer/src/components/onboarding/concepts.js`, `CONCEPTS` array): lists **7 concepts** by adding **Chart** as a top-level concept (Source, Model, Semantic layer, Insight, **Chart**, Input, Dashboard). The docs treat Chart as a container inside Dashboard, not a 7th concept.
- **www `Lineage.jsx`** (`www/src/Lineage.jsx`): the product object-model visualization is built entirely on the **removed 1.0 `traces` primitive** (Traces nodes, `traces:` YAML, "reused across all traces"). This is both a concept-set mismatch (no Semantic-layer/Insight framing; Traces + Charts + Tables instead) AND stale 2.0 vocabulary. www has no `/product` route; `Lineage.jsx` and `FAQ.jsx` are the surfaces that describe the object model, and both still use `traces`. (The viewer `objectTypeConfigs.js` is a flat editor catalog of all object values incl. Chart/Table/Markdown, so it is not a "concept count" per se, but it also surfaces Chart and Table alongside the six.)

Recommend a follow-up to align the viewer onboarding to 6 and migrate `www/src/Lineage.jsx` + `FAQ.jsx` off `traces` to Insights + the semantic layer, pending founder decision on whether Chart is a concept or a container.

## Gates

- `bash scripts/docs_gen.sh`: GREEN (build + spellcheck clean; no new known_words needed).
- `bash scripts/docs_sandbox.sh test`: GREEN (54 passed, link crawl found no broken links).
- `tests/docs/test_docs_parity.py`: 5 passed (no banned 2.0 phrases in the new prose).
- Playwright spot-check (light/dark, desktop/mobile) saved to `.design-review/`: Mermaid renders in both themes, no dark-on-dark / light-on-light, no horizontal overflow.
- No `.py` changes. The regenerated `mkdocs/assets/visivo_schema.json` build artifact is intentionally not committed (CI regenerates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)