### PR TITLE
feat(viewer): source schema outline in the workspace right-rail (VIS-1004)

### DIFF
--- a/viewer/src/components/new-views/workspace/RightRail.jsx
+++ b/viewer/src/components/new-views/workspace/RightRail.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { PiList, PiPencil, PiSidebar } from 'react-icons/pi';
+import { PiList, PiPencil, PiSidebar, PiTreeStructure } from 'react-icons/pi';
 import useStore from '../../../stores/store';
+import useWorkspaceScope from './useWorkspaceScope';
 import OutlineTreePanel from './OutlineTreePanel';
+import SourceOutlineTreePanel from './SourceOutlineTreePanel';
 import RightRailEditPanel from './RightRailEditPanel';
 import { emitWorkspaceEvent } from './telemetry';
 
@@ -18,10 +20,19 @@ import { emitWorkspaceEvent } from './telemetry';
  *     auto-saves with a debounce (no Save buttons for the structure forms).
  */
 
-const TABS = [
-  { key: 'outline', label: 'Outline', icon: PiList },
-  { key: 'edit', label: 'Edit', icon: PiPencil },
-];
+// The Outline tab is contextual: for a `source` it browses the schema tree, so
+// it reads "Data" with a tree icon (VIS-1004 §8.5 — show the outline only where
+// relevant, renamed to fit the object). Every other object keeps "Outline".
+const getTabs = isSource =>
+  isSource
+    ? [
+        { key: 'outline', label: 'Data', icon: PiTreeStructure },
+        { key: 'edit', label: 'Edit', icon: PiPencil },
+      ]
+    : [
+        { key: 'outline', label: 'Outline', icon: PiList },
+        { key: 'edit', label: 'Edit', icon: PiPencil },
+      ];
 
 const TabBtn = ({ tab, active, onClick }) => {
   const Icon = tab.icon;
@@ -50,9 +61,14 @@ const TabBtn = ({ tab, active, onClick }) => {
   );
 };
 
-const RightRailBody = ({ activeTab }) => {
+const RightRailBody = ({ activeTab, selectedItem }) => {
   if (activeTab === 'outline') {
-    // VIS-793 / Track F F-3 — the real Outline tree of the scoped dashboard.
+    // VIS-1004 — when a `source` is the active object, the Outline ("Data") tab
+    // browses its db → schema → table → column tree instead of dead-ending on
+    // NoDashboardState. Every other object keeps the dashboard outline (F-3).
+    if (selectedItem && selectedItem.type === 'source') {
+      return <SourceOutlineTreePanel sourceName={selectedItem.name} />;
+    }
     return <OutlineTreePanel />;
   }
   // Edit is the default tab — also the fallthrough so any unknown tab key
@@ -63,6 +79,8 @@ const RightRailBody = ({ activeTab }) => {
 
 const RightRailExpanded = ({
   activeTab,
+  tabs,
+  selectedItem,
   onSelectTab,
   onCollapse,
 }) => {
@@ -74,7 +92,7 @@ const RightRailExpanded = ({
     >
       <div className="flex h-10 shrink-0 items-center justify-between border-b border-gray-200 pl-2 pr-3">
         <div role="tablist" aria-label="Right rail" className="flex h-full items-center gap-1">
-          {TABS.map((tab) => (
+          {tabs.map((tab) => (
             <TabBtn
               key={tab.key}
               tab={tab}
@@ -94,12 +112,12 @@ const RightRailExpanded = ({
           <PiSidebar className="h-4 w-4 -scale-x-100" />
         </button>
       </div>
-      <RightRailBody activeTab={activeTab} />
+      <RightRailBody activeTab={activeTab} selectedItem={selectedItem} />
     </aside>
   );
 };
 
-const RightRailCollapsed = ({ activeTab, onExpand }) => {
+const RightRailCollapsed = ({ activeTab, tabs, onExpand }) => {
   return (
     <aside
       data-testid="workspace-right-rail"
@@ -117,7 +135,7 @@ const RightRailCollapsed = ({ activeTab, onExpand }) => {
         <PiSidebar className="h-4 w-4 -scale-x-100" />
       </button>
       <div className="flex flex-1 flex-col items-center gap-1 py-2">
-        {TABS.map((tab) => {
+        {tabs.map((tab) => {
           const Icon = tab.icon;
           const active = tab.key === activeTab;
           return (
@@ -150,6 +168,12 @@ const RightRail = () => {
   const activeTab = useStore(s => s.workspaceRightTab);
   const setRightTab = useStore(s => s.setWorkspaceRightTab);
 
+  // The active object decides BOTH which Outline body mounts (source → schema
+  // tree) and the Outline tab label (source → "Data"). VIS-1004.
+  const { selectedItem } = useWorkspaceScope();
+  const isSource = selectedItem?.type === 'source';
+  const tabs = React.useMemo(() => getTabs(isSource), [isSource]);
+
   // Wrap the store setter so the right-rail tab switch fires telemetry
   // (VIS-793). Only emit when the tab actually changes — re-clicking the
   // active tab is a no-op.
@@ -163,10 +187,12 @@ const RightRail = () => {
   );
 
   return collapsed ? (
-    <RightRailCollapsed activeTab={activeTab} onExpand={toggleCollapsed} />
+    <RightRailCollapsed activeTab={activeTab} tabs={tabs} onExpand={toggleCollapsed} />
   ) : (
     <RightRailExpanded
       activeTab={activeTab}
+      tabs={tabs}
+      selectedItem={selectedItem}
       onSelectTab={onSelectTab}
       onCollapse={toggleCollapsed}
     />

--- a/viewer/src/components/new-views/workspace/RightRail.test.jsx
+++ b/viewer/src/components/new-views/workspace/RightRail.test.jsx
@@ -18,6 +18,18 @@ import RightRail from './RightRail';
 import useStore from '../../../stores/store';
 import { setWorkspaceTelemetryListener } from './telemetry';
 
+// SourceOutlineTreePanel (mounted for source scope) hits the source-metadata +
+// schema-jobs APIs on mount — stub them so the branch test stays isolated.
+jest.mock('../../../api/explorer', () => ({
+  fetchSourceMetadata: jest.fn(() => Promise.resolve({ sources: [] })),
+}));
+jest.mock('../../../api/sourceSchemaJobs', () => ({
+  generateSourceSchema: jest.fn(),
+  fetchSchemaGenerationStatus: jest.fn(),
+  fetchSourceTables: jest.fn(() => Promise.resolve([])),
+  fetchTableColumns: jest.fn(() => Promise.resolve([])),
+}));
+
 const resetStore = (overrides = {}) => {
   act(() => {
     useStore.setState({
@@ -87,5 +99,59 @@ describe('RightRail (VIS-793)', () => {
     } finally {
       unsubscribe();
     }
+  });
+});
+
+describe('RightRail Outline body branch (VIS-1004)', () => {
+  // Drive the active object via a workspace tab so `useWorkspaceScope` yields
+  // the desired `selectedItem.type`. A `source` tab takes precedence over the
+  // dashboard URL param (see useWorkspaceScope), so the source outline mounts.
+  const resetForScope = ({ tabType, tabName, dashboards = [] }) => {
+    act(() => {
+      useStore.setState({
+        workspaceRightCollapsed: false,
+        workspaceRightTab: 'outline',
+        workspaceTabs: [{ id: 't1', type: tabType, name: tabName }],
+        workspaceActiveTabId: 't1',
+        workspaceActiveObject: { type: tabType, name: tabName },
+        workspaceOutlineSelectedKey: 'dashboard',
+        workspaceSourceOutlineSelectedKey: null,
+        workspaceSourceOutlineExpanded: {},
+        dashboards,
+        saveDashboard: jest.fn(),
+      });
+    });
+  };
+
+  const renderAt = (entry) => {
+    const router = createMemoryRouter(
+      createRoutesFromElements(
+        <Route path="/workspace/dashboard/:dashboardName" element={<RightRail />} />
+      ),
+      { initialEntries: [entry], future: futureFlags }
+    );
+    return render(<RouterProvider router={router} future={futureFlags} />);
+  };
+
+  test('source scope mounts the source outline (not the dashboard outline)', async () => {
+    resetForScope({ tabType: 'source', tabName: 'analytics_db' });
+    renderAt('/workspace/dashboard/simple-dashboard');
+
+    expect(screen.getByTestId('workspace-source-outline')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-right-rail-outline')).not.toBeInTheDocument();
+    // The Outline tab is relabelled "Data" for a source.
+    expect(screen.getByTestId('workspace-right-rail-tab-outline')).toHaveTextContent('Data');
+    // Let the source-metadata fetch settle so its state update is wrapped in act
+    // (the mock resolves an empty source → the cold-source affordance).
+    expect(await screen.findByTestId('source-outline-cold')).toBeInTheDocument();
+  });
+
+  test('dashboard scope mounts the dashboard outline (not the source outline)', () => {
+    resetForScope({ tabType: 'dashboard', tabName: 'simple-dashboard' });
+    renderAt('/workspace/dashboard/simple-dashboard');
+
+    expect(screen.getByTestId('workspace-right-rail-outline')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-source-outline')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-right-rail-tab-outline')).toHaveTextContent('Outline');
   });
 });

--- a/viewer/src/components/new-views/workspace/SourceOutlineTreePanel.jsx
+++ b/viewer/src/components/new-views/workspace/SourceOutlineTreePanel.jsx
@@ -1,0 +1,434 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  PiCaretDown,
+  PiDatabase,
+  PiFolder,
+  PiColumns,
+  PiMagnifyingGlass,
+  PiArrowsClockwise,
+  PiSpinnerGap,
+  PiHardDrives,
+  PiWarningCircle,
+} from 'react-icons/pi';
+import useStore from '../../../stores/store';
+import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
+import useSourceOutline, { sourceRootKey } from './useSourceOutline';
+
+/**
+ * SourceOutlineTreePanel — VIS-1004 (Canvas Object Surfaces, Track N).
+ *
+ * The right-rail "Data" outline when a `source` is the active workspace object.
+ * Mounted by branching `RightRail::RightRailBody` on the active object type —
+ * `source` → this panel, anything else → the dashboard `OutlineTreePanel`.
+ *
+ * Renders the source's database → schema → table → column tree as an
+ * Explorer-style expandable, searchable tree. It REUSES `OutlineTreePanel`'s
+ * recursive Node shell idiom (the mulberry selection bar + caret disclosure +
+ * indent + truncation) rather than importing the left-nav `SchemaTreeNode`, and
+ * layers the Explorer's in-tree search + type badges on top. Data + the
+ * cold-source generate/poll flow come from `useSourceOutline` (mirroring the
+ * Explorer's SourceBrowser backend + frontend).
+ *
+ * Selection / expand state:
+ *   - Selection writes a DISJOINT `source-outline::…` key into the new
+ *     `workspaceSourceOutlineSelectedKey` store slice (never the dashboard's
+ *     `workspaceOutlineSelectedKey`), so the two outlines can't collide.
+ *   - Expand/collapse is remembered PER SESSION, PER SOURCE in
+ *     `workspaceSourceOutlineExpanded[sourceName]`.
+ *
+ * Type colours + icons come ONLY from `objectTypeConfigs` (source = orange,
+ * table = fuchsia); db/schema use neutral grouping icons; columns render a
+ * monospace type badge.
+ */
+
+const SourceIcon = getTypeIcon('source');
+const TableIcon = getTypeIcon('table');
+
+const KIND_ICON = {
+  database: PiDatabase,
+  schema: PiFolder,
+  table: TableIcon,
+  column: PiColumns,
+};
+
+const matchesSearch = (name, query) =>
+  !query || (name || '').toLowerCase().includes(query.toLowerCase());
+
+/** Does this node (or any descendant) match the query? Drives search filtering. */
+const nodeMatches = (node, query) => {
+  if (!query) return true;
+  if (matchesSearch(node.name, query)) return true;
+  const children = Array.isArray(node.children) ? node.children : [];
+  return children.some(child => nodeMatches(child, query));
+};
+
+/**
+ * One tree row. Recursive: `children` renders the nested sub-tree. Indent is
+ * computed from `level`. Mirrors OutlineTreePanel.Node's mulberry selection
+ * idiom; adds a right-aligned type badge for column nodes.
+ */
+const Node = ({
+  level,
+  kind,
+  icon: Icon,
+  iconClassName,
+  label,
+  badge,
+  meta,
+  selected,
+  selectionKey,
+  onSelect,
+  testId,
+  collapsed = false,
+  onToggle,
+  hasChildren = false,
+  children,
+}) => {
+  const indent = 6 + level * 14;
+
+  const handleClick = useCallback(
+    e => {
+      e.stopPropagation();
+      onSelect && onSelect(selectionKey);
+    },
+    [onSelect, selectionKey]
+  );
+
+  return (
+    <div className="flex flex-col">
+      <div
+        role="button"
+        tabIndex={0}
+        data-testid={testId}
+        data-kind={kind}
+        data-selected={selected ? 'true' : 'false'}
+        data-selection-key={selectionKey}
+        onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect && onSelect(selectionKey);
+          }
+        }}
+        className={[
+          'group/node relative flex h-7 cursor-pointer items-center gap-1.5 pr-2 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[#713b57]/30',
+          selected ? 'bg-[#e2d7dd]/55 text-[#5a2f45]' : 'hover:bg-gray-50',
+        ].join(' ')}
+        style={{ paddingLeft: indent }}
+      >
+        {selected && (
+          <span
+            aria-hidden="true"
+            className="absolute left-0 top-1 bottom-1 w-[2px] rounded-r bg-[#713b57]"
+          />
+        )}
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
+            aria-expanded={!collapsed}
+            data-testid={`${testId}-toggle`}
+            onClick={e => {
+              e.stopPropagation();
+              onToggle && onToggle();
+            }}
+            className="-ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-200/70 hover:text-gray-600"
+          >
+            <PiCaretDown
+              aria-hidden="true"
+              className={`h-3 w-3 transition-transform ${collapsed ? '-rotate-90' : ''}`}
+            />
+          </button>
+        ) : (
+          <span aria-hidden="true" className="h-3 w-3 shrink-0" />
+        )}
+        <Icon
+          aria-hidden="true"
+          style={{ fontSize: 14 }}
+          className={`shrink-0 ${selected ? 'text-[#5a2f45]' : iconClassName || 'text-gray-500'}`}
+        />
+        <span
+          className={`min-w-0 flex-1 truncate text-[12.5px] ${selected ? 'font-semibold' : ''}`}
+        >
+          {label}
+        </span>
+        {badge && (
+          <span className="shrink-0 rounded bg-gray-100 px-1 py-px font-mono text-[9.5px] uppercase tracking-tight text-gray-500 group-hover/node:bg-gray-200/70">
+            {badge}
+          </span>
+        )}
+        {meta && (
+          <span className="shrink-0 text-[10px] uppercase tracking-wide text-gray-400 group-hover/node:text-gray-500">
+            {meta}
+          </span>
+        )}
+      </div>
+      {hasChildren && !collapsed && <div className="flex flex-col">{children}</div>}
+    </div>
+  );
+};
+
+const EmptyState = ({ icon: Icon, title, body, testId, children }) => (
+  <div
+    data-testid={testId}
+    className="flex flex-1 flex-col items-center justify-center px-6 py-8 text-center"
+  >
+    <div className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+      <Icon aria-hidden="true" className="h-4 w-4" />
+    </div>
+    <p className="mt-2 text-[13px] font-medium text-gray-900">{title}</p>
+    {body && <p className="mt-1 text-[11px] leading-relaxed text-gray-500">{body}</p>}
+    {children}
+  </div>
+);
+
+const SourceOutlineTreePanel = ({ sourceName }) => {
+  const {
+    available,
+    loading,
+    nodes,
+    error,
+    isCold,
+    generating,
+    generateSchema,
+    loadFlatColumns,
+    flatColumns,
+  } = useSourceOutline(sourceName);
+
+  const selectedKey = useStore(s => s.workspaceSourceOutlineSelectedKey);
+  const setSelectedKey = useStore(s => s.setWorkspaceSourceOutlineSelectedKey);
+  const expandedBySource = useStore(s => s.workspaceSourceOutlineExpanded);
+  const toggleExpanded = useStore(s => s.toggleWorkspaceSourceOutlineExpanded);
+
+  const [query, setQuery] = useState('');
+
+  const sourceColors = getTypeColors('source');
+  const tableColors = getTypeColors('table');
+
+  // Per-source expanded set (session memory). The source root is expanded by
+  // default; everything else honours the remembered set.
+  const expandedSet = useMemo(
+    () => new Set(expandedBySource?.[sourceName] || []),
+    [expandedBySource, sourceName]
+  );
+
+  const handleToggle = useCallback(
+    key => {
+      const wasExpanded = expandedSet.has(key);
+      toggleExpanded(sourceName, key);
+      // Lazy-load columns for flat-fallback tables on first expand.
+      if (!wasExpanded && key.includes('::table::')) {
+        loadFlatColumns(key);
+      }
+    },
+    [expandedSet, toggleExpanded, sourceName, loadFlatColumns]
+  );
+
+  // Dist / cloud: every source endpoint is null → degrade to a clear empty state.
+  if (!available) {
+    return (
+      <div
+        data-testid="workspace-source-outline"
+        className="flex flex-1 flex-col overflow-hidden"
+      >
+        <EmptyState
+          icon={PiHardDrives}
+          testId="source-outline-unavailable"
+          title="Schema browsing isn't available here"
+          body={
+            <>
+              The database outline is available under{' '}
+              <span className="font-mono text-[10.5px] text-gray-700">visivo serve</span>.
+            </>
+          }
+        />
+      </div>
+    );
+  }
+
+  const renderColumnNode = (col, level) => {
+    if (!col || !col.name) return null;
+    return (
+      <Node
+        key={col.key}
+        level={level}
+        kind="column"
+        icon={KIND_ICON.column}
+        iconClassName="text-fuchsia-400"
+        label={col.name}
+        badge={col.type || null}
+        selected={selectedKey === col.key}
+        selectionKey={col.key}
+        onSelect={setSelectedKey}
+        testId={`source-outline-node-${col.key}`}
+      />
+    );
+  };
+
+  const renderTableNode = (table, level) => {
+    if (!nodeMatches(table, query)) return null;
+    // Nested feed columns are eager (`table.children`); flat feed lazy-loads
+    // into `flatColumns[tableKey]`. Either supplies the column rows.
+    const lazyCols = flatColumns?.[table.key];
+    const cols = Array.isArray(table.children)
+      ? table.children
+      : Array.isArray(lazyCols)
+        ? lazyCols
+        : null;
+    const hasChildren = cols == null || cols.length > 0;
+    const collapsed = !expandedSet.has(table.key);
+
+    return (
+      <Node
+        key={table.key}
+        level={level}
+        kind="table"
+        icon={KIND_ICON.table}
+        iconClassName={tableColors.text}
+        label={table.name}
+        meta={Array.isArray(cols) ? `${cols.length} col${cols.length === 1 ? '' : 's'}` : null}
+        selected={selectedKey === table.key}
+        selectionKey={table.key}
+        onSelect={setSelectedKey}
+        hasChildren={hasChildren}
+        collapsed={collapsed}
+        onToggle={() => handleToggle(table.key)}
+        testId={`source-outline-node-${table.key}`}
+      >
+        {Array.isArray(cols)
+          ? cols
+              .filter(col => matchesSearch(col.name, query))
+              .map(col => renderColumnNode(col, level + 1))
+          : null}
+      </Node>
+    );
+  };
+
+  const renderGroupNode = (node, level) => {
+    if (!nodeMatches(node, query)) return null;
+    const children = Array.isArray(node.children) ? node.children : [];
+    const collapsed = !expandedSet.has(node.key);
+    const isSchema = node.kind === 'schema';
+    return (
+      <Node
+        key={node.key}
+        level={level}
+        kind={node.kind}
+        icon={KIND_ICON[node.kind] || PiFolder}
+        iconClassName="text-gray-400"
+        label={node.name}
+        meta={node.kind}
+        selected={selectedKey === node.key}
+        selectionKey={node.key}
+        onSelect={setSelectedKey}
+        hasChildren={children.length > 0}
+        collapsed={collapsed}
+        onToggle={() => handleToggle(node.key)}
+        testId={`source-outline-node-${node.key}`}
+      >
+        {children.map(child =>
+          isSchema || node.kind === 'database'
+            ? child.kind === 'table'
+              ? renderTableNode(child, level + 1)
+              : renderGroupNode(child, level + 1)
+            : renderTableNode(child, level + 1)
+        )}
+      </Node>
+    );
+  };
+
+  const rootKey = sourceRootKey(sourceName);
+  const databaseNodes = Array.isArray(nodes) ? nodes : [];
+  const rootCollapsed = expandedSet.has(`${rootKey}::collapsed`);
+
+  return (
+    <div
+      data-testid="workspace-source-outline"
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      {/* In-tree search (Explorer idiom). */}
+      <div className="shrink-0 border-b border-gray-100 p-2">
+        <div className="relative">
+          <PiMagnifyingGlass
+            aria-hidden="true"
+            className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search tables & columns"
+            data-testid="source-outline-search"
+            className="h-7 w-full rounded-md border border-gray-200 bg-white pl-7 pr-2 text-[12px] text-gray-800 outline-none transition-colors placeholder:text-gray-400 focus:border-[#713b57]/40 focus:ring-2 focus:ring-[#713b57]/15"
+          />
+        </div>
+      </div>
+
+      {loading ? (
+        <EmptyState
+          icon={PiSpinnerGap}
+          testId="source-outline-loading"
+          title="Introspecting source…"
+          body="Reading databases, schemas, and tables."
+        />
+      ) : isCold ? (
+        <EmptyState
+          icon={SourceIcon}
+          testId="source-outline-cold"
+          title="No schema cached yet"
+          body={
+            generating
+              ? `Generating schema… ${Math.round((generating.progress || 0) * 100)}%`
+              : 'Generate the schema to browse this source.'
+          }
+        >
+          <button
+            type="button"
+            onClick={generateSchema}
+            disabled={!!generating}
+            data-testid="source-outline-generate"
+            className="mt-3 inline-flex h-7 items-center gap-1.5 rounded-md bg-[#713b57] px-2.5 text-[12px] font-semibold text-white shadow-sm transition-colors hover:bg-[#5a2f45] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {generating ? (
+              <PiSpinnerGap aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <PiArrowsClockwise aria-hidden="true" className="h-3.5 w-3.5" />
+            )}
+            {generating ? 'Generating…' : 'Generate schema'}
+          </button>
+          {error && (
+            <p className="mt-2 inline-flex items-center gap-1 text-[10.5px] text-red-600">
+              <PiWarningCircle aria-hidden="true" className="h-3.5 w-3.5" />
+              {error}
+            </p>
+          )}
+        </EmptyState>
+      ) : (
+        <div
+          data-testid="source-outline-tree"
+          className="flex-1 overflow-y-auto py-2 text-[13px] text-gray-800"
+        >
+          <Node
+            level={0}
+            kind="source"
+            icon={SourceIcon}
+            iconClassName={sourceColors.text}
+            label={sourceName}
+            meta={`${databaseNodes.length} db${databaseNodes.length === 1 ? '' : 's'}`}
+            selected={selectedKey === rootKey}
+            selectionKey={rootKey}
+            onSelect={setSelectedKey}
+            hasChildren={databaseNodes.length > 0}
+            collapsed={rootCollapsed}
+            onToggle={() => handleToggle(`${rootKey}::collapsed`)}
+            testId="source-outline-node-root"
+          >
+            {databaseNodes.map(db => renderGroupNode(db, 1))}
+          </Node>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SourceOutlineTreePanel;

--- a/viewer/src/components/new-views/workspace/SourceOutlineTreePanel.test.jsx
+++ b/viewer/src/components/new-views/workspace/SourceOutlineTreePanel.test.jsx
@@ -1,0 +1,177 @@
+/**
+ * SourceOutlineTreePanel tests (VIS-1004 / Canvas Object Surfaces, Track N).
+ *
+ * The panel renders a source's database → schema → table → column tree from the
+ * nested `fetchSourceMetadata` feed (mirroring the Explorer's SourceBrowser),
+ * dispatches selection through the DISJOINT `workspaceSourceOutlineSelectedKey`
+ * store slice, remembers expand/collapse per source, offers a cold-source
+ * "Generate schema" affordance, and degrades to an empty state when the source
+ * endpoints are null (dist/cloud).
+ */
+import React from 'react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import SourceOutlineTreePanel from './SourceOutlineTreePanel';
+import useStore from '../../../stores/store';
+import {
+  setGlobalURLConfig,
+  createURLConfig,
+} from '../../../contexts/URLContext';
+
+jest.mock('../../../api/explorer', () => ({
+  fetchSourceMetadata: jest.fn(),
+}));
+jest.mock('../../../api/sourceSchemaJobs', () => ({
+  generateSourceSchema: jest.fn(),
+  fetchSchemaGenerationStatus: jest.fn(),
+  fetchSourceTables: jest.fn(),
+  fetchTableColumns: jest.fn(),
+}));
+
+const { fetchSourceMetadata } = require('../../../api/explorer');
+const {
+  generateSourceSchema,
+  fetchSchemaGenerationStatus,
+  fetchSourceTables,
+} = require('../../../api/sourceSchemaJobs');
+
+const SRC = 'analytics_db';
+
+// A connected source with a database that has a schema, a table, and columns.
+const NESTED_CONNECTED = {
+  sources: [
+    {
+      name: SRC,
+      type: 'postgresql',
+      status: 'connected',
+      databases: [
+        {
+          name: 'main',
+          schemas: [
+            {
+              name: 'public',
+              tables: [
+                { name: 'orders', columns: ['id', 'amount'] },
+                { name: 'users', columns: ['id', 'email'] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const resetStore = () => {
+  act(() => {
+    useStore.setState({
+      workspaceSourceOutlineSelectedKey: null,
+      workspaceSourceOutlineExpanded: {},
+    });
+  });
+};
+
+const setServerEnv = () => {
+  setGlobalURLConfig(createURLConfig({ environment: 'server' }));
+};
+const setDistEnv = () => {
+  setGlobalURLConfig(createURLConfig({ environment: 'dist' }));
+};
+
+describe('SourceOutlineTreePanel (VIS-1004)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+    setServerEnv();
+    fetchSourceMetadata.mockResolvedValue(NESTED_CONNECTED);
+  });
+
+  afterEach(() => {
+    setServerEnv();
+  });
+
+  test('renders the nested db → schema → table tree from mocked metadata', async () => {
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+
+    // Source root renders immediately; the tree fills after the metadata load.
+    expect(screen.getByTestId('workspace-source-outline')).toBeInTheDocument();
+    expect(await screen.findByTestId('source-outline-node-root')).toBeInTheDocument();
+
+    // The database grouping node renders under the (default-expanded) root.
+    const dbKey = `source-outline::${SRC}::db::main`;
+    expect(await screen.findByTestId(`source-outline-node-${dbKey}`)).toBeInTheDocument();
+
+    // Children are collapsed by default — expanding the db reveals its schema.
+    fireEvent.click(screen.getByTestId(`source-outline-node-${dbKey}-toggle`));
+    expect(
+      await screen.findByTestId(`source-outline-node-${dbKey}::schema::public`)
+    ).toBeInTheDocument();
+  });
+
+  test('expand/collapse toggles a node and persists per source in the store', async () => {
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+    const dbKey = `source-outline::${SRC}::db::main`;
+    const schemaKey = `${dbKey}::schema::public`;
+
+    // The schema node exists (db is expanded by default since the root + db are
+    // not in the collapsed-by-default set — expand state defaults to collapsed,
+    // so first we expand the root, db, then the schema to reach a table).
+    const dbToggle = await screen.findByTestId(`source-outline-node-${dbKey}-toggle`);
+    fireEvent.click(dbToggle);
+    expect(useStore.getState().workspaceSourceOutlineExpanded[SRC]).toContain(dbKey);
+
+    // The table appears once the schema is expanded.
+    const schemaToggle = screen.getByTestId(`source-outline-node-${schemaKey}-toggle`);
+    fireEvent.click(schemaToggle);
+    expect(useStore.getState().workspaceSourceOutlineExpanded[SRC]).toContain(schemaKey);
+    expect(
+      await screen.findByTestId(`source-outline-node-${schemaKey}::table::orders`)
+    ).toBeInTheDocument();
+  });
+
+  test('clicking a node writes the disjoint source-outline selection key', async () => {
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+    const dbNode = await screen.findByTestId(
+      `source-outline-node-source-outline::${SRC}::db::main`
+    );
+    fireEvent.click(dbNode);
+    expect(useStore.getState().workspaceSourceOutlineSelectedKey).toBe(
+      `source-outline::${SRC}::db::main`
+    );
+    // The dashboard outline key is never touched.
+    expect(useStore.getState().workspaceOutlineSelectedKey).not.toContain('source-outline');
+  });
+
+  test('cold source offers Generate schema and fills the tree after polling', async () => {
+    // Nested feed returns a connection_failed source (zero databases) → cold.
+    fetchSourceMetadata.mockResolvedValue({
+      sources: [
+        { name: SRC, type: 'postgresql', status: 'connection_failed', databases: [] },
+      ],
+    });
+    generateSourceSchema.mockResolvedValue({ run_id: 'run-1' });
+    fetchSchemaGenerationStatus.mockResolvedValue({ status: 'completed', progress: 1 });
+    fetchSourceTables.mockResolvedValue([{ name: 'events' }]);
+
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+
+    const generateBtn = await screen.findByTestId('source-outline-generate');
+    expect(screen.getByTestId('source-outline-cold')).toBeInTheDocument();
+
+    fireEvent.click(generateBtn);
+
+    await waitFor(() => expect(generateSourceSchema).toHaveBeenCalledWith(SRC));
+    // After generation completes the flat tree (events table) is rendered.
+    expect(
+      await screen.findByTestId(`source-outline-node-source-outline::${SRC}::db::${SRC}`)
+    ).toBeInTheDocument();
+  });
+
+  test('degrades to the visivo serve empty state when endpoints are null (dist)', async () => {
+    setDistEnv();
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+    expect(screen.getByTestId('source-outline-unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/visivo serve/i)).toBeInTheDocument();
+    // The nested feed is never called when unavailable.
+    expect(fetchSourceMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/new-views/workspace/useSourceOutline.js
+++ b/viewer/src/components/new-views/workspace/useSourceOutline.js
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isAvailable } from '../../../contexts/URLContext';
+import { fetchSourceMetadata } from '../../../api/explorer';
+import {
+  generateSourceSchema,
+  fetchSchemaGenerationStatus,
+  fetchSourceTables,
+  fetchTableColumns,
+} from '../../../api/sourceSchemaJobs';
+
+/**
+ * useSourceOutline — VIS-1004 data feed for the right-rail source outline.
+ *
+ * Mirrors the Explorer's backend + frontend (SourceBrowser) but normalises the
+ * two divergent shapes into ONE nested db → schema → table → column tree:
+ *
+ *   - **Nested (primary):** `fetchSourceMetadata()` → the legacy introspect
+ *     path is the only feed carrying db/schema. Shape:
+ *       { sources: [{ name, type, status, databases:[
+ *           { name, schemas:[{ name, tables:[{ name, columns:[colName,…] }] }],
+ *                   tables:[{ name, columns:[colName,…] }] }  // schemas|tables
+ *       ] }] }
+ *     Columns here are bare strings (no type info).
+ *   - **Flat (fallback):** the cached `source-schema-jobs` path
+ *     (`fetchSourceTables` / `fetchTableColumns`) is source → table → column
+ *     with NO db/schema and column objects `{ name, type }`. Used to enrich
+ *     column types and as the cold-source generate target.
+ *
+ * Both normalise to nodes of the form:
+ *   { key, kind: 'database'|'schema'|'table'|'column', name, type?, children? }
+ * keyed with the disjoint `source-outline::…` grammar so the dashboard outline
+ * consumers never collide.
+ *
+ * `isAvailable` gating means this degrades cleanly in dist/cloud (every source
+ * endpoint URL is null there) — `available` flips false and the panel renders
+ * the "available under `visivo serve`" empty state instead of dead-ending.
+ */
+
+const KEY_ROOT = 'source-outline';
+
+export const sourceRootKey = src => `${KEY_ROOT}::${src}`;
+export const dbKey = (src, db) => `${sourceRootKey(src)}::db::${db}`;
+export const schemaKey = (src, db, schema) => `${dbKey(src, db)}::schema::${schema}`;
+export const tableKey = (src, db, schema, table) =>
+  schema != null
+    ? `${schemaKey(src, db, schema)}::table::${table}`
+    : `${dbKey(src, db)}::table::${table}`;
+export const columnKey = (parentTableKey, col) => `${parentTableKey}::col::${col}`;
+
+/**
+ * Normalise the nested `fetchSourceMetadata` entry for one source into the
+ * shared node tree. Returns `{ nodes, status, error }`.
+ */
+const normalizeNested = (sourceName, entry) => {
+  if (!entry) return { nodes: [], status: 'missing', error: null };
+  const databases = Array.isArray(entry.databases) ? entry.databases : [];
+
+  const databaseNodes = databases.map(db => {
+    const dKey = dbKey(sourceName, db.name);
+
+    const buildTableNode = (table, schemaName) => {
+      const tKey = tableKey(sourceName, db.name, schemaName, table.name);
+      const columns = Array.isArray(table.columns) ? table.columns : [];
+      return {
+        key: tKey,
+        kind: 'table',
+        name: table.name,
+        children: columns.map(col => {
+          // Nested columns are bare strings; flat columns are { name, type }.
+          const colName = typeof col === 'string' ? col : col?.name;
+          const colType = typeof col === 'string' ? null : col?.type || null;
+          return {
+            key: columnKey(tKey, colName),
+            kind: 'column',
+            name: colName,
+            type: colType,
+          };
+        }),
+      };
+    };
+
+    if (Array.isArray(db.schemas)) {
+      return {
+        key: dKey,
+        kind: 'database',
+        name: db.name,
+        children: db.schemas.map(schema => {
+          const sKey = schemaKey(sourceName, db.name, schema.name);
+          const tables = Array.isArray(schema.tables) ? schema.tables : [];
+          return {
+            key: sKey,
+            kind: 'schema',
+            name: schema.name,
+            children: tables.map(t => buildTableNode(t, schema.name)),
+          };
+        }),
+      };
+    }
+
+    const tables = Array.isArray(db.tables) ? db.tables : [];
+    return {
+      key: dKey,
+      kind: 'database',
+      name: db.name,
+      // No schemas → tables hang directly off the database.
+      children: tables.map(t => buildTableNode(t, null)),
+      error: db.error || null,
+    };
+  });
+
+  return {
+    nodes: databaseNodes,
+    status: entry.status || 'connected',
+    error: entry.error || null,
+  };
+};
+
+/**
+ * Build a flat-fallback tree (no db/schema) from the cached schema-jobs path.
+ * Synthesises a single pseudo-database node so the renderer stays uniform.
+ */
+const buildFlatTree = (sourceName, tables) => {
+  const dKey = dbKey(sourceName, sourceName);
+  return [
+    {
+      key: dKey,
+      kind: 'database',
+      name: sourceName,
+      flat: true,
+      children: (tables || []).map(table => {
+        const name = typeof table === 'string' ? table : table.name;
+        const tKey = tableKey(sourceName, sourceName, null, name);
+        return {
+          key: tKey,
+          kind: 'table',
+          name,
+          // Columns lazy-load on expand for the flat path (see loadFlatColumns).
+          children: null,
+        };
+      }),
+    },
+  ];
+};
+
+export default function useSourceOutline(sourceName) {
+  // The nested feed is the source of truth; `null` until first load completes.
+  const [nestedNodes, setNestedNodes] = useState(null);
+  const [status, setStatus] = useState('idle'); // idle | loading | connected | connection_failed | missing | error
+  const [error, setError] = useState(null);
+
+  // Flat-fallback state (cold source generate + lazy column loads).
+  const [flatNodes, setFlatNodes] = useState(null);
+  const [flatColumns, setFlatColumns] = useState({}); // tableKey -> column nodes
+  const [generating, setGenerating] = useState(null); // { status, progress, message } | null
+  const cancelledRef = useRef(false);
+
+  const available = useMemo(
+    () => isAvailable('sourcesMetadata') || isAvailable('sourceSchemaJobsList'),
+    []
+  );
+  const nestedAvailable = useMemo(() => isAvailable('sourcesMetadata'), []);
+
+  const loadNested = useCallback(async () => {
+    if (!sourceName || !nestedAvailable) return;
+    setStatus('loading');
+    setError(null);
+    try {
+      const data = await fetchSourceMetadata();
+      if (cancelledRef.current) return;
+      const entry = (data?.sources || []).find(s => s.name === sourceName);
+      const { nodes, status: entryStatus, error: entryError } = normalizeNested(
+        sourceName,
+        entry
+      );
+      setNestedNodes(nodes);
+      setStatus(entryStatus);
+      setError(entryError);
+    } catch (e) {
+      if (cancelledRef.current) return;
+      setStatus('error');
+      setError(e.message);
+      setNestedNodes([]);
+    }
+  }, [sourceName, nestedAvailable]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    // Reset per-source so switching sources never bleeds stale nodes.
+    setNestedNodes(null);
+    setFlatNodes(null);
+    setFlatColumns({});
+    setGenerating(null);
+    setStatus('idle');
+    setError(null);
+    loadNested();
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [sourceName, loadNested]);
+
+  /**
+   * Cold-source "Generate schema" — lifted from SourceBrowser.handleGenerateSchema.
+   * Triggers the schema-jobs generate run, polls to completion, then loads the
+   * flat tables as a fallback feed (the nested feed remains primary when it can
+   * connect; this fills the tree for sources the nested introspect can't reach).
+   */
+  const generateSchema = useCallback(async () => {
+    if (!sourceName || !isAvailable('sourceSchemaJobCreate')) return;
+    setGenerating({ status: 'starting', progress: 0, message: '' });
+    setError(null);
+    try {
+      const { run_id: runId } = await generateSourceSchema(sourceName);
+      const maxWaitTime = 120000;
+      const pollInterval = 2000;
+      const startTime = Date.now();
+
+      while (Date.now() - startTime < maxWaitTime) {
+        if (cancelledRef.current) return;
+        const st = await fetchSchemaGenerationStatus(runId);
+        setGenerating({
+          status: st.status,
+          progress: st.progress || 0,
+          message: st.progress_message || '',
+        });
+
+        if (st.status === 'completed') {
+          const tables = await fetchSourceTables(sourceName);
+          if (cancelledRef.current) return;
+          setFlatNodes(buildFlatTree(sourceName, tables));
+          setGenerating(null);
+          // Re-attempt the nested feed; it may now connect/cache.
+          loadNested();
+          return;
+        }
+        if (st.status === 'failed') {
+          throw new Error(st.error || 'Schema generation failed');
+        }
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+      }
+      throw new Error('Schema generation timed out');
+    } catch (e) {
+      if (cancelledRef.current) return;
+      setGenerating(null);
+      setError(e.message);
+    }
+  }, [sourceName, loadNested]);
+
+  /**
+   * Lazy-load columns for a flat-fallback table on expand (the flat path has no
+   * eager column data). No-op for the nested feed, whose columns are eager.
+   */
+  const loadFlatColumns = useCallback(
+    async tKey => {
+      if (!sourceName || flatColumns[tKey]) return;
+      // tableKey grammar: …::table::<name>
+      const match = tKey.match(/::table::(.+)$/);
+      const tableName = match ? match[1] : null;
+      if (!tableName) return;
+      try {
+        const cols = await fetchTableColumns(sourceName, tableName);
+        if (cancelledRef.current) return;
+        setFlatColumns(prev => ({
+          ...prev,
+          [tKey]: (cols || []).map(c => {
+            const name = typeof c === 'string' ? c : c.name;
+            return {
+              key: columnKey(tKey, name),
+              kind: 'column',
+              name,
+              type: typeof c === 'string' ? null : c.type || null,
+            };
+          }),
+        }));
+      } catch (e) {
+        if (cancelledRef.current) return;
+        setFlatColumns(prev => ({ ...prev, [tKey]: { error: e.message } }));
+      }
+    },
+    [sourceName, flatColumns]
+  );
+
+  // Prefer the nested tree; fall back to the generated flat tree. A source is
+  // "cold" (offer Generate) when the nested feed connected with zero databases
+  // AND no flat tree has been generated yet.
+  const nodes = useMemo(() => {
+    if (nestedNodes && nestedNodes.length > 0) return nestedNodes;
+    if (flatNodes && flatNodes.length > 0) return flatNodes;
+    if (nestedNodes && nestedNodes.length === 0) return [];
+    return null;
+  }, [nestedNodes, flatNodes]);
+
+  const isCold = useMemo(() => {
+    if (!available) return false;
+    if (generating) return false;
+    if (flatNodes && flatNodes.length > 0) return false;
+    // Empty nested result (no dbs / connection_failed) → cold, offer generate.
+    return (
+      status === 'connection_failed' ||
+      status === 'missing' ||
+      (nestedNodes != null && nestedNodes.length === 0)
+    );
+  }, [available, generating, flatNodes, status, nestedNodes]);
+
+  return {
+    available,
+    loading: status === 'loading' && nestedNodes == null,
+    nodes,
+    status,
+    error,
+    isCold,
+    generating,
+    generateSchema,
+    loadFlatColumns,
+    flatColumns,
+    reload: loadNested,
+  };
+}

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -79,6 +79,24 @@ const createWorkspaceSlice = (set, get) => ({
   // hovering never mutates selection.
   workspaceCanvasHoverKey: null,
 
+  // Source outline (right-rail "Data" tab when a `source` is the active object,
+  // VIS-1004). A DISJOINT selection-key grammar from the dashboard outline so
+  // the two consumers never collide:
+  //   `source-outline::<src>::db::<d>` ·
+  //   `…::schema::<s>` · `…::table::<t>` · `…::col::<c>`
+  // The dashboard's `parseOutlineKey` safely falls through for these keys (it
+  // only recognises `dashboard` / `row.N` / `row.N.item.M`), and this lives on
+  // its own store key so a source selection can never leak into the dashboard
+  // Edit form. `null` = nothing selected in the source tree.
+  workspaceSourceOutlineSelectedKey: null,
+
+  // Per-source, per-session expand/collapse memory for the source outline. Keyed
+  // by source name → array of expanded node keys (db/schema/table). Arrays (not
+  // Sets) keep the slice serialisable and test-friendly; the panel rehydrates a
+  // Set from these on render. NOT persisted across reloads — session-only, as the
+  // schema can change between sessions (VIS-1004 §8.5).
+  workspaceSourceOutlineExpanded: {},
+
   // Resize state (Phase 0 visual stub; actual resizing comes later) --------
   workspaceLeftWidth: 320,
   workspaceRightWidth: 360,
@@ -339,6 +357,55 @@ const createWorkspaceSlice = (set, get) => ({
         ? state
         : { workspaceCanvasHoverKey: key || null }
     );
+  },
+
+  /**
+   * Select a node in the source outline (VIS-1004). `key` follows the disjoint
+   * `source-outline::…` grammar; passing the already-selected key (or `null`)
+   * toggles the selection off. Stored separately from the dashboard outline key
+   * so the two never collide.
+   */
+  setWorkspaceSourceOutlineSelectedKey: (key) => {
+    if (key != null && typeof key !== 'string') return;
+    set(state => ({
+      workspaceSourceOutlineSelectedKey:
+        state.workspaceSourceOutlineSelectedKey === key ? null : key || null,
+    }));
+  },
+
+  /**
+   * Toggle a node's expand state in the source outline for a given source.
+   * Per-source, per-session — `sourceName` partitions the expanded set so two
+   * sources keep independent disclosure state.
+   */
+  toggleWorkspaceSourceOutlineExpanded: (sourceName, nodeKey) => {
+    if (!sourceName || !nodeKey) return;
+    set(state => {
+      const current = state.workspaceSourceOutlineExpanded[sourceName] || [];
+      const next = current.includes(nodeKey)
+        ? current.filter(k => k !== nodeKey)
+        : [...current, nodeKey];
+      return {
+        workspaceSourceOutlineExpanded: {
+          ...state.workspaceSourceOutlineExpanded,
+          [sourceName]: next,
+        },
+      };
+    });
+  },
+
+  /**
+   * Replace the expanded-node set for a source (e.g. auto-expanding the tree
+   * after a cold-source schema generation completes). `nodeKeys` is an array.
+   */
+  setWorkspaceSourceOutlineExpanded: (sourceName, nodeKeys) => {
+    if (!sourceName || !Array.isArray(nodeKeys)) return;
+    set(state => ({
+      workspaceSourceOutlineExpanded: {
+        ...state.workspaceSourceOutlineExpanded,
+        [sourceName]: nodeKeys,
+      },
+    }));
   },
 
   /**

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -574,6 +574,58 @@ describe('workspace store slice', () => {
     expect(useStore.getState().workspaceOutlineSelectedKey).toBe('row.2.item.0');
   });
 
+  // Source outline (VIS-1004) — disjoint selection key + per-source expand -----
+
+  test('setWorkspaceSourceOutlineSelectedKey selects, toggles off, and stays disjoint', () => {
+    const key = 'source-outline::analytics_db::db::main::table::orders';
+    act(() => {
+      useStore.getState().setWorkspaceSourceOutlineSelectedKey(key);
+    });
+    expect(useStore.getState().workspaceSourceOutlineSelectedKey).toBe(key);
+    // The dashboard outline key is never touched by the source selection.
+    expect(useStore.getState().workspaceOutlineSelectedKey).not.toBe(key);
+    // Re-selecting the same key toggles the selection off.
+    act(() => {
+      useStore.getState().setWorkspaceSourceOutlineSelectedKey(key);
+    });
+    expect(useStore.getState().workspaceSourceOutlineSelectedKey).toBeNull();
+  });
+
+  test('toggleWorkspaceSourceOutlineExpanded adds/removes a node per source', () => {
+    act(() => {
+      useStore.getState().toggleWorkspaceSourceOutlineExpanded('src_a', 'node-1');
+      useStore.getState().toggleWorkspaceSourceOutlineExpanded('src_b', 'node-2');
+    });
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_a).toEqual(['node-1']);
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_b).toEqual(['node-2']);
+    // Toggling the same node removes it without touching the other source.
+    act(() => {
+      useStore.getState().toggleWorkspaceSourceOutlineExpanded('src_a', 'node-1');
+    });
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_a).toEqual([]);
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_b).toEqual(['node-2']);
+  });
+
+  test('setWorkspaceSourceOutlineExpanded replaces a source expanded set (auto-expand)', () => {
+    act(() => {
+      useStore
+        .getState()
+        .setWorkspaceSourceOutlineExpanded('src_a', ['db::main', 'db::main::schema::public']);
+    });
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_a).toEqual([
+      'db::main',
+      'db::main::schema::public',
+    ]);
+    // Non-array input is ignored.
+    act(() => {
+      useStore.getState().setWorkspaceSourceOutlineExpanded('src_a', 'not-an-array');
+    });
+    expect(useStore.getState().workspaceSourceOutlineExpanded.src_a).toEqual([
+      'db::main',
+      'db::main::schema::public',
+    ]);
+  });
+
   test('addDashboardRow appends an empty row, selects it, and persists the draft', () => {
     const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
     act(() => {


### PR DESCRIPTION
## VIS-1004 — Source schema outline in the workspace right-rail (Canvas Object Surfaces, Track N)

When a `source` is the active workspace object, the right-rail Outline tab now renders its **database → schema → table → column** tree (Explorer-style, expandable + searchable) instead of dead-ending on `NoDashboardState` — mirroring how dashboards have an outline.

Design: *Canvas Object Surfaces — Research & Design* §3 (Source canvas, part (a) Outline) + §8.5 (v2 source decisions, which override the earlier text).

### What's in this PR (Outline only)
This issue scopes the **right-rail outline**; the source ERD + outline→ERD filter wiring belongs to VIS-1005. The new `workspaceSourceErdTableFilter`-style ERD scope is intentionally **not** added here — VIS-1005 owns that consumer. This PR ships the outline and its disjoint selection key.

### Highlights
- **`SourceOutlineTreePanel.jsx`** (sibling of `OutlineTreePanel`): reuses `OutlineTreePanel`'s recursive `Node` shell (mulberry selection bar + caret disclosure + indent + truncation) — it does **not** import the left-nav `SchemaTreeNode`. Layers the Explorer's in-tree search + type badges on top. Icons/colours come **only** from `objectTypeConfigs` (source=orange root, table=fuchsia, columns = `PiColumns` + mono type badge; db/schema use neutral grouping icons).
- **`useSourceOutline.js`**: mirrors the Explorer backend+frontend. Primary feed is the **nested** `fetchSourceMetadata` path (the only one carrying db/schema); a cold-source **"Generate schema"** flow (lifted from `SourceBrowser.handleGenerateSchema`) generates + polls and fills a **flat fallback** tree. Both data shapes normalise into one nested tree (nested columns are bare strings; flat columns carry `{name,type}`). `isAvailable()` gating degrades cleanly in dist/cloud.
- **`RightRail.jsx`**: branches `RightRailBody` on the active object type via `useWorkspaceScope().selectedItem` — `source` → `<SourceOutlineTreePanel sourceName={name}/>`, else the dashboard outline. Keeps the fixed two-tab rail; the Outline tab reads **"Data"** (tree icon) for a source per §8.5.
- **Store** (`workspaceStore.js`): new **disjoint** `workspaceSourceOutlineSelectedKey` with the `source-outline::<src>::db::…::col::<c>` grammar (the dashboard's `parseOutlineKey` only recognises `dashboard`/`row.N`/`row.N.item.M`, so it safely falls through for these keys), plus per-source, per-session `workspaceSourceOutlineExpanded` expand memory.

### Graceful degradation
On a dist/cloud build every source endpoint URL is null → the panel renders a clear "available under `visivo serve`" empty state and never fires the introspect fetch.

### Tests
- `SourceOutlineTreePanel.test.jsx`: tree render from mocked metadata, expand/collapse persistence, disjoint selection-key write, cold-source generate→poll→fill, dist-degrade empty state.
- `RightRail.test.jsx`: source scope → source outline (+ "Data" tab); dashboard scope → dashboard outline (+ "Outline" tab).
- `workspaceStore.test.js`: selection-key toggle/disjointness, per-source expand toggle, bulk auto-expand.

**+10 tests.** `bash scripts/viewer-check.sh "SourceOutline|RightRail|OutlineTree"` → ALL PASSED; full `bash scripts/viewer-check.sh` → 209 suites / 2878 passed, lint clean. No `yarn format` run on JSX.

Closes VIS-1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)