### PR TITLE
VIS-993 fix: canvas resize/DnD persists through the validation gate + regression tests

### DIFF
--- a/viewer/e2e/stories/canvas-editing.spec.mjs
+++ b/viewer/e2e/stories/canvas-editing.spec.mjs
@@ -1,0 +1,366 @@
+/**
+ * Story: Canvas editing persists to the BACKEND (VIS-993 regression).
+ *
+ * USER-REPORTED REGRESSION: after the validation gate replaced
+ * sanitizeDashboardConfig (PR #509), canvas drag-edits appeared to work
+ * (optimistic store swap) but were silently never persisted — a blocked gate
+ * emits only telemetry, so the in-session UI looks fine and the edit vanishes
+ * on reload. The older canvas stories only asserted the STORE config, which is
+ * exactly the blind spot; every assertion here goes through the BACKEND:
+ * `/api/dashboards/` GET (the draft cache) and a full page reload.
+ *
+ * Real gestures covered:
+ *   (a) row-height handle drag  → height changes visually AND survives reload;
+ *   (b) item-width handle drag  → width persists to /api/dashboards/;
+ *   (c) item reorder within row → order persists;
+ *   (d) item move across rows   → persists;
+ *   (e) Library chart → canvas  → new item persists.
+ *
+ * Runs in the `state-mutating` playwright project (standard sandbox :3001/:8001,
+ * serial; the draft cache is discarded in afterAll).
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
+const API = BASE.replace(':3001', ':8001');
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+// A wide viewport keeps the canvas ≥768px so rows lay out side-by-side and the
+// item slots get real pixel boxes for the edge handles.
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+// ── Backend truth ────────────────────────────────────────────────────────────
+// The regression's blind spot: the store's optimistic copy diverges from the
+// draft cache when the gate blocks. These helpers read the BACKEND state.
+const apiRows = async page => {
+  const res = await page.request.get(`${API}/api/dashboards/`);
+  const data = await res.json().catch(() => ({ dashboards: [] }));
+  const d = (data.dashboards || []).find(x => x.name === DASHBOARD);
+  const cfg = d ? d.config || d : null;
+  return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+};
+
+const storeRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+// A STABLE per-item signature for order comparison (items carry either a ref
+// string or an embedded leaf object with a name — both survive a save →
+// refetch round-trip).
+const itemKey = it => {
+  if (!it || typeof it !== 'object') return '(slot)';
+  const leaf = it.chart ?? it.table ?? it.markdown ?? it.input;
+  if (leaf == null) return Array.isArray(it.rows) ? '(container)' : '(slot)';
+  if (typeof leaf === 'string') return leaf;
+  return leaf.name || leaf.path || JSON.stringify(leaf).slice(0, 64);
+};
+
+const selectKey = (page, key) =>
+  page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(dash.locator('[data-row-index]').first()).toBeVisible({ timeout: WAIT });
+};
+
+// ── Resize harness (real mouse drag on the raw-pointer handles) ─────────────
+const dragHandle = async (page, handle, dx, dy, { shift = false } = {}) => {
+  await handle.scrollIntoViewIfNeeded();
+  const b = await handle.boundingBox();
+  expect(b, 'the resize handle has a box').toBeTruthy();
+  const sx = b.x + b.width / 2;
+  const sy = b.y + b.height / 2;
+  if (shift) await page.keyboard.down('Shift');
+  await page.mouse.move(sx, sy);
+  await page.mouse.down();
+  await page.mouse.move(sx + Math.sign(dx) * 4, sy + Math.sign(dy) * 4, { steps: 4 });
+  await page.mouse.move(sx + dx, sy + dy, { steps: 20 });
+  await page.mouse.up();
+  if (shift) await page.keyboard.up('Shift');
+};
+
+// ── DnD harness (dnd-kit PointerSensor) ──────────────────────────────────────
+// pointerdown is dispatched on the grip element directly (the grip overlay is
+// occluded for hit-testing by the dashboard's z-40 item wrappers — see
+// canvas-dnd.spec.mjs for the full rationale); travel is document-level
+// pointermoves and the COMMIT is a real page.mouse.up().
+const dndDrag = async (page, source, target) => {
+  await expect(source).toBeVisible();
+  await page.waitForTimeout(150);
+  const sb = await source.boundingBox();
+  const tb = await target.boundingBox();
+  expect(sb && tb, 'both drag endpoints have a box').toBeTruthy();
+  const tx = tb.x + tb.width / 2;
+  const ty = tb.y + tb.height / 2;
+  await source.evaluate(el => {
+    const r = el.getBoundingClientRect();
+    window.__canvasEditSrc = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: window.__canvasEditSrc.x,
+        clientY: window.__canvasEditSrc.y,
+        pointerId: 1,
+        button: 0,
+        pointerType: 'mouse',
+        isPrimary: true,
+        view: window,
+      })
+    );
+  });
+  await page.waitForTimeout(40);
+  await page.evaluate(
+    ([txx, tyy]) => {
+      const s = window.__canvasEditSrc;
+      const ev = (x, y) =>
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          pointerId: 1,
+          button: 0,
+          pointerType: 'mouse',
+          isPrimary: true,
+          view: window,
+        });
+      document.dispatchEvent(ev(s.x + 10, s.y + 10));
+      document.dispatchEvent(ev((s.x + txx) / 2, (s.y + tyy) / 2));
+      document.dispatchEvent(ev(txx, tyy));
+      document.dispatchEvent(ev(txx, tyy));
+    },
+    [tx, ty]
+  );
+  await page.waitForTimeout(40);
+};
+
+const revealItemHandle = async (page, itemPath) => {
+  await page
+    .locator(`[data-canvas-path="${itemPath}"]`)
+    .first()
+    .click({ position: { x: 6, y: 6 }, force: true });
+  const handle = page.getByTestId(`canvas-drag-frame-${itemPath}`);
+  await expect(handle).toBeVisible({ timeout: WAIT });
+  return handle;
+};
+
+test.describe('Canvas editing persists to the backend (VIS-993 regression)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    // Drop the drafts this story cached so later suites see a clean backend.
+    await page.request.post(`${API}/api/commit/discard/`).catch(() => {});
+    await page.close();
+  });
+
+  test('(a) row-height drag: visual change + retained through a full reload', async () => {
+    await openCanvas(page);
+    const before = await storeRows(page);
+    const beforeHeight = before[0].height;
+
+    // The row's rendered box before the resize (visual baseline).
+    const rowEl = page.locator('[data-canvas-path="row.0"]').first();
+    const boxBefore = await rowEl.boundingBox();
+
+    await selectKey(page, 'row.0');
+    const handle = page.getByTestId('canvas-resize-height-row.0');
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    // Drag DOWN far enough to cross at least one HeightEnum stop.
+    await dragHandle(page, handle, 0, 160);
+
+    // The selection SURVIVES the gesture (regression: the drag's terminal
+    // click used to fall through the selection overlay's chrome branch and
+    // deselect — hiding the handles after every single resize).
+    await expect
+      .poll(() => page.evaluate(() => window.useStore.getState().workspaceOutlineSelectedKey))
+      .toBe('row.0');
+    await expect(handle).toBeVisible();
+
+    // Visual: the rendered row box grew.
+    await expect
+      .poll(async () => (await rowEl.boundingBox())?.height, { timeout: WAIT })
+      .toBeGreaterThan(boxBefore.height + 40);
+
+    // Backend: the draft cache holds the new height (THE regression assertion —
+    // a blocked gate leaves the API at the old value while the store lies).
+    await expect
+      .poll(async () => (await apiRows(page))[0]?.height, { timeout: WAIT })
+      .not.toBe(beforeHeight);
+    const apiHeight = (await apiRows(page))[0].height;
+
+    // Reload: the height is retained (served back from the draft cache).
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+    await expect
+      .poll(async () => (await storeRows(page))[0]?.height, { timeout: WAIT })
+      .toBe(apiHeight);
+  });
+
+  test('(b) item-width drag persists to /api/dashboards/', async () => {
+    await openCanvas(page);
+    const rows = await storeRows(page);
+    const ri = rows.findIndex(r => (r.items || []).length >= 2);
+    expect(ri, 'a row with ≥2 items exists').toBeGreaterThanOrEqual(0);
+    const beforeWidth = rows[ri].items[0].width || 1;
+
+    const itemKeyPath = `row.${ri}.item.0`;
+    await selectKey(page, itemKeyPath);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKeyPath}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    const rowBox = await page.locator(`[data-canvas-path="row.${ri}"]`).first().boundingBox();
+    const colPx = rowBox.width / (rows[ri].items.reduce((s, it) => s + (it.width || 1), 0) || 1);
+    const dir = beforeWidth > 1 ? -1 : 1;
+    await dragHandle(page, handle, dir * Math.round(colPx * 2), 0);
+
+    // Backend truth: the width change reached the draft cache.
+    await expect
+      .poll(async () => (await apiRows(page))[ri]?.items?.[0]?.width, { timeout: WAIT })
+      .not.toBe(beforeWidth);
+    const after = (await apiRows(page))[ri].items[0].width;
+    expect(Number.isInteger(after)).toBe(true);
+    expect(after).toBeGreaterThanOrEqual(1);
+    expect(after).toBeLessThanOrEqual(12);
+  });
+
+  test('(c) item reorder within a row persists to /api/dashboards/', async () => {
+    await openCanvas(page);
+    const rows = await storeRows(page);
+    const ri = rows.findIndex(r => (r.items || []).length >= 2);
+    const before = rows[ri].items.map(itemKey);
+
+    const handle = await revealItemHandle(page, `row.${ri}.item.0`);
+    const endZone = page.getByTestId(`canvas-dropzone-row.${ri}-end`);
+    await dndDrag(page, handle, endZone);
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // Backend truth: the first item moved to the end IN THE DRAFT CACHE.
+    await expect
+      .poll(
+        async () => {
+          const r = await apiRows(page);
+          const items = r[ri]?.items || [];
+          return items.length ? itemKey(items[items.length - 1]) : null;
+        },
+        { timeout: WAIT }
+      )
+      .toBe(before[0]);
+  });
+
+  test('(d) item move ACROSS rows persists to /api/dashboards/', async () => {
+    await openCanvas(page);
+    const rows = await storeRows(page);
+    const fromRi = rows.findIndex(r => (r.items || []).length >= 2);
+    const toRi = rows.findIndex((r, i) => i !== fromRi && Array.isArray(r.items));
+    expect(fromRi, 'a source row exists').toBeGreaterThanOrEqual(0);
+    expect(toRi, 'a target row exists').toBeGreaterThanOrEqual(0);
+
+    const movedKey = itemKey(rows[fromRi].items[0]);
+    const targetCountBefore = (rows[toRi].items || []).length;
+
+    const handle = await revealItemHandle(page, `row.${fromRi}.item.0`);
+    const endZone = page.getByTestId(`canvas-dropzone-row.${toRi}-end`);
+    await endZone.waitFor({ timeout: WAIT });
+    await dndDrag(page, handle, endZone);
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // Backend truth: the item left its row and landed at the target row's end.
+    await expect
+      .poll(
+        async () => {
+          const r = await apiRows(page);
+          const target = r[toRi]?.items || [];
+          return (
+            target.length === targetCountBefore + 1 &&
+            itemKey(target[target.length - 1]) === movedKey
+          );
+        },
+        { timeout: WAIT }
+      )
+      .toBe(true);
+  });
+
+  test('(e) Library chart dropped on the canvas persists a new item', async () => {
+    await openCanvas(page);
+    const rowsBefore = await apiRows(page);
+    const totalBefore = rowsBefore.reduce((n, r) => n + (r.items || []).length, 0);
+
+    // Expand the Charts subsection in the Library and grab a chart row.
+    const chartHeader = page.getByTestId('library-subsection-chart-header');
+    await chartHeader.waitFor({ timeout: WAIT });
+    const anyChartRow = page.locator('[data-testid^="library-row-chart-"]').first();
+    if (!(await anyChartRow.count())) {
+      await chartHeader.click();
+    }
+    await anyChartRow.waitFor({ timeout: WAIT });
+    const chartName = await anyChartRow.evaluate(el =>
+      (el.getAttribute('data-testid') || '').replace('library-row-chart-', '')
+    );
+    expect(chartName).toBeTruthy();
+
+    const endZone = page.getByTestId('canvas-dropzone-row.0-end');
+    await endZone.waitFor({ timeout: WAIT });
+    await dndDrag(page, anyChartRow, endZone);
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 4000 });
+    await page.mouse.up();
+
+    // Backend truth: a new item referencing the chart is IN THE DRAFT CACHE.
+    await expect
+      .poll(
+        async () => {
+          const rows = await apiRows(page);
+          const total = rows.reduce((n, r) => n + (r.items || []).length, 0);
+          const hasRef = rows.some(r =>
+            (r.items || []).some(
+              it => typeof it.chart === 'string' && it.chart.includes(chartName)
+            )
+          );
+          return total > totalBefore && hasRef;
+        },
+        { timeout: WAIT }
+      )
+      .toBe(true);
+  });
+
+  test('no console errors and no save 400s across the gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'canvas edits must persist backend-valid configs').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -33,6 +33,9 @@ export default defineConfig({
         '**/external-edit-banner.spec.mjs',
         '**/library-inline-create.spec.mjs',
         '**/validation-as-save.spec.mjs',
+        // VIS-993 regression: canvas edits must persist to the DRAFT CACHE
+        // (backend), so this story writes state and runs serially.
+        '**/canvas-editing.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -48,6 +51,9 @@ export default defineConfig({
         '**/library-inline-create.spec.mjs',
         // VIS-993: the valid-save step drafts a dimension into the cache.
         '**/validation-as-save.spec.mjs',
+        // VIS-993 regression: canvas resize/DnD edits draft dashboard changes
+        // into the cache and assert them via /api/dashboards/ + reload.
+        '**/canvas-editing.spec.mjs',
       ],
       dependencies: ['parallel'],
     },

--- a/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.jsx
@@ -201,6 +201,14 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
   const handleClick = useCallback(
     e => {
       const root = rootRef.current;
+      // A resize gesture ends with the browser synthesizing a `click` on the
+      // handle itself (pointer capture keeps down/up on the same element).
+      // The handles are overlay nodes with NO data-canvas-path, so that click
+      // used to fall through to the chrome branch and DESELECT the node the
+      // user just resized — hiding the handles after every single gesture
+      // (the "drag to resize is broken" feel). A click originating on a
+      // resize handle is part of the gesture, never a selection intent.
+      if (e.target?.closest?.('[data-resize-axis]')) return;
       const target = resolveTarget(e.target, root);
       if (!target) return;
       const nextKey = keyForTarget(target);

--- a/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.test.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.test.jsx
@@ -340,4 +340,48 @@ describe('CanvasSelectionOverlay (VIS-768)', () => {
       expect(useStore.getState().workspaceOutlineSelectedKey).toBe('row.2.item.0.row.0');
     });
   });
+
+  describe('resize-gesture clicks (VIS-993 canvas-editing regression)', () => {
+    // CanvasResizeLayer paints its handles as SIBLING overlay nodes inside the
+    // same root — they carry `data-resize-axis` but NO `data-canvas-path`. A
+    // resize drag ends with the browser synthesizing a `click` on the handle
+    // (pointer capture keeps down/up on the same element), which used to fall
+    // through resolveTarget's chrome branch and DESELECT the node the user
+    // just resized — the handles vanished after every single gesture.
+    const ResizeHarness = () => {
+      const rootRef = useRef(null);
+      return (
+        <div ref={rootRef} data-testid="root" style={{ position: 'relative' }}>
+          <div data-testid="dashboard-row-0" data-row-index="0" data-canvas-path="row.0">
+            <div data-testid="slot-0-0" data-canvas-path="row.0.item.0">
+              chart a
+            </div>
+          </div>
+          {/* Stand-in for a CanvasResizeLayer handle: overlay node, no canvas path. */}
+          <div data-testid="fake-resize-handle" data-resize-axis="height" />
+          <CanvasSelectionOverlay rootRef={rootRef} />
+        </div>
+      );
+    };
+
+    test("a click on a resize handle does NOT collapse the selection to chrome", () => {
+      render(<ResizeHarness />);
+      act(() => {
+        useStore.getState().setWorkspaceOutlineSelectedKey('row.0');
+      });
+      fireEvent.click(screen.getByTestId('fake-resize-handle'));
+      // The selection the user is resizing must SURVIVE the gesture's
+      // terminal click — otherwise every resize hides the handles.
+      expect(useStore.getState().workspaceOutlineSelectedKey).toBe('row.0');
+    });
+
+    test('a genuine chrome click still deselects to the dashboard', () => {
+      render(<ResizeHarness />);
+      act(() => {
+        useStore.getState().setWorkspaceOutlineSelectedKey('row.0');
+      });
+      fireEvent.click(screen.getByTestId('root'));
+      expect(useStore.getState().workspaceOutlineSelectedKey).toBe('dashboard');
+    });
+  });
 });

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -34,9 +34,8 @@ import {
   appendEmptyItem,
   createRow,
   setItemWidth,
-  checkLeafExclusivity,
+  runDashboardConfigGate,
 } from './itemMutations';
-import { validateRecordConfig, validateRecordConfigSync } from './validateAgainstSchema';
 import { emitWorkspaceEvent } from './telemetry';
 
 /**
@@ -252,23 +251,11 @@ const RightRailEditPanel = () => {
           ...meta,
         });
       };
-      // The mutual-exclusion rule is a backend model_validator with no
-      // JSON-schema encoding — check it first (cheap, schema-free).
-      const exclusivity = checkLeafExclusivity(nextConfig);
-      if (!exclusivity.valid) {
-        finish(exclusivity);
-        return;
-      }
-      // Sync schema fast path; when the schema isn't loaded yet (null), defer
-      // to the async authoritative check before arming the save.
-      const sync = validateRecordConfigSync('dashboard', nextConfig);
-      if (sync) {
-        finish(sync.valid ? null : sync);
-        return;
-      }
-      validateRecordConfig('dashboard', nextConfig).then(result =>
-        finish(result.valid ? null : result)
-      );
+      // The shared gate runner (exclusivity → sync schema → async schema)
+      // delivers exactly one verdict and FAILS OPEN on gate-internal errors —
+      // a crashed gate must never silently swallow the save (the
+      // canvas-persist regression). Same runner as commitCanvasConfig.
+      runDashboardConfigGate(nextConfig, finish);
     },
     [updateDashboardConfigOptimistic, scheduleSave, dashboardName, readOnly]
   );

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
@@ -1,0 +1,458 @@
+/**
+ * Canvas commit-path regression tests (VIS-993 follow-up).
+ *
+ * USER-REPORTED REGRESSION: after the validation gate replaced
+ * sanitizeDashboardConfig, canvas drag-edits (row-height resize, item-width
+ * resize, reorder, cross-row move, Library drop) appeared to work but never
+ * persisted. These tests drive the REAL pipeline end to end in jsdom:
+ *
+ *   REAL gesture transform (canvasReorder) → REAL mounted WorkspaceDndContext
+ *   commit (checkLeafExclusivity + validateRecordConfigSync against the REAL
+ *   bundled $defs snapshot) → store saveDashboard.
+ *
+ * The dashboard fixture mirrors what `/api/dashboards/` actually serves for the
+ * integration project's `simple-dashboard` — `model_dump(mode='json',
+ * exclude_none=True, exclude={'file_path','path'})` — including EMBEDDED chart
+ * objects (name + `${ref()}` insights + a Plotly layout), `${ref()}` string
+ * leaves, empty slots, level/tags/type sidecar fields, and nested container
+ * rows. If the gate rejects any gesture-produced config here, the canvas
+ * "works then silently never saves" — exactly the regression this pins.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import WorkspaceDndContext, { routeWorkspaceDragEnd, useWorkspaceCommit } from './WorkspaceDndContext';
+import { preloadValidationSchema, validateRecordConfigSync } from './validateAgainstSchema';
+import { checkLeafExclusivity } from './itemMutations';
+import {
+  setRowHeight,
+  setItemWidth,
+  resizeItemFromLeft,
+  reorderTopLevelRows,
+  reorderItemsInRow,
+  moveItemBetweenRows,
+  insertItemAtTarget,
+  buildLibraryItem,
+} from '../project/canvas/canvasReorder';
+import useStore from '../../../stores/store';
+
+const clone = value => JSON.parse(JSON.stringify(value));
+
+// Capture the REAL store action at module load — earlier tests in this file
+// overwrite it with jest.fn() via useStore.setState, and the full-stack
+// describe below needs the genuine optimistic write.
+const REAL_UPDATE_DASHBOARD_OPTIMISTIC = useStore.getState().updateDashboardConfigOptimistic;
+
+/**
+ * A dashboard config shaped EXACTLY like the local Flask `/api/dashboards/`
+ * list endpoint's `config` field (DashboardManager._serialize_object →
+ * model_dump(mode='json', exclude_none=True, exclude={'file_path','path'})):
+ *   - `name`, `level`, `tags`, `type: 'internal'` sidecar fields present;
+ *   - items with EMBEDDED chart objects (integration project pre-resolves
+ *     inline charts to objects with name/insights/layout);
+ *   - `${ref(...)}` context-string leaves;
+ *   - an EMPTY slot ({ width } only);
+ *   - a container item with nested rows.
+ */
+const API_SHAPED_CONFIG = {
+  name: 'simple-dashboard',
+  level: 0,
+  tags: ['charts', 'simple'],
+  type: 'internal',
+  rows: [
+    {
+      height: 'medium',
+      items: [
+        {
+          width: 9,
+          chart: {
+            name: 'a-very-fibonacci-waterfall',
+            insights: ['${ref(fibonacci-waterfall)}', '${ref(example-indicator)}'], // eslint-disable-line no-template-curly-in-string
+            layout: {
+              title: { text: 'AAPL P&L' },
+              waterfallgroupgap: 0.1,
+            },
+          },
+        },
+        {
+          width: 2,
+          chart: {
+            name: 'aggregated-fib',
+            insights: ['${ref(aggregated-line)}'], // eslint-disable-line no-template-curly-in-string
+            layout: {
+              title: { text: 'Aggregated Fibonacci' },
+              yaxis: { title: { text: 'output' } },
+              xaxis: { title: { text: 'More if x>3 Less if x<=3' } },
+            },
+          },
+        },
+        { width: 1 }, // empty slot
+      ],
+    },
+    {
+      height: 512,
+      items: [
+        { width: 1, table: '${ref(a-table)}' }, // eslint-disable-line no-template-curly-in-string
+        { width: 2, markdown: '${ref(welcome-md)}' }, // eslint-disable-line no-template-curly-in-string
+      ],
+    },
+    {
+      height: 'small',
+      items: [
+        {
+          width: 1,
+          rows: [
+            { height: 'small', items: [{ width: 1, chart: '${ref(nested-chart)}' }] }, // eslint-disable-line no-template-curly-in-string
+            { height: 'small', items: [{ width: 1 }] },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const CommitProbe = ({ name, config }) => {
+  const commit = useWorkspaceCommit();
+  return (
+    <button
+      type="button"
+      data-testid="commit-probe"
+      onClick={() => commit && commit(name, config)}
+    >
+      commit
+    </button>
+  );
+};
+
+/** Mount the REAL provider, click-commit `config`, return the saveDashboard spy. */
+const commitThroughProvider = config => {
+  const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+  const updateDashboardConfigOptimistic = jest.fn();
+  useStore.setState({ saveDashboard, updateDashboardConfigOptimistic });
+  render(
+    <WorkspaceDndContext>
+      <CommitProbe name="simple-dashboard" config={config} />
+    </WorkspaceDndContext>
+  );
+  fireEvent.click(screen.getByTestId('commit-probe'));
+  return { saveDashboard, updateDashboardConfigOptimistic };
+};
+
+beforeAll(async () => {
+  // Warm the bundled $defs snapshot so the gate takes its SYNC path — the same
+  // steady state the production workspace reaches after the first commit.
+  await preloadValidationSchema();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('gate accepts the API-shaped dashboard config itself (baseline)', () => {
+  test('the untouched /api/dashboards config passes the schema gate', () => {
+    const result = validateRecordConfigSync('dashboard', clone(API_SHAPED_CONFIG));
+    expect(result).not.toBeNull();
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  test('the untouched config passes leaf exclusivity', () => {
+    expect(checkLeafExclusivity(clone(API_SHAPED_CONFIG)).valid).toBe(true);
+  });
+});
+
+describe('canvas gestures persist through the REAL commit gate (VIS-993 regression)', () => {
+  test('row-height FLUID resize (pixel int) persists byte-identical', () => {
+    const next = setRowHeight(clone(API_SHAPED_CONFIG), 'row.0', 487);
+    expect(next.rows[0].height).toBe(487);
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    expect(saveDashboard.mock.calls[0][0]).toBe('simple-dashboard');
+    expect(saveDashboard.mock.calls[0][1]).toBe(next); // byte-identical, never repaired
+  });
+
+  test('row-height TICK resize (enum token) persists', () => {
+    const next = setRowHeight(clone(API_SHAPED_CONFIG), 'row.1', 'xlarge');
+    expect(next.rows[1].height).toBe('xlarge');
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    expect(saveDashboard.mock.calls[0][1]).toBe(next);
+  });
+
+  test('NESTED row-height resize (enum inside a container) persists', () => {
+    const next = setRowHeight(clone(API_SHAPED_CONFIG), 'row.2.item.0.row.0', 'medium');
+    expect(next.rows[2].items[0].rows[0].height).toBe('medium');
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('item-width resize persists byte-identical', () => {
+    const next = setItemWidth(clone(API_SHAPED_CONFIG), 'row.0.item.0', 7);
+    expect(next.rows[0].items[0].width).toBe(7);
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    expect(saveDashboard.mock.calls[0][1]).toBe(next);
+  });
+
+  test('LEFT-edge width resize (column transfer with neighbour) persists', () => {
+    const next = resizeItemFromLeft(clone(API_SHAPED_CONFIG), 'row.0', 1, 3);
+    expect(next.rows[0].items[1].width).toBe(5);
+    expect(next.rows[0].items[0].width).toBe(6);
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('top-level row reorder persists', () => {
+    const next = reorderTopLevelRows(clone(API_SHAPED_CONFIG), 0, 1);
+    expect(next.rows[0].height).toBe(512);
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('item reorder within a row persists', () => {
+    const next = reorderItemsInRow(clone(API_SHAPED_CONFIG), 'row.0', 0, 2);
+    expect(next.rows[0].items[2].chart?.name).toBe('a-very-fibonacci-waterfall');
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('cross-row item move persists (source row may go empty)', () => {
+    const next = moveItemBetweenRows(clone(API_SHAPED_CONFIG), 'row.1', 0, {
+      kind: 'end-of-row',
+      rowPath: 'row.0',
+    });
+    expect(next.rows[0].items).toHaveLength(4);
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('Library chart drop (between-rows insert) persists', () => {
+    const item = buildLibraryItem('chart', 'indicator-chart');
+    const next = insertItemAtTarget(clone(API_SHAPED_CONFIG), { kind: 'between-rows', index: 3 }, item);
+    expect(next.rows[3].items[0].chart).toBe('ref(indicator-chart)');
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('Library markdown drop into an existing row (between-items) persists', () => {
+    const item = buildLibraryItem('markdown', 'welcome-md');
+    const next = insertItemAtTarget(
+      clone(API_SHAPED_CONFIG),
+      { kind: 'between-items', rowPath: 'row.1', index: 1 },
+      item
+    );
+    expect(next.rows[1].items[1].markdown).toBe('ref(welcome-md)');
+    const { saveDashboard } = commitThroughProvider(next);
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('router → REAL commit integration (drag-end payloads persist)', () => {
+  const routerDeps = commitCanvasConfig => ({
+    dashboards: [],
+    projectDefaults: null,
+    reassignDashboardLevel: jest.fn(),
+    moveLevel: jest.fn(),
+    commitCanvasConfig,
+    emit: jest.fn(),
+  });
+
+  const RouterProbe = ({ event }) => {
+    const commit = useWorkspaceCommit();
+    return (
+      <button
+        type="button"
+        data-testid="router-probe"
+        onClick={() => routeWorkspaceDragEnd(event, routerDeps(commit))}
+      >
+        route
+      </button>
+    );
+  };
+
+  const driveRouter = event => {
+    const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+    useStore.setState({ saveDashboard, updateDashboardConfigOptimistic: jest.fn() });
+    render(
+      <WorkspaceDndContext>
+        <RouterProbe event={event} />
+      </WorkspaceDndContext>
+    );
+    fireEvent.click(screen.getByTestId('router-probe'));
+    return saveDashboard;
+  };
+
+  test('a real drag-end row reorder routes through the gate and saves', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveDashboard = driveRouter({
+      active: {
+        data: { current: { source: 'canvas', kind: 'row', rowIndex: 0, rowPath: 'row.0' } },
+      },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'between-rows', index: 2 },
+          },
+        },
+      },
+    });
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    const persisted = saveDashboard.mock.calls[0][1];
+    expect(persisted.rows[0].height).toBe(512);
+  });
+
+  test('a real drag-end Library insert routes through the gate and saves', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveDashboard = driveRouter({
+      active: { data: { current: { source: 'library', type: 'chart', name: 'indicator-chart' } } },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'end-of-row', rowPath: 'row.1' },
+          },
+        },
+      },
+    });
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    const persisted = saveDashboard.mock.calls[0][1];
+    expect(persisted.rows[1].items[2].chart).toBe('ref(indicator-chart)');
+  });
+
+  test('a real drag-end cross-row item move routes through the gate and saves', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveDashboard = driveRouter({
+      active: {
+        data: { current: { source: 'canvas', kind: 'item', rowPath: 'row.1', itemIndex: 0 } },
+      },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'end-of-row', rowPath: 'row.0' },
+          },
+        },
+      },
+    });
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('full-stack resize gesture → REAL provider commit (jsdom pointer drive)', () => {
+  // Borrowed from CanvasResizeLayer.test.jsx, but WITHOUT mocking the commit
+  // hook: the layer runs against the REAL WorkspaceDndContext provider, so a
+  // resize exercises the exact production pipeline down to saveDashboard.
+  /* eslint-disable global-require */
+  const CanvasResizeLayer = require('../project/canvas/CanvasResizeLayer').default;
+  /* eslint-enable global-require */
+  const { useRef } = React;
+
+  const makeEvt = (type, { clientX, clientY, shiftKey = false }) =>
+    new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, shiftKey });
+
+  const firePointer = (type, coords) => {
+    act(() => {
+      window.dispatchEvent(makeEvt(type, coords));
+    });
+  };
+  const firePointerDown = (el, coords) => {
+    act(() => {
+      el.dispatchEvent(makeEvt('pointerdown', coords));
+    });
+  };
+
+  const Host = () => {
+    const rootRef = useRef(null);
+    return (
+      <WorkspaceDndContext>
+        <div ref={rootRef} style={{ position: 'relative' }}>
+          <div data-canvas-path="row.0" data-testid="r0">
+            <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+            <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+          </div>
+          <CanvasResizeLayer rootRef={rootRef} dashboardName="simple-dashboard" />
+        </div>
+      </WorkspaceDndContext>
+    );
+  };
+
+  const BOXES = {
+    r0: { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+    r0i0: { top: 0, left: 0, width: 600, height: 200, bottom: 200, right: 600 },
+    r0i1: { top: 0, left: 610, width: 190, height: 200, bottom: 200, right: 800 },
+    root: { top: 0, left: 0, width: 800, height: 360, bottom: 360, right: 800 },
+  };
+
+  let saveDashboard;
+
+  beforeEach(() => {
+    saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+    useStore.setState({
+      dashboards: [{ name: 'simple-dashboard', config: clone(API_SHAPED_CONFIG) }],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+      saveDashboard,
+      updateDashboardConfigOptimistic: REAL_UPDATE_DASHBOARD_OPTIMISTIC,
+    });
+    Element.prototype.getBoundingClientRect = function () {
+      const tid = this.getAttribute && this.getAttribute('data-testid');
+      if (tid && BOXES[tid]) return BOXES[tid];
+      return BOXES.root;
+    };
+    if (!Element.prototype.setPointerCapture) {
+      Element.prototype.setPointerCapture = () => {};
+    }
+  });
+
+  test('a real width drag on the handle persists the resized config', async () => {
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+
+    // 12 grid cols over an 800px row → ~66.7px/col. Drag LEFT ~2 columns.
+    firePointerDown(handle, { clientX: 600, clientY: 100 });
+    firePointer('pointermove', { clientX: 466, clientY: 100 });
+    firePointer('pointerup', { clientX: 466, clientY: 100 });
+
+    await waitFor(() => expect(saveDashboard).toHaveBeenCalledTimes(1));
+    const persisted = saveDashboard.mock.calls[0][1];
+    expect(persisted.rows[0].items[0].width).toBe(7);
+    // The store's optimistic copy converged on the same config object.
+    const entry = useStore.getState().dashboards.find(d => d.name === 'simple-dashboard');
+    expect(entry.config).toBe(persisted);
+  });
+
+  test('a real Shift-fluid height drag persists an integer pixel height', async () => {
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0.item.0');
+
+    firePointerDown(handle, { clientX: 400, clientY: 195, shiftKey: true });
+    firePointer('pointermove', { clientX: 400, clientY: 288, shiftKey: true });
+    firePointer('pointerup', { clientX: 400, clientY: 288, shiftKey: true });
+
+    await waitFor(() => expect(saveDashboard).toHaveBeenCalledTimes(1));
+    const persisted = saveDashboard.mock.calls[0][1];
+    expect(typeof persisted.rows[0].height).toBe('number');
+    expect(Number.isInteger(persisted.rows[0].height)).toBe(true);
+  });
+
+  test('a tick-mode height drag persists a HeightEnum token', async () => {
+    render(<Host />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0.item.0');
+
+    firePointerDown(handle, { clientX: 400, clientY: 195 });
+    firePointer('pointermove', { clientX: 400, clientY: 335 });
+    firePointer('pointerup', { clientX: 400, clientY: 335 });
+
+    await waitFor(() => expect(saveDashboard).toHaveBeenCalledTimes(1));
+    const persisted = saveDashboard.mock.calls[0][1];
+    expect(typeof persisted.rows[0].height).toBe('string');
+    expect(['compact', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']).toContain(
+      persisted.rows[0].height
+    );
+  });
+});

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -15,8 +15,7 @@ import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
 import LibraryDragPreview from './library/LibraryDragPreview';
 import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
 import { emitWorkspaceEvent } from './telemetry';
-import { checkLeafExclusivity } from './itemMutations';
-import { validateRecordConfig, validateRecordConfigSync } from './validateAgainstSchema';
+import { runDashboardConfigGate } from './itemMutations';
 import {
   reorderItemsInRow,
   moveItemBetweenRows,
@@ -604,16 +603,18 @@ const WorkspaceDndContext = ({ children }) => {
   // BORN-valid configs, so the gate — $defs schema (validateAgainstSchema)
   // plus the leaf mutual-exclusion check the JSON schema cannot express — is
   // defense-in-depth: an invalid config is never handed to saveDashboard
-  // (sanitizeDashboardConfig is retired; nothing repairs the payload). This is
-  // the SAME contract RightRailEditPanel.persistConfig applies on the
-  // structure-form path.
+  // (sanitizeDashboardConfig is retired; nothing repairs the payload). The
+  // shared runDashboardConfigGate delivers EXACTLY ONE verdict and FAILS OPEN
+  // on gate-internal errors (a crashed gate must never silently swallow the
+  // save — the canvas-persist regression). This is the SAME runner
+  // RightRailEditPanel.persistConfig uses on the structure-form path.
   const commitCanvasConfig = useCallback(
     (dashboardName, nextConfig) => {
       if (!dashboardName) return;
       if (updateDashboardConfigOptimistic) {
         updateDashboardConfigOptimistic(dashboardName, nextConfig);
       }
-      const persist = blocked => {
+      runDashboardConfigGate(nextConfig, blocked => {
         if (blocked) {
           emitWorkspaceEvent('canvas_commit_blocked', {
             name: dashboardName,
@@ -624,21 +625,7 @@ const WorkspaceDndContext = ({ children }) => {
         if (typeof saveDashboard === 'function') {
           saveDashboard(dashboardName, nextConfig);
         }
-      };
-      const exclusivity = checkLeafExclusivity(nextConfig);
-      if (!exclusivity.valid) {
-        persist(exclusivity);
-        return;
-      }
-      // Sync schema fast path; pre-load (null) defers to the async check.
-      const sync = validateRecordConfigSync('dashboard', nextConfig);
-      if (sync) {
-        persist(sync.valid ? null : sync);
-        return;
-      }
-      validateRecordConfig('dashboard', nextConfig).then(result =>
-        persist(result.valid ? null : result)
-      );
+      });
     },
     [updateDashboardConfigOptimistic, saveDashboard]
   );

--- a/viewer/src/components/views/workspace/expressionPreflight.js
+++ b/viewer/src/components/views/workspace/expressionPreflight.js
@@ -96,7 +96,18 @@ export async function checkExpressions(type, config, sourceDialect) {
       return errors.length === 0 ? SKIP : { valid: false, errors };
     }
 
-    const byName = new Map((response?.results || []).map(r => [r.name, r]));
+    // A well-behaved endpoint returns { results: [...] }, but never trust the
+    // shape: a malformed 200 body (results absent, an object, or holding
+    // nullish entries) must not throw out of this pre-flight — that would
+    // reject the whole save (the backend stays authoritative). Treat an
+    // unusable body exactly like an unreachable endpoint: fail open.
+    const rawResults = Array.isArray(response?.results) ? response.results : null;
+    if (!rawResults) {
+      return errors.length === 0 ? SKIP : { valid: false, errors };
+    }
+    const byName = new Map(
+      rawResults.filter(r => r && typeof r === 'object' && 'name' in r).map(r => [r.name, r])
+    );
     for (const p of pending) {
       const result = byName.get(p.field);
       if (!result) continue;

--- a/viewer/src/components/views/workspace/expressionPreflight.test.js
+++ b/viewer/src/components/views/workspace/expressionPreflight.test.js
@@ -94,4 +94,25 @@ describe('checkExpressions', () => {
     const result = await checkExpressions('metric', { name: 'm', expression: 'SUM(y)' });
     expect(result.valid).toBe(false);
   });
+
+  // A malformed 200 body must NEVER throw out of the pre-flight (that would
+  // reject the whole save — the silent-swallow bug shape). Each shape fails
+  // open instead.
+  test.each([
+    ['results absent', {}],
+    ['results is an object', { results: {} }],
+    ['results is a string', { results: 'nope' }],
+    ['response is null', null],
+  ])('a malformed body (%s) fails open without throwing', async (_label, body) => {
+    validateExpressions.mockResolvedValue(body);
+    const result = await checkExpressions('metric', { name: 'm', expression: 'SUM(x)' });
+    expect(result.valid).toBe(true);
+    expect(result.skipped).toBe(true);
+  });
+
+  test('nullish entries inside results are skipped, not dereferenced', async () => {
+    validateExpressions.mockResolvedValue({ results: [null, { name: 'expression', valid: true }] });
+    const result = await checkExpressions('metric', { name: 'm', expression: 'SUM(x)' });
+    expect(result.valid).toBe(true);
+  });
 });

--- a/viewer/src/components/views/workspace/itemMutations.gate.test.js
+++ b/viewer/src/components/views/workspace/itemMutations.gate.test.js
@@ -1,0 +1,112 @@
+/**
+ * runDashboardConfigGate (VIS-993 canvas-persist regression) — the ONE shared
+ * gate runner for dashboard-structure persistence (canvas commitCanvasConfig +
+ * the rail's persistConfig). Exactly-once verdict callback, sync when the
+ * schema is warm, and — the regression pin — FAIL-OPEN when the async gate
+ * errors: a gate crash must persist (backend stays authoritative), never
+ * silently swallow the save.
+ */
+import { runDashboardConfigGate } from './itemMutations';
+import {
+  validateRecordConfig,
+  validateRecordConfigSync,
+} from './validateAgainstSchema';
+
+jest.mock('./validateAgainstSchema', () => ({
+  validateRecordConfig: jest.fn(),
+  validateRecordConfigSync: jest.fn(),
+}));
+
+const VALID = { name: 'd', rows: [{ height: 'medium', items: [{ width: 1 }] }] };
+
+let consoleErrorSpy;
+beforeEach(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  jest.clearAllMocks();
+});
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('runDashboardConfigGate', () => {
+  test('leaf-exclusivity violations block BEFORE any schema work', () => {
+    const onResult = jest.fn();
+    runDashboardConfigGate(
+      {
+        rows: [
+          // eslint-disable-next-line no-template-curly-in-string
+          { items: [{ width: 1, chart: '${ref(a)}', table: '${ref(b)}' }] }, // eslint-disable-line no-template-curly-in-string
+        ],
+      },
+      onResult
+    );
+    expect(onResult).toHaveBeenCalledTimes(1);
+    const blocked = onResult.mock.calls[0][0];
+    expect(blocked.valid).toBe(false);
+    expect(blocked.errors[0].keyword).toBe('exclusive');
+    expect(validateRecordConfigSync).not.toHaveBeenCalled();
+  });
+
+  test('warm sync path: valid verdict → onResult(null) synchronously', () => {
+    validateRecordConfigSync.mockReturnValue({ valid: true, errors: [] });
+    const onResult = jest.fn();
+    runDashboardConfigGate(VALID, onResult);
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(null);
+    expect(validateRecordConfig).not.toHaveBeenCalled();
+  });
+
+  test('warm sync path: invalid verdict → onResult(blocked)', () => {
+    const verdict = { valid: false, errors: [{ path: 'rows.0', message: 'bad', keyword: 'type' }] };
+    validateRecordConfigSync.mockReturnValue(verdict);
+    const onResult = jest.fn();
+    runDashboardConfigGate(VALID, onResult);
+    expect(onResult).toHaveBeenCalledWith(verdict);
+  });
+
+  test('cold async path: valid verdict persists', async () => {
+    validateRecordConfigSync.mockReturnValue(null);
+    validateRecordConfig.mockResolvedValue({ valid: true, errors: [] });
+    const onResult = jest.fn();
+    runDashboardConfigGate(VALID, onResult);
+    expect(onResult).not.toHaveBeenCalled(); // deferred to the async verdict
+    await flush();
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(null);
+  });
+
+  test('cold async path: invalid verdict blocks', async () => {
+    validateRecordConfigSync.mockReturnValue(null);
+    const verdict = { valid: false, errors: [{ path: '', message: 'nope', keyword: 'required' }] };
+    validateRecordConfig.mockResolvedValue(verdict);
+    const onResult = jest.fn();
+    runDashboardConfigGate(VALID, onResult);
+    await flush();
+    expect(onResult).toHaveBeenCalledWith(verdict);
+  });
+
+  test('REGRESSION: a rejecting async gate FAILS OPEN — the save still fires', async () => {
+    // The field failure: cold session → sync returns null → async gate errors
+    // internally → with a bare `.then` the verdict never arrived, so the
+    // canvas showed the resize (optimistic) but NOTHING persisted and not even
+    // canvas_commit_blocked fired. The shared runner must fail open instead.
+    validateRecordConfigSync.mockReturnValue(null);
+    validateRecordConfig.mockRejectedValue(new Error('ajv exploded'));
+    const onResult = jest.fn();
+    runDashboardConfigGate(VALID, onResult);
+    await flush();
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(null); // fail-open → persist
+  });
+
+  test('a THROWING sync gate fails open too (never breaks the commit call)', () => {
+    validateRecordConfigSync.mockImplementation(() => {
+      throw new Error('sync validator exploded');
+    });
+    const onResult = jest.fn();
+    expect(() => runDashboardConfigGate(VALID, onResult)).not.toThrow();
+    expect(onResult).toHaveBeenCalledWith(null);
+  });
+});

--- a/viewer/src/components/views/workspace/itemMutations.js
+++ b/viewer/src/components/views/workspace/itemMutations.js
@@ -24,6 +24,7 @@
  */
 
 import { formatRefExpression } from '../../../utils/refString';
+import { validateRecordConfig, validateRecordConfigSync } from './validateAgainstSchema';
 
 /** The four mutually-exclusive leaf ref fields on a dashboard Item. */
 export const LEAF_REF_FIELDS = ['chart', 'table', 'markdown', 'input'];
@@ -164,6 +165,60 @@ export const checkLeafExclusivity = config => {
     walkRows(config.rows, '');
   }
   return errors.length === 0 ? { valid: true, errors: [] } : { valid: false, errors };
+};
+
+/**
+ * runDashboardConfigGate — the ONE shared gate runner for dashboard-structure
+ * persistence (VIS-993 §3). Both the canvas commit path (commitCanvasConfig)
+ * and the rail's structure-form path (RightRailEditPanel.persistConfig) route
+ * their verdict through here so the sequencing — leaf exclusivity → sync
+ * schema fast path → async authoritative schema — and, critically, the
+ * FAIL-OPEN error handling can never drift between the two surfaces.
+ *
+ * `onResult(blocked)` is invoked EXACTLY ONCE: synchronously whenever a
+ * verdict is available without an async hop, else after the authoritative
+ * check settles. `blocked` is `null` when persistence may proceed, or the
+ * `{ valid:false, errors }` verdict when the gate holds it.
+ *
+ * FAIL-OPEN (the canvas-persist regression): a gate that CRASHES — sync throw
+ * or async rejection — must never swallow the save. Before this runner, the
+ * call sites consumed `validateRecordConfig(...)` with a bare `.then`, so any
+ * internal gate error left the commit in limbo: the optimistic UI applied,
+ * telemetry fired, but nothing persisted and not even the blocked event was
+ * emitted. A crashed gate now resolves `onResult(null)` (persist; the backend
+ * Pydantic validator stays authoritative) with a console.error for
+ * observability. Only a real `{ valid:false }` VERDICT blocks.
+ *
+ * @param {object} config     the dashboard config that would be persisted.
+ * @param {Function} onResult receives `null` (persist) or the blocking verdict.
+ */
+export const runDashboardConfigGate = (config, onResult) => {
+  // The mutual-exclusion rule is a backend model_validator with no
+  // JSON-schema encoding — check it first (cheap, schema-free).
+  const exclusivity = checkLeafExclusivity(config);
+  if (!exclusivity.valid) {
+    onResult(exclusivity);
+    return;
+  }
+  let sync;
+  try {
+    sync = validateRecordConfigSync('dashboard', config);
+  } catch (err) {
+    console.error('runDashboardConfigGate: sync gate crashed — failing open', err);
+    onResult(null);
+    return;
+  }
+  if (sync) {
+    onResult(sync.valid ? null : sync);
+    return;
+  }
+  // Schema not loaded yet (null) — defer to the async authoritative check.
+  validateRecordConfig('dashboard', config)
+    .then(result => onResult(result.valid ? null : result))
+    .catch(err => {
+      console.error('runDashboardConfigGate: async gate crashed — failing open', err);
+      onResult(null);
+    });
 };
 
 /**

--- a/viewer/src/components/views/workspace/validateAgainstSchema.failopen.test.js
+++ b/viewer/src/components/views/workspace/validateAgainstSchema.failopen.test.js
@@ -1,0 +1,79 @@
+/**
+ * validateAgainstSchema fail-open hardening (VIS-993 canvas-persist regression).
+ *
+ * The module's documented policy is FAIL-OPEN: "this gate only ever ADDS
+ * protection, never bricks a save path the backend would accept." But
+ * registerRoot (the $id-strip JSON round-trip + ajv.addSchema) and the
+ * validator execution ran OUTSIDE any try/catch — any internal error REJECTED
+ * the async gate promise. Every persistence call site consumed the gate with
+ * a bare `.then(...)`, so a rejected gate silently swallowed the save: the
+ * optimistic UI applied, canvas_action telemetry fired, and NOTHING persisted
+ * — no POST, and not even the canvas_commit_blocked event. That is exactly
+ * the field regression ("all of the drag to resize is broken").
+ *
+ * These tests force an internal registerRoot error (a circular $defs graph
+ * makes the JSON round-trip throw) and pin that the gate RESOLVES with the
+ * policy's skip verdict instead of rejecting.
+ */
+import {
+  validateRecordConfig,
+  validateRecordConfigSync,
+  clearValidationCache,
+} from './validateAgainstSchema';
+import { getObjectSchema } from '../../../schemas/projectSchema';
+
+jest.mock('../../../schemas/projectSchema', () => {
+  const actual = jest.requireActual('../../../schemas/projectSchema');
+  return {
+    ...actual,
+    getObjectSchema: jest.fn(actual.getObjectSchema),
+    preloadProjectSchema: jest.fn(() => Promise.resolve()),
+  };
+});
+
+// Silence the expected console.error from the hardened fail-open path.
+let consoleErrorSpy;
+beforeEach(() => {
+  clearValidationCache();
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  jest.clearAllMocks();
+});
+
+describe('gate-internal errors fail OPEN (never reject, never swallow a save)', () => {
+  test('a registerRoot crash resolves skipped-valid instead of rejecting', async () => {
+    // A circular $defs graph makes registerRoot's JSON.stringify round-trip
+    // throw — standing in for any internal registration/compile failure.
+    const circular = { Dashboard: { type: 'object' } };
+    circular.Dashboard.self = circular;
+    getObjectSchema.mockResolvedValueOnce({ $defs: circular });
+
+    // BEFORE the fix this REJECTED (TypeError: circular structure) — and the
+    // call sites' bare `.then` swallowed the save with zero telemetry.
+    await expect(
+      validateRecordConfig('dashboard', { name: 'd', rows: [] })
+    ).resolves.toMatchObject({ valid: true, skipped: true });
+  });
+
+  test('after a registerRoot crash the sync path stays fail-open too', async () => {
+    const circular = { Dashboard: { type: 'object' } };
+    circular.Dashboard.self = circular;
+    getObjectSchema.mockResolvedValueOnce({ $defs: circular });
+    await validateRecordConfig('dashboard', { name: 'd', rows: [] }).catch(() => {});
+
+    // Root never registered — the sync fast path must keep returning its
+    // "defer to fire time" null, not throw.
+    expect(() => validateRecordConfigSync('dashboard', { name: 'd', rows: [] })).not.toThrow();
+  });
+
+  test('a healthy schema still validates normally after the hardening', async () => {
+    const result = await validateRecordConfig('dashboard', {
+      name: 'd',
+      rows: [{ height: 487, items: [{ width: 7 }] }],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.skipped).toBeUndefined();
+  });
+});

--- a/viewer/src/components/views/workspace/validateAgainstSchema.js
+++ b/viewer/src/components/views/workspace/validateAgainstSchema.js
@@ -139,6 +139,25 @@ const runValidator = (validate, config) => {
 const SKIP = { valid: true, errors: [], skipped: true };
 
 /**
+ * Fail-open guard for gate-internal work (VIS-993 canvas-persist regression).
+ * The module's contract is that internal failures NEVER produce a rejection
+ * or a throw — a crashed gate must yield SKIP so persistence proceeds and the
+ * backend Pydantic validator stays authoritative. Before this guard, an error
+ * inside registerRoot/runValidator REJECTED the async gate promise; every
+ * call site consumed the gate with a bare `.then`, so the save was silently
+ * swallowed: the optimistic UI applied but nothing persisted and not even the
+ * blocked-telemetry fired (the "canvas resize doesn't save" field failure).
+ */
+const failOpen = (label, fn) => {
+  try {
+    return fn();
+  } catch (err) {
+    console.error(`validateAgainstSchema: ${label} failed — failing open`, err);
+    return SKIP;
+  }
+};
+
+/**
  * Authoritative (async) validation of a record config against its $defs slice.
  *
  * @param {string} type   canonical object type ('dimension', 'markdown', …)
@@ -154,10 +173,16 @@ export async function validateRecordConfig(type, config) {
   if (!validate) {
     if (!rootReady) {
       // getObjectSchema returns the $defs-attached slice (and caches it) —
-      // its $defs IS the full graph, which we register once.
+      // its $defs IS the full graph, which we register once. Registration
+      // errors FAIL OPEN (see failOpen): a rejection here used to silently
+      // swallow the caller's save.
       const slice = await getObjectSchema(type);
       if (!slice?.$defs) return SKIP;
-      registerRoot(slice.$defs);
+      const registered = failOpen('registerRoot', () => {
+        registerRoot(slice.$defs);
+        return true;
+      });
+      if (registered !== true) return SKIP;
     }
     try {
       validate = compileForDef(defName);
@@ -168,7 +193,7 @@ export async function validateRecordConfig(type, config) {
       return SKIP;
     }
   }
-  const structural = runValidator(validate, config);
+  const structural = failOpen('validate', () => runValidator(validate, config));
 
   // Insight props precision: the registered graph relaxes props to a plain
   // object (see registerRoot), so run the per-type Plotly validator here and
@@ -213,7 +238,7 @@ export function validateRecordConfigSync(type, config) {
       return SKIP;
     }
   }
-  return runValidator(validate, config);
+  return failOpen('validate', () => runValidator(validate, config));
 }
 
 /**
@@ -225,7 +250,12 @@ export async function preloadValidationSchema() {
   if (!rootReady) {
     // Any type resolves the root; 'dimension' is a stable mapping.
     const slice = await getObjectSchema('dimension');
-    if (slice?.$defs) registerRoot(slice.$defs);
+    if (slice?.$defs) {
+      failOpen('registerRoot (preload)', () => {
+        registerRoot(slice.$defs);
+        return true;
+      });
+    }
   }
 }
 

--- a/viewer/src/hooks/useRecordSave.gateFailOpen.test.js
+++ b/viewer/src/hooks/useRecordSave.gateFailOpen.test.js
@@ -1,0 +1,134 @@
+/**
+ * useRecordSave gate fail-open (VIS-993 canvas-persist regression).
+ *
+ * runSave awaited `validateRecordConfig` OUTSIDE its try/catch: a gate that
+ * REJECTED (any internal AJV/registration error) crashed the debounced persist
+ * — no saveX call, no 'invalid' status, an unhandled rejection, and the edit
+ * silently never persisted. Fail-open policy: a gate CRASH must persist (the
+ * backend Pydantic validator stays authoritative); only a real invalid VERDICT
+ * blocks.
+ */
+import { renderHook, act } from '@testing-library/react';
+
+import useRecordSave from './useRecordSave';
+import useStore from '../stores/store';
+import { validateRecordConfig } from '../components/views/workspace/validateAgainstSchema';
+import { checkRefTargets } from '../components/views/workspace/refPreflight';
+import { checkExpressions } from '../components/views/workspace/expressionPreflight';
+
+jest.mock('../components/views/workspace/validateAgainstSchema', () => ({
+  validateRecordConfig: jest.fn(),
+  validateRecordConfigSync: jest.fn(() => null),
+}));
+jest.mock('../components/views/workspace/refPreflight', () => ({
+  checkRefTargets: jest.fn(() => ({ valid: true, errors: [] })),
+}));
+jest.mock('../components/views/workspace/expressionPreflight', () => ({
+  checkExpressions: jest.fn(async () => ({ valid: true, errors: [] })),
+}));
+
+let consoleErrorSpy;
+beforeEach(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  // clearAllMocks (afterEach) clears calls but NOT implementations — reset the
+  // two helper layers to their valid defaults so a throw/reject set by one test
+  // cannot leak into the next.
+  checkRefTargets.mockImplementation(() => ({ valid: true, errors: [] }));
+  checkExpressions.mockImplementation(async () => ({ valid: true, errors: [] }));
+});
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  jest.clearAllMocks();
+});
+
+test('a REJECTING validation gate fails open: saveX still fires', async () => {
+  validateRecordConfig.mockRejectedValue(new Error('gate exploded'));
+  const saveFn = jest.fn(() => Promise.resolve({ success: true }));
+  useStore.setState({
+    markdowns: [{ name: 'notes', config: { name: 'notes', content: 'hi' } }],
+    saveMarkdown: saveFn,
+    saveActivityCount: 0,
+    lastSaveFailed: false,
+  });
+
+  const { result } = renderHook(() => useRecordSave('markdown', 'notes', { delay: 0 }));
+
+  await act(async () => {
+    await result.current.saveNow({ name: 'notes', content: 'edited' });
+  });
+
+  expect(saveFn).toHaveBeenCalledTimes(1);
+  expect(saveFn).toHaveBeenCalledWith('notes', expect.objectContaining({ content: 'edited' }));
+  expect(result.current.status).not.toBe('invalid');
+});
+
+test('a REJECTING expression layer fails open too (all 3 layers in one try/catch)', async () => {
+  // The expression pre-flight is fail-open internally, but a defensive guard:
+  // if it ever rejects (e.g. a future refactor throws before its own catch),
+  // the persist must still fire — it must not escape runSave uncaught and
+  // silently swallow the save, which is the exact canvas-persist bug shape.
+  validateRecordConfig.mockResolvedValue({ valid: true, errors: [] });
+  checkExpressions.mockRejectedValue(new Error('expression endpoint exploded'));
+  const saveFn = jest.fn(() => Promise.resolve({ success: true }));
+  useStore.setState({
+    metrics: [{ name: 'm', config: { name: 'm', expression: 'SUM(x)' } }],
+    saveMetric: saveFn,
+    saveActivityCount: 0,
+    lastSaveFailed: false,
+  });
+
+  const { result } = renderHook(() => useRecordSave('metric', 'm', { delay: 0 }));
+
+  await act(async () => {
+    await result.current.saveNow({ name: 'm', expression: 'SUM(y)' });
+  });
+
+  expect(saveFn).toHaveBeenCalledTimes(1);
+  expect(result.current.status).not.toBe('invalid');
+});
+
+test('a THROWING ref layer fails open too', async () => {
+  validateRecordConfig.mockResolvedValue({ valid: true, errors: [] });
+  checkRefTargets.mockImplementation(() => {
+    throw new Error('ref walk exploded');
+  });
+  const saveFn = jest.fn(() => Promise.resolve({ success: true }));
+  useStore.setState({
+    markdowns: [{ name: 'notes', config: { name: 'notes', content: 'hi' } }],
+    saveMarkdown: saveFn,
+    saveActivityCount: 0,
+    lastSaveFailed: false,
+  });
+
+  const { result } = renderHook(() => useRecordSave('markdown', 'notes', { delay: 0 }));
+
+  await act(async () => {
+    await result.current.saveNow({ name: 'notes', content: 'edited' });
+  });
+
+  expect(saveFn).toHaveBeenCalledTimes(1);
+  expect(result.current.status).not.toBe('invalid');
+});
+
+test('a real INVALID verdict still blocks (the gate is not weakened)', async () => {
+  validateRecordConfig.mockResolvedValue({
+    valid: false,
+    errors: [{ path: 'align', message: 'must be equal to one of the allowed values', keyword: 'enum' }],
+  });
+  const saveFn = jest.fn(() => Promise.resolve({ success: true }));
+  useStore.setState({
+    markdowns: [{ name: 'notes', config: { name: 'notes', content: 'hi' } }],
+    saveMarkdown: saveFn,
+    saveActivityCount: 0,
+    lastSaveFailed: false,
+  });
+
+  const { result } = renderHook(() => useRecordSave('markdown', 'notes', { delay: 0 }));
+
+  await act(async () => {
+    await result.current.saveNow({ name: 'notes', content: 'hi', align: 'diagonal' });
+  });
+
+  expect(saveFn).not.toHaveBeenCalled();
+  expect(result.current.status).toBe('invalid');
+});

--- a/viewer/src/hooks/useRecordSave.js
+++ b/viewer/src/hooks/useRecordSave.js
@@ -151,16 +151,30 @@ export default function useRecordSave(type, name, opts = {}) {
     // save-activity tick: a blocked edit is not a save in flight. Three
     // layers, cheapest first: $defs schema → dangling refs → SQL parse of
     // expression fields (backend sqlglot; async-only, fail-open off-server).
-    const validation = await validateRecordConfig(t, config);
-    let blocked = !validation.valid
-      ? validation
-      : (() => {
-          const refCheck = checkRefTargets(config, useStore.getState());
-          return refCheck.valid ? null : refCheck;
-        })();
-    if (!blocked) {
-      const exprCheck = await checkExpressions(t, config);
-      if (!exprCheck.valid) blocked = exprCheck;
+    // FAIL-OPEN on a gate CRASH (canvas-persist regression): an internal gate
+    // error must never swallow the persist — only a real invalid VERDICT
+    // blocks; the backend Pydantic validator stays authoritative either way.
+    // ALL THREE layers run inside ONE try/catch — a throw from ANY of them
+    // (validateRecordConfig's AJV, a malformed config walked by checkRefTargets,
+    // or checkExpressions' network layer) must fail open, not escape runSave and
+    // silently swallow the persist. Each layer only runs while `blocked` is
+    // still null, so the catch can only ever fire pre-verdict: a real invalid
+    // VERDICT is never erased by a later-layer crash.
+    let blocked = null;
+    try {
+      const validation = await validateRecordConfig(t, config);
+      if (!validation.valid) blocked = validation;
+      if (!blocked) {
+        const refCheck = checkRefTargets(config, useStore.getState());
+        if (!refCheck.valid) blocked = refCheck;
+      }
+      if (!blocked) {
+        const exprCheck = await checkExpressions(t, config);
+        if (!exprCheck.valid) blocked = exprCheck;
+      }
+    } catch (err) {
+      console.error('useRecordSave: validation gate crashed — failing open', err);
+      blocked = null;
     }
     if (blocked) {
       if (mountedRef.current) {


### PR DESCRIPTION
## The user's report

"All of the drag to resize is broken in dashboard canvas editing." Row-height resize, item-width resize, reorder, cross-row moves — none persisted.

## Root cause (two coupled defects, proven — not guessed)

**The validation gate was innocent.** Every real config (all 6 sandbox dashboards, pre- and post-resize) validates clean through both an exact AJV replica and the backend `/validate/` endpoint. `Row.height anyOf[HeightEnum,int]` and `Item.width int` match backend truth; the resize writers already clamp to integers.

1. **Silent gate death** — `registerRoot` + validator execution ran *outside* any try/catch, and all three call sites consumed the gate with a bare `.then`/un-guarded `await`. Any internal gate error → rejected promise → the optimistic UI applied but **no POST fired and not even `canvas_commit_blocked`**. PostHog forensics of the user's failing session: **8 resize gestures = 8 `canvas_action`, 0 save POSTs, 0 block events**, draft cache pristine — exactly this shape.
2. **Deselect-after-resize** — resize handles carried `data-resize-axis` but no `data-canvas-path`, so the drag's terminal click fell through to the chrome branch and collapsed the selection after *every* gesture (handles vanished, forcing re-selection).

## Fix
- **Fail-open, everywhere**: `validateAgainstSchema` (registerRoot + runValidator) and `useRecordSave` now treat a gate *crash* as fail-open (SKIP) — a gate error must never swallow the persist; only a real invalid **verdict** blocks. In `useRecordSave`, **all three layers** (schema → refs → sqlglot expressions) run inside one try/catch, so a throw from any layer fails open. (Merged with the expression-parse gate from #511.)
- **Defense in depth**: `expressionPreflight` hardened so a malformed 200 body (results absent/object/string/nullish entries) fails open instead of throwing out of the pre-flight.
- **Selection**: `CanvasSelectionOverlay` ignores clicks on `[data-resize-axis]` — a resize no longer deselects; genuine chrome clicks still do.
- **One shared gate runner** in `itemMutations` used by both `commitCanvasConfig` and the rail's `persistConfig`.

## The blind spot that let this regress
Every e2e assertion for canvas editing now goes through the **backend** (`/api/dashboards/` after a full reload), not the in-memory store — the reason the original regression slipped past.

## Test strategy
- **Unit**: fail-open tests for all three gate layers (schema throw, ref throw, expression reject) + malformed-body cases; `CanvasSelectionOverlay` handle-click tests.
- **Integration**: 18 `WorkspaceDndContext` regression tests — resize/reorder/cross-row/drop persist **byte-identical** through the real mounted provider + real validators.
- **E2E (live sandbox)**: `canvas-editing.spec.mjs` — row-height, item-width, in-row reorder, cross-row move, Library drop, each **retained through a full page reload**; zero console errors/400s.
- Full viewer suite (5,000+) green, eslint `--max-warnings=0` clean. **Verified 11/11 e2e live** (6 canvas + 5 validation-as-save).

## Review
The merge resolution of the fail-open guard against #511's expression layer was adversarially reviewed by 3 independent lenses; it flagged the all-three-layer gap and the malformed-body path — both fixed here with regression tests.

Refs VIS-993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)