### PR TITLE
feat(authorize): send anonymous machine_id at visivo authorize for PostHog account stitching (VIS-842)

### DIFF
--- a/tests/commands/test_authorize.py
+++ b/tests/commands/test_authorize.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import urllib.parse
 from click.testing import CliRunner
 import pytest
 
@@ -133,3 +134,77 @@ def test_authorize_existing_token_overwrite(monkeypatch):
 
     assert result.exit_code == 0
     assert "Waiting for visivo token response" in result.output
+
+
+def _capture_opened_url(monkeypatch):
+    """
+    Patch open_url (where it is used in authorize) to capture the URL it is
+    called with, returning a one-element list that will hold the captured URL.
+    """
+    captured = []
+
+    def fake_open_url(url):
+        captured.append(url)
+        return True
+
+    monkeypatch.setattr("visivo.commands.authorize.open_url", fake_open_url)
+    return captured
+
+
+def test_authorize_includes_machine_id_when_telemetry_enabled(monkeypatch):
+    """
+    When telemetry is enabled, the opened authorize URL must carry the anonymous
+    machine_id (the PostHog distinct_id) so the server can stitch it to the account.
+    """
+    known_machine_id = "11111111-2222-3333-4444-555555555555"
+    monkeypatch.setattr("visivo.commands.authorize.get_existing_token", lambda host=None: None)
+    monkeypatch.setattr("visivo.commands.authorize.is_telemetry_enabled", lambda: True)
+    monkeypatch.setattr("visivo.commands.authorize.get_machine_id", lambda: known_machine_id)
+    monkeypatch.setattr(token_received_event, "wait", lambda timeout=None: True)
+
+    captured = _capture_opened_url(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(authorize, ["--host", "http://localhost:3030"])
+
+    assert result.exit_code == 0
+    assert len(captured) == 1
+    opened_url = captured[0]
+    parsed = urllib.parse.urlparse(opened_url)
+    query = urllib.parse.parse_qs(parsed.query)
+
+    assert query.get("machine_id") == [known_machine_id]
+    # Regression: original params are still present.
+    assert "redirect_url" in query
+    assert query.get("name") is not None
+
+
+def test_authorize_excludes_machine_id_when_telemetry_disabled(monkeypatch):
+    """
+    When telemetry is disabled (opt-out), the opened authorize URL must NOT carry
+    machine_id, so no stitching happens and the CLI stays anonymous.
+    """
+    monkeypatch.setattr("visivo.commands.authorize.get_existing_token", lambda host=None: None)
+    monkeypatch.setattr("visivo.commands.authorize.is_telemetry_enabled", lambda: False)
+
+    def fail_get_machine_id():
+        raise AssertionError("get_machine_id must not be called when telemetry is disabled")
+
+    monkeypatch.setattr("visivo.commands.authorize.get_machine_id", fail_get_machine_id)
+    monkeypatch.setattr(token_received_event, "wait", lambda timeout=None: True)
+
+    captured = _capture_opened_url(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(authorize, ["--host", "http://localhost:3030"])
+
+    assert result.exit_code == 0
+    assert len(captured) == 1
+    opened_url = captured[0]
+    parsed = urllib.parse.urlparse(opened_url)
+    query = urllib.parse.parse_qs(parsed.query)
+
+    assert "machine_id" not in query
+    # Regression: original params are still present.
+    assert "redirect_url" in query
+    assert query.get("name") is not None

--- a/visivo/commands/authorize.py
+++ b/visivo/commands/authorize.py
@@ -14,6 +14,8 @@ from visivo.tokens.server import (
     token_received_event,
     FLASK_PORT,
 )
+from visivo.telemetry.config import is_telemetry_enabled
+from visivo.telemetry.machine_id import get_machine_id
 
 PROFILE_PATH = os.path.expanduser("~/.visivo/profile.yml")
 CALLBACK_RESPONSE_WAIT_TIME = 120
@@ -56,6 +58,16 @@ def authorize(host):
     redirect_url = f"http://localhost:{FLASK_PORT}/authorize-device-token"
 
     params = {"redirect_url": redirect_url, "name": device_name}
+
+    # Only attach the anonymous machine_id when telemetry is enabled, so the server can
+    # stitch machine_id<->account in PostHog (VIS-842). Never send email/PII -- machine_id
+    # is the same anonymous PostHog distinct_id the CLI already uses for telemetry, and the
+    # existing telemetry opt-out covers this disclosure.
+    if is_telemetry_enabled():
+        try:
+            params["machine_id"] = get_machine_id()
+        except Exception:
+            pass  # never block authorize on telemetry id resolution
 
     query_string = urllib.parse.urlencode(params)
 


### PR DESCRIPTION
Closes VIS-842 (CLI side). Ships together with the core PR (cross-repo dependency): **visivo-io/core#303**.

## What this does
When telemetry is enabled, `visivo authorize` now appends the anonymous `machine_id` (the CLI's existing PostHog distinct_id, a UUID) to the `/authorize-device?...&machine_id=<uuid>` browser URL. The cloud app forwards it to the token POST so the backend can stitch `machine_id<->account` in PostHog (`group_identify(account)` + a `cli_account_linked` capture, server-side).

## End-to-end flow
CLI authorize URL (this PR) -> React `AuthorizeDevice` reads `machine_id` -> `createToken` POSTs it -> backend `request.data["machine_id"]` -> PostHog stitch *(all in core#303)*.

## Changes
- `visivo/commands/authorize.py`: when `is_telemetry_enabled()`, add `machine_id=get_machine_id()` to the authorize URL params. Never sends email/PII; the existing telemetry opt-out covers this disclosure; resolving the id is wrapped so it can never block authorize.
- `tests/commands/test_authorize.py`: assert `machine_id` is present in the opened URL when telemetry is enabled and absent when disabled, with `redirect_url`/`name` preserved in both cases.

## Tests
`tests/commands/test_authorize.py` passes (6 tests); `black --check --target-version py312` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)