### PR TITLE
fix: post-#422 follow-ups — deploy-error UX, dead MRT path, outline column search, form validation gaps

### DIFF
--- a/viewer/src/components/deploy/StageSelection.jsx
+++ b/viewer/src/components/deploy/StageSelection.jsx
@@ -21,6 +21,7 @@ const StageSelection = ({ status }) => {
   const [loading, setLoading] = useState(false);
   const [deploying, setDeploying] = useState(false);
   const [deployingMsg, setDeployingMsg] = useState('Deploying...');
+  const [deployError, setDeployError] = useState(null);
   const [deploymentSuccess, setDeploymentSuccess] = useState(false);
   const [previewUrl, setPreviewUrl] = useState('');
   const [showAddForm, setShowAddForm] = useState(false);
@@ -48,6 +49,7 @@ const StageSelection = ({ status }) => {
     setDeploying(false);
     setDeploymentSuccess(false);
     setDeployingMsg('Deploying...');
+    setDeployError(null);
     setPreviewUrl('');
   };
 
@@ -108,8 +110,12 @@ const StageSelection = ({ status }) => {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       pollDeploymentStatus(data.deploy_id);
     } catch (err) {
+      // A failed POST must leave a VISIBLE error — `deployingMsg` only renders
+      // while `deploying === true`, so setting it here silently returned the
+      // form to idle. The error alert renders below and clears on retry
+      // (handleDeploy starts with resetDeploymentState).
       setDeploying(false);
-      setDeployingMsg('Deployment failed');
+      setDeployError('Deployment failed. Please check your connection and try again.');
     }
   };
 
@@ -230,6 +236,22 @@ const StageSelection = ({ status }) => {
                   <p className="text-blue-600 mt-1">
                     Make sure your code is ready for the {selectedStage} environment.
                   </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Deploy Error */}
+          {deployError && !deploying && (
+            <div data-testid="deploy-error" className="p-3 bg-red-50 border border-red-200 rounded-md">
+              <div className="flex items-start">
+                <FontAwesomeIcon
+                  icon={faTriangleExclamation}
+                  className="w-5 h-5 text-red-400 mt-0.5 mr-2"
+                />
+                <div className="text-sm">
+                  <p className="font-medium text-red-800">Deployment failed</p>
+                  <p className="text-red-600 mt-1">{deployError}</p>
                 </div>
               </div>
             </div>

--- a/viewer/src/components/deploy/StageSelection.test.jsx
+++ b/viewer/src/components/deploy/StageSelection.test.jsx
@@ -328,4 +328,36 @@ describe('deployment polling', () => {
     expect(statusCallCount()).toBe(0);
     expect(screen.queryByText('Deployment Successful!')).not.toBeInTheDocument();
   });
+
+  it('shows a VISIBLE error after a failed deploy POST and clears it on retry', async () => {
+    // Previously the catch set `deployingMsg` AFTER setDeploying(false), but the
+    // message only renders while `deploying === true` — a failed POST silently
+    // returned the form to idle with no feedback.
+    let failDeploy = true;
+    fetch.mockImplementation(url => {
+      if (url === '/api/cloud/stages/') {
+        return Promise.resolve({ json: async () => mockStages });
+      }
+      if (url === '/api/cloud/deploy/') {
+        return failDeploy
+          ? Promise.resolve({ ok: false, status: 500, json: async () => ({}) })
+          : new Promise(() => {}); // retry stays in flight → deploying state
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    await renderAndPickStaging();
+
+    fireEvent.click(screen.getByRole('button', { name: /deploy to staging/i }));
+
+    // The failure renders a visible error alert (not a silent idle form)…
+    const alert = await screen.findByTestId('deploy-error');
+    expect(alert).toHaveTextContent(/deployment failed/i);
+    // …while the form is back to idle so the user can retry.
+    expect(screen.getByRole('button', { name: /deploy to staging/i })).not.toBeDisabled();
+
+    // Retrying clears the stale error immediately.
+    failDeploy = false;
+    fireEvent.click(screen.getByRole('button', { name: /deploy to staging/i }));
+    await waitFor(() => expect(screen.queryByTestId('deploy-error')).not.toBeInTheDocument());
+  });
 });

--- a/viewer/src/components/explorer/ExplorerInputsToolbar.jsx
+++ b/viewer/src/components/explorer/ExplorerInputsToolbar.jsx
@@ -12,14 +12,14 @@ const ExplorerInputsToolbar = ({ projectId }) => {
 
   const inputConfigs = useMemo(
     () =>
-      derivedInputNames
-        .map((name) => {
-          const storeInput = storeInputs.find((i) => i.name === name);
-          if (!storeInput) return null;
-          // Flatten config into the input object so Input.jsx can read input.type, input.display, etc.
-          return { name: storeInput.name, ...storeInput.config };
-        })
-        .filter(Boolean),
+      derivedInputNames.map((name) => {
+        // Guaranteed to resolve: selectDerivedInputNames only returns names it
+        // found in s.inputs (candidates are filtered through inputNameSet), and
+        // both selectors read the same store snapshot.
+        const storeInput = storeInputs.find((i) => i.name === name);
+        // Flatten config into the input object so Input.jsx can read input.type, input.display, etc.
+        return { name: storeInput.name, ...storeInput.config };
+      }),
     [derivedInputNames, storeInputs]
   );
 

--- a/viewer/src/components/explorer/ExplorerInputsToolbar.test.jsx
+++ b/viewer/src/components/explorer/ExplorerInputsToolbar.test.jsx
@@ -128,6 +128,22 @@ describe('ExplorerInputsToolbar', () => {
     dispatchSpy.mockRestore();
   });
 
+  it('renders a referenced input even when its store record has no config (names always resolve)', () => {
+    // Covers the unguarded resolve path: selectDerivedInputNames only returns
+    // names present in s.inputs (candidates are filtered through inputNameSet),
+    // so every derived name resolves — a config-less record still renders with
+    // its bare name (spreading an undefined config is a no-op).
+    useStore.setState({
+      inputs: [{ name: 'region' }, { name: 'threshold', config: { type: 'single-select' } }],
+    });
+
+    render(<ExplorerInputsToolbar projectId="proj_1" />);
+
+    expect(screen.getByTestId('mock-input-region')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-input-threshold')).toBeInTheDocument();
+    expect(screen.getByText('Inputs (2)')).toBeInTheDocument();
+  });
+
   it('only shows inputs referenced by insights attached to the chart', () => {
     useStore.setState({
       explorerChartInsightNames: [],

--- a/viewer/src/components/items/Table.jsx
+++ b/viewer/src/components/items/Table.jsx
@@ -33,10 +33,6 @@ import {
 /* eslint-enable react/jsx-pascal-case */
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { mkConfig, generateCsv } from 'export-to-csv';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
 import { itemNameToSlug } from './utils';
 import { parseRefValue, extractRefNamesFromStrings } from '../../utils/refString';
 
@@ -146,6 +142,11 @@ const Table = ({ table, itemWidth, height, width, shouldLoad = true }) => {
 
 
   const handleExportData = () => {
+    // export-to-csv's generateCsv THROWS on an empty dataset with
+    // useKeysAsHeaders (it reads Object.keys(data[0])). On the legacy MRT path
+    // tableData is always empty, so exporting must be a no-op (the button is
+    // also disabled below).
+    if (tableData.length === 0) return;
     const csv = generateCsv(csvConfig)(tableData);
     const csvBlob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(csvBlob);
@@ -172,29 +173,14 @@ const Table = ({ table, itemWidth, height, width, shouldLoad = true }) => {
   // PivotableTable will render. This removes the churn entirely with no visible change.
   const usesPivotableRenderer = isPivotableTable;
 
-  // Memoize the columns passed to MRT. `columns.map(...)` builds a brand-new array
-  // (with fresh Cell closures) each render; a new ref every render would itself
-  // re-trigger MRT's columnOrder effect, so this is keyed on the (stable) `columns`.
+  // Memoize the columns passed to MRT (a new ref every render would itself
+  // re-trigger MRT's columnOrder effect). Note: on the MRT path (no dataName)
+  // `computed.columns` is provably always [] — any table with a resolvable
+  // dataName renders PivotableTable instead — so the legacy per-cell renderers
+  // (markdown / number formatting) that used to be mapped on here were
+  // unreachable and have been removed.
   const mrtColumns = useMemo(
-    () =>
-      usesPivotableRenderer
-        ? []
-        : columns.map(column => ({
-            ...column,
-            Cell: ({ cell }) => {
-              const value = cell.getValue();
-              if (column.markdown) {
-                return (
-                  <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw, rehypeSanitize]}>
-                    {value}
-                  </Markdown>
-                );
-              } else if (typeof value === 'number' && `${value}`.length < 18) {
-                return new Intl.NumberFormat(navigator.language).format(value);
-              }
-              return value;
-            },
-          })),
+    () => (usesPivotableRenderer ? [] : columns),
     [columns, usesPivotableRenderer]
   );
 
@@ -350,6 +336,7 @@ const Table = ({ table, itemWidth, height, width, shouldLoad = true }) => {
               <Button
                 aria-label="DownloadCsv"
                 onClick={handleExportData}
+                disabled={tableData.length === 0}
                 size="small"
                 sx={{ minWidth: '40px' }}
               >

--- a/viewer/src/components/items/Table.test.jsx
+++ b/viewer/src/components/items/Table.test.jsx
@@ -13,14 +13,10 @@ jest.mock('./PivotableTable', () => ({ table, sourceData }) => (
   </div>
 ));
 
-// The legacy MRT path exports whatever tableData holds (always empty on that
-// path — data-backed tables render PivotableTable); the real generateCsv
-// throws on an empty dataset, so stub the CSV builder and assert the download
-// wiring behaviorally instead.
-jest.mock('export-to-csv', () => ({
-  mkConfig: jest.fn(cfg => cfg),
-  generateCsv: jest.fn(() => () => 'csv-content'),
-}));
+// export-to-csv is intentionally NOT mocked: the legacy MRT path always has an
+// empty tableData (data-backed tables render PivotableTable), and the REAL
+// generateCsv throws on an empty dataset with useKeysAsHeaders — the export
+// guard below must prevent that from ever running.
 
 let table;
 
@@ -111,18 +107,22 @@ test('reads model-backed data from modelJobs when table.data is a model object',
 describe('legacy MRT path (no data ref)', () => {
   const legacyTable = { name: 'legacy-table', rows_per_page: 5 };
 
-  test('renders the MRT toolbar with a CSV export named after the table', () => {
+  test('renders the MRT toolbar with the CSV export guarded when there are no rows', () => {
     render(<Table table={legacyTable} shouldLoad={true} />, { wrapper: withProviders });
 
     const exportButton = screen.getByRole('button', { name: 'DownloadCsv' });
     expect(exportButton).toBeInTheDocument();
     expect(screen.queryByTestId('pivotable-table')).not.toBeInTheDocument();
 
+    // This path always has zero rows, and the REAL export-to-csv generateCsv
+    // (unmocked here) THROWS on an empty dataset with useKeysAsHeaders. The
+    // button must be disabled and the click a no-op — no crash, no download.
+    expect(exportButton).toBeDisabled();
+
     const appendSpy = jest.spyOn(document.body, 'appendChild');
-    fireEvent.click(exportButton);
+    expect(() => fireEvent.click(exportButton)).not.toThrow();
     const link = appendSpy.mock.calls.map(c => c[0]).find(n => n.tagName === 'A');
-    expect(link).toBeDefined();
-    expect(link.getAttribute('download')).toBe('legacy-table.csv');
+    expect(link).toBeUndefined();
     appendSpy.mockRestore();
   });
 

--- a/viewer/src/components/views/common/EmbeddedTypesIndicator.jsx
+++ b/viewer/src/components/views/common/EmbeddedTypesIndicator.jsx
@@ -52,13 +52,15 @@ export const EmbeddedTypesIndicator = ({ types }) => {
 
   if (typeIcons.length === 0) return null;
 
-  // Single type - just show the icon in a square
+  // Single type - just show the icon in a square. The title must name the same
+  // (first RESOLVABLE) type the icon renders — `types[0]` could be an
+  // unresolvable entry that was filtered out of `typeIcons` above.
   if (typeIcons.length === 1) {
-    const { Icon, color } = typeIcons[0];
+    const { Icon, color, type } = typeIcons[0];
     return (
       <span
         className="flex-shrink-0 flex items-center justify-center w-5 h-5 bg-white rounded shadow-sm"
-        title={`Contains embedded ${types[0]}`}
+        title={`Contains embedded ${type}`}
       >
         <Icon style={{ fontSize: 14 }} className={color} />
       </span>

--- a/viewer/src/components/views/common/EmbeddedTypesIndicator.test.jsx
+++ b/viewer/src/components/views/common/EmbeddedTypesIndicator.test.jsx
@@ -93,6 +93,15 @@ describe('EmbeddedTypesIndicator', () => {
     expect(within(stack).getAllByTestId(/Icon$/)).toHaveLength(2);
   });
 
+  it('names the first RESOLVABLE type in the single-icon tooltip (unknown entries first)', () => {
+    // Regression: the tooltip used `types[0]`, so ['bogus', 'source'] rendered
+    // the source icon but titled it "Contains embedded bogus".
+    render(<EmbeddedTypesIndicator types={['bogus', 'source']} />);
+    const badge = screen.getByTitle('Contains embedded source');
+    expect(within(badge).getAllByTestId(/Icon$/)).toHaveLength(1);
+    expect(screen.queryByTitle('Contains embedded bogus')).not.toBeInTheDocument();
+  });
+
   it('drops unknown types but keeps known ones', () => {
     render(<EmbeddedTypesIndicator types={['bogus', 'dimension', 'metric']} />);
     // Title reflects the full list; only resolvable icons render.

--- a/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.js
+++ b/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.js
@@ -91,20 +91,10 @@ export function getStaticSchema(schema, defs = {}) {
       return singleOption;
     }
 
-    // If only array option, return it
-    if (arrayOption) {
-      return arrayOption;
-    }
-
-    // Fallback: return first static option, recursing if needed
-    const firstOption = staticOptions[0];
-    if (firstOption.oneOf || firstOption.anyOf) {
-      return getStaticSchema(firstOption, defs);
-    }
-    if (firstOption.$ref) {
-      return resolveRef(firstOption.$ref, defs) || firstOption;
-    }
-    return firstOption;
+    // No single option means EVERY remaining static option is an
+    // array-with-items (anything else would have matched singleOption), so
+    // arrayOption is always the first static option here — return it.
+    return arrayOption;
   }
 
   return schema;

--- a/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.test.js
+++ b/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.test.js
@@ -396,6 +396,24 @@ describe('schemaUtils', () => {
       expect(getStaticSchema(schema, defs)).toEqual(schema);
     });
 
+    it('returns the FIRST array option when every static option is an array-with-items', () => {
+      // Exhaustiveness pin: when no single-value option exists, every static
+      // option is an array-with-items (anything else would have matched
+      // singleOption), so the arrayOption return always resolves — there is no
+      // reachable fallback beyond it.
+      const schema = {
+        oneOf: [
+          { $ref: '#/$defs/query-string' },
+          { type: 'array', items: { type: 'number' } },
+          { type: 'array', items: { type: 'string' } },
+        ],
+      };
+      expect(getStaticSchema(schema, defs)).toEqual({
+        type: 'array',
+        items: { type: 'number' },
+      });
+    });
+
     it('supports anyOf the same as oneOf', () => {
       const schema = {
         anyOf: [{ $ref: '#/$defs/query-string' }, { $ref: '#/$defs/color' }],

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -53,14 +53,17 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
       setName(source.name || '');
 
       const configToUse = source.config;
-      setSourceType(configToUse?.type || '');
 
       // Extract form values from the config object
       if (configToUse) {
+        setSourceType(configToUse.type || '');
         const { name: _, type: __, ...formProps } = configToUse;
         setFormValues(formProps);
       } else {
-        // Fallback for flat source objects
+        // Fallback for flat source objects — restore the type from the flat
+        // object too, otherwise a config-less source renders the "select a
+        // source type" placeholder instead of its connection fields.
+        setSourceType(source.type || '');
         const { name: _, type: __, status: ___, config: ____, _embedded: _____, ...formProps } = source;
         setFormValues(formProps);
       }

--- a/viewer/src/components/views/common/SourceEditForm.test.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.test.jsx
@@ -163,18 +163,20 @@ describe('SourceEditForm — edit mode', () => {
     );
   });
 
-  test('falls back to flat source fields when config is missing (type is not recovered)', () => {
+  test('falls back to flat source fields when config is missing (type recovered from the flat object)', () => {
     renderForm({
       source: { name: 'flat1', type: 'duckdb', database: ':memory:', status: 'PUBLISHED' },
       isCreate: false,
     });
     expect(screen.getByLabelText(/Source Name/)).toHaveValue('flat1');
-    // The init effect only reads type from source.config, so a flat source
-    // renders the "pick a type" placeholder instead of its fields.
-    expect(screen.getByTestId('source-type-value')).toHaveTextContent('');
+    // The init fallback restores form values AND the type from the flat object,
+    // so the form renders duckdb's connection fields — not the "pick a source
+    // type" placeholder it used to dead-end on.
+    expect(screen.getByTestId('source-type-value')).toHaveTextContent('duckdb');
+    expect(screen.getByLabelText(/Database Path/)).toHaveValue(':memory:');
     expect(
-      screen.getByText('Select a source type to configure connection settings')
-    ).toBeInTheDocument();
+      screen.queryByText('Select a source type to configure connection settings')
+    ).not.toBeInTheDocument();
   });
 
   test('clears the connection status for the source on unmount', () => {

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -110,6 +110,11 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded 
     setSaveError(null);
   }, [table, isCreate]);
 
+  // Blank pivot entries (the '' scaffold RefListField's Add button creates, or
+  // whitespace-only edits) must never save — `columns: ['']` is not a valid
+  // pivot config. Validation rejects them with a visible per-list error.
+  const hasBlankEntry = list => list.some(entry => typeof entry === 'string' && entry.trim() === '');
+
   const validateForm = () => {
     const newErrors = {};
 
@@ -132,6 +137,16 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded 
 
     if ((rows.length > 0) !== (values.length > 0)) {
       newErrors.rows = 'Rows and values must be specified together';
+    }
+
+    if (hasBlankEntry(columns)) {
+      newErrors.columns = 'Column entries cannot be empty';
+    }
+    if (hasBlankEntry(rows)) {
+      newErrors.rows = 'Row entries cannot be empty';
+    }
+    if (hasBlankEntry(values)) {
+      newErrors.values = 'Value entries cannot be empty';
     }
 
     setErrors(newErrors);

--- a/viewer/src/components/views/common/TableEditForm.test.jsx
+++ b/viewer/src/components/views/common/TableEditForm.test.jsx
@@ -168,6 +168,39 @@ describe('TableEditForm — validation', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  test('a pivot list holding only a blank entry blocks save with a visible error', async () => {
+    // Regression: `columns: ['']` used to pass validation and save the blank
+    // entry into the config.
+    seed();
+    const onSave = jest.fn(async () => ({ success: true }));
+    renderForm({ onSave });
+
+    setName('tbl');
+    addPivotEntry('columns'); // RefListField's Add scaffolds '' — leave it blank
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Column entries cannot be empty')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('whitespace-only rows/values entries are rejected too', async () => {
+    seed();
+    const onSave = jest.fn(async () => ({ success: true }));
+    renderForm({ onSave });
+
+    setName('tbl');
+    addPivotEntry('columns');
+    addPivotEntry('rows');
+    addPivotEntry('values'); // stays '' (blank)
+    setRefEntry(0, 'ref(m).month');
+    setRefEntry(1, '   ');
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Row entries cannot be empty')).toBeInTheDocument();
+    expect(screen.getByText('Value entries cannot be empty')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
   test('rows without values (or vice versa) blocks save', async () => {
     seed();
     const onSave = jest.fn();

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -27,7 +27,6 @@ import LevelEditForm from '../common/LevelEditForm';
 import DefaultsEditForm from '../common/DefaultsEditForm';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { COLLECTION_KEY } from './collectionKeys';
-import { formatRef } from '../../../utils/refString';
 import { useObjectSave } from '../../../hooks/useObjectSave';
 import sanitizeDashboardConfig from './sanitizeDashboardConfig';
 import { emitWorkspaceEvent } from './telemetry';
@@ -334,6 +333,10 @@ const RightRailEditPanel = () => {
               </p>
             ) : (
               rows.map((row, rowIndex) => (
+                // `onItemChange` is the SOLE item-update channel here — RowEditForm
+                // always prefers it over the legacy onItemWidthChange/onItemRefChange
+                // callbacks (those exist only for the bundled DashboardEditForm path),
+                // so passing them alongside it would be dead code.
                 <RowEditForm
                   key={rowIndex}
                   row={row}
@@ -351,25 +354,6 @@ const RightRailEditPanel = () => {
                     updateRow(rowIndex, {
                       ...row,
                       items: (row.items || []).filter((_, i) => i !== itemIndex),
-                    })
-                  }
-                  onItemWidthChange={(itemIndex, width) =>
-                    updateRow(rowIndex, {
-                      ...row,
-                      items: (row.items || []).map((it, i) =>
-                        i === itemIndex ? { ...it, width } : it
-                      ),
-                    })
-                  }
-                  onItemRefChange={(itemIndex, ref) =>
-                    updateRow(rowIndex, {
-                      ...row,
-                      items: (row.items || []).map((it, i) => {
-                        if (i !== itemIndex) return it;
-                        const reset = { ...it, ...emptyLeafFields() };
-                        if (ref && ref.type && ref.name) reset[ref.type] = formatRef(ref.name);
-                        return reset;
-                      }),
                     })
                   }
                   onItemChange={(itemIndex, nextItem) =>
@@ -453,23 +437,6 @@ const RightRailEditPanel = () => {
               }
               onRemoveItem={itemIndex =>
                 updateRow({ ...row, items: items.filter((_, i) => i !== itemIndex) })
-              }
-              onItemWidthChange={(itemIndex, width) =>
-                updateRow({
-                  ...row,
-                  items: items.map((it, i) => (i === itemIndex ? { ...it, width } : it)),
-                })
-              }
-              onItemRefChange={(itemIndex, ref) =>
-                updateRow({
-                  ...row,
-                  items: items.map((it, i) => {
-                    if (i !== itemIndex) return it;
-                    const reset = { ...it, ...emptyLeafFields() };
-                    if (ref && ref.type && ref.name) reset[ref.type] = formatRef(ref.name);
-                    return reset;
-                  }),
-                })
               }
               onItemChange={(itemIndex, nextItem) =>
                 updateRow({

--- a/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
@@ -60,6 +60,21 @@ jest.mock('../common/DefaultsEditForm', () => ({
   __esModule: true,
   default: ({ name }) => <div data-testid="defaults-edit-form-stub">{`defaults:${name || 'none'}`}</div>,
 }));
+// Wrap the REAL RowEditForm to capture the props each render receives. Used to
+// pin that the panel passes `onItemChange` as the SOLE item-update channel —
+// RowEditForm unconditionally prefers `onItemChange`, so passing the legacy
+// onItemWidthChange/onItemRefChange alongside it would be dead props. All
+// behavior stays real (the wrapper just records and delegates).
+let mockRowEditFormProps = [];
+jest.mock('../common/RowEditForm', () => {
+  const React = require('react');
+  const actual = jest.requireActual('../common/RowEditForm');
+  const CapturingRowEditForm = props => {
+    mockRowEditFormProps.push(props);
+    return React.createElement(actual.default, props);
+  };
+  return { ...actual, __esModule: true, default: CapturingRowEditForm };
+});
 
 const SIMPLE_DASHBOARD = {
   name: 'simple-dashboard',
@@ -615,6 +630,29 @@ describe('RightRailEditPanel structural edits (VIS-802 auto-save)', () => {
     fireEvent.click(within(dropzone).getByTitle('chart: rev_chart — click to open'));
     expect(openWorkspaceTab).toHaveBeenCalledWith({ type: 'chart', name: 'rev_chart' });
   });
+});
+
+// ── RowEditForm prop contract (post-#422 dead-prop removal) ──────────────────
+describe('RightRailEditPanel → RowEditForm prop contract', () => {
+  beforeEach(() => {
+    mockRowEditFormProps = [];
+  });
+
+  test.each([['dashboard'], ['row.0']])(
+    'the %s view passes onItemChange as the SOLE item-update channel (no dead legacy handlers)',
+    key => {
+      resetStore({ workspaceOutlineSelectedKey: key });
+      renderPanel();
+      expect(mockRowEditFormProps.length).toBeGreaterThan(0);
+      mockRowEditFormProps.forEach(props => {
+        expect(typeof props.onItemChange).toBe('function');
+        // RowEditForm prefers onItemChange unconditionally, so these legacy
+        // callbacks could never run here — they must not be passed.
+        expect('onItemWidthChange' in props).toBe(false);
+        expect('onItemRefChange' in props).toBe(false);
+      });
+    }
+  );
 });
 
 // ── Breadcrumb keyboard nav wired to the live config (G-2) ──────────────────

--- a/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
+++ b/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
@@ -55,12 +55,20 @@ const KIND_ICON = {
 const matchesSearch = (name, query) =>
   !query || (name || '').toLowerCase().includes(query.toLowerCase());
 
-/** Does this node (or any descendant) match the query? Drives search filtering. */
-const nodeMatches = (node, query) => {
+/**
+ * Does this node (or any descendant) match the query? Drives search filtering.
+ * Lazily-loaded columns live in `flatColumns[tableKey]` (NOT `node.children` —
+ * the cached feed carries no eager column data), so LOADED columns must be
+ * consulted too: a table whose loaded column matches stays visible, as do its
+ * ancestor groups. Unloaded columns can't match (they aren't known yet).
+ */
+const nodeMatches = (node, query, flatColumns) => {
   if (!query) return true;
   if (matchesSearch(node.name, query)) return true;
   const children = Array.isArray(node.children) ? node.children : [];
-  return children.some(child => nodeMatches(child, query));
+  if (children.some(child => nodeMatches(child, query, flatColumns))) return true;
+  const lazyCols = node.key ? flatColumns?.[node.key] : null;
+  return Array.isArray(lazyCols) && lazyCols.some(col => matchesSearch(col?.name, query));
 };
 
 /**
@@ -269,7 +277,7 @@ const SourceOutlineTreePanel = ({ sourceName }) => {
   };
 
   const renderTableNode = (table, level) => {
-    if (!nodeMatches(table, query)) return null;
+    if (!nodeMatches(table, query, flatColumns)) return null;
     // Columns lazy-load into `flatColumns[tableKey]` on expand (the cached feed
     // carries no eager column data). `table.children` only matters if a future
     // feed ever supplies columns eagerly.
@@ -316,7 +324,7 @@ const SourceOutlineTreePanel = ({ sourceName }) => {
   };
 
   const renderGroupNode = (node, level) => {
-    if (!nodeMatches(node, query)) return null;
+    if (!nodeMatches(node, query, flatColumns)) return null;
     const children = Array.isArray(node.children) ? node.children : [];
     const collapsed = !expandedSet.has(node.key);
     const isSchema = node.kind === 'schema';

--- a/viewer/src/components/views/workspace/SourceOutlineTreePanel.test.jsx
+++ b/viewer/src/components/views/workspace/SourceOutlineTreePanel.test.jsx
@@ -265,6 +265,34 @@ describe('SourceOutlineTreePanel (VIS-1004)', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('a query matching only a LOADED column keeps its table (and ancestors) visible', async () => {
+    render(<SourceOutlineTreePanel sourceName={SRC} />);
+    const tableKey = `${DB_KEY}::table::orders`;
+    fireEvent.click(await screen.findByTestId(`source-outline-node-${DB_KEY}-toggle`));
+    fireEvent.click(await screen.findByTestId(`source-outline-node-${tableKey}-toggle`));
+    await screen.findByTestId(`source-outline-node-${tableKey}::col::amount`);
+
+    // 'amount' matches ONLY the orders table's lazily-loaded `amount` column —
+    // not the source/db name nor either table name. Loaded columns live in
+    // `flatColumns[tableKey]` (not `node.children`), so the match must consult
+    // them: the table AND its ancestor db group stay visible.
+    fireEvent.change(screen.getByTestId('source-outline-search'), {
+      target: { value: 'amount' },
+    });
+    expect(screen.getByTestId(`source-outline-node-${DB_KEY}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`source-outline-node-${tableKey}`)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`source-outline-node-${tableKey}::col::amount`)
+    ).toBeInTheDocument();
+    // Non-matching siblings are still filtered out.
+    expect(
+      screen.queryByTestId(`source-outline-node-${tableKey}::col::id`)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`source-outline-node-${DB_KEY}::table::users`)
+    ).not.toBeInTheDocument();
+  });
+
   test('Enter / Space on a focused node selects it (keyboard parity with click)', async () => {
     render(<SourceOutlineTreePanel sourceName={SRC} />);
     const dbNode = await screen.findByTestId(`source-outline-node-${DB_KEY}`);


### PR DESCRIPTION
Nine follow-ups that were flagged (not fixed) during the #422 review and coverage passes. Each fix ships with a regression test that fails on the old code (items 8–9 are pure dead-code removals with no observable behavior delta, so they carry covering/invariant tests instead).

- **[UX bug] `deploy/StageSelection.jsx`** — a failed deploy POST silently returned the form to idle (`deployingMsg` was set after `setDeploying(false)` but only renders while deploying). Now renders a visible error alert (existing alert styling, red variant) that clears on retry.
- **[Dead code + latent throw] `items/Table.jsx`** — removed the unreachable legacy MRT `Cell` renderers (any table with a resolvable `dataName` renders `PivotableTable`; without one `computed.columns` is always `[]`) and guarded the CSV export: `generateCsv` throws on an empty dataset with `useKeysAsHeaders`, so the export button is disabled + the handler no-ops with zero rows. The MRT shell (empty-state toolbar/pagination UI) is kept. The test now uses the REAL `export-to-csv` (mock removed) so the old code demonstrably crashes.
- **[Bug] `workspace/SourceOutlineTreePanel.jsx`** — search claimed "tables & columns" but lazily-loaded columns live in `flatColumns[tableKey]`, not `node.children`, so a query matching only a loaded column hid its table (and its ancestor db group). `nodeMatches` now consults LOADED columns; unloaded columns still can't match (they aren't known yet).
- **[Dead props] `workspace/RightRailEditPanel.jsx`** — removed `onItemWidthChange`/`onItemRefChange` from both `RowEditForm` call sites. Verified `RowEditForm.handleItemChange` returns early whenever `onItemChange` is supplied (it always was), so the legacy handlers were unreachable. A prop-capture test pins `onItemChange` as the sole item-update channel.
- **[Validation gap] `common/TableEditForm.jsx`** — pivot lists accepted blank entries (`columns: ['']` saved clean). Validation now rejects blank/whitespace-only entries with visible per-list errors.
- **[Quirk] `common/SourceEditForm.jsx`** — the flat-source init fallback restored form values but not `type`, so a config-less source dead-ended on the "select a source type" placeholder. The type is now restored from the flat object too.
- **[Quirk] `common/EmbeddedTypesIndicator.jsx`** — the single-icon tooltip used `types[0]`, so `['bogus','source']` rendered the source icon titled "Contains embedded bogus". It now names the first RESOLVABLE type, consistent with the icon.
- **[Dead code] `explorer/ExplorerInputsToolbar.jsx`** — removed the unreachable `if (!storeInput) return null` guard (`selectDerivedInputNames` only returns names present in `s.inputs`; both selectors read the same store snapshot). Covering test added for the config-less-record path.
- **[Dead code] `SchemaEditor/utils/schemaUtils.js`** — removed the unreachable `getStaticSchema` fallback: when no `singleOption` exists, every static option is an array-with-items, so `arrayOption` always resolves. Exhaustiveness test pins first-array-option behavior.

**Verification**
- Old-code check: with the source fixes stashed, the 7 behavioral regression tests fail exactly as intended (9 failing tests across 7 suites); with the fixes applied, all pass.
- `bash scripts/viewer-check.sh` (full): 4405 passed, 2 skipped (pre-existing skips), lint clean — ALL PASSED.
- `npx eslint src --ext .js,.jsx,.ts,.tsx --max-warnings=0`: clean.
- Coverage on every touched file ≥85% (RightRailEditPanel branch coverage improved 68.4% → 79.7%; Table.jsx branch/function coverage improved, stmts/lines stay ≥86%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)