### PR TITLE
Insight preview MODE-A fix + input widgets in chart/table/insight previews (VIS-1002, VIS-1003)

### DIFF
--- a/viewer/e2e/stories/workspace-object-previews.spec.mjs
+++ b/viewer/e2e/stories/workspace-object-previews.spec.mjs
@@ -14,9 +14,21 @@
  *   (Vite on :3001 proxying to :8001 — `bash scripts/sandbox.sh start`)
  *
  * Object names are from the integration project:
- *   chart   = simple-scatter-chart
- *   table   = new_table
- *   insight = simple-scatter-insight
+ *   chart                = simple-scatter-chart
+ *   table                = new_table
+ *   insight              = simple-scatter-insight        (MODE A: present in main run)
+ *   input-driven chart   = split-input-test-chart        (insight depends on split_threshold)
+ *   input-driven table   = filter-input-test-table       (insight depends on min_x_value)
+ *   input-driven insight = toggle-mode-insight           (props depend on show_markers)
+ *
+ * VIS-1002 (insight preview, MODE A): a PUBLISHED insight that is present in the
+ *   `visivo run` main run renders the saved Plotly chart immediately — no preview
+ *   run, no indefinite spinner. (MODE B — an unsaved/never-run insight firing a
+ *   preview run — is exercised by the Explorer right-rail stories and the
+ *   usePreviewData unit suite; it must not regress.)
+ * VIS-1003 (inputs in previews): an input-driven chart / table / insight renders
+ *   its input control widget(s) ABOVE the body, defaulted, so the body renders
+ *   immediately and the value can be changed live.
  */
 
 import { test, expect } from '@playwright/test';
@@ -97,7 +109,9 @@ test.describe('Workspace per-object Preview lens (Track N)', () => {
     ).toBeVisible({ timeout: 30000 });
   });
 
-  test('Step 4: selecting an insight mounts the InsightPreview as a chart', async ({ page }) => {
+  test('Step 4: a PUBLISHED insight (MODE A) renders the saved chart immediately, no preview run', async ({
+    page,
+  }) => {
     await page.goto(`${BASE_URL}/workspace`);
     await page.waitForLoadState('networkidle');
 
@@ -108,13 +122,79 @@ test.describe('Workspace per-object Preview lens (Track N)', () => {
     });
     await expect(page.getByTestId('insight-preview')).toBeVisible();
 
-    // The Explorer insight render path draws a real Plotly chart.
+    // MODE A: a published insight present in the main run renders the real
+    // Plotly chart directly from main-run data — it must NOT sit on the preview
+    // "Running Preview" spinner (that path is MODE B / unsaved only).
+    await expect(page.getByTestId('preview-loading')).toHaveCount(0);
     await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
       timeout: 30000,
     });
   });
 
-  test('Step 5: a preview-less object (source) falls back to the Lineage lens', async ({ page }) => {
+  test('Step 6: an input-driven chart renders its input control above a Plotly chart (VIS-1003)', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    await openObject(page, 'chart', 'split-input-test-chart');
+
+    await expect(page.getByTestId('workspace-middle-chart-preview')).toBeVisible({
+      timeout: 15000,
+    });
+
+    // The input control strip renders (defaulted) above the chart body.
+    const strip = page.locator('[data-testid="chart-preview"] [data-testid="input-controls-section"]');
+    await expect(strip).toBeVisible({ timeout: 15000 });
+    await expect(strip.getByTestId('preview-input-type-chip')).toBeVisible();
+
+    // And — because the input defaults — the Plotly chart still renders.
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('Step 7: an input-driven insight renders its input control above the chart (VIS-1003)', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    await openObject(page, 'insight', 'toggle-mode-insight');
+
+    await expect(page.getByTestId('workspace-middle-insight-preview')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const strip = page.locator('[data-testid="insight-preview"] [data-testid="input-controls-section"]');
+    await expect(strip).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('Step 8: an input-driven table renders its input control and populates (VIS-1003)', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+
+    await openObject(page, 'table', 'filter-input-test-table');
+
+    await expect(page.getByTestId('workspace-middle-table-preview')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const strip = page.locator('[data-testid="table-preview"] [data-testid="input-controls-section"]');
+    await expect(strip).toBeVisible({ timeout: 15000 });
+
+    // Defaulted input → the table renders (its search toolbar appears).
+    await expect(
+      page.locator('[data-testid="table-preview"]').getByPlaceholder('Search...')
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test('Step 9: a preview-less object (source) falls back to the Lineage lens', async ({ page }) => {
     await page.goto(`${BASE_URL}/workspace`);
     await page.waitForLoadState('networkidle');
 

--- a/viewer/src/components/new-views/common/InsightPreview.jsx
+++ b/viewer/src/components/new-views/common/InsightPreview.jsx
@@ -1,24 +1,24 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import Chart from '../../items/Chart';
-import Input from '../../items/Input';
-import { useInsightPreviewData } from '../../../hooks/usePreviewData';
-import { useInputsData } from '../../../hooks/useInputsData';
-import { extractInputDependenciesFromProps } from '../../../models/Insight';
-import useStore from '../../../stores/store';
+import { usePreviewInsightData } from '../../../hooks/usePreviewData';
+import { usePreviewInputDependencies } from '../workspace/usePreviewInputDependencies';
+import PreviewInputControls from '../workspace/PreviewInputControls';
 import CircularProgress from '@mui/material/CircularProgress';
 
 /**
  * InsightPreview - A minimal dashboard for previewing a single insight
  *
  * This component creates a synthetic dashboard configuration with:
- * - Input controls for any inputs referenced in the insight
+ * - Input controls for any inputs referenced in the insight (props + layout +
+ *   interactions), always defaulted so the chart renders immediately
  * - A single chart displaying the insight
  *
- * The preview flow:
- * 1. User edits insight config in the editor
- * 2. useInsightPreviewData detects changes in query-affecting properties
- * 3. Only triggers preview run when necessary
- * 4. Displays loading/error states and chart when ready
+ * The preview flow (VIS-1002):
+ * 1. usePreviewInsightData picks MODE A (published, main-run data under the
+ *    un-prefixed key) or MODE B (unsaved/edited, preview-run under __preview__).
+ * 2. The synthetic chart points at the resolved key either way.
+ * 3. Input widgets render via the shared PreviewInputControls (VIS-1003),
+ *    outside the chart spinner gate so a value is always suppliable.
  *
  * Props:
  * - insightConfig: The insight configuration object
@@ -26,29 +26,22 @@ import CircularProgress from '@mui/material/CircularProgress';
  * - layoutValues: Optional layout configuration for the chart
  */
 const InsightPreview = ({ insightConfig, projectId, layoutValues = {} }) => {
-  const { inputs: storeInputs, fetchInputs } = useStore();
+  const { isLoading, error, progress, progressMessage, chartInsightKey } = usePreviewInsightData(
+    insightConfig,
+    { projectId }
+  );
 
-  const { isLoading, error, progress, progressMessage, previewInsightKey } =
-    useInsightPreviewData(insightConfig, { projectId });
-
-  useEffect(() => {
-    fetchInputs();
-  }, [fetchInputs]);
-
-  const allReferencedNames = useMemo(() => {
-    if (!insightConfig) return [];
-    return extractInputDependenciesFromProps(insightConfig);
-  }, [insightConfig]);
-
-  const inputs = useMemo(() => {
-    if (!storeInputs || storeInputs.length === 0) return [];
-
-    const inputConfigMap = new Map(storeInputs.map(ic => [ic.name, ic.config]));
-
-    return allReferencedNames
-      .filter(name => inputConfigMap.has(name))
-      .map(name => inputConfigMap.get(name));
-  }, [allReferencedNames, storeInputs]);
+  // Union of input widgets this insight depends on (runtime inputDependencies +
+  // pendingInputs, with a props/layout/interactions config fallback), defaults
+  // seeded so the chart renders without waiting.
+  const insightNames = useMemo(
+    () => (insightConfig?.name ? [insightConfig.name] : []),
+    [insightConfig]
+  );
+  const { inputConfigs } = usePreviewInputDependencies(projectId, {
+    insightNames,
+    configForFallback: insightConfig,
+  });
 
   const chart = useMemo(() => {
     const previewLayout = {
@@ -57,10 +50,10 @@ const InsightPreview = ({ insightConfig, projectId, layoutValues = {} }) => {
       ...layoutValues,
     };
 
-    if (previewInsightKey) {
+    if (chartInsightKey) {
       return {
         name: 'Preview Chart',
-        insights: [{ name: previewInsightKey }],
+        insights: [{ name: chartInsightKey }],
         traces: [],
         layout: previewLayout,
       };
@@ -72,11 +65,7 @@ const InsightPreview = ({ insightConfig, projectId, layoutValues = {} }) => {
       traces: [],
       layout: previewLayout,
     };
-  }, [previewInsightKey, layoutValues]);
-
-  const inputNamesToLoad = useMemo(() => inputs.map(input => input.name), [inputs]);
-
-  useInputsData(projectId, inputNamesToLoad);
+  }, [chartInsightKey, layoutValues]);
 
   if (isLoading) {
     return (
@@ -128,16 +117,7 @@ const InsightPreview = ({ insightConfig, projectId, layoutValues = {} }) => {
 
   return (
     <div className="flex flex-col h-full">
-      {inputs.length > 0 && (
-        <div
-          className="flex flex-wrap gap-2 p-3 border-b border-gray-200 bg-gray-50"
-          data-testid="input-controls-section"
-        >
-          {inputs.map(input => (
-            <Input key={input.name} input={input} projectId={projectId} itemWidth={1} />
-          ))}
-        </div>
-      )}
+      <PreviewInputControls inputConfigs={inputConfigs} projectId={projectId} />
 
       <div className="flex-1 min-h-0 p-4 overflow-hidden">
         <div className="w-full h-full relative" style={{ minWidth: 0 }}>

--- a/viewer/src/components/new-views/common/InsightPreview.test.jsx
+++ b/viewer/src/components/new-views/common/InsightPreview.test.jsx
@@ -1,29 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import InsightPreview from './InsightPreview';
-import useStore from '../../../stores/store';
-import { useInsightPreviewData } from '../../../hooks/usePreviewData';
-import { useInputsData } from '../../../hooks/useInputsData';
+import { usePreviewInsightData } from '../../../hooks/usePreviewData';
+import { usePreviewInputDependencies } from '../workspace/usePreviewInputDependencies';
 
-// Mock dependencies
-jest.mock('../../../stores/store');
+// Mock the two-mode resolver (VIS-1002) and the shared input-dependency hook
+// (VIS-1003). The component is a thin shell over them, so mocking both keeps
+// this a focused unit test of the render branches.
 jest.mock('../../../hooks/usePreviewData', () => ({
-  useInsightPreviewData: jest.fn(),
+  usePreviewInsightData: jest.fn(),
 }));
-jest.mock('../../../hooks/useInputsData');
-jest.mock('../../items/Chart', () => ({ chart, project }) => (
-  <div data-testid="chart-component">
-    Chart: {chart?.name}
-  </div>
+jest.mock('../workspace/usePreviewInputDependencies', () => ({
+  usePreviewInputDependencies: jest.fn(),
+}));
+jest.mock('../../items/Chart', () => ({ chart }) => (
+  <div data-testid="chart-component">Chart: {chart?.name}</div>
 ));
 jest.mock('../../items/Input', () => ({ input }) => (
-  <div data-testid="input-component">
-    Input: {input?.name}
-  </div>
+  <div data-testid="input-component">Input: {input?.name}</div>
 ));
 
 describe('InsightPreview', () => {
-  const mockFetchInputs = jest.fn();
   const defaultInsightConfig = {
     name: 'test_insight',
     props: {
@@ -34,45 +31,32 @@ describe('InsightPreview', () => {
     interactions: [],
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    // Default store state
-    useStore.mockImplementation(selector => {
-      const state = {
-        inputs: [],
-        fetchInputs: mockFetchInputs,
-      };
-      return typeof selector === 'function' ? selector(state) : state;
-    });
-
-    // Default hook implementations
-    useInsightPreviewData.mockReturnValue({
+  const setResolver = (overrides = {}) => {
+    usePreviewInsightData.mockReturnValue({
       isLoading: false,
       error: null,
       progress: 0,
       progressMessage: '',
-      previewInsightKey: '__preview__test_insight',
+      chartInsightKey: 'test_insight',
+      insightNotInMain: false,
+      ...overrides,
     });
-    useInputsData.mockReturnValue(undefined);
+  };
+
+  const setInputs = (inputConfigs = []) => {
+    usePreviewInputDependencies.mockReturnValue({ inputConfigs });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setResolver();
+    setInputs([]);
   });
 
   describe('Unsaved insights', () => {
     it('shows message for unsaved insights without name', () => {
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: null,
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={{ props: { type: 'scatter' } }}
-          projectId="proj-1"
-        />
-      );
+      setResolver({ chartInsightKey: null });
+      render(<InsightPreview insightConfig={{ props: { type: 'scatter' } }} projectId="proj-1" />);
 
       expect(screen.getByTestId('unsaved-insight-message')).toBeInTheDocument();
       expect(screen.getByText('Save to Preview with Data')).toBeInTheDocument();
@@ -80,14 +64,7 @@ describe('InsightPreview', () => {
     });
 
     it('shows message for preview placeholder name', () => {
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview____preview__',
-      });
-
+      setResolver({ chartInsightKey: '__preview____preview__' });
       render(
         <InsightPreview
           insightConfig={{ name: '__preview__', props: { type: 'scatter' } }}
@@ -101,32 +78,24 @@ describe('InsightPreview', () => {
   });
 
   describe('Saved insights', () => {
-    it('calls useInsightPreviewData with insight config and projectId', () => {
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
+    it('calls usePreviewInsightData with insight config and projectId', () => {
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
-      expect(useInsightPreviewData).toHaveBeenCalledWith(
-        defaultInsightConfig,
-        { projectId: 'proj-1' }
-      );
+      expect(usePreviewInsightData).toHaveBeenCalledWith(defaultInsightConfig, {
+        projectId: 'proj-1',
+      });
     });
 
-    it('fetches inputs on mount', () => {
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
+    it('passes the resolved insight name to the input-dependency hook', () => {
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
-      expect(mockFetchInputs).toHaveBeenCalled();
+      expect(usePreviewInputDependencies).toHaveBeenCalledWith('proj-1', {
+        insightNames: ['test_insight'],
+        configForFallback: defaultInsightConfig,
+      });
     });
 
-    it('renders chart when insight has name', () => {
+    it('renders chart when insight has a resolved key', () => {
       render(
         <InsightPreview
           insightConfig={defaultInsightConfig}
@@ -137,24 +106,20 @@ describe('InsightPreview', () => {
 
       expect(screen.getByTestId('chart-component')).toBeInTheDocument();
     });
+
+    it('points the synthetic chart at the resolved (MODE A) un-prefixed key', () => {
+      setResolver({ chartInsightKey: 'test_insight' });
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
+
+      // MODE A: chart references the un-prefixed insight name.
+      expect(screen.getByTestId('chart-component')).toBeInTheDocument();
+    });
   });
 
   describe('Loading and error states', () => {
     it('shows loading state when preview is running', () => {
-      useInsightPreviewData.mockReturnValue({
-        isLoading: true,
-        error: null,
-        progress: 0.5,
-        progressMessage: 'Running query...',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
+      setResolver({ isLoading: true, progress: 0.5, progressMessage: 'Running query...' });
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
       expect(screen.getByTestId('preview-loading')).toBeInTheDocument();
       expect(screen.getByText('Running Preview')).toBeInTheDocument();
@@ -162,20 +127,8 @@ describe('InsightPreview', () => {
     });
 
     it('shows error state when preview fails', () => {
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: 'Query syntax error',
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
+      setResolver({ error: 'Query syntax error' });
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
       expect(screen.getByTestId('preview-error')).toBeInTheDocument();
       expect(screen.getByText('Preview Failed')).toBeInTheDocument();
@@ -185,243 +138,44 @@ describe('InsightPreview', () => {
 
   describe('Input controls', () => {
     it('does not render input controls section when no inputs referenced', () => {
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
+      setInputs([]);
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
-
-      // Should not have the input controls section
       expect(screen.queryByTestId('input-controls-section')).not.toBeInTheDocument();
     });
 
-    it('renders input controls when inputs are referenced in props', () => {
-      const configWithInputs = {
-        name: 'test_insight',
-        props: {
-          type: 'scatter',
-          mode: `\${show_markers.value}`,
-        },
-      };
+    it('renders an input widget for each resolved input config', () => {
+      setInputs([{ name: 'show_markers', type: 'single-select' }]);
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            { name: 'show_markers', config: { name: 'show_markers', type: 'select' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithInputs}
-          projectId="proj-1"
-        />
-      );
-
-      expect(screen.getByTestId('input-component')).toBeInTheDocument();
-    });
-
-    it('renders input controls when inputs are referenced in interactions', () => {
-      const configWithInputs = {
-        name: 'test_insight',
-        props: { type: 'scatter' },
-        interactions: [
-          {
-            type: 'filter',
-            value: `x > \${min_value.value}`,
-          },
-        ],
-      };
-
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            { name: 'min_value', config: { name: 'min_value', type: 'number' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithInputs}
-          projectId="proj-1"
-        />
-      );
-
-      expect(screen.getByTestId('input-component')).toBeInTheDocument();
-    });
-
-    it('calls useInputsData with extracted input names', () => {
-      const configWithInputs = {
-        name: 'test_insight',
-        props: {
-          type: 'scatter',
-          mode: `\${show_markers.value}`,
-        },
-      };
-
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            { name: 'show_markers', config: { name: 'show_markers', type: 'select' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithInputs}
-          projectId="proj-1"
-        />
-      );
-
-      expect(useInputsData).toHaveBeenCalledWith('proj-1', ['show_markers']);
-    });
-
-    it('filters out model references and only loads actual inputs', () => {
-      const configWithMixedRefs = {
-        name: 'test_insight',
-        props: {
-          type: 'scatter',
-          x: 'ref(some_model).column_x', // model reference
-          mode: `\${show_markers.value}`, // input reference
-        },
-      };
-
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            // Only show_markers is an actual input
-            { name: 'show_markers', config: { name: 'show_markers', type: 'select' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithMixedRefs}
-          projectId="proj-1"
-        />
-      );
-
-      // Should only load actual inputs, not model references
-      expect(useInputsData).toHaveBeenCalledWith('proj-1', ['show_markers']);
-    });
-
-    it('renders input controls section when inputs are present', () => {
-      const configWithInputs = {
-        name: 'test_insight',
-        props: {
-          mode: `\${show_markers.value}`,
-        },
-      };
-
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            { name: 'show_markers', config: { name: 'show_markers', type: 'select' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithInputs}
-          projectId="proj-1"
-        />
-      );
-
-      // Check for input controls section
       expect(screen.getByTestId('input-controls-section')).toBeInTheDocument();
+      expect(screen.getByTestId('input-component')).toHaveTextContent('show_markers');
+    });
+
+    it('renders the input controls outside the chart (above it) when both present', () => {
+      setInputs([{ name: 'show_markers', type: 'single-select' }]);
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
+
+      expect(screen.getByTestId('input-component')).toBeInTheDocument();
+      expect(screen.getByTestId('chart-component')).toBeInTheDocument();
     });
   });
 
   describe('Layout configuration', () => {
     it('applies layout values to chart', () => {
-      const layoutValues = {
-        title: 'Custom Title',
-        showlegend: true,
-      };
-
       render(
         <InsightPreview
           insightConfig={defaultInsightConfig}
           projectId="proj-1"
-          layoutValues={layoutValues}
+          layoutValues={{ title: 'Custom Title', showlegend: true }}
         />
       );
 
-      // Chart component should receive layout with custom values
       expect(screen.getByTestId('chart-component')).toBeInTheDocument();
     });
 
     it('uses default layout when no layoutValues provided', () => {
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
 
       expect(screen.getByTestId('chart-component')).toBeInTheDocument();
     });
@@ -429,98 +183,11 @@ describe('InsightPreview', () => {
 
   describe('Error handling', () => {
     it('renders without crashing when insightConfig is null', () => {
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: null,
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={null}
-          projectId="proj-1"
-        />
-      );
+      setResolver({ chartInsightKey: null });
+      render(<InsightPreview insightConfig={null} projectId="proj-1" />);
 
       expect(screen.getByTestId('unsaved-insight-message')).toBeInTheDocument();
       expect(screen.getByText('Save to Preview with Data')).toBeInTheDocument();
-    });
-
-    it('renders without crashing when inputs fail to load', () => {
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: null,
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
-
-      expect(screen.getByTestId('chart-component')).toBeInTheDocument();
-    });
-  });
-
-  describe('Component structure', () => {
-    it('renders inputs above chart when both present', () => {
-      const configWithInputs = {
-        name: 'test_insight',
-        props: {
-          type: 'scatter',
-          mode: `\${show_markers.value}`,
-        },
-      };
-
-      useInsightPreviewData.mockReturnValue({
-        isLoading: false,
-        error: null,
-        progress: 0,
-        progressMessage: '',
-        previewInsightKey: '__preview__test_insight',
-      });
-
-      useStore.mockImplementation(selector => {
-        const state = {
-          inputs: [
-            { name: 'show_markers', config: { name: 'show_markers', type: 'select' } },
-          ],
-          fetchInputs: mockFetchInputs,
-        };
-        return typeof selector === 'function' ? selector(state) : state;
-      });
-
-      render(
-        <InsightPreview
-          insightConfig={configWithInputs}
-          projectId="proj-1"
-        />
-      );
-
-      const inputComponent = screen.getByTestId('input-component');
-      const chartComponent = screen.getByTestId('chart-component');
-
-      // Both should be present
-      expect(inputComponent).toBeInTheDocument();
-      expect(chartComponent).toBeInTheDocument();
-    });
-
-    it('renders with proper layout structure', () => {
-      render(
-        <InsightPreview
-          insightConfig={defaultInsightConfig}
-          projectId="proj-1"
-        />
-      );
-
-      // Chart component should be rendered
-      expect(screen.getByTestId('chart-component')).toBeInTheDocument();
     });
   });
 });

--- a/viewer/src/components/new-views/workspace/ChartPreview.jsx
+++ b/viewer/src/components/new-views/workspace/ChartPreview.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 import useStore from '../../../stores/store';
 import Chart from '../../items/Chart';
 import { useInsightsData } from '../../../hooks/useInsightsData';
-import { useInputsData } from '../../../hooks/useInputsData';
 import { parseRefValue } from '../../../utils/refString';
+import { usePreviewInputDependencies } from './usePreviewInputDependencies';
+import PreviewInputControls from './PreviewInputControls';
 
 /**
  * ChartPreview — VIS-784 / N-1.
@@ -60,19 +60,17 @@ const ChartPreview = ({ activeObject, projectId }) => {
   );
 
   // Load each insight's data from the main run (the same hook the Dashboard
-  // drives) plus any inputs those insights depend on.
+  // drives).
   useInsightsData(projectId, insightNames);
-  const inputDeps = useStore(
-    useShallow(s => {
-      const names = new Set();
-      for (const n of insightNames) {
-        const job = s.insightJobs?.[n];
-        (job?.inputDependencies || []).forEach(dep => names.add(dep));
-      }
-      return Array.from(names).sort();
-    })
-  );
-  useInputsData(projectId, inputDeps);
+
+  // Resolve the UNION of input widgets across all parent insights (runtime
+  // inputDependencies + pendingInputs) with a config fallback across the
+  // chart's props/layout/interactions, and seed their defaults so the chart
+  // renders immediately (VIS-1003).
+  const { inputConfigs } = usePreviewInputDependencies(projectId, {
+    insightNames,
+    configForFallback: chart,
+  });
 
   if (!chart) {
     return (
@@ -88,9 +86,12 @@ const ChartPreview = ({ activeObject, projectId }) => {
   }
 
   return (
-    <div data-testid="chart-preview" className="flex flex-1 min-h-0 bg-white p-4">
-      <div className="relative h-full w-full" style={{ minWidth: 0 }}>
-        <Chart chart={chart} projectId={projectId} shouldLoad={true} hideToolbar={true} />
+    <div data-testid="chart-preview" className="flex flex-1 min-h-0 flex-col bg-white">
+      <PreviewInputControls inputConfigs={inputConfigs} projectId={projectId} />
+      <div className="relative flex-1 min-h-0 p-4">
+        <div className="relative h-full w-full" style={{ minWidth: 0 }}>
+          <Chart chart={chart} projectId={projectId} shouldLoad={true} hideToolbar={true} />
+        </div>
       </div>
     </div>
   );

--- a/viewer/src/components/new-views/workspace/ChartPreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/ChartPreview.test.jsx
@@ -28,10 +28,22 @@ jest.mock('../../../hooks/useInsightsData', () => ({
 jest.mock('../../../hooks/useInputsData', () => ({
   useInputsData: jest.fn(),
 }));
+// Spy on the Input widget so we can assert controls render OUTSIDE the mocked
+// Chart (above it), independent of the chart's spinner gate.
+jest.mock('../../items/Input', () => ({
+  __esModule: true,
+  default: ({ input }) => <div data-testid="input-component">{input?.name}</div>,
+}));
 
-const seed = (charts = []) => {
+const seed = (charts = [], { inputs = [], insightJobs = {} } = {}) => {
   act(() => {
-    useStore.setState({ charts, fetchCharts: jest.fn(), insightJobs: {} });
+    useStore.setState({
+      charts,
+      fetchCharts: jest.fn(),
+      insightJobs,
+      inputs,
+      fetchInputs: jest.fn(),
+    });
   });
 };
 
@@ -66,5 +78,34 @@ describe('ChartPreview (VIS-784)', () => {
     seed([]);
     render(<ChartPreview activeObject={{ type: 'chart', name: 'missing' }} projectId="p1" />);
     expect(screen.getByTestId('chart-preview-empty')).toHaveTextContent(/not found/i);
+  });
+
+  // VIS-1003: input-driven chart renders its control widget ABOVE the chart,
+  // outside the spinner gate, from the union of its parent insights' deps.
+  test('renders input controls outside the Chart for an input-driven chart', () => {
+    seed(
+      [{ name: 'revenue', config: { insights: ['${ref(rev-insight)}'] } }],
+      {
+        inputs: [{ name: 'region', config: { name: 'region', type: 'single-select' } }],
+        insightJobs: { 'rev-insight': { inputDependencies: ['region'], pendingInputs: null } },
+      }
+    );
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'revenue' }} projectId="p1" />);
+
+    // Control strip renders, with the resolved input widget, alongside the chart.
+    expect(screen.getByTestId('input-controls-section')).toBeInTheDocument();
+    expect(screen.getByTestId('input-component')).toHaveTextContent('region');
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+  });
+
+  test('renders no control strip for a chart with no input dependencies', () => {
+    seed(
+      [{ name: 'revenue', config: { insights: ['${ref(rev-insight)}'] } }],
+      { insightJobs: { 'rev-insight': { inputDependencies: [], pendingInputs: [] } } }
+    );
+    render(<ChartPreview activeObject={{ type: 'chart', name: 'revenue' }} projectId="p1" />);
+
+    expect(screen.queryByTestId('input-controls-section')).not.toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/new-views/workspace/PreviewInputControls.jsx
+++ b/viewer/src/components/new-views/workspace/PreviewInputControls.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Input from '../../items/Input';
+import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
+
+/**
+ * PreviewInputControls — VIS-1003 / design §5 + §8.3.
+ *
+ * Pure presentational strip of `<Input>` widgets rendered ABOVE a preview body
+ * (chart / table / insight) and OUTSIDE the `<Chart>`/`<Table>` spinner gate, so
+ * a value is always suppliable even while the body is loading. Renders `null`
+ * when there are no input dependencies — a no-dependency object shows no chrome.
+ *
+ * The input-type chip (icon + "Input" label) is sourced from the shared
+ * `objectTypeConfigs` palette (never hand-rolled colors) so it matches every
+ * other input surface in the app.
+ *
+ * @param {Object} props
+ * @param {Object[]} props.inputConfigs - Resolved `<Input>` configs (from usePreviewInputDependencies)
+ * @param {string} props.projectId
+ */
+const PreviewInputControls = ({ inputConfigs, projectId }) => {
+  if (!inputConfigs || inputConfigs.length === 0) return null;
+
+  const colors = getTypeColors('input');
+  const InputIcon = getTypeIcon('input');
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 p-3"
+      data-testid="input-controls-section"
+    >
+      <span
+        className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium ${colors.bg} ${colors.text} ${colors.border}`}
+        data-testid="preview-input-type-chip"
+      >
+        <InputIcon sx={{ fontSize: 14 }} />
+        Inputs
+      </span>
+      {inputConfigs.map(input => (
+        <Input key={input.name} input={input} projectId={projectId} itemWidth={1} />
+      ))}
+    </div>
+  );
+};
+
+export default PreviewInputControls;

--- a/viewer/src/components/new-views/workspace/PreviewInputControls.test.jsx
+++ b/viewer/src/components/new-views/workspace/PreviewInputControls.test.jsx
@@ -1,0 +1,60 @@
+/**
+ * PreviewInputControls tests (VIS-1003 / design §5 + §8.3).
+ *
+ * Pure presentational strip: one <Input> per resolved config, null when empty,
+ * and an input-type chip whose colors/icon come from the shared
+ * objectTypeConfigs palette (never hand-rolled).
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PreviewInputControls from './PreviewInputControls';
+import { getTypeColors } from '../common/objectTypeConfigs';
+
+jest.mock('../../items/Input', () => ({ input }) => (
+  <div data-testid="input-component">Input: {input?.name}</div>
+));
+
+describe('PreviewInputControls', () => {
+  it('renders nothing when there are no input configs', () => {
+    render(<PreviewInputControls inputConfigs={[]} projectId="p1" />);
+    expect(screen.queryByTestId('input-controls-section')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('preview-input-type-chip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('input-component')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when inputConfigs is undefined', () => {
+    render(<PreviewInputControls projectId="p1" />);
+    expect(screen.queryByTestId('input-controls-section')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('input-component')).not.toBeInTheDocument();
+  });
+
+  it('renders one <Input> per resolved config', () => {
+    render(
+      <PreviewInputControls
+        inputConfigs={[{ name: 'region' }, { name: 'quarter' }]}
+        projectId="p1"
+      />
+    );
+    const inputs = screen.getAllByTestId('input-component');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveTextContent('region');
+    expect(inputs[1]).toHaveTextContent('quarter');
+  });
+
+  it('renders the input-controls-section strip when configs are present', () => {
+    render(<PreviewInputControls inputConfigs={[{ name: 'region' }]} projectId="p1" />);
+    expect(screen.getByTestId('input-controls-section')).toBeInTheDocument();
+  });
+
+  it('renders an input-type chip styled from objectTypeConfigs (not hand-rolled)', () => {
+    render(<PreviewInputControls inputConfigs={[{ name: 'region' }]} projectId="p1" />);
+    const chip = screen.getByTestId('preview-input-type-chip');
+    expect(chip).toBeInTheDocument();
+
+    // The chip's classes come from the shared palette's 'input' entry.
+    const colors = getTypeColors('input');
+    expect(chip).toHaveClass(colors.bg);
+    expect(chip).toHaveClass(colors.text);
+    expect(chip).toHaveClass(colors.border);
+  });
+});

--- a/viewer/src/components/new-views/workspace/TablePreview.jsx
+++ b/viewer/src/components/new-views/workspace/TablePreview.jsx
@@ -3,11 +3,12 @@ import useStore from '../../../stores/store';
 import Table from '../../items/Table';
 import { useInsightsData } from '../../../hooks/useInsightsData';
 import { useModelsData } from '../../../hooks/useModelsData';
-import { useInputsData } from '../../../hooks/useInputsData';
 import {
   parseRefValue,
   extractRefNamesFromStrings,
 } from '../../../utils/refString';
+import { usePreviewInputDependencies } from './usePreviewInputDependencies';
+import PreviewInputControls from './PreviewInputControls';
 
 /**
  * TablePreview — VIS-791 / N-2.
@@ -82,9 +83,15 @@ const TablePreview = ({ activeObject, projectId }) => {
 
   useModelsData(projectId, modelNames);
   useInsightsData(projectId, insightNames);
-  // Inputs referenced by insight-backed tables (pivot/data) so input-driven
-  // tables resolve their pending values.
-  useInputsData(projectId, []);
+
+  // Resolve the UNION of input widgets across the table's insight-backed parents
+  // (the insightNames it already classifies), with a config fallback across the
+  // table config (props/layout/interactions), and seed defaults so the table
+  // populates immediately (VIS-1003). Replaces the hardcoded empty input list.
+  const { inputConfigs } = usePreviewInputDependencies(projectId, {
+    insightNames,
+    configForFallback: tableConfig,
+  });
 
   if (!tableConfig) {
     return (
@@ -100,9 +107,12 @@ const TablePreview = ({ activeObject, projectId }) => {
   }
 
   return (
-    <div data-testid="table-preview" className="flex flex-1 min-h-0 overflow-auto bg-white p-4">
-      <div className="w-full">
-        <Table table={tableConfig} projectId={projectId} shouldLoad={true} height={600} />
+    <div data-testid="table-preview" className="flex flex-1 min-h-0 flex-col bg-white">
+      <PreviewInputControls inputConfigs={inputConfigs} projectId={projectId} />
+      <div className="flex-1 min-h-0 overflow-auto p-4">
+        <div className="w-full">
+          <Table table={tableConfig} projectId={projectId} shouldLoad={true} height={600} />
+        </div>
       </div>
     </div>
   );

--- a/viewer/src/components/new-views/workspace/TablePreview.test.jsx
+++ b/viewer/src/components/new-views/workspace/TablePreview.test.jsx
@@ -32,14 +32,21 @@ jest.mock('../../../hooks/useInsightsData', () => ({
 jest.mock('../../../hooks/useInputsData', () => ({
   useInputsData: jest.fn(),
 }));
+jest.mock('../../items/Input', () => ({
+  __esModule: true,
+  default: ({ input }) => <div data-testid="input-component">{input?.name}</div>,
+}));
 
-const seed = (tables = [], models = []) => {
+const seed = (tables = [], models = [], { inputs = [], insightJobs = {} } = {}) => {
   act(() => {
     useStore.setState({
       tables,
       models,
       fetchTables: jest.fn(),
       fetchModels: jest.fn(),
+      inputs,
+      fetchInputs: jest.fn(),
+      insightJobs,
     });
   });
 };
@@ -76,5 +83,31 @@ describe('TablePreview (VIS-791)', () => {
     seed([], []);
     render(<TablePreview activeObject={{ type: 'table', name: 'missing' }} projectId="p1" />);
     expect(screen.getByTestId('table-preview-empty')).toHaveTextContent(/not found/i);
+  });
+
+  // VIS-1003: input-driven, insight-backed table renders its control widget(s)
+  // (the hardcoded empty input list is replaced by the classified insightNames).
+  test('renders input controls for an input-driven insight-backed table', () => {
+    seed(
+      [{ name: 't', config: { data: '${ref(sales_insight)}' } }],
+      [],
+      {
+        inputs: [{ name: 'region', config: { name: 'region', type: 'single-select' } }],
+        insightJobs: { sales_insight: { inputDependencies: ['region'], pendingInputs: null } },
+      }
+    );
+    render(<TablePreview activeObject={{ type: 'table', name: 't' }} projectId="p1" />);
+
+    expect(screen.getByTestId('input-controls-section')).toBeInTheDocument();
+    expect(screen.getByTestId('input-component')).toHaveTextContent('region');
+    expect(screen.getByTestId('table-renderer-mock')).toBeInTheDocument();
+  });
+
+  test('renders no control strip for a model-backed table with no inputs', () => {
+    seed([{ name: 'orders', config: { data: '${ref(orders_model)}' } }], [{ name: 'orders_model' }]);
+    render(<TablePreview activeObject={{ type: 'table', name: 'orders' }} projectId="p1" />);
+
+    expect(screen.queryByTestId('input-controls-section')).not.toBeInTheDocument();
+    expect(screen.getByTestId('table-renderer-mock')).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/new-views/workspace/usePreviewInputDependencies.js
+++ b/viewer/src/components/new-views/workspace/usePreviewInputDependencies.js
@@ -1,0 +1,102 @@
+import { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import useStore from '../../../stores/store';
+import { useInputsData } from '../../../hooks/useInputsData';
+import { extractInputDependenciesFromProps } from '../../../models/Insight';
+
+/**
+ * usePreviewInputDependencies — VIS-1003 / design §5 + §8.3.
+ *
+ * The single source of truth for "which input widgets does this preview need?"
+ * across chart, table, and insight previews. It produces the UNION of every
+ * input an object's parent insights depend on and resolves each to its `<Input>`
+ * config so a presentational strip can render the controls.
+ *
+ * Dependency discovery (union of two sources):
+ *   1. RUNTIME (graph-resolved): for each insight name, `insightJobs[n]
+ *      .inputDependencies` plus `insightJobs[n].pendingInputs`. This is the
+ *      authoritative set once an insight's metadata has loaded.
+ *   2. CONFIG FALLBACK (timing window): `extractInputDependenciesFromProps`
+ *      across props + layout + interactions of `configForFallback`, covering
+ *      the window before `inputDependencies` populates (and the never-run case).
+ *
+ * Each discovered name is resolved against the store `inputs` collection to an
+ * `<Input>` config; unresolvable names are dropped. `useInputsData` is then
+ * called with the resolved names so options load and a DEFAULT value is seeded
+ * (always-default — the body renders immediately; the widget lets the user
+ * change it).
+ *
+ * VIS-831 INVARIANT: this hook NEVER keys insight refetch on a pending/resolved
+ * boolean. It reads `pendingInputs` only to widen the *name set* passed to
+ * `useInputsData`; the sole refetch trigger remains a VALUE write via
+ * `setInputJobValue` (driven by the rendered `<Input>` widgets), which
+ * `useInsightsData` keys on through `stableRelevantInputs`.
+ *
+ * @param {string} projectId
+ * @param {Object} params
+ * @param {string[]} params.insightNames - Parent insight names (multi-insight → union)
+ * @param {Object} [params.configForFallback] - Object config (props/layout/interactions) for the config-only window
+ * @returns {{ inputConfigs: Object[] }} resolved `<Input>` configs (empty when none)
+ */
+export const usePreviewInputDependencies = (projectId, { insightNames = [], configForFallback }) => {
+  const storeInputs = useStore(s => s.inputs);
+  const fetchInputs = useStore(s => s.fetchInputs);
+
+  useEffect(() => {
+    if ((!storeInputs || storeInputs.length === 0) && typeof fetchInputs === 'function') {
+      fetchInputs();
+    }
+  }, [storeInputs, fetchInputs]);
+
+  const stableInsightNames = useMemo(
+    () => [...new Set((insightNames || []).filter(Boolean))].sort(),
+    [insightNames]
+  );
+
+  // Runtime dependency union: inputDependencies + pendingInputs per insight job.
+  // Read via a shallow selector that returns a stable sorted array so the memo
+  // below doesn't churn on unrelated insightJobs writes.
+  const runtimeNames = useStore(
+    useShallow(s => {
+      const names = new Set();
+      for (const n of stableInsightNames) {
+        const job = s.insightJobs?.[n];
+        if (!job) continue;
+        (job.inputDependencies || []).forEach(dep => names.add(dep));
+        (job.pendingInputs || []).forEach(dep => names.add(dep));
+      }
+      return Array.from(names).sort();
+    })
+  );
+
+  // Config-fallback union across props + layout + interactions (timing window
+  // before inputDependencies populates, and the never-run case).
+  const fallbackNames = useMemo(() => {
+    if (!configForFallback) return [];
+    return extractInputDependenciesFromProps(configForFallback);
+  }, [configForFallback]);
+
+  const allReferencedNames = useMemo(
+    () => [...new Set([...runtimeNames, ...fallbackNames])].sort(),
+    [runtimeNames, fallbackNames]
+  );
+
+  // Resolve name → <Input> config from the store inputs collection. Names with
+  // no matching input config (e.g. a model ref mistaken as an input) are dropped.
+  const inputConfigs = useMemo(() => {
+    if (!storeInputs || storeInputs.length === 0 || allReferencedNames.length === 0) return [];
+    const configByName = new Map(storeInputs.map(ic => [ic.name, ic.config || ic]));
+    return allReferencedNames
+      .filter(name => configByName.has(name))
+      .map(name => configByName.get(name));
+  }, [allReferencedNames, storeInputs]);
+
+  // Load options + seed defaults for the resolved inputs. Keyed only on the
+  // resolved NAMES — never on pending/resolved state (VIS-831).
+  const inputNamesToLoad = useMemo(() => inputConfigs.map(c => c.name), [inputConfigs]);
+  useInputsData(projectId, inputNamesToLoad);
+
+  return { inputConfigs };
+};
+
+export default usePreviewInputDependencies;

--- a/viewer/src/components/new-views/workspace/usePreviewInputDependencies.test.js
+++ b/viewer/src/components/new-views/workspace/usePreviewInputDependencies.test.js
@@ -1,0 +1,181 @@
+/* eslint-disable no-template-curly-in-string -- literal ${input.accessor} strings under test */
+/**
+ * usePreviewInputDependencies tests (VIS-1003 / design §5 + §8.3).
+ *
+ * The hook produces the UNION of input dependencies across an object's parent
+ * insights — runtime (insightJobs[n].inputDependencies + pendingInputs) unioned
+ * with a config fallback (extractInputDependenciesFromProps across props +
+ * layout + interactions) — resolves each to its <Input> config, and calls
+ * useInputsData so options load and a DEFAULT is seeded.
+ *
+ * VIS-831 invariant under test: the names passed to useInputsData are derived
+ * ONLY from the resolved input configs (graph metadata + config), never from a
+ * pending/resolved boolean.
+ */
+import { renderHook } from '@testing-library/react';
+import { usePreviewInputDependencies } from './usePreviewInputDependencies';
+import useStore from '../../../stores/store';
+import { useInputsData } from '../../../hooks/useInputsData';
+
+jest.mock('../../../stores/store');
+jest.mock('../../../hooks/useInputsData', () => ({
+  useInputsData: jest.fn(),
+}));
+// Use the REAL extractor so the config-fallback union (props+layout+interactions)
+// is genuinely exercised end-to-end.
+jest.mock('zustand/react/shallow', () => ({
+  useShallow: fn => fn,
+}));
+
+const seedStore = ({ inputs = [], insightJobs = {} } = {}) => {
+  const state = { inputs, insightJobs, fetchInputs: jest.fn() };
+  useStore.mockImplementation(selector =>
+    typeof selector === 'function' ? selector(state) : state
+  );
+  useStore.getState = jest.fn(() => state);
+};
+
+const lastInputsDataCall = () =>
+  useInputsData.mock.calls[useInputsData.mock.calls.length - 1];
+
+describe('usePreviewInputDependencies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves runtime inputDependencies from insightJobs into <Input> configs', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region', type: 'single-select' } }],
+      insightJobs: { sales: { inputDependencies: ['region'], pendingInputs: null } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', { insightNames: ['sales'] })
+    );
+
+    expect(result.current.inputConfigs).toEqual([{ name: 'region', type: 'single-select' }]);
+    expect(lastInputsDataCall()).toEqual(['p1', ['region']]);
+  });
+
+  it('unions inputDependencies AND pendingInputs across multiple insights', () => {
+    seedStore({
+      inputs: [
+        { name: 'region', config: { name: 'region' } },
+        { name: 'quarter', config: { name: 'quarter' } },
+        { name: 'segment', config: { name: 'segment' } },
+      ],
+      insightJobs: {
+        a: { inputDependencies: ['region'], pendingInputs: ['quarter'] },
+        b: { inputDependencies: ['segment'], pendingInputs: [] },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', { insightNames: ['a', 'b'] })
+    );
+
+    const names = result.current.inputConfigs.map(c => c.name);
+    expect(names).toEqual(['quarter', 'region', 'segment']); // sorted, deduped union
+  });
+
+  it('falls back to the config (props + layout + interactions) before runtime metadata lands', () => {
+    seedStore({
+      inputs: [
+        { name: 'show_markers', config: { name: 'show_markers' } },
+        { name: 'min_value', config: { name: 'min_value' } },
+        { name: 'y_max', config: { name: 'y_max' } },
+      ],
+      insightJobs: {}, // no runtime metadata yet
+    });
+
+    const config = {
+      props: { mode: '${show_markers.value}' },
+      interactions: [{ filter: 'x > ${min_value.value}' }],
+      layout: { yaxis: { range: [0, '${y_max.value}'] } },
+    };
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', {
+        insightNames: ['unloaded'],
+        configForFallback: config,
+      })
+    );
+
+    const names = result.current.inputConfigs.map(c => c.name);
+    // Union across props + interactions + layout, from the fallback path.
+    expect(names).toEqual(['min_value', 'show_markers', 'y_max']);
+  });
+
+  it('unions runtime metadata with the config fallback (dedupe across sources)', () => {
+    seedStore({
+      inputs: [
+        { name: 'region', config: { name: 'region' } },
+        { name: 'segment', config: { name: 'segment' } },
+      ],
+      insightJobs: { sales: { inputDependencies: ['region'] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', {
+        insightNames: ['sales'],
+        // region overlaps with runtime; segment is new from the fallback.
+        configForFallback: { props: { color: '${region.value}', mode: '${segment.value}' } },
+      })
+    );
+
+    const names = result.current.inputConfigs.map(c => c.name);
+    expect(names).toEqual(['region', 'segment']);
+  });
+
+  it('drops names that have no matching <Input> config (e.g. a model ref)', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      insightJobs: { sales: { inputDependencies: ['region', 'some_model'] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', { insightNames: ['sales'] })
+    );
+
+    // some_model is not an input → dropped; only region is loaded.
+    expect(result.current.inputConfigs.map(c => c.name)).toEqual(['region']);
+    expect(lastInputsDataCall()).toEqual(['p1', ['region']]);
+  });
+
+  it('returns no configs and loads no inputs for a no-dependency object', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      insightJobs: { sales: { inputDependencies: [], pendingInputs: [] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', {
+        insightNames: ['sales'],
+        configForFallback: { props: { type: 'scatter' } },
+      })
+    );
+
+    expect(result.current.inputConfigs).toEqual([]);
+    expect(lastInputsDataCall()).toEqual(['p1', []]);
+  });
+
+  it('keys useInputsData ONLY on resolved names — never on pending state (VIS-831)', () => {
+    // Two insightJobs that differ ONLY in pendingInputs presence must produce
+    // the same name set passed to useInputsData (because the union of
+    // inputDependencies + pendingInputs is identical). We assert the call shape
+    // is purely the resolved input names — there is no pending/resolved boolean
+    // anywhere in the arguments.
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      insightJobs: { sales: { inputDependencies: ['region'], pendingInputs: ['region'] } },
+    });
+
+    renderHook(() => usePreviewInputDependencies('p1', { insightNames: ['sales'] }));
+
+    const call = lastInputsDataCall();
+    expect(call[0]).toBe('p1');
+    expect(call[1]).toEqual(['region']);
+    // No third argument carrying pending/resolved state.
+    expect(call.length).toBe(2);
+  });
+});

--- a/viewer/src/hooks/usePreviewData.js
+++ b/viewer/src/hooks/usePreviewData.js
@@ -9,6 +9,7 @@ import {
 } from '../utils/queryPropertyDetection';
 import useStore from '../stores/store';
 import { useShallow } from 'zustand/react/shallow';
+import { DEFAULT_RUN_ID } from '../constants';
 
 /**
  * Build the batched preview POST body for a single insight.
@@ -245,6 +246,85 @@ export const useInsightPreviewData = (insightConfig, options = {}) => {
     previewInsightKey,
     data: previewInsightEntry?.data || null,
     insight: previewInsightEntry || null,
+  };
+};
+
+/**
+ * Shared two-mode insight-preview resolver (VIS-1002 / design §2 + §8.3).
+ *
+ * Decides where a single previewed insight's data lives and which synthetic
+ * chart key to point the renderer at, mirroring what the dashboard already
+ * does. The mode is gated on the presence of the insight's MAIN-run job entry
+ * (`insightNotInMain = !insightJobs[name]`) — NOT on data completeness — so it
+ * does not flap while inputs resolve:
+ *
+ *   MODE A — published / saved (dominant case): the insight already has
+ *     main-run data, so point the synthetic chart at the UN-prefixed key
+ *     `insightJobs[name]` and load via `useInsightsData(projectId, [name])` at
+ *     the default `runId='main'` (no prefix) — the exact path
+ *     `workspace/ChartPreview` uses. No preview run, no spinner hang. The prior
+ *     bug always targeted `__preview__name` and only loaded via a preview run
+ *     that fires when the insight is ABSENT — so published insights never
+ *     loaded (inverted).
+ *
+ *   MODE B — unsaved / never-run / query-affecting edit: keep the existing
+ *     `__preview__`-prefixed preview-run path (`useInsightPreviewData`). The
+ *     Explorer right-rail editor (`ExplorerChartPreview`/`useChartPreviewJob`)
+ *     depends on this path, so it must not regress.
+ *
+ * Both underlying hooks are always called (rules of hooks); the result is
+ * selected by mode. The canvas is BIDIRECTIONAL like the dashboard — every
+ * config change re-runs MODE B (no staleness gate here) and inputs always
+ * default, so there is no "waiting for input" empty state.
+ *
+ * @param {Object} insightConfig - Insight configuration object (must have name)
+ * @param {Object} options
+ * @param {string} options.projectId
+ * @returns {Object} { chartInsightKey, isLoading, error, insightNotInMain, ...modeBState }
+ */
+export const usePreviewInsightData = (insightConfig, options = {}) => {
+  const insightName = insightConfig?.name || null;
+
+  // Mode is keyed on PRESENCE of the main-run job entry, never data
+  // completeness — that's what keeps the mode from flapping while an
+  // input-driven insight resolves its default value.
+  const insightNotInMain = useStore(
+    useCallback(
+      state => {
+        if (!insightName) return false;
+        return !state.insightJobs?.[insightName];
+      },
+      [insightName]
+    )
+  );
+
+  // MODE B path (existing): preview-run under the __preview__ prefix. Always
+  // invoked so it tracks edits, but only SELECTED when insightNotInMain.
+  const previewState = useInsightPreviewData(insightConfig, options);
+
+  // MODE A path: load the published insight's main-run data under its
+  // un-prefixed key — identical to the dashboard / ChartPreview call.
+  const mainState = useInsightsData(
+    options.projectId,
+    insightName ? [insightName] : [],
+    DEFAULT_RUN_ID
+  );
+
+  if (insightNotInMain) {
+    return {
+      ...previewState,
+      chartInsightKey: previewState.previewInsightKey,
+      insightNotInMain: true,
+    };
+  }
+
+  return {
+    chartInsightKey: insightName,
+    isLoading: mainState.isInsightsLoading,
+    error: mainState.error,
+    progress: 0,
+    progressMessage: '',
+    insightNotInMain: false,
   };
 };
 

--- a/viewer/src/hooks/usePreviewData.test.js
+++ b/viewer/src/hooks/usePreviewData.test.js
@@ -1,5 +1,10 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { usePreviewData, useInsightPreviewData, useChartPreviewJob } from './usePreviewData';
+import {
+  usePreviewData,
+  useInsightPreviewData,
+  usePreviewInsightData,
+  useChartPreviewJob,
+} from './usePreviewData';
 import { usePreviewJob } from './usePreviewJob';
 import { useInsightsData } from './useInsightsData';
 import {
@@ -618,5 +623,125 @@ describe('useChartPreviewJob — runHash gating', () => {
 
     rerender({ req: buildRequest({ type: 'indicator', value: '?{MAX(x)}', mode: 'delta' }) });
     expect(useStore.mockStoreState.updateInsightJob).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePreviewInsightData — the two-mode resolver (VIS-1002 / design §2 + §8.3).
+//
+// MODE A (published/saved, insight present in the main run): point the chart at
+//   the UN-prefixed key and load via useInsightsData(projectId, [name], 'main').
+// MODE B (unsaved/never-run, insight ABSENT from the main run): keep the
+//   __preview__-prefixed preview-run path (must not regress).
+// ---------------------------------------------------------------------------
+describe('usePreviewInsightData — MODE-A / MODE-B selection', () => {
+  let mockStartRun;
+  let mockResetRun;
+
+  const makePreviewJob = (overrides = {}) => ({
+    runId: null,
+    status: null,
+    progress: 0,
+    progressMessage: '',
+    result: null,
+    error: null,
+    isRunning: false,
+    isCompleted: false,
+    isFailed: false,
+    startRun: mockStartRun,
+    resetRun: mockResetRun,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStartRun = jest.fn().mockReturnValue(pendingPromise());
+    mockResetRun = jest.fn();
+
+    usePreviewJob.mockReturnValue(makePreviewJob());
+
+    useInsightsData.mockReturnValue({
+      insights: {},
+      insightsData: {},
+      isInsightsLoading: false,
+      hasAllInsightData: false,
+      error: null,
+    });
+
+    hashQueryProps.mockImplementation(() => 'hash');
+    queryPropsHaveChanged.mockReturnValue(false);
+    extractNonQueryProps.mockReturnValue({});
+
+    useStore.mockStoreState = { insightJobs: {}, updateInsightJob: jest.fn() };
+    useStore.mockImplementation(selector => {
+      if (typeof selector === 'function') {
+        return selector(useStore.mockStoreState);
+      }
+      return undefined;
+    });
+    useStore.getState = jest.fn(() => useStore.mockStoreState);
+  });
+
+  test('MODE A: published insight (present in main run) points chart at the un-prefixed key', () => {
+    // Insight IS in the main run → insightNotInMain=false → MODE A.
+    useStore.mockStoreState.insightJobs = {
+      sales: { data: [{ x: 1 }], query: 'SELECT 1' },
+    };
+
+    const { result } = renderHook(() =>
+      usePreviewInsightData({ name: 'sales' }, { projectId: 'proj-1' })
+    );
+
+    // The synthetic chart targets the UN-prefixed key (= the dashboard key).
+    expect(result.current.chartInsightKey).toBe('sales');
+    expect(result.current.insightNotInMain).toBe(false);
+  });
+
+  test('MODE A: loads main-run data via useInsightsData at runId=main, no prefix', () => {
+    useStore.mockStoreState.insightJobs = {
+      sales: { data: [{ x: 1 }], query: 'SELECT 1' },
+    };
+
+    renderHook(() => usePreviewInsightData({ name: 'sales' }, { projectId: 'proj-1' }));
+
+    // The MODE-A load is the exact ChartPreview/dashboard call: default runId,
+    // no storeKeyPrefix.
+    expect(useInsightsData).toHaveBeenCalledWith('proj-1', ['sales'], 'main');
+  });
+
+  test('MODE A: does NOT fire a preview run for a published insight', () => {
+    useStore.mockStoreState.insightJobs = {
+      sales: { data: [{ x: 1 }], query: 'SELECT 1' },
+    };
+
+    renderHook(() => usePreviewInsightData({ name: 'sales' }, { projectId: 'proj-1' }));
+
+    expect(mockStartRun).not.toHaveBeenCalled();
+  });
+
+  test('MODE B: unsaved/never-run insight (absent from main) uses the __preview__ key', () => {
+    // Insight is NOT in the main run → insightNotInMain=true → MODE B.
+    const { result } = renderHook(() =>
+      usePreviewInsightData({ name: 'draft' }, { projectId: 'proj-1' })
+    );
+
+    expect(result.current.chartInsightKey).toBe('__preview__draft');
+    expect(result.current.insightNotInMain).toBe(true);
+  });
+
+  test('MODE B: fires a preview run for an absent insight (regression guard)', () => {
+    renderHook(() => usePreviewInsightData({ name: 'draft' }, { projectId: 'proj-1' }));
+
+    // The existing preview-run path (useInsightPreviewData → startRun) still
+    // fires for the never-run case — ExplorerChartPreview depends on this.
+    expect(mockStartRun).toHaveBeenCalled();
+  });
+
+  test('returns null chartInsightKey when config has no name', () => {
+    const { result } = renderHook(() => usePreviewInsightData({}, { projectId: 'proj-1' }));
+
+    // No name → insightNotInMain=false → MODE A returns the (null) name as key.
+    expect(result.current.chartInsightKey).toBeNull();
   });
 });

--- a/viewer/src/models/Insight.js
+++ b/viewer/src/models/Insight.js
@@ -81,9 +81,16 @@ export function processInputRefsInProps(props, inputs) {
 }
 
 /**
- * Extract input names referenced in insight config (props and interactions)
- * Looks for ${inputName.accessor} and ${ref(inputName).accessor} patterns
- * @param {Object} configOrProps - Insight configuration object with props/interactions, or just props object
+ * Extract input names referenced in an object config (props, interactions, AND layout)
+ * Looks for ${inputName.accessor} and ${ref(inputName).accessor} patterns.
+ *
+ * The dependency set is the UNION across props, interactions, and layout
+ * positions (VIS-1003 / design §8.3): an input referenced only from a chart/item
+ * `layout` expression (e.g. an axis range, annotation, title, or shape) must
+ * still surface a control. When passed a bare props object (no props/layout/
+ * interactions keys) the whole object is scanned for backward compatibility.
+ *
+ * @param {Object} configOrProps - Object config with props/interactions/layout, or just a props object
  * @returns {string[]} - Array of unique input names found
  */
 export function extractInputDependenciesFromProps(configOrProps) {
@@ -117,12 +124,14 @@ export function extractInputDependenciesFromProps(configOrProps) {
     }
   }
 
-  // Check if this is a config object (has props or interactions) or just props
+  // Treat the argument as a structured config when it carries any of the
+  // dependency-bearing positions; otherwise scan it as a bare props object.
   const hasPropsKey = 'props' in configOrProps;
   const hasInteractionsKey = 'interactions' in configOrProps;
+  const hasLayoutKey = 'layout' in configOrProps;
 
-  if (hasPropsKey || hasInteractionsKey) {
-    // It's a config object with props and/or interactions
+  if (hasPropsKey || hasInteractionsKey || hasLayoutKey) {
+    // It's a config object with props, interactions, and/or layout positions
     if (configOrProps.props) {
       scanValue(configOrProps.props);
     }
@@ -132,6 +141,11 @@ export function extractInputDependenciesFromProps(configOrProps) {
           scanValue(interaction);
         }
       });
+    }
+    // Layout positions: input refs can drive axis ranges, titles, annotations,
+    // shapes, etc. on a chart/item layout. Detect them so the widget renders.
+    if (configOrProps.layout) {
+      scanValue(configOrProps.layout);
     }
   } else {
     // It's just a props object (backward compatibility for tests)

--- a/viewer/src/models/Insight.test.js
+++ b/viewer/src/models/Insight.test.js
@@ -458,6 +458,46 @@ describe('extractInputDependenciesFromProps', () => {
     };
     expect(extractInputDependenciesFromProps(props)).toEqual(['dynamic']);
   });
+
+  // VIS-1003 / §8.3: union detection across props + interactions + LAYOUT.
+  it('extracts an input referenced only from a layout position (axis range)', () => {
+    const config = {
+      props: { type: 'scatter' },
+      layout: { xaxis: { range: ['${start_date.value}', '${end_date.value}'] } },
+    };
+    const result = extractInputDependenciesFromProps(config);
+    expect(result).toContain('start_date');
+    expect(result).toContain('end_date');
+    expect(result.length).toBe(2);
+  });
+
+  it('extracts an input from a layout title via ${ref(input).accessor}', () => {
+    const config = {
+      props: { type: 'bar' },
+      layout: { title: { text: 'Sales for ${ref(region).value}' } },
+    };
+    expect(extractInputDependenciesFromProps(config)).toEqual(['region']);
+  });
+
+  it('unions input deps across props, interactions, AND layout', () => {
+    const config = {
+      props: { mode: '${show_markers.value}' },
+      interactions: [{ filter: 'x > ${min_value.value}' }],
+      layout: { yaxis: { range: [0, '${y_max.value}'] } },
+    };
+    const result = extractInputDependenciesFromProps(config);
+    expect(result).toContain('show_markers');
+    expect(result).toContain('min_value');
+    expect(result).toContain('y_max');
+    expect(result.length).toBe(3);
+  });
+
+  it('treats a config with only a layout key as a structured config (not bare props)', () => {
+    const config = { layout: { xaxis: { range: ['${lo.value}', '${hi.value}'] } } };
+    const result = extractInputDependenciesFromProps(config);
+    expect(result).toContain('lo');
+    expect(result).toContain('hi');
+  });
 });
 /* eslint-enable no-template-curly-in-string */
 


### PR DESCRIPTION
Implements two Canvas Object Surfaces viewer fixes from the Dashboard Building v1 initiative (Track N). They overlap on the same preview files, so they ship together.

## VIS-1002 — Insight preview: reuse main-run data for published insights (stop the infinite spinner)

The bug: `useInsightPreviewData` always targeted `insightJobs['__preview__'+name]` and only loaded via a preview RUN that fires when the insight is ABSENT from the main run — so a **published** insight (already present in the main run) never loaded, leaving `items/Chart` spinning forever. Exactly inverted.

Fix — a shared two-mode resolver `usePreviewInsightData`, gated on `insightNotInMain = !insightJobs[name]` (keyed on **presence** of the job entry, not data completeness, so it doesn't flap while inputs resolve):

- **MODE A (published/saved, dominant case):** point the synthetic chart at the **un-prefixed** key `insightJobs[name]` and load via `useInsightsData(projectId, [name])` at default `runId='main'` — the exact path `workspace/ChartPreview` already uses. No preview run, no hang.
- **MODE B (unsaved/never-run/edit):** keeps the existing `__preview__` preview-run path. `usePreviewData.js` is **purely additive** — `useInsightPreviewData` and `useChartPreviewJob` are untouched, so `ExplorerChartPreview`/`useChartPreviewJob` cannot regress.

Per the v2 (§8) decisions: the canvas is bidirectional like the dashboard (MODE B re-runs on every config change, no staleness gate), and inputs **always default** so there is no "waiting for input" empty state.

## VIS-1003 — Render input widgets in chart/table/insight previews (always default)

Input-driven previews used to hang: the insight stayed `pendingInputs`, `Chart`/`Table` spun forever, and there was no widget to supply a value (`TablePreview` even hardcoded `useInputsData(projectId, [])`).

- **Detection across props + layout + interactions (union).** `extractInputDependenciesFromProps` now also scans a `layout` key. Inputs are referenced in insight **props** (e.g. `props.mode: "${show_markers.value}"`) and in chart/item **layout** positions — axis ranges, titles, annotations, shapes (e.g. `layout.xaxis.range: ["${start_date.value}", "${end_date.value}"]`). Both `${input.x}` and `${ref(input).x}` forms are handled.
- **New `usePreviewInputDependencies` hook:** unions runtime `insightJobs[n].inputDependencies` + `pendingInputs` across `insightNames` with a config fallback (props+layout+interactions), resolves each name → `<Input>` config from store `inputs`, and calls `useInputsData` to seed defaults. **Keyed only on resolved names — never on a pending/resolved boolean (VIS-831 safe).**
- **New `PreviewInputControls` component:** renders `null` when empty, else a flex-wrap strip of `<Input>` widgets **above** the body and **outside** the `Chart`/`Table` spinner gate, with an input-type chip from `objectTypeConfigs`.
- **Wired into** `ChartPreview` (replaces inline union), `TablePreview` (replaces the hardcoded empty input list with its classified `insightNames`), and `common/InsightPreview` (parity). Multi-insight objects show the UNION of all parent inputs.

## Tests
- New: `usePreviewInsightData` MODE-A/MODE-B suite, layout-detection cases in `Insight.test.js`, `usePreviewInputDependencies.test.js` (union/fallback/resolution/dedupe/no-pending-key/always-default), `PreviewInputControls.test.jsx`.
- Extended: `ChartPreview`/`TablePreview`/`common/InsightPreview` suites for the control strip; `common/InsightPreview` rewired to the new hooks.
- E2E `workspace-object-previews.spec.mjs`: Step 4 tightened to assert the MODE-A published path renders with **no** preview-loading spinner; added input-driven chart / insight / table steps (defaulted control + body renders).
- `bash scripts/viewer-check.sh` green: **210 suites, 2889 passing**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)