### PR TITLE
Explore 2.0 Phase 1: Exploration entity (Pydantic model, Flask CRUD, store slice)

### DIFF
--- a/tests/factories/model_factories.py
+++ b/tests/factories/model_factories.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 
 import factory
 from visivo.models.alert import Alert
@@ -30,6 +31,14 @@ from visivo.models.inputs.types.single_select import SingleSelectInput
 from visivo.models.inputs.types.multi_select import MultiSelectInput
 from visivo.models.inputs.types.display import RangeConfig
 from visivo.models.base.query_string import QueryString
+from visivo.models.exploration import (
+    Exploration,
+    ExplorationDraft,
+    ExplorationQueryDraft,
+    PromotionRecord,
+    ReturnToRef,
+    SeedRef,
+)
 
 
 class SingleSelectInputFactory(factory.Factory):
@@ -393,3 +402,61 @@ class ProjectFactory(factory.Factory):
                 [factory.SubFactory(DashboardFactory, table_item=True) for _ in range(1)]
             ),
         )
+
+
+class ExplorationQueryDraftFactory(factory.Factory):
+    class Meta:
+        model = ExplorationQueryDraft
+
+    name = "orders_q"
+    sql = "SELECT * FROM orders"
+    source = "warehouse"
+
+
+class ExplorationDraftFactory(factory.Factory):
+    class Meta:
+        model = ExplorationDraft
+
+    queries = factory.List([factory.SubFactory(ExplorationQueryDraftFactory)])
+    insights = factory.List([])
+    chart = None
+    computed_columns = factory.List([])
+
+
+class SeedRefFactory(factory.Factory):
+    class Meta:
+        model = SeedRef
+
+    type = "model"
+    name = "orders"
+
+
+class ReturnToRefFactory(factory.Factory):
+    class Meta:
+        model = ReturnToRef
+
+    dashboard = "kpis"
+    slot = "r2-i1"
+
+
+class PromotionRecordFactory(factory.Factory):
+    class Meta:
+        model = PromotionRecord
+
+    type = "metric"
+    name = "churn_rate"
+    promoted_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+
+
+class ExplorationFactory(factory.Factory):
+    class Meta:
+        model = Exploration
+
+    id = factory.Sequence(lambda n: f"exp_test{n:04x}")
+    name = "Scratch"
+    created_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+    updated_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+    seeded_from = None
+    return_to = None
+    draft = factory.SubFactory(ExplorationDraftFactory)
+    promoted = factory.List([])

--- a/tests/models/test_exploration.py
+++ b/tests/models/test_exploration.py
@@ -1,0 +1,128 @@
+"""Tests for the Exploration Pydantic model (Explore 2.0 Phase 1, S3 contract).
+
+Also asserts the model is NOT reachable from ``visivo.models.project`` — the
+guarantee that ``generate_project_schema_json`` is a no-op for this file (the
+actual regen + git-diff assertion is a manual protocol step; see the PR body).
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from visivo.models.exploration import (
+    Exploration,
+    ExplorationDraft,
+    ExplorationQueryDraft,
+    PromotionRecord,
+    ReturnToRef,
+    SeedRef,
+)
+from tests.factories.model_factories import (
+    ExplorationDraftFactory,
+    ExplorationFactory,
+    ExplorationQueryDraftFactory,
+    PromotionRecordFactory,
+    ReturnToRefFactory,
+    SeedRefFactory,
+)
+
+
+class TestExplorationNotInProjectDag:
+    def test_project_module_does_not_import_exploration(self):
+        import visivo.models.project as project_module
+
+        assert "exploration" not in project_module.__dict__.get("__name__", "").lower()
+        # The Exploration symbol must not be reachable off the Project module —
+        # if it were, it would show up in the generated project schema.
+        assert not hasattr(project_module, "Exploration")
+
+    def test_exploration_module_not_in_project_schema_defs(self):
+        from visivo.parsers.schema_generator import generate_schema
+
+        schema = json.loads(generate_schema())
+        defs = schema.get("$defs", {})
+        assert "Exploration" not in defs
+        assert "ExplorationDraft" not in defs
+
+
+class TestExplorationDefaults:
+    def test_draft_defaults_are_empty(self):
+        draft = ExplorationDraft()
+        assert draft.queries == []
+        assert draft.insights == []
+        assert draft.chart is None
+        assert draft.computed_columns == []
+
+    def test_exploration_draft_defaults_when_omitted(self):
+        # draft is required-with-default: omitting it entirely (not passed at
+        # all) falls back to an empty ExplorationDraft via default_factory.
+        exploration = ExplorationFactory()
+        naked = Exploration(
+            id="exp_1",
+            name="Scratch",
+            created_at=exploration.created_at,
+            updated_at=exploration.updated_at,
+        )
+        assert naked.draft == ExplorationDraft()
+
+
+class TestExplorationSerialization:
+    def test_timestamps_serialize_with_z_suffix(self):
+        exploration = ExplorationFactory()
+        dumped = exploration.model_dump(mode="json")
+        assert dumped["created_at"].endswith("Z")
+        assert dumped["updated_at"].endswith("Z")
+        assert "+00:00" not in dumped["created_at"]
+
+    def test_promotion_record_timestamp_serializes_with_z_suffix(self):
+        record = PromotionRecordFactory()
+        dumped = record.model_dump(mode="json")
+        assert dumped["promoted_at"].endswith("Z")
+
+    def test_round_trip_via_model_validate(self):
+        exploration = ExplorationFactory(
+            seeded_from=SeedRefFactory(),
+            return_to=ReturnToRefFactory(),
+            promoted=[PromotionRecordFactory()],
+        )
+        payload = json.loads(exploration.model_dump_json())
+        restored = Exploration.model_validate(payload)
+        assert restored == exploration
+
+
+class TestExplorationDraftLooseValidation:
+    """draft.* inner objects (insights/chart/computed_columns) are
+    deliberately loosely validated at rest — a draft may be semantically
+    invalid pre-promote."""
+
+    def test_insights_accepts_arbitrary_shaped_dicts(self):
+        draft = ExplorationDraft(insights=[{"anything": "goes", "nested": {"a": 1}}])
+        assert draft.insights == [{"anything": "goes", "nested": {"a": 1}}]
+
+    def test_chart_accepts_arbitrary_shaped_dict(self):
+        draft = ExplorationDraft(chart={"not": "a real chart config"})
+        assert draft.chart == {"not": "a real chart config"}
+
+    def test_computed_columns_accepts_arbitrary_shaped_dicts(self):
+        draft = ExplorationDraft(computed_columns=[{"expression": "?{ 1 + 1 }"}])
+        assert draft.computed_columns == [{"expression": "?{ 1 + 1 }"}]
+
+    def test_query_draft_requires_name_and_sql(self):
+        with pytest.raises(ValidationError):
+            ExplorationQueryDraft(name="q")  # missing sql
+
+    def test_query_draft_source_is_optional(self):
+        query = ExplorationQueryDraftFactory(source=None)
+        assert query.source is None
+
+
+class TestSeedRefAndReturnTo:
+    def test_seed_ref_shape(self):
+        seed = SeedRefFactory()
+        assert seed.type == "model"
+        assert seed.name == "orders"
+
+    def test_return_to_slot_optional(self):
+        return_to = ReturnToRef(dashboard="kpis")
+        assert return_to.slot is None

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -27,7 +27,11 @@ def integration_app(output_dir):
 
     create_file_database(url=source.url(), output_dir=abs_output_dir)
 
-    app = FlaskApp(abs_output_dir, project)
+    # Explicit working_dir (isolated tmp dir, not the real cwd) so anything
+    # that writes project-root workbench state — e.g. ExplorationRepository's
+    # `.visivo/explorations/` — stays inside the test's temp folder instead of
+    # leaking files into the actual repo working tree.
+    app = FlaskApp(abs_output_dir, project, working_dir=abs_output_dir)
     app.app.config["TESTING"] = True
     return app
 

--- a/tests/server/repositories/test_exploration_repository.py
+++ b/tests/server/repositories/test_exploration_repository.py
@@ -1,0 +1,294 @@
+"""Tests for ExplorationRepository — the file-backed JSON-document store
+under `.visivo/explorations/` (Explore 2.0 Phase 1).
+
+Structural precedent: the removed 2.0-era ``test_exploration_repository.py``
+(commits ``00a83329``/``e172d91b``), adapted from a SQLite-backed repo to a
+JSON-document one (02-architecture.md §2).
+"""
+
+import json
+import os
+
+import pytest
+
+from visivo.models.exploration import Exploration
+from visivo.server.repositories.exploration_repository import ExplorationRepository
+from tests.factories.model_factories import (
+    ExplorationDraftFactory,
+    SeedRefFactory,
+    ReturnToRefFactory,
+)
+
+
+@pytest.fixture
+def explorations_dir(tmp_path):
+    return str(tmp_path / ".visivo" / "explorations")
+
+
+@pytest.fixture
+def repo(explorations_dir):
+    return ExplorationRepository(explorations_dir)
+
+
+class TestMkdirOnFirstUse:
+    def test_directory_not_created_on_construction(self, explorations_dir):
+        ExplorationRepository(explorations_dir)
+        assert not os.path.exists(explorations_dir)
+
+    def test_directory_created_on_first_create(self, repo, explorations_dir):
+        assert not os.path.exists(explorations_dir)
+        repo.create()
+        assert os.path.isdir(explorations_dir)
+
+
+class TestCreate:
+    def test_create_mints_url_safe_id(self, repo):
+        exploration = repo.create()
+        assert exploration.id.startswith("exp_")
+        assert exploration.id.replace("exp_", "").isalnum()
+
+    def test_create_ids_are_unique(self, repo):
+        ids = {repo.create().id for _ in range(10)}
+        assert len(ids) == 10
+
+    def test_create_writes_one_json_file_per_exploration(self, repo, explorations_dir):
+        exploration = repo.create(name="My Exploration")
+        path = os.path.join(explorations_dir, f"{exploration.id}.json")
+        assert os.path.exists(path)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["name"] == "My Exploration"
+
+    def test_create_defaults_draft_to_empty(self, repo):
+        exploration = repo.create()
+        assert exploration.draft.queries == []
+        assert exploration.draft.insights == []
+        assert exploration.draft.chart is None
+
+    def test_create_accepts_seeded_from_and_return_to(self, repo):
+        exploration = repo.create(
+            seeded_from={"type": "model", "name": "orders"},
+            return_to={"dashboard": "kpis", "slot": "r2-i1"},
+        )
+        assert exploration.seeded_from.type == "model"
+        assert exploration.seeded_from.name == "orders"
+        assert exploration.return_to.dashboard == "kpis"
+        assert exploration.return_to.slot == "r2-i1"
+
+    def test_create_accepts_draft_dict(self, repo):
+        draft_dict = json.loads(ExplorationDraftFactory().model_dump_json())
+        exploration = repo.create(draft=draft_dict)
+        assert exploration.draft.queries[0].name == "orders_q"
+
+    def test_create_sets_created_and_updated_at_equal(self, repo):
+        exploration = repo.create()
+        assert exploration.created_at == exploration.updated_at
+
+    def test_create_starts_with_no_promotions(self, repo):
+        exploration = repo.create()
+        assert exploration.promoted == []
+
+
+class TestDefaultNaming:
+    def test_first_exploration_defaults_to_scratch(self, repo):
+        exploration = repo.create()
+        assert exploration.name == "Scratch"
+
+    def test_second_exploration_defaults_to_exploration_2(self, repo):
+        repo.create()
+        second = repo.create()
+        assert second.name == "Exploration 2"
+
+    def test_third_exploration_defaults_to_exploration_3(self, repo):
+        repo.create()
+        repo.create()
+        third = repo.create()
+        assert third.name == "Exploration 3"
+
+    def test_custom_name_is_not_overridden(self, repo):
+        exploration = repo.create(name="Churn dig")
+        assert exploration.name == "Churn dig"
+
+    def test_default_naming_counts_all_explorations_incl_custom_named(self, repo):
+        repo.create(name="Churn dig")
+        second = repo.create()
+        assert second.name == "Exploration 2"
+
+
+class TestGet:
+    def test_get_returns_created_exploration(self, repo):
+        created = repo.create(name="Get me")
+        fetched = repo.get(created.id)
+        assert fetched == created
+
+    def test_get_unknown_id_returns_none(self, repo):
+        assert repo.get("exp_doesnotexist") is None
+
+
+class TestList:
+    def test_list_empty_repo_returns_empty_list(self, repo):
+        assert repo.list() == []
+
+    def test_list_orders_by_updated_at_desc(self, repo):
+        first = repo.create(name="First")
+        second = repo.create(name="Second")
+        # Touch `first` so it becomes the most recently updated.
+        repo.update(first.id, {"name": "First (touched)"})
+
+        listed = repo.list()
+        assert [e.id for e in listed] == [first.id, second.id]
+
+    def test_list_reflects_current_state_not_stale_cache(self, repo):
+        repo.create(name="A")
+        repo.create(name="B")
+        assert len(repo.list()) == 2
+
+
+class TestUpdate:
+    def test_update_replaces_name(self, repo):
+        created = repo.create(name="Old")
+        updated = repo.update(created.id, {"name": "New"})
+        assert updated.name == "New"
+
+    def test_update_replaces_draft_wholesale(self, repo):
+        created = repo.create()
+        new_draft = json.loads(ExplorationDraftFactory().model_dump_json())
+        updated = repo.update(created.id, {"draft": new_draft})
+        assert updated.draft.queries[0].name == "orders_q"
+
+    def test_update_sets_return_to(self, repo):
+        created = repo.create()
+        updated = repo.update(created.id, {"return_to": {"dashboard": "kpis", "slot": "r1-i1"}})
+        assert updated.return_to.dashboard == "kpis"
+
+    def test_update_can_clear_return_to_with_explicit_null(self, repo):
+        created = repo.create(return_to={"dashboard": "kpis"})
+        updated = repo.update(created.id, {"return_to": None})
+        assert updated.return_to is None
+
+    def test_update_omitting_a_mutable_field_leaves_it_unchanged(self, repo):
+        created = repo.create(name="Keep me", return_to={"dashboard": "kpis"})
+        updated = repo.update(created.id, {"name": "Renamed"})
+        assert updated.name == "Renamed"
+        assert updated.return_to.dashboard == "kpis"
+
+    def test_update_bumps_updated_at(self, repo):
+        created = repo.create()
+        updated = repo.update(created.id, {"name": "Bump"})
+        assert updated.updated_at >= created.updated_at
+
+    def test_update_unknown_id_returns_none(self, repo):
+        assert repo.update("exp_nope", {"name": "x"}) is None
+
+    def test_update_persists_to_disk(self, repo, explorations_dir):
+        created = repo.create(name="Old")
+        repo.update(created.id, {"name": "Persisted"})
+        path = os.path.join(explorations_dir, f"{created.id}.json")
+        with open(path) as f:
+            assert json.load(f)["name"] == "Persisted"
+
+
+class TestImmutability:
+    """id/created_at/seeded_from/promoted are immutable via the update route —
+    a patch containing any of them is silently ignored, not applied."""
+
+    def test_update_ignores_id_in_patch(self, repo):
+        created = repo.create()
+        updated = repo.update(created.id, {"id": "exp_hijacked", "name": "x"})
+        assert updated.id == created.id
+
+    def test_update_ignores_created_at_in_patch(self, repo):
+        created = repo.create()
+        updated = repo.update(created.id, {"created_at": "2000-01-01T00:00:00Z", "name": "x"})
+        assert updated.created_at == created.created_at
+
+    def test_update_ignores_seeded_from_in_patch(self, repo):
+        created = repo.create(seeded_from={"type": "model", "name": "orders"})
+        updated = repo.update(
+            created.id, {"seeded_from": {"type": "model", "name": "hijacked"}, "name": "x"}
+        )
+        assert updated.seeded_from.name == "orders"
+
+    def test_update_ignores_promoted_in_patch(self, repo):
+        created = repo.create()
+        updated = repo.update(
+            created.id,
+            {
+                "promoted": [
+                    {"type": "metric", "name": "hijacked", "promoted_at": "2000-01-01T00:00:00Z"}
+                ],
+                "name": "x",
+            },
+        )
+        assert updated.promoted == []
+
+
+class TestDelete:
+    def test_delete_removes_the_record(self, repo):
+        created = repo.create()
+        assert repo.delete(created.id) is True
+        assert repo.get(created.id) is None
+
+    def test_delete_unknown_id_returns_false(self, repo):
+        assert repo.delete("exp_nope") is False
+
+    def test_delete_removes_file_from_disk(self, repo, explorations_dir):
+        created = repo.create()
+        path = os.path.join(explorations_dir, f"{created.id}.json")
+        assert os.path.exists(path)
+        repo.delete(created.id)
+        assert not os.path.exists(path)
+
+
+class TestConsumeReturnTo:
+    def test_consume_nulls_return_to(self, repo):
+        created = repo.create(return_to={"dashboard": "kpis", "slot": "r1-i1"})
+        consumed = repo.consume_return_to(created.id)
+        assert consumed.return_to is None
+
+    def test_consume_persists_the_null(self, repo):
+        created = repo.create(return_to={"dashboard": "kpis"})
+        repo.consume_return_to(created.id)
+        assert repo.get(created.id).return_to is None
+
+    def test_consume_is_idempotent_when_already_null(self, repo):
+        created = repo.create()
+        assert created.return_to is None
+        consumed = repo.consume_return_to(created.id)
+        assert consumed is not None
+        assert consumed.return_to is None
+
+    def test_consume_unknown_id_returns_none(self, repo):
+        assert repo.consume_return_to("exp_nope") is None
+
+    def test_consume_leaves_other_fields_untouched(self, repo):
+        created = repo.create(name="Keep", return_to={"dashboard": "kpis"})
+        consumed = repo.consume_return_to(created.id)
+        assert consumed.name == "Keep"
+
+
+class TestAtomicWrites:
+    def test_write_leaves_no_tmp_files_behind(self, repo, explorations_dir):
+        repo.create()
+        repo.create()
+        leftovers = [f for f in os.listdir(explorations_dir) if f.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_failed_write_does_not_corrupt_existing_file(self, repo, explorations_dir, monkeypatch):
+        created = repo.create(name="Safe")
+        path = os.path.join(explorations_dir, f"{created.id}.json")
+        with open(path) as f:
+            original_contents = f.read()
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError):
+            repo.update(created.id, {"name": "Corrupted"})
+
+        with open(path) as f:
+            assert f.read() == original_contents
+        # No leftover tmp file after the failed write.
+        leftovers = [f for f in os.listdir(explorations_dir) if f.endswith(".tmp")]
+        assert leftovers == []

--- a/tests/server/test_run_views.py
+++ b/tests/server/test_run_views.py
@@ -183,6 +183,60 @@ class TestRunOnSave:
         assert runs[0]["dag_filter"] == "+a+,+b+"
 
 
+class TestExplorationRunIsolation:
+    """Explorations are workbench drafts, never DAG/YAML config — saving or
+    deleting one must never schedule a run (02-architecture.md §2, 07 S3
+    contract). What actually protects them is being absent from
+    RESOURCE_META/_RESOURCE_ROUTE_RE (run_views.py's hooks gate on
+    `request.method in ("POST", "DELETE")` and then consult that table) — so
+    the regression test asserts the real invariant, not just "the endpoint
+    works": a PUT-based test would pass vacuously since PUT isn't even in the
+    hook's method filter.
+    """
+
+    def test_explorations_absent_from_resource_meta(self):
+        assert "explorations" not in RESOURCE_META
+
+    def test_exploration_routes_do_not_match_resource_route_regex(self):
+        for path in [
+            "/api/explorations/exp_abc123/",
+            "/api/explorations/exp_abc123/consume-return-to/",
+        ]:
+            assert _RESOURCE_ROUTE_RE.match(path) is None, path
+
+    def test_create_exploration_schedules_no_run(self, integration_client):
+        with patch("visivo.server.views.run_views.request_run") as req:
+            resp = integration_client.post("/api/explorations/", json={"name": "Scratch"})
+            assert resp.status_code == 201
+            req.assert_not_called()
+
+    def test_update_exploration_schedules_no_run(self, integration_client):
+        created = integration_client.post("/api/explorations/", json={}).get_json()
+        with patch("visivo.server.views.run_views.request_run") as req:
+            resp = integration_client.post(
+                f"/api/explorations/{created['id']}/",
+                json={"draft": {"queries": [{"name": "q", "sql": "SELECT 1"}]}},
+            )
+            assert resp.status_code == 200
+            req.assert_not_called()
+
+    def test_delete_exploration_schedules_no_run(self, integration_client):
+        created = integration_client.post("/api/explorations/", json={}).get_json()
+        with patch("visivo.server.views.run_views.request_run") as req:
+            resp = integration_client.delete(f"/api/explorations/{created['id']}/")
+            assert resp.status_code == 204
+            req.assert_not_called()
+
+    def test_consume_return_to_schedules_no_run(self, integration_client):
+        created = integration_client.post(
+            "/api/explorations/", json={"return_to": {"dashboard": "kpis"}}
+        ).get_json()
+        with patch("visivo.server.views.run_views.request_run") as req:
+            resp = integration_client.post(f"/api/explorations/{created['id']}/consume-return-to/")
+            assert resp.status_code == 200
+            req.assert_not_called()
+
+
 class TestDataAffectingGate:
     """A save only triggers a run when it changed the DATA — presentation-only
     edits (an insight type/color, whose query leaves are unchanged) just update

--- a/tests/server/views/test_exploration_views.py
+++ b/tests/server/views/test_exploration_views.py
@@ -1,0 +1,240 @@
+"""Flask test-client coverage for the Exploration CRUD endpoints (S3 contract).
+
+Uses a REAL ExplorationRepository backed by a tmp dir (not a mock) mounted
+behind a bare Flask app, per the "prefer factories/real objects over mocking"
+convention — the repository is cheap and deterministic, so mocking it would
+only hide real serialization/validation bugs.
+"""
+
+import pytest
+from flask import Flask
+
+from visivo.server.repositories.exploration_repository import ExplorationRepository
+from visivo.server.views.exploration_views import register_exploration_views
+
+
+@pytest.fixture
+def app(tmp_path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    flask_app = type("FlaskAppStub", (), {})()
+    flask_app.exploration_repo = ExplorationRepository(str(tmp_path / ".visivo" / "explorations"))
+
+    register_exploration_views(app, flask_app, str(tmp_path))
+    app.flask_app = flask_app
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestList:
+    def test_list_empty(self, client):
+        resp = client.get("/api/explorations/")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+    def test_list_returns_created_explorations(self, client):
+        client.post("/api/explorations/", json={"name": "A"})
+        client.post("/api/explorations/", json={"name": "B"})
+        resp = client.get("/api/explorations/")
+        assert resp.status_code == 200
+        names = {e["name"] for e in resp.get_json()}
+        assert names == {"A", "B"}
+
+    def test_list_ordered_by_updated_at_desc(self, client):
+        first = client.post("/api/explorations/", json={"name": "First"}).get_json()
+        client.post("/api/explorations/", json={"name": "Second"})
+        client.post(f"/api/explorations/{first['id']}/", json={"name": "First touched"})
+
+        resp = client.get("/api/explorations/")
+        data = resp.get_json()
+        assert data[0]["id"] == first["id"]
+
+
+class TestCreate:
+    def test_create_returns_201_with_minted_id(self, client):
+        resp = client.post("/api/explorations/", json={"name": "My Exploration"})
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["name"] == "My Exploration"
+        assert data["id"].startswith("exp_")
+
+    def test_create_no_body_defaults_name_to_scratch(self, client):
+        resp = client.post("/api/explorations/", content_type="application/json")
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "Scratch"
+
+    def test_create_empty_json_object_defaults_name(self, client):
+        resp = client.post("/api/explorations/", json={})
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "Scratch"
+
+    def test_create_second_defaults_to_exploration_2(self, client):
+        client.post("/api/explorations/", json={})
+        resp = client.post("/api/explorations/", json={})
+        assert resp.get_json()["name"] == "Exploration 2"
+
+    def test_create_with_seeded_from(self, client):
+        resp = client.post(
+            "/api/explorations/",
+            json={"seeded_from": {"type": "model", "name": "orders"}},
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["seeded_from"] == {"type": "model", "name": "orders"}
+
+    def test_create_with_draft(self, client):
+        resp = client.post(
+            "/api/explorations/",
+            json={
+                "draft": {
+                    "queries": [{"name": "q1", "sql": "SELECT 1", "source": "warehouse"}],
+                    "insights": [{"anything": "goes"}],
+                }
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["draft"]["queries"][0]["name"] == "q1"
+        assert data["draft"]["insights"] == [{"anything": "goes"}]
+
+    def test_create_non_object_body_is_malformed(self, client):
+        resp = client.post("/api/explorations/", data="[1, 2, 3]", content_type="application/json")
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_create_malformed_draft_shape_is_400(self, client):
+        resp = client.post("/api/explorations/", json={"draft": "not an object"})
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_create_query_missing_required_field_is_400(self, client):
+        resp = client.post(
+            "/api/explorations/",
+            json={"draft": {"queries": [{"name": "missing_sql"}]}},
+        )
+        assert resp.status_code == 400
+
+    def test_create_never_validates_insight_draft_content(self, client):
+        # Deliberately semantically-invalid insight config — must still 201.
+        resp = client.post(
+            "/api/explorations/",
+            json={"draft": {"insights": [{"type": "bar", "missing_everything_else": True}]}},
+        )
+        assert resp.status_code == 201
+
+
+class TestGetOne:
+    def test_get_existing(self, client):
+        created = client.post("/api/explorations/", json={"name": "Get me"}).get_json()
+        resp = client.get(f"/api/explorations/{created['id']}/")
+        assert resp.status_code == 200
+        assert resp.get_json()["id"] == created["id"]
+
+    def test_get_missing_is_404(self, client):
+        resp = client.get("/api/explorations/exp_missing/")
+        assert resp.status_code == 404
+        assert "error" in resp.get_json()
+
+
+class TestUpdate:
+    def test_update_name(self, client):
+        created = client.post("/api/explorations/", json={"name": "Old"}).get_json()
+        resp = client.post(f"/api/explorations/{created['id']}/", json={"name": "New"})
+        assert resp.status_code == 200
+        assert resp.get_json()["name"] == "New"
+
+    def test_update_draft(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        resp = client.post(
+            f"/api/explorations/{created['id']}/",
+            json={"draft": {"queries": [{"name": "q", "sql": "SELECT 2"}]}},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["draft"]["queries"][0]["sql"] == "SELECT 2"
+
+    def test_update_missing_is_404(self, client):
+        resp = client.post("/api/explorations/exp_missing/", json={"name": "x"})
+        assert resp.status_code == 404
+
+    def test_update_no_body_is_400(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        resp = client.post(f"/api/explorations/{created['id']}/", content_type="application/json")
+        assert resp.status_code == 400
+
+    def test_update_non_object_body_is_400(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        resp = client.post(
+            f"/api/explorations/{created['id']}/",
+            data='"just a string"',
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_update_ignores_immutable_fields(self, client):
+        created = client.post(
+            "/api/explorations/",
+            json={"seeded_from": {"type": "model", "name": "orders"}},
+        ).get_json()
+        resp = client.post(
+            f"/api/explorations/{created['id']}/",
+            json={
+                "id": "exp_hijacked",
+                "created_at": "2000-01-01T00:00:00Z",
+                "seeded_from": {"type": "model", "name": "hijacked"},
+                "promoted": [
+                    {"type": "metric", "name": "hijacked", "promoted_at": "2000-01-01T00:00:00Z"}
+                ],
+                "name": "Renamed",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["id"] == created["id"]
+        assert data["created_at"] == created["created_at"]
+        assert data["seeded_from"] == {"type": "model", "name": "orders"}
+        assert data["promoted"] == []
+        assert data["name"] == "Renamed"
+
+
+class TestDelete:
+    def test_delete_existing_returns_204(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        resp = client.delete(f"/api/explorations/{created['id']}/")
+        assert resp.status_code == 204
+        assert resp.get_data() == b""
+        assert client.get(f"/api/explorations/{created['id']}/").status_code == 404
+
+    def test_delete_missing_returns_404(self, client):
+        resp = client.delete("/api/explorations/exp_missing/")
+        assert resp.status_code == 404
+
+
+class TestConsumeReturnTo:
+    def test_consume_nulls_return_to(self, client):
+        created = client.post(
+            "/api/explorations/",
+            json={"return_to": {"dashboard": "kpis", "slot": "r1-i1"}},
+        ).get_json()
+        assert created["return_to"] == {"dashboard": "kpis", "slot": "r1-i1"}
+
+        resp = client.post(f"/api/explorations/{created['id']}/consume-return-to/")
+        assert resp.status_code == 200
+        assert resp.get_json()["return_to"] is None
+
+        # Survives being re-fetched — the null persisted, not just the response.
+        assert client.get(f"/api/explorations/{created['id']}/").get_json()["return_to"] is None
+
+    def test_consume_missing_is_404(self, client):
+        resp = client.post("/api/explorations/exp_missing/consume-return-to/")
+        assert resp.status_code == 404
+
+    def test_consume_idempotent(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        assert created["return_to"] is None
+        resp = client.post(f"/api/explorations/{created['id']}/consume-return-to/")
+        assert resp.status_code == 200
+        assert resp.get_json()["return_to"] is None

--- a/viewer/src/api/explorations.js
+++ b/viewer/src/api/explorations.js
@@ -1,0 +1,103 @@
+import { getUrl } from '../contexts/URLContext';
+import { apiFetch } from './utils';
+
+/**
+ * Exploration persistence (Explore 2.0, Phase 1) — S3 wire contract
+ * (specs/plan/explorer-workspace-unification/07-exploration-api-contract.md).
+ * This module is a thin, shape-agnostic wire client: it neither camelCases
+ * nor validates payloads — that translation lives in
+ * `stores/workspaceExplorationsStore.js`.
+ */
+
+const parseErrorOr = async (response, fallback) => {
+  const data = await response.json().catch(() => ({}));
+  return data.error || fallback;
+};
+
+/**
+ * List explorations, ordered by `updated_at` desc.
+ */
+export const fetchExplorations = async () => {
+  const response = await apiFetch(getUrl('explorationsList'));
+  if (response.status === 200) {
+    return await response.json();
+  }
+  throw new Error(await parseErrorOr(response, 'Failed to fetch explorations'));
+};
+
+/**
+ * Create an exploration. `payload` is optional and wire-shaped:
+ * `{ name?, seeded_from?, return_to?, draft? }` — the server mints `id` and
+ * defaults `name` ("Scratch", "Exploration N") when omitted.
+ */
+export const createExploration = async (payload = {}) => {
+  const response = await apiFetch(getUrl('explorationsList'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (response.status === 201) {
+    return await response.json();
+  }
+  throw new Error(await parseErrorOr(response, 'Failed to create exploration'));
+};
+
+/**
+ * Fetch a single exploration by id. Returns `null` on 404 (mirrors
+ * `fetchModel`'s convention) rather than throwing.
+ */
+export const fetchExploration = async id => {
+  const response = await apiFetch(getUrl('explorationDetail', { id }));
+  if (response.status === 200) {
+    return await response.json();
+  }
+  if (response.status === 404) {
+    return null;
+  }
+  throw new Error(await parseErrorOr(response, `Failed to fetch exploration: ${id}`));
+};
+
+/**
+ * Update an exploration (POST, not PUT — matches every sibling resource
+ * route). Full-document replace of the mutable fields present in `payload`
+ * (`name`/`draft`/`return_to`); `id`/`created_at`/`seeded_from`/`promoted`
+ * are immutable via this route regardless of what's included.
+ */
+export const updateExploration = async (id, payload) => {
+  const response = await apiFetch(getUrl('explorationDetail', { id }), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (response.status === 200) {
+    return await response.json();
+  }
+  throw new Error(await parseErrorOr(response, 'Failed to update exploration'));
+};
+
+/**
+ * Delete an exploration. Resolves `true` on success (204, no body).
+ */
+export const deleteExploration = async id => {
+  const response = await apiFetch(getUrl('explorationDetail', { id }), {
+    method: 'DELETE',
+  });
+  if (response.status === 204) {
+    return true;
+  }
+  throw new Error(await parseErrorOr(response, 'Failed to delete exploration'));
+};
+
+/**
+ * Atomically null `return_to` — the placement intent has been consumed.
+ * Idempotent: consuming an already-null `return_to` still resolves 200.
+ */
+export const consumeReturnTo = async id => {
+  const response = await apiFetch(getUrl('explorationConsumeReturnTo', { id }), {
+    method: 'POST',
+  });
+  if (response.status === 200) {
+    return await response.json();
+  }
+  throw new Error(await parseErrorOr(response, 'Failed to consume return_to'));
+};

--- a/viewer/src/api/explorations.test.js
+++ b/viewer/src/api/explorations.test.js
@@ -1,0 +1,161 @@
+/**
+ * Exploration API client (Explore 2.0 Phase 1 — S3 wire contract).
+ *
+ * A thin wire client: each helper resolves its endpoint via URLContext and
+ * either returns the parsed JSON on success or throws (surfacing the
+ * server's `error` message when parseable, a generic fallback otherwise).
+ */
+import {
+  fetchExplorations,
+  createExploration,
+  fetchExploration,
+  updateExploration,
+  deleteExploration,
+  consumeReturnTo,
+} from './explorations';
+import { apiFetch } from './utils';
+
+jest.mock('./utils', () => ({ apiFetch: jest.fn() }));
+jest.mock('../contexts/URLContext', () => ({
+  getUrl: (key, params = {}) =>
+    key === 'explorationsList'
+      ? '/api/explorations/'
+      : key === 'explorationDetail'
+        ? `/api/explorations/${params.id}/`
+        : key === 'explorationConsumeReturnTo'
+          ? `/api/explorations/${params.id}/consume-return-to/`
+          : `/api/${key}/`,
+}));
+
+const ok = (data, status = 200) => ({ status, json: async () => data });
+const fail = (status, data = {}) => ({ status, json: async () => data });
+const failUnparseable = status => ({
+  status,
+  json: async () => {
+    throw new Error('malformed body');
+  },
+});
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+describe('fetchExplorations', () => {
+  it('returns the list on 200', async () => {
+    apiFetch.mockResolvedValueOnce(ok([{ id: 'exp_1', name: 'Scratch' }]));
+    await expect(fetchExplorations()).resolves.toEqual([{ id: 'exp_1', name: 'Scratch' }]);
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/');
+  });
+
+  it('throws a stable message on non-200', async () => {
+    apiFetch.mockResolvedValueOnce(fail(500));
+    await expect(fetchExplorations()).rejects.toThrow('Failed to fetch explorations');
+  });
+});
+
+describe('createExploration', () => {
+  it('POSTs the payload and returns the created record on 201', async () => {
+    apiFetch.mockResolvedValueOnce(ok({ id: 'exp_new', name: 'Scratch' }, 201));
+    await expect(createExploration({ name: 'Scratch' })).resolves.toEqual({
+      id: 'exp_new',
+      name: 'Scratch',
+    });
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Scratch' }),
+    });
+  });
+
+  it('defaults to an empty payload when called with no arguments', async () => {
+    apiFetch.mockResolvedValueOnce(ok({ id: 'exp_new', name: 'Scratch' }, 201));
+    await createExploration();
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/explorations/',
+      expect.objectContaining({ body: '{}' })
+    );
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    apiFetch.mockResolvedValueOnce(fail(400, { error: 'malformed body' }));
+    await expect(createExploration({})).rejects.toThrow('malformed body');
+  });
+
+  it('falls back to a generic message when the failure body is unparseable', async () => {
+    apiFetch.mockResolvedValueOnce(failUnparseable(500));
+    await expect(createExploration({})).rejects.toThrow('Failed to create exploration');
+  });
+});
+
+describe('fetchExploration', () => {
+  it('returns the record on 200', async () => {
+    apiFetch.mockResolvedValueOnce(ok({ id: 'exp_1', name: 'Scratch' }));
+    await expect(fetchExploration('exp_1')).resolves.toEqual({ id: 'exp_1', name: 'Scratch' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/exp_1/');
+  });
+
+  it('returns null on 404 (not a throw)', async () => {
+    apiFetch.mockResolvedValueOnce(fail(404));
+    await expect(fetchExploration('exp_missing')).resolves.toBeNull();
+  });
+
+  it('throws on other failures', async () => {
+    apiFetch.mockResolvedValueOnce(fail(500));
+    await expect(fetchExploration('exp_1')).rejects.toThrow('Failed to fetch exploration: exp_1');
+  });
+});
+
+describe('updateExploration', () => {
+  it('POSTs (not PUTs) the patch and returns the updated record', async () => {
+    apiFetch.mockResolvedValueOnce(ok({ id: 'exp_1', name: 'Renamed' }));
+    await expect(updateExploration('exp_1', { name: 'Renamed' })).resolves.toEqual({
+      id: 'exp_1',
+      name: 'Renamed',
+    });
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/exp_1/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+  });
+
+  it('throws on 404', async () => {
+    apiFetch.mockResolvedValueOnce(fail(404, { error: 'Exploration not found' }));
+    await expect(updateExploration('exp_missing', { name: 'x' })).rejects.toThrow(
+      'Exploration not found'
+    );
+  });
+
+  it('falls back to a generic message when the failure body is unparseable', async () => {
+    apiFetch.mockResolvedValueOnce(failUnparseable(500));
+    await expect(updateExploration('exp_1', {})).rejects.toThrow('Failed to update exploration');
+  });
+});
+
+describe('deleteExploration', () => {
+  it('resolves true on 204', async () => {
+    apiFetch.mockResolvedValueOnce(ok(undefined, 204));
+    await expect(deleteExploration('exp_1')).resolves.toBe(true);
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/exp_1/', { method: 'DELETE' });
+  });
+
+  it('throws on 404', async () => {
+    apiFetch.mockResolvedValueOnce(fail(404, { error: 'Exploration not found' }));
+    await expect(deleteExploration('exp_missing')).rejects.toThrow('Exploration not found');
+  });
+});
+
+describe('consumeReturnTo', () => {
+  it('POSTs to the consume-return-to endpoint and returns the updated record', async () => {
+    apiFetch.mockResolvedValueOnce(ok({ id: 'exp_1', return_to: null }));
+    await expect(consumeReturnTo('exp_1')).resolves.toEqual({ id: 'exp_1', return_to: null });
+    expect(apiFetch).toHaveBeenCalledWith('/api/explorations/exp_1/consume-return-to/', {
+      method: 'POST',
+    });
+  });
+
+  it('throws on 404', async () => {
+    apiFetch.mockResolvedValueOnce(fail(404, { error: 'Exploration not found' }));
+    await expect(consumeReturnTo('exp_missing')).rejects.toThrow('Exploration not found');
+  });
+});

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -140,6 +140,7 @@ const URL_PATTERNS = {
     // Exploration persistence endpoints
     explorationsList: '/api/explorations/',
     explorationDetail: '/api/explorations/{id}/',
+    explorationConsumeReturnTo: '/api/explorations/{id}/consume-return-to/',
 
     // Workspace telemetry forwarding endpoint (VIS-822) — the local Flask
     // server relays workspace events through the CLI's PostHog client so the
@@ -277,6 +278,7 @@ const URL_PATTERNS = {
     // Exploration persistence endpoints (not available in dist)
     explorationsList: null,
     explorationDetail: null,
+    explorationConsumeReturnTo: null,
 
     // Workspace telemetry forwarding (not available in dist — no Flask server)
     workspaceTelemetry: null,

--- a/viewer/src/stores/store.js
+++ b/viewer/src/stores/store.js
@@ -26,6 +26,7 @@ import createLocalMergeModelSlice from './localMergeModelStore';
 import createExplorerSlice from './explorerStore';
 import createModelJobsSlice from './modelJobsStore';
 import createWorkspaceSlice from './workspaceStore';
+import createWorkspaceExplorationsSlice from './workspaceExplorationsStore';
 import createWorkspaceErdLayoutSlice from './workspaceErdLayoutStore';
 import createLibraryPrefsSlice from './libraryPrefsStore';
 
@@ -58,6 +59,7 @@ const useStore = create(
     ...createExplorerSlice(...a),
     ...createModelJobsSlice(...a),
     ...createWorkspaceSlice(...a),
+    ...createWorkspaceExplorationsSlice(...a),
     // Session-only ERD layout (dragged node positions + pill waypoints), kept
     // OUTSIDE persist() — ephemeral view state, not config.
     ...createWorkspaceErdLayoutSlice(...a),

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -1,0 +1,252 @@
+/**
+ * Workspace Explorations Store Slice (Explore 2.0 Phase 1 — backend + slice,
+ * no visible UI yet; see specs/plan/explorer-workspace-unification/).
+ *
+ * Keyed collection of Exploration records, synced against the Flask/Django
+ * `/api/explorations/` S3 contract
+ * (specs/plan/explorer-workspace-unification/07-exploration-api-contract.md):
+ *
+ *   workspaceExplorations: {
+ *     byId: { 'exp_a1': { id, name, createdAt, updatedAt, seededFrom, returnTo,
+ *                          promoted[], draft: { queries[], insights[], chart,
+ *                          computedColumns[] }, syncStatus, staleness } },
+ *     order: [...],   // Home listing order (recency) — server list order.
+ *   }
+ *
+ * Draft edits touch ONLY this slice — never the shared per-type collections —
+ * so exploratory typing can never clobber project state or fire a run (the
+ * Flask routes are deliberately excluded from run_views.RESOURCE_META).
+ *
+ * DEBOUNCED SYNC: `updateExplorationDraft` writes the new draft into the
+ * slice immediately (optimistic), then debounces (~1s) the persist. The
+ * debounce timer is bookkept in a module-level Map (`_pendingSyncTimers`) —
+ * not reactive state — because Zustand state is global while the "is a save
+ * armed for this record" fact is really per-record, ephemeral, non-serializable
+ * bookkeeping (mirrors `save_run_executor.py`'s module-level pending-timer
+ * globals on the backend).
+ *
+ * FLUSH-ON-UNMOUNT: `flushExplorationSync(id)` is the primitive a future
+ * exploration-editing component calls from its unmount cleanup — mirroring
+ * `useRecordSave.js:245-256` / `useDebouncedSave.js:81-99`'s "flush a still-
+ * armed debounced save on unmount rather than dropping the edit" convention.
+ * It only fires a network request when a timer was actually armed (a clean
+ * record unmounting is a no-op), and is safe to call without awaiting.
+ *
+ * PROMOTION IS OUT OF SCOPE for Phase 1 (arrives in Phase 4, 03-delivery-
+ * plan.md) — there is no `promoteExploration` here.
+ */
+
+import * as explorationsApi from '../api/explorations';
+
+const SYNC_DEBOUNCE_MS = 1000;
+
+// Exploration id -> setTimeout handle for an armed-but-not-yet-fired debounced
+// sync. Deliberately module-level (outside the Zustand store) — see the
+// FLUSH-ON-UNMOUNT note above. Exported so tests can assert/flush/reset it.
+export const _pendingSyncTimers = new Map();
+
+/** Test-only: clear all armed timers so state doesn't leak across test files. */
+export const _resetExplorationSyncTimersForTests = () => {
+  _pendingSyncTimers.forEach(timer => clearTimeout(timer));
+  _pendingSyncTimers.clear();
+};
+
+const clearPendingSyncTimer = id => {
+  const timer = _pendingSyncTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    _pendingSyncTimers.delete(id);
+  }
+};
+
+const mapDraftFromApi = draft => ({
+  queries: draft?.queries || [],
+  insights: draft?.insights || [],
+  chart: draft?.chart ?? null,
+  computedColumns: draft?.computed_columns || [],
+});
+
+const mapDraftToApi = draft => ({
+  queries: draft?.queries || [],
+  insights: draft?.insights || [],
+  chart: draft?.chart ?? null,
+  computed_columns: draft?.computedColumns || [],
+});
+
+const mapExplorationFromApi = record => ({
+  id: record.id,
+  name: record.name,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+  seededFrom: record.seeded_from ?? null,
+  returnTo: record.return_to ?? null,
+  draft: mapDraftFromApi(record.draft),
+  promoted: record.promoted || [],
+  // Just fetched/created/persisted — the store mirrors the server exactly.
+  syncStatus: 'synced',
+  // Staleness detection (re-run-to-refresh banner) is Phase 5 scope; the field
+  // is reserved on the record now so later phases don't need a shape migration.
+  staleness: null,
+});
+
+const insertExploration = (state, mapped) => ({
+  workspaceExplorations: {
+    byId: { ...state.workspaceExplorations.byId, [mapped.id]: mapped },
+    // Newest-first, matching the server's `updated_at desc` list order.
+    order: [mapped.id, ...state.workspaceExplorations.order.filter(id => id !== mapped.id)],
+  },
+});
+
+const patchExploration = (state, id, patch) => {
+  const existing = state.workspaceExplorations.byId[id];
+  if (!existing) return state;
+  return {
+    workspaceExplorations: {
+      ...state.workspaceExplorations,
+      byId: {
+        ...state.workspaceExplorations.byId,
+        [id]: { ...existing, ...patch },
+      },
+    },
+  };
+};
+
+const createWorkspaceExplorationsSlice = (set, get) => {
+  /** Fire the debounced POST for `id`'s CURRENT draft (read at fire time —
+   * not a captured closure — so a save always persists the latest edit). */
+  const runSync = async id => {
+    clearPendingSyncTimer(id);
+    const record = get().workspaceExplorations.byId[id];
+    if (!record) return { success: false };
+    set(state => patchExploration(state, id, { syncStatus: 'saving' }));
+    try {
+      // `record` was read at the top of runSync (fire time), which — thanks to
+      // scheduleSync always clearing/re-arming a single timer per id — already
+      // reflects the LATEST optimistic draft, not a stale scheduling-time one.
+      const updated = await explorationsApi.updateExploration(id, {
+        draft: mapDraftToApi(record.draft),
+      });
+      set(state =>
+        patchExploration(state, id, {
+          draft: mapDraftFromApi(updated.draft),
+          updatedAt: updated.updated_at,
+          syncStatus: 'synced',
+        })
+      );
+      return { success: true };
+    } catch (error) {
+      set(state => patchExploration(state, id, { syncStatus: 'error' }));
+      return { success: false, error: error.message };
+    }
+  };
+
+  const scheduleSync = id => {
+    clearPendingSyncTimer(id);
+    const timer = setTimeout(() => {
+      _pendingSyncTimers.delete(id);
+      runSync(id);
+    }, SYNC_DEBOUNCE_MS);
+    _pendingSyncTimers.set(id, timer);
+  };
+
+  return {
+    workspaceExplorations: {
+      byId: {},
+      order: [],
+    },
+
+    /** Hydrate the slice from `GET /api/explorations/` (reload rehydrates
+     * from the backend — localStorage is not a source of truth). */
+    fetchExplorations: async () => {
+      try {
+        const list = await explorationsApi.fetchExplorations();
+        const byId = {};
+        const order = [];
+        list.forEach(record => {
+          const mapped = mapExplorationFromApi(record);
+          byId[mapped.id] = mapped;
+          order.push(mapped.id);
+        });
+        set({ workspaceExplorations: { byId, order } });
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    },
+
+    /** Create a new exploration. `seed` (optional) is a durable provenance
+     * ref — `{ type, name }` — e.g. from an "Explore this" action. */
+    createExploration: async (seed = null) => {
+      try {
+        const created = await explorationsApi.createExploration(seed ? { seeded_from: seed } : {});
+        const mapped = mapExplorationFromApi(created);
+        set(state => insertExploration(state, mapped));
+        return { success: true, id: mapped.id, exploration: mapped };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    },
+
+    /** Optimistically replace `id`'s draft and debounce-persist it. */
+    updateExplorationDraft: (id, nextDraft) => {
+      const existing = get().workspaceExplorations.byId[id];
+      if (!existing) return;
+      set(state => patchExploration(state, id, { draft: nextDraft, syncStatus: 'saving' }));
+      scheduleSync(id);
+    },
+
+    /** Flush a still-armed debounced sync immediately — call from an
+     * exploration-editing component's unmount cleanup. A no-op (resolves
+     * immediately) when nothing is pending. Safe to call without awaiting. */
+    flushExplorationSync: async id => {
+      if (!_pendingSyncTimers.has(id)) return { success: true, flushed: false };
+      clearPendingSyncTimer(id);
+      const result = await runSync(id);
+      return { ...result, flushed: true };
+    },
+
+    /** Create a copy of `id` (same provenance + current draft, fresh id,
+     * never carries over `return_to`/`promoted`). */
+    duplicateExploration: async id => {
+      const existing = get().workspaceExplorations.byId[id];
+      if (!existing) return { success: false, error: 'Exploration not found' };
+      try {
+        const created = await explorationsApi.createExploration({
+          name: `${existing.name} copy`,
+          seeded_from: existing.seededFrom || undefined,
+          draft: mapDraftToApi(existing.draft),
+        });
+        const mapped = mapExplorationFromApi(created);
+        set(state => insertExploration(state, mapped));
+        return { success: true, id: mapped.id, exploration: mapped };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    },
+
+    /** Delete `id` — force-closes a bound open workspace tab (01 §4) and
+     * drops any armed debounced sync so it can't fire against a gone record. */
+    deleteExploration: async id => {
+      try {
+        await explorationsApi.deleteExploration(id);
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+      clearPendingSyncTimer(id);
+      get().closeWorkspaceTab?.(`exploration:${id}`);
+      set(state => {
+        const nextById = { ...state.workspaceExplorations.byId };
+        delete nextById[id];
+        return {
+          workspaceExplorations: {
+            byId: nextById,
+            order: state.workspaceExplorations.order.filter(existingId => existingId !== id),
+          },
+        };
+      });
+      return { success: true };
+    },
+  };
+};
+
+export default createWorkspaceExplorationsSlice;

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -1,0 +1,436 @@
+/**
+ * workspaceExplorations store slice (Explore 2.0 Phase 1 — backend + slice,
+ * no visible UI yet).
+ *
+ * Pins: byId/order hydration + insertion order, the create/duplicate/delete
+ * CRUD actions, the ~1s debounced optimistic sync (coalescing + clobber-
+ * safety), the flush-on-unmount primitive, and per-record syncStatus.
+ */
+import { act } from '@testing-library/react';
+import useStore from './store';
+import * as explorationsApi from '../api/explorations';
+import {
+  _pendingSyncTimers,
+  _resetExplorationSyncTimersForTests,
+} from './workspaceExplorationsStore';
+
+jest.mock('../api/explorations');
+
+const wireExploration = overrides => ({
+  id: 'exp_1',
+  name: 'Scratch',
+  created_at: '2026-07-17T18:00:00Z',
+  updated_at: '2026-07-17T18:00:00Z',
+  seeded_from: null,
+  return_to: null,
+  draft: { queries: [], insights: [], chart: null, computed_columns: [] },
+  promoted: [],
+  ...overrides,
+});
+
+const mappedRecord = overrides => ({
+  id: 'exp_1',
+  name: 'Scratch',
+  createdAt: '2026-07-17T18:00:00Z',
+  updatedAt: '2026-07-17T18:00:00Z',
+  seededFrom: null,
+  returnTo: null,
+  draft: { queries: [], insights: [], chart: null, computedColumns: [] },
+  promoted: [],
+  syncStatus: 'synced',
+  staleness: null,
+  ...overrides,
+});
+
+/** Seed the store with an already-loaded (camelCase) record, as if it had
+ * come from a prior fetchExplorations/createExploration call. */
+const seedRecord = (overrides = {}) => {
+  const record = mappedRecord(overrides);
+  act(() => {
+    useStore.setState({
+      workspaceExplorations: { byId: { [record.id]: record }, order: [record.id] },
+    });
+  });
+  return record;
+};
+
+const reset = () => {
+  _resetExplorationSyncTimersForTests();
+  act(() => {
+    useStore.setState({
+      workspaceExplorations: { byId: {}, order: [] },
+      closeWorkspaceTab: jest.fn(),
+    });
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  reset();
+});
+
+afterEach(() => {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  jest.useRealTimers();
+  _resetExplorationSyncTimersForTests();
+});
+
+describe('fetchExplorations', () => {
+  test('hydrates byId/order from the server list, preserving server order', async () => {
+    explorationsApi.fetchExplorations.mockResolvedValueOnce([
+      wireExploration({ id: 'exp_a', name: 'A' }),
+      wireExploration({ id: 'exp_b', name: 'B' }),
+    ]);
+
+    await act(async () => {
+      await useStore.getState().fetchExplorations();
+    });
+
+    const state = useStore.getState().workspaceExplorations;
+    expect(state.order).toEqual(['exp_a', 'exp_b']);
+    expect(state.byId.exp_a).toMatchObject({ id: 'exp_a', name: 'A', syncStatus: 'synced' });
+  });
+
+  test('maps snake_case draft fields to camelCase', async () => {
+    explorationsApi.fetchExplorations.mockResolvedValueOnce([
+      wireExploration({
+        draft: {
+          queries: [{ name: 'q1', sql: 'SELECT 1', source: 'warehouse' }],
+          insights: [{ x: 1 }],
+          chart: { y: 2 },
+          computed_columns: [{ expression: 'a+b' }],
+        },
+      }),
+    ]);
+
+    await act(async () => {
+      await useStore.getState().fetchExplorations();
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.draft).toEqual({
+      queries: [{ name: 'q1', sql: 'SELECT 1', source: 'warehouse' }],
+      insights: [{ x: 1 }],
+      chart: { y: 2 },
+      computedColumns: [{ expression: 'a+b' }],
+    });
+  });
+
+  test('returns success:false on failure without throwing', async () => {
+    explorationsApi.fetchExplorations.mockRejectedValueOnce(new Error('network down'));
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().fetchExplorations();
+    });
+
+    expect(result).toEqual({ success: false, error: 'network down' });
+  });
+});
+
+describe('createExploration', () => {
+  test('creates with no seed, POSTs {}, and inserts at the front of order', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(wireExploration({ name: 'Scratch' }));
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().createExploration();
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith({});
+    expect(result).toMatchObject({ success: true, id: 'exp_1' });
+    const state = useStore.getState().workspaceExplorations;
+    expect(state.order[0]).toBe('exp_1');
+    expect(state.byId.exp_1).toMatchObject({ name: 'Scratch', syncStatus: 'synced' });
+  });
+
+  test('passes a seed through as seeded_from', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ seeded_from: { type: 'model', name: 'orders' } })
+    );
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'model', name: 'orders' });
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith({
+      seeded_from: { type: 'model', name: 'orders' },
+    });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.seededFrom).toEqual({
+      type: 'model',
+      name: 'orders',
+    });
+  });
+
+  test('newer creations land ahead of older ones in order', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(wireExploration({ id: 'exp_a' }));
+    await act(async () => {
+      await useStore.getState().createExploration();
+    });
+    explorationsApi.createExploration.mockResolvedValueOnce(wireExploration({ id: 'exp_b' }));
+    await act(async () => {
+      await useStore.getState().createExploration();
+    });
+
+    expect(useStore.getState().workspaceExplorations.order).toEqual(['exp_b', 'exp_a']);
+  });
+
+  test('returns success:false on failure and does not touch the collection', async () => {
+    explorationsApi.createExploration.mockRejectedValueOnce(new Error('boom'));
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().createExploration();
+    });
+
+    expect(result).toEqual({ success: false, error: 'boom' });
+    expect(useStore.getState().workspaceExplorations.order).toEqual([]);
+  });
+});
+
+describe('updateExplorationDraft', () => {
+  test('writes optimistically (syncStatus "saving") before the debounce fires', () => {
+    seedRecord();
+    const nextDraft = { queries: [{ name: 'q', sql: 'SELECT 1' }], insights: [], chart: null, computedColumns: [] };
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', nextDraft);
+    });
+
+    const record = useStore.getState().workspaceExplorations.byId.exp_1;
+    expect(record.draft).toEqual(nextDraft);
+    expect(record.syncStatus).toBe('saving');
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+  });
+
+  test('persists (wire-shaped) after the ~1s debounce and flips to synced', async () => {
+    seedRecord();
+    const nextDraft = { queries: [], insights: [], chart: null, computedColumns: [{ expression: 'a' }] };
+    explorationsApi.updateExploration.mockResolvedValueOnce(
+      wireExploration({ draft: { queries: [], insights: [], chart: null, computed_columns: [{ expression: 'a' }] } })
+    );
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', nextDraft);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledWith('exp_1', {
+      draft: { queries: [], insights: [], chart: null, computed_columns: [{ expression: 'a' }] },
+    });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe('synced');
+  });
+
+  test('coalesces rapid edits into a single request with the LATEST draft', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockResolvedValue(wireExploration());
+
+    await act(async () => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'v1', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+      jest.advanceTimersByTime(400);
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'v2', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+      jest.advanceTimersByTime(400);
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'v3', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+    expect(explorationsApi.updateExploration).toHaveBeenCalledWith('exp_1', {
+      draft: { queries: [{ name: 'v3', sql: 'x' }], insights: [], chart: null, computed_columns: [] },
+    });
+  });
+
+  test('sets syncStatus to error when the persist fails', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockRejectedValueOnce(new Error('offline'));
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe('error');
+  });
+
+  test('is a no-op for an unknown id (no crash, no API call)', () => {
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_nope', { queries: [] });
+    });
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+  });
+});
+
+describe('flushExplorationSync', () => {
+  test('fires the pending sync immediately instead of waiting the full debounce', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration());
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().flushExplorationSync('exp_1');
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ success: true, flushed: true });
+    expect(_pendingSyncTimers.has('exp_1')).toBe(false);
+  });
+
+  test('is a no-op when nothing is pending', async () => {
+    seedRecord();
+    let result;
+    await act(async () => {
+      result = await useStore.getState().flushExplorationSync('exp_1');
+    });
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, flushed: false });
+  });
+
+  test('does not double-fire once the debounce has already run', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockResolvedValue(wireExploration());
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await useStore.getState().flushExplorationSync('exp_1');
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('duplicateExploration', () => {
+  test('creates a copy seeded from the source draft + provenance, named "<name> copy"', async () => {
+    seedRecord({
+      name: 'Churn dig',
+      seededFrom: { type: 'model', name: 'orders' },
+      draft: { queries: [{ name: 'q', sql: 'x' }], insights: [], chart: null, computedColumns: [] },
+    });
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ id: 'exp_2', name: 'Churn dig copy' })
+    );
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().duplicateExploration('exp_1');
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith({
+      name: 'Churn dig copy',
+      seeded_from: { type: 'model', name: 'orders' },
+      draft: { queries: [{ name: 'q', sql: 'x' }], insights: [], chart: null, computed_columns: [] },
+    });
+    expect(result).toMatchObject({ success: true, id: 'exp_2' });
+    expect(useStore.getState().workspaceExplorations.order).toEqual(['exp_2', 'exp_1']);
+  });
+
+  test('returns success:false for an unknown id without calling the API', async () => {
+    let result;
+    await act(async () => {
+      result = await useStore.getState().duplicateExploration('exp_missing');
+    });
+    expect(result).toEqual({ success: false, error: 'Exploration not found' });
+    expect(explorationsApi.createExploration).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteExploration', () => {
+  test('deletes via the API, force-closes a bound tab, and drops the record', async () => {
+    seedRecord();
+    explorationsApi.deleteExploration.mockResolvedValueOnce(true);
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().deleteExploration('exp_1');
+    });
+
+    expect(explorationsApi.deleteExploration).toHaveBeenCalledWith('exp_1');
+    expect(useStore.getState().closeWorkspaceTab).toHaveBeenCalledWith('exploration:exp_1');
+    expect(result).toEqual({ success: true });
+    const state = useStore.getState().workspaceExplorations;
+    expect(state.byId.exp_1).toBeUndefined();
+    expect(state.order).toEqual([]);
+  });
+
+  test('clears an armed debounced sync so it cannot fire against a deleted record', async () => {
+    seedRecord();
+    explorationsApi.deleteExploration.mockResolvedValueOnce(true);
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      await useStore.getState().deleteExploration('exp_1');
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+  });
+
+  test('returns success:false on failure and leaves the record in place', async () => {
+    seedRecord();
+    explorationsApi.deleteExploration.mockRejectedValueOnce(new Error('locked'));
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().deleteExploration('exp_1');
+    });
+
+    expect(result).toEqual({ success: false, error: 'locked' });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1).toBeDefined();
+    expect(useStore.getState().closeWorkspaceTab).not.toHaveBeenCalled();
+  });
+});

--- a/visivo/models/exploration.py
+++ b/visivo/models/exploration.py
@@ -1,0 +1,86 @@
+"""Exploration — Explore 2.0 workbench state (S3 wire contract).
+
+Deliberately NOT part of the Project DAG / project YAML: explorations are
+scratch workbench state, not committed config. This module must never be
+imported by ``visivo.models.project`` or anything it pulls in — that keeps
+``generate_project_schema_json`` a no-op for this file (asserted in CI; see
+``tests/models/test_exploration.py``).
+
+Mirrors the frozen contract in
+``specs/plan/explorer-workspace-unification/07-exploration-api-contract.md``.
+Both backends (this Flask model + the Django twin) implement the same shape.
+
+``draft.*`` sub-objects are deliberately loosely typed (``dict``) — a draft is
+allowed to be semantically invalid (e.g. an insight config missing required
+fields); the promote gate (Phase 4) is where strictness lives. ``queries`` is
+the one draft field with a concrete shape (a scratch SQL query chip), which is
+still just plain-string typing, not semantic validation.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_serializer
+
+
+def _serialize_utc_z(dt: datetime) -> str:
+    """ISO-8601 with a ``Z`` suffix (contract sample uses ``Z``, not ``+00:00``)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class ExplorationQueryDraft(BaseModel):
+    """One scratch query — a chip in the SQL editor header."""
+
+    name: str
+    sql: str
+    source: Optional[str] = None
+
+
+class ExplorationDraft(BaseModel):
+    queries: List[ExplorationQueryDraft] = Field(default_factory=list)
+    insights: List[dict] = Field(default_factory=list)
+    chart: Optional[dict] = None
+    computed_columns: List[dict] = Field(default_factory=list)
+
+
+class PromotionRecord(BaseModel):
+    type: str
+    name: str
+    promoted_at: datetime
+
+    @field_serializer("promoted_at")
+    def _serialize_promoted_at(self, dt: datetime) -> str:
+        return _serialize_utc_z(dt)
+
+
+class ReturnToRef(BaseModel):
+    """One-shot placement intent — survives park/resume + reload, self-clears
+    on consume (see ``consume_return_to``)."""
+
+    dashboard: str
+    slot: Optional[str] = None
+
+
+class SeedRef(BaseModel):
+    """Durable provenance — what this exploration was seeded from, shown on
+    Home cards. Unlike ``return_to`` this never clears."""
+
+    type: str
+    name: str
+
+
+class Exploration(BaseModel):
+    id: str
+    name: str
+    created_at: datetime
+    updated_at: datetime
+    seeded_from: Optional[SeedRef] = None
+    return_to: Optional[ReturnToRef] = None
+    draft: ExplorationDraft = Field(default_factory=ExplorationDraft)
+    promoted: List[PromotionRecord] = Field(default_factory=list)
+
+    @field_serializer("created_at", "updated_at")
+    def _serialize_timestamps(self, dt: datetime) -> str:
+        return _serialize_utc_z(dt)

--- a/visivo/server/flask_app.py
+++ b/visivo/server/flask_app.py
@@ -4,6 +4,7 @@ from visivo.models.project import Project
 from visivo.parsers.serializer import Serializer
 from visivo.server.views import register_views
 from visivo.logger.logger import Logger
+from visivo.server.repositories.exploration_repository import ExplorationRepository
 
 from visivo.telemetry.middleware import init_telemetry_middleware
 from visivo.server.managers.source_manager import SourceManager
@@ -42,6 +43,16 @@ class FlaskApp:
         self.run_manager = RunManager()
 
         self.app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
+
+        # Explorations are project-root workbench data (NOT a rebuildable
+        # target/ artifact), stored under a NEW `.visivo/explorations/` dir,
+        # created lazily on first write (see ExplorationRepository). Falls
+        # back to cwd like the CLI's own `--working-dir` default so ad-hoc
+        # FlaskApp construction (e.g. in tests) never crashes on `None`.
+        explorations_root = working_dir or os.getcwd()
+        self.exploration_repo = ExplorationRepository(
+            os.path.join(explorations_root, ".visivo", "explorations")
+        )
 
         # Initialize object managers with DAG for efficient loading
         dag = project.dag()

--- a/visivo/server/repositories/exploration_repository.py
+++ b/visivo/server/repositories/exploration_repository.py
@@ -1,0 +1,157 @@
+"""File-backed repository for Explorations (Explore 2.0, Phase 1).
+
+Structural precedent: the removed 2.0-era ``exploration_repository.py``
+(commits ``00a83329``/``e172d91b``) — a plain repository class with
+create/list/get/update/delete methods, constructed with a storage path and
+handed to ``FlaskApp``. Storage diverges deliberately: that repository used
+SQLite under ``target/``; explorations are user workbench data that must
+survive ``rm -rf target`` (a rebuildable output dir), so this repository
+writes one JSON document per exploration under a NEW project-root directory,
+``.visivo/explorations/`` (already covered by the generated ``.gitignore``
+template, never populated by any other code path, and ignored by the file
+watcher — ``hot_reload_server.py`` only reacts to ``.yml``/``.yaml``).
+
+The directory is created lazily (mkdir on first write), never at
+construction time, so simply instantiating this repository — as ``FlaskApp``
+does for every ``visivo serve`` session — never touches disk.
+"""
+
+import json
+import os
+import secrets
+import tempfile
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from visivo.models.exploration import Exploration
+
+
+class ExplorationRepository:
+    def __init__(self, explorations_dir: str):
+        self.explorations_dir = explorations_dir
+
+    def _ensure_dir(self) -> None:
+        os.makedirs(self.explorations_dir, exist_ok=True)
+
+    def _path(self, exploration_id: str) -> str:
+        return os.path.join(self.explorations_dir, f"{exploration_id}.json")
+
+    def _existing_ids(self) -> List[str]:
+        if not os.path.isdir(self.explorations_dir):
+            return []
+        return [
+            name[: -len(".json")]
+            for name in os.listdir(self.explorations_dir)
+            if name.endswith(".json") and not name.startswith(".")
+        ]
+
+    def _mint_id(self) -> str:
+        while True:
+            candidate = f"exp_{secrets.token_hex(4)}"
+            if not os.path.exists(self._path(candidate)):
+                return candidate
+
+    def _default_name(self) -> str:
+        # "Scratch" for the very first exploration, "Exploration N" after
+        # (resolved question 3, 03-delivery-plan.md): a one-gesture create
+        # with no naming prompt.
+        count = len(self._existing_ids())
+        return "Scratch" if count == 0 else f"Exploration {count + 1}"
+
+    def _write(self, exploration: Exploration) -> None:
+        self._ensure_dir()
+        target_path = self._path(exploration.id)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self.explorations_dir, prefix=f".{exploration.id}.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(exploration.model_dump_json(indent=2))
+            os.replace(tmp_path, target_path)  # atomic on the same filesystem
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+
+    def _read(self, exploration_id: str) -> Optional[Exploration]:
+        path = self._path(exploration_id)
+        if not os.path.exists(path):
+            return None
+        with open(path) as f:
+            data = json.load(f)
+        return Exploration.model_validate(data)
+
+    def list(self) -> List[Exploration]:
+        explorations = [self._read(i) for i in self._existing_ids()]
+        explorations = [e for e in explorations if e is not None]
+        explorations.sort(key=lambda e: e.updated_at, reverse=True)
+        return explorations
+
+    def create(
+        self,
+        name: Optional[str] = None,
+        seeded_from: Optional[dict] = None,
+        return_to: Optional[dict] = None,
+        draft: Optional[dict] = None,
+    ) -> Exploration:
+        now = datetime.now(timezone.utc)
+        exploration = Exploration(
+            id=self._mint_id(),
+            name=name or self._default_name(),
+            created_at=now,
+            updated_at=now,
+            seeded_from=seeded_from,
+            return_to=return_to,
+            draft=draft if draft is not None else {},
+            promoted=[],
+        )
+        self._write(exploration)
+        return exploration
+
+    def get(self, exploration_id: str) -> Optional[Exploration]:
+        return self._read(exploration_id)
+
+    def update(self, exploration_id: str, patch: dict) -> Optional[Exploration]:
+        """Full-document replace of the mutable fields (``name``, ``draft``,
+        ``return_to``) present in ``patch``. ``id``/``created_at``/
+        ``seeded_from``/``promoted`` are immutable via this route: any of
+        those keys present in ``patch`` are silently ignored rather than
+        erroring, so a client echoing the full record back never corrupts it.
+        A key simply absent from ``patch`` leaves that mutable field
+        unchanged (partial-update-safe); pass it explicitly (``null`` for
+        ``return_to``) to clear it.
+        """
+        existing = self._read(exploration_id)
+        if existing is None:
+            return None
+
+        data = existing.model_dump(mode="json")
+        for mutable_field in ("name", "draft", "return_to"):
+            if mutable_field in patch:
+                data[mutable_field] = patch[mutable_field]
+        data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+        updated = Exploration.model_validate(data)
+        self._write(updated)
+        return updated
+
+    def delete(self, exploration_id: str) -> bool:
+        path = self._path(exploration_id)
+        if not os.path.exists(path):
+            return False
+        os.remove(path)
+        return True
+
+    def consume_return_to(self, exploration_id: str) -> Optional[Exploration]:
+        """Atomically null ``return_to`` (the placement intent is consumed).
+        Idempotent: consuming an already-null ``return_to`` is a no-op that
+        still returns the current record, not a 404."""
+        existing = self._read(exploration_id)
+        if existing is None:
+            return None
+        if existing.return_to is None:
+            return existing
+        existing.return_to = None
+        existing.updated_at = datetime.now(timezone.utc)
+        self._write(existing)
+        return existing

--- a/visivo/server/views/__init__.py
+++ b/visivo/server/views/__init__.py
@@ -26,6 +26,7 @@ from visivo.server.views.sources_views import register_source_views
 from visivo.server.views.source_schema_jobs_views import register_source_schema_jobs_views
 from visivo.server.views.telemetry_views import register_telemetry_views
 from visivo.server.views.explorer_views import register_explorer_views
+from visivo.server.views.exploration_views import register_exploration_views
 from visivo.server.views.expression_views import register_expression_views
 from visivo.server.views.model_data_views import register_model_data_views
 from visivo.server.views.run_views import register_run_views
@@ -62,6 +63,7 @@ def register_views(app, flask_app, output_dir):
     register_telemetry_views(app, flask_app, output_dir)
 
     register_explorer_views(app, flask_app, output_dir)
+    register_exploration_views(app, flask_app, output_dir)
     register_expression_views(app, flask_app, output_dir)
     register_model_data_views(app, flask_app, output_dir)
     register_run_views(app, flask_app, output_dir)

--- a/visivo/server/views/exploration_views.py
+++ b/visivo/server/views/exploration_views.py
@@ -1,0 +1,110 @@
+"""Exploration CRUD endpoints (Explore 2.0, Phase 1) — S3 wire contract.
+
+Deliberately absent from ``run_views.RESOURCE_META`` / ``_RESOURCE_ROUTE_RE``:
+explorations are workbench drafts, never DAG/YAML config, so saving or
+deleting one must never schedule a run (regression-tested in
+``tests/server/test_run_views.py``).
+
+400 is reserved for a malformed top-level body shape (not a JSON object, or a
+field with the wrong type/structure) — draft CONTENT (``insights``/``chart``/
+``computed_columns``) is intentionally never validated at rest; a draft is
+allowed to be semantically invalid until promote.
+"""
+
+from flask import jsonify, request
+from pydantic import ValidationError
+
+from visivo.logger.logger import Logger
+
+
+def _as_body_dict(silent_json):
+    """``None``/omitted body -> ``{}``; a JSON object -> itself; anything else
+    (a list, string, number) -> ``None`` to signal a malformed top-level shape."""
+    if silent_json is None:
+        return {}
+    return silent_json if isinstance(silent_json, dict) else None
+
+
+def register_exploration_views(app, flask_app, output_dir):
+    @app.route("/api/explorations/", methods=["GET"])
+    def list_explorations():
+        try:
+            explorations = flask_app.exploration_repo.list()
+            return jsonify([e.model_dump(mode="json") for e in explorations])
+        except Exception as e:
+            Logger.instance().error(f"Error listing explorations: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/explorations/", methods=["POST"])
+    def create_exploration():
+        body = _as_body_dict(request.get_json(silent=True))
+        if body is None:
+            return jsonify({"error": "Request body must be a JSON object"}), 400
+        try:
+            exploration = flask_app.exploration_repo.create(
+                name=body.get("name"),
+                seeded_from=body.get("seeded_from"),
+                return_to=body.get("return_to"),
+                draft=body.get("draft"),
+            )
+            return jsonify(exploration.model_dump(mode="json")), 201
+        except ValidationError as e:
+            return jsonify({"error": f"Invalid exploration payload: {e}"}), 400
+        except Exception as e:
+            Logger.instance().error(f"Error creating exploration: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/explorations/<exploration_id>/", methods=["GET"])
+    def get_exploration(exploration_id):
+        try:
+            exploration = flask_app.exploration_repo.get(exploration_id)
+            if exploration is None:
+                return jsonify({"error": "Exploration not found"}), 404
+            return jsonify(exploration.model_dump(mode="json"))
+        except Exception as e:
+            Logger.instance().error(f"Error getting exploration: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    # POST, not PUT — matches every sibling resource route in this codebase.
+    @app.route("/api/explorations/<exploration_id>/", methods=["POST"])
+    def update_exploration(exploration_id):
+        raw_body = request.get_json(silent=True)
+        if raw_body is None:
+            # Unlike create (where an absent body just means "use defaults"),
+            # an update with no body at all provides nothing to update.
+            return jsonify({"error": "Update requires a JSON body"}), 400
+        body = _as_body_dict(raw_body)
+        if body is None:
+            return jsonify({"error": "Request body must be a JSON object"}), 400
+        try:
+            exploration = flask_app.exploration_repo.update(exploration_id, body)
+            if exploration is None:
+                return jsonify({"error": "Exploration not found"}), 404
+            return jsonify(exploration.model_dump(mode="json"))
+        except ValidationError as e:
+            return jsonify({"error": f"Invalid exploration payload: {e}"}), 400
+        except Exception as e:
+            Logger.instance().error(f"Error updating exploration: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/explorations/<exploration_id>/", methods=["DELETE"])
+    def delete_exploration(exploration_id):
+        try:
+            deleted = flask_app.exploration_repo.delete(exploration_id)
+            if not deleted:
+                return jsonify({"error": "Exploration not found"}), 404
+            return "", 204
+        except Exception as e:
+            Logger.instance().error(f"Error deleting exploration: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/explorations/<exploration_id>/consume-return-to/", methods=["POST"])
+    def consume_return_to(exploration_id):
+        try:
+            exploration = flask_app.exploration_repo.consume_return_to(exploration_id)
+            if exploration is None:
+                return jsonify({"error": "Exploration not found"}), 404
+            return jsonify(exploration.model_dump(mode="json"))
+        except Exception as e:
+            Logger.instance().error(f"Error consuming return_to: {str(e)}")
+            return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary

Phase 1 of the Explore 2.0 plan — the Exploration entity, backend + store slice only (no visible UI; that's Phase 2). Implements the frozen S3 wire contract exactly: [`07-exploration-api-contract.md`](../blob/feature/explorer-workspace/specs/plan/explorer-workspace-unification/07-exploration-api-contract.md).

## Contract conformance checklist

- [x] `visivo/models/exploration.py`: `Exploration`/`ExplorationDraft`/`ExplorationQueryDraft`/`PromotionRecord`/`ReturnToRef`/`SeedRef`, field-for-field per contract §Entity. Timestamps serialize with a `Z` suffix (not `+00:00`) to match the sample.
- [x] **Not part of the DAG/schema**: `visivo/models/exploration.py` is never imported by `visivo.models.project`; `python -m visivo.generate_project_schema_json` + `git diff --exit-code visivo/src/visivo_project_schema.json` confirmed a true no-op (verified locally; no schema diff to commit).
- [x] Repository: JSON documents in `<project root>/.visivo/explorations/<id>.json`; mkdir-on-first-use (construction never touches disk); atomic writes (tmp file + `os.replace`); server-minted url-safe id (`exp_<8 hex>`); list ordered by `updated_at` desc.
- [x] Endpoints, verbatim: `GET/POST /api/explorations/`, `GET/POST/DELETE /api/explorations/<id>/` (**POST, not PUT** for update), `POST /api/explorations/<id>/consume-return-to/`.
- [x] Name defaulting: "Scratch" for the first exploration, "Exploration N" after (resolved question 3).
- [x] Update is a full-document replace of the mutable fields (`name`/`draft`/`return_to`) *present in the patch*; `id`/`created_at`/`seeded_from`/`promoted` are immutable via this route regardless of what the patch contains.
- [x] 400 reserved for a malformed **top-level** body shape; draft *content* (`insights`/`chart`/`computed_columns`) is never validated at rest — only the wire-shaped `queries` sub-list is structurally typed.
- [x] `consume-return-to` atomically (and idempotently) nulls `return_to`.
- [x] **Run isolation**: exploration routes are absent from `run_views.RESOURCE_META`/`_RESOURCE_ROUTE_RE`; regression-tested that POST-update + DELETE schedule no run via a real integration client (not a vacuous PUT-based test).
- [x] Client: `viewer/src/api/explorations.js` (thin wire client) + `stores/workspaceExplorationsStore.js` (byId/order slice, debounced optimistic sync, flush-on-unmount primitive).

## S4 git-history recon (reused vs. diverged)

Recovered the removed 2.0-era exploration files (commits `00a83329`/`e172d91b`):
- **Reused structurally**: the repository class shape (constructed with a storage path; `create/list/get/update/delete` methods returning plain dicts/records), the `register_x_views(app, flask_app, output_dir)` view-registration convention, and the view test's "mount blueprint on a bare Flask app" pattern.
- **Diverged deliberately** (per `02-architecture.md` §2): the old repository was SQLite-backed at `target/explorations.db` — rejected here because `target/` is a rebuildable output dir and explorations are user workbench data that must survive `rm -rf target`. This repository instead writes one JSON document per exploration under a new project-root `.visivo/explorations/` directory (already covered by the generated `.gitignore` template; watcher-safe since `hot_reload_server.py` only reacts to `.yml`/`.yaml`).
- The old model was a SQLAlchemy `ExplorationModel` with a flat single-query-per-tab shape (`sql`, `source_name`, `left_panel_tab`, …) — replaced entirely by the Pydantic S3 contract shape (`draft.queries[]`, `seeded_from`, `return_to`, `promoted[]`), since the wire shape changed fundamentally between the old pre-2.0 Explorer and Explore 2.0.

## Run-isolation evidence

`tests/server/test_run_views.py::TestExplorationRunIsolation`:
- `"explorations" not in RESOURCE_META`
- `_RESOURCE_ROUTE_RE.match(...)` is `None` for both `/api/explorations/<id>/` and the `consume-return-to` sub-route
- Real `integration_client` POST-update, DELETE, and consume-return-to calls all assert `visivo.server.views.run_views.request_run` is never called

## Test counts

- Backend (Python): full suite `2082 passed, 2 skipped, 5 xfailed, 1 xpassed` (no regressions). New: 14 model tests, 42 repository tests, 26 view tests, 5 run-isolation regression tests. `black --check` clean.
- Frontend (JS): full viewer suite `317 suites / 5257 passed` (no regressions), `eslint` clean. New: 16 API client tests, 20 store slice tests.

## Deviations / judgment calls (flagged for the orchestrator)

1. **`promoted` mutability ambiguity in the frozen contract itself**: the endpoint table says `promoted` is immutable via the POST-update route, but the informative note directly below it says "the client then appends `promoted[]` records via the update route" — those two statements conflict. Phase 1 conservatively implements the literal endpoint-table rule (`promoted` fully immutable via `POST /api/explorations/<id>/`) since promotion itself is out of scope until Phase 4. Phase 4 will need to either add an explicit allowance/sub-route for appending `PromotionRecord`s, or this doc needs a follow-up PR to resolve the contradiction before that phase starts.
2. **Update-with-no-body is 400** (not treated as a no-op): an absent JSON body on `POST /api/explorations/<id>/` returns 400 ("nothing to update"), while an empty object `{}` is accepted as a valid (if pointless) no-op update. This wasn't explicitly specified in the contract; it mirrors the removed 2.0-era view's behavior and is a defensive guard against a client bug that forgets to send a body.
3. **Default-name counting**: "Scratch" → "Exploration 2" → "Exploration 3" counts *all* existing explorations (including custom-named ones), not just auto-named ones — e.g. creating "Churn dig" then a nameless one yields "Exploration 2", not "Scratch". This reads naturally from the resolved-question wording but wasn't spelled out; flagging in case product intent differs.
4. **`integration_app` test fixture** (`tests/server/conftest.py`) now passes an explicit `working_dir` (the same isolated tmp dir as `output_dir`) instead of implicit `None`. This was necessary so exploration writes in tests stay inside the temp folder rather than leaking `.visivo/explorations/*.json` into the real working tree when `working_dir` defaulted to `os.getcwd()`. Verified no other test relies on the previous `None` default.

## Nothing left blocking Phase 2

Phase 2 (Explorer joins the shell) can proceed against this backend + slice as-is — `objectTypeConfigs`, `MiddlePane` routing, and the Home gallery are all additive from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX