### PR TITLE
fix(viewer): thread project_id through resource save/delete calls

### DIFF
--- a/viewer/src/api/charts.js
+++ b/viewer/src/api/charts.js
@@ -31,8 +31,10 @@ export const fetchChart = async name => {
 /**
  * Save a chart configuration to cache (draft state)
  */
-export const saveChart = async (name, config) => {
-  const response = await apiFetch(getUrl('chartDetail', { name }), {
+export const saveChart = async (name, config, projectId = null) => {
+  let url = getUrl('chartDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveChart = async (name, config) => {
 /**
  * Delete a chart from cache (revert to published version)
  */
-export const deleteChart = async name => {
-  const response = await apiFetch(getUrl('chartDetail', { name }), {
+export const deleteChart = async (name, projectId = null) => {
+  let url = getUrl('chartDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/csvScriptModels.js
+++ b/viewer/src/api/csvScriptModels.js
@@ -17,8 +17,10 @@ export const fetchAllCsvScriptModels = async (projectId = null) => {
 /**
  * Save a CsvScriptModel configuration to cache (draft state)
  */
-export const saveCsvScriptModel = async (name, config) => {
-  const response = await apiFetch(getUrl('csvScriptModelDetail', { name }), {
+export const saveCsvScriptModel = async (name, config, projectId = null) => {
+  let url = getUrl('csvScriptModelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -35,8 +37,10 @@ export const saveCsvScriptModel = async (name, config) => {
 /**
  * Delete a CsvScriptModel (mark for deletion)
  */
-export const deleteCsvScriptModel = async name => {
-  const response = await apiFetch(getUrl('csvScriptModelDetail', { name }), {
+export const deleteCsvScriptModel = async (name, projectId = null) => {
+  let url = getUrl('csvScriptModelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/dashboards.js
+++ b/viewer/src/api/dashboards.js
@@ -17,8 +17,10 @@ export const fetchAllDashboards = async (projectId = null) => {
 /**
  * Save a dashboard configuration to cache (draft state)
  */
-export const saveDashboard = async (name, config) => {
-  const response = await apiFetch(getUrl('dashboardSave', { name }), {
+export const saveDashboard = async (name, config, projectId = null) => {
+  let url = getUrl('dashboardSave', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -35,8 +37,10 @@ export const saveDashboard = async (name, config) => {
 /**
  * Delete a dashboard (mark for deletion)
  */
-export const deleteDashboard = async name => {
-  const response = await apiFetch(getUrl('dashboardDelete', { name }), {
+export const deleteDashboard = async (name, projectId = null) => {
+  let url = getUrl('dashboardDelete', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/defaults.js
+++ b/viewer/src/api/defaults.js
@@ -17,8 +17,10 @@ export const fetchDefaults = async (projectId = null) => {
 /**
  * Save defaults configuration to cache (draft state)
  */
-export const saveDefaults = async config => {
-  const response = await apiFetch(getUrl('defaults'), {
+export const saveDefaults = async (config, projectId = null) => {
+  let url = getUrl('defaults');
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/viewer/src/api/dimensions.js
+++ b/viewer/src/api/dimensions.js
@@ -31,8 +31,10 @@ export const fetchDimension = async name => {
 /**
  * Save a dimension configuration to cache (draft state)
  */
-export const saveDimension = async (name, config) => {
-  const response = await apiFetch(getUrl('dimensionDetail', { name }), {
+export const saveDimension = async (name, config, projectId = null) => {
+  let url = getUrl('dimensionDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveDimension = async (name, config) => {
 /**
  * Delete a dimension from cache (revert to published version)
  */
-export const deleteDimension = async name => {
-  const response = await apiFetch(getUrl('dimensionDetail', { name }), {
+export const deleteDimension = async (name, projectId = null) => {
+  let url = getUrl('dimensionDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/inputs.js
+++ b/viewer/src/api/inputs.js
@@ -31,8 +31,10 @@ export const fetchInput = async name => {
 /**
  * Save an input configuration to cache (draft state)
  */
-export const saveInput = async (name, config) => {
-  const response = await apiFetch(getUrl('inputDetail', { name }), {
+export const saveInput = async (name, config, projectId = null) => {
+  let url = getUrl('inputDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveInput = async (name, config) => {
 /**
  * Delete an input from cache (revert to published version)
  */
-export const deleteInput = async name => {
-  const response = await apiFetch(getUrl('inputDetail', { name }), {
+export const deleteInput = async (name, projectId = null) => {
+  let url = getUrl('inputDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/insights.js
+++ b/viewer/src/api/insights.js
@@ -31,8 +31,10 @@ export const fetchInsight = async name => {
 /**
  * Save an insight configuration to cache (draft state)
  */
-export const saveInsight = async (name, config) => {
-  const response = await apiFetch(getUrl('insightDetail', { name }), {
+export const saveInsight = async (name, config, projectId = null) => {
+  let url = getUrl('insightDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveInsight = async (name, config) => {
 /**
  * Delete an insight from cache (revert to published version)
  */
-export const deleteInsight = async name => {
-  const response = await apiFetch(getUrl('insightDetail', { name }), {
+export const deleteInsight = async (name, projectId = null) => {
+  let url = getUrl('insightDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/localMergeModels.js
+++ b/viewer/src/api/localMergeModels.js
@@ -17,8 +17,10 @@ export const fetchAllLocalMergeModels = async (projectId = null) => {
 /**
  * Save a LocalMergeModel configuration to cache (draft state)
  */
-export const saveLocalMergeModel = async (name, config) => {
-  const response = await apiFetch(getUrl('localMergeModelDetail', { name }), {
+export const saveLocalMergeModel = async (name, config, projectId = null) => {
+  let url = getUrl('localMergeModelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -35,8 +37,10 @@ export const saveLocalMergeModel = async (name, config) => {
 /**
  * Delete a LocalMergeModel (mark for deletion)
  */
-export const deleteLocalMergeModel = async name => {
-  const response = await apiFetch(getUrl('localMergeModelDetail', { name }), {
+export const deleteLocalMergeModel = async (name, projectId = null) => {
+  let url = getUrl('localMergeModelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/markdowns.js
+++ b/viewer/src/api/markdowns.js
@@ -31,8 +31,10 @@ export const fetchMarkdown = async name => {
 /**
  * Save a markdown configuration to cache (draft state)
  */
-export const saveMarkdown = async (name, config) => {
-  const response = await apiFetch(getUrl('markdownDetail', { name }), {
+export const saveMarkdown = async (name, config, projectId = null) => {
+  let url = getUrl('markdownDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveMarkdown = async (name, config) => {
 /**
  * Delete a markdown from cache (revert to published version)
  */
-export const deleteMarkdown = async name => {
-  const response = await apiFetch(getUrl('markdownDetail', { name }), {
+export const deleteMarkdown = async (name, projectId = null) => {
+  let url = getUrl('markdownDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/metrics.js
+++ b/viewer/src/api/metrics.js
@@ -31,8 +31,10 @@ export const fetchMetric = async name => {
 /**
  * Save a metric configuration to cache (draft state)
  */
-export const saveMetric = async (name, config) => {
-  const response = await apiFetch(getUrl('metricDetail', { name }), {
+export const saveMetric = async (name, config, projectId = null) => {
+  let url = getUrl('metricDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveMetric = async (name, config) => {
 /**
  * Delete a metric from cache (revert to published version)
  */
-export const deleteMetric = async name => {
-  const response = await apiFetch(getUrl('metricDetail', { name }), {
+export const deleteMetric = async (name, projectId = null) => {
+  let url = getUrl('metricDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/models.js
+++ b/viewer/src/api/models.js
@@ -31,8 +31,10 @@ export const fetchModel = async name => {
 /**
  * Save a model configuration to cache (draft state)
  */
-export const saveModel = async (name, config) => {
-  const response = await apiFetch(getUrl('modelDetail', { name }), {
+export const saveModel = async (name, config, projectId = null) => {
+  let url = getUrl('modelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveModel = async (name, config) => {
 /**
  * Delete a model from cache (revert to published version)
  */
-export const deleteModel = async name => {
-  const response = await apiFetch(getUrl('modelDetail', { name }), {
+export const deleteModel = async (name, projectId = null) => {
+  let url = getUrl('modelDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/relations.js
+++ b/viewer/src/api/relations.js
@@ -31,8 +31,10 @@ export const fetchRelation = async name => {
 /**
  * Save a relation configuration to cache (draft state)
  */
-export const saveRelation = async (name, config) => {
-  const response = await apiFetch(getUrl('relationDetail', { name }), {
+export const saveRelation = async (name, config, projectId = null) => {
+  let url = getUrl('relationDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveRelation = async (name, config) => {
 /**
  * Delete a relation from cache (revert to published version)
  */
-export const deleteRelation = async name => {
-  const response = await apiFetch(getUrl('relationDetail', { name }), {
+export const deleteRelation = async (name, projectId = null) => {
+  let url = getUrl('relationDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/api/resourceApis.test.js
+++ b/viewer/src/api/resourceApis.test.js
@@ -26,18 +26,102 @@ const notFound = () => ({ status: 404, json: async () => ({}) });
 const fail = (status, data = {}) => ({ status, json: async () => data });
 
 const CASES = [
-  { name: 'charts', fetchAll: charts.fetchAllCharts, fetchOne: charts.fetchChart, save: charts.saveChart, del: charts.deleteChart, validate: charts.validateChart },
-  { name: 'sources', fetchAll: sources.fetchAllSources, fetchOne: sources.fetchSource, save: sources.saveSource, del: sources.deleteSource, validate: sources.validateSource },
-  { name: 'dimensions', fetchAll: dimensions.fetchAllDimensions, fetchOne: dimensions.fetchDimension, save: dimensions.saveDimension, del: dimensions.deleteDimension, validate: dimensions.validateDimension },
-  { name: 'metrics', fetchAll: metrics.fetchAllMetrics, fetchOne: metrics.fetchMetric, save: metrics.saveMetric, del: metrics.deleteMetric, validate: metrics.validateMetric },
-  { name: 'relations', fetchAll: relations.fetchAllRelations, fetchOne: relations.fetchRelation, save: relations.saveRelation, del: relations.deleteRelation, validate: relations.validateRelation },
-  { name: 'models', fetchAll: models.fetchAllModels, fetchOne: models.fetchModel, save: models.saveModel, del: models.deleteModel, validate: models.validateModel },
-  { name: 'csvScriptModels', fetchAll: csvScriptModels.fetchAllCsvScriptModels, fetchOne: null, save: csvScriptModels.saveCsvScriptModel, del: csvScriptModels.deleteCsvScriptModel, validate: csvScriptModels.validateCsvScriptModel },
-  { name: 'localMergeModels', fetchAll: localMergeModels.fetchAllLocalMergeModels, fetchOne: null, save: localMergeModels.saveLocalMergeModel, del: localMergeModels.deleteLocalMergeModel, validate: localMergeModels.validateLocalMergeModel },
-  { name: 'markdowns', fetchAll: markdowns.fetchAllMarkdowns, fetchOne: markdowns.fetchMarkdown, save: markdowns.saveMarkdown, del: markdowns.deleteMarkdown, validate: markdowns.validateMarkdown },
-  { name: 'inputs', fetchAll: inputs.fetchAllInputs, fetchOne: inputs.fetchInput, save: inputs.saveInput, del: inputs.deleteInput, validate: inputs.validateInput },
-  { name: 'insights', fetchAll: insights.fetchAllInsights, fetchOne: insights.fetchInsight, save: insights.saveInsight, del: insights.deleteInsight, validate: insights.validateInsight },
-  { name: 'tables', fetchAll: tables.fetchAllTables, fetchOne: tables.fetchTable, save: tables.saveTable, del: tables.deleteTable, validate: tables.validateTable },
+  {
+    name: 'charts',
+    fetchAll: charts.fetchAllCharts,
+    fetchOne: charts.fetchChart,
+    save: charts.saveChart,
+    del: charts.deleteChart,
+    validate: charts.validateChart,
+  },
+  {
+    name: 'sources',
+    fetchAll: sources.fetchAllSources,
+    fetchOne: sources.fetchSource,
+    save: sources.saveSource,
+    del: sources.deleteSource,
+    validate: sources.validateSource,
+  },
+  {
+    name: 'dimensions',
+    fetchAll: dimensions.fetchAllDimensions,
+    fetchOne: dimensions.fetchDimension,
+    save: dimensions.saveDimension,
+    del: dimensions.deleteDimension,
+    validate: dimensions.validateDimension,
+  },
+  {
+    name: 'metrics',
+    fetchAll: metrics.fetchAllMetrics,
+    fetchOne: metrics.fetchMetric,
+    save: metrics.saveMetric,
+    del: metrics.deleteMetric,
+    validate: metrics.validateMetric,
+  },
+  {
+    name: 'relations',
+    fetchAll: relations.fetchAllRelations,
+    fetchOne: relations.fetchRelation,
+    save: relations.saveRelation,
+    del: relations.deleteRelation,
+    validate: relations.validateRelation,
+  },
+  {
+    name: 'models',
+    fetchAll: models.fetchAllModels,
+    fetchOne: models.fetchModel,
+    save: models.saveModel,
+    del: models.deleteModel,
+    validate: models.validateModel,
+  },
+  {
+    name: 'csvScriptModels',
+    fetchAll: csvScriptModels.fetchAllCsvScriptModels,
+    fetchOne: null,
+    save: csvScriptModels.saveCsvScriptModel,
+    del: csvScriptModels.deleteCsvScriptModel,
+    validate: csvScriptModels.validateCsvScriptModel,
+  },
+  {
+    name: 'localMergeModels',
+    fetchAll: localMergeModels.fetchAllLocalMergeModels,
+    fetchOne: null,
+    save: localMergeModels.saveLocalMergeModel,
+    del: localMergeModels.deleteLocalMergeModel,
+    validate: localMergeModels.validateLocalMergeModel,
+  },
+  {
+    name: 'markdowns',
+    fetchAll: markdowns.fetchAllMarkdowns,
+    fetchOne: markdowns.fetchMarkdown,
+    save: markdowns.saveMarkdown,
+    del: markdowns.deleteMarkdown,
+    validate: markdowns.validateMarkdown,
+  },
+  {
+    name: 'inputs',
+    fetchAll: inputs.fetchAllInputs,
+    fetchOne: inputs.fetchInput,
+    save: inputs.saveInput,
+    del: inputs.deleteInput,
+    validate: inputs.validateInput,
+  },
+  {
+    name: 'insights',
+    fetchAll: insights.fetchAllInsights,
+    fetchOne: insights.fetchInsight,
+    save: insights.saveInsight,
+    del: insights.deleteInsight,
+    validate: insights.validateInsight,
+  },
+  {
+    name: 'tables',
+    fetchAll: tables.fetchAllTables,
+    fetchOne: tables.fetchTable,
+    save: tables.saveTable,
+    del: tables.deleteTable,
+    validate: tables.validateTable,
+  },
 ];
 
 describe('per-type resource API modules', () => {
@@ -80,6 +164,21 @@ describe('per-type resource API modules', () => {
       );
     });
 
+    it('save scopes by project_id when one is given, and omits it otherwise', async () => {
+      apiFetch.mockResolvedValueOnce(ok({ saved: true }));
+      await save('x', { a: 1 }, 'proj-1');
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.stringContaining('project_id=proj-1'),
+        expect.objectContaining({ method: 'POST' })
+      );
+      apiFetch.mockResolvedValueOnce(ok({ saved: true }));
+      await save('x', { a: 1 });
+      expect(apiFetch).toHaveBeenLastCalledWith(
+        expect.not.stringContaining('project_id'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
     it("save surfaces the server's error message on failure", async () => {
       apiFetch.mockResolvedValueOnce(fail(400, { error: 'bad config' }));
       await expect(save('x', {})).rejects.toThrow('bad config');
@@ -94,6 +193,15 @@ describe('per-type resource API modules', () => {
       );
       apiFetch.mockResolvedValueOnce(fail(500));
       await expect(del('x')).rejects.toThrow();
+    });
+
+    it('delete scopes by project_id when one is given', async () => {
+      apiFetch.mockResolvedValueOnce(ok({ deleted: true }));
+      await del('x', 'proj-1');
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.stringContaining('project_id=proj-1'),
+        expect.objectContaining({ method: 'DELETE' })
+      );
     });
 
     it('validate returns the parsed body regardless of status', async () => {

--- a/viewer/src/api/sources.js
+++ b/viewer/src/api/sources.js
@@ -31,8 +31,10 @@ export const fetchSource = async name => {
 /**
  * Save a source configuration to cache (draft state)
  */
-export const saveSource = async (name, config) => {
-  const response = await apiFetch(getUrl('sourceDetail', { name }), {
+export const saveSource = async (name, config, projectId = null) => {
+  let url = getUrl('sourceDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveSource = async (name, config) => {
 /**
  * Delete a source from cache (revert to published version)
  */
-export const deleteSource = async name => {
-  const response = await apiFetch(getUrl('sourceDetail', { name }), {
+export const deleteSource = async (name, projectId = null) => {
+  let url = getUrl('sourceDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {
@@ -94,4 +98,3 @@ export const testSourceConnection = async config => {
     error: errorData.error || 'Connection test failed',
   };
 };
-

--- a/viewer/src/api/tables.js
+++ b/viewer/src/api/tables.js
@@ -31,8 +31,10 @@ export const fetchTable = async name => {
 /**
  * Save a table configuration to cache (draft state)
  */
-export const saveTable = async (name, config) => {
-  const response = await apiFetch(getUrl('tableDetail', { name }), {
+export const saveTable = async (name, config, projectId = null) => {
+  let url = getUrl('tableDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,8 +51,10 @@ export const saveTable = async (name, config) => {
 /**
  * Delete a table from cache (revert to published version)
  */
-export const deleteTable = async name => {
-  const response = await apiFetch(getUrl('tableDetail', { name }), {
+export const deleteTable = async (name, projectId = null) => {
+  let url = getUrl('tableDetail', { name });
+  if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;
+  const response = await apiFetch(url, {
     method: 'DELETE',
   });
   if (response.status === 200) {

--- a/viewer/src/stores/chartStore.js
+++ b/viewer/src/stores/chartStore.js
@@ -29,7 +29,8 @@ const createChartSlice = (set, get) => ({
   // Save chart to cache
   saveChart: async (name, config) => {
     try {
-      const result = await chartsApi.saveChart(name, config);
+      const projectId = get().project?.id;
+      const result = await chartsApi.saveChart(name, config, projectId);
       // Refresh charts list to get updated status
       await get().fetchCharts();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createChartSlice = (set, get) => ({
   // Mark chart for deletion (will be removed from YAML on commit)
   deleteChart: async name => {
     try {
-      await chartsApi.deleteChart(name);
+      const projectId = get().project?.id;
+      await chartsApi.deleteChart(name, projectId);
       await get().fetchCharts();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/csvScriptModelStore.js
+++ b/viewer/src/stores/csvScriptModelStore.js
@@ -26,7 +26,8 @@ const createCsvScriptModelSlice = (set, get) => ({
   // Save csv script model to cache
   saveCsvScriptModel: async (name, config) => {
     try {
-      const result = await csvScriptModelsApi.saveCsvScriptModel(name, config);
+      const projectId = get().project?.id;
+      const result = await csvScriptModelsApi.saveCsvScriptModel(name, config, projectId);
       await get().fetchCsvScriptModels();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();
@@ -40,7 +41,8 @@ const createCsvScriptModelSlice = (set, get) => ({
   // Mark csv script model for deletion
   deleteCsvScriptModel: async name => {
     try {
-      await csvScriptModelsApi.deleteCsvScriptModel(name);
+      const projectId = get().project?.id;
+      await csvScriptModelsApi.deleteCsvScriptModel(name, projectId);
       await get().fetchCsvScriptModels();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -28,7 +28,8 @@ const createDashboardSlice = (set, get) => ({
   // Save dashboard to cache
   saveDashboard: async (name, config) => {
     try {
-      const result = await dashboardsApi.saveDashboard(name, config);
+      const projectId = get().project?.id;
+      const result = await dashboardsApi.saveDashboard(name, config, projectId);
       await get().fetchDashboards();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();
@@ -44,7 +45,8 @@ const createDashboardSlice = (set, get) => ({
   // Mark dashboard for deletion
   deleteDashboard: async name => {
     try {
-      await dashboardsApi.deleteDashboard(name);
+      const projectId = get().project?.id;
+      await dashboardsApi.deleteDashboard(name, projectId);
       await get().fetchDashboards();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();

--- a/viewer/src/stores/defaultsStore.js
+++ b/viewer/src/stores/defaultsStore.js
@@ -26,7 +26,8 @@ const createDefaultsSlice = (set, get) => ({
   // Save defaults to cache
   saveDefaults: async config => {
     try {
-      const result = await defaultsApi.saveDefaults(config);
+      const projectId = get().project?.id;
+      const result = await defaultsApi.saveDefaults(config, projectId);
       // Refresh defaults
       await get().fetchDefaults();
       // Trigger commit status check

--- a/viewer/src/stores/dimensionStore.js
+++ b/viewer/src/stores/dimensionStore.js
@@ -29,7 +29,8 @@ const createDimensionSlice = (set, get) => ({
   // Save dimension to cache
   saveDimension: async (name, config) => {
     try {
-      const result = await dimensionsApi.saveDimension(name, config);
+      const projectId = get().project?.id;
+      const result = await dimensionsApi.saveDimension(name, config, projectId);
       // Refresh dimensions list to get updated status
       await get().fetchDimensions();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createDimensionSlice = (set, get) => ({
   // Mark dimension for deletion (will be removed from YAML on commit)
   deleteDimension: async name => {
     try {
-      await dimensionsApi.deleteDimension(name);
+      const projectId = get().project?.id;
+      await dimensionsApi.deleteDimension(name, projectId);
       await get().fetchDimensions();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/inputStore.js
+++ b/viewer/src/stores/inputStore.js
@@ -29,7 +29,8 @@ const createInputSlice = (set, get) => ({
   // Save input to cache
   saveInput: async (name, config) => {
     try {
-      const result = await inputsApi.saveInput(name, config);
+      const projectId = get().project?.id;
+      const result = await inputsApi.saveInput(name, config, projectId);
       // Refresh inputs list to get updated status
       await get().fetchInputs();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createInputSlice = (set, get) => ({
   // Mark input for deletion (will be removed from YAML on commit)
   deleteInput: async name => {
     try {
-      await inputsApi.deleteInput(name);
+      const projectId = get().project?.id;
+      await inputsApi.deleteInput(name, projectId);
       await get().fetchInputs();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/insightStore.js
+++ b/viewer/src/stores/insightStore.js
@@ -30,7 +30,8 @@ const createInsightSlice = (set, get) => ({
   // Save insight to cache
   saveInsight: async (name, config) => {
     try {
-      const result = await insightsApi.saveInsight(name, config);
+      const projectId = get().project?.id;
+      const result = await insightsApi.saveInsight(name, config, projectId);
       // Refresh insights list to get updated status
       await get().fetchInsights();
       // Trigger commit status check
@@ -48,7 +49,8 @@ const createInsightSlice = (set, get) => ({
   // Mark insight for deletion (will be removed from YAML on commit)
   deleteInsight: async name => {
     try {
-      await insightsApi.deleteInsight(name);
+      const projectId = get().project?.id;
+      await insightsApi.deleteInsight(name, projectId);
       await get().fetchInsights();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/localMergeModelStore.js
+++ b/viewer/src/stores/localMergeModelStore.js
@@ -26,7 +26,8 @@ const createLocalMergeModelSlice = (set, get) => ({
   // Save local merge model to cache
   saveLocalMergeModel: async (name, config) => {
     try {
-      const result = await localMergeModelsApi.saveLocalMergeModel(name, config);
+      const projectId = get().project?.id;
+      const result = await localMergeModelsApi.saveLocalMergeModel(name, config, projectId);
       await get().fetchLocalMergeModels();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();
@@ -40,7 +41,8 @@ const createLocalMergeModelSlice = (set, get) => ({
   // Mark local merge model for deletion
   deleteLocalMergeModel: async name => {
     try {
-      await localMergeModelsApi.deleteLocalMergeModel(name);
+      const projectId = get().project?.id;
+      await localMergeModelsApi.deleteLocalMergeModel(name, projectId);
       await get().fetchLocalMergeModels();
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();

--- a/viewer/src/stores/markdownStore.js
+++ b/viewer/src/stores/markdownStore.js
@@ -29,7 +29,8 @@ const createMarkdownSlice = (set, get) => ({
   // Save markdown to cache
   saveMarkdown: async (name, config) => {
     try {
-      const result = await markdownsApi.saveMarkdown(name, config);
+      const projectId = get().project?.id;
+      const result = await markdownsApi.saveMarkdown(name, config, projectId);
       // Refresh markdowns list to get updated status
       await get().fetchMarkdowns();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createMarkdownSlice = (set, get) => ({
   // Mark markdown for deletion (will be removed from YAML on commit)
   deleteMarkdown: async name => {
     try {
-      await markdownsApi.deleteMarkdown(name);
+      const projectId = get().project?.id;
+      await markdownsApi.deleteMarkdown(name, projectId);
       await get().fetchMarkdowns();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/metricStore.js
+++ b/viewer/src/stores/metricStore.js
@@ -29,7 +29,8 @@ const createMetricSlice = (set, get) => ({
   // Save metric to cache
   saveMetric: async (name, config) => {
     try {
-      const result = await metricsApi.saveMetric(name, config);
+      const projectId = get().project?.id;
+      const result = await metricsApi.saveMetric(name, config, projectId);
       // Refresh metrics list to get updated status
       await get().fetchMetrics();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createMetricSlice = (set, get) => ({
   // Mark metric for deletion (will be removed from YAML on commit)
   deleteMetric: async name => {
     try {
-      await metricsApi.deleteMetric(name);
+      const projectId = get().project?.id;
+      await metricsApi.deleteMetric(name, projectId);
       await get().fetchMetrics();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/modelStore.js
+++ b/viewer/src/stores/modelStore.js
@@ -30,7 +30,8 @@ const createModelSlice = (set, get) => ({
   // Save model to cache
   saveModel: async (name, config) => {
     try {
-      const result = await modelsApi.saveModel(name, config);
+      const projectId = get().project?.id;
+      const result = await modelsApi.saveModel(name, config, projectId);
       // Refresh models list to get updated status
       await get().fetchModels();
       // Trigger commit status check
@@ -48,7 +49,8 @@ const createModelSlice = (set, get) => ({
   // Mark model for deletion (will be removed from YAML on commit)
   deleteModel: async name => {
     try {
-      await modelsApi.deleteModel(name);
+      const projectId = get().project?.id;
+      await modelsApi.deleteModel(name, projectId);
       await get().fetchModels();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/perTypeStores.test.js
+++ b/viewer/src/stores/perTypeStores.test.js
@@ -70,8 +70,18 @@ const STORES = [
   { name: 'table', slice: createTableSlice, api: tablesApi },
   { name: 'markdown', slice: createMarkdownSlice, api: markdownsApi },
   // These two map a snake_case api payload key onto a camelCase state key.
-  { name: 'csvScriptModel', slice: createCsvScriptModelSlice, api: csvScriptModelsApi, dataKey: 'csv_script_models' },
-  { name: 'localMergeModel', slice: createLocalMergeModelSlice, api: localMergeModelsApi, dataKey: 'local_merge_models' },
+  {
+    name: 'csvScriptModel',
+    slice: createCsvScriptModelSlice,
+    api: csvScriptModelsApi,
+    dataKey: 'csv_script_models',
+  },
+  {
+    name: 'localMergeModel',
+    slice: createLocalMergeModelSlice,
+    api: localMergeModelsApi,
+    dataKey: 'local_merge_models',
+  },
 ];
 
 describe.each(STORES)('$name store slice', ({ slice, api, dataKey }) => {
@@ -123,9 +133,9 @@ describe.each(STORES)('$name store slice', ({ slice, api, dataKey }) => {
     expect(store.get()[loadingKey]).toBe(false);
   });
 
-  it('save calls the api and returns success', async () => {
+  it('save calls the project-scoped api and returns success', async () => {
     const res = await store.get()[saveFn]('x', { a: 1 });
-    expect(api[saveApiName]).toHaveBeenCalledWith('x', { a: 1 });
+    expect(api[saveApiName]).toHaveBeenCalledWith('x', { a: 1 }, 'proj-1');
     expect(res.success).toBe(true);
   });
 
@@ -135,9 +145,9 @@ describe.each(STORES)('$name store slice', ({ slice, api, dataKey }) => {
     expect(res).toEqual({ success: false, error: 'nope' });
   });
 
-  it('delete calls the api and returns success', async () => {
+  it('delete calls the project-scoped api and returns success', async () => {
     const res = await store.get()[deleteFn]('x');
-    expect(api[deleteApiName]).toHaveBeenCalledWith('x');
+    expect(api[deleteApiName]).toHaveBeenCalledWith('x', 'proj-1');
     expect(res.success).toBe(true);
   });
 

--- a/viewer/src/stores/relationStore.js
+++ b/viewer/src/stores/relationStore.js
@@ -29,7 +29,8 @@ const createRelationSlice = (set, get) => ({
   // Save relation to cache
   saveRelation: async (name, config) => {
     try {
-      const result = await relationsApi.saveRelation(name, config);
+      const projectId = get().project?.id;
+      const result = await relationsApi.saveRelation(name, config, projectId);
       // Refresh relations list to get updated status
       await get().fetchRelations();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createRelationSlice = (set, get) => ({
   // Mark relation for deletion (will be removed from YAML on commit)
   deleteRelation: async name => {
     try {
-      await relationsApi.deleteRelation(name);
+      const projectId = get().project?.id;
+      await relationsApi.deleteRelation(name, projectId);
       await get().fetchRelations();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/sourceStore.js
+++ b/viewer/src/stores/sourceStore.js
@@ -38,7 +38,8 @@ const createSourceSlice = (set, get) => ({
   // Save source to cache
   saveSource: async (name, config) => {
     try {
-      const result = await sourcesApi.saveSource(name, config);
+      const projectId = get().project?.id;
+      const result = await sourcesApi.saveSource(name, config, projectId);
       // Refresh sources list to get updated status
       await get().fetchSources();
       // Trigger commit status check
@@ -54,7 +55,8 @@ const createSourceSlice = (set, get) => ({
   // Mark source for deletion (will be removed from YAML on commit)
   deleteSource: async name => {
     try {
-      await sourcesApi.deleteSource(name);
+      const projectId = get().project?.id;
+      await sourcesApi.deleteSource(name, projectId);
       await get().fetchSources();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/storeSlices.test.js
+++ b/viewer/src/stores/storeSlices.test.js
@@ -110,9 +110,9 @@ describe('defaultsStore', () => {
   it('saveDefaults persists, refreshes, and reports failures', async () => {
     defaultsApi.saveDefaults.mockResolvedValueOnce({ ok: true });
     defaultsApi.fetchDefaults.mockResolvedValue({ source: 'duckdb' });
-    const store = makeStore(createDefaultsSlice);
+    const store = makeStore(createDefaultsSlice, { project: { id: 'proj-1' } });
     await expect(store.get().saveDefaults({ a: 1 })).resolves.toMatchObject({ success: true });
-    expect(defaultsApi.saveDefaults).toHaveBeenCalledWith({ a: 1 });
+    expect(defaultsApi.saveDefaults).toHaveBeenCalledWith({ a: 1 }, 'proj-1');
     expect(defaultsApi.fetchDefaults).toHaveBeenCalled(); // refresh
 
     defaultsApi.saveDefaults.mockRejectedValueOnce(new Error('nope'));

--- a/viewer/src/stores/tableStore.js
+++ b/viewer/src/stores/tableStore.js
@@ -29,7 +29,8 @@ const createTableSlice = (set, get) => ({
   // Save table to cache
   saveTable: async (name, config) => {
     try {
-      const result = await tablesApi.saveTable(name, config);
+      const projectId = get().project?.id;
+      const result = await tablesApi.saveTable(name, config, projectId);
       // Refresh tables list to get updated status
       await get().fetchTables();
       // Trigger commit status check
@@ -45,7 +46,8 @@ const createTableSlice = (set, get) => ({
   // Mark table for deletion (will be removed from YAML on commit)
   deleteTable: async name => {
     try {
-      await tablesApi.deleteTable(name);
+      const projectId = get().project?.id;
+      await tablesApi.deleteTable(name, projectId);
       await get().fetchTables();
       // Trigger commit status check
       if (get().checkCommitStatus) {


### PR DESCRIPTION
The per-project resource endpoints (tables, insights, models, dashboards, defaults, …) require a `?project_id=` query param on every request. The viewer's list calls (`fetchAll*`) already append it, but the `save*` and `delete*` calls did not — so the editor's draft saves/deletes reached the backend without it and failed with `{"error":"project_id is required param"}`.

Fix it the same way the fetches do, per resource:
- api/*.js: `save*`/`delete*` take an optional `projectId` and append `?project_id=${encodeURIComponent(projectId)}`, mirroring `fetchAll*`.
- stores/*.js: each save/delete action reads `get().project?.id` and passes it, mirroring the existing fetch action.

Covers all 14 resource types (tables, insights, markdowns, inputs, dashboards, charts, models, sources, dimensions, metrics, relations, csv-script models, local-merge models, defaults). Visivo Studio passes no projectId, so the shared viewer is unchanged for the single-project Flask backend.

Tests: per-type store + resource-api suites updated to assert project scoping on save/delete; added save/delete project_id coverage. Full viewer jest suite green (1960 passed); prettier + eslint clean.