### PR TITLE
VIS-1025: rail respects cloud read-only + project-keyed schema caches

### DIFF
--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -115,6 +115,22 @@ const parseOutlineKey = key => {
   };
 };
 
+/**
+ * ReadOnlyNotice — VIS-1025. Compact muted band shown when the cloud stage is
+ * read-only (capabilities.can_edit === false): names the state and surfaces the
+ * server's `edit_action` hint (e.g. "Create a draft to edit"). Local serve
+ * (capabilities null) never renders this.
+ */
+const ReadOnlyNotice = ({ editAction }) => (
+  <div
+    data-testid="right-rail-readonly"
+    className="border-b border-gray-200 bg-gray-50 px-3 py-2 text-[11px] leading-relaxed text-gray-600"
+  >
+    <span className="font-semibold">Read-only</span>
+    {editAction ? ` — ${editAction}` : ''}
+  </div>
+);
+
 const Placeholder = ({ title, body, testId }) => (
   <div
     data-testid={testId}
@@ -158,6 +174,10 @@ const RightRailEditPanel = () => {
   const saveDashboard = useStore(s => s.saveDashboard);
   const updateDashboardConfigOptimistic = useStore(s => s.updateDashboardConfigOptimistic);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  // VIS-1025: null = local serve (always editable); a cloud capability object
+  // with can_edit:false makes every rail write a no-op.
+  const capabilities = useStore(s => s.capabilities);
+  const readOnly = !!(capabilities && capabilities.can_edit === false);
   const { dashboardName } = useWorkspaceScope();
 
   const type = activeObject?.type || null;
@@ -206,6 +226,10 @@ const RightRailEditPanel = () => {
    */
   const persistConfig = useCallback(
     (nextConfig, meta) => {
+      // VIS-1025 read-only hold — BEFORE the optimistic write and BEFORE the
+      // validation gate (not-allowed is not 'invalid'): structure edits under
+      // a read-only stage neither write into the store nor persist.
+      if (readOnly) return;
       if (updateDashboardConfigOptimistic) {
         updateDashboardConfigOptimistic(dashboardName, nextConfig);
       }
@@ -246,8 +270,12 @@ const RightRailEditPanel = () => {
         finish(result.valid ? null : result)
       );
     },
-    [updateDashboardConfigOptimistic, scheduleSave, dashboardName]
+    [updateDashboardConfigOptimistic, scheduleSave, dashboardName, readOnly]
   );
+
+  // VIS-1025: the compact read-only band rendered above every structure form
+  // (LeafObjectForm renders its own — see below).
+  const readOnlyNotice = readOnly ? <ReadOnlyNotice editAction={capabilities?.edit_action} /> : null;
 
   const writeRows = useCallback(
     (nextRows, meta) => {
@@ -381,6 +409,7 @@ const RightRailEditPanel = () => {
             subtitle={`${rows.length} row${rows.length === 1 ? '' : 's'}`}
             saveStatus={effectiveSaveStatus}
           />
+          {readOnlyNotice}
           {validationBanner}
           <div
             data-testid="right-rail-edit-dashboard"
@@ -481,6 +510,7 @@ const RightRailEditPanel = () => {
             subtitle={`${row.height || 'medium'} · ${items.length} item${items.length === 1 ? '' : 's'}`}
             saveStatus={effectiveSaveStatus}
           />
+          {readOnlyNotice}
           {validationBanner}
           <div data-testid="right-rail-edit-row" className="flex-1 overflow-y-auto p-3">
             <RowEditForm
@@ -585,6 +615,7 @@ const RightRailEditPanel = () => {
             }
             saveStatus={effectiveSaveStatus}
           />
+          {readOnlyNotice}
           {validationBanner}
           <div data-testid="right-rail-edit-item" className="flex-1 overflow-y-auto p-3">
             <ItemEditForm
@@ -669,6 +700,11 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   const collectionKey = COLLECTION_KEY[type];
   const collection = useStore(s => (collectionKey ? s[collectionKey] : null));
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  // VIS-1025: cloud read-only — render the form for inspection, but disabled
+  // behind the Read-only notice. The write path is independently held by
+  // useRecordSave's short-circuit; this is the UX affordance layer.
+  const capabilities = useStore(s => s.capabilities);
+  const readOnly = !!(capabilities && capabilities.can_edit === false);
   const record = useMemo(
     () => (Array.isArray(collection) ? collection.find(o => o.name === name) || null : null),
     [collection, name]
@@ -723,6 +759,7 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
     return (
       <>
         <SelectionChip type={type} name={name} subtitle={singular} saveStatus={saveStatus} />
+        {readOnly && <ReadOnlyNotice editAction={capabilities?.edit_action} />}
         {/* VIS-993 §2 — the save-status block: the validation gate's 'invalid'
             errors (rail-level `path: message` list; per-field mapping comes
             with VIS-996) + the run-failure loop-back banner for THIS record,
@@ -745,7 +782,21 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
         )}
         <RecordRunStatus name={name} />
         <div data-testid="right-rail-edit-leaf-form" className="flex-1 overflow-y-auto">
-          {renderForm(record, common)}
+          {/* None of the leaf forms take a disabled prop, so read-only uses the
+              one mechanism that covers them all: a disabled <fieldset> (native
+              controls + keyboard) with pointer-events held (react-select /
+              contenteditable / editor surfaces). */}
+          {readOnly ? (
+            <fieldset
+              disabled
+              data-testid="right-rail-readonly-fieldset"
+              className="pointer-events-none opacity-60"
+            >
+              {renderForm(record, common)}
+            </fieldset>
+          ) : (
+            renderForm(record, common)
+          )}
         </div>
       </>
     );

--- a/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
@@ -182,6 +182,9 @@ const resetStore = (overrides = {}) => {
       inputs: [],
       saveDashboard: jest.fn(() => Promise.resolve({ success: true })),
       openWorkspaceTab: jest.fn(),
+      // Local serve default (always editable) — the VIS-1025 read-only suite
+      // overrides this with a cloud capability object.
+      capabilities: null,
       ...overrides,
     });
   });
@@ -1099,5 +1102,154 @@ describe('RightRailEditPanel run-failure loop-back + invalid errors (VIS-993 §2
     fireEvent.click(screen.getByTestId('chart-stub-save'));
     await waitFor(() => expect(saveChart).toHaveBeenCalledTimes(1));
     expect(screen.queryByTestId('record-save-errors')).not.toBeInTheDocument();
+  });
+});
+
+// ── VIS-1025: the rail respects cloud read-only ─────────────────────────────
+// capabilities (branchingStore): null = local serve (always editable); a cloud
+// capability object with can_edit:false makes the stage read-only — the rail
+// renders forms disabled behind a "Read-only — <edit_action>" notice and holds
+// EVERY write (leaf saves via useRecordSave, structure writes via persistConfig).
+describe('RightRailEditPanel cloud read-only (VIS-1025)', () => {
+  const READONLY_CAPS = {
+    can_view: true,
+    can_edit: false,
+    can_branch: true,
+    is_default_stage: true,
+    edit_action: 'Create a draft to edit',
+  };
+
+  afterEach(() => {
+    act(() => useStore.setState({ capabilities: null }));
+  });
+
+  test('leaf form: renders the Read-only notice with the edit_action hint + a disabled fieldset', () => {
+    resetStore({
+      workspaceActiveObject: { type: 'chart', name: 'rev_chart' },
+      charts: [{ name: 'rev_chart', config: { title: 'Old' } }],
+      capabilities: READONLY_CAPS,
+    });
+    renderPanel();
+
+    const notice = screen.getByTestId('right-rail-readonly');
+    expect(notice).toHaveTextContent('Read-only');
+    expect(notice).toHaveTextContent('Create a draft to edit');
+    // The form still renders (viewers can inspect the config)…
+    expect(screen.getByTestId('chart-edit-form-stub')).toBeInTheDocument();
+    // …but its fields sit inside a disabled fieldset (native controls disabled,
+    // pointer events held for non-native editors).
+    expect(screen.getByTestId('right-rail-readonly-fieldset')).toBeDisabled();
+  });
+
+  test('leaf form: an edit attempt produces ZERO optimistic store writes and ZERO saves', async () => {
+    const saveChart = jest.fn(() => Promise.resolve({ success: true }));
+    resetStore({
+      workspaceActiveObject: { type: 'chart', name: 'rev_chart' },
+      charts: [{ name: 'rev_chart', config: { title: 'Old' } }],
+      saveChart,
+      capabilities: READONLY_CAPS,
+    });
+    renderPanel();
+
+    // The stub's save button routes onSave('chart', name, config) → saveNow.
+    fireEvent.click(screen.getByTestId('chart-stub-save'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(saveChart).not.toHaveBeenCalled();
+    const entry = useStore.getState().charts.find(c => c.name === 'rev_chart');
+    expect(entry.config).toEqual({ title: 'Old' });
+    // And it never masquerades as a validation failure.
+    expect(screen.queryByTestId('record-save-errors')).not.toBeInTheDocument();
+  });
+
+  test('structure form (persistConfig path): edits neither write optimistically nor persist', async () => {
+    jest.useFakeTimers();
+    try {
+      const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+      resetStore({
+        workspaceOutlineSelectedKey: 'row.0',
+        saveDashboard,
+        capabilities: READONLY_CAPS,
+      });
+      renderPanel();
+
+      expect(screen.getByTestId('right-rail-readonly')).toBeInTheDocument();
+
+      // Attempt a row-height edit through the live form.
+      selectEvent.openMenu(screen.getByLabelText('Row 1 height'));
+      fireEvent.click(screen.getAllByRole('option').find(o => o.textContent === 'large'));
+      await act(async () => {
+        jest.advanceTimersByTime(600);
+      });
+
+      expect(saveDashboard).not.toHaveBeenCalled();
+      // The store dashboard was NOT optimistically rewritten.
+      const dash = useStore.getState().dashboards.find(d => d.name === 'simple-dashboard');
+      expect(dash.config.rows[0].height).toBe('medium');
+      // No 'invalid' churn either — the edit is not-allowed, not invalid.
+      expect(screen.queryByTestId('right-rail-validation-errors')).not.toBeInTheDocument();
+    } finally {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    }
+  });
+
+  test('dashboard-chrome view: the notice renders and "Add row" is held', async () => {
+    jest.useFakeTimers();
+    try {
+      const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+      resetStore({
+        workspaceOutlineSelectedKey: 'dashboard',
+        saveDashboard,
+        capabilities: READONLY_CAPS,
+      });
+      renderPanel();
+
+      expect(screen.getByTestId('right-rail-readonly')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('right-rail-edit-add-row'));
+      await act(async () => {
+        jest.advanceTimersByTime(600);
+      });
+
+      expect(saveDashboard).not.toHaveBeenCalled();
+      const dash = useStore.getState().dashboards.find(d => d.name === 'simple-dashboard');
+      expect(dash.config.rows).toHaveLength(2);
+    } finally {
+      act(() => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    }
+  });
+
+  test('capabilities null (local serve) → no notice, no fieldset, saves flow — pin', async () => {
+    const saveChart = jest.fn(() => Promise.resolve({ success: true }));
+    resetStore({
+      workspaceActiveObject: { type: 'chart', name: 'rev_chart' },
+      charts: [{ name: 'rev_chart', config: { title: 'Old' } }],
+      saveChart,
+      capabilities: null,
+    });
+    renderPanel();
+
+    expect(screen.queryByTestId('right-rail-readonly')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('right-rail-readonly-fieldset')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('chart-stub-save'));
+    await waitFor(() => expect(saveChart).toHaveBeenCalledTimes(1));
+  });
+
+  test('cloud EDITABLE capabilities ({can_edit:true}) behave exactly like local serve — pin', async () => {
+    const saveChart = jest.fn(() => Promise.resolve({ success: true }));
+    resetStore({
+      workspaceActiveObject: { type: 'chart', name: 'rev_chart' },
+      charts: [{ name: 'rev_chart', config: { title: 'Old' } }],
+      saveChart,
+      capabilities: { ...READONLY_CAPS, can_edit: true, edit_action: null },
+    });
+    renderPanel();
+
+    expect(screen.queryByTestId('right-rail-readonly')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('chart-stub-save'));
+    await waitFor(() => expect(saveChart).toHaveBeenCalledTimes(1));
   });
 });

--- a/viewer/src/hooks/useRecordSave.js
+++ b/viewer/src/hooks/useRecordSave.js
@@ -9,6 +9,16 @@ import {
 import { checkRefTargets } from '../components/views/workspace/refPreflight';
 
 /**
+ * Cloud read-only probe (VIS-1025). `capabilities` is null/undefined under
+ * local serve (always editable); in cloud it's the stage's capability object
+ * and `can_edit === false` holds every write.
+ */
+const isReadOnly = state => {
+  const caps = state.capabilities;
+  return !!(caps && caps.can_edit === false);
+};
+
+/**
  * useRecordSave(type, name, opts) — the unified optimistic + debounced save
  * backbone for editing surfaces (VIS-1018 step 1).
  *
@@ -40,10 +50,17 @@ import { checkRefTargets } from '../components/views/workspace/refPreflight';
  * fast path inside `scheduleSave` marks errors the moment the user stops
  * typing; the async fire-time check remains the authoritative gate.
  *
+ * READ-ONLY SHORT-CIRCUIT (VIS-1025): `capabilities` (branchingStore) is null
+ * under local serve (always editable) and an object in cloud, where
+ * `can_edit: false` marks the stage read-only. The check runs BEFORE the
+ * optimistic write AND before the validation gate — a not-allowed edit is not
+ * 'invalid' (no error churn for a viewer-only user): nothing writes, nothing
+ * persists, and the hook reports `status: 'readonly'` with `errors: null`.
+ *
  * The status model ('idle' | 'pending' | 'saving' | 'saved' | 'error' |
- * 'invalid') and the `{ status, errors, scheduleSave, saveNow, reset }`
- * surface extend `useDebouncedSave` so existing indicators map straight
- * across.
+ * 'invalid' | 'readonly') and the `{ status, errors, scheduleSave, saveNow,
+ * reset }` surface extend `useDebouncedSave` so existing indicators map
+ * straight across.
  *
  * @param {string} type  one of the canonical object types (see COLLECTION_KEY).
  * @param {string} name  the record name (the collection key + persist arg).
@@ -108,6 +125,17 @@ export default function useRecordSave(type, name, opts = {}) {
     const seqAtFire = seqRef.current;
     const saveActionName = SAVE_ACTION[t];
     const state = useStore.getState();
+
+    // VIS-1025 fire-time hold — BEFORE validation (not-allowed is not
+    // 'invalid'). Catches timers armed before capabilities flipped read-only.
+    if (isReadOnly(state)) {
+      if (mountedRef.current) {
+        setStatus('readonly');
+        setErrors(null);
+      }
+      return { success: false, readonly: true };
+    }
+
     const saveFn = saveActionName ? state[saveActionName] : null;
 
     // Read the CURRENT optimistic value at FIRE time (clobber-safety).
@@ -179,6 +207,15 @@ export default function useRecordSave(type, name, opts = {}) {
 
   const scheduleSave = useCallback(
     nextConfig => {
+      // VIS-1025 read-only short-circuit — BEFORE the optimistic write and
+      // BEFORE validation: nothing writes, nothing arms, no 'invalid' churn.
+      if (isReadOnly(useStore.getState())) {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = null;
+        setStatus('readonly');
+        setErrors(null);
+        return;
+      }
       // Record this as the latest edit (used by runSave's refetch-revert guard).
       latestConfigRef.current = nextConfig;
       seqRef.current += 1;
@@ -220,6 +257,18 @@ export default function useRecordSave(type, name, opts = {}) {
 
   const saveNow = useCallback(
     async nextConfig => {
+      // VIS-1025 read-only short-circuit — mirror scheduleSave: no optimistic
+      // write, no persist, status 'readonly' (runSave would also hold, but the
+      // early return keeps the blocked config out of latestConfigRef too).
+      if (isReadOnly(useStore.getState())) {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+        setStatus('readonly');
+        setErrors(null);
+        return { success: false, readonly: true };
+      }
       // When called with a config, apply it optimistically first so the persist
       // reads it; called bare, it just flushes the current optimistic value.
       if (nextConfig !== undefined) {

--- a/viewer/src/hooks/useRecordSave.test.js
+++ b/viewer/src/hooks/useRecordSave.test.js
@@ -11,6 +11,12 @@
 import { renderHook, act } from '@testing-library/react';
 import useRecordSave from './useRecordSave';
 import useStore from '../stores/store';
+// The mocked gate fns (jest.mock below is hoisted above imports) — used by the
+// read-only ordering test to prove the short-circuit lands BEFORE validation.
+import {
+  validateRecordConfig,
+  validateRecordConfigSync,
+} from '../components/views/workspace/validateAgainstSchema';
 
 // The validation gate has its own suite (useRecordSave.validation.test.js,
 // real schema). Here it is stubbed permissive so the backbone mechanics —
@@ -32,6 +38,8 @@ const setupCollection = (collectionKey, name, config, saveActionName) => {
     [saveActionName]: saveFn,
     saveActivityCount: 0,
     lastSaveFailed: false,
+    // Local serve default — the cloud read-only suite below overrides this.
+    capabilities: null,
   });
   return saveFn;
 };
@@ -277,6 +285,161 @@ describe('useRecordSave (VIS-1018)', () => {
       jest.advanceTimersByTime(300);
     });
     expect(saveFn).toHaveBeenLastCalledWith('md1', { name: 'md1', content: 'C' });
+  });
+
+  // ── VIS-1025: cloud read-only short-circuit ────────────────────────────────
+  // capabilities (branchingStore): null = local serve (always editable); an
+  // object = cloud, where can_edit:false means the stage is read-only. The
+  // check is mechanics (not validation): a not-allowed edit is not 'invalid'.
+  describe('cloud read-only short-circuit (VIS-1025)', () => {
+    const READONLY_CAPS = {
+      can_view: true,
+      can_edit: false,
+      can_branch: true,
+      is_default_stage: true,
+      edit_action: 'Create a draft to edit',
+    };
+
+    afterEach(() => {
+      act(() => useStore.setState({ capabilities: null }));
+      validateRecordConfigSync.mockImplementation(() => null);
+    });
+
+    test('scheduleSave: no optimistic write, no timer, status readonly, errors null', async () => {
+      const saveFn = setupCollection('charts', 'c1', { name: 'c1', v: 0 }, 'saveChart');
+      act(() => useStore.setState({ capabilities: READONLY_CAPS }));
+      const { result } = renderHook(() => useRecordSave('chart', 'c1', { delay: 500 }));
+
+      act(() => result.current.scheduleSave({ name: 'c1', v: 1 }));
+
+      expect(result.current.status).toBe('readonly');
+      expect(result.current.errors).toBeNull();
+      // NO optimistic write — the store still holds the server value.
+      expect(useStore.getState().charts.find(c => c.name === 'c1').config).toEqual({
+        name: 'c1',
+        v: 0,
+      });
+      // NO doomed persist was armed.
+      expect(jest.getTimerCount()).toBe(0);
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(saveFn).not.toHaveBeenCalled();
+    });
+
+    test('saveNow: no write, no persist, resolves { success:false, readonly:true }', async () => {
+      const saveFn = setupCollection('tables', 't1', { name: 't1', v: 0 }, 'saveTable');
+      act(() => useStore.setState({ capabilities: READONLY_CAPS }));
+      const { result } = renderHook(() => useRecordSave('table', 't1', { delay: 500 }));
+
+      let outcome;
+      await act(async () => {
+        outcome = await result.current.saveNow({ name: 't1', v: 9 });
+      });
+
+      expect(outcome).toEqual({ success: false, readonly: true });
+      expect(saveFn).not.toHaveBeenCalled();
+      expect(useStore.getState().tables.find(t => t.name === 't1').config).toEqual({
+        name: 't1',
+        v: 0,
+      });
+      expect(result.current.status).toBe('readonly');
+      expect(result.current.errors).toBeNull();
+    });
+
+    test('the short-circuit lands BEFORE validation — an invalid config still reads readonly, never invalid', () => {
+      setupCollection('markdowns', 'md1', { name: 'md1', content: 'hi' }, 'saveMarkdown');
+      act(() => useStore.setState({ capabilities: READONLY_CAPS }));
+      // Were validation consulted first, this would flip the hook to 'invalid'.
+      validateRecordConfigSync.mockImplementation(() => ({
+        valid: false,
+        errors: [{ path: 'align', message: 'bad', keyword: 'enum' }],
+      }));
+      validateRecordConfig.mockClear();
+      validateRecordConfigSync.mockClear();
+      const { result } = renderHook(() => useRecordSave('markdown', 'md1', { delay: 500 }));
+
+      act(() => result.current.scheduleSave({ name: 'md1', content: 'hi', align: 'diagonal' }));
+
+      expect(result.current.status).toBe('readonly');
+      expect(result.current.errors).toBeNull();
+      // The gate was never even consulted for the blocked edit.
+      expect(validateRecordConfigSync).not.toHaveBeenCalled();
+      expect(validateRecordConfig).not.toHaveBeenCalled();
+    });
+
+    test('saveNow under read-only also cancels a previously-armed debounce timer', async () => {
+      const saveFn = setupCollection('charts', 'c1', { name: 'c1', v: 0 }, 'saveChart');
+      const { result } = renderHook(() => useRecordSave('chart', 'c1', { delay: 500 }));
+
+      // Armed while editable…
+      act(() => result.current.scheduleSave({ name: 'c1', v: 1 }));
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+      // …then the stage flips read-only and a flush is attempted.
+      act(() => useStore.setState({ capabilities: READONLY_CAPS }));
+      let outcome;
+      await act(async () => {
+        outcome = await result.current.saveNow();
+      });
+
+      expect(outcome).toEqual({ success: false, readonly: true });
+      // The doomed timer was cancelled — nothing fires later either.
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(saveFn).not.toHaveBeenCalled();
+      expect(result.current.status).toBe('readonly');
+    });
+
+    test('a save armed BEFORE capabilities flip read-only is held at fire time', async () => {
+      const saveFn = setupCollection('charts', 'c1', { name: 'c1', v: 0 }, 'saveChart');
+      const { result } = renderHook(() => useRecordSave('chart', 'c1', { delay: 500 }));
+
+      act(() => result.current.scheduleSave({ name: 'c1', v: 1 }));
+      expect(result.current.status).toBe('pending');
+
+      // The stage flips read-only while the debounce is running (e.g. the
+      // draft was published under the user).
+      act(() => useStore.setState({ capabilities: READONLY_CAPS }));
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(saveFn).not.toHaveBeenCalled();
+      expect(result.current.status).toBe('readonly');
+    });
+
+    test('cloud EDITABLE capabilities ({can_edit:true}) persist exactly like local serve', async () => {
+      const saveFn = setupCollection('charts', 'c1', { name: 'c1', v: 0 }, 'saveChart');
+      act(() =>
+        useStore.setState({
+          capabilities: { ...READONLY_CAPS, can_edit: true, edit_action: null },
+        })
+      );
+      const { result } = renderHook(() => useRecordSave('chart', 'c1', { delay: 500 }));
+
+      act(() => result.current.scheduleSave({ name: 'c1', v: 2 }));
+      expect(useStore.getState().charts.find(c => c.name === 'c1').config.v).toBe(2);
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(saveFn).toHaveBeenCalledWith('c1', { name: 'c1', v: 2 });
+      expect(result.current.status).toBe('saved');
+    });
+
+    test('capabilities null (local serve) stays fully editable — pin', async () => {
+      const saveFn = setupCollection('charts', 'c1', { name: 'c1', v: 0 }, 'saveChart');
+      act(() => useStore.setState({ capabilities: null }));
+      const { result } = renderHook(() => useRecordSave('chart', 'c1', { delay: 500 }));
+
+      act(() => result.current.scheduleSave({ name: 'c1', v: 3 }));
+      expect(result.current.status).toBe('pending');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(saveFn).toHaveBeenCalledWith('c1', { name: 'c1', v: 3 });
+    });
   });
 
   test('reports into the global save-activity counter while a save is in flight', async () => {

--- a/viewer/src/schemas/projectSchema.js
+++ b/viewer/src/schemas/projectSchema.js
@@ -104,6 +104,21 @@ export async function preloadProjectSchema() {
 }
 
 /**
+ * Drop every module-level cache (VIS-1025). The caches carry no project
+ * identity, so the store layer calls this when the active `project.id`
+ * CHANGES (commonStore) — the next load re-binds against the new project.
+ * validateAgainstSchema keeps its own compiled-validator cache on top; its
+ * `clearValidationCache` is cleared alongside this at the same seam.
+ */
+export function resetProjectSchemaCache() {
+  rootSchemaCache = null;
+  loadingPromise = null;
+  Object.keys(objectSchemaCache).forEach(key => {
+    delete objectSchemaCache[key];
+  });
+}
+
+/**
  * Whether the project schema has finished loading (and is cached).
  * @returns {boolean}
  */

--- a/viewer/src/schemas/projectSchema.test.js
+++ b/viewer/src/schemas/projectSchema.test.js
@@ -11,6 +11,7 @@ import {
   getDefNameForType,
   isObjectSchemaLoaded,
   preloadProjectSchema,
+  resetProjectSchemaCache,
   OBJECT_TYPE_TO_DEF,
 } from './projectSchema';
 
@@ -75,6 +76,14 @@ describe('getObjectSchema', () => {
     const b = await getObjectSchema('metric');
     expect(a).toBe(b);
   });
+
+  test('concurrent cold loads share a single in-flight import', async () => {
+    resetProjectSchemaCache();
+    const [a, b] = await Promise.all([getObjectSchema('dimension'), getObjectSchema('metric')]);
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(isObjectSchemaLoaded()).toBe(true);
+  });
 });
 
 describe('preload / loaded flags / sync accessor', () => {
@@ -84,5 +93,76 @@ describe('preload / loaded flags / sync accessor', () => {
     const sync = getObjectSchemaSync('dimension');
     expect(sync).toBeTruthy();
     expect(sync.$defs).toBeTruthy();
+  });
+});
+
+// VIS-1025: the module-level caches carry no project identity, so a project
+// switch (cloud draft flip, project change) must be able to drop them —
+// resetProjectSchemaCache is the seam the store layer invokes on id change.
+describe('resetProjectSchemaCache (VIS-1025)', () => {
+  test('drops the root + per-type caches so the schema re-binds to the new project', async () => {
+    await preloadProjectSchema();
+    const before = await getObjectSchema('dimension');
+    expect(isObjectSchemaLoaded()).toBe(true);
+    expect(getObjectSchemaSync('dimension')).toBeTruthy();
+
+    resetProjectSchemaCache();
+
+    // Fully cold: nothing loaded, the sync accessor yields nothing.
+    expect(isObjectSchemaLoaded()).toBe(false);
+    expect(getObjectSchemaSync('dimension')).toBeNull();
+    expect(getObjectSchemaSync('metric')).toBeNull();
+
+    // Re-warming rebuilds a FRESH assembled slice (not the stale cached object).
+    const after = await getObjectSchema('dimension');
+    expect(after).toBeTruthy();
+    expect(after).not.toBe(before);
+    expect(after.required).toEqual(['expression']);
+    expect(isObjectSchemaLoaded()).toBe(true);
+  });
+
+  test('reset is safe on already-cold caches', () => {
+    resetProjectSchemaCache();
+    expect(() => resetProjectSchemaCache()).not.toThrow();
+    expect(isObjectSchemaLoaded()).toBe(false);
+  });
+
+  test('after a reset, getObjectSchemaSync re-assembles a fresh slice once the root is re-loaded', async () => {
+    resetProjectSchemaCache();
+    await preloadProjectSchema();
+
+    // metric was never assembled in this cold state — the SYNC path builds it.
+    const sync = getObjectSchemaSync('metric');
+    expect(sync).toBeTruthy();
+    expect(sync.$defs.Dimension).toBeTruthy();
+    // …and caches it for the next sync read.
+    expect(getObjectSchemaSync('metric')).toBe(sync);
+
+    // A mapped type with no def in the graph returns null (sync + async agree).
+    expect(getObjectSchemaSync('relation')).toBeNull();
+    expect(await getObjectSchema('relation')).toBeNull();
+  });
+});
+
+describe('fail-open on an unloadable schema bundle', () => {
+  test('a failed import rejects the preload and getObjectSchema returns null (backend stays authoritative)', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.resetModules();
+    jest.doMock('./visivo_project_schema.json', () => {
+      throw new Error('bundle missing');
+    });
+    let fresh;
+    jest.isolateModules(() => {
+      fresh = require('./projectSchema');
+    });
+
+    await expect(fresh.preloadProjectSchema()).rejects.toThrow('bundle missing');
+    expect(fresh.isObjectSchemaLoaded()).toBe(false);
+    // getObjectSchema swallows the load failure and fails open with null.
+    expect(await fresh.getObjectSchema('dimension')).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    jest.dontMock('./visivo_project_schema.json');
   });
 });

--- a/viewer/src/stores/commonStore.js
+++ b/viewer/src/stores/commonStore.js
@@ -1,6 +1,8 @@
 import { fetchProjectBlob } from '../api/project';
 import { fetchProjectFilePath } from '../api/projectFilePath';
 import { hasCompletedOnboarding } from '../components/onboarding/onboardingState';
+import { resetProjectSchemaCache } from '../schemas/projectSchema';
+import { clearValidationCache } from '../components/views/workspace/validateAgainstSchema';
 
 // `visivo init` opens the viewer at `?onboarding=1` to explicitly request
 // the onboarding flow. This is needed because the new-project heuristic
@@ -29,6 +31,22 @@ const createCommonSlice = (set, get) => {
     set({ isNewProject: isNew });
   };
 
+  // VIS-1025: the schema caches (projectSchema's loader caches + the compiled
+  // AJV validators layered on top) carry no project identity. Every project
+  // write lands here (setProject, fetchProject — and the commitStore
+  // project_changed soft refresh routes through fetchProject), so this is the
+  // seam that keys them by project: drop BOTH layers when the id CHANGES.
+  // A same-id refetch, the first project landing, and id-less local blobs all
+  // keep a warm cache intact.
+  const invalidateSchemaCachesOnProjectSwitch = nextProject => {
+    const prevId = get().project?.id;
+    const nextId = nextProject?.id;
+    if (prevId != null && nextId != null && prevId !== nextId) {
+      resetProjectSchemaCache();
+      clearValidationCache();
+    }
+  };
+
   return {
     project: null,
     projectFilePath: null,
@@ -41,6 +59,7 @@ const createCommonSlice = (set, get) => {
       }));
     },
     setProject: project => {
+      invalidateSchemaCachesOnProjectSwitch(project);
       set({ project });
       evaluateIsNewProject();
     },
@@ -56,6 +75,7 @@ const createCommonSlice = (set, get) => {
       // those consumers. Switch to `fetchProject` from api/project.js
       // when the loader + Onboarding are migrated.
       const project = await fetchProjectBlob();
+      invalidateSchemaCachesOnProjectSwitch(project);
       set({ project });
       evaluateIsNewProject();
     },

--- a/viewer/src/stores/commonStore.test.js
+++ b/viewer/src/stores/commonStore.test.js
@@ -11,9 +11,29 @@
 import createCommonSlice from './commonStore';
 import { fetchProjectBlob } from '../api/project';
 import { fetchProjectFilePath } from '../api/projectFilePath';
+import { isObjectSchemaLoaded, resetProjectSchemaCache } from '../schemas/projectSchema';
+import {
+  preloadValidationSchema,
+  validateRecordConfigSync,
+  clearValidationCache,
+} from '../components/views/workspace/validateAgainstSchema';
 
 jest.mock('../api/project', () => ({ fetchProjectBlob: jest.fn() }));
 jest.mock('../api/projectFilePath', () => ({ fetchProjectFilePath: jest.fn() }));
+// Keep the schema-identity tests fast: swap the multi-MB bundled snapshot for a
+// tiny $defs fixture (the loader/validator contract is identical).
+jest.mock('../schemas/visivo_project_schema.json', () => ({
+  __esModule: true,
+  default: {
+    $defs: {
+      Dimension: {
+        type: 'object',
+        required: ['expression'],
+        properties: { expression: { type: 'string' } },
+      },
+    },
+  },
+}));
 
 // Mirrors the KEY constant in components/onboarding/onboardingState.js
 const ONBOARDING_STATE_KEY = 'visivo.onboarding.v1';
@@ -183,6 +203,106 @@ describe('commonStore slice actions', () => {
       await store.getState().fetchProjectFilePath();
 
       expect(store.getState().projectFilePath).toBe('/repo/project.visivo.yml');
+    });
+  });
+
+  // ── VIS-1025: project-keyed schema caches ──────────────────────────────────
+  // projectSchema's module-level caches (and validateAgainstSchema's compiled
+  // validators on top) carry no project identity. The store layer is the seam
+  // where project switches land — commonStore compares the previous project.id
+  // on EVERY project write (setProject, fetchProject — and transitively the
+  // commitStore project_changed soft refresh, which routes through
+  // fetchProject) and drops BOTH cache layers only when the id CHANGES.
+  describe('project-keyed schema caches (VIS-1025)', () => {
+    const warm = async () => {
+      await preloadValidationSchema();
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
+        expect.objectContaining({ valid: true })
+      );
+      expect(isObjectSchemaLoaded()).toBe(true);
+    };
+
+    beforeEach(() => {
+      clearValidationCache();
+      resetProjectSchemaCache();
+    });
+    afterEach(() => {
+      clearValidationCache();
+      resetProjectSchemaCache();
+    });
+
+    test('switching to a DIFFERENT project id clears the schema + validator caches', async () => {
+      const store = createHarness();
+      store.getState().setProject({ id: 'proj-1' });
+      await warm();
+
+      store.getState().setProject({ id: 'proj-2' });
+
+      // Cold until re-warmed: the sync gate yields null (defer to async),
+      // and the root schema is no longer loaded.
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toBeNull();
+      expect(isObjectSchemaLoaded()).toBe(false);
+
+      // Re-warming binds cleanly against the new identity.
+      await preloadValidationSchema();
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
+        expect.objectContaining({ valid: true })
+      );
+    });
+
+    test('a same-id refetch keeps both cache layers warm', async () => {
+      const store = createHarness();
+      store.getState().setProject({ id: 'proj-1' });
+      await warm();
+
+      store.getState().setProject({ id: 'proj-1', refetched_at: 'now' });
+
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
+        expect.objectContaining({ valid: true })
+      );
+      expect(isObjectSchemaLoaded()).toBe(true);
+    });
+
+    test('the FIRST project landing does not blow a pre-warmed cache', async () => {
+      const store = createHarness();
+      await warm(); // preloaded before any project id is known
+
+      store.getState().setProject({ id: 'proj-1' });
+
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
+        expect.objectContaining({ valid: true })
+      );
+      expect(isObjectSchemaLoaded()).toBe(true);
+    });
+
+    test('a project write WITHOUT an id (local blob) never clears', async () => {
+      const store = createHarness();
+      store.getState().setProject({ id: 'proj-1' });
+      await warm();
+
+      store.getState().setProject({ project_json: { name: 'local', dashboards: [] } });
+
+      expect(isObjectSchemaLoaded()).toBe(true);
+    });
+
+    test('fetchProject routes through the same identity check (id change clears, same id keeps)', async () => {
+      const store = createHarness();
+      store.getState().setProject({ id: 'proj-1' });
+      await warm();
+
+      // Same-id refetch (the project_changed soft-refresh shape) — intact.
+      fetchProjectBlob.mockResolvedValue({ id: 'proj-1', project_json: { name: 'p' } });
+      await store.getState().fetchProject();
+      expect(isObjectSchemaLoaded()).toBe(true);
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
+        expect.objectContaining({ valid: true })
+      );
+
+      // Id flip (e.g. the active project became a different one) — cleared.
+      fetchProjectBlob.mockResolvedValue({ id: 'proj-2', project_json: { name: 'p2' } });
+      await store.getState().fetchProject();
+      expect(validateRecordConfigSync('dimension', { expression: 'x' })).toBeNull();
+      expect(isObjectSchemaLoaded()).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What

Two cloud-correctness gaps from the 2026-07-02 review, TDD'd:

### Read-only short-circuit
When `capabilities.can_edit === false` (cloud viewer role / no draft), the rail stops pretending edits work:
- `useRecordSave` holds every write at three points — `scheduleSave` (before the optimistic write), `saveNow` (also cancels an armed timer), and fire-time in `runSave` **before** the VIS-993 validation gate (not-allowed is not 'invalid' — a viewer-only user gets a calm `'readonly'` status, never error churn).
- The rail renders a muted **Read-only — <edit_action>** notice and wraps leaf forms in a disabled fieldset (native controls + keyboard) with pointer-events-none (react-select/contenteditable); structure forms hold `persistConfig` before the optimistic write.
- Local serve (`capabilities === null`) is pinned unchanged.

### Schema cache identity
`projectSchema`'s module caches carried no project identity — across cloud draft switches (a draft is a NEW project id) forms could render/validate against a stale schema. `resetProjectSchemaCache()` + `clearValidationCache()` now fire from `commonStore` when the active `project.id` CHANGES (same-id refetches keep caches warm; draft flips via `startEdit`/`startBranch`/`refreshFromProjectChange` route through transitively).

## Test strategy
- Unit: 7 new mechanics tests (read-only ordering pinned by asserting the validators are never called), 7 cache-identity tests (id change → sync validation cold until re-warmed; same-id / first-landing / id-less local keep warm).
- Integration: rail read-only rendering + zero-optimistic-writes + structure-form holds; capabilities-null behavior pinned.
- Gates: full suite 5,053 green; eslint `--max-warnings=0` clean; touched files ≥85% coverage.

Closes VIS-1025. Stacked on VIS-993 (#509, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)