### PR TITLE
fix(viewer/workspace): canvas lens tab always reads 'Canvas'

### DIFF
--- a/viewer/src/components/new-views/workspace/MiddlePane.jsx
+++ b/viewer/src/components/new-views/workspace/MiddlePane.jsx
@@ -194,7 +194,7 @@ const PerObjectPane = ({ activeObject, projectId }) => {
           <PreviewLensPicker
             value={lens}
             onChange={setLensEffective}
-            previewLabel="Preview"
+            previewLabel="Canvas"
             previewDisabled={!hasPreview}
           />
         }

--- a/viewer/src/components/new-views/workspace/SubBar.jsx
+++ b/viewer/src/components/new-views/workspace/SubBar.jsx
@@ -29,15 +29,17 @@ export const SubBar = ({ left, right, testId = 'workspace-subbar' }) => {
  * belongs next to the thing it's switching the view of (per the chat
  * transcript in `design/cofounder-mockups/chats/chat1.md`).
  *
- * `previewLabel` lets non-dashboard objects say "Preview" instead of
- * "Canvas". `previewDisabled` is the lineage-fallback case — object types
- * that don't have a preview component yet (e.g. Phase 0 models) stay parked
- * on Lineage and Preview reads as muted.
+ * The first lens is labelled "Canvas" for EVERY object type (dashboards and
+ * per-object surfaces alike) — a single consistent name avoids the cognitive
+ * load of the tab renaming itself per selection. `previewLabel` stays
+ * overridable but defaults to "Canvas". `previewDisabled` is the
+ * lineage-fallback case — object types that don't have a canvas component yet
+ * (e.g. Phase 0 models) stay parked on Lineage and the Canvas lens reads muted.
  */
 export const PreviewLensPicker = ({
   value,
   onChange,
-  previewLabel = 'Preview',
+  previewLabel = 'Canvas',
   previewDisabled = false,
   testId = 'workspace-lens-picker',
 }) => {


### PR DESCRIPTION
The middle-pane lens picker labelled its first tab "Canvas" for dashboards but "Preview" for every other object type, so the tab name changed as you moved between objects — confusing, unneeded cognitive load (acceptance-test feedback). Now consistently "Canvas" everywhere: PreviewLensPicker defaults to "Canvas" and the per-object pane passes "Canvas".

SubBar/MiddlePane unit tests green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)