### PR TITLE
fix(docs): repair malformed "Common Uses" admonitions on 39 Insight Props pages (VIS-1016)

### DIFF
--- a/mkdocs/reference/props-docs/insight/contourcarpet.md
+++ b/mkdocs/reference/props-docs/insight/contourcarpet.md
@@ -11,7 +11,11 @@ The `contourcarpet` insight type is used to create contour plots over a carpet p
 
 You can control contour levels, colors, and other properties to display data patterns over an underlying carpet plot.
 
-!!! tip "Common Uses" - **Distorted Grids**: Visualizing data over irregular grids or non-linear spaces. - **Engineering Data**: Representing data that spans across irregular dimensions. - **Multivariate Visualization**: Handling data with multiple independent variables.
+!!! tip "Common Uses"
+
+    - **Distorted Grids**: Visualizing data over irregular grids or non-linear spaces.
+    - **Engineering Data**: Representing data that spans across irregular dimensions.
+    - **Multivariate Visualization**: Handling data with multiple independent variables.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Contourcarpet/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/densitymap.md
+++ b/mkdocs/reference/props-docs/insight/densitymap.md
@@ -11,7 +11,11 @@ The `densitymap` insight is used to create density maps on a **MapLibre** layer.
 
 You can customize the colorscale, radius of influence for each point, and other properties to fine-tune the visualization.
 
-!!! tip "Common Uses" - **Geospatial Data Analysis**: Identifying hotspots in geographic data, such as crime rates or customer locations. - **Event Density**: Visualizing the concentration of events or occurrences across regions. - **Heatmap for Geographic Points**: Creating heatmaps based on spatial data distributions on a map.
+!!! tip "Common Uses"
+
+    - **Geospatial Data Analysis**: Identifying hotspots in geographic data, such as crime rates or customer locations.
+    - **Event Density**: Visualizing the concentration of events or occurrences across regions.
+    - **Heatmap for Geographic Points**: Creating heatmaps based on spatial data distributions on a map.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Densitymap/#attributes) for the full set of configuration options.**_
 

--- a/mkdocs/reference/props-docs/insight/densitymapbox.md
+++ b/mkdocs/reference/props-docs/insight/densitymapbox.md
@@ -11,7 +11,11 @@ The `densitymapbox` insight is used to create density maps on a **Mapbox** layer
 
 You can customize the colorscale, radius of influence for each point, and other properties to fine-tune the visualization.
 
-!!! tip "Common Uses" - **Geospatial Data Analysis**: Identifying hotspots in geographic data, such as crime rates or customer locations. - **Event Density**: Visualizing the concentration of events or occurrences across regions. - **Heatmap for Geographic Points**: Creating heatmaps based on spatial data distributions on a map.
+!!! tip "Common Uses"
+
+    - **Geospatial Data Analysis**: Identifying hotspots in geographic data, such as crime rates or customer locations.
+    - **Event Density**: Visualizing the concentration of events or occurrences across regions.
+    - **Heatmap for Geographic Points**: Creating heatmaps based on spatial data distributions on a map.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Densitymapbox/#attributes) for the full set of configuration options.**_
 

--- a/mkdocs/reference/props-docs/insight/funnel.md
+++ b/mkdocs/reference/props-docs/insight/funnel.md
@@ -11,7 +11,11 @@ The `funnel` insight type is used to create funnel charts, which visualize data 
 
 You can control the orientation, marker styles, and colors to better represent your data flow. Funnel charts help in identifying bottlenecks or drop-off points in a process.
 
-!!! tip "Common Uses" - **Sales Funnels**: Tracking the stages from lead generation to closing a deal. - **Conversion Funnels**: Visualizing the steps in a user journey and where drop-offs occur. - **Progression Through Stages**: Representing data at different stages of a sequential process.
+!!! tip "Common Uses"
+
+    - **Sales Funnels**: Tracking the stages from lead generation to closing a deal.
+    - **Conversion Funnels**: Visualizing the steps in a user journey and where drop-offs occur.
+    - **Progression Through Stages**: Representing data at different stages of a sequential process.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Funnel/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/funnelarea.md
+++ b/mkdocs/reference/props-docs/insight/funnelarea.md
@@ -11,7 +11,11 @@ The `funnelarea` insight type is used to create funnel area charts, which are si
 
 You can control the colors, labels, and orientation of the funnel area sections to visualize proportional data across different stages.
 
-!!! tip "Common Uses" - **Proportional Stages**: Showing the proportion of data at each stage in a circular format. - **Conversion Rates**: Visualizing the drop-off rates in different stages of a process. - **Sales and Marketing Funnels**: Representing funnels like leads-to-sales in a circular format.
+!!! tip "Common Uses"
+
+    - **Proportional Stages**: Showing the proportion of data at each stage in a circular format.
+    - **Conversion Rates**: Visualizing the drop-off rates in different stages of a process.
+    - **Sales and Marketing Funnels**: Representing funnels like leads-to-sales in a circular format.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Funnelarea/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/heatmap.md
+++ b/mkdocs/reference/props-docs/insight/heatmap.md
@@ -11,7 +11,11 @@ The `heatmap` insight type is used to create heatmaps, which represent data usin
 
 You can customize the colorscale, gridlines, and other properties to fit your data and visualization needs.
 
-!!! tip "Common Uses" - **Correlation Matrices**: Visualizing relationships between variables. - **Frequency Distributions**: Showing how frequently data points occur across categories. - **Geospatial Heatmaps**: Visualizing the density or intensity of occurrences in a 2D space.
+!!! tip "Common Uses"
+
+    - **Correlation Matrices**: Visualizing relationships between variables.
+    - **Frequency Distributions**: Showing how frequently data points occur across categories.
+    - **Geospatial Heatmaps**: Visualizing the density or intensity of occurrences in a 2D space.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Heatmap/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/heatmapgl.md
+++ b/mkdocs/reference/props-docs/insight/heatmapgl.md
@@ -11,7 +11,11 @@ The `heatmapgl` insight type is similar to the regular `heatmap` but is rendered
 
 You can customize the colorscale, text annotations, and other properties to create high-performance heatmaps for large-scale data.
 
-!!! tip "Common Uses" - **High-Performance Heatmaps**: Visualizing large datasets efficiently. - **Big Data Visualization**: Rendering heatmaps with thousands or millions of points. - **Correlation Matrices & Density Maps**: Displaying data where relationships or density are critical to analyze.
+!!! tip "Common Uses"
+
+    - **High-Performance Heatmaps**: Visualizing large datasets efficiently.
+    - **Big Data Visualization**: Rendering heatmaps with thousands or millions of points.
+    - **Correlation Matrices & Density Maps**: Displaying data where relationships or density are critical to analyze.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Heatmapgl/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/histogram.md
+++ b/mkdocs/reference/props-docs/insight/histogram.md
@@ -11,7 +11,11 @@ The `histogram` insight type is used to create histograms, which represent the d
 
 You can customize bin size, orientation, and colors to fit your data. Histograms are especially useful in statistical analysis, data science, and exploratory data analysis.
 
-!!! tip "Common Uses" - **Data Distribution**: Visualizing how data points are distributed across different ranges. - **Frequency Analysis**: Showing the frequency of values within specific intervals. - **Statistical Summaries**: Understanding the spread, central tendency, and outliers in data.
+!!! tip "Common Uses"
+
+    - **Data Distribution**: Visualizing how data points are distributed across different ranges.
+    - **Frequency Analysis**: Showing the frequency of values within specific intervals.
+    - **Statistical Summaries**: Understanding the spread, central tendency, and outliers in data.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Histogram/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/histogram2d.md
+++ b/mkdocs/reference/props-docs/insight/histogram2d.md
@@ -11,7 +11,11 @@ The `histogram2d` insight type is used to create 2D histograms, where data is bi
 
 You can customize the binning along both axes, as well as the colorscale and aggregation method, to better represent your data.
 
-!!! tip "Common Uses" - **Joint Distributions**: Visualizing the relationship between two variables. - **Density Plots**: Showing the density of data points across two dimensions. - **Statistical Analysis**: Identifying patterns, correlations, or anomalies in bivariate data.
+!!! tip "Common Uses"
+
+    - **Joint Distributions**: Visualizing the relationship between two variables.
+    - **Density Plots**: Showing the density of data points across two dimensions.
+    - **Statistical Analysis**: Identifying patterns, correlations, or anomalies in bivariate data.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Histogram2d/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/histogram2dcontour.md
+++ b/mkdocs/reference/props-docs/insight/histogram2dcontour.md
@@ -11,7 +11,11 @@ The `histogram2dcontour` insight type is used to create 2D contour plots that re
 
 You can customize the binning along both axes, contour lines, and the color mapping to suit your data. This insight type is useful for visualizing patterns and clusters in bivariate data.
 
-!!! tip "Common Uses" - **Density Contours**: Showing how data points are distributed and clustered. - **Joint Distribution Analysis**: Visualizing the relationship between two variables with density contours. - **Bivariate Statistical Analysis**: Analyzing two variables and their joint behavior.
+!!! tip "Common Uses"
+
+    - **Density Contours**: Showing how data points are distributed and clustered.
+    - **Joint Distribution Analysis**: Visualizing the relationship between two variables with density contours.
+    - **Bivariate Statistical Analysis**: Analyzing two variables and their joint behavior.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Histogram2dcontour/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/icicle.md
+++ b/mkdocs/reference/props-docs/insight/icicle.md
@@ -11,7 +11,11 @@ The `icicle` insight type is used to create icicle charts, which are a variation
 
 You can customize the colors, labels, and depth of the icicle chart to represent your hierarchical data effectively.
 
-!!! tip "Common Uses" - **Hierarchical Data Representation**: Visualizing categories and subcategories in a hierarchy. - **Part-to-Whole Relationships**: Showing how parts relate to the whole, with breakdowns for subcategories. - **Drill-Down Analysis**: Allowing users to explore different levels of data.
+!!! tip "Common Uses"
+
+    - **Hierarchical Data Representation**: Visualizing categories and subcategories in a hierarchy.
+    - **Part-to-Whole Relationships**: Showing how parts relate to the whole, with breakdowns for subcategories.
+    - **Drill-Down Analysis**: Allowing users to explore different levels of data.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Icicle/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/image.md
+++ b/mkdocs/reference/props-docs/insight/image.md
@@ -11,7 +11,11 @@ The `image` insight type is used to display raster images in a plot. This is par
 
 You can customize the image size, position, and color scaling to represent image data effectively. Images can be used in scientific visualizations, geographic data, or any scenario where image data is needed.
 
-!!! tip "Common Uses" - **Raster Images**: Displaying raster images in data visualizations. - **Geographic Maps**: Visualizing maps or satellite images. - **Image Data**: Rendering images directly as part of data exploration and analysis.
+!!! tip "Common Uses"
+
+    - **Raster Images**: Displaying raster images in data visualizations.
+    - **Geographic Maps**: Visualizing maps or satellite images.
+    - **Image Data**: Rendering images directly as part of data exploration and analysis.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Image/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/indicator.md
+++ b/mkdocs/reference/props-docs/insight/indicator.md
@@ -11,7 +11,11 @@ The `indicator` insight type is used to create key performance indicator (KPI) v
 
 You can customize the gauge, delta values, colors, and text annotations to represent your data effectively. Indicator plots are widely used in dashboards and reporting.
 
-!!! tip "Common Uses" - **KPI Dashboards**: Displaying key metrics, progress, or performance indicators. - **Gauges**: Visualizing values as a gauge to track goals or targets. - **Highlighting Change**: Showing the difference between two points in time.
+!!! tip "Common Uses"
+
+    - **KPI Dashboards**: Displaying key metrics, progress, or performance indicators.
+    - **Gauges**: Visualizing values as a gauge to track goals or targets.
+    - **Highlighting Change**: Showing the difference between two points in time.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Indicator/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/isosurface.md
+++ b/mkdocs/reference/props-docs/insight/isosurface.md
@@ -11,7 +11,11 @@ The `isosurface` insight type is used to create 3D isosurface visualizations, wh
 
 You can customize the colors, opacity, and surface rendering to visualize 3D data effectively.
 
-!!! tip "Common Uses" - **Scientific Visualization**: Representing surfaces of constant values in a 3D volume. - **Medical Imaging**: Displaying 3D representations of structures, such as in MRI or CT scans. - **Geospatial and Engineering Data**: Visualizing 3D volumes and their properties.
+!!! tip "Common Uses"
+
+    - **Scientific Visualization**: Representing surfaces of constant values in a 3D volume.
+    - **Medical Imaging**: Displaying 3D representations of structures, such as in MRI or CT scans.
+    - **Geospatial and Engineering Data**: Visualizing 3D volumes and their properties.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Isosurface/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/mesh3d.md
+++ b/mkdocs/reference/props-docs/insight/mesh3d.md
@@ -11,7 +11,11 @@ The `mesh3d` insight type is used to create 3D mesh plots, which visualize 3D su
 
 You can customize the colors, vertex positions, and opacity to represent 3D data and geometries effectively.
 
-!!! tip "Common Uses" - **3D Geometries**: Visualizing surfaces and volumes in 3D space. - **Scientific Visualization**: Representing complex 3D data in fields like physics, engineering, and geology. - **3D Surface Rendering**: Displaying 3D surfaces from a set of points and connectivity information.
+!!! tip "Common Uses"
+
+    - **3D Geometries**: Visualizing surfaces and volumes in 3D space.
+    - **Scientific Visualization**: Representing complex 3D data in fields like physics, engineering, and geology.
+    - **3D Surface Rendering**: Displaying 3D surfaces from a set of points and connectivity information.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Mesh3d/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/ohlc.md
+++ b/mkdocs/reference/props-docs/insight/ohlc.md
@@ -11,7 +11,11 @@ The `ohlc` insight type is used to create OHLC (Open, High, Low, Close) charts, 
 
 You can customize the colors, bar widths, and date ranges to represent financial data effectively.
 
-!!! tip "Common Uses" - **Stock Market Visualization**: Displaying price movement data for stocks, currencies, or commodities. - **Financial Time Series**: Visualizing price fluctuations over time. - **Trading Analysis**: Understanding market trends through candlestick-like visualizations.
+!!! tip "Common Uses"
+
+    - **Stock Market Visualization**: Displaying price movement data for stocks, currencies, or commodities.
+    - **Financial Time Series**: Visualizing price fluctuations over time.
+    - **Trading Analysis**: Understanding market trends through candlestick-like visualizations.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Ohlc/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/parcats.md
+++ b/mkdocs/reference/props-docs/insight/parcats.md
@@ -11,7 +11,11 @@ The `parcats` insight type is used to create parallel categories diagrams, which
 
 You can customize the colors, line widths, and category order to represent your data and patterns effectively.
 
-!!! tip "Common Uses" - **Categorical Data Visualization**: Visualizing relationships between different categorical variables. - **Flow Analysis**: Showing how data is distributed across multiple dimensions and comparing those paths. - **Segmentation**: Visualizing how different segments of data flow through categories.
+!!! tip "Common Uses"
+
+    - **Categorical Data Visualization**: Visualizing relationships between different categorical variables.
+    - **Flow Analysis**: Showing how data is distributed across multiple dimensions and comparing those paths.
+    - **Segmentation**: Visualizing how different segments of data flow through categories.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Parcats/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/parcoords.md
+++ b/mkdocs/reference/props-docs/insight/parcoords.md
@@ -11,7 +11,11 @@ The `parcoords` insight type is used to create parallel coordinates plots, which
 
 You can customize the axis scaling, color mapping, and line properties to represent your data effectively.
 
-!!! tip "Common Uses" - **Multivariate Data Analysis**: Visualizing relationships between multiple variables. - **Data Exploration**: Exploring patterns and outliers in high-dimensional datasets. - **Decision Making**: Identifying optimal points or anomalies in multi-variable data.
+!!! tip "Common Uses"
+
+    - **Multivariate Data Analysis**: Visualizing relationships between multiple variables.
+    - **Data Exploration**: Exploring patterns and outliers in high-dimensional datasets.
+    - **Decision Making**: Identifying optimal points or anomalies in multi-variable data.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Parcoords/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/pie.md
+++ b/mkdocs/reference/props-docs/insight/pie.md
@@ -11,7 +11,11 @@ The `pie` insight type is used to create pie charts, which are circular charts d
 
 You can customize the colors, labels, and hover information to display your data effectively.
 
-!!! tip "Common Uses" - **Part-to-Whole Relationships**: Visualizing how different parts contribute to the whole. - **Categorical Data**: Showing the proportions of different categories in a dataset. - **Survey Data**: Visualizing how responses are distributed among categories.
+!!! tip "Common Uses"
+
+    - **Part-to-Whole Relationships**: Visualizing how different parts contribute to the whole.
+    - **Categorical Data**: Showing the proportions of different categories in a dataset.
+    - **Survey Data**: Visualizing how responses are distributed among categories.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Pie/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/sankey.md
+++ b/mkdocs/reference/props-docs/insight/sankey.md
@@ -11,7 +11,11 @@ The `sankey` insight type is used to create Sankey diagrams, which visualize the
 
 You can customize the colors, labels, and flow paths to represent your data and flows effectively.
 
-!!! tip "Common Uses" - **Flow of Resources**: Visualizing how resources (e.g., money, energy, or materials) move between stages. - **Part-to-Part Relationships**: Displaying how parts contribute to other parts rather than the whole. - **Energy or Supply Chains**: Showing energy transfers or supply chain processes.
+!!! tip "Common Uses"
+
+    - **Flow of Resources**: Visualizing how resources (e.g., money, energy, or materials) move between stages.
+    - **Part-to-Part Relationships**: Displaying how parts contribute to other parts rather than the whole.
+    - **Energy or Supply Chains**: Showing energy transfers or supply chain processes.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Sankey/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scatter.md
+++ b/mkdocs/reference/props-docs/insight/scatter.md
@@ -16,7 +16,11 @@ The `scatter` insight type is used to create scatter plots, which visualize data
 
 You can customize the marker size, color, and add lines to connect the points to represent the data in various forms like scatter plots, line charts, and more.
 
-!!! tip "Common Uses" - **Relationship Analysis**: Exploring the relationship between two variables. - **Trend Detection**: Identifying trends or patterns in data. - **Outlier Identification**: Spotting outliers in data distributions.
+!!! tip "Common Uses"
+
+    - **Relationship Analysis**: Exploring the relationship between two variables.
+    - **Trend Detection**: Identifying trends or patterns in data.
+    - **Outlier Identification**: Spotting outliers in data distributions.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scatter/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scatter3d.md
+++ b/mkdocs/reference/props-docs/insight/scatter3d.md
@@ -11,7 +11,11 @@ The `scatter3d` insight type is used to create 3D scatter plots, which visualize
 
 You can customize the marker size, color, and add lines to connect points in 3D space to represent the data effectively.
 
-!!! tip "Common Uses" - **3D Relationship Analysis**: Exploring the relationship between three numerical variables. - **Pattern Detection**: Identifying trends and clusters in three dimensions. - **High-Dimensional Data**: Visualizing higher-dimensional datasets.
+!!! tip "Common Uses"
+
+    - **3D Relationship Analysis**: Exploring the relationship between three numerical variables.
+    - **Pattern Detection**: Identifying trends and clusters in three dimensions.
+    - **High-Dimensional Data**: Visualizing higher-dimensional datasets.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scatter3d/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattercarpet.md
+++ b/mkdocs/reference/props-docs/insight/scattercarpet.md
@@ -11,7 +11,11 @@ The `scattercarpet` insight type is used to create scatter plots on a 2D carpet 
 
 You can customize the marker size, color, and line connections, similar to standard scatter plots but on a carpet axis.
 
-!!! tip "Common Uses" - **Non-Linear Grids**: Visualizing data points on non-standard grids where the x and y axes are distorted or uneven. - **Data Visualization with Carpet Axes**: Displaying data points in cases where the relationships between variables are non-linear or require a more flexible grid. - **Heatmap-Like Data**: Scatter plots combined with other insights like `carpet` for advanced visualizations.
+!!! tip "Common Uses"
+
+    - **Non-Linear Grids**: Visualizing data points on non-standard grids where the x and y axes are distorted or uneven.
+    - **Data Visualization with Carpet Axes**: Displaying data points in cases where the relationships between variables are non-linear or require a more flexible grid.
+    - **Heatmap-Like Data**: Scatter plots combined with other insights like `carpet` for advanced visualizations.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattercarpet/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattergeo.md
+++ b/mkdocs/reference/props-docs/insight/scattergeo.md
@@ -11,7 +11,11 @@ The `scattergeo` insight type is used to create scatter plots on a geographic ma
 
 You can customize the marker size, color, and geo-coordinates (longitude and latitude) to effectively represent the geographic data.
 
-!!! tip "Common Uses" - **Geospatial Data**: Visualizing points or patterns on a geographic map. - **Location-Based Analysis**: Exploring the distribution of data points across different locations. - **Mapping**: Plotting geographical points such as cities, events, or regions.
+!!! tip "Common Uses"
+
+    - **Geospatial Data**: Visualizing points or patterns on a geographic map.
+    - **Location-Based Analysis**: Exploring the distribution of data points across different locations.
+    - **Mapping**: Plotting geographical points such as cities, events, or regions.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattergeo/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattergl.md
+++ b/mkdocs/reference/props-docs/insight/scattergl.md
@@ -11,7 +11,11 @@ The `scattergl` insight type is used to create scatter plots with WebGL renderin
 
 You can customize the marker size, color, and add lines to connect points, similar to the `scatter` insight type, but with WebGL's performance advantages.
 
-!!! tip "Common Uses" - **Large Datasets**: Efficiently visualizing datasets with thousands or millions of points. - **Performance Optimization**: Use when scatter plots with standard rendering struggle with performance. - **Real-Time Data**: Useful for real-time visualizations with large or dynamic datasets.
+!!! tip "Common Uses"
+
+    - **Large Datasets**: Efficiently visualizing datasets with thousands or millions of points.
+    - **Performance Optimization**: Use when scatter plots with standard rendering struggle with performance.
+    - **Real-Time Data**: Useful for real-time visualizations with large or dynamic datasets.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattergl/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattermap.md
+++ b/mkdocs/reference/props-docs/insight/scattermap.md
@@ -11,7 +11,11 @@ The `scattermap` insight type is used to create scatter plots on a MapLibre map.
 
 You can plot geographic points with latitude and longitude and customize the marker size, color, and labels to represent data effectively.
 
-!!! tip "Common Uses" - **Geospatial Analysis**: Plotting geographic points on an interactive map. - **Location-Based Data**: Visualizing locations and patterns on a MapLibre map. - **Mapping Events**: Plotting real-world events, like earthquakes or delivery points.
+!!! tip "Common Uses"
+
+    - **Geospatial Analysis**: Plotting geographic points on an interactive map.
+    - **Location-Based Data**: Visualizing locations and patterns on a MapLibre map.
+    - **Mapping Events**: Plotting real-world events, like earthquakes or delivery points.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattermap/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattermapbox.md
+++ b/mkdocs/reference/props-docs/insight/scattermapbox.md
@@ -11,7 +11,11 @@ The `scattermapbox` insight type is used to create scatter plots on a Mapbox map
 
 You can plot geographic points with latitude and longitude and customize the marker size, color, and labels to represent data effectively.
 
-!!! tip "Common Uses" - **Geospatial Analysis**: Plotting geographic points on an interactive map. - **Location-Based Data**: Visualizing locations and patterns on a Mapbox map. - **Mapping Events**: Plotting real-world events, like earthquakes or delivery points.
+!!! tip "Common Uses"
+
+    - **Geospatial Analysis**: Plotting geographic points on an interactive map.
+    - **Location-Based Data**: Visualizing locations and patterns on a Mapbox map.
+    - **Mapping Events**: Plotting real-world events, like earthquakes or delivery points.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattermapbox/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scatterpolar.md
+++ b/mkdocs/reference/props-docs/insight/scatterpolar.md
@@ -11,7 +11,11 @@ The `scatterpolar` insight type is used to create scatter plots on polar coordin
 
 You can customize the marker size, color, and lines to connect points, similar to standard scatter plots, but within a polar coordinate system.
 
-!!! tip "Common Uses" - **Cyclic Data Visualization**: Representing cyclic data such as time of day, seasonality, or wind direction. - **Directional Data**: Visualizing data with directional components, such as angular measurements. - **Circular Data Analysis**: Useful for data where radial distance and angle are key factors.
+!!! tip "Common Uses"
+
+    - **Cyclic Data Visualization**: Representing cyclic data such as time of day, seasonality, or wind direction.
+    - **Directional Data**: Visualizing data with directional components, such as angular measurements.
+    - **Circular Data Analysis**: Useful for data where radial distance and angle are key factors.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scatterpolar/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scatterpolargl.md
+++ b/mkdocs/reference/props-docs/insight/scatterpolargl.md
@@ -11,7 +11,11 @@ The `scatterpolargl` insight type is used to create scatter plots on polar coord
 
 You can customize marker size, color, and lines to connect points, similar to `scatterpolar`, but with WebGL's performance advantages.
 
-!!! tip "Common Uses" - **Large Datasets in Polar Coordinates**: Efficiently visualize many data points. - **Performance Optimization**: Use WebGL for fast rendering. - **Circular Data with Directional Components**: Ideal for cyclic data where radial distance and angle are key factors.
+!!! tip "Common Uses"
+
+    - **Large Datasets in Polar Coordinates**: Efficiently visualize many data points.
+    - **Performance Optimization**: Use WebGL for fast rendering.
+    - **Circular Data with Directional Components**: Ideal for cyclic data where radial distance and angle are key factors.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scatterpolargl/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scattersmith.md
+++ b/mkdocs/reference/props-docs/insight/scattersmith.md
@@ -11,7 +11,11 @@ The `scattersmith` insight type is used to create scatter plots on a Smith chart
 
 You can customize marker size, color, and lines to connect points, similar to scatter plots, but specifically tailored for Smith charts.
 
-!!! tip "Common Uses" - **Impedance and Reflection Coefficients**: Visualizing electrical properties in transmission lines. - **Complex Data Visualization**: Representing data points in terms of complex numbers. - **Electrical Engineering Analysis**: Useful for RF and microwave engineering applications.
+!!! tip "Common Uses"
+
+    - **Impedance and Reflection Coefficients**: Visualizing electrical properties in transmission lines.
+    - **Complex Data Visualization**: Representing data points in terms of complex numbers.
+    - **Electrical Engineering Analysis**: Useful for RF and microwave engineering applications.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scattersmith/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/scatterternary.md
+++ b/mkdocs/reference/props-docs/insight/scatterternary.md
@@ -11,7 +11,11 @@ The `scatterternary` insight type is used to create scatter plots on ternary plo
 
 You can customize marker size, color, and lines to connect points, similar to scatter plots but within a ternary coordinate system.
 
-!!! tip "Common Uses" - **Proportional Data Visualization**: Visualizing data involving three interdependent components. - **Ternary Relationship Analysis**: Exploring how three components relate to one another. - **Chemistry and Economics**: Useful for compositional data visualization.
+!!! tip "Common Uses"
+
+    - **Proportional Data Visualization**: Visualizing data involving three interdependent components.
+    - **Ternary Relationship Analysis**: Exploring how three components relate to one another.
+    - **Chemistry and Economics**: Useful for compositional data visualization.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Scatterternary/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/splom.md
+++ b/mkdocs/reference/props-docs/insight/splom.md
@@ -11,7 +11,11 @@ The `splom` insight type is used to create scatter plot matrices, which visualiz
 
 You can customize marker size, color, and lines for each pair of variables in the matrix.
 
-!!! tip "Common Uses" - **Pairwise Relationship Analysis**: Exploring multiple variable relationships simultaneously. - **Correlation Visualization**: Identifying patterns, clusters, or outliers in high-dimensional data. - **Multivariate Data Exploration**: Useful in statistics, machine learning, and data science.
+!!! tip "Common Uses"
+
+    - **Pairwise Relationship Analysis**: Exploring multiple variable relationships simultaneously.
+    - **Correlation Visualization**: Identifying patterns, clusters, or outliers in high-dimensional data.
+    - **Multivariate Data Exploration**: Useful in statistics, machine learning, and data science.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Splom/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/streamtube.md
+++ b/mkdocs/reference/props-docs/insight/streamtube.md
@@ -11,7 +11,11 @@ The `streamtube` insight type is used to create 3D streamtube plots for visualiz
 
 You can customize the color, tube size, and vector paths to highlight patterns and behaviors in the flow data.
 
-!!! tip "Common Uses" - **Fluid Dynamics**: Visualizing fluid flow in 3D space. - **Vector Field Analysis**: Representing wind, magnetic, or electric fields. - **Flow Visualization**: Showing flow behavior across time or space.
+!!! tip "Common Uses"
+
+    - **Fluid Dynamics**: Visualizing fluid flow in 3D space.
+    - **Vector Field Analysis**: Representing wind, magnetic, or electric fields.
+    - **Flow Visualization**: Showing flow behavior across time or space.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Streamtube/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/sunburst.md
+++ b/mkdocs/reference/props-docs/insight/sunburst.md
@@ -11,7 +11,11 @@ The `sunburst` insight type is used to create sunburst charts, visualizing hiera
 
 You can customize labels, hierarchy, colors, and segment sizes to represent your data effectively.
 
-!!! tip "Common Uses" - **Hierarchical Data Visualization**: Showing relationships between multiple levels of data. - **Part-to-Whole Relationships**: Visualizing contributions of parts to the whole. - **Categorical Data Breakdown**: Representing nested categories.
+!!! tip "Common Uses"
+
+    - **Hierarchical Data Visualization**: Showing relationships between multiple levels of data.
+    - **Part-to-Whole Relationships**: Visualizing contributions of parts to the whole.
+    - **Categorical Data Breakdown**: Representing nested categories.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Sunburst/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/surface.md
+++ b/mkdocs/reference/props-docs/insight/surface.md
@@ -11,7 +11,11 @@ The `surface` insight type is used to create 3D surface plots, visualizing the r
 
 You can customize the colorscale, lighting, and contours to represent your 3D data effectively.
 
-!!! tip "Common Uses" - **3D Data Visualization**: Showing relationships between three variables. - **Topographical Maps**: Representing elevation or landscape contours. - **3D Heatmaps**: Visualizing intensity or magnitude variations in three dimensions.
+!!! tip "Common Uses"
+
+    - **3D Data Visualization**: Showing relationships between three variables.
+    - **Topographical Maps**: Representing elevation or landscape contours.
+    - **3D Heatmaps**: Visualizing intensity or magnitude variations in three dimensions.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Surface/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/treemap.md
+++ b/mkdocs/reference/props-docs/insight/treemap.md
@@ -11,7 +11,11 @@ The `treemap` insight type is used to create treemap charts, visualizing hierarc
 
 You can customize the colors, labels, hierarchy, and tiling to represent your data effectively.
 
-!!! tip "Common Uses" - **Hierarchical Data Visualization**: Displaying nested data as rectangles. - **Part-to-Whole Relationships**: Visualizing contributions of categories to the whole. - **Categorical Data**: Showing nested categorical breakdowns.
+!!! tip "Common Uses"
+
+    - **Hierarchical Data Visualization**: Displaying nested data as rectangles.
+    - **Part-to-Whole Relationships**: Visualizing contributions of categories to the whole.
+    - **Categorical Data**: Showing nested categorical breakdowns.
 
 !!! warning "Unexpected Behavior"
 The terminal values of a `treemap` must be unique. Values must be unique across all leaf nodes.

--- a/mkdocs/reference/props-docs/insight/violin.md
+++ b/mkdocs/reference/props-docs/insight/violin.md
@@ -11,7 +11,11 @@ The `violin` insight type is used to create violin plots, visualizing the distri
 
 You can customize the orientation, box overlay, points, and colors to represent your distribution data effectively.
 
-!!! tip "Common Uses" - **Distribution Analysis**: Visualizing the distribution of numerical data, similar to box plots but with density information. - **Comparing Categories**: Comparing distributions across multiple categories. - **Outlier Detection**: Identifying outliers and distribution shape.
+!!! tip "Common Uses"
+
+    - **Distribution Analysis**: Visualizing the distribution of numerical data, similar to box plots but with density information.
+    - **Comparing Categories**: Comparing distributions across multiple categories.
+    - **Outlier Detection**: Identifying outliers and distribution shape.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Violin/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/volume.md
+++ b/mkdocs/reference/props-docs/insight/volume.md
@@ -11,7 +11,11 @@ The `volume` insight type is used to create 3D volume plots, visualizing 3D scal
 
 You can customize opacity, surface levels, and colors to effectively show the internal structure of the volume.
 
-!!! tip "Common Uses" - **Medical Imaging**: Visualizing 3D scans like MRI or CT data. - **Fluid Dynamics**: Representing 3D fields of density, pressure, or velocity. - **Scientific Visualization**: Displaying volumetric or scalar field data.
+!!! tip "Common Uses"
+
+    - **Medical Imaging**: Visualizing 3D scans like MRI or CT data.
+    - **Fluid Dynamics**: Representing 3D fields of density, pressure, or velocity.
+    - **Scientific Visualization**: Displaying volumetric or scalar field data.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Volume/#attributes) for the full set of configuration options**_
 

--- a/mkdocs/reference/props-docs/insight/waterfall.md
+++ b/mkdocs/reference/props-docs/insight/waterfall.md
@@ -11,7 +11,11 @@ The `waterfall` insight type is used to create waterfall charts, which visualize
 
 You can customize colors, connectors, and base values to represent your data effectively.
 
-!!! tip "Common Uses" - **Financial Analysis**: Visualizing profit and loss over time or across categories. - **Incremental Changes**: Showing how individual positive or negative changes affect a starting value. - **Part-to-Whole Visualization**: Highlighting how parts contribute to a cumulative total.
+!!! tip "Common Uses"
+
+    - **Financial Analysis**: Visualizing profit and loss over time or across categories.
+    - **Incremental Changes**: Showing how individual positive or negative changes affect a starting value.
+    - **Part-to-Whole Visualization**: Highlighting how parts contribute to a cumulative total.
 
 _**Check out the [Attributes](../../configuration/Insight/Props/Waterfall/#attributes) for the full set of configuration options**_
 


### PR DESCRIPTION
Fixes **VIS-1016**.

## Problem

39 hand-authored MkDocs partials under `mkdocs/reference/props-docs/insight/*.md` contained a malformed `!!! tip "Common Uses"` admonition: the title and its list items were jammed onto **one line**, so Material for MkDocs rendered the whole block as **raw literal text** instead of a styled tip box.

**Before** (`scatter.md` line 19):

```
!!! tip "Common Uses" - **Relationship Analysis**: Exploring the relationship between two variables. - **Trend Detection**: Identifying trends or patterns in data. - **Outlier Identification**: Spotting outliers in data distributions.
```

**After**:

```
!!! tip "Common Uses"

    - **Relationship Analysis**: Exploring the relationship between two variables.
    - **Trend Detection**: Identifying trends or patterns in data.
    - **Outlier Identification**: Spotting outliers in data distributions.
```

## Fix

Restructured the single malformed line in each of the 39 files into the correct multi-line admonition shape (title alone, one blank line, then 4-space-indented `- ` bullets). **Layout-only**: every file’s title text, `**bold**` markers, punctuation, and wording are byte-preserved (verified by normalizing whitespace and diffing the inline-item content before/after across all 39 files). Already-correct admonitions (e.g. the `!!! note "Gotchas"` blocks) were left untouched.

## Scope

Source-partial-only. The generator `mkdocs/src/write_mkdocs_markdown_files.py` does **not** write to `props-docs/`, so no generator was run and no schema JSON was regenerated. The diff is exactly the **39 `.md` files** — no script, no `mkdocs.yml`, no schema.

## Verification

- `mkdocs build` runs green with **no errors** and a **clean spellcheck** gate (built in an isolated Python 3.12 venv since the repo poetry env lacks mkdocs-material).
- Inspected the generated HTML: the block now renders as a styled admonition, not raw text. For scatter/waterfall/pie the output is:
  ```html
  <div class="admonition tip">
  <p class="admonition-title">Common Uses</p>
  <ul>
  <li><strong>Relationship Analysis</strong>: …</li>
  …
  </ul>
  </div>
  ```
  and there is **zero** remaining `!!! tip` literal text in any built page.
- Spot-checked scatter, waterfall, pie, and indicator diffs by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)