### PR TITLE
VIS-993 follow-up: expression-parse gate + auto-save forms (no Save button)

### DIFF
--- a/tests/server/views/test_expression_views.py
+++ b/tests/server/views/test_expression_views.py
@@ -174,3 +174,93 @@ class TestExpressionViews:
         data = response.get_json()
         assert len(data["translations"]) == 1
         assert data["translations"][0]["duckdb_expression"] is not None
+
+
+class TestExpressionValidateView:
+    """/api/expressions/validate/ (VIS-993 layer 2): sqlglot parse validation.
+
+    Unlike /translate/ (which gracefully passes unparseable expressions through
+    so the explorer keeps working), /validate/ REPORTS parse failures so the
+    viewer's validation-as-save gate can block persistence of a doomed
+    expression before it caches and fires a run.
+    """
+
+    @pytest.fixture
+    def app(self):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        register_expression_views(app, flask_app, "/tmp/output")
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    def _validate(self, client, expression, name="expr", dialect="duckdb"):
+        response = client.post(
+            "/api/expressions/validate/",
+            json={
+                "expressions": [{"name": name, "expression": expression}],
+                "source_dialect": dialect,
+            },
+        )
+        assert response.status_code == 200
+        return response.get_json()["results"][0]
+
+    def test_valid_aggregate_expression(self, client):
+        result = self._validate(client, "AVG(value)")
+        assert result["valid"] is True
+        assert result["name"] == "expr"
+
+    def test_unbalanced_brace_is_invalid(self, client):
+        result = self._validate(client, "AVG(value)}")
+        assert result["valid"] is False
+        assert result["error"]
+
+    def test_error_messages_carry_no_ansi_escapes(self, client):
+        result = self._validate(client, "AVG(value)}")
+        assert "\x1b" not in result["error"]
+
+    def test_unbalanced_quote_is_invalid(self, client):
+        result = self._validate(client, "SUM('amount")
+        assert result["valid"] is False
+
+    def test_context_ref_with_field_is_substituted_and_valid(self, client):
+        result = self._validate(client, "${ref(daily_metrics).value} * 2")
+        assert result["valid"] is True
+
+    def test_composite_metric_refs_are_substituted_and_valid(self, client):
+        result = self._validate(client, "${ref(avg_value)} / ${ref(new_y_sum)}")
+        assert result["valid"] is True
+
+    def test_relation_condition_with_refs_is_valid(self, client):
+        result = self._validate(client, "${ref(orders).id} = ${ref(users).order_id}")
+        assert result["valid"] is True
+
+    def test_broken_sql_around_valid_refs_is_invalid(self, client):
+        result = self._validate(client, "${ref(daily_metrics).value} +* 2")
+        assert result["valid"] is False
+
+    def test_empty_expression_is_invalid(self, client):
+        result = self._validate(client, "")
+        assert result["valid"] is False
+
+    def test_multiple_expressions_validate_independently(self, client):
+        response = client.post(
+            "/api/expressions/validate/",
+            json={
+                "expressions": [
+                    {"name": "good", "expression": "SUM(x)"},
+                    {"name": "bad", "expression": "SUM(x))"},
+                ],
+                "source_dialect": "duckdb",
+            },
+        )
+        results = response.get_json()["results"]
+        assert results[0]["valid"] is True
+        assert results[1]["valid"] is False
+
+    def test_missing_body_is_400(self, client):
+        response = client.post("/api/expressions/validate/", json=None)
+        assert response.status_code == 400

--- a/viewer/e2e/stories/validation-as-save.spec.mjs
+++ b/viewer/e2e/stories/validation-as-save.spec.mjs
@@ -1,22 +1,27 @@
 /**
  * Story: validation-as-save (VIS-993).
  *
- * The rail's save path is gated: a semantically doomed edit (dangling ref in a
- * dimension expression) never POSTs — no draft-cache write, no run under
- * runs-on-changes, no cloud commit block — and the blocking reason renders on
- * the field. Fixing the value saves normally and the commit badge reflects the
- * pending change.
+ * The rail is AUTO-SAVE with a gated backbone: there is no Save button in edit
+ * mode — every field change debounces through useRecordSave, where a
+ * semantically doomed edit (dangling ref, unparseable SQL expression) never
+ * POSTs — no draft-cache write, no run under runs-on-changes, no cloud commit
+ * block — and the blocking reason renders on the field. Fixing the value
+ * auto-saves and the change lands in the backend pending set.
  *
- * Runs in the `state-mutating` playwright project (writes the in-memory draft
- * cache on the valid-save step; discarded in afterAll).
+ * Runs in the `state-mutating` playwright project (the valid-save steps write
+ * the in-memory draft cache; discarded in afterAll).
  */
 import { test, expect } from '@playwright/test';
 
 const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
 const API = BASE.replace(':3001', ':8001');
 const WAIT = 20000;
+// The backbone debounces 500ms, then the async gate (schema + refs + backend
+// sqlglot) must run before any POST could fire. 1500ms comfortably covers it.
+const SETTLE = 1500;
 
 const DIMENSION = 'x_rounded';
+const METRIC = 'avg_value';
 
 test.describe('Validation-as-save gates the rail (VIS-993)', () => {
   test.describe.configure({ mode: 'serial' });
@@ -24,14 +29,14 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
 
   /** @type {import('@playwright/test').Page} */
   let page;
-  const dimensionPosts = [];
+  const posts = { dimensions: [], metrics: [] };
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
     page.on('request', req => {
-      if (req.method() === 'POST' && req.url().includes('/api/dimensions/')) {
-        dimensionPosts.push(req.url());
-      }
+      if (req.method() !== 'POST') return;
+      if (req.url().includes('/api/dimensions/')) posts.dimensions.push(req.url());
+      if (req.url().includes('/api/metrics/')) posts.metrics.push(req.url());
     });
   });
 
@@ -41,14 +46,14 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     await page.close();
   });
 
-  const openDimensionForm = async () => {
+  const openForm = async (type, name) => {
     await page.goto(`${BASE}/workspace`);
     await page.waitForLoadState('networkidle');
-    const section = page.getByTestId('library-subsection-dimension-header');
+    const section = page.getByTestId(`library-subsection-${type}-header`);
     if (await section.isVisible().catch(() => false)) {
       await section.click();
     }
-    const row = page.getByTestId(`library-row-dimension-${DIMENSION}`);
+    const row = page.getByTestId(`library-row-${type}-${name}`);
     await row.scrollIntoViewIfNeeded();
     await row.click();
     await expect(page.getByTestId('ref-textarea-editable')).toBeVisible({ timeout: WAIT });
@@ -62,51 +67,67 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     await editable.pressSequentially(text, { delay: 10 });
   };
 
-  test('a dangling ref blocks Save: inline reason, zero POSTs, badge unchanged', async () => {
-    await openDimensionForm();
-
-    const postsBefore = dimensionPosts.length;
-    await setExpression('${ref(ghost_model)}');
-    await page.getByRole('button', { name: 'Save' }).click();
-
-    // The gate's reason lands on the expression field.
-    await expect(page.getByText(/ghost_model/).first()).toBeVisible({ timeout: WAIT });
-
-    // Nothing persisted: no dimension POST left the browser.
-    expect(dimensionPosts.length).toBe(postsBefore);
-
-    // And the backend agrees — the draft cache holds no pending changes.
+  const backendPending = async name => {
     const changes = await page.request
       .get(`${API}/api/commit/pending/`)
       .then(r => r.json())
       .catch(() => ({ pending: [] }));
-    const pendingDimension = (changes.pending || []).find(c => c.name === DIMENSION);
-    expect(pendingDimension).toBeUndefined();
+    return (changes.pending || []).some(c => c.name === name);
+  };
+
+  test('there is no Save button — the rail is auto-save', async () => {
+    await openForm('dimension', DIMENSION);
+    await expect(page.getByRole('button', { name: 'Save' })).toHaveCount(0);
   });
 
-  test('fixing the expression saves through: POST fires and the change is pending', async () => {
-    const postsBefore = dimensionPosts.length;
+  test('a dangling ref blocks the auto-save: inline reason, zero POSTs', async () => {
+    const postsBefore = posts.dimensions.length;
+    await setExpression('${ref(ghost_model)}');
+    await page.waitForTimeout(SETTLE);
+
+    // The gate's reason lands on the expression field.
+    await expect(page.getByText(/ghost_model/).first()).toBeVisible({ timeout: WAIT });
+
+    // Nothing persisted: no dimension POST left the browser, backend agrees.
+    expect(posts.dimensions.length).toBe(postsBefore);
+    expect(await backendPending(DIMENSION)).toBe(false);
+  });
+
+  test('fixing the expression auto-saves: POST fires without any Save click', async () => {
+    const postsBefore = posts.dimensions.length;
 
     await setExpression('ROUND(x, 1)');
-    await page.getByRole('button', { name: 'Save' }).click();
 
-    // The save leaves the browser…
     await expect
-      .poll(() => dimensionPosts.length, { timeout: WAIT })
+      .poll(() => posts.dimensions.length, { timeout: WAIT })
       .toBeGreaterThan(postsBefore);
+    await expect.poll(() => backendPending(DIMENSION), { timeout: WAIT }).toBe(true);
+  });
 
-    // …and the backend now reports the dimension as a pending draft change.
+  test("an unparseable metric expression blocks: the user's AVG(value)} repro", async () => {
+    await openForm('metric', METRIC);
+
+    const postsBefore = posts.metrics.length;
+    await setExpression('AVG(value)}');
+    await page.waitForTimeout(SETTLE);
+
+    // The backend sqlglot parse error surfaces on the expression field.
+    await expect(
+      page.getByText(/Expecting|Invalid expression|parse/i).first()
+    ).toBeVisible({ timeout: WAIT });
+
+    expect(posts.metrics.length).toBe(postsBefore);
+    expect(await backendPending(METRIC)).toBe(false);
+  });
+
+  test('fixing the metric expression auto-saves through', async () => {
+    const postsBefore = posts.metrics.length;
+
+    await setExpression('AVG(value)');
+
     await expect
-      .poll(
-        async () => {
-          const changes = await page.request
-            .get(`${API}/api/commit/pending/`)
-            .then(r => r.json())
-            .catch(() => ({ pending: [] }));
-          return (changes.pending || []).some(c => c.name === DIMENSION);
-        },
-        { timeout: WAIT }
-      )
-      .toBe(true);
+      .poll(() => posts.metrics.length, { timeout: WAIT })
+      .toBeGreaterThan(postsBefore);
+    await expect.poll(() => backendPending(METRIC), { timeout: WAIT }).toBe(true);
   });
 });

--- a/viewer/src/api/expressions.js
+++ b/viewer/src/api/expressions.js
@@ -32,3 +32,32 @@ export const translateExpressions = async (expressions, sourceDialect) => {
 
   throw new Error('Failed to translate expressions');
 };
+
+/**
+ * Validate that SQL expressions parse under the source dialect (VIS-993).
+ *
+ * Fail-open contract: when the endpoint isn't available (dist mode, cloud),
+ * every expression reports valid — the gate must never block on a check it
+ * cannot run; the backend and the run remain the net.
+ *
+ * @param {Array<{name: string, expression: string}>} expressions
+ * @param {string} [sourceDialect]
+ * @returns {Promise<{results: Array<{name: string, valid: boolean, error?: string}>}>}
+ */
+export const validateExpressions = async (expressions, sourceDialect) => {
+  if (!isAvailable('expressionsValidate')) {
+    return { results: expressions.map(e => ({ name: e.name, valid: true })) };
+  }
+
+  const response = await apiFetch(getUrl('expressionsValidate'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ expressions, source_dialect: sourceDialect }),
+  });
+
+  if (response.status === 200) {
+    return await response.json();
+  }
+
+  throw new Error('Failed to validate expressions');
+};

--- a/viewer/src/components/styled/FormFooter.jsx
+++ b/viewer/src/components/styled/FormFooter.jsx
@@ -34,6 +34,11 @@ const FormFooter = ({
   saveLabel = 'Save',
   cancelLabel = 'Cancel',
   leftActions,
+  // VIS-993 auto-save mode: persistence is debounced through useRecordSave,
+  // so the footer renders NO Cancel/Save buttons — just Delete plus whatever
+  // the form passes as rightContent (typically a SaveStateIndicator).
+  autoSave = false,
+  rightContent = null,
 }) => {
   return (
     <div className="border-t border-gray-200 bg-gray-50">
@@ -77,21 +82,27 @@ const FormFooter = ({
           )}
         </div>
 
-        <div className="flex gap-2">
-          <ButtonOutline type="button" onClick={onCancel} className="text-sm">
-            {cancelLabel}
-          </ButtonOutline>
-          <Button type="button" onClick={onSave} disabled={saving} className="text-sm">
-            {saving ? (
-              <>
-                <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
-                Saving...
-              </>
-            ) : (
-              saveLabel
-            )}
-          </Button>
-        </div>
+        {autoSave ? (
+          <div className="flex items-center gap-2" data-testid="form-footer-autosave">
+            {rightContent}
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            <ButtonOutline type="button" onClick={onCancel} className="text-sm">
+              {cancelLabel}
+            </ButtonOutline>
+            <Button type="button" onClick={onSave} disabled={saving} className="text-sm">
+              {saving ? (
+                <>
+                  <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
+                  Saving...
+                </>
+              ) : (
+                saveLabel
+              )}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/viewer/src/components/views/common/DimensionEditForm.jsx
+++ b/viewer/src/components/views/common/DimensionEditForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import useRecordSave from '../../../hooks/useRecordSave';
+import SaveStateIndicator from '../workspace/SaveStateIndicator';
 import { FormInput, FormTextarea, FormFooter, FormLayout, FormAlert } from '../../styled/FormComponents';
 import RefTextArea from './RefTextArea';
 import { validateName } from './namedModel';
@@ -25,11 +26,16 @@ import { BackNavigationButton } from '../../styled/BackNavigationButton';
 const DimensionEditForm = ({ dimension, isCreate, onClose, onSave, onGoBack }) => {
   const { saveDimension, deleteDimension, checkCommitStatus } = useStore();
 
-  // VIS-993: edit-mode saves flush through the gated optimistic backbone —
-  // one useRecordSave per open record — so schema/ref-invalid configs are
-  // blocked BEFORE they persist (no POST, no doomed run). Create mode keeps
-  // the direct saveDimension call: the record isn't in the collection yet.
-  const { saveNow } = useRecordSave('dimension', dimension?.name || null);
+  // VIS-993: edit mode is AUTO-SAVE — every field change debounces through
+  // the gated optimistic backbone (no Save button), so schema/ref/expression-
+  // invalid configs are blocked BEFORE they persist (no POST, no doomed run)
+  // and the gate's errors render live on the fields. Create mode keeps the
+  // explicit saveDimension button: the record isn't in the collection yet.
+  const {
+    scheduleSave,
+    status: autoSaveStatus,
+    errors: gateErrors,
+  } = useRecordSave('dimension', dimension?.name || null);
 
   // Detect embedded mode (inline dimension within a model)
   const isEmbedded = isEmbeddedObject(dimension);
@@ -92,6 +98,29 @@ const DimensionEditForm = ({ dimension, isCreate, onClose, onSave, onGoBack }) =
     return Object.keys(newErrors).length === 0;
   };
 
+  // Build the config the backbone persists; `over` carries the just-typed
+  // value so we never read one keystroke behind React state.
+  const buildConfig = (over = {}) => {
+    const cfg = { name, expression, description: description || undefined, ...over };
+    if (cfg.description === undefined) delete cfg.description;
+    return cfg;
+  };
+
+  const isAutoSave = isEditMode;
+  const autoSave = over => {
+    if (!isAutoSave) return;
+    scheduleSave(buildConfig(over));
+  };
+
+  // Gate errors (VIS-993) render live: expression-path errors land on the
+  // field, anything else in the form-level alert.
+  const gateExpressionError = gateErrors?.find(
+    e => e.path === 'expression' || e.path?.startsWith('expression')
+  )?.message;
+  const gateOtherErrors = (gateErrors || []).filter(
+    e => !(e.path === 'expression' || e.path?.startsWith('expression'))
+  );
+
   const handleSave = async () => {
     if (!validateForm()) return;
 
@@ -116,27 +145,13 @@ const DimensionEditForm = ({ dimension, isCreate, onClose, onSave, onGoBack }) =
         }
         // Parent handles panel close on success
       } else {
-        // Save as project-level dimension (always multi-model)
-        const result = isEditMode ? await saveNow(config) : await saveDimension(name, config);
+        // Create mode only — edit mode auto-saves via scheduleSave.
+        const result = await saveDimension(name, config);
 
         setSaving(false);
-        if (result?.success !== false) {
+        if (result?.success) {
           onSave && onSave(config);
           onClose();
-        } else if (result?.validation) {
-          // Gate-blocked (VIS-993): map field-path errors onto the form; the
-          // expression field owns anything under its path.
-          const exprError = result.validation.errors?.find(
-            e => e.path === 'expression' || e.path?.startsWith('expression')
-          );
-          if (exprError) {
-            setErrors(prev => ({ ...prev, expression: exprError.message }));
-          } else {
-            setSaveError(
-              result.validation.errors?.map(e => `${e.path}: ${e.message}`).join('; ') ||
-                'Configuration is invalid'
-            );
-          }
         } else {
           setSaveError(result?.error || 'Failed to save dimension');
         }
@@ -186,10 +201,13 @@ const DimensionEditForm = ({ dimension, isCreate, onClose, onSave, onGoBack }) =
 
         <RefTextArea
           value={expression}
-          onChange={setExpression}
+          onChange={v => {
+            setExpression(v);
+            autoSave({ expression: v });
+          }}
           label="Expression"
           required
-          error={errors.expression}
+          error={errors.expression || gateExpressionError}
           allowedTypes={isEmbedded ? [] : ['model', 'dimension']}
           hideAddButton={isEmbedded}
           rows={4}
@@ -204,14 +222,24 @@ const DimensionEditForm = ({ dimension, isCreate, onClose, onSave, onGoBack }) =
           id="dimensionDescription"
           label="Description"
           value={description}
-          onChange={e => setDescription(e.target.value)}
+          onChange={e => {
+            setDescription(e.target.value);
+            autoSave({ description: e.target.value || undefined });
+          }}
           rows={2}
         />
 
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
+        {gateOtherErrors.length > 0 && (
+          <FormAlert variant="error">
+            {gateOtherErrors.map(e => `${e.path}: ${e.message}`).join('; ')}
+          </FormAlert>
+        )}
       </FormLayout>
 
       <FormFooter
+        autoSave={isAutoSave}
+        rightContent={<SaveStateIndicator status={autoSaveStatus} />}
         onCancel={onClose}
         onSave={handleSave}
         saving={saving}

--- a/viewer/src/components/views/common/MarkdownEditForm.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.jsx
@@ -6,6 +6,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { validateName } from './namedModel';
 import Select from '../../common/Select';
 import useRecordSave from '../../../hooks/useRecordSave';
+import SaveStateIndicator from '../workspace/SaveStateIndicator';
 
 /**
  * MarkdownEditForm - Form component for editing/creating markdowns
@@ -50,7 +51,24 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
   // the footer save flushes through this (writes the config optimistically into
   // the markdown store, then persists the CURRENT store value), sharing the same
   // backbone as the editor canvas so the two can't clobber each other.
-  const { saveNow } = useRecordSave('markdown', markdown?.name || null);
+  const {
+    scheduleSave,
+    status: autoSaveStatus,
+    errors: gateErrors,
+  } = useRecordSave('markdown', markdown?.name || null);
+
+  const buildConfig = (over = {}) => ({ name, content, align, justify, ...over });
+
+  const gateErrorText =
+    gateErrors && gateErrors.length > 0
+      ? gateErrors.map(e => (e.path ? `${e.path}: ${e.message}` : e.message)).join('; ')
+      : null;
+
+  const isAutoSave = isEditMode;
+  const autoSave = over => {
+    if (!isAutoSave) return;
+    scheduleSave(buildConfig(over));
+  };
 
   // Initialize form when markdown changes
   useEffect(() => {
@@ -102,18 +120,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
         justify,
       };
 
-      let result;
-      if (isEditMode) {
-        // EDIT mode: flush through the shared optimistic + fire-time-read
-        // backbone (writes `config` into the markdown store optimistically, then
-        // persists the current store value) so this form and the editor canvas
-        // converge on the last write instead of clobbering each other.
-        result = await saveNow(config);
-      } else {
-        // CREATE mode: the record isn't in the store collection yet, so there is
-        // nothing to optimistically update — persist directly.
-        result = await saveMarkdown(name, config);
-      }
+      // Create mode only — edit mode auto-saves via scheduleSave (VIS-993:
+      // no Save button; each field change debounces through the gated
+      // optimistic backbone).
+      const result = await saveMarkdown(name, config);
 
       if (result?.success) {
         onSave && onSave(config);
@@ -215,7 +225,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
               <textarea
                 id="markdownContent"
                 value={content}
-                onChange={e => setContent(e.target.value)}
+                onChange={e => {
+                  setContent(e.target.value);
+                  autoSave({ content: e.target.value });
+                }}
                 placeholder=" "
                 rows={10}
                 className={`block w-full px-3 py-2.5 text-sm text-gray-900 bg-white rounded-md border appearance-none focus:outline-none focus:ring-2 focus:border-primary-500 peer placeholder-transparent resize-y font-mono ${errors.content ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`}
@@ -246,7 +259,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
                 aria-label="Horizontal Alignment"
                 value={align}
                 options={ALIGN_OPTIONS}
-                onChange={setAlign}
+                onChange={v => {
+                  setAlign(v);
+                  autoSave({ align: v });
+                }}
               />
               <label
                 htmlFor="markdownAlign"
@@ -263,7 +279,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
                 aria-label="Vertical Distribution"
                 value={justify}
                 options={JUSTIFY_OPTIONS}
-                onChange={setJustify}
+                onChange={v => {
+                  setJustify(v);
+                  autoSave({ justify: v });
+                }}
               />
               <label
                 htmlFor="markdownJustify"
@@ -276,6 +295,11 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
 
           {/* Save Error */}
           {saveError && <div className="p-3 rounded-md bg-red-50 text-red-700 text-sm">{saveError}</div>}
+          {gateErrorText && (
+            <div className="p-3 rounded-md bg-red-50 text-red-700 text-sm" data-testid="markdown-gate-errors">
+              {gateErrorText}
+            </div>
+          )}
         </div>
       </div>
 
@@ -323,21 +347,27 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
             )}
           </div>
 
-          <div className="flex gap-2">
-            <ButtonOutline type="button" onClick={onClose} className="text-sm">
-              Cancel
-            </ButtonOutline>
-            <Button type="button" onClick={handleSave} disabled={saving} className="text-sm">
-              {saving ? (
-                <>
-                  <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
-                  Saving...
-                </>
-              ) : (
-                'Save'
-              )}
-            </Button>
-          </div>
+          {isAutoSave ? (
+            <div className="flex items-center gap-2" data-testid="form-footer-autosave">
+              <SaveStateIndicator status={autoSaveStatus} />
+            </div>
+          ) : (
+            <div className="flex gap-2">
+              <ButtonOutline type="button" onClick={onClose} className="text-sm">
+                Cancel
+              </ButtonOutline>
+              <Button type="button" onClick={handleSave} disabled={saving} className="text-sm">
+                {saving ? (
+                  <>
+                    <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
+                    Saving...
+                  </>
+                ) : (
+                  'Save'
+                )}
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/viewer/src/components/views/common/MarkdownEditForm.test.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.test.jsx
@@ -12,9 +12,11 @@ const mockActions = {
 // Edit mode persists through the useRecordSave backbone (VIS-1018) — mock it
 // (the backbone has its own suite) and assert the component's contract.
 const mockSaveNow = jest.fn();
+const mockScheduleSave = jest.fn();
+let mockRecordSave;
 jest.mock('../../../hooks/useRecordSave', () => ({
   __esModule: true,
-  default: () => ({ saveNow: mockSaveNow, status: 'idle' }),
+  default: () => mockRecordSave,
 }));
 jest.mock('../../../stores/store', () => ({
   __esModule: true,
@@ -26,6 +28,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   Object.values(mockActions).forEach(fn => fn.mockResolvedValue({ success: true }));
   mockSaveNow.mockResolvedValue({ success: true });
+  mockScheduleSave.mockClear();
+  mockRecordSave = { scheduleSave: mockScheduleSave, saveNow: mockSaveNow, status: 'idle', errors: null };
 });
 
 const renderForm = (props = {}) =>
@@ -135,7 +139,7 @@ describe('MarkdownEditForm — save paths', () => {
 });
 
 describe('MarkdownEditForm — edit mode', () => {
-  test('initializes from markdown.config, disables the name, and re-saves it', async () => {
+  test('initializes from markdown.config, disables the name, and auto-saves edits', () => {
     const markdown = {
       name: 'md1',
       status: 'PUBLISHED',
@@ -146,17 +150,15 @@ describe('MarkdownEditForm — edit mode', () => {
     expect(screen.getByLabelText(/Markdown Name/)).toBeDisabled();
     expect(screen.getByLabelText(/Content/)).toHaveValue('Hi there');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    // Edit mode flushes through the useRecordSave backbone (VIS-1018), not a
-    // direct saveMarkdown call — create mode keeps the direct call.
-    await waitFor(() =>
-      expect(mockSaveNow).toHaveBeenCalledWith({
-        name: 'md1',
-        content: 'Hi there',
-        align: 'right',
-        justify: 'center',
-      })
-    );
+    // Edit mode auto-saves through the useRecordSave backbone (VIS-993) —
+    // there is no Save button; each change debounces via scheduleSave.
+    fireEvent.change(screen.getByLabelText(/Content/), { target: { value: 'Hi again' } });
+    expect(mockScheduleSave).toHaveBeenCalledWith({
+      name: 'md1',
+      content: 'Hi again',
+      align: 'right',
+      justify: 'center',
+    });
     expect(mockActions.saveMarkdown).not.toHaveBeenCalled();
   });
 
@@ -205,5 +207,32 @@ describe('MarkdownEditForm — delete flow', () => {
     expect(screen.queryByRole('button', { name: 'Confirm Delete' })).not.toBeInTheDocument();
     expect(mockActions.deleteMarkdown).not.toHaveBeenCalled();
     expect(screen.getByTitle('Delete markdown')).toBeInTheDocument();
+  });
+});
+
+describe('edit mode auto-saves through the gated backbone (VIS-993)', () => {
+  const record = {
+    name: 'notes',
+    config: { name: 'notes', content: 'hello', align: 'left', justify: 'start' },
+  };
+
+  test('renders NO Save button — persistence is debounced auto-save', () => {
+    render(<MarkdownEditForm markdown={record} onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  test('a content edit schedules a debounced save with the full config', () => {
+    render(<MarkdownEditForm markdown={record} onClose={jest.fn()} onSave={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/Content/), { target: { value: 'updated text' } });
+
+    expect(mockScheduleSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'notes', content: 'updated text' })
+    );
+  });
+
+  test('create mode still uses an explicit save button', () => {
+    render(<MarkdownEditForm isCreate onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /Create|Save/ })).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/common/MetricEditForm.jsx
+++ b/viewer/src/components/views/common/MetricEditForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import useRecordSave from '../../../hooks/useRecordSave';
+import SaveStateIndicator from '../workspace/SaveStateIndicator';
 import { FormInput, FormTextarea, FormFooter, FormLayout, FormAlert } from '../../styled/FormComponents';
 import RefTextArea from './RefTextArea';
 import { validateName } from './namedModel';
@@ -25,11 +26,16 @@ import { BackNavigationButton } from '../../styled/BackNavigationButton';
 const MetricEditForm = ({ metric, isCreate, onClose, onSave, onGoBack }) => {
   const { saveMetric, deleteMetric, checkCommitStatus } = useStore();
 
-  // VIS-993: edit-mode saves flush through the gated optimistic backbone —
-  // one useRecordSave per open record — so schema/ref-invalid configs are
-  // blocked BEFORE they persist (no POST, no doomed run). Create mode keeps
-  // the direct saveMetric call: the record isn't in the collection yet.
-  const { saveNow } = useRecordSave('metric', metric?.name || null);
+  // VIS-993: edit mode is AUTO-SAVE — every field change debounces through
+  // the gated optimistic backbone (no Save button), so schema/ref/expression-
+  // invalid configs are blocked BEFORE they persist (no POST, no doomed run)
+  // and the gate's errors render live on the fields. Create mode keeps the
+  // explicit saveMetric button: the record isn't in the collection yet.
+  const {
+    scheduleSave,
+    status: autoSaveStatus,
+    errors: gateErrors,
+  } = useRecordSave('metric', metric?.name || null);
 
   // Detect embedded mode (inline metric within a model)
   const isEmbedded = isEmbeddedObject(metric);
@@ -92,6 +98,29 @@ const MetricEditForm = ({ metric, isCreate, onClose, onSave, onGoBack }) => {
     return Object.keys(newErrors).length === 0;
   };
 
+  // Build the config the backbone persists; `over` carries the just-typed
+  // value so we never read one keystroke behind React state.
+  const buildConfig = (over = {}) => {
+    const cfg = { name, expression, description: description || undefined, ...over };
+    if (cfg.description === undefined) delete cfg.description;
+    return cfg;
+  };
+
+  const isAutoSave = isEditMode;
+  const autoSave = over => {
+    if (!isAutoSave) return;
+    scheduleSave(buildConfig(over));
+  };
+
+  // Gate errors (VIS-993) render live: expression-path errors land on the
+  // field, anything else in the form-level alert.
+  const gateExpressionError = gateErrors?.find(
+    e => e.path === 'expression' || e.path?.startsWith('expression')
+  )?.message;
+  const gateOtherErrors = (gateErrors || []).filter(
+    e => !(e.path === 'expression' || e.path?.startsWith('expression'))
+  );
+
   const handleSave = async () => {
     if (!validateForm()) return;
 
@@ -116,27 +145,13 @@ const MetricEditForm = ({ metric, isCreate, onClose, onSave, onGoBack }) => {
         }
         // Parent handles panel close on success
       } else {
-        // Save as project-level metric (always multi-model)
-        const result = isEditMode ? await saveNow(config) : await saveMetric(name, config);
+        // Create mode only — edit mode auto-saves via scheduleSave.
+        const result = await saveMetric(name, config);
 
         setSaving(false);
-        if (result?.success !== false) {
+        if (result?.success) {
           onSave && onSave(config);
           onClose();
-        } else if (result?.validation) {
-          // Gate-blocked (VIS-993): map field-path errors onto the form; the
-          // expression field owns anything under its path.
-          const exprError = result.validation.errors?.find(
-            e => e.path === 'expression' || e.path?.startsWith('expression')
-          );
-          if (exprError) {
-            setErrors(prev => ({ ...prev, expression: exprError.message }));
-          } else {
-            setSaveError(
-              result.validation.errors?.map(e => `${e.path}: ${e.message}`).join('; ') ||
-                'Configuration is invalid'
-            );
-          }
         } else {
           setSaveError(result?.error || 'Failed to save metric');
         }
@@ -186,10 +201,13 @@ const MetricEditForm = ({ metric, isCreate, onClose, onSave, onGoBack }) => {
 
         <RefTextArea
           value={expression}
-          onChange={setExpression}
+          onChange={v => {
+            setExpression(v);
+            autoSave({ expression: v });
+          }}
           label="Expression"
           required
-          error={errors.expression}
+          error={errors.expression || gateExpressionError}
           allowedTypes={isEmbedded ? [] : ['model', 'metric', 'dimension']}
           hideAddButton={isEmbedded}
           rows={4}
@@ -204,14 +222,24 @@ const MetricEditForm = ({ metric, isCreate, onClose, onSave, onGoBack }) => {
           id="metricDescription"
           label="Description"
           value={description}
-          onChange={e => setDescription(e.target.value)}
+          onChange={e => {
+            setDescription(e.target.value);
+            autoSave({ description: e.target.value || undefined });
+          }}
           rows={2}
         />
 
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
+        {gateOtherErrors.length > 0 && (
+          <FormAlert variant="error">
+            {gateOtherErrors.map(e => `${e.path}: ${e.message}`).join('; ')}
+          </FormAlert>
+        )}
       </FormLayout>
 
       <FormFooter
+        autoSave={isAutoSave}
+        rightContent={<SaveStateIndicator status={autoSaveStatus} />}
         onCancel={onClose}
         onSave={handleSave}
         saving={saving}

--- a/viewer/src/components/views/common/RelationEditForm.jsx
+++ b/viewer/src/components/views/common/RelationEditForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import useRecordSave from '../../../hooks/useRecordSave';
+import SaveStateIndicator from '../workspace/SaveStateIndicator';
 import RefTextArea from './RefTextArea';
 import Select from '../../common/Select';
 import {
@@ -27,11 +28,15 @@ import { validateName } from './namedModel';
 const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
   const { saveRelation, deleteRelation, checkCommitStatus } = useStore();
 
-  // VIS-993: edit-mode saves flush through the gated optimistic backbone so
-  // schema/ref-invalid configs are blocked BEFORE they persist (no POST, no
-  // doomed run). Create mode keeps the direct saveRelation call: the record
-  // isn't in the collection yet.
-  const { saveNow } = useRecordSave('relation', relation?.name || null);
+  // VIS-993: edit mode is AUTO-SAVE — every field change debounces through
+  // the gated optimistic backbone (no Save button); gate errors render live
+  // on the fields. Create mode keeps the explicit button: the record isn't
+  // in the collection yet.
+  const {
+    scheduleSave,
+    status: autoSaveStatus,
+    errors: gateErrors,
+  } = useRecordSave('relation', relation?.name || null);
 
   // Form state
   const [name, setName] = useState('');
@@ -82,6 +87,27 @@ const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
     return Object.keys(newErrors).length === 0;
   };
 
+  const buildConfig = (over = {}) => ({
+    name,
+    join_type: joinType,
+    condition,
+    is_default: isDefault || undefined,
+    ...over,
+  });
+
+  const isAutoSave = isEditMode;
+  const autoSave = over => {
+    if (!isAutoSave) return;
+    scheduleSave(buildConfig(over));
+  };
+
+  const gateConditionError = gateErrors?.find(
+    e => e.path === 'condition' || e.path?.startsWith('condition')
+  )?.message;
+  const gateOtherErrors = (gateErrors || []).filter(
+    e => !(e.path === 'condition' || e.path?.startsWith('condition'))
+  );
+
   const handleSave = async () => {
     if (!validateForm()) return;
 
@@ -95,27 +121,14 @@ const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
       is_default: isDefault || undefined,
     };
 
-    const result = isEditMode ? await saveNow(config) : await saveRelation(name, config);
+    // Create mode only — edit mode auto-saves via scheduleSave.
+    const result = await saveRelation(name, config);
 
     setSaving(false);
 
-    if (result?.success !== false) {
+    if (result?.success) {
       onSave && onSave(config);
       onClose();
-    } else if (result?.validation) {
-      // Gate-blocked (VIS-993): the condition field owns anything under its
-      // path; everything else lands in the form-level alert.
-      const condError = result.validation.errors?.find(
-        e => e.path === 'condition' || e.path?.startsWith('condition')
-      );
-      if (condError) {
-        setErrors(prev => ({ ...prev, condition: condError.message }));
-      } else {
-        setSaveError(
-          result.validation.errors?.map(e => `${e.path}: ${e.message}`).join('; ') ||
-            'Configuration is invalid'
-        );
-      }
     } else {
       setSaveError(result?.error || 'Failed to save relation');
     }
@@ -149,7 +162,15 @@ const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
         />
 
         <div className="relative">
-          <Select id="joinType" aria-label="Join Type" value={joinType} onChange={setJoinType}>
+          <Select
+            id="joinType"
+            aria-label="Join Type"
+            value={joinType}
+            onChange={v => {
+              setJoinType(v);
+              autoSave({ join_type: v });
+            }}
+          >
             <option value="inner">Inner Join</option>
             <option value="left">Left Join</option>
             <option value="right">Right Join</option>
@@ -165,10 +186,13 @@ const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
 
         <RefTextArea
           value={condition}
-          onChange={setCondition}
+          onChange={v => {
+            setCondition(v);
+            autoSave({ condition: v });
+          }}
           label="Condition"
           required
-          error={errors.condition}
+          error={errors.condition || gateConditionError}
           allowedTypes={['model']}
           rows={4}
           /* eslint-disable-next-line no-template-curly-in-string */
@@ -179,13 +203,23 @@ const RelationEditForm = ({ relation, isCreate, onClose, onSave }) => {
           id="isDefault"
           label="Default relation for these models"
           checked={isDefault}
-          onChange={e => setIsDefault(e.target.checked)}
+          onChange={e => {
+            setIsDefault(e.target.checked);
+            autoSave({ is_default: e.target.checked || undefined });
+          }}
         />
 
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
+        {gateOtherErrors.length > 0 && (
+          <FormAlert variant="error">
+            {gateOtherErrors.map(e => `${e.path}: ${e.message}`).join('; ')}
+          </FormAlert>
+        )}
       </FormLayout>
 
       <FormFooter
+        autoSave={isAutoSave}
+        rightContent={<SaveStateIndicator status={autoSaveStatus} />}
         onCancel={onClose}
         onSave={handleSave}
         saving={saving}

--- a/viewer/src/components/views/common/RelationEditForm.test.jsx
+++ b/viewer/src/components/views/common/RelationEditForm.test.jsx
@@ -9,9 +9,11 @@ const mockActions = {
   checkCommitStatus: jest.fn(),
 };
 const mockSaveNow = jest.fn();
+const mockScheduleSave = jest.fn();
+let mockRecordSave;
 jest.mock('../../../hooks/useRecordSave', () => ({
   __esModule: true,
-  default: () => ({ saveNow: mockSaveNow, status: 'idle', errors: null }),
+  default: () => mockRecordSave,
 }));
 jest.mock('../../../stores/store', () => ({
   __esModule: true,
@@ -33,6 +35,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockActions.saveRelation.mockResolvedValue({ success: true });
   mockSaveNow.mockResolvedValue({ success: true });
+  mockScheduleSave.mockClear();
+  mockRecordSave = { scheduleSave: mockScheduleSave, saveNow: mockSaveNow, status: 'idle', errors: null };
   mockActions.deleteRelation.mockResolvedValue({ success: true });
   mockActions.checkCommitStatus.mockResolvedValue();
 });
@@ -105,38 +109,42 @@ describe('RelationEditForm', () => {
   });
 });
 
-describe('edit-mode save routes through the gated backbone (VIS-993)', () => {
+describe('edit mode auto-saves through the gated backbone (VIS-993)', () => {
   const record = {
     name: 'orders_to_users',
     config: { name: 'orders_to_users', join_type: 'inner', condition: 'a.id = b.a_id' },
   };
 
-  test('edit mode persists via useRecordSave.saveNow, never the raw store action', async () => {
+  test('renders NO Save button — persistence is debounced auto-save', () => {
     render(<RelationEditForm relation={record} onClose={jest.fn()} onSave={jest.fn()} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await waitFor(() => expect(mockSaveNow).toHaveBeenCalledTimes(1));
-    expect(mockSaveNow).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'orders_to_users', condition: 'a.id = b.a_id' })
-    );
-    expect(mockActions.saveRelation).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 
-  test('a gate-blocked save maps the condition error onto the field', async () => {
-    mockSaveNow.mockResolvedValue({
-      success: false,
-      validation: {
-        errors: [
-          { path: 'condition', message: "ref 'ghost_model' does not match any existing object", keyword: 'ref' },
-        ],
-      },
-    });
+  test('a condition edit schedules a debounced save with the full config', () => {
     render(<RelationEditForm relation={record} onClose={jest.fn()} onSave={jest.fn()} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.change(screen.getByLabelText('Condition'), {
+      target: { value: 'a.id = b.parent_id' },
+    });
 
-    expect(await screen.findByText(/ghost_model/)).toBeInTheDocument();
-    expect(mockActions.saveRelation).not.toHaveBeenCalled();
+    expect(mockScheduleSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'orders_to_users', condition: 'a.id = b.parent_id' })
+    );
+  });
+
+  test('gate errors surface on the condition field', () => {
+    mockRecordSave = {
+      scheduleSave: mockScheduleSave,
+      saveNow: mockSaveNow,
+      status: 'invalid',
+      errors: [{ path: 'condition', message: 'Expecting ). parse error', keyword: 'expression' }],
+    };
+    render(<RelationEditForm relation={record} onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.getByText(/parse error/)).toBeInTheDocument();
+  });
+
+  test('create mode still uses an explicit save button', () => {
+    render(<RelationEditForm isCreate onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /Create|Save/ })).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/common/dimensionMetricEditForm.test.jsx
+++ b/viewer/src/components/views/common/dimensionMetricEditForm.test.jsx
@@ -14,9 +14,12 @@ const mockActions = {
   checkCommitStatus: jest.fn(),
 };
 const mockSaveNow = jest.fn();
+const mockScheduleSave = jest.fn();
+// Mutable so individual tests can drive the gate's status/errors surface.
+let mockRecordSave;
 jest.mock('../../../hooks/useRecordSave', () => ({
   __esModule: true,
-  default: () => ({ saveNow: mockSaveNow, status: 'idle', errors: null }),
+  default: () => mockRecordSave,
 }));
 jest.mock('../../../stores/store', () => ({
   __esModule: true,
@@ -58,6 +61,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   Object.values(mockActions).forEach(fn => fn.mockResolvedValue({ success: true }));
   mockSaveNow.mockResolvedValue({ success: true });
+  mockScheduleSave.mockClear();
+  mockRecordSave = { scheduleSave: mockScheduleSave, saveNow: mockSaveNow, status: 'idle', errors: null };
 });
 
 describe.each(CASES)('$label EditForm', ({ Form, prop, word, nameLabel, save, del }) => {
@@ -231,33 +236,41 @@ describe.each(CASES)('$label EditForm', ({ Form, prop, word, nameLabel, save, de
   });
 });
 
-describe.each(CASES)('$label edit-mode save routes through the gated backbone (VIS-993)', ({ Form, prop, word, save }) => {
-  test('edit mode persists via useRecordSave.saveNow, never the raw store action', async () => {
-    const record = { name: 'existing', config: { name: 'existing', expression: 'ROUND(x, 2)' } };
+describe.each(CASES)('$label edit mode auto-saves through the gated backbone (VIS-993)', ({ Form, prop, word }) => {
+  const record = { name: 'existing', config: { name: 'existing', expression: 'ROUND(x, 2)' } };
+
+  test('renders NO Save button — persistence is debounced auto-save', () => {
     render(<Form {...{ [prop]: record }} onClose={jest.fn()} onSave={jest.fn()} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await waitFor(() => expect(mockSaveNow).toHaveBeenCalledTimes(1));
-    expect(mockSaveNow).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'existing', expression: 'ROUND(x, 2)' })
-    );
-    expect(save()).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   });
 
-  test('a gate-blocked save maps the expression error onto the field', async () => {
-    mockSaveNow.mockResolvedValue({
-      success: false,
-      validation: {
-        errors: [{ path: 'expression', message: "ref 'ghost' does not match any existing object", keyword: 'ref' }],
-      },
-    });
-    const record = { name: 'existing', config: { name: 'existing', expression: 'ROUND(x, 2)' } };
+  test('an expression edit schedules a debounced save with the full config', () => {
     render(<Form {...{ [prop]: record }} onClose={jest.fn()} onSave={jest.fn()} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.change(screen.getByLabelText('Expression'), { target: { value: 'ROUND(x, 3)' } });
 
-    expect(await screen.findByText(/ghost/)).toBeInTheDocument();
-    expect(save()).not.toHaveBeenCalled();
+    expect(mockScheduleSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'existing', expression: 'ROUND(x, 3)' })
+    );
+    expect(mockSaveNow).not.toHaveBeenCalled();
+  });
+
+  test('gate errors surface on the expression field', () => {
+    mockRecordSave = {
+      scheduleSave: mockScheduleSave,
+      saveNow: mockSaveNow,
+      status: 'invalid',
+      errors: [
+        { path: 'expression', message: 'Expecting ). Line 1, Col: 25.', keyword: 'expression' },
+      ],
+    };
+    render(<Form {...{ [prop]: record }} onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.getByText(/Expecting \)/)).toBeInTheDocument();
+  });
+
+  test('create mode still uses an explicit Create button', () => {
+    render(<Form isCreate onClose={jest.fn()} onSave={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /Create|Save/ })).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/workspace/expressionPreflight.js
+++ b/viewer/src/components/views/workspace/expressionPreflight.js
@@ -1,0 +1,115 @@
+/**
+ * expressionPreflight (VIS-993 layer 2, async half)
+ *
+ * SQL parse validation for expression-bearing fields — the piece of the
+ * semantic pre-flight the schema cannot see: `AVG(value)}` is a perfectly
+ * valid STRING per the $defs, but sqlglot rejects it, so under
+ * runs-on-changes it would cache fine and then fail a real DAG run (in
+ * cloud, blocking Commit on run_failed).
+ *
+ * Runs at fire time inside useRecordSave's async gate (network call — never
+ * in the sync path). The backend endpoint substitutes Visivo context tokens
+ * (${ref(m).col}) before parsing, so composite metrics and ref-bearing
+ * relation conditions validate correctly.
+ *
+ * Fail-open policy: no expression fields for the type, empty values (the
+ * schema owns required-ness), endpoint unavailable (dist/cloud), or network
+ * failure → { valid: true, skipped: true }. Successful verdicts are cached
+ * per (type, field, expression) so a debounce cadence costs one POST per
+ * distinct value; failures to REACH the endpoint are never cached.
+ */
+
+import { validateExpressions } from '../../../api/expressions';
+
+// The fields per object type whose string values must parse as SQL.
+const EXPRESSION_FIELDS = {
+  metric: ['expression'],
+  dimension: ['expression'],
+  relation: ['condition'],
+};
+
+const SKIP = { valid: true, errors: [], skipped: true };
+
+// verdict cache: `${type}:${field}:${expression}` → {valid, error}
+const cache = new Map();
+const CACHE_MAX = 200;
+
+const cacheKey = (type, field, expression) => `${type}:${field}:${expression}`;
+
+const remember = (key, verdict) => {
+  if (cache.size >= CACHE_MAX) {
+    // Drop the oldest entry (Map preserves insertion order).
+    cache.delete(cache.keys().next().value);
+  }
+  cache.set(key, verdict);
+};
+
+/** Test seam + project-switch invalidation (cleared with the schema caches). */
+export function clearExpressionCache() {
+  cache.clear();
+}
+
+/**
+ * Validate the expression-bearing fields of a record config.
+ *
+ * @param {string} type    canonical object type ('metric', 'dimension', 'relation')
+ * @param {object} config  the config that would be persisted
+ * @param {string} [sourceDialect]  optional dialect hint for the backend parser
+ * @returns {Promise<{valid: boolean, errors: Array<{path:string,message:string,keyword:'expression'}>, skipped?: boolean}>}
+ */
+export async function checkExpressions(type, config, sourceDialect) {
+  const fields = EXPRESSION_FIELDS[type];
+  if (!fields || !config) return SKIP;
+
+  const pending = [];
+  const errors = [];
+  for (const field of fields) {
+    const value = config[field];
+    if (typeof value !== 'string' || !value.trim()) continue;
+    const key = cacheKey(type, field, value);
+    const cached = cache.get(key);
+    if (cached) {
+      if (!cached.valid) {
+        errors.push({ path: field, message: cached.error, keyword: 'expression' });
+      }
+      continue;
+    }
+    pending.push({ field, value, key });
+  }
+
+  if (pending.length === 0 && errors.length === 0) {
+    return errors.length === 0 && pending.length === 0 && !fields.some(f => config[f])
+      ? SKIP
+      : { valid: true, errors: [] };
+  }
+
+  if (pending.length > 0) {
+    let response;
+    try {
+      response = await validateExpressions(
+        pending.map(p => ({ name: p.field, expression: p.value })),
+        sourceDialect
+      );
+    } catch (err) {
+      // Endpoint unreachable — never block on a check we couldn't run, and
+      // never cache the non-verdict.
+      return errors.length === 0 ? SKIP : { valid: false, errors };
+    }
+
+    const byName = new Map((response?.results || []).map(r => [r.name, r]));
+    for (const p of pending) {
+      const result = byName.get(p.field);
+      if (!result) continue;
+      const verdict = {
+        valid: result.valid !== false,
+        error: result.error || 'Expression does not parse',
+      };
+      remember(p.key, verdict);
+      if (!verdict.valid) {
+        errors.push({ path: p.field, message: verdict.error, keyword: 'expression' });
+      }
+    }
+  }
+
+  return errors.length === 0 ? { valid: true, errors: [] } : { valid: false, errors };
+}

--- a/viewer/src/components/views/workspace/expressionPreflight.test.js
+++ b/viewer/src/components/views/workspace/expressionPreflight.test.js
@@ -1,0 +1,97 @@
+/**
+ * expressionPreflight (VIS-993 layer 2, async half) — SQL parse validation.
+ *
+ * A metric expression like `AVG(value)}` is schema-valid (it's a string) but
+ * unparseable: under runs-on-changes it caches fine and then fails the DAG run.
+ * The pre-flight sends expression-bearing fields to the backend sqlglot
+ * validator at fire time; parse failures block persistence with the error on
+ * the field's path. Fail-open everywhere the check cannot run (dist/cloud,
+ * network failure) — the backend and the run remain the net.
+ */
+import { checkExpressions, clearExpressionCache } from './expressionPreflight';
+import { validateExpressions } from '../../../api/expressions';
+
+jest.mock('../../../api/expressions', () => ({
+  validateExpressions: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearExpressionCache();
+  validateExpressions.mockResolvedValue({ results: [{ name: 'expression', valid: true }] });
+});
+
+describe('checkExpressions', () => {
+  test('a valid metric expression passes', async () => {
+    const result = await checkExpressions('metric', { name: 'm', expression: 'AVG(value)' });
+    expect(result.valid).toBe(true);
+    expect(validateExpressions).toHaveBeenCalledWith(
+      [{ name: 'expression', expression: 'AVG(value)' }],
+      undefined
+    );
+  });
+
+  test('a parse failure blocks with the error on the field path', async () => {
+    validateExpressions.mockResolvedValue({
+      results: [{ name: 'expression', valid: false, error: "Expecting ). Line 1, Col: 25" }],
+    });
+    const result = await checkExpressions('metric', { name: 'm', expression: 'AVG(value)}' });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        path: 'expression',
+        keyword: 'expression',
+        message: expect.stringMatching(/Expecting/),
+      }),
+    ]);
+  });
+
+  test('relation conditions validate under the condition path', async () => {
+    validateExpressions.mockResolvedValue({
+      results: [{ name: 'condition', valid: false, error: 'parse error' }],
+    });
+    const result = await checkExpressions('relation', {
+      name: 'r',
+      condition: 'a.id == = b.id',
+      join_type: 'inner',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].path).toBe('condition');
+  });
+
+  test('types without expression fields skip without a network call', async () => {
+    const result = await checkExpressions('markdown', { name: 'md', content: 'hello' });
+    expect(result.valid).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(validateExpressions).not.toHaveBeenCalled();
+  });
+
+  test('empty or missing expression fields skip (schema owns required-ness)', async () => {
+    const result = await checkExpressions('metric', { name: 'm', expression: '' });
+    expect(result.valid).toBe(true);
+    expect(validateExpressions).not.toHaveBeenCalled();
+  });
+
+  test('identical expressions are served from cache — one POST per distinct value', async () => {
+    await checkExpressions('metric', { name: 'm', expression: 'SUM(x)' });
+    await checkExpressions('metric', { name: 'm', expression: 'SUM(x)' });
+    expect(validateExpressions).toHaveBeenCalledTimes(1);
+  });
+
+  test('a network failure fails open', async () => {
+    validateExpressions.mockRejectedValue(new Error('boom'));
+    const result = await checkExpressions('metric', { name: 'm', expression: 'SUM(x)' });
+    expect(result.valid).toBe(true);
+    expect(result.skipped).toBe(true);
+  });
+
+  test('failed results are NOT cached (a transient backend hiccup must not stick)', async () => {
+    validateExpressions.mockRejectedValueOnce(new Error('boom'));
+    await checkExpressions('metric', { name: 'm', expression: 'SUM(y)' });
+    validateExpressions.mockResolvedValue({
+      results: [{ name: 'expression', valid: false, error: 'parse error' }],
+    });
+    const result = await checkExpressions('metric', { name: 'm', expression: 'SUM(y)' });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -127,6 +127,9 @@ const URL_PATTERNS = {
     // Expression translation endpoint
     expressionsTranslate: '/api/expressions/translate/',
 
+    // Expression parse validation (VIS-993 gate; server-only — dist/cloud fail open)
+    expressionsValidate: '/api/expressions/validate/',
+
     // Model data endpoint
     modelData: '/api/models/{name}/data/',
 

--- a/viewer/src/hooks/useRecordSave.js
+++ b/viewer/src/hooks/useRecordSave.js
@@ -7,6 +7,7 @@ import {
   validateRecordConfigSync,
 } from '../components/views/workspace/validateAgainstSchema';
 import { checkRefTargets } from '../components/views/workspace/refPreflight';
+import { checkExpressions } from '../components/views/workspace/expressionPreflight';
 
 /**
  * Cloud read-only probe (VIS-1025). `capabilities` is null/undefined under
@@ -147,14 +148,20 @@ export default function useRecordSave(type, name, opts = {}) {
     }
 
     // VIS-993 gate — authoritative fire-time check. Runs BEFORE the global
-    // save-activity tick: a blocked edit is not a save in flight.
+    // save-activity tick: a blocked edit is not a save in flight. Three
+    // layers, cheapest first: $defs schema → dangling refs → SQL parse of
+    // expression fields (backend sqlglot; async-only, fail-open off-server).
     const validation = await validateRecordConfig(t, config);
-    const blocked = !validation.valid
+    let blocked = !validation.valid
       ? validation
       : (() => {
           const refCheck = checkRefTargets(config, useStore.getState());
           return refCheck.valid ? null : refCheck;
         })();
+    if (!blocked) {
+      const exprCheck = await checkExpressions(t, config);
+      if (!exprCheck.valid) blocked = exprCheck;
+    }
     if (blocked) {
       if (mountedRef.current) {
         setStatus('invalid');

--- a/viewer/src/hooks/useRecordSave.validation.test.js
+++ b/viewer/src/hooks/useRecordSave.validation.test.js
@@ -9,13 +9,21 @@
  * stubbed permissive.
  */
 import { renderHook, act } from '@testing-library/react';
-
+import { validateExpressions } from '../api/expressions';
 import useRecordSave from './useRecordSave';
 import useStore from '../stores/store';
 import {
   preloadValidationSchema,
   clearValidationCache,
 } from '../components/views/workspace/validateAgainstSchema';
+
+// The expression pre-flight's network layer — the real endpoint contract is
+// covered by the backend suite + the e2e story. (jest.mock is hoisted.)
+jest.mock('../api/expressions', () => ({
+  validateExpressions: jest.fn(async exprs => ({
+    results: exprs.map(e => ({ name: e.name, valid: true })),
+  })),
+}));
 // The real $defs validators compile heavyweight unions; under full-suite
 // CPU contention the first compile can exceed jest's 5s default.
 jest.setTimeout(30000);
@@ -196,6 +204,36 @@ describe('useRecordSave validation gate (VIS-993)', () => {
     expect(saveFn).not.toHaveBeenCalled();
     expect(result.current.status).toBe('invalid');
     expect(result.current.errors.some(e => e.path === 'props.mode')).toBe(true);
+  });
+
+  test('an unparseable metric expression is blocked at fire time (VIS-993 layer 2)', async () => {
+    const { clearExpressionCache } = jest.requireActual(
+      '../components/views/workspace/expressionPreflight'
+    );
+    clearExpressionCache();
+    validateExpressions.mockResolvedValueOnce({
+      results: [{ name: 'expression', valid: false, error: "Expecting ). Line 1, Col: 25." }],
+    });
+    const saveFn = setupCollection(
+      'metrics',
+      'avg_value',
+      { name: 'avg_value', expression: 'AVG(value)' },
+      'saveMetric'
+    );
+    const { result } = renderHook(() => useRecordSave('metric', 'avg_value', { delay: 500 }));
+
+    act(() => result.current.scheduleSave({ name: 'avg_value', expression: 'AVG(value)}' }));
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(saveFn).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('invalid');
+    expect(result.current.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'expression', keyword: 'expression' }),
+      ])
+    );
   });
 
   test('types without a schema mapping still save (fail-open)', async () => {

--- a/visivo/server/views/expression_views.py
+++ b/visivo/server/views/expression_views.py
@@ -1,7 +1,10 @@
+import re
+
 from flask import jsonify, request
 from visivo.logger.logger import Logger
 import sqlglot
 from sqlglot import exp
+from visivo.query.patterns import CONTEXT_STRING_VALUE_PATTERN
 from visivo.query.sqlglot_utils import get_sqlglot_dialect, has_aggregate_function
 
 
@@ -104,4 +107,71 @@ def register_expression_views(app, flask_app, output_dir):
 
         except Exception as e:
             Logger.instance().error(f"Error translating expressions: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/expressions/validate/", methods=["POST"])
+    def validate_expressions():
+        """Validate SQL expressions parse under the source dialect (VIS-993).
+
+        Unlike /translate/, which passes unparseable expressions through so the
+        explorer degrades gracefully, this endpoint REPORTS parse failures so
+        the viewer's validation-as-save gate can block a doomed expression
+        before it caches and fires a run.
+
+        Visivo context tokens (${ref(model).column}, ${ref(metric)}) are
+        substituted with a neutral identifier before parsing — the pattern is
+        the canonical templating-token pattern from visivo.query.patterns, not
+        SQL parsing; the resulting pure SQL goes to sqlglot.
+
+        Request body:
+        {
+            "expressions": [{"name": "avg_value", "expression": "AVG(value)"}],
+            "source_dialect": "duckdb"
+        }
+
+        Response:
+        {"results": [{"name": "avg_value", "valid": true}]}
+        with "error" carrying the parse message when valid is false.
+        """
+        try:
+            data = request.get_json(silent=True)
+            if not data:
+                return jsonify({"error": "Request body is required"}), 400
+
+            expressions = data.get("expressions", [])
+            source_dialect = data.get("source_dialect")
+
+            read_dialect = None
+            if source_dialect:
+                try:
+                    read_dialect = get_sqlglot_dialect(source_dialect)
+                except NotImplementedError:
+                    read_dialect = None
+
+            results = []
+            for expr_item in expressions:
+                name = expr_item.get("name", "")
+                expression = expr_item.get("expression", "")
+
+                if not expression or not expression.strip():
+                    results.append({"name": name, "valid": False, "error": "Empty expression"})
+                    continue
+
+                substituted = re.sub(CONTEXT_STRING_VALUE_PATTERN, "__visivo_ctx__", expression)
+                try:
+                    sqlglot.parse_one(
+                        f"SELECT {substituted} FROM __placeholder__",
+                        read=read_dialect or "duckdb",
+                    )
+                    results.append({"name": name, "valid": True})
+                except Exception as e:
+                    # sqlglot decorates messages with ANSI underlines — strip
+                    # them; this error renders in the viewer UI.
+                    message = re.sub(r"\x1b\[[0-9;]*m", "", str(e))
+                    results.append({"name": name, "valid": False, "error": message})
+
+            return jsonify({"results": results}), 200
+
+        except Exception as e:
+            Logger.instance().error(f"Expression validation failed: {e}")
             return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## What

Closes the two gaps found in smoke testing after #509:

### 1. `AVG(value)}` saved fine
The schema says `expression: string`, and the existing `/translate/` endpoint **swallows sqlglot failures** (deliberate graceful pass-through for the explorer) — so the gate had nothing to block on.

- **New backend endpoint** `/api/expressions/validate/`: parses with sqlglot under the source dialect and reports failures. Visivo context tokens (`${ref(m).col}`, composite-metric refs) are substituted via the canonical templating pattern before parsing — the SQL itself goes to sqlglot per repo law. ANSI escapes stripped (errors render in the UI). 11 backend tests.
- **`expressionPreflight`** runs it at fire time inside the `useRecordSave` gate for `metric.expression` / `dimension.expression` / `relation.condition` — per-value verdict cache (one POST per distinct value at debounce cadence), fail-open wherever the check can't run (dist/cloud unavailable, network failure; non-verdicts never cached).

### 2. The Save button
Dimension/metric/relation/markdown **edit forms are now auto-save**: every field change debounces through the gated backbone. `FormFooter` grows an `autoSave` mode — no Cancel/Save buttons, `SaveStateIndicator` + Delete instead. Gate errors render live on the expression/condition fields. Create mode keeps its explicit button (the record isn't in a collection yet).

## Test strategy
- **Backend**: 11 new endpoint tests (parse failures, ref substitution, composite metrics, relation conditions, ANSI-free errors, multi-expression independence). Full pytest: 2,000 green.
- **Unit**: expressionPreflight (8: cache semantics, fail-open, non-verdict non-caching), gate suite pins the fire-time block, 4 form suites rewritten to the auto-save contract (no-Save-button, scheduleSave-on-change, live gate errors, create-mode button pinned).
- **E2E (live sandbox)**: no Save button exists; dangling ref blocks with zero POSTs; **the exact `AVG(value)}` repro** blocks with the sqlglot reason on the field; fixed expressions auto-save through to the backend pending set. 5/5.
- Full viewer suite + eslint `--max-warnings=0` clean.

Refs VIS-993 (reopened for these gaps). A separate PR addresses the canvas resize/DnD regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)