### PR TITLE
TopNav: configurable user-menu items (userMenuItems prop)

### DIFF
--- a/viewer/src/components/common/TopNav.jsx
+++ b/viewer/src/components/common/TopNav.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import logo from '../../images/logo.png';
 import Dropdown from './Dropdown';
-import { FiChevronDown, FiFolder, FiCheck, FiX, FiSearch, FiClock, FiUser, FiUsers, FiLogOut, FiLayers, FiArrowRight } from 'react-icons/fi';
+import { FiChevronDown, FiFolder, FiCheck, FiX, FiSearch, FiClock, FiLogOut, FiLayers, FiArrowRight } from 'react-icons/fi';
 import { FaStar, FaRocket } from 'react-icons/fa';
 import { VscGitCommit } from 'react-icons/vsc';
 import { SiGithub } from 'react-icons/si';
@@ -376,7 +376,7 @@ function localMenu(close) {
   );
 }
 
-function UserMenu({ user, onSignOut }) {
+function UserMenu({ user, onSignOut, items = [] }) {
   const initial = user?.name ? user.name[0].toUpperCase() : 'U';
   const trigger = (
     <span style={{ display: 'inline-flex', cursor: 'pointer' }}>
@@ -394,8 +394,15 @@ function UserMenu({ user, onSignOut }) {
               <div style={{ fontSize: 13, fontWeight: 600, color: '#111827' }}>{user.name}</div>
               {user.email && <div style={{ fontSize: 11.5, color: '#6b7280' }}>{user.email}</div>}
             </div>
-            <Row onClick={close} style={{ borderRadius: 6 }}><FiUser size={15} color="#6b7280" /> Account</Row>
-            <Row onClick={close} style={{ borderRadius: 6 }}><FiUsers size={15} color="#6b7280" /> Organization</Row>
+            {items.map(item => (
+              <Row
+                key={item.label}
+                onClick={() => { item.onClick && item.onClick(); close(); }}
+                style={{ borderRadius: 6 }}
+              >
+                {item.icon ? <item.icon size={15} color="#6b7280" /> : null} {item.label}
+              </Row>
+            ))}
             <Row onClick={() => { onSignOut && onSignOut(); close(); }} style={{ borderRadius: 6 }}><FiLogOut size={15} color="#6b7280" /> Sign out</Row>
           </div>
         ) : (
@@ -432,6 +439,9 @@ const TopNav = ({
   // user (cloud) — absent ⇒ local login/docs/community menu
   user,
   onSignOut,
+  // cloud: items shown above "Sign out" in the user menu ({label, icon, onClick}).
+  // The host app (core) supplies these so the shared viewer carries no app routes.
+  userMenuItems,
   // cloud unifiers: a custom logo node (the account menu) and an "All stages"
   // link in the stage dropdown. Absent locally → plain logo, no all-stages.
   renderLogo,
@@ -504,7 +514,7 @@ const TopNav = ({
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             {showVersions && <VersionPill versions={versions} currentVersion={currentVersion} onVersionChange={onVersionChange} compact />}
             {showProject && action}
-            <UserMenu user={user} onSignOut={onSignOut} />
+            <UserMenu user={user} onSignOut={onSignOut} items={userMenuItems} />
           </div>
         </div>
         {banner}
@@ -529,7 +539,7 @@ const TopNav = ({
           {showVersions && <VersionPill versions={versions} currentVersion={currentVersion} onVersionChange={onVersionChange} />}
           {showProject && action}
           <div style={{ width: 1, height: 22, background: HAIR }} />
-          <UserMenu user={user} onSignOut={onSignOut} />
+          <UserMenu user={user} onSignOut={onSignOut} items={userMenuItems} />
         </div>
       </div>
       {banner}

--- a/viewer/src/components/common/TopNav.test.jsx
+++ b/viewer/src/components/common/TopNav.test.jsx
@@ -107,4 +107,41 @@ describe('TopNav', () => {
     // eslint-disable-next-line no-bitwise
     expect(def.compareDocumentPosition(starred) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
+
+  describe('user menu (cloud)', () => {
+    // The avatar trigger shows the user's initial; click it to open the menu.
+    const openMenu = props => {
+      renderNav({ tools: [], stages: [], user: { name: 'Zoe', email: 'zoe@x.io' }, ...props });
+      fireEvent.click(screen.getByText('Z'));
+    };
+
+    it('renders userMenuItems and invokes their onClick', () => {
+      const onProfile = jest.fn();
+      openMenu({
+        userMenuItems: [
+          { label: 'Profile', onClick: onProfile },
+          { label: 'Account', onClick: () => {} },
+        ],
+      });
+      expect(screen.getByText('Profile')).toBeInTheDocument();
+      expect(screen.getByText('Account')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Profile'));
+      expect(onProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it('always offers Sign out and calls onSignOut', () => {
+      const onSignOut = jest.fn();
+      openMenu({ onSignOut, userMenuItems: [] });
+      fireEvent.click(screen.getByText('Sign out'));
+      expect(onSignOut).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows no menu items beyond Sign out when none are provided', () => {
+      // The old dead "Account"/"Organization" placeholders are gone.
+      openMenu({});
+      expect(screen.getByText('Sign out')).toBeInTheDocument();
+      expect(screen.queryByText('Organization')).not.toBeInTheDocument();
+      expect(screen.queryByText('Account')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## What
The cloud user menu in `TopNav` hardcoded **Account** and **Organization** rows whose `onClick` only closed the dropdown — dead placeholders. This replaces them with an optional **`userMenuItems`** prop (`{label, icon, onClick}[]`) rendered above "Sign out", so the host app supplies real, working items without the shared viewer carrying any app-specific routes.

- `UserMenu` now takes `items = []` and maps them to rows (icon is a component, rendered as `<item.icon/>`).
- `TopNav` threads a `userMenuItems` prop to both (narrow + wide) render sites.
- Drops the now-unused `FiUser` / `FiUsers` imports.

## Why
`core` (consumer) was showing the dead Account/Organization items on its unified bar. With this prop, core passes Profile→`/profile`, Account→`/{slug}`, Documentation, Install CLI — matching its legacy Navbar dropdown. See the companion core change (visivo-io/core#302).

## Tests
- `TopNav.test.jsx`: 10 passing.
- `eslint src/components/common/TopNav.jsx`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)