### PR TITLE
Explore 2.0 Phase 3a: Library drill-down + DnD unification + query chips (VIS-1051–VIS-1056)

### DIFF
--- a/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
+++ b/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
@@ -28,6 +28,17 @@
 
 import { test, expect } from '@playwright/test';
 
+// A tall viewport keeps the Build rail's insight properties in view without
+// scrolling (mirrors canvas-dnd.spec.mjs's `test.use({ viewport: ... })`):
+// dnd-kit's built-in auto-scroll triggers when the pointer lingers near a
+// scrollable container's edge, and a target row near the DEFAULT viewport's
+// bottom edge was observed to drift ~200px mid-drag as the panel
+// auto-scrolled — by the time the drop resolved, the row that started under
+// the cursor had moved, and an ADJACENT row (or nothing) was under it
+// instead. A generously tall viewport keeps every drop target comfortably
+// away from any edge for the whole gesture.
+test.use({ viewport: { width: 1280, height: 1600 } });
+
 const BASE_URL =
   process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
 const apiBase = (() => {
@@ -42,10 +53,23 @@ const apiBase = (() => {
 const SOURCE = 'local-duckdb';
 const TABLE = 'test_table';
 
-/** Manual mouse-driven drag, matching the established dnd-kit PointerSensor
- * activation pattern (>8px movement) used by the (now-superseded)
- * `explorer-dnd.spec.mjs`. Library rows + the SQL editor / prop slots are
- * plain, unoccluded DOM nodes — no overlay hit-testing workaround needed. */
+/**
+ * Manual mouse-driven drag, matching the established dnd-kit PointerSensor
+ * activation pattern (>8px movement — see `workspace-tabs-shortcuts.spec.mjs`'s
+ * `drag-to-reorder tabs with a real cursor`, the reference green DnD story
+ * this mirrors, including its "settle at the same final point twice" move).
+ * Library rows + the SQL editor / prop slots are plain, unoccluded DOM
+ * nodes — no overlay hit-testing workaround needed.
+ *
+ * Root-caused via a mid-drag DOM inspection (temporary instrumentation, not
+ * kept): a drop aimed at the "x" prop row's box center landed on "y" (the
+ * next row down) instead. The row's LIVE rect during the drag had shifted
+ * ~200px from where `boundingBox()` measured it just before — dnd-kit's
+ * built-in auto-scroll was firing because that row sat near the (default,
+ * 720px-tall) viewport's bottom edge, scrolling the panel while the pointer
+ * lingered nearby. Fixed at the source with a tall viewport (this file's
+ * `test.use`), not by chasing the target's position mid-gesture.
+ */
 async function dragAndDrop(page, sourceLocator, targetLocator) {
   const sourceBox = await sourceLocator.boundingBox();
   const targetBox = await targetLocator.boundingBox();
@@ -60,8 +84,12 @@ async function dragAndDrop(page, sourceLocator, targetLocator) {
   await page.mouse.down();
   await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
   await page.waitForTimeout(100);
-  await page.mouse.move(targetX, targetY, { steps: 10 });
-  await page.waitForTimeout(50);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  // Settle at the exact same final point (mirrors the reference green
+  // story's double-move) so dnd-kit's continuous re-measurement resolves
+  // against the pointer's RESTING position, not one still mid-interpolation.
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
   await page.mouse.up();
   await page.waitForTimeout(300);
 }
@@ -81,6 +109,15 @@ async function newExploration(page) {
   await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
   return new URL(page.url()).pathname.split('/').pop();
 }
+
+/**
+ * The actual chip row locator — NOT `[data-testid^="query-chip-"]` alone.
+ * That prefix also matches other real elements (`query-chip-status-dot`,
+ * `query-chip-<name>-menu-trigger` on the active chip, and the
+ * `query-chip-add` button), so counting it directly over-counts. Only the
+ * chip row itself carries `data-active`.
+ */
+const chips = page => page.locator('[data-testid^="query-chip-"][data-active]');
 
 async function expandSourceTable(page) {
   const sourceHeader = page.getByTestId('library-subsection-source-header');
@@ -128,20 +165,31 @@ test.describe('Exploration DnD pull-in (Explore 2.0 Phase 3a — D9)', () => {
   }) => {
     await gotoExplorerHome(page);
     const id = await newExploration(page);
-    const existingChips = await page.locator('[data-testid^="query-chip-"]').count();
+    const existingChips = await chips(page).count();
 
     const tableRow = await expandSourceTable(page);
     const dropZone = page.getByTestId('sql-editor-drop-zone');
     await dragAndDrop(page, tableRow, dropZone);
 
     // A new chip appears (one more than before) and becomes active.
-    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(existingChips + 1, {
+    await expect(chips(page)).toHaveCount(existingChips + 1, {
       timeout: 10000,
     });
     await expect(page.locator('.view-lines').first()).toContainText(`SELECT * FROM ${TABLE}`, {
       timeout: 10000,
     });
 
+    // Wait for the client-side debounced sync to settle (mirrors
+    // exploration-lifecycle.spec.mjs's dirty-dot check) BEFORE polling the
+    // backend — a generous timeout absorbs a cold sandbox's first-request
+    // warm-up cost (observed when this is the first test to hit the backend
+    // in a fresh run: the debounce itself is the same ~1.6s always, but the
+    // very first `/api/explorations/` round-trip in a run can take
+    // noticeably longer). Polling the backend directly with only a flat
+    // timeout raced that warm-up instead of waiting it out.
+    await expect(page.getByTestId(`workspace-tab-dirty-exploration:${id}`)).not.toBeVisible({
+      timeout: 25000,
+    });
     await waitForBackendDraft(page, id, draft =>
       (draft.queries || []).some(q => (q.sql || '').includes(`SELECT * FROM ${TABLE}`))
     );
@@ -152,7 +200,7 @@ test.describe('Exploration DnD pull-in (Explore 2.0 Phase 3a — D9)', () => {
   }) => {
     await gotoExplorerHome(page);
     await newExploration(page);
-    const existingChips = await page.locator('[data-testid^="query-chip-"]').count();
+    const existingChips = await chips(page).count();
 
     const tableRow = await expandSourceTable(page);
     await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
@@ -169,7 +217,7 @@ test.describe('Exploration DnD pull-in (Explore 2.0 Phase 3a — D9)', () => {
     await dragAndDrop(page, firstColumn, page.getByTestId('sql-editor-drop-zone'));
 
     // No new chip — the drop targeted the ACTIVE query's editor, not a seed.
-    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(existingChips);
+    await expect(chips(page)).toHaveCount(existingChips);
     await expect(page.locator('.view-lines').first()).toContainText(columnName, { timeout: 10000 });
   });
 

--- a/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
+++ b/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
@@ -1,0 +1,210 @@
+/**
+ * Story: Exploration DnD pull-in (Explore 2.0 Phase 3a — D9 / D7,
+ * 02-architecture.md §4). `ExplorerDndContext` is deleted from the
+ * ExplorationWorkbench nesting; the exploration surface mounts under the
+ * shell's single `WorkspaceDndContext`, whose router
+ * (`routeExplorationDragEnd`) ported the legacy right panel's drop-zone
+ * resolution logic verbatim AND adds the new Library payload extension +
+ * SQL-editor drop target. Successor to `explorer-dnd.spec.mjs` /
+ * `explorer-interaction-dnd.spec.mjs`'s DnD-mechanics half (05-e2e-ledger.md).
+ *
+ * Three pull-in gestures, all asserted THROUGH THE BACKEND record after the
+ * draft debounce settles (never a client-only proxy signal):
+ *   1. Library schema table → SQL editor: seeds a brand-new query chip
+ *      (`SELECT * FROM <table>`) bound to that table's source.
+ *   2. Library schema column → SQL editor: inserts the bare column name at
+ *      the Monaco cursor (does NOT create a new query).
+ *   3. Library schema column → an insight prop slot (`droppable-property-x`,
+ *      live via `InsightCRUDSection`'s `SchemaEditor` — the legacy right
+ *      panel, unchanged by this phase): serializes `?{${ref(query).col}}`
+ *      underneath while rendering a resolved pill/text, never raw `?{`/`${`
+ *      syntax (D8).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationDndPullIn VISIVO_SANDBOX_BACKEND_PORT=8046 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3046 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3046 npx playwright test exploration-dnd-pull-in
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+/** Manual mouse-driven drag, matching the established dnd-kit PointerSensor
+ * activation pattern (>8px movement) used by the (now-superseded)
+ * `explorer-dnd.spec.mjs`. Library rows + the SQL editor / prop slots are
+ * plain, unoccluded DOM nodes — no overlay hit-testing workaround needed. */
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 10 });
+  await page.waitForTimeout(50);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+/** Poll the backend exploration record until its draft settles — a hard
+ * reload (or a promote) only ever sees what's actually persisted, so this is
+ * the meaningful assertion, not the optimistic client-side dirty flag
+ * (mirrors exploration-lifecycle.spec.mjs's waitForBackendDraftSql). */
+async function waitForBackendDraft(page, id, predicate, timeout = 15000) {
+  await expect(async () => {
+    const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(predicate(data.draft)).toBe(true);
+  }).toPass({ timeout });
+}
+
+test.describe('Exploration DnD pull-in (Explore 2.0 Phase 3a — D9)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('Library table → SQL editor seeds a new query chip bound to that table + source', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const existingChips = await page.locator('[data-testid^="query-chip-"]').count();
+
+    const tableRow = await expandSourceTable(page);
+    const dropZone = page.getByTestId('sql-editor-drop-zone');
+    await dragAndDrop(page, tableRow, dropZone);
+
+    // A new chip appears (one more than before) and becomes active.
+    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(existingChips + 1, {
+      timeout: 10000,
+    });
+    await expect(page.locator('.view-lines').first()).toContainText(`SELECT * FROM ${TABLE}`, {
+      timeout: 10000,
+    });
+
+    await waitForBackendDraft(page, id, draft =>
+      (draft.queries || []).some(q => (q.sql || '').includes(`SELECT * FROM ${TABLE}`))
+    );
+  });
+
+  test('Library column → SQL editor inserts the bare column name at the cursor (no new query)', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const existingChips = await page.locator('[data-testid^="query-chip-"]').count();
+
+    const tableRow = await expandSourceTable(page);
+    await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+    const firstColumn = page.locator('[data-testid^="library-source-column-"]').first();
+    await expect(firstColumn).toBeVisible({ timeout: 10000 });
+    const columnName = await firstColumn.getAttribute('data-testid').then(t =>
+      t.replace(`library-source-column-${SOURCE}-${TABLE}-`, '')
+    );
+
+    // Focus the editor at the end of its current content before dropping.
+    await page.locator('.view-lines').first().click();
+    await page.keyboard.press('Control+End');
+
+    await dragAndDrop(page, firstColumn, page.getByTestId('sql-editor-drop-zone'));
+
+    // No new chip — the drop targeted the ACTIVE query's editor, not a seed.
+    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(existingChips);
+    await expect(page.locator('.view-lines').first()).toContainText(columnName, { timeout: 10000 });
+  });
+
+  test('Library column → an insight prop slot serializes ?{${ref(query).col}} underneath, rendering a resolved pill/text (D8) — asserted through the backend', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    const tableRow = await expandSourceTable(page);
+    await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+    const firstColumn = page.locator('[data-testid^="library-source-column-"]').first();
+    await expect(firstColumn).toBeVisible({ timeout: 10000 });
+    const columnName = await firstColumn.getAttribute('data-testid').then(t =>
+      t.replace(`library-source-column-${SOURCE}-${TABLE}-`, '')
+    );
+
+    const xPropSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+    await expect(xPropSlot).toBeVisible({ timeout: 15000 });
+    await dragAndDrop(page, firstColumn, xPropSlot);
+
+    // D8: the Build rail never shows raw ref syntax — the prop slot renders
+    // a resolved pill/text (RefTextArea's existing behavior), not `?{`/`${`.
+    await expect(xPropSlot).not.toContainText('?{');
+    await expect(xPropSlot).not.toContainText('${');
+    await expect(xPropSlot).toContainText(columnName);
+
+    // The real assertion: the SERIALIZED value underneath, through the
+    // backend record after the draft debounce settles.
+    const expectedSerialized = `?{\${ref(${queryName}).${columnName}}}`;
+    await waitForBackendDraft(page, id, draft =>
+      (draft.insights || []).some(insight =>
+        Object.values(insight.props || {}).includes(expectedSerialized)
+      )
+    );
+  });
+});

--- a/viewer/e2e/stories/exploration-query-chips.spec.mjs
+++ b/viewer/e2e/stories/exploration-query-chips.spec.mjs
@@ -1,0 +1,190 @@
+/**
+ * Story: Exploration query chips (Explore 2.0 Phase 3a — 01-ux-spec.md §3).
+ *
+ * `ModelTabBar` (horizontal bordered tabs) is replaced by compact query
+ * chips on the exploration surface ONLY — the standalone `/explorer` route
+ * keeps `ModelTabBar` untouched (a separate, still-passing suite covers it).
+ * Named successor to the general query-chip/tab CRUD gap
+ * (05-e2e-ledger.md's orchestrator resolution #3: "Query-chip CRUD gets a
+ * named successor: exploration-query-chips.spec.mjs (create/switch/rename/
+ * no-duplicate-names + the delete-with-dependents case)") — and to
+ * `explorer-insight-survives-model-close.spec.mjs`'s delete-with-referrers
+ * regression class specifically (03-delivery-plan.md's Phase 3a gate).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationQueryChips VISIVO_SANDBOX_BACKEND_PORT=8047 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3047 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3047 npx playwright test exploration-query-chips
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+test.describe('Exploration query chips (Explore 2.0 Phase 3a)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('a fresh exploration seeds one chip; [+] creates + activates a second', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+
+    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(1);
+    const firstName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId('query-chip-add').click();
+    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(2);
+    const secondName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    expect(secondName).not.toBe(firstName);
+    await expect(page.getByTestId(`query-chip-${secondName}`)).toHaveAttribute('data-active', 'true');
+  });
+
+  test('clicking an inactive chip switches the active query (SQL editor content follows)', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const firstName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.locator('.view-lines').first().click();
+    await page.keyboard.type('SELECT 1 AS one', { delay: 5 });
+
+    await page.getByTestId('query-chip-add').click();
+    await page.locator('.view-lines').first().click();
+    await page.keyboard.type('SELECT 2 AS two', { delay: 5 });
+
+    await page.getByTestId(`query-chip-${firstName}`).click();
+    await expect(page.locator('.view-lines').first()).toContainText('SELECT 1 AS one', {
+      timeout: 5000,
+    });
+  });
+
+  test('renaming the active chip via its ⋮ menu persists the new name', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const originalName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId(`query-chip-${originalName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${originalName}-rename-action`).click();
+    const input = page.getByTestId(`query-chip-${originalName}-rename-input`);
+    await input.fill('orders_query');
+    await input.press('Enter');
+
+    await expect(page.getByTestId('query-chip-orders_query')).toBeVisible();
+    await expect(page.getByTestId(`query-chip-${originalName}`)).not.toBeVisible();
+  });
+
+  test('no-duplicate-names: renaming to an existing chip name shows an inline error and does not rename', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const firstName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    await page.getByTestId('query-chip-add').click();
+    const secondName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId(`query-chip-${secondName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${secondName}-rename-action`).click();
+    const input = page.getByTestId(`query-chip-${secondName}-rename-input`);
+    await input.fill(firstName);
+    await input.press('Enter');
+
+    await expect(page.getByTestId(`query-chip-${secondName}-rename-error`)).toBeVisible();
+    // Both original chips still present — the collision blocked the rename.
+    await expect(page.getByTestId(`query-chip-${firstName}`)).toBeVisible();
+    await expect(page.getByTestId(`query-chip-${secondName}`)).toBeVisible();
+  });
+
+  // Successor to explorer-insight-survives-model-close.spec.mjs's regression
+  // class (03-delivery-plan.md's Phase 3a gate: "a query-chip delete-with-
+  // dependents warning story").
+  test('deleting a query with draft-insight referrers warns via ConfirmDialog; confirming deletes it, cancel keeps it', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    // The exploration auto-creates one insight referencing the active query
+    // (useExplorerWorkbenchInit's "auto-create insight" effect) — drop a
+    // column onto its x prop so the query has a real referrer, mirroring how
+    // exploration-dnd-pull-in.spec.mjs establishes this same precondition.
+    await page.evaluate(name => {
+      const s = window.useStore.getState();
+      const insightName = s.explorerActiveInsightName;
+      if (insightName) s.setInsightProp(insightName, 'x', `?{\${ref(${name}).x}}`);
+    }, queryName);
+
+    await page.getByTestId('query-chip-add').click();
+    const secondName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    // Attempt to delete the REFERENCED query (queryName), not the new one.
+    await page.getByTestId(`query-chip-${queryName}`).click();
+    await page.getByTestId(`query-chip-${queryName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${queryName}-delete-action`).click();
+
+    const confirmDialog = page.getByTestId(`query-chip-${queryName}-delete-confirm`);
+    await expect(confirmDialog).toBeVisible({ timeout: 5000 });
+    await expect(confirmDialog).toContainText('1 draft insight');
+
+    // Cancel — the query survives.
+    await page.getByTestId(`query-chip-${queryName}-delete-confirm-cancel`).click();
+    await expect(page.getByTestId(`query-chip-${queryName}`)).toBeVisible();
+
+    // Now confirm — the query is deleted despite the warning.
+    await page.getByTestId(`query-chip-${queryName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${queryName}-delete-action`).click();
+    await expect(page.getByTestId(`query-chip-${queryName}-delete-confirm`)).toBeVisible();
+    await page.getByTestId(`query-chip-${queryName}-delete-confirm-confirm`).click();
+
+    await expect(page.getByTestId(`query-chip-${queryName}`)).not.toBeVisible();
+    await expect(page.getByTestId(`query-chip-${secondName}`)).toBeVisible();
+  });
+
+  test('cannot delete the last remaining chip — no Delete action offered', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const onlyName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId(`query-chip-${onlyName}-menu-trigger`).click();
+    await expect(page.getByTestId(`query-chip-${onlyName}-delete-action`)).not.toBeVisible();
+    await expect(page.getByTestId(`query-chip-${onlyName}-rename-action`)).toBeVisible();
+  });
+});

--- a/viewer/e2e/stories/exploration-query-chips.spec.mjs
+++ b/viewer/e2e/stories/exploration-query-chips.spec.mjs
@@ -46,6 +46,15 @@ async function newExploration(page) {
   return new URL(page.url()).pathname.split('/').pop();
 }
 
+/**
+ * The actual chip row locator — NOT `[data-testid^="query-chip-"]` alone.
+ * That prefix also matches other real elements inside/beside each chip
+ * (`query-chip-status-dot`, `query-chip-<name>-menu-trigger` on the active
+ * chip, and the `query-chip-add` button), so counting it directly over-counts
+ * by 3 for a single chip. Only the chip row itself carries `data-active`.
+ */
+const chips = page => page.locator('[data-testid^="query-chip-"][data-active]');
+
 test.describe('Exploration query chips (Explore 2.0 Phase 3a)', () => {
   let idsBeforeTest = [];
 
@@ -66,11 +75,11 @@ test.describe('Exploration query chips (Explore 2.0 Phase 3a)', () => {
     await gotoExplorerHome(page);
     await newExploration(page);
 
-    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(1);
+    await expect(chips(page)).toHaveCount(1);
     const firstName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
 
     await page.getByTestId('query-chip-add').click();
-    await expect(page.locator('[data-testid^="query-chip-"]')).toHaveCount(2);
+    await expect(chips(page)).toHaveCount(2);
     const secondName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
     expect(secondName).not.toBe(firstName);
     await expect(page.getByTestId(`query-chip-${secondName}`)).toHaveAttribute('data-active', 'true');

--- a/viewer/e2e/stories/library-source-drilldown.spec.mjs
+++ b/viewer/e2e/stories/library-source-drilldown.spec.mjs
@@ -1,0 +1,144 @@
+/**
+ * Story: Library source drill-down (Explore 2.0 Phase 3a — D9 / VIS-1052).
+ *
+ * The Library's "Sources" subsection stops being a flat list: each source
+ * row expands lazily into source → table → columns, reading the SAME
+ * backend-cached schema feed the right-rail source Data tab uses
+ * (`useSourceOutline` — B10 consolidation, 04-bug-inventory.md). Successor to
+ * `explorer-source-browser.spec.mjs` (verdict REWRITE, 05-e2e-ledger.md —
+ * "surfaced through the Library's D9 drill-down (retires SourceBrowser as a
+ * component)").
+ *
+ * Covers:
+ *   1. A source row is collapsed by default and does NOT fetch its schema
+ *      until expanded (genuinely lazy, not just visually collapsed).
+ *   2. Expanding a source shows its tables (from the cached feed); expanding
+ *      a table shows its columns, with type glyphs (# numeric, T text).
+ *   3. Table + column rows expose a drag handle (hover-revealed) — the drag
+ *      SOURCE half of D9's DnD unification (the drop-target half is covered
+ *      by exploration-dnd-pull-in.spec.mjs).
+ *   4. Collapse/re-expand does not re-fetch (session cache).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=librarySourceDrilldown VISIVO_SANDBOX_BACKEND_PORT=8045 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3045 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3045 npx playwright test library-source-drilldown
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+
+// Real sources in the integration test project (test-projects/integration/
+// project.visivo.yml): local-duckdb (file source, warms instantly) and
+// local-sqlite. `test_table` is a real table selected by several models.
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function gotoWorkspace(page) {
+  await page.goto(`${BASE_URL}/workspace`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 30000 });
+}
+
+/** Expand the "Sources" subsection itself (VIS-828: subsections default
+ * collapsed) so the per-source rows are visible at all. */
+async function expandSourcesSubsection(page) {
+  const header = page.getByTestId('library-subsection-source-header');
+  const body = page.getByTestId('library-subsection-source-body');
+  if (!(await body.isVisible().catch(() => false))) {
+    await header.click();
+  }
+  await expect(body).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoWorkspace(page);
+    await expandSourcesSubsection(page);
+  });
+
+  test('a source row is collapsed by default and lazily fetches its schema only on expand', async ({
+    page,
+  }) => {
+    const sourceRow = page.getByTestId(`library-row-source-${SOURCE}`);
+    await expect(sourceRow).toBeVisible();
+    await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(page.getByTestId(`library-source-${SOURCE}-tables`)).not.toBeVisible();
+
+    // Watch the network for the schema-jobs/tables fetch — it must not have
+    // fired before expansion.
+    let fetchedBeforeExpand = false;
+    page.on('request', req => {
+      if (req.url().includes('/api/source-schema-jobs/')) fetchedBeforeExpand = true;
+    });
+    await page.waitForTimeout(500);
+    expect(fetchedBeforeExpand).toBe(false);
+
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('expanding a table shows its columns with type glyphs (# numeric, T text)', async ({
+    page,
+  }) => {
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+    await expect(tableRow).toBeVisible({ timeout: 15000 });
+
+    await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+    const columns = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}-columns`);
+    await expect(columns).toBeVisible({ timeout: 10000 });
+    // At least one column row rendered with a glyph badge (# or T) — the
+    // exact column set depends on the fixture table's real schema, so assert
+    // structurally rather than pinning specific column names.
+    await expect(columns.locator('[data-testid^="library-source-column-"]').first()).toBeVisible();
+  });
+
+  test('table and column rows expose a hover-revealed drag handle', async ({ page }) => {
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+    await expect(tableRow).toBeVisible({ timeout: 15000 });
+    await tableRow.hover();
+    await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}-drag-handle`)).toBeVisible();
+
+    await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+    const firstColumn = page.locator('[data-testid^="library-source-column-"]').first();
+    await expect(firstColumn).toBeVisible({ timeout: 10000 });
+    await firstColumn.hover();
+    await expect(firstColumn.locator('[data-testid$="-drag-handle"]')).toBeVisible();
+  });
+
+  test('collapsing and re-expanding a source does not re-fetch the schema (session cache)', async ({
+    page,
+  }) => {
+    let fetchCount = 0;
+    page.on('request', req => {
+      if (req.url().includes('/api/source-schema-jobs/')) fetchCount += 1;
+    });
+
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
+      timeout: 15000,
+    });
+    const countAfterFirstExpand = fetchCount;
+    expect(countAfterFirstExpand).toBeGreaterThan(0);
+
+    // Collapse.
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await expect(page.getByTestId(`library-source-${SOURCE}-tables`)).not.toBeVisible();
+
+    // Re-expand — reads the session cache, no additional fetch.
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
+      timeout: 5000,
+    });
+    expect(fetchCount).toBe(countAfterFirstExpand);
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -42,6 +42,13 @@ export default defineConfig({
         // the 'exploration-mutations' project below.
         '**/explorer-home.spec.mjs',
         '**/exploration-lifecycle.spec.mjs',
+        // Phase 3a (VIS-1053/1054): both create/delete real backend
+        // exploration records via the same shared `.visivo/explorations/`
+        // repository (query-chip CRUD mutates the draft directly; the DnD
+        // pull-in specs each mint + clean up an exploration) — same
+        // isolation need as the two specs above, same project.
+        '**/exploration-dnd-pull-in.spec.mjs',
+        '**/exploration-query-chips.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -108,7 +115,14 @@ export default defineConfig({
       // not reproducible across 7+ repeated runs and wasn't worth the
       // dependency's cost.
       name: 'exploration-mutations',
-      testMatch: ['**/explorer-home.spec.mjs', '**/exploration-lifecycle.spec.mjs'],
+      testMatch: [
+        '**/explorer-home.spec.mjs',
+        '**/exploration-lifecycle.spec.mjs',
+        // Phase 3a additions (VIS-1053/1054) — see the 'parallel' project's
+        // testIgnore entry for the same two files for why.
+        '**/exploration-dnd-pull-in.spec.mjs',
+        '**/exploration-query-chips.spec.mjs',
+      ],
       fullyParallel: false,
       workers: 1,
       retries: 0,

--- a/viewer/src/components/explorer/CenterPanel.jsx
+++ b/viewer/src/components/explorer/CenterPanel.jsx
@@ -28,7 +28,20 @@ import useExplorerDuckDB from '../../hooks/useExplorerDuckDB';
 
 const NARROW_THRESHOLD = 600;
 
-const CenterPanel = () => {
+const CenterPanel = ({
+  // Explore 2.0 Phase 3a: the exploration surface (`ExplorationWorkbench`)
+  // replaces the horizontal `ModelTabBar` with compact query chips
+  // (`ExplorationQueryChips`); the standalone `/explorer` route
+  // (`ExplorerPage`) passes nothing and keeps `ModelTabBar` exactly as it
+  // was — `CenterPanel` is shared between the two, so the swap is a prop,
+  // never a hardcoded import change.
+  modelTabBar,
+  // Explore 2.0 Phase 3a (D9): opts the SQL editor into being a Library
+  // column/table drop target. Default false — only the exploration surface
+  // passes true; the standalone route's editor (and any other CenterPanel
+  // consumer) stays exactly as it was.
+  enableLibraryDrop = false,
+}) => {
   const activeModelName = useStore((s) => s.explorerActiveModelName);
   const sourceName = useStore(selectActiveModelSourceName);
   const setSourceName = useStore((s) => s.setActiveModelSource);
@@ -219,6 +232,7 @@ const CenterPanel = () => {
             onQueryComplete={handleQueryComplete}
             toolbarExtra={sourceSelector}
             toolbarRight={editorToggleButton}
+            dropInsertEnabled={enableLibraryDrop}
           />
         </div>
       ) : (
@@ -247,8 +261,8 @@ const CenterPanel = () => {
       data-testid="center-panel"
       ref={containerRef}
     >
-      {/* Model Tab Bar */}
-      <ModelTabBar />
+      {/* Model Tab Bar (standalone /explorer) or query chips (exploration surface) */}
+      {modelTabBar !== undefined ? modelTabBar : <ModelTabBar />}
 
       {/* Top row: Editor + Chart */}
       <div style={{ flex: topFlex }} className="overflow-hidden min-h-0" ref={topRowRef}>

--- a/viewer/src/components/explorer/CenterPanel.test.jsx
+++ b/viewer/src/components/explorer/CenterPanel.test.jsx
@@ -16,9 +16,19 @@ jest.mock('./DraggableColumnHeader', () => {
 // and the completion buttons deliver results with that captured context.
 jest.mock('./SQLEditor', () => {
   let capturedContext;
-  return function MockSQLEditor({ sourceName, initialValue, onSave, onQueryComplete, hideResults, queryContext, toolbarExtra, toolbarRight }) {
+  return function MockSQLEditor({
+    sourceName,
+    initialValue,
+    onSave,
+    onQueryComplete,
+    hideResults,
+    queryContext,
+    toolbarExtra,
+    toolbarRight,
+    dropInsertEnabled,
+  }) {
     return (
-      <div data-testid="sql-editor">
+      <div data-testid="sql-editor" data-drop-insert-enabled={String(!!dropInsertEnabled)}>
         <span data-testid="editor-source">{sourceName || 'no-source'}</span>
         <span data-testid="editor-value">{initialValue}</span>
         <span data-testid="editor-hide-results">{String(hideResults)}</span>
@@ -199,6 +209,28 @@ describe('CenterPanel', () => {
     render(<CenterPanel />);
 
     expect(screen.getByTestId('model-tab-bar')).toBeInTheDocument();
+  });
+
+  // Explore 2.0 Phase 3a: CenterPanel is shared between the standalone
+  // `/explorer` route (ExplorerPage, no props — keeps ModelTabBar
+  // untouched) and the new exploration surface (ExplorationWorkbench, which
+  // passes its own query chips + opts into the Library SQL-editor drop
+  // target). Both branches must coexist behind these opt-in props.
+  it('renders a custom modelTabBar when provided, instead of ModelTabBar', () => {
+    render(<CenterPanel modelTabBar={<div data-testid="custom-tab-bar">chips</div>} />);
+
+    expect(screen.getByTestId('custom-tab-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('model-tab-bar')).not.toBeInTheDocument();
+  });
+
+  it('defaults enableLibraryDrop to false — the SQL editor is not a drop target unless opted in', () => {
+    render(<CenterPanel />);
+    expect(screen.getByTestId('sql-editor')).toHaveAttribute('data-drop-insert-enabled', 'false');
+  });
+
+  it('forwards enableLibraryDrop to the SQL editor as dropInsertEnabled', () => {
+    render(<CenterPanel enableLibraryDrop />);
+    expect(screen.getByTestId('sql-editor')).toHaveAttribute('data-drop-insert-enabled', 'true');
   });
 
   it('renders SQL Editor and chart preview in wide mode', () => {

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import Editor from '@monaco-editor/react';
+import { useDroppable } from '@dnd-kit/core';
 import { PiPlay, PiStop, PiX, PiKeyboard } from 'react-icons/pi';
 import { useModelQueryJob } from '../../hooks/useModelQueryJob';
 import { useSourceSchema } from '../../hooks/useSourceSchema';
@@ -22,6 +23,13 @@ const SQLEditor = ({
   onQueryComplete,
   toolbarExtra,
   toolbarRight,
+  // Explore 2.0 Phase 3a (D9, 02-architecture.md §4): a Library column drag
+  // (schema drill-down OR the results grid) dropped on the editor inserts
+  // its bare name at the cursor. Default false/inert — `SQLEditor` is
+  // shared with the plain Workspace `ModelPreview` model-edit form, which
+  // must NOT become a drop target as a side effect of this change; only
+  // `CenterPanel` (the exploration surface) opts in.
+  dropInsertEnabled = false,
 }) => {
   const editorRef = useRef(null);
   const monacoRef = useRef(null);
@@ -130,6 +138,30 @@ const SQLEditor = ({
   const handleDismissError = useCallback(() => {
     setShowError(false);
   }, []);
+
+  // Explore 2.0 Phase 3a (D9): insert `text` at the Monaco cursor/selection.
+  // `editor.trigger('keyboard', 'type', ...)` (rather than `executeEdits`)
+  // both inserts at the live cursor position AND runs it through Monaco's
+  // normal typing pipeline, so `onChange`/`handleEditorChange` fires exactly
+  // as if the user had typed it — no separate setSql/onSave call needed.
+  const handleInsertTextAtCursor = useCallback(text => {
+    const editor = editorRef.current;
+    if (!editor || !text) return;
+    editor.focus();
+    editor.trigger('library-drop', 'type', { text });
+  }, []);
+
+  // The SQL editor as a drop target (disabled unless the caller opts in —
+  // see `dropInsertEnabled`'s docstring above). Data carries the callback
+  // itself (mirrors the `pivot-field`/`property-zone` "callback lives on the
+  // droppable" pattern) — the router (`WorkspaceDndContext.routeExplorationDragEnd`)
+  // never needs to know HOW to reach a Monaco instance, just that the
+  // droppable can insert text.
+  const { setNodeRef: setSqlDropRef, isOver: isSqlDropOver } = useDroppable({
+    id: 'sql-editor-drop',
+    data: { type: 'sql-editor-drop', onInsertText: handleInsertTextAtCursor },
+    disabled: !dropInsertEnabled,
+  });
 
   // Handle editor changes
   const handleEditorChange = useCallback(
@@ -304,7 +336,15 @@ const SQLEditor = ({
       )}
 
       {/* Editor */}
-      <div className="bg-[#1E1E1E]" style={{ height }}>
+      <div
+        ref={setSqlDropRef}
+        data-testid="sql-editor-drop-zone"
+        data-drop-over={isSqlDropOver ? 'true' : 'false'}
+        className={`bg-[#1E1E1E] ${
+          dropInsertEnabled && isSqlDropOver ? 'ring-2 ring-inset ring-primary-400' : ''
+        }`}
+        style={{ height }}
+      >
         <Editor
           height="100%"
           language="sql"

--- a/viewer/src/components/explorer/SQLEditor.test.jsx
+++ b/viewer/src/components/explorer/SQLEditor.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useDroppable } from '@dnd-kit/core';
 import SQLEditor from './SQLEditor';
 
 // Mock Monaco editor — selection state is configurable per-test
@@ -13,7 +14,16 @@ const mockEditor = {
   }),
   addCommand: jest.fn(),
   focus: jest.fn(),
+  trigger: jest.fn(),
 };
+
+// Explore 2.0 Phase 3a (D9): wrap the real dnd-kit so the drop-zone tests can
+// inspect the `useDroppable` call (id/data/disabled) without simulating a
+// real dnd-kit pointer drag (jsdom can't do that — Playwright covers it).
+jest.mock('@dnd-kit/core', () => {
+  const actual = jest.requireActual('@dnd-kit/core');
+  return { __esModule: true, ...actual, useDroppable: jest.fn(actual.useDroppable) };
+});
 
 const mockMonaco = {
   KeyMod: { CtrlCmd: 2048 },
@@ -662,6 +672,49 @@ describe('SQLEditor', () => {
 
       fireEvent.click(screen.getByTestId('close-profile'));
       expect(screen.queryByTestId('column-profile-panel')).not.toBeInTheDocument();
+    });
+  });
+
+  // Explore 2.0 Phase 3a (D9, 02-architecture.md §4): Library column drag →
+  // SQL editor cursor insert. The actual drag/drop can't run in jsdom, so
+  // these tests capture the `useDroppable` call the router
+  // (`WorkspaceDndContext.routeExplorationDragEnd`) would invoke and drive
+  // it directly.
+  describe('library drop target (D9)', () => {
+    beforeEach(() => {
+      useDroppable.mockClear();
+      mockEditor.trigger.mockClear();
+    });
+
+    it('registers the sql-editor-drop zone DISABLED by default (dropInsertEnabled not passed)', () => {
+      render(<SQLEditor sourceName="test_source" />);
+      const call = useDroppable.mock.calls.find(([opts]) => opts.id === 'sql-editor-drop');
+      expect(call[0].disabled).toBe(true);
+      // Still renders the container — ModelPreview's plain usage is simply
+      // inert, not absent.
+      expect(screen.getByTestId('sql-editor-drop-zone')).toBeInTheDocument();
+    });
+
+    it('enables the drop zone when dropInsertEnabled is true', () => {
+      render(<SQLEditor sourceName="test_source" dropInsertEnabled />);
+      const call = useDroppable.mock.calls.find(([opts]) => opts.id === 'sql-editor-drop');
+      expect(call[0].disabled).toBe(false);
+    });
+
+    it('the droppable data carries an onInsertText callback that types at the Monaco cursor', async () => {
+      render(<SQLEditor sourceName="test_source" dropInsertEnabled />);
+      // Wait for the mocked Editor's onMount (fired via setTimeout) so
+      // editorRef.current is populated.
+      await screen.findByTestId('monaco-editor');
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      const call = useDroppable.mock.calls.find(([opts]) => opts.id === 'sql-editor-drop');
+      act(() => call[0].data.onInsertText('region'));
+
+      expect(mockEditor.focus).toHaveBeenCalled();
+      expect(mockEditor.trigger).toHaveBeenCalledWith('library-drop', 'type', { text: 'region' });
     });
   });
 });

--- a/viewer/src/components/explorer/useExplorerWorkbenchInit.js
+++ b/viewer/src/components/explorer/useExplorerWorkbenchInit.js
@@ -1,13 +1,12 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import useStore from '../../stores/store';
+import { fetchSourceSchemaJobs } from '../../api/sourceSchemaJobs';
 
 /**
  * useExplorerWorkbenchInit — the mount-time + reactive init/lifecycle effects
- * shared by every host of the legacy Explorer 3-panel bundle (LeftPanel +
- * CenterPanel + RightPanel under ExplorerDndContext): the standalone
+ * shared by every host of the legacy Explorer bundle: the standalone
  * `/explorer` route (`ExplorerPage`) AND the Explore 2.0 in-shell exploration
- * pane (`ExplorationWorkbench`, `/workspace/exploration/:id` — Phase 2,
- * specs/plan/explorer-workspace-unification/03-delivery-plan.md).
+ * pane (`ExplorationWorkbench`, `/workspace/exploration/:id`).
  *
  * Extracted verbatim from `ExplorerPage.jsx` so both hosts run IDENTICAL init
  * logic — a second, independently-evolving copy is exactly the "fork" the
@@ -16,6 +15,9 @@ import useStore from '../../stores/store';
  * fork logic").
  *
  * Runs:
+ *   - fetch `explorerSources` on mount if empty (see the dedicated note
+ *     below — this is a Phase 3a addition, not part of the original
+ *     extraction);
  *   - a debounced (300ms) backend diff fetch whenever the working explorer
  *     state changes (`/api/explorer/diff/`);
  *   - fetch project defaults on mount (default source selection);
@@ -30,6 +32,21 @@ import useStore from '../../stores/store';
  * transient empty state that's about to be overwritten by the restore. The
  * Workspace host gates mounting `ExplorationWorkbench` (and therefore this
  * hook) on that restore having completed for the current exploration id.
+ *
+ * Phase 3a regression fix (VIS-1053): `explorerSources` used to be populated
+ * ONLY as a side effect of `ExplorerLeftPanel`'s nested `SourceBrowser`
+ * mounting (`SourceBrowser.onSourcesLoaded` -> `ExplorerLeftPanel`'s
+ * `handleSourcesLoaded` -> `setExplorerSources`) — true for the standalone
+ * route (still mounts `ExplorerLeftPanel`), but Phase 3a's DnD unification
+ * removed `ExplorerLeftPanel` from `ExplorationWorkbench` entirely (the
+ * Library is now the browse surface). That silently starved
+ * `explorerSources` to `[]` forever in the new surface, which in turn starved
+ * the auto-create-model-tab effect below (its `explorerSources.length > 0`
+ * guard never became true) — no query ever auto-created, `CenterPanel`'s
+ * source selector stuck on "Select source." Fetching directly in this
+ * SHARED init hook (rather than depending on a browse-panel component
+ * happening to be mounted) fixes both hosts at once and removes that
+ * component-render dependency entirely.
  */
 export default function useExplorerWorkbenchInit() {
   const modelTabs = useStore(s => s.explorerModelTabs);
@@ -39,6 +56,28 @@ export default function useExplorerWorkbenchInit() {
   const createInsight = useStore(s => s.createInsight);
   const fetchDefaults = useStore(s => s.fetchDefaults);
   const fetchExplorerDiff = useStore(s => s.fetchExplorerDiff);
+  const setExplorerSources = useStore(s => s.setExplorerSources);
+
+  // Populate explorerSources on mount if not already loaded — see the Phase
+  // 3a regression note above. Guarded on length so re-mounting this hook for
+  // a DIFFERENT exploration (switching tabs) doesn't keep re-fetching once a
+  // session already has sources cached; the sandbox's project sources don't
+  // change mid-session.
+  const explorerSourcesLength = explorerSources.length;
+  useEffect(() => {
+    if (explorerSourcesLength > 0) return undefined;
+    let cancelled = false;
+    fetchSourceSchemaJobs()
+      .then(data => {
+        if (!cancelled) setExplorerSources(data || []);
+      })
+      .catch(() => {
+        /* best-effort — mirrors SourceBrowser's own console-only error handling */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [explorerSourcesLength, setExplorerSources]);
 
   // Watch explorer state changes to trigger backend diff (debounced).
   const explorerModelStates = useStore(s => s.explorerModelStates);

--- a/viewer/src/components/explorer/useExplorerWorkbenchInit.test.js
+++ b/viewer/src/components/explorer/useExplorerWorkbenchInit.test.js
@@ -1,0 +1,91 @@
+/**
+ * useExplorerWorkbenchInit — Phase 3a regression coverage (VIS-1053).
+ *
+ * `explorerSources` used to be populated only as a side effect of
+ * `ExplorerLeftPanel`'s nested `SourceBrowser` mounting. Phase 3a's DnD
+ * unification removed `ExplorerLeftPanel` from `ExplorationWorkbench`
+ * entirely, which silently starved `explorerSources` to `[]` forever in the
+ * new surface — no query ever auto-created (the auto-create-model-tab effect
+ * gates on `explorerSources.length > 0`), and every e2e test that created a
+ * fresh exploration timed out waiting for `explorerActiveModelName`. This
+ * hook now fetches sources itself so both hosts get them regardless of
+ * whether a browse-panel component is mounted.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import useStore from '../../stores/store';
+import useExplorerWorkbenchInit from './useExplorerWorkbenchInit';
+import { fetchSourceSchemaJobs } from '../../api/sourceSchemaJobs';
+
+jest.mock('../../api/sourceSchemaJobs', () => ({
+  fetchSourceSchemaJobs: jest.fn(),
+}));
+
+const resetStore = () => {
+  useStore.setState({
+    explorerModelTabs: [],
+    explorerModelStates: {},
+    explorerSources: [],
+    explorerChartInsightNames: [],
+    explorerInsightStates: {},
+    explorerChartName: null,
+    explorerChartLayout: {},
+    createModelTab: jest.fn(),
+    createInsight: jest.fn(),
+    fetchDefaults: jest.fn(),
+    fetchExplorerDiff: jest.fn(),
+    setExplorerSources: sources => useStore.setState({ explorerSources: sources }),
+  });
+};
+
+describe('useExplorerWorkbenchInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  test('fetches explorerSources on mount when empty', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([{ source_name: 'local-duckdb' }]);
+    renderHook(() => useExplorerWorkbenchInit());
+
+    await waitFor(() => expect(fetchSourceSchemaJobs).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(useStore.getState().explorerSources).toEqual([{ source_name: 'local-duckdb' }])
+    );
+  });
+
+  test('does NOT re-fetch when explorerSources is already populated', () => {
+    useStore.setState({ explorerSources: [{ source_name: 'already-loaded' }] });
+    renderHook(() => useExplorerWorkbenchInit());
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
+  });
+
+  test('a fetch failure is swallowed (best-effort, mirrors SourceBrowser)', async () => {
+    fetchSourceSchemaJobs.mockRejectedValue(new Error('boom'));
+    expect(() => renderHook(() => useExplorerWorkbenchInit())).not.toThrow();
+    await waitFor(() => expect(fetchSourceSchemaJobs).toHaveBeenCalled());
+  });
+
+  // The actual regression: sources arriving must unblock the pre-existing
+  // auto-create-model-tab effect.
+  test('once sources arrive, auto-creates a model tab (the fixed end-to-end path)', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([{ source_name: 'local-duckdb' }]);
+    const createModelTab = jest.fn();
+    useStore.setState({ createModelTab });
+
+    renderHook(() => useExplorerWorkbenchInit());
+
+    await waitFor(() => expect(useStore.getState().explorerSources).toHaveLength(1));
+    await waitFor(() => expect(createModelTab).toHaveBeenCalledTimes(1));
+  });
+
+  test('does not create a model tab if one already exists, even once sources arrive', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([{ source_name: 'local-duckdb' }]);
+    const createModelTab = jest.fn();
+    useStore.setState({ createModelTab, explorerModelTabs: ['existing_q'] });
+
+    renderHook(() => useExplorerWorkbenchInit());
+
+    await waitFor(() => expect(useStore.getState().explorerSources).toHaveLength(1));
+    expect(createModelTab).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -4,6 +4,7 @@ import useStore from '../../../stores/store';
 import SubBar from './SubBar';
 import ExplorationWorkbench from './ExplorationWorkbench';
 import InlineRenameInput from './InlineRenameInput';
+import useInlineRename from '../../../hooks/useInlineRename';
 import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import { legacyStateToDraft, draftToLegacyState } from './explorationLegacyBridge';
 
@@ -39,18 +40,17 @@ const FrameState = ({ testId, title, body, icon: Icon = PiCircleNotch, spin = fa
  * `InlineRenameInput`.
  */
 const RenameField = ({ name, onCommit }) => {
-  const [editing, setEditing] = useState(false);
+  // B16 (04-bug-inventory.md): the shared "am I editing this name" toggle —
+  // see useInlineRename's docstring for why this hook exists.
+  const rename = useInlineRename({ onCommit });
 
-  if (editing) {
+  if (rename.editing) {
     return (
       <InlineRenameInput
         name={name}
         testIdPrefix="exploration-rename"
-        onCommit={nextName => {
-          setEditing(false);
-          onCommit(nextName);
-        }}
-        onCancel={() => setEditing(false)}
+        onCommit={rename.commit}
+        onCancel={rename.cancel}
       />
     );
   }
@@ -60,7 +60,7 @@ const RenameField = ({ name, onCommit }) => {
       <span className="truncate font-semibold text-gray-900">{name}</span>
       <button
         type="button"
-        onClick={() => setEditing(true)}
+        onClick={rename.start}
         title="Rename"
         aria-label="Rename exploration"
         data-testid="exploration-rename-start"

--- a/viewer/src/components/views/workspace/ExplorationQueryChips.jsx
+++ b/viewer/src/components/views/workspace/ExplorationQueryChips.jsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useMemo } from 'react';
+import { PiPlus, PiDotsThree, PiLink } from 'react-icons/pi';
+import useStore from '../../../stores/store';
+import Dropdown from '../../common/Dropdown';
+import { useConfirm } from '../../common/ConfirmDialog';
+import InlineRenameInput from './InlineRenameInput';
+import useInlineRename from '../../../hooks/useInlineRename';
+import { countReferencingInsights } from '../../../utils/refWalk';
+
+/**
+ * ExplorationQueryChips — Explore 2.0 Phase 3a (01-ux-spec.md §3).
+ *
+ * Replaces the legacy `ModelTabBar` (horizontal bordered tabs) on the
+ * EXPLORATION surface only — the standalone `/explorer` route keeps
+ * `ModelTabBar` exactly as it was (`CenterPanel`'s `modelTabBar` prop is how
+ * the two surfaces diverge; see that component's docstring). Same
+ * underlying store — `explorerModelTabs`/`explorerActiveModelName`/
+ * `switchModelTab`/`createModelTab`/`closeModelTab`/`renameModelTab` (a
+ * "model tab" IS a scratch query) — just a compact chip anatomy instead of
+ * bordered tabs:
+ *
+ *   [● orders_q ⛓2 ⋮] [○ cohort_q] [+]
+ *
+ *   - run-status dot: green (last run succeeded) · red (last run errored) ·
+ *     gray (not yet run) — read straight off `explorerModelStates[name]`
+ *     (`queryResult`/`queryError`), no separate tracking needed.
+ *   - ⛓n referenced-by badge: how many of the chart's draft insights
+ *     reference this query (successor to `ModelTabBar`'s boolean
+ *     `ring-purple` — a COUNT now), via the shared `refWalk` util (B16).
+ *   - ⋮ menu (active chip only, mirroring `ModelTabBar`'s rename-only-when-
+ *     active convention... actually ModelTabBar allowed rename on any tab via
+ *     double-click; here it's exposed via the ACTIVE chip's kebab, since a
+ *     compact chip has no room for a persistent affordance on every chip):
+ *     Rename (shared `useInlineRename`, B16) and Delete — Delete warns via
+ *     `ConfirmDialog` when the query has draft-insight referrers (the
+ *     `explorer-insight-survives-model-close.spec.mjs` regression class's
+ *     query-chip successor, 03-delivery-plan.md Phase 3a gate).
+ *   - Cannot delete the last remaining chip (an exploration always has at
+ *     least one query) — mirrors `ModelTabBar`'s `showCloseButton`.
+ *   - [+] creates a new chip (`createModelTab()`, auto-named + disambiguated
+ *     — cross-type uniqueness enforced by the store's `assertNameUnique`).
+ *
+ * Most explorations are single-query, so with one tab this collapses to
+ * just `[● query_1] [+]` — no menu needed until there's something to
+ * rename/delete relative to (a lone chip still gets its menu on select,
+ * consistent rather than a special-cased single-chip UI).
+ */
+
+const RunStatusDot = ({ modelState }) => {
+  const status = !modelState ? 'idle' : modelState.queryError ? 'error' : modelState.queryResult ? 'success' : 'idle';
+  const cls =
+    status === 'success' ? 'bg-green-500' : status === 'error' ? 'bg-highlight-500' : 'bg-gray-300';
+  const title =
+    status === 'success' ? 'Last run: success' : status === 'error' ? 'Last run: error' : 'Not yet run';
+  return (
+    <span
+      className={`h-1.5 w-1.5 shrink-0 rounded-full ${cls}`}
+      title={title}
+      data-testid="query-chip-status-dot"
+      data-status={status}
+    />
+  );
+};
+
+const QueryChip = ({
+  name,
+  active,
+  modelState,
+  referencedCount,
+  canDelete,
+  onActivate,
+  onRenameCommit,
+  onDelete,
+}) => {
+  const rename = useInlineRename({ onCommit: onRenameCommit });
+  const { confirm, ConfirmDialog: deleteConfirmDialog } = useConfirm();
+
+  const handleDeleteClick = useCallback(
+    async close => {
+      close();
+      if (referencedCount > 0) {
+        const ok = await confirm({
+          title: `Delete "${name}"?`,
+          body: `${referencedCount} draft insight${referencedCount === 1 ? '' : 's'} reference${
+            referencedCount === 1 ? 's' : ''
+          } this query. Deleting it may break ${referencedCount === 1 ? 'it' : 'them'}.`,
+          confirmLabel: 'Delete anyway',
+          danger: true,
+          testId: `query-chip-${name}-delete-confirm`,
+        });
+        if (!ok) return;
+      }
+      onDelete(name);
+    },
+    [confirm, referencedCount, name, onDelete]
+  );
+
+  if (rename.editing) {
+    return (
+      <div
+        data-testid={`query-chip-${name}`}
+        className="flex h-6 items-center gap-1 rounded-md border border-primary-300 bg-white px-1.5"
+      >
+        <InlineRenameInput
+          name={name}
+          testIdPrefix={`query-chip-${name}-rename`}
+          onCommit={rename.commit}
+          onCancel={rename.cancel}
+        />
+        {rename.error && (
+          <span
+            data-testid={`query-chip-${name}-rename-error`}
+            className="text-[10px] text-highlight-600"
+          >
+            {rename.error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid={`query-chip-${name}`}
+      data-active={active ? 'true' : 'false'}
+      onClick={() => onActivate(name)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onActivate(name);
+        }
+      }}
+      className={[
+        'flex h-6 shrink-0 cursor-pointer items-center gap-1 rounded-md pl-2 pr-1 text-[11px] transition-colors',
+        active
+          ? 'border border-primary-200 bg-primary-50 text-primary-700'
+          : 'border border-transparent bg-gray-100 text-gray-600 hover:bg-gray-200/70',
+      ].join(' ')}
+    >
+      <RunStatusDot modelState={modelState} />
+      <span className="max-w-[140px] truncate font-medium">{name}</span>
+      {referencedCount > 0 && (
+        <span
+          data-testid={`query-chip-${name}-ref-badge`}
+          title={`${referencedCount} draft insight${referencedCount === 1 ? '' : 's'} reference this query`}
+          className="ml-0.5 inline-flex items-center gap-0.5 rounded bg-teal-100 px-1 py-0.5 text-[9px] font-semibold text-teal-700"
+        >
+          <PiLink className="h-2.5 w-2.5" aria-hidden="true" />
+          {referencedCount}
+        </span>
+      )}
+      {active && (
+        // Stop the click from bubbling to the chip's own onClick (onActivate)
+        // — but only AFTER Dropdown's own trigger wrapper has had a chance to
+        // toggle the panel: Dropdown puts its open-toggle onClick on a div
+        // wrapping `trigger`, and a *descendant* handler that calls
+        // stopPropagation would suppress that toggle too. Stopping
+        // propagation here (a sibling-level ancestor of Dropdown's own
+        // wrapper) lets the toggle fire first, then blocks it from reaching
+        // the chip.
+        <span onClick={e => e.stopPropagation()}>
+          <Dropdown
+            align="left"
+            width={140}
+            trigger={
+              <button
+                type="button"
+                title="Query options"
+                aria-label={`Options for ${name}`}
+                data-testid={`query-chip-${name}-menu-trigger`}
+                className="ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-primary-400 hover:bg-primary-100 hover:text-primary-600"
+              >
+                <PiDotsThree className="h-3 w-3" />
+              </button>
+            }
+          >
+            {close => (
+              <div className="py-1">
+                <button
+                  type="button"
+                  data-testid={`query-chip-${name}-rename-action`}
+                  onClick={() => {
+                    close();
+                    rename.start();
+                  }}
+                  className="flex w-full items-center px-3 py-1.5 text-left text-[12px] text-gray-800 hover:bg-gray-50"
+                >
+                  Rename
+                </button>
+                {canDelete && (
+                  <button
+                    type="button"
+                    data-testid={`query-chip-${name}-delete-action`}
+                    onClick={() => handleDeleteClick(close)}
+                    className="flex w-full items-center px-3 py-1.5 text-left text-[12px] text-highlight-600 hover:bg-highlight-50"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            )}
+          </Dropdown>
+        </span>
+      )}
+      {deleteConfirmDialog}
+    </div>
+  );
+};
+
+const ExplorationQueryChips = () => {
+  const tabs = useStore(s => s.explorerModelTabs);
+  const activeModelName = useStore(s => s.explorerActiveModelName);
+  const modelStates = useStore(s => s.explorerModelStates);
+  const chartInsightNames = useStore(s => s.explorerChartInsightNames);
+  const insightStates = useStore(s => s.explorerInsightStates);
+  const switchModelTab = useStore(s => s.switchModelTab);
+  const createModelTab = useStore(s => s.createModelTab);
+  const closeModelTab = useStore(s => s.closeModelTab);
+  const renameModelTab = useStore(s => s.renameModelTab);
+
+  const referencedCounts = useMemo(
+    () => countReferencingInsights(tabs, chartInsightNames, insightStates),
+    [tabs, chartInsightNames, insightStates]
+  );
+
+  return (
+    <div
+      className="flex flex-shrink-0 items-center gap-1 overflow-x-auto border-b border-secondary-200 bg-white px-2 py-1.5"
+      data-testid="exploration-query-chips"
+    >
+      {tabs.map(name => (
+        <QueryChip
+          key={name}
+          name={name}
+          active={name === activeModelName}
+          modelState={modelStates[name]}
+          referencedCount={referencedCounts.get(name) || 0}
+          canDelete={tabs.length > 1}
+          onActivate={switchModelTab}
+          onRenameCommit={nextName => renameModelTab(name, nextName)}
+          onDelete={closeModelTab}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={() => createModelTab()}
+        title="New query"
+        aria-label="New query"
+        data-testid="query-chip-add"
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-dashed border-gray-300 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-500"
+      >
+        <PiPlus className="h-3 w-3" />
+      </button>
+    </div>
+  );
+};
+
+export default ExplorationQueryChips;

--- a/viewer/src/components/views/workspace/ExplorationQueryChips.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationQueryChips.test.jsx
@@ -1,0 +1,223 @@
+/**
+ * ExplorationQueryChips — Explore 2.0 Phase 3a (01-ux-spec.md §3).
+ *
+ * Covers create/switch/rename/no-duplicate-names/delete(-with-dependents) —
+ * the query-chip CRUD ledger resolution (05-e2e-ledger.md orchestrator
+ * resolution #3), plus the run-status dot and referenced-by badge.
+ */
+/* eslint-disable no-template-curly-in-string -- fixtures use literal Visivo ref-string syntax, not JS template interpolation */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
+import useStore from '../../../stores/store';
+import ExplorationQueryChips from './ExplorationQueryChips';
+
+const resetStore = () => {
+  act(() => {
+    useStore.setState({
+      explorerModelTabs: [],
+      explorerActiveModelName: null,
+      explorerModelStates: {},
+      explorerChartInsightNames: [],
+      explorerInsightStates: {},
+    });
+  });
+};
+
+describe('ExplorationQueryChips', () => {
+  beforeEach(resetStore);
+
+  test('renders a chip per query tab, with the active one flagged', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+      useStore.getState().createModelTab('cohort_q');
+    });
+    render(<ExplorationQueryChips />);
+    expect(screen.getByTestId('query-chip-orders_q')).toHaveAttribute('data-active', 'false');
+    expect(screen.getByTestId('query-chip-cohort_q')).toHaveAttribute('data-active', 'true');
+  });
+
+  test('[+] creates a new, auto-named query chip and activates it', () => {
+    render(<ExplorationQueryChips />);
+    expect(screen.queryByTestId(/^query-chip-model/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('query-chip-add'));
+    expect(useStore.getState().explorerModelTabs).toHaveLength(1);
+    const name = useStore.getState().explorerModelTabs[0];
+    expect(screen.getByTestId(`query-chip-${name}`)).toHaveAttribute('data-active', 'true');
+  });
+
+  test('clicking an inactive chip switches to it', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+      useStore.getState().createModelTab('cohort_q');
+    });
+    render(<ExplorationQueryChips />);
+    fireEvent.click(screen.getByTestId('query-chip-orders_q'));
+    expect(useStore.getState().explorerActiveModelName).toBe('orders_q');
+  });
+
+  test('the run-status dot reflects queryResult/queryError/not-yet-run', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+      useStore.getState().setModelQueryResult('orders_q', { rows: [], columns: [] });
+      useStore.getState().createModelTab('cohort_q');
+      useStore.getState().setModelQueryError('cohort_q', 'boom');
+      useStore.getState().createModelTab('never_run_q');
+    });
+    render(<ExplorationQueryChips />);
+    const dotFor = name =>
+      within(screen.getByTestId(`query-chip-${name}`)).getByTestId('query-chip-status-dot');
+    expect(dotFor('orders_q')).toHaveAttribute('data-status', 'success');
+    expect(dotFor('cohort_q')).toHaveAttribute('data-status', 'error');
+    expect(dotFor('never_run_q')).toHaveAttribute('data-status', 'idle');
+  });
+
+  test('shows a referenced-by badge counting draft insights that reference the query', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+      useStore.setState({
+        explorerChartInsightNames: ['churn_by_cohort', 'revenue_by_region'],
+        explorerInsightStates: {
+          churn_by_cohort: { props: { x: '${ref(orders_q).cohort}' }, interactions: [] },
+          revenue_by_region: { props: { x: '${ref(orders_q).region}' }, interactions: [] },
+        },
+      });
+    });
+    render(<ExplorationQueryChips />);
+    expect(screen.getByTestId('query-chip-orders_q-ref-badge')).toHaveTextContent('2');
+  });
+
+  test('no badge when nothing references the query', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+    });
+    render(<ExplorationQueryChips />);
+    expect(screen.queryByTestId('query-chip-orders_q-ref-badge')).not.toBeInTheDocument();
+  });
+
+  describe('rename (active chip only)', () => {
+    test('the ⋮ menu Rename action swaps the chip for an inline input; committing renames the tab', () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-orders_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-orders_q-rename-action'));
+
+      const input = screen.getByTestId('query-chip-orders_q-rename-input');
+      fireEvent.change(input, { target: { value: 'orders_query' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_query']);
+      expect(screen.getByTestId('query-chip-orders_query')).toBeInTheDocument();
+    });
+
+    test('no-duplicate-names: renaming to an existing tab name shows an inline collision error and stays editable', () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+        useStore.getState().createModelTab('cohort_q');
+      });
+      render(<ExplorationQueryChips />);
+      // cohort_q is active (most recently created).
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-rename-action'));
+
+      const input = screen.getByTestId('query-chip-cohort_q-rename-input');
+      fireEvent.change(input, { target: { value: 'orders_q' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(screen.getByTestId('query-chip-cohort_q-rename-error')).toBeInTheDocument();
+      // Still both original tabs — the rename did not go through.
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_q', 'cohort_q']);
+      // Still in edit mode for a retry.
+      expect(screen.getByTestId('query-chip-cohort_q-rename-input')).toBeInTheDocument();
+    });
+
+    test('Escape cancels the rename without committing', () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-orders_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-orders_q-rename-action'));
+      const input = screen.getByTestId('query-chip-orders_q-rename-input');
+      fireEvent.change(input, { target: { value: 'whatever' } });
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_q']);
+      expect(screen.getByTestId('query-chip-orders_q')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete', () => {
+    test('deletes a query with no referrers immediately (no confirm dialog)', () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+        useStore.getState().createModelTab('cohort_q');
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-delete-action'));
+
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_q']);
+    });
+
+    // Successor to explorer-insight-survives-model-close.spec.mjs (03's Phase
+    // 3a gate: "query-chip delete-with-dependents warning story").
+    test('warns via ConfirmDialog when draft insights reference the query; cancel keeps it', async () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+        useStore.getState().createModelTab('cohort_q');
+        useStore.setState({
+          explorerChartInsightNames: ['churn_by_cohort'],
+          explorerInsightStates: {
+            churn_by_cohort: { props: { x: '${ref(cohort_q).cohort}' }, interactions: [] },
+          },
+        });
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-delete-action'));
+
+      await screen.findByTestId('query-chip-cohort_q-delete-confirm');
+      expect(screen.getByTestId('query-chip-cohort_q-delete-confirm')).toHaveTextContent(
+        '1 draft insight'
+      );
+
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-delete-confirm-cancel'));
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_q', 'cohort_q']);
+    });
+
+    test('confirming the warning deletes the query anyway', async () => {
+      act(() => {
+        useStore.getState().createModelTab('orders_q');
+        useStore.getState().createModelTab('cohort_q');
+        useStore.setState({
+          explorerChartInsightNames: ['churn_by_cohort'],
+          explorerInsightStates: {
+            churn_by_cohort: { props: { x: '${ref(cohort_q).cohort}' }, interactions: [] },
+          },
+        });
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-menu-trigger'));
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-delete-action'));
+
+      await screen.findByTestId('query-chip-cohort_q-delete-confirm');
+      fireEvent.click(screen.getByTestId('query-chip-cohort_q-delete-confirm-confirm'));
+
+      await waitFor(() => expect(useStore.getState().explorerModelTabs).toEqual(['orders_q']));
+    });
+
+    test('cannot delete the last remaining query — no Delete action offered', () => {
+      act(() => {
+        useStore.getState().createModelTab('only_q');
+      });
+      render(<ExplorationQueryChips />);
+      fireEvent.click(screen.getByTestId('query-chip-only_q-menu-trigger'));
+      expect(screen.queryByTestId('query-chip-only_q-delete-action')).not.toBeInTheDocument();
+      // Rename is still offered even with one tab.
+      expect(screen.getByTestId('query-chip-only_q-rename-action')).toBeInTheDocument();
+    });
+  });
+});

--- a/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
+++ b/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
@@ -1,79 +1,79 @@
-import React, { useRef } from 'react';
-import LeftPanel from '../../explorer/ExplorerLeftPanel';
+import React from 'react';
 import CenterPanel from '../../explorer/CenterPanel';
 import ExplorerRightPanel from '../../explorer/ExplorerRightPanel';
-import ExplorerDndContext from '../../explorer/ExplorerDndContext';
-import VerticalDivider from '../../common/VerticalDivider';
-import useStore from '../../../stores/store';
-import { usePanelResize } from '../../../hooks/usePanelResize';
 import useExplorerWorkbenchInit from '../../explorer/useExplorerWorkbenchInit';
+import ExplorationQueryChips from './ExplorationQueryChips';
 
 /**
- * ExplorationWorkbench — the legacy Explorer 3-panel bundle
- * (ExplorerLeftPanel + CenterPanel + ExplorerRightPanel under
- * ExplorerDndContext), sized to fill an `ExplorationPane` inside the
+ * ExplorationWorkbench — the legacy Explorer bundle (now CenterPanel +
+ * ExplorerRightPanel), sized to fill an `ExplorationPane` inside the
  * Workspace shell rather than the standalone `/explorer` route's full
- * viewport (Explore 2.0 Phase 2 — 03-delivery-plan.md's composition-scoping
- * note: "nests the entire legacy 3-panel bundle + its DndContext inside
- * ExplorationPane as a temporary internal implementation detail").
+ * viewport (Explore 2.0 Phase 2 origin; SURGICALLY REDUCED in Phase 3a per
+ * 03-delivery-plan.md's Phase 3a scope: "Delete ExplorerLeftPanel... delete
+ * ExplorerDndContext").
  *
- * Deliberately the SAME composition + init lifecycle as `ExplorerPage`
- * (the standalone route), just re-parented and re-sized:
- *   - `useExplorerWorkbenchInit()` is the extracted, SHARED init hook (diff
- *     debounce, auto-create-model-tab, auto-create-insight, fetch-defaults) —
- *     see its docstring for why a second copy would be a forbidden fork.
+ * What changed in Phase 3a (D9 / DnD unification), and — just as
+ * importantly — what did NOT:
+ *
+ *   - `ExplorerLeftPanel` (+ its nested `SourceBrowser`) is REMOVED from
+ *     this composition. The Workspace's own Library (the shell's persistent
+ *     left rail, one level up from this component) is now the ONE browse
+ *     surface for the exploration surface too — its new source → schema →
+ *     table → column drill-down (`LibrarySourceRow.jsx`) replaces
+ *     `SourceBrowser`, and its existing model/metric/dimension/insight/input
+ *     rows keep their drag semantics (`LibraryRow.jsx`'s
+ *     `EXPLORATION_DRAG_TYPES`). Both files stay ALIVE in the tree —
+ *     `ExplorerPage.jsx` (the standalone `/explorer` route) still renders
+ *     `ExplorerLeftPanel` directly and must keep passing its existing e2e
+ *     stories untouched until the Phase 3b cutover deletes that route
+ *     entirely (per this task's explicit test-compat directive — the
+ *     03-delivery-plan.md phrasing "Delete ExplorerLeftPanel" describes the
+ *     Phase 3b END STATE, not a Phase 3a file deletion). Only THIS
+ *     component's use of it is removed.
+ *   - `ExplorerDndContext` is likewise REMOVED from this nesting — it stays
+ *     alive as a component + its own DndContext for `ExplorerPage.jsx`'s
+ *     standalone route (same reasoning as above). Deleting it here is what
+ *     "DnD unification" means concretely: this pane now mounts INSIDE the
+ *     shell's single `WorkspaceDndContext` (`WorkspaceShell.jsx`), whose
+ *     router (`routeExplorationDragEnd`) has the SAME resolution logic
+ *     `ExplorerDndContext.handleDragEnd` had, ported verbatim — see that
+ *     function's docstring. Nested dnd-kit contexts don't compose, so this
+ *     was the only way a Library drag (now sourced from the OUTER rail, not
+ *     a nested one) could ever reach the exploration surface's drop targets
+ *     (SQL editor, insight prop slots, interactions, the chart's insight
+ *     zone) in the first place.
+ *   - `CenterPanel` gets two new opt-in props (both default OFF, so
+ *     `ExplorerPage`'s call site is unaffected): `modelTabBar` (this pane
+ *     passes `<ExplorationQueryChips/>`, replacing the horizontal
+ *     `ModelTabBar` with compact chips, 01-ux-spec.md §3) and
+ *     `enableLibraryDrop` (turns the SQL editor into a Library table/column
+ *     drop target, D9).
+ *   - `ExplorerRightPanel` is UNCHANGED — its existing droppable prop slots
+ *     (`property-zone`/`axis-zone`/`interaction-zone`/`insight-zone`) keep
+ *     working exactly as before; rebuilding that rail is explicitly Phase
+ *     3b's job (S5), not this phase's.
+ *   - `useExplorerWorkbenchInit()` (the shared init hook) is unchanged —
+ *     still the SAME hook `ExplorerPage` uses, per its own docstring on why
+ *     a second copy would be a forbidden fork.
  *   - No return-bar / `?return_to=` handling here — that's the dashboard
- *     round-trip intent, out of Phase 2's scope (lands with Phase 5's
- *     `return_to` placement-intent work, 02-architecture.md §5).
- *   - Nested `ExplorerDndContext` under the outer `WorkspaceDndContext` is
- *     accepted ONLY because the outer context has no drop targets inside this
- *     pane yet (dnd-kit contexts don't compose) — DnD unifies in Phase 3a.
+ *     round-trip intent, out of scope until Phase 5's `return_to`
+ *     placement-intent work (02-architecture.md §5).
  *
  * The HOST (`ExplorationPane`) is responsible for gating this component's
  * mount on the per-exploration state restore having already landed — see
  * `useExplorerWorkbenchInit`'s docstring.
  */
 const ExplorationWorkbench = () => {
-  const leftNavCollapsed = useStore(s => s.explorerLeftNavCollapsed);
-
   useExplorerWorkbenchInit();
 
-  const containerRef = useRef(null);
-  const {
-    ratio: leftRatio,
-    isResizing: isLeftResizing,
-    handleMouseDown: handleLeftMouseDown,
-  } = usePanelResize({
-    containerRef,
-    direction: 'horizontal',
-    initialRatio: 0.18,
-    minSize: 48,
-    maxRatio: 0.3,
-    minRatio: 0.03,
-  });
-
-  const leftWidth = leftNavCollapsed ? 48 : Math.round(leftRatio * 100);
-
   return (
-    <ExplorerDndContext>
-      <div
-        className="flex min-h-0 flex-1 overflow-hidden bg-gray-50"
-        data-testid="exploration-workbench"
-        ref={containerRef}
-      >
-        <div
-          style={{ width: leftNavCollapsed ? '48px' : `${leftWidth}%` }}
-          className="flex-shrink-0 overflow-hidden"
-        >
-          <LeftPanel />
-        </div>
-        {!leftNavCollapsed && (
-          <VerticalDivider isDragging={isLeftResizing} handleMouseDown={handleLeftMouseDown} />
-        )}
-        <CenterPanel />
-        <ExplorerRightPanel />
-      </div>
-    </ExplorerDndContext>
+    <div
+      className="flex min-h-0 flex-1 overflow-hidden bg-gray-50"
+      data-testid="exploration-workbench"
+    >
+      <CenterPanel modelTabBar={<ExplorationQueryChips />} enableLibraryDrop />
+      <ExplorerRightPanel />
+    </div>
   );
 };
 

--- a/viewer/src/components/views/workspace/ExplorationWorkbench.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationWorkbench.test.jsx
@@ -1,28 +1,23 @@
 /**
- * ExplorationWorkbench — the legacy Explorer 3-panel bundle re-parented for
- * `ExplorationPane` (Explore 2.0 Phase 2). Same composition as `ExplorerPage`
- * (the standalone route), just re-sized — pinned here as a light structural
- * test; the shared init lifecycle is `useExplorerWorkbenchInit`'s own
- * concern (mirrored, not duplicated, from `ExplorerPage.test.jsx`).
+ * ExplorationWorkbench — the legacy Explorer bundle re-parented for
+ * `ExplorationPane` (Explore 2.0 Phase 2, SURGICALLY REDUCED in Phase 3a —
+ * see the component's own docstring for exactly what changed and why
+ * `ExplorerLeftPanel`/`ExplorerDndContext` stay alive as files for the
+ * still-untouched standalone `/explorer` route).
  */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ExplorationWorkbench from './ExplorationWorkbench';
 import useStore from '../../../stores/store';
 
-jest.mock('../../explorer/ExplorerDndContext', () => {
-  return function MockExplorerDndContext({ children }) {
-    return <div data-testid="dnd-context">{children}</div>;
-  };
-});
-jest.mock('../../explorer/ExplorerLeftPanel', () => {
-  return function MockExplorerLeftPanel() {
-    return <div data-testid="left-panel">ExplorerLeftPanel</div>;
-  };
-});
 jest.mock('../../explorer/CenterPanel', () => {
-  return function MockCenterPanel() {
-    return <div data-testid="center-panel">CenterPanel</div>;
+  return function MockCenterPanel({ modelTabBar, enableLibraryDrop }) {
+    return (
+      <div data-testid="center-panel" data-enable-library-drop={enableLibraryDrop ? 'true' : 'false'}>
+        CenterPanel
+        {modelTabBar}
+      </div>
+    );
   };
 });
 jest.mock('../../explorer/ExplorerRightPanel', () => {
@@ -30,23 +25,15 @@ jest.mock('../../explorer/ExplorerRightPanel', () => {
     return <div data-testid="right-panel">ExplorerRightPanel</div>;
   };
 });
-jest.mock('../../common/VerticalDivider', () => {
-  return function MockVerticalDivider({ handleMouseDown }) {
-    return (
-      <div data-testid="vertical-divider" onMouseDown={handleMouseDown}>
-        VD
-      </div>
-    );
+jest.mock('./ExplorationQueryChips', () => {
+  return function MockExplorationQueryChips() {
+    return <div data-testid="exploration-query-chips-mock">chips</div>;
   };
 });
-jest.mock('../../../hooks/usePanelResize', () => ({
-  usePanelResize: () => ({ ratio: 0.18, isResizing: false, handleMouseDown: jest.fn() }),
-}));
 
 describe('ExplorationWorkbench', () => {
   beforeEach(() => {
     useStore.setState({
-      explorerLeftNavCollapsed: false,
       explorerModelTabs: [],
       explorerActiveModelName: null,
       explorerChartInsightNames: [],
@@ -58,24 +45,27 @@ describe('ExplorationWorkbench', () => {
     });
   });
 
-  test('renders all three legacy panels under the DnD context', () => {
+  test('renders CenterPanel + ExplorerRightPanel — NO nested DnD context, NO ExplorerLeftPanel', () => {
     render(<ExplorationWorkbench />);
     expect(screen.getByTestId('exploration-workbench')).toBeInTheDocument();
-    expect(screen.getByTestId('dnd-context')).toBeInTheDocument();
-    expect(screen.getByTestId('left-panel')).toBeInTheDocument();
     expect(screen.getByTestId('center-panel')).toBeInTheDocument();
     expect(screen.getByTestId('right-panel')).toBeInTheDocument();
+    // Phase 3a: DnD unifies onto the shell's WorkspaceDndContext — this
+    // component no longer wraps a nested one, and the Library (the
+    // Workspace's own left rail, not a component this pane mounts) replaces
+    // the old ExplorerLeftPanel as the browse surface.
+    expect(screen.queryByTestId('dnd-context')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('left-panel')).not.toBeInTheDocument();
   });
 
-  test('hides the vertical divider when the left nav is collapsed', () => {
-    useStore.setState({ explorerLeftNavCollapsed: true });
+  test('passes the new query chips as CenterPanel.modelTabBar (replaces ModelTabBar)', () => {
     render(<ExplorationWorkbench />);
-    expect(screen.queryByTestId('vertical-divider')).not.toBeInTheDocument();
+    expect(screen.getByTestId('exploration-query-chips-mock')).toBeInTheDocument();
   });
 
-  test('shows the vertical divider when the left nav is expanded', () => {
+  test('opts CenterPanel into the Library SQL-editor drop target (D9)', () => {
     render(<ExplorationWorkbench />);
-    expect(screen.getByTestId('vertical-divider')).toBeInTheDocument();
+    expect(screen.getByTestId('center-panel')).toHaveAttribute('data-enable-library-drop', 'true');
   });
 
   test('sizes to fill its container (no fixed viewport height, unlike the standalone route)', () => {

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -13,9 +13,11 @@ import {
 import useStore from '../../../stores/store';
 import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
 import LibraryDragPreview from './library/LibraryDragPreview';
+import { DROPPABLE_TYPES } from './library/LibraryRow';
 import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
 import { emitWorkspaceEvent } from './telemetry';
 import { runDashboardConfigGate } from './itemMutations';
+import { formatRefExpression } from '../../../utils/refString';
 import {
   reorderItemsInRow,
   moveItemBetweenRows,
@@ -197,7 +199,15 @@ export const WorkspaceCommitProvider = ({ value, children }) => (
  */
 export const routeWorkspaceDragEnd = (
   event,
-  { dashboards, projectDefaults, reassignDashboardLevel, moveLevel, commitCanvasConfig, emit }
+  {
+    dashboards,
+    projectDefaults,
+    reassignDashboardLevel,
+    moveLevel,
+    commitCanvasConfig,
+    emit,
+    exploration,
+  }
 ) => {
   const { active, over } = event || {};
   if (!over) return 'noop';
@@ -439,6 +449,16 @@ export const routeWorkspaceDragEnd = (
 
     // 3b. Library → canvas insert (creates a new item referencing the object).
     if (dragData.source === 'library') {
+      // Explore 2.0 Phase 3a: the Library's exploration drag sources
+      // (source/metric/dimension/insight — EXPLORATION_DRAG_TYPES in
+      // LibraryRow.jsx — plus the new source/sourceTable/sourceColumn
+      // drill-down rows) are NOT canvas items; only DROPPABLE_TYPES
+      // (chart/table/markdown/input) are. Without this guard, making those
+      // rows draggable (so they can reach the exploration surface's drop
+      // targets below) would let a dashboard-canvas drop build a bogus item
+      // like `{ metric: '${ref(churn_rate)}' }` — a shape the canvas schema
+      // has no rendering for.
+      if (!DROPPABLE_TYPES.includes(dragData.type)) return 'noop';
       const newItem = buildLibraryItem(dragData.type, dragData.name);
       const next = insertItemAtTarget(config, target, newItem);
       if (next === config) return 'noop';
@@ -454,6 +474,189 @@ export const routeWorkspaceDragEnd = (
         });
       return 'canvas_library_insert';
     }
+  }
+
+  // ── Branch 4: Exploration surface drop zones (Explore 2.0 Phase 3a's DnD
+  // unification, 02-architecture.md §4) ────────────────────────────────────
+  // `ExplorerDndContext` is deleted from the ExplorationWorkbench nesting
+  // (it stays alive as a component + its own DndContext for the standalone
+  // `/explorer` route, which keeps running its own nested context — see
+  // `ExplorationWorkbench.jsx`'s docstring for why). These zone kinds
+  // (`axis-zone`/`property-zone`/`interaction-zone`/`source-zone`/
+  // `insight-zone`/`data-table-drop`) are the legacy right panel's EXISTING
+  // droppables, ported here verbatim (same resolution logic, same `type` key
+  // — renaming that to `kind` is S5/Phase 3b's job for the not-yet-built
+  // Build rail). `sql-editor-drop` is new (D9): Library table → seeds a new
+  // scratch query; Library column → inserts at the SQL editor's cursor.
+  if (
+    dropData.type === 'axis-zone' ||
+    dropData.type === 'property-zone' ||
+    dropData.type === 'interaction-zone' ||
+    dropData.type === 'source-zone' ||
+    dropData.type === 'insight-zone' ||
+    dropData.type === 'data-table-drop' ||
+    dropData.type === 'sql-editor-drop'
+  ) {
+    return routeExplorationDragEnd(event, exploration || {});
+  }
+
+  return 'noop';
+};
+
+/**
+ * Pure router for the exploration surface's drop zones (Explore 2.0 Phase 3a
+ * DnD unification, D9 / 02-architecture.md §4). Ported verbatim from
+ * `components/explorer/ExplorerDndContext.jsx`'s `handleDragEnd` — same
+ * resolution logic, same zone `type` values — just re-homed onto this shared
+ * router so a Library drag started outside the exploration pane (the Library
+ * now lives in the outer Workspace rail, not nested inside the exploration
+ * like the old `ExplorerLeftPanel`) can reach these targets at all (dnd-kit
+ * contexts don't compose). Exported + pure so it's unit-testable without a
+ * real dnd-kit pointer drag, mirroring `routeWorkspaceDragEnd`'s own pattern.
+ *
+ * @param {object} event dnd-kit drag-end event `{ active, over }`.
+ * @param {object} deps
+ * @param {string} deps.activeModelName - the exploration's active query/model
+ *   name (already resolved with its `'preview_model'` fallback by the
+ *   caller — mirrors `ExplorerDndContext`'s own `useStore` selector).
+ * @param {string|null} deps.activeInsightName
+ * @param {Function} deps.setInsightProp
+ * @param {Function} deps.addComputedColumn
+ * @param {Function} deps.setActiveModelSource
+ * @param {Function} deps.updateInsightInteraction
+ * @param {Function} deps.addExistingInsightToChart
+ * @param {Function} deps.seedModelTabFromTable - `({ tableName, sourceName }) => void`,
+ *   new for D9: creates a query chip seeded `SELECT * FROM <tableName>`.
+ * @returns {string} a short tag describing the routed action (for tests).
+ */
+export const routeExplorationDragEnd = (event, deps) => {
+  const { active, over } = event || {};
+  if (!over) return 'noop';
+  const dragData = active?.data?.current;
+  const dropData = over?.data?.current;
+  if (!dragData || !dropData) return 'noop';
+
+  const {
+    activeModelName,
+    activeInsightName,
+    setInsightProp,
+    addComputedColumn,
+    setActiveModelSource,
+    updateInsightInteraction,
+    addExistingInsightToChart,
+    seedModelTabFromTable,
+  } = deps || {};
+
+  // A dragged metric/dimension/input resolves the SAME way it always has;
+  // anything else (a plain results-grid `column` drag, or the new D9
+  // `sourceColumn` drag) is treated as belonging to whichever query is
+  // currently active — exactly like `DraggableColumnHeader`'s existing
+  // behavior, which this generalizes rather than replaces.
+  const buildRefExpr = () => {
+    if (dragData.type === 'metric' || dragData.type === 'dimension') {
+      return dragData.parentModel
+        ? formatRefExpression(dragData.parentModel, dragData.name)
+        : formatRefExpression(dragData.name);
+    }
+    if (dragData.type === 'input') {
+      const accessor = dragData.inputType === 'multi-select' ? 'values' : 'value';
+      return formatRefExpression(dragData.name, accessor);
+    }
+    return formatRefExpression(activeModelName, dragData.name);
+  };
+
+  if (dropData.type === 'axis-zone' || dropData.type === 'property-zone') {
+    // A whole table isn't a scalar ref — only a column-shaped drag resolves.
+    if (dragData.type === 'sourceTable') return 'noop';
+    const fieldName = dropData.type === 'axis-zone' ? dropData.fieldName : dropData.path;
+    const refExpr = buildRefExpr();
+    const dropEl = document.querySelector(
+      dropData.type === 'axis-zone'
+        ? `[data-testid="droppable-property-${fieldName}"]`
+        : `[data-testid="droppable-property-${dropData.path}"]`
+    );
+    const hasCursor = dropEl?.querySelector('[data-has-cursor="true"]');
+    if (hasCursor && activeInsightName) {
+      hasCursor.dispatchEvent(
+        new CustomEvent('ref-insert-at-cursor', { detail: { refExpr }, bubbles: false })
+      );
+    } else if (activeInsightName && typeof setInsightProp === 'function') {
+      setInsightProp(activeInsightName, fieldName, '?{' + refExpr + '}');
+    }
+    return 'exploration_prop_drop';
+  }
+
+  if (dropData.type === 'data-table-drop') {
+    if (
+      (dragData.type === 'metric' || dragData.type === 'dimension') &&
+      typeof addComputedColumn === 'function'
+    ) {
+      addComputedColumn({
+        name: dragData.name,
+        expression: dragData.expression || dragData.name,
+        type: dragData.type,
+      });
+      return 'exploration_computed_column_drop';
+    }
+    return 'noop';
+  }
+
+  if (dropData.type === 'interaction-zone') {
+    if (dragData.type === 'sourceTable') return 'noop';
+    const { insightName, index } = dropData;
+    if (!insightName) return 'noop';
+    const refExpr = buildRefExpr();
+    const dropEl = document.querySelector(`[data-testid="interaction-value-field-${index}"]`);
+    const hasCursor = dropEl?.querySelector('[data-has-cursor="true"]');
+    if (hasCursor) {
+      hasCursor.dispatchEvent(
+        new CustomEvent('ref-insert-at-cursor', { detail: { refExpr }, bubbles: false })
+      );
+    } else if (typeof updateInsightInteraction === 'function') {
+      updateInsightInteraction(insightName, index, { value: `?{${refExpr}}` });
+    }
+    return 'exploration_interaction_drop';
+  }
+
+  if (dropData.type === 'source-zone') {
+    if (dragData.type === 'source' && typeof setActiveModelSource === 'function') {
+      setActiveModelSource(dragData.name);
+      return 'exploration_source_drop';
+    }
+    return 'noop';
+  }
+
+  if (dropData.type === 'insight-zone') {
+    if (
+      dragData.type === 'insight' &&
+      dragData.name &&
+      typeof addExistingInsightToChart === 'function'
+    ) {
+      addExistingInsightToChart(dragData.name);
+      return 'exploration_insight_drop';
+    }
+    return 'noop';
+  }
+
+  if (dropData.type === 'sql-editor-drop') {
+    // D9: Library table → seeds a new scratch query bound to that table's
+    // source. Library column (schema OR results-grid) → inserts the bare
+    // column name at the Monaco cursor via the droppable's own callback (the
+    // SQL editor owns cursor access — mirrors the `pivot-field`/
+    // `property-zone` "callback lives on the droppable" pattern).
+    if (dragData.type === 'sourceTable') {
+      if (typeof seedModelTabFromTable === 'function') {
+        seedModelTabFromTable({ tableName: dragData.name, sourceName: dragData.sourceName });
+      }
+      return 'exploration_seed_query_from_table';
+    }
+    if (dragData.type === 'sourceColumn' || dragData.type === 'column') {
+      if (typeof dropData.onInsertText === 'function') {
+        dropData.onInsertText(dragData.name);
+      }
+      return 'exploration_sql_cursor_insert';
+    }
+    return 'noop';
   }
 
   return 'noop';
@@ -593,6 +796,22 @@ const WorkspaceDndContext = ({ children }) => {
   const saveDashboard = useStore(s => s.saveDashboard);
   const updateDashboardConfigOptimistic = useStore(s => s.updateDashboardConfigOptimistic);
 
+  // Explore 2.0 Phase 3a: the exploration surface's drop-zone deps
+  // (`routeExplorationDragEnd`) — read here (the shared shell-level context)
+  // rather than in the exploration pane itself, since that's what "DnD
+  // unification" means: one DndContext, one place that knows how to reach
+  // every drop target's store actions. `explorerActiveModelName` falls back
+  // to `'preview_model'` exactly like the (still-alive, standalone-only)
+  // `ExplorerDndContext.jsx` does.
+  const explorerActiveModelName = useStore(s => s.explorerActiveModelName) || 'preview_model';
+  const explorerActiveInsightName = useStore(s => s.explorerActiveInsightName);
+  const setInsightProp = useStore(s => s.setInsightProp);
+  const addActiveModelComputedColumn = useStore(s => s.addActiveModelComputedColumn);
+  const setActiveModelSource = useStore(s => s.setActiveModelSource);
+  const updateInsightInteraction = useStore(s => s.updateInsightInteraction);
+  const addExistingInsightToChart = useStore(s => s.addExistingInsightToChart);
+  const seedModelTabFromTable = useStore(s => s.seedModelTabFromTable);
+
   // `activeDrag` mirrors the dnd-kit `active` payload in a shape both overlays
   // and consumers (ProjectEditor) can read: `{ kind, name, level, type }`.
   const [activeDrag, setActiveDrag] = useState(null);
@@ -663,9 +882,33 @@ const WorkspaceDndContext = ({ children }) => {
         moveLevel,
         commitCanvasConfig,
         emit: emitWorkspaceEvent,
+        exploration: {
+          activeModelName: explorerActiveModelName,
+          activeInsightName: explorerActiveInsightName,
+          setInsightProp,
+          addComputedColumn: addActiveModelComputedColumn,
+          setActiveModelSource,
+          updateInsightInteraction,
+          addExistingInsightToChart,
+          seedModelTabFromTable,
+        },
       });
     },
-    [dashboards, projectDefaults, reassignDashboardLevel, moveLevel, commitCanvasConfig]
+    [
+      dashboards,
+      projectDefaults,
+      reassignDashboardLevel,
+      moveLevel,
+      commitCanvasConfig,
+      explorerActiveModelName,
+      explorerActiveInsightName,
+      setInsightProp,
+      addActiveModelComputedColumn,
+      setActiveModelSource,
+      updateInsightInteraction,
+      addExistingInsightToChart,
+      seedModelTabFromTable,
+    ]
   );
 
   return (

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -10,12 +10,14 @@
  *      pointer drags can't run in jsdom, so we unit-test the router directly;
  *      the real drag is exercised by the Playwright stories.
  */
+/* eslint-disable no-template-curly-in-string -- fixtures use literal Visivo ref-string syntax, not JS template interpolation */
 import React from 'react';
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import { useDraggable } from '@dnd-kit/core';
 import WorkspaceDndContext, {
   useWorkspaceDrag,
   routeWorkspaceDragEnd,
+  routeExplorationDragEnd,
   mapDragStartData,
   workspaceCollisionDetection,
   useCommitCanvasConfig,
@@ -1042,5 +1044,408 @@ describe('WorkspaceDndContext commit path (D-3 / D-4, gated per VIS-993)', () =>
     render(<OrphanProbe />);
     // Invoking the fallback never throws and touches nothing.
     expect(() => fireEvent.click(screen.getByTestId('orphan-probe'))).not.toThrow();
+  });
+});
+
+// ── Explore 2.0 Phase 3a: canvas-insert guard (02-architecture.md §4) ───────
+describe('routeWorkspaceDragEnd — canvas-insert type guard (Explore 2.0 Phase 3a)', () => {
+  const overCanvasDrop = target => ({
+    data: { current: { kind: 'canvas-drop', dashboardName: 'dash', config: { rows: [] }, target } },
+  });
+
+  // Library's exploration drag sources (source/metric/dimension/insight) are
+  // NOT canvas items — without this guard, making them draggable (so they
+  // can reach the exploration surface's new drop targets) would let a
+  // dashboard-canvas drop build a bogus item shape.
+  test.each(['source', 'sourceTable', 'sourceColumn', 'metric', 'dimension', 'insight'])(
+    'library drag of type %s onto the canvas is rejected (no commit)',
+    type => {
+      const commitCanvasConfig = jest.fn();
+      const result = routeWorkspaceDragEnd(
+        {
+          active: { data: { current: { source: 'library', type, name: 'x' } } },
+          over: overCanvasDrop({ kind: 'between-rows', index: 0 }),
+        },
+        { commitCanvasConfig }
+      );
+      expect(result).toBe('noop');
+      expect(commitCanvasConfig).not.toHaveBeenCalled();
+    }
+  );
+
+  // Unchanged behavior for the types that WERE always canvas-insertable.
+  test.each(['chart', 'table', 'markdown', 'input'])(
+    'library drag of type %s onto the canvas still inserts (unchanged)',
+    type => {
+      const commitCanvasConfig = jest.fn();
+      const result = routeWorkspaceDragEnd(
+        {
+          active: { data: { current: { source: 'library', type, name: 'x' } } },
+          over: overCanvasDrop({ kind: 'between-rows', index: 0 }),
+        },
+        { commitCanvasConfig }
+      );
+      expect(result).toBe('canvas_library_insert');
+      expect(commitCanvasConfig).toHaveBeenCalled();
+    }
+  );
+});
+
+// ── Explore 2.0 Phase 3a: exploration surface DnD (D9 / 02-architecture.md
+// §4). `ExplorerDndContext.jsx`'s onDragEnd is deleted from the
+// ExplorationWorkbench nesting; these zone kinds now route through this
+// shared context via `routeExplorationDragEnd`, ported verbatim from that
+// file's resolution logic (see its own still-passing test suite,
+// `components/explorer/ExplorerDndContext.test.jsx`, for the standalone
+// route's copy of this same logic). ────────────────────────────────────────
+describe('routeExplorationDragEnd (Explore 2.0 Phase 3a)', () => {
+  const baseDeps = () => ({
+    activeModelName: 'preview_model',
+    activeInsightName: 'ins_1',
+    setInsightProp: jest.fn(),
+    addComputedColumn: jest.fn(),
+    setActiveModelSource: jest.fn(),
+    updateInsightInteraction: jest.fn(),
+    addExistingInsightToChart: jest.fn(),
+    seedModelTabFromTable: jest.fn(),
+  });
+
+  test('returns noop when there is no drop target', () => {
+    expect(routeExplorationDragEnd({ active: { data: { current: {} } }, over: null }, baseDeps())).toBe(
+      'noop'
+    );
+  });
+
+  describe('axis-zone / property-zone', () => {
+    test('a plain column drop resolves against the active model (preview_model fallback)', () => {
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'col_a', type: 'column' } } },
+          over: { data: { current: { fieldName: 'x', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith(
+        'ins_1',
+        'x',
+        '?{${ref(preview_model).col_a}}'
+      );
+    });
+
+    test('a sourceColumn (D9 schema drill-down) resolves the same way a plain column does', () => {
+      const deps = { ...baseDeps(), activeModelName: 'orders_q' };
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region', type: 'sourceColumn', sourceName: 'warehouse' } } },
+          over: { data: { current: { path: 'marker.color', type: 'property-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith(
+        'ins_1',
+        'marker.color',
+        '?{${ref(orders_q).region}}'
+      );
+    });
+
+    test('a sourceTable drop is rejected — a whole table is not a scalar ref', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'orders', type: 'sourceTable', sourceName: 'warehouse' } } },
+          over: { data: { current: { fieldName: 'x', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(deps.setInsightProp).not.toHaveBeenCalled();
+    });
+
+    test('a model-scoped metric drop qualifies the ref with parentModel', () => {
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: {
+            data: { current: { name: 'total_revenue', type: 'metric', parentModel: 'orders_model' } },
+          },
+          over: { data: { current: { fieldName: 'y', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith(
+        'ins_1',
+        'y',
+        '?{${ref(orders_model).total_revenue}}'
+      );
+    });
+
+    test('an unscoped metric drop is a bare ref (no parentModel)', () => {
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'composite_metric', type: 'metric' } } },
+          over: { data: { current: { fieldName: 'y', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith('ins_1', 'y', '?{${ref(composite_metric)}}');
+    });
+
+    test('a multi-select input drop yields the .values accessor', () => {
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region_filter', type: 'input', inputType: 'multi-select' } } },
+          over: { data: { current: { fieldName: 'x', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith(
+        'ins_1',
+        'x',
+        '?{${ref(region_filter).values}}'
+      );
+    });
+
+    test('a single-select input drop yields the .value accessor', () => {
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region_filter', type: 'input', inputType: 'single-select' } } },
+          over: { data: { current: { fieldName: 'x', type: 'axis-zone' } } },
+        },
+        deps
+      );
+      expect(deps.setInsightProp).toHaveBeenCalledWith('ins_1', 'x', '?{${ref(region_filter).value}}');
+    });
+
+    test('inserts at cursor instead of replacing the whole value when the drop target has an active cursor', () => {
+      const listener = jest.fn();
+      render(
+        <div data-testid="droppable-property-x">
+          <span
+            data-has-cursor="true"
+            ref={el => el && el.addEventListener('ref-insert-at-cursor', listener)}
+          />
+        </div>
+      );
+
+      const deps = baseDeps();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'col_a', type: 'column' } } },
+          over: { data: { current: { fieldName: 'x', type: 'axis-zone' } } },
+        },
+        deps
+      );
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].detail.refExpr).toBe('${ref(preview_model).col_a}');
+      expect(deps.setInsightProp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('data-table-drop (computed column)', () => {
+    test('a metric drop adds a computed column with its expression', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'churn_rate', type: 'metric', expression: 'sum(x)/count(x)' } } },
+          over: { data: { current: { type: 'data-table-drop' } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_computed_column_drop');
+      expect(deps.addComputedColumn).toHaveBeenCalledWith({
+        name: 'churn_rate',
+        expression: 'sum(x)/count(x)',
+        type: 'metric',
+      });
+    });
+
+    test('a non metric/dimension drop is a noop', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'orders', type: 'sourceTable' } } },
+          over: { data: { current: { type: 'data-table-drop' } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(deps.addComputedColumn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interaction-zone', () => {
+    test('sets the interaction value from a dropped field', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region', type: 'dimension', parentModel: 'orders_q' } } },
+          over: { data: { current: { type: 'interaction-zone', insightName: 'ins_1', index: 0 } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_interaction_drop');
+      expect(deps.updateInsightInteraction).toHaveBeenCalledWith('ins_1', 0, {
+        value: '?{${ref(orders_q).region}}',
+      });
+    });
+
+    test('a sourceTable drop is rejected', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'orders', type: 'sourceTable' } } },
+          over: { data: { current: { type: 'interaction-zone', insightName: 'ins_1', index: 0 } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(deps.updateInsightInteraction).not.toHaveBeenCalled();
+    });
+
+    test('missing insightName is a noop', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region', type: 'dimension' } } },
+          over: { data: { current: { type: 'interaction-zone', index: 0 } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+    });
+  });
+
+  describe('source-zone', () => {
+    test('a source drop sets the active model source', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'warehouse', type: 'source' } } },
+          over: { data: { current: { type: 'source-zone' } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_source_drop');
+      expect(deps.setActiveModelSource).toHaveBeenCalledWith('warehouse');
+    });
+
+    test('a non-source drop is a noop', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'x', type: 'metric' } } },
+          over: { data: { current: { type: 'source-zone' } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(deps.setActiveModelSource).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('insight-zone', () => {
+    test('an insight drop adds it to the chart', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'churn_by_cohort', type: 'insight' } } },
+          over: { data: { current: { type: 'insight-zone' } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_insight_drop');
+      expect(deps.addExistingInsightToChart).toHaveBeenCalledWith('churn_by_cohort');
+    });
+
+    test('a non-insight drop is a noop', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'x', type: 'model' } } },
+          over: { data: { current: { type: 'insight-zone' } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(deps.addExistingInsightToChart).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── sql-editor-drop (D9, new) ──────────────────────────────────────────
+  describe('sql-editor-drop', () => {
+    test('a sourceTable drop seeds a new query chip bound to that table + source', () => {
+      const deps = baseDeps();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'orders', type: 'sourceTable', sourceName: 'warehouse' } } },
+          over: { data: { current: { type: 'sql-editor-drop' } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_seed_query_from_table');
+      expect(deps.seedModelTabFromTable).toHaveBeenCalledWith({
+        tableName: 'orders',
+        sourceName: 'warehouse',
+      });
+    });
+
+    test('a sourceColumn drop inserts the bare column name via the droppable-supplied callback', () => {
+      const deps = baseDeps();
+      const onInsertText = jest.fn();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'region', type: 'sourceColumn' } } },
+          over: { data: { current: { type: 'sql-editor-drop', onInsertText } } },
+        },
+        deps
+      );
+      expect(result).toBe('exploration_sql_cursor_insert');
+      expect(onInsertText).toHaveBeenCalledWith('region');
+    });
+
+    test('a plain results-grid column drop also inserts (generalizes DraggableColumnHeader)', () => {
+      const deps = baseDeps();
+      const onInsertText = jest.fn();
+      routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'amount', type: 'column' } } },
+          over: { data: { current: { type: 'sql-editor-drop', onInsertText } } },
+        },
+        deps
+      );
+      expect(onInsertText).toHaveBeenCalledWith('amount');
+    });
+
+    test('an unrecognized type is a noop', () => {
+      const deps = baseDeps();
+      const onInsertText = jest.fn();
+      const result = routeExplorationDragEnd(
+        {
+          active: { data: { current: { name: 'x', type: 'model' } } },
+          over: { data: { current: { type: 'sql-editor-drop', onInsertText } } },
+        },
+        deps
+      );
+      expect(result).toBe('noop');
+      expect(onInsertText).not.toHaveBeenCalled();
+    });
+  });
+
+  test('routeWorkspaceDragEnd dispatches exploration zone kinds through routeExplorationDragEnd', () => {
+    const setActiveModelSource = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { name: 'warehouse', type: 'source' } } },
+        over: { data: { current: { type: 'source-zone' } } },
+      },
+      { exploration: { setActiveModelSource } }
+    );
+    expect(result).toBe('exploration_source_drop');
+    expect(setActiveModelSource).toHaveBeenCalledWith('warehouse');
   });
 });

--- a/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { PiDotsThreeVertical, PiPencilSimple, PiCopy, PiTrash } from 'react-icons/pi';
 import Dropdown from '../../../common/Dropdown';
 import FieldPill from '../../common/FieldPill';
 import InlineRenameInput from '../InlineRenameInput';
+import useInlineRename from '../../../../hooks/useInlineRename';
 import { draftSummary } from '../explorationLegacyBridge';
 
 /**
@@ -17,7 +18,9 @@ import { draftSummary } from '../explorationLegacyBridge';
  * Phase 5") — the mock depicts the end state, this is v1.
  */
 const ExplorationCard = ({ exploration, onOpen, onRename, onDuplicate, onDelete }) => {
-  const [renaming, setRenaming] = useState(false);
+  // B16 (04-bug-inventory.md): the shared "am I editing this name" toggle —
+  // see useInlineRename's docstring for why this hook exists.
+  const rename = useInlineRename({ onCommit: nextName => onRename(exploration.id, nextName) });
   const { queryCount, insightCount } = draftSummary(exploration.draft);
   const editedLabel = exploration.updatedAt
     ? `edited ${formatDistanceToNowStrict(new Date(exploration.updatedAt), { addSuffix: true })}`
@@ -29,15 +32,12 @@ const ExplorationCard = ({ exploration, onOpen, onRename, onDuplicate, onDelete 
       className="rounded-lg border border-gray-200 bg-white p-4 transition-all hover:border-gray-300 hover:shadow-md"
     >
       <div className="mb-2 flex items-start justify-between gap-2">
-        {renaming ? (
+        {rename.editing ? (
           <InlineRenameInput
             name={exploration.name}
             testIdPrefix={`exploration-card-${exploration.id}-rename`}
-            onCommit={nextName => {
-              setRenaming(false);
-              onRename(exploration.id, nextName);
-            }}
-            onCancel={() => setRenaming(false)}
+            onCommit={rename.commit}
+            onCancel={rename.cancel}
           />
         ) : (
           <span
@@ -67,7 +67,7 @@ const ExplorationCard = ({ exploration, onOpen, onRename, onDuplicate, onDelete 
               <button
                 type="button"
                 onClick={() => {
-                  setRenaming(true);
+                  rename.start();
                   close();
                 }}
                 data-testid={`exploration-card-${exploration.id}-rename-action`}

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -201,7 +201,7 @@ describe('Library', () => {
     );
   });
 
-  test('Layout-Items rows expose drag handles; Data-Layer rows do not', () => {
+  test('Layout-Items rows expose drag handles; model/relation Data-Layer rows do not', () => {
     renderLibrary();
     fireEvent.mouseEnter(screen.getByTestId('library-row-chart-waterfall'));
     expect(screen.getByTestId('library-row-chart-waterfall-drag-handle')).toBeInTheDocument();
@@ -211,10 +211,14 @@ describe('Library', () => {
     expect(
       screen.queryByTestId('library-row-model-monthly_revenue-drag-handle')
     ).not.toBeInTheDocument();
-    fireEvent.mouseEnter(screen.getByTestId('library-row-source-local-duck'));
-    expect(
-      screen.queryByTestId('library-row-source-local-duck-drag-handle')
-    ).not.toBeInTheDocument();
+  });
+
+  // Explore 2.0 Phase 3a (D9 / 02-architecture.md §4): source rows are now an
+  // exploration drag source (via LibrarySourceRow, the new drill-down row) —
+  // this is a deliberate capability ADD, not a leftover Layout-Items check.
+  test('source rows (the D9 drill-down) expose a drag handle', () => {
+    renderLibrary();
+    expect(screen.getByTestId('library-row-source-local-duck-drag-handle')).toBeInTheDocument();
   });
 
   test('clicking a chart row delegates to openWorkspaceTab', () => {

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -46,6 +46,19 @@ export const DATA_TYPES = ['source', 'model', 'dimension', 'metric', 'relation',
 // not a canvas-droppable item — clicking it scopes the middle pane instead.
 export const DROPPABLE_TYPES = ['chart', 'table', 'markdown', 'input'];
 
+// Explore 2.0 Phase 3a (D9 / 02-architecture.md §4): these Data-Layer types
+// are drag sources INTO an open exploration (SQL editor cursor, insight prop
+// slots, interaction fields, the chart's insight zone) even though they are
+// NOT canvas-droppable dashboard items — `source`/`metric`/`dimension`/
+// `insight` had this exact drag capability in the legacy `ExplorerLeftPanel`
+// (`DraggableItem` / `ObjectList`'s `draggableType`), which the Library
+// replaces. Kept DISTINCT from `DROPPABLE_TYPES` (rather than folding into
+// it) so the `droppable`/`accent` computation below — and the canvas-insert
+// routing in `WorkspaceDndContext.routeWorkspaceDragEnd`, which must reject
+// these types — stay unchanged: a Library row being an exploration drag
+// source is orthogonal to it being a valid DASHBOARD canvas item.
+export const EXPLORATION_DRAG_TYPES = ['source', 'metric', 'dimension', 'insight'];
+
 // Every type except `relation` supports inline create (a draft with a
 // minimal valid config — see stores/inlineCreateStore.js). A relation can't
 // be templated: its condition must reference two real models.
@@ -72,10 +85,16 @@ export const getTypeDef = type => {
     droppable,
     creatable: CREATABLE_TYPES.includes(type),
     accent: droppable ? 'mulberry' : 'teal',
+    // Independent of `droppable` (canvas-item eligibility) — see
+    // EXPLORATION_DRAG_TYPES's comment above.
+    explorationDragSource: EXPLORATION_DRAG_TYPES.includes(type),
   };
 };
 
-const StatusDot = ({ status }) => {
+// Exported so `LibrarySourceRow.jsx` (the D9 source drill-down's top-level
+// row, which doesn't route through this file's own row shell) can render the
+// identical unpublished-changes dot rather than forking it.
+export const StatusDot = ({ status }) => {
   if (!status || status === ObjectStatus.PUBLISHED) return null;
   const isNew = status === ObjectStatus.NEW;
   const colorClass = isNew ? 'bg-green-500' : 'bg-amber-500';
@@ -203,11 +222,24 @@ const LibraryRow = ({ obj, selected = false, draggable = true, onClick, onContex
   const def = getTypeDef(obj.type);
   const Icon = def.icon;
 
-  // dnd-kit draggable wiring. `data.current` is what drop targets read —
-  // the canvas (D2) consumes `{ source: 'library', type, name, subtype }`.
+  // dnd-kit draggable wiring. `data.current` is what drop targets read — the
+  // canvas (D2) consumes `{ source: 'library', type, name, subtype }`.
+  // `parentModel` / `expression` / `inputType` are the Explore 2.0 Phase 3a
+  // payload extension (02-architecture.md §4): `undefined` for row shapes
+  // that don't carry them (chart/table/markdown/model/relation/dashboard),
+  // which is exactly what the pre-Phase-3a payload looked like for those
+  // types — no behavior change there.
   const drag = useDraggable({
     id: `library:${obj.type}:${obj.name}`,
-    data: { source: 'library', type: obj.type, name: obj.name, subtype: obj.subtype },
+    data: {
+      source: 'library',
+      type: obj.type,
+      name: obj.name,
+      subtype: obj.subtype,
+      parentModel: obj.parentModel,
+      expression: obj.expression,
+      inputType: obj.inputType,
+    },
     disabled: !draggable,
   });
 

--- a/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
@@ -53,6 +53,29 @@ describe('LibraryRow', () => {
     expect(dashboardDef.droppable).toBe(false);
   });
 
+  // Explore 2.0 Phase 3a (D9 / 02-architecture.md §4): source/metric/
+  // dimension/insight are exploration drag sources (SQL editor, prop slots,
+  // interactions, the chart insight zone) even though they are NOT
+  // canvas-droppable dashboard items — kept independent of `droppable` so
+  // the dashboard canvas-insert path (WorkspaceDndContext) can still reject
+  // them.
+  test('getTypeDef flags source/metric/dimension/insight as exploration drag sources, independent of droppable', () => {
+    ['source', 'metric', 'dimension', 'insight'].forEach(t => {
+      const def = getTypeDef(t);
+      expect(def.explorationDragSource).toBe(true);
+      expect(def.droppable).toBe(false); // unchanged — not a canvas item
+    });
+    ['model', 'relation'].forEach(t => {
+      expect(getTypeDef(t).explorationDragSource).toBe(false);
+    });
+    ['chart', 'table', 'markdown', 'input'].forEach(t => {
+      // Already draggable via `droppable` — explorationDragSource is simply
+      // not needed for these (LibrarySubsection ORs the two flags).
+      expect(getTypeDef(t).explorationDragSource).toBe(false);
+      expect(getTypeDef(t).droppable).toBe(true);
+    });
+  });
+
   test('getTypeDef derives icon + label + plural from the canonical objectTypeConfigs', () => {
     // The Library must not fork per-type metadata — every type's icon, label
     // and plural come from the app-wide canonical `objectTypeConfigs.js` so
@@ -178,6 +201,39 @@ describe('LibraryRow', () => {
     expect(
       screen.getByTestId('library-row-chart-waterfall-drag-handle')
     ).toBeInTheDocument();
+  });
+
+  // Explore 2.0 Phase 3a payload extension (02-architecture.md §4): the
+  // drop side (WorkspaceDndContext) needs parentModel/expression/inputType
+  // on the drag payload to resolve ref scoping and input accessors.
+  test('drag payload carries parentModel/expression/inputType when the row has them', () => {
+    useDraggable.mockClear();
+    const METRIC = {
+      id: 'metric:churn_rate',
+      type: 'metric',
+      name: 'churn_rate',
+      parentModel: 'orders_q',
+      expression: 'sum(churned) / count(*)',
+    };
+    render(withDnd(<LibraryRow obj={METRIC} draggable />));
+    const call = useDraggable.mock.calls.find(([opts]) => opts.id === 'library:metric:churn_rate');
+    expect(call[0].data).toEqual(
+      expect.objectContaining({
+        source: 'library',
+        type: 'metric',
+        name: 'churn_rate',
+        parentModel: 'orders_q',
+        expression: 'sum(churned) / count(*)',
+      })
+    );
+  });
+
+  test('drag payload carries inputType for input rows', () => {
+    useDraggable.mockClear();
+    const INPUT = { id: 'input:region', type: 'input', name: 'region', inputType: 'multi-select' };
+    render(withDnd(<LibraryRow obj={INPUT} draggable />));
+    const call = useDraggable.mock.calls.find(([opts]) => opts.id === 'library:input:region');
+    expect(call[0].data.inputType).toBe('multi-select');
   });
 
   // VIS-836: the source row must NOT translate with the cursor during a drag —

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
@@ -1,0 +1,468 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import {
+  PiCaretDown,
+  PiCaretRight,
+  PiDotsSix,
+  PiHash,
+  PiTextAa,
+  PiToggleLeft,
+  PiCalendarBlank,
+  PiSpinnerGap,
+  PiWarningCircle,
+  PiArrowsClockwise,
+} from 'react-icons/pi';
+import useStore from '../../../../stores/store';
+import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
+import useSourceOutline from '../useSourceOutline';
+import { StatusDot } from './LibraryRow';
+
+/**
+ * LibrarySourceRow — Explore 2.0 Phase 3a (D9 / VIS-1052).
+ *
+ * The Library's "Sources" subsection stops being a flat list: each source
+ * row expands lazily into **source → table → columns** (schemas fold in as
+ * an extra level for dialects that have them — most of Visivo's sources
+ * today, DuckDB/warehouse file sources, are flat, so this ships the
+ * source→table→column path; a schema level is a straightforward addition
+ * once `useSourceOutline`'s cached feed carries one, per 01-ux-spec.md §3a's
+ * "when the dialect has them").
+ *
+ * B10 consolidation (04-bug-inventory.md): reads the SAME shared
+ * `useSourceOutline` hook the right-rail source Data tab
+ * (`SourceOutlineTreePanel.jsx`) already uses — the one cached
+ * `/api/source-schema-jobs/*` feed, not a second re-implementation. The
+ * standalone `/explorer` route's `SourceBrowser.jsx` keeps its own
+ * independent fetch for now (kept alive deliberately — see
+ * `ExplorationWorkbench.jsx`'s docstring — because the standalone route must
+ * keep passing its existing e2e stories untouched until the Phase 3b
+ * cutover deletes that route entirely); no NEW code depends on it.
+ *
+ * LAZY by construction: `useSourceOutline(sourceName)` only mounts (and
+ * therefore only fetches) once this row's `expanded` flag
+ * (`librarySourceRowExpanded`, `stores/workspaceStore.js`) is true — collapsed
+ * sources never hit the network. Expand state for this top-level "is the
+ * drill-down open at all" gate is a NEW, separate store key; per-node
+ * (table) expand/collapse REUSES `workspaceSourceOutlineExpanded` (keyed by
+ * source name, same as the right-rail panel), so expanding a table in one
+ * surface is remembered in the other too. Session-only, matching that
+ * slice's existing contract (schema can change between sessions).
+ *
+ * Drag payload taxonomy (all under `source: 'library'`, routed by
+ * `WorkspaceDndContext.routeWorkspaceDragEnd`):
+ *   - `type: 'source'`       — the row itself (unchanged from the flat list).
+ *   - `type: 'sourceTable'`  — a table node. Dropped on the SQL editor, seeds
+ *     a new query chip (`SELECT * FROM <table>`, bound to this source).
+ *   - `type: 'sourceColumn'` — a column node. Dropped on the SQL editor,
+ *     inserts the bare column name at the cursor; dropped on an insight prop
+ *     slot / interaction field, resolves through the SAME fallback branch a
+ *     results-grid column drag already uses (`formatRefExpression(activeModel,
+ *     name)`) — a schema column is treated as belonging to whichever query is
+ *     currently active, exactly like `DraggableColumnHeader`.
+ * `sourceTable`/`sourceColumn` are deliberately NOT reused as `'table'`/
+ * `'column'` — `'table'` already means "dashboard Table widget" elsewhere in
+ * the Library (LAYOUT_TYPES), and building a canvas item from a raw schema
+ * table name would be nonsensical (WorkspaceDndContext's canvas-insert
+ * branch additionally guards against this by type-allowlisting canvas
+ * inserts).
+ *
+ * Known scope-narrowing: this row's click still opens the source in the
+ * right rail (the same `onClick` every Library row gets), but it does NOT
+ * yet carry the plain `LibraryRow`'s hover flip-popover / kebab context menu
+ * (Open in new tab · Show lineage · Delete…) — those are deferred, noted for
+ * a follow-up rather than silently dropped. Nothing in this phase's gate
+ * (`library-source-drilldown.spec.mjs`) exercises them for source rows.
+ */
+
+const glyphForColumnType = type => {
+  const t = (type || '').toLowerCase();
+  if (!t) return { Icon: PiTextAa, label: null };
+  if (/int|numeric|float|double|decimal|real|serial/.test(t)) return { Icon: PiHash, label: '#' };
+  if (/bool/.test(t)) return { Icon: PiToggleLeft, label: 'B' };
+  if (/date|time/.test(t)) return { Icon: PiCalendarBlank, label: null };
+  return { Icon: PiTextAa, label: 'T' };
+};
+
+const RowShell = ({
+  level,
+  hasCaret,
+  expanded,
+  onToggle,
+  icon,
+  name,
+  meta,
+  draggable,
+  dragProps,
+  isDragging,
+  testId,
+}) => (
+  <div
+    {...(dragProps || {})}
+    data-testid={testId}
+    data-dragging={isDragging ? 'true' : 'false'}
+    className={[
+      'group flex h-6 items-center gap-1 rounded pr-1 text-[12px] text-gray-700 transition-colors hover:bg-gray-50',
+      isDragging ? 'opacity-40' : '',
+      draggable ? 'cursor-grab active:cursor-grabbing' : '',
+    ].join(' ')}
+    style={{ paddingLeft: 8 + level * 14, ...(dragProps?.style || {}) }}
+  >
+    {hasCaret ? (
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        data-testid={`${testId}-toggle`}
+        className="-ml-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center text-gray-400 hover:text-gray-600"
+      >
+        {expanded ? (
+          <PiCaretDown className="h-2.5 w-2.5" />
+        ) : (
+          <PiCaretRight className="h-2.5 w-2.5" />
+        )}
+      </button>
+    ) : (
+      <span className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+    )}
+    {icon}
+    <span className="min-w-0 flex-1 truncate">{name}</span>
+    {meta && (
+      <span className="shrink-0 text-[10px] text-gray-400 group-hover:text-gray-500">{meta}</span>
+    )}
+    {draggable && (
+      <span
+        aria-hidden="true"
+        data-testid={`${testId}-drag-handle`}
+        className="flex h-3 w-3 shrink-0 items-center justify-center text-gray-300 opacity-0 transition-opacity group-hover:opacity-100"
+      >
+        <PiDotsSix className="h-3 w-3" />
+      </span>
+    )}
+  </div>
+);
+
+const ColumnRow = ({ sourceName, tableName, col }) => {
+  const { Icon, label } = glyphForColumnType(col.type);
+  const drag = useDraggable({
+    id: `library:sourceColumn:${sourceName}:${tableName}:${col.name}`,
+    data: {
+      source: 'library',
+      type: 'sourceColumn',
+      name: col.name,
+      sourceName,
+      tableName,
+      columnType: col.type || null,
+    },
+  });
+  const dragProps = {
+    ref: drag.setNodeRef,
+    ...drag.listeners,
+    ...drag.attributes,
+    style: { touchAction: 'none' },
+  };
+  return (
+    <RowShell
+      level={2}
+      hasCaret={false}
+      icon={
+        label ? (
+          <span className="w-3 shrink-0 text-center font-mono text-[9px] font-semibold text-gray-400">
+            {label}
+          </span>
+        ) : (
+          <Icon className="h-3 w-3 shrink-0 text-gray-400" aria-hidden="true" />
+        )
+      }
+      name={col.name}
+      draggable
+      dragProps={dragProps}
+      isDragging={drag.isDragging}
+      testId={`library-source-column-${sourceName}-${tableName}-${col.name}`}
+    />
+  );
+};
+
+const TableRow = ({ sourceName, table, expandedSet, onToggle, flatColumns, loadFlatColumns }) => {
+  const TableIcon = getTypeIcon('table');
+  const tableColors = getTypeColors('table');
+  const expanded = expandedSet.has(table.key);
+  const cols = flatColumns?.[table.key];
+  const colsLoaded = Array.isArray(cols);
+  const colCount = colsLoaded ? cols.length : table.columnCount;
+
+  const drag = useDraggable({
+    id: `library:sourceTable:${sourceName}:${table.name}`,
+    data: { source: 'library', type: 'sourceTable', name: table.name, sourceName },
+  });
+  const dragProps = {
+    ref: drag.setNodeRef,
+    ...drag.listeners,
+    ...drag.attributes,
+    style: { touchAction: 'none' },
+  };
+
+  const handleToggle = useCallback(
+    e => {
+      e.stopPropagation();
+      const willExpand = !expanded;
+      onToggle(table.key);
+      if (willExpand && !colsLoaded) loadFlatColumns(table.key);
+    },
+    [expanded, onToggle, table.key, colsLoaded, loadFlatColumns]
+  );
+
+  return (
+    <>
+      <RowShell
+        level={1}
+        hasCaret
+        expanded={expanded}
+        onToggle={handleToggle}
+        icon={<TableIcon className={`h-3 w-3 shrink-0 ${tableColors.text}`} aria-hidden="true" />}
+        name={table.name}
+        meta={typeof colCount === 'number' ? `${colCount}` : null}
+        draggable
+        dragProps={dragProps}
+        isDragging={drag.isDragging}
+        testId={`library-source-table-${sourceName}-${table.name}`}
+      />
+      {expanded && colsLoaded && !cols.error && (
+        <div data-testid={`library-source-table-${sourceName}-${table.name}-columns`}>
+          {cols.map(col => (
+            <ColumnRow key={col.key} sourceName={sourceName} tableName={table.name} col={col} />
+          ))}
+        </div>
+      )}
+      {expanded && colsLoaded && cols.error && (
+        <div
+          className="py-1 pl-10 text-[11px] text-highlight-600"
+          data-testid={`library-source-table-${sourceName}-${table.name}-error`}
+        >
+          {cols.error}
+        </div>
+      )}
+      {expanded && !colsLoaded && (
+        <div className="flex items-center gap-1.5 py-1 pl-10 text-[11px] text-gray-400">
+          <PiSpinnerGap className="h-3 w-3 animate-spin" aria-hidden="true" />
+          Loading columns…
+        </div>
+      )}
+    </>
+  );
+};
+
+/** The lazily-mounted drill-down body for one expanded source row. Only
+ * rendered (and therefore only calls `useSourceOutline`, which fetches) once
+ * the source row is expanded — see `LibrarySourceRow` below. */
+const LibrarySourceDrilldown = ({ sourceName }) => {
+  const {
+    available,
+    loading,
+    nodes,
+    status,
+    error,
+    isCold,
+    generating,
+    generateSchema,
+    loadFlatColumns,
+    flatColumns,
+    reload,
+  } = useSourceOutline(sourceName);
+
+  const expandedBySource = useStore(s => s.workspaceSourceOutlineExpanded);
+  const toggleExpanded = useStore(s => s.toggleWorkspaceSourceOutlineExpanded);
+  const expandedSet = useMemo(
+    () => new Set(expandedBySource?.[sourceName] || []),
+    [expandedBySource, sourceName]
+  );
+  const handleToggle = useCallback(
+    key => toggleExpanded(sourceName, key),
+    [sourceName, toggleExpanded]
+  );
+
+  if (!available) {
+    return (
+      <div
+        className="py-1 pl-10 text-[11px] italic text-gray-400"
+        data-testid={`library-source-${sourceName}-unavailable`}
+      >
+        Schema browsing needs `visivo serve`.
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-1.5 py-1 pl-10 text-[11px] text-gray-400">
+        <PiSpinnerGap className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Loading schema…
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="flex items-center gap-1.5 py-1 pl-10 text-[11px] text-highlight-600">
+        <PiWarningCircle className="h-3 w-3 shrink-0" aria-hidden="true" />
+        <span className="truncate">{error}</span>
+        <button
+          type="button"
+          onClick={reload}
+          data-testid={`library-source-${sourceName}-retry`}
+          className="shrink-0 font-medium text-primary-600 hover:underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (isCold) {
+    return (
+      <div className="flex items-center gap-1.5 py-1 pl-10 text-[11px] text-gray-400">
+        <button
+          type="button"
+          onClick={generateSchema}
+          disabled={!!generating}
+          data-testid={`library-source-${sourceName}-generate`}
+          className="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <PiArrowsClockwise
+            className={`h-3 w-3 ${generating ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
+          {generating ? 'Generating schema…' : 'Generate schema to browse'}
+        </button>
+      </div>
+    );
+  }
+
+  const tables = (nodes && nodes[0] && nodes[0].children) || [];
+  if (tables.length === 0) {
+    return (
+      <div
+        className="py-1 pl-10 text-[11px] italic text-gray-400"
+        data-testid={`library-source-${sourceName}-empty`}
+      >
+        No tables found.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid={`library-source-${sourceName}-tables`}>
+      {tables.map(table => (
+        <TableRow
+          key={table.key}
+          sourceName={sourceName}
+          table={table}
+          expandedSet={expandedSet}
+          onToggle={handleToggle}
+          flatColumns={flatColumns}
+          loadFlatColumns={loadFlatColumns}
+        />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * LibrarySourceRow — the top-level row `LibrarySubsection` renders for each
+ * `source` object instead of the plain `LibraryRow` (see `LibrarySubsection`'s
+ * `typeKey === 'source'` branch). Same click/context-menu delegation as a
+ * normal Library row (via `onClick`/`onContextAction`), plus the caret that
+ * lazily mounts `LibrarySourceDrilldown`.
+ */
+const LibrarySourceRow = ({ obj, selected = false, onClick }) => {
+  const SourceIcon = getTypeIcon('source');
+  const sourceColors = getTypeColors('source');
+  const expanded = useStore(s => !!s.librarySourceRowExpanded[obj.name]);
+  const toggleExpanded = useStore(s => s.toggleLibrarySourceRowExpanded);
+  const [hovered, setHovered] = useState(false);
+
+  const drag = useDraggable({
+    id: `library:source:${obj.name}`,
+    data: { source: 'library', type: 'source', name: obj.name, subtype: obj.subtype },
+  });
+  const dragProps = {
+    ref: drag.setNodeRef,
+    ...drag.listeners,
+    ...drag.attributes,
+    style: { touchAction: 'none' },
+  };
+
+  const handleToggle = useCallback(
+    e => {
+      e.stopPropagation();
+      toggleExpanded(obj.name);
+    },
+    [obj.name, toggleExpanded]
+  );
+
+  const handleClick = useCallback(
+    e => {
+      if (drag.isDragging) return;
+      onClick && onClick(obj, e);
+    },
+    [drag.isDragging, obj, onClick]
+  );
+
+  const tid = `library-row-source-${obj.name}`;
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onContextMenu={e => {
+        e.preventDefault();
+      }}
+    >
+      <div
+        {...dragProps}
+        data-testid={tid}
+        data-selected={selected ? 'true' : 'false'}
+        data-dragging={drag.isDragging ? 'true' : 'false'}
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        className={[
+          'group relative flex h-7 cursor-grab items-center gap-1.5 rounded-md pl-1 pr-2 text-[13px] transition-colors active:cursor-grabbing',
+          selected ? 'bg-primary-100/55 text-primary-600' : hovered ? 'bg-gray-100' : 'hover:bg-gray-50',
+          drag.isDragging ? 'opacity-40' : '',
+        ].join(' ')}
+      >
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-expanded={expanded}
+          data-testid={`${tid}-toggle`}
+          className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-400 hover:text-gray-600"
+        >
+          {expanded ? <PiCaretDown className="h-3 w-3" /> : <PiCaretRight className="h-3 w-3" />}
+        </button>
+        <SourceIcon
+          aria-hidden="true"
+          style={{ fontSize: 14 }}
+          className={`shrink-0 ${selected ? 'text-primary-600' : sourceColors.text}`}
+        />
+        <StatusDot status={obj.status} />
+        <span className={`min-w-0 flex-1 truncate ${selected ? 'font-medium' : ''}`}>
+          {obj.name}
+        </span>
+        <span
+          aria-hidden="true"
+          data-testid={`${tid}-drag-handle`}
+          className={[
+            'flex h-3 w-3 shrink-0 items-center justify-center text-gray-300 transition-opacity',
+            hovered || drag.isDragging ? 'opacity-100' : 'opacity-0',
+          ].join(' ')}
+        >
+          <PiDotsSix className="h-3 w-3" />
+        </span>
+      </div>
+      {expanded && <LibrarySourceDrilldown sourceName={obj.name} />}
+    </div>
+  );
+};
+
+export default LibrarySourceRow;

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
@@ -1,0 +1,200 @@
+/**
+ * LibrarySourceRow — Explore 2.0 Phase 3a (D9 / VIS-1052) source drill-down.
+ *
+ * Covers: lazy expansion (useSourceOutline only fetches once expanded),
+ * source -> table -> column levels rendering from the cached feed, type
+ * glyphs, drag handles + payload shape, and per-session collapse memory via
+ * the store (not re-fetching on re-render once cached).
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { DndContext, useDraggable } from '@dnd-kit/core';
+import useStore from '../../../../stores/store';
+import LibrarySourceRow from './LibrarySourceRow';
+import {
+  fetchSourceSchemaJobs,
+  fetchSourceTables,
+  fetchTableColumns,
+} from '../../../../api/sourceSchemaJobs';
+
+jest.mock('../../../../contexts/URLContext', () => ({
+  isAvailable: () => true,
+}));
+jest.mock('../../../../api/sourceSchemaJobs', () => ({
+  fetchSourceSchemaJobs: jest.fn(),
+  generateSourceSchema: jest.fn(),
+  fetchSchemaGenerationStatus: jest.fn(),
+  fetchSourceTables: jest.fn(),
+  fetchTableColumns: jest.fn(),
+}));
+
+jest.mock('@dnd-kit/core', () => {
+  const actual = jest.requireActual('@dnd-kit/core');
+  return { __esModule: true, ...actual, useDraggable: jest.fn(actual.useDraggable) };
+});
+
+const withDnd = ui => <DndContext>{ui}</DndContext>;
+
+const SOURCE = { id: 'source:warehouse', type: 'source', name: 'warehouse', subtype: 'postgresql' };
+
+describe('LibrarySourceRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDraggable.mockClear();
+    act(() => {
+      useStore.setState({
+        librarySourceRowExpanded: {},
+        workspaceSourceOutlineExpanded: {},
+        workspaceSourceOutlineDataCache: {},
+      });
+    });
+  });
+
+  test('renders the source row collapsed by default, no schema fetch', () => {
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    expect(screen.getByTestId('library-row-source-warehouse')).toHaveTextContent('warehouse');
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
+  });
+
+  test('clicking the row delegates to onClick (does not expand)', () => {
+    const onClick = jest.fn();
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
+    expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
+  });
+
+  test('expanding the caret lazily loads the cached schema feed (source -> table)', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceTables.mockResolvedValue([{ name: 'orders', column_count: 4 }]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+
+    await waitFor(() => expect(fetchSourceSchemaJobs).toHaveBeenCalledTimes(1));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+    expect(screen.getByTestId('library-source-table-warehouse-orders')).toHaveTextContent('orders');
+    // Column count shown as a meta badge before columns are even expanded.
+    expect(screen.getByTestId('library-source-table-warehouse-orders')).toHaveTextContent('4');
+  });
+
+  test('collapsing and re-expanding does not re-fetch (session cache)', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceTables.mockResolvedValue([{ name: 'orders', column_count: 4 }]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    await waitFor(() => expect(fetchSourceSchemaJobs).toHaveBeenCalledTimes(1));
+
+    // Collapse.
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    expect(screen.queryByTestId('library-source-table-warehouse-orders')).not.toBeInTheDocument();
+
+    // Re-expand — reads the per-session cache, no second fetch.
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+    expect(fetchSourceSchemaJobs).toHaveBeenCalledTimes(1);
+  });
+
+  test('expanding a table lazily loads its columns, with type glyphs', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceTables.mockResolvedValue([{ name: 'orders', column_count: 2 }]);
+    fetchTableColumns.mockResolvedValue([
+      { name: 'id', type: 'INTEGER' },
+      { name: 'region', type: 'VARCHAR' },
+    ]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+
+    expect(fetchTableColumns).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('library-source-table-warehouse-orders-toggle'));
+
+    await waitFor(() => expect(fetchTableColumns).toHaveBeenCalledWith('warehouse', 'orders'));
+    await screen.findByTestId('library-source-column-warehouse-orders-id');
+    expect(screen.getByTestId('library-source-column-warehouse-orders-id')).toHaveTextContent('#');
+    expect(
+      screen.getByTestId('library-source-column-warehouse-orders-region')
+    ).toHaveTextContent('T');
+  });
+
+  test('table row drag payload carries type sourceTable + sourceName', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceTables.mockResolvedValue([{ name: 'orders', column_count: 1 }]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+
+    const call = useDraggable.mock.calls.find(
+      ([opts]) => opts.id === 'library:sourceTable:warehouse:orders'
+    );
+    expect(call[0].data).toEqual(
+      expect.objectContaining({ source: 'library', type: 'sourceTable', name: 'orders', sourceName: 'warehouse' })
+    );
+  });
+
+  test('column row drag payload carries type sourceColumn + tableName + columnType', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceTables.mockResolvedValue([{ name: 'orders', column_count: 1 }]);
+    fetchTableColumns.mockResolvedValue([{ name: 'amount', type: 'DOUBLE' }]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+    fireEvent.click(screen.getByTestId('library-source-table-warehouse-orders-toggle'));
+    await screen.findByTestId('library-source-column-warehouse-orders-amount');
+
+    const call = useDraggable.mock.calls.find(
+      ([opts]) => opts.id === 'library:sourceColumn:warehouse:orders:amount'
+    );
+    expect(call[0].data).toEqual(
+      expect.objectContaining({
+        source: 'library',
+        type: 'sourceColumn',
+        name: 'amount',
+        sourceName: 'warehouse',
+        tableName: 'orders',
+        columnType: 'DOUBLE',
+      })
+    );
+  });
+
+  test('cold source (no cached schema) shows a Generate prompt instead of a tree', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: false },
+    ]);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+
+    await screen.findByTestId('library-source-warehouse-generate');
+    expect(fetchSourceTables).not.toHaveBeenCalled();
+  });
+
+  test('source row itself is a drag source (type source, unchanged payload shape)', () => {
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    const call = useDraggable.mock.calls.find(([opts]) => opts.id === 'library:source:warehouse');
+    expect(call[0].data).toEqual(
+      expect.objectContaining({ source: 'library', type: 'source', name: 'warehouse', subtype: 'postgresql' })
+    );
+  });
+
+  test('renders the drag handle on the source row', () => {
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    expect(screen.getByTestId('library-row-source-warehouse-drag-handle')).toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { PiCaretDown } from 'react-icons/pi';
 import LibraryRow from './LibraryRow';
 import { getTypeDef } from './LibraryRow';
+import LibrarySourceRow from './LibrarySourceRow';
 import useStore from '../../../../stores/store';
 import { isLibrarySubsectionCollapsed } from '../../../../stores/libraryPrefsStore';
 
@@ -98,17 +99,31 @@ const LibrarySubsection = ({
               className="flex flex-col gap-px"
               data-testid={`library-subsection-${typeKey}-rows`}
             >
-              {rows.map(obj => (
-                <li key={obj.id} className="relative">
-                  <LibraryRow
-                    obj={obj}
-                    selected={selectedRowId === obj.id}
-                    draggable={def.droppable}
-                    onClick={onRowClick}
-                    onContextAction={onContextAction}
-                  />
-                </li>
-              ))}
+              {rows.map(obj =>
+                // Sources get the D9 source → table → column drill-down
+                // (Explore 2.0 Phase 3a) instead of the plain flat row — see
+                // LibrarySourceRow's docstring.
+                typeKey === 'source' ? (
+                  <li key={obj.id} className="relative">
+                    <LibrarySourceRow
+                      obj={obj}
+                      selected={selectedRowId === obj.id}
+                      onClick={onRowClick}
+                      onContextAction={onContextAction}
+                    />
+                  </li>
+                ) : (
+                  <li key={obj.id} className="relative">
+                    <LibraryRow
+                      obj={obj}
+                      selected={selectedRowId === obj.id}
+                      draggable={def.droppable || def.explorationDragSource}
+                      onClick={onRowClick}
+                      onContextAction={onContextAction}
+                    />
+                  </li>
+                )
+              )}
             </ul>
           )}
         </div>

--- a/viewer/src/components/views/workspace/library/useLibraryData.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.js
@@ -32,21 +32,26 @@ import useStore from '../../../../stores/store';
  *       chart:    { id, type, name, status }[],
  *       table:    { id, type, name, status }[],
  *       markdown:  { id, type, name, status }[],
- *       input:     { id, type, name, status }[],
+ *       input:     { id, type, name, status, inputType }[],
  *       dashboard: { id, type, name, status }[],
  *     },
  *     dataLayer: {
  *       source:    { id, type, name, status, subtype }[],
  *       model:     { id, type, name, status, subtype }[],
- *       dimension: { id, type, name, status }[],
- *       metric:    { id, type, name, status }[],
+ *       dimension: { id, type, name, status, parentModel, expression }[],
+ *       metric:    { id, type, name, status, parentModel, expression }[],
  *       relation:  { id, type, name, status }[],
  *       insight:   { id, type, name, status }[],
  *     },
  *   }
  *
  * The `status` field is passed straight through from the store record so
- * the row can render its unpublished-changes dot.
+ * the row can render its unpublished-changes dot. `inputType` /
+ * `parentModel` / `expression` are the Explore 2.0 Phase 3a drag-payload
+ * extension (02-architecture.md §4's "payload gap" — `LibraryRow.jsx` reads
+ * these onto its `useDraggable` data so the exploration DnD router can
+ * resolve a dropped field's ref scoping and an input's `.value`/`.values`
+ * accessor without a second lookup).
  */
 const safeArray = v => (Array.isArray(v) ? v : []);
 
@@ -115,19 +120,50 @@ export function useLibraryData() {
       status: s.status || null,
     }));
 
+    // Inputs carry `inputType` (single-select | multi-select) — the Explore
+    // 2.0 Phase 3a DnD payload gap (02-architecture.md §4): a dropped input's
+    // accessor (`.value` vs `.values`) depends on it.
+    const inputRows = safeArray(inputs).map(i => ({
+      id: `input:${i.name}`,
+      type: 'input',
+      name: i.name,
+      status: i.status || null,
+      inputType: i.config?.type || i.type || null,
+    }));
+
+    // Dimensions/metrics carry `parentModel` (the owning model's name, when
+    // model-scoped) — the same Phase 3a payload gap: a dropped field's ref
+    // must serialize `${ref(model).name}` (scoped) vs bare `${ref(name)}`
+    // (unscoped), and only `parentModel` on the drag payload lets the drop
+    // side decide which. Mirrors `useFieldParentModel.js`'s own resolution
+    // (`fieldRecord.parentModel || fieldRecord.config?.model`).
+    const withParentModel = (list, type) =>
+      safeArray(list).map(f => ({
+        id: `${type}:${f.name}`,
+        type,
+        name: f.name,
+        status: f.status || null,
+        parentModel: f.parentModel || f.config?.model || null,
+        // The field's own expression — carried so a metric/dimension dropped
+        // onto the results grid's computed-column zone can be replicated as
+        // a computed column bound to a DIFFERENT model (mirrors the legacy
+        // `ExplorerLeftPanel.DraggableItem`'s `item.config?.expression`).
+        expression: f.config?.expression || null,
+      }));
+
     return {
       layoutItems: {
         chart: mapRows(charts, 'chart'),
         table: mapRows(tables, 'table'),
         markdown: mapRows(markdowns, 'markdown'),
-        input: mapRows(inputs, 'input'),
+        input: inputRows,
         dashboard: mapRows(dashboards, 'dashboard'),
       },
       dataLayer: {
         source: sourceRows,
         model: modelRows,
-        dimension: mapRows(dimensions, 'dimension'),
-        metric: mapRows(metrics, 'metric'),
+        dimension: withParentModel(dimensions, 'dimension'),
+        metric: withParentModel(metrics, 'metric'),
         relation: mapRows(relations, 'relation'),
         insight: mapRows(insights, 'insight'),
       },

--- a/viewer/src/components/views/workspace/library/useLibraryData.test.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.test.js
@@ -8,6 +8,7 @@
  * — with stable ids and `model` being the union of sql_model +
  * csv_script_model + local_merge_model.
  */
+/* eslint-disable no-template-curly-in-string -- fixtures use literal Visivo ref-string syntax, not JS template interpolation */
 import { renderHook, act } from '@testing-library/react';
 import useStore from '../../../../stores/store';
 import useLibraryData from './useLibraryData';
@@ -103,13 +104,67 @@ describe('useLibraryData', () => {
     });
     const { result } = renderHook(() => useLibraryData());
     expect(result.current.dataLayer.dimension).toEqual([
-      { id: 'dimension:period', type: 'dimension', name: 'period', status: null },
+      {
+        id: 'dimension:period',
+        type: 'dimension',
+        name: 'period',
+        status: null,
+        parentModel: null,
+        expression: null,
+      },
     ]);
     expect(result.current.dataLayer.metric[0].type).toBe('metric');
     expect(result.current.dataLayer.relation[0].type).toBe('relation');
     expect(result.current.dataLayer.insight).toEqual([
       { id: 'insight:revenue_growth', type: 'insight', name: 'revenue_growth', status: 'new' },
     ]);
+  });
+
+  // Explore 2.0 Phase 3a — 02-architecture.md §4's DnD "payload gap": a
+  // dropped field's ref-scoping and an input's `.value`/`.values` accessor
+  // both depend on data the Library row previously didn't carry.
+  test('dimensions/metrics carry parentModel + expression when model-scoped', () => {
+    act(() => {
+      useStore.setState({
+        dimensions: [
+          { name: 'scoped_dim', parentModel: 'orders', config: { expression: 'UPPER(region)' } },
+          { name: 'ref_scoped_dim', config: { model: '${ref(users)}', expression: 'region' } },
+          { name: 'unscoped_dim', config: { expression: 'count(*)' } },
+        ],
+        metrics: [
+          { name: 'scoped_metric', parentModel: 'orders', config: { expression: 'sum(amount)' } },
+        ],
+      });
+    });
+    const { result } = renderHook(() => useLibraryData());
+    const [scoped, refScoped, unscoped] = result.current.dataLayer.dimension;
+    expect(scoped.parentModel).toBe('orders');
+    expect(scoped.expression).toBe('UPPER(region)');
+    // Falls back to config.model (a ref string) when parentModel isn't set
+    // directly on the record — mirrors useFieldParentModel.js's resolution.
+    expect(refScoped.parentModel).toBe('${ref(users)}');
+    expect(unscoped.parentModel).toBeNull();
+
+    const [scopedMetric] = result.current.dataLayer.metric;
+    expect(scopedMetric.parentModel).toBe('orders');
+    expect(scopedMetric.expression).toBe('sum(amount)');
+  });
+
+  test('inputs carry inputType (single-select | multi-select)', () => {
+    act(() => {
+      useStore.setState({
+        inputs: [
+          { name: 'region', config: { type: 'single-select' } },
+          { name: 'products', config: { type: 'multi-select' } },
+          { name: 'no_config' },
+        ],
+      });
+    });
+    const { result } = renderHook(() => useLibraryData());
+    const [single, multi, noConfig] = result.current.layoutItems.input;
+    expect(single.inputType).toBe('single-select');
+    expect(multi.inputType).toBe('multi-select');
+    expect(noConfig.inputType).toBeNull();
   });
 
   test('model is the union of sql / csv-script / local-merge models', () => {

--- a/viewer/src/hooks/useInlineRename.js
+++ b/viewer/src/hooks/useInlineRename.js
@@ -1,0 +1,88 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * useInlineRename — the shared "am I editing this name right now" state
+ * machine behind every inline-rename gesture in the app (Explore 2.0 Phase 3a
+ * / B16, specs/plan/explorer-workspace-unification/04-bug-inventory.md).
+ *
+ * Before this hook, `ModelTabBar`, `InsightCRUDSection`, and `ChartCRUDSection`
+ * each hand-rolled their own copy of the same shape: `[value, setValue]` +
+ * `[error, setError]` + a `commitRename` that catches a collision error and
+ * keeps the input open, + Enter/Escape/blur wiring. `ExplorationCard` and
+ * `ExplorationPane`'s SubBar pencil independently hand-rolled the SIMPLER
+ * "am I editing" toggle half of the same pattern around the shared
+ * `InlineRenameInput` widget (`viewer/src/components/views/workspace/
+ * InlineRenameInput.jsx`, which already owns the actual text-entry +
+ * Enter/Escape/blur/commit-or-cancel mechanics).
+ *
+ * This hook is the ONE state machine both shapes need:
+ *   - `editing`         — is the rename UI showing right now.
+ *   - `error`            — the last collision/validation message, if any
+ *                          (kept populated so the input stays open for a retry).
+ *   - `start()`          — enter edit mode (clears any stale error).
+ *   - `cancel()`         — leave edit mode without committing.
+ *   - `commit(nextName)` — call the caller's rename action; if it THROWS an
+ *                          error with `.code === 'NAME_COLLISION'` (the shape
+ *                          `stores/explorerStore.js`'s `NameCollisionError`
+ *                          already uses), the message is captured in `error`
+ *                          and edit mode stays open for a retry. Any other
+ *                          thrown error rethrows (a real bug, not a name
+ *                          clash). A rename action that doesn't throw (e.g.
+ *                          `workspaceExplorationsStore.js`'s `renameExploration`,
+ *                          which resolves `{success, error}` instead of
+ *                          throwing) simply exits edit mode — the exact
+ *                          behavior `ExplorationCard`/`ExplorationPane` already
+ *                          had.
+ *
+ * Callers that need the full text-entry mechanics pair this with
+ * `InlineRenameInput`:
+ *
+ *   const rename = useInlineRename({ onCommit: nextName => renameThing(id, nextName) });
+ *   return rename.editing ? (
+ *     <InlineRenameInput name={name} onCommit={rename.commit} onCancel={rename.cancel} />
+ *   ) : (
+ *     <button onClick={rename.start}>{name}</button>
+ *   );
+ *   {rename.error && <span>{rename.error}</span>}
+ *
+ * Adopted by the Explore 2.0 Phase 3a query chips (`ExplorationQueryChips.jsx`,
+ * which needs the full collision-retry behavior for `renameModelTab`) and by
+ * `ExplorationCard`/`ExplorationPane`'s SubBar pencil (the simpler toggle
+ * usage). `InsightCRUDSection`/`ChartCRUDSection`'s own hand-rolled copies are
+ * a follow-up — noted, not swept in this change (03-delivery-plan.md's Phase
+ * 3a scope: "adopt in the new chips + at least the Home-card rename; full
+ * sweep of legacy call sites can note follow-ups").
+ */
+export default function useInlineRename({ onCommit } = {}) {
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState(null);
+
+  const start = useCallback(() => {
+    setError(null);
+    setEditing(true);
+  }, []);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    setError(null);
+  }, []);
+
+  const commit = useCallback(
+    nextName => {
+      try {
+        onCommit && onCommit(nextName);
+        setEditing(false);
+        setError(null);
+      } catch (err) {
+        if (err && err.code === 'NAME_COLLISION') {
+          setError(err.message);
+          return; // stay in edit mode so the user can retry
+        }
+        throw err;
+      }
+    },
+    [onCommit]
+  );
+
+  return { editing, error, start, cancel, commit };
+}

--- a/viewer/src/hooks/useInlineRename.test.js
+++ b/viewer/src/hooks/useInlineRename.test.js
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import useInlineRename from './useInlineRename';
+
+class NameCollisionError extends Error {
+  constructor(message) {
+    super(message);
+    this.code = 'NAME_COLLISION';
+  }
+}
+
+describe('useInlineRename', () => {
+  test('starts not editing, with no error', () => {
+    const { result } = renderHook(() => useInlineRename({ onCommit: jest.fn() }));
+    expect(result.current.editing).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('start() enters edit mode', () => {
+    const { result } = renderHook(() => useInlineRename({ onCommit: jest.fn() }));
+    act(() => result.current.start());
+    expect(result.current.editing).toBe(true);
+  });
+
+  test('cancel() leaves edit mode and clears any error', () => {
+    const onCommit = jest.fn(() => {
+      throw new NameCollisionError('taken');
+    });
+    const { result } = renderHook(() => useInlineRename({ onCommit }));
+    act(() => result.current.start());
+    act(() => result.current.commit('dup'));
+    expect(result.current.error).toBe('taken');
+    act(() => result.current.cancel());
+    expect(result.current.editing).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('commit() calls onCommit and exits edit mode on success', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() => useInlineRename({ onCommit }));
+    act(() => result.current.start());
+    act(() => result.current.commit('Renamed'));
+    expect(onCommit).toHaveBeenCalledWith('Renamed');
+    expect(result.current.editing).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('commit() catches a NAME_COLLISION error, sets it, and stays in edit mode', () => {
+    const onCommit = jest.fn(() => {
+      throw new NameCollisionError('Name "dup" is already in use.');
+    });
+    const { result } = renderHook(() => useInlineRename({ onCommit }));
+    act(() => result.current.start());
+    act(() => result.current.commit('dup'));
+    expect(result.current.editing).toBe(true);
+    expect(result.current.error).toBe('Name "dup" is already in use.');
+  });
+
+  test('commit() rethrows a non-collision error', () => {
+    const boom = new Error('boom');
+    const onCommit = jest.fn(() => {
+      throw boom;
+    });
+    const { result } = renderHook(() => useInlineRename({ onCommit }));
+    act(() => result.current.start());
+    expect(() => act(() => result.current.commit('x'))).toThrow('boom');
+  });
+
+  test('start() clears a stale error from a previous failed attempt', () => {
+    let shouldThrow = true;
+    const onCommit = jest.fn(name => {
+      if (shouldThrow) throw new NameCollisionError('taken');
+    });
+    const { result } = renderHook(() => useInlineRename({ onCommit }));
+    act(() => result.current.start());
+    act(() => result.current.commit('dup'));
+    expect(result.current.error).toBe('taken');
+    shouldThrow = false;
+    act(() => result.current.start());
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -519,6 +519,43 @@ const createExplorerSlice = (set, get) => ({
     });
   },
 
+  /**
+   * Explore 2.0 Phase 3a (D9): a Library schema-table row dropped on the SQL
+   * editor seeds a brand-new query chip bound to that table's source, with
+   * `SELECT * FROM <table>` pre-filled — 01-ux-spec.md §3a's "Table →
+   * canvas/editor: seeds a new scratch query." Mirrors `createModelTab`'s
+   * auto-naming; the only difference is the pre-filled sql + source (which
+   * `createModelTab` has no way to accept in one call).
+   */
+  seedModelTabFromTable: ({ tableName, sourceName } = {}) => {
+    if (!tableName) return;
+    const state = get();
+    const existing = new Set([
+      ...state.explorerModelTabs,
+      ...Object.keys(state.explorerModelStates || {}),
+    ]);
+    const finalName = generateUniqueName('model', Array.from(existing));
+
+    const projectDefaultSource = state.defaults?.source_name || null;
+    const firstAvailableSource = (state.explorerSources || [])[0]?.source_name || null;
+    const resolvedSource = sourceName || projectDefaultSource || firstAvailableSource;
+
+    const newModelState = {
+      ...createEmptyModelState(true),
+      sourceName: resolvedSource,
+      sql: `SELECT * FROM ${tableName}`,
+    };
+
+    set({
+      explorerModelTabs: [...state.explorerModelTabs, finalName],
+      explorerActiveModelName: finalName,
+      explorerModelStates: {
+        ...state.explorerModelStates,
+        [finalName]: newModelState,
+      },
+    });
+  },
+
   switchModelTab: (modelName) => {
     set({
       explorerActiveModelName: modelName,

--- a/viewer/src/stores/explorerStore.test.js
+++ b/viewer/src/stores/explorerStore.test.js
@@ -240,6 +240,45 @@ describe('explorerStore', () => {
     });
   });
 
+  // Explore 2.0 Phase 3a (D9): a Library schema-table row dropped on the SQL
+  // editor seeds a new query chip — 01-ux-spec.md §3a's "Table → canvas/
+  // editor: seeds a new scratch query."
+  describe('seedModelTabFromTable', () => {
+    it('creates a new tab pre-filled with SELECT * FROM <table> bound to the given source', () => {
+      useStore.getState().seedModelTabFromTable({ tableName: 'orders', sourceName: 'warehouse' });
+
+      const state = useStore.getState();
+      expect(state.explorerModelTabs).toHaveLength(1);
+      const name = state.explorerModelTabs[0];
+      expect(state.explorerActiveModelName).toBe(name);
+      expect(state.explorerModelStates[name].sql).toBe('SELECT * FROM orders');
+      expect(state.explorerModelStates[name].sourceName).toBe('warehouse');
+      expect(state.explorerModelStates[name].isNew).toBe(true);
+    });
+
+    it('auto-disambiguates the new tab name against existing tabs', () => {
+      useStore.getState().createModelTab(); // 'model'
+      useStore.getState().seedModelTabFromTable({ tableName: 'orders', sourceName: 'warehouse' });
+
+      const state = useStore.getState();
+      expect(state.explorerModelTabs).toHaveLength(2);
+      expect(state.explorerModelTabs[1]).not.toBe('model');
+    });
+
+    it('falls back to the project default source when none is given', () => {
+      useStore.setState({ defaults: { source_name: 'default-src' } });
+      useStore.getState().seedModelTabFromTable({ tableName: 'orders' });
+
+      const name = useStore.getState().explorerActiveModelName;
+      expect(useStore.getState().explorerModelStates[name].sourceName).toBe('default-src');
+    });
+
+    it('is a no-op without a tableName', () => {
+      useStore.getState().seedModelTabFromTable({ sourceName: 'warehouse' });
+      expect(useStore.getState().explorerModelTabs).toEqual([]);
+    });
+  });
+
   describe('switchModelTab', () => {
     it('sets the active model name', () => {
       useStore.getState().createModelTab('model_a');

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -183,6 +183,28 @@ const createWorkspaceSlice = (set, get) => ({
   // it. Session-only (schema can change between sessions). (VIS-1004 caching.)
   workspaceSourceOutlineDataCache: {},
 
+  // Library source drill-down (Explore 2.0 Phase 3a / D9): does the Library's
+  // "Sources" subsection have THIS source's row expanded at all (source →
+  // schema → table → columns)? A DIFFERENT concept from
+  // `workspaceSourceOutlineExpanded` above (which tracks expand state of
+  // individual db/schema/table NODES once a source's tree is already being
+  // shown) — this is the top-level gate that decides whether
+  // `useSourceOutline(sourceName)` mounts at all for a given Library row, so
+  // the drill-down is genuinely lazy: collapsed sources never fetch their
+  // cached schema. Keyed by source name → boolean. Session-only, same
+  // rationale as its sibling above (schema can change between sessions).
+  librarySourceRowExpanded: {},
+
+  toggleLibrarySourceRowExpanded: sourceName => {
+    if (!sourceName) return;
+    set(state => ({
+      librarySourceRowExpanded: {
+        ...state.librarySourceRowExpanded,
+        [sourceName]: !state.librarySourceRowExpanded[sourceName],
+      },
+    }));
+  },
+
   // Resize state (Phase 0 visual stub; actual resizing comes later) --------
   workspaceLeftWidth: 320,
   workspaceRightWidth: 360,

--- a/viewer/src/utils/refWalk.js
+++ b/viewer/src/utils/refWalk.js
@@ -1,0 +1,87 @@
+/**
+ * refWalk — the shared `ref(name)` walker (Explore 2.0 Phase 3a / B16,
+ * specs/plan/explorer-workspace-unification/04-bug-inventory.md).
+ *
+ * Before this util, at least four call sites independently re-implemented the
+ * same "scan this value for `ref(name)` occurrences" regex walk:
+ * `stores/explorerStore.js` (`selectDerivedInputNames`, and again inline for
+ * chart-lineage resolution), `components/explorer/ModelTabBar.jsx`
+ * (`getReferencedModelNames`), `components/explorer/ExplorerLeftPanel.jsx`
+ * (chart lineage resolution), and `models/Insight.js` (a stricter
+ * `${ref(name).field}`-only variant). Each walked props/interactions by hand
+ * with a slightly different regex and a slightly different traversal.
+ *
+ * This module is the ONE walker. Adopted by the new query chips
+ * (`ExplorationQueryChips.jsx`)'s referenced-by badge; the other call sites
+ * are a noted follow-up (03-delivery-plan.md's Phase 3a scope: "adopt in the
+ * new chips... full sweep of legacy call sites can note follow-ups").
+ */
+
+// Matches `ref(name)` — deliberately loose (no `${}` wrapper requirement, no
+// `.field` requirement) so it catches every existing call site's target
+// shape: bare `ref(name)`, `ref(name).field`, and refs embedded inside a
+// larger expression like `sum(ref(model).amount)`.
+const REF_CALL_PATTERN = /ref\(([^.)]+)\)/g;
+
+/**
+ * Recursively collect every `ref(name)` occurrence's `name` inside `value`
+ * (a string, or an object/array nested to any depth), adding to `into` (a
+ * Set, so repeated calls across multiple values can accumulate into one
+ * result). Returns `into` for chaining.
+ */
+export function collectRefNames(value, into = new Set()) {
+  if (value == null) return into;
+  if (typeof value === 'string') {
+    // A fresh RegExp per call — `REF_CALL_PATTERN` carries a `lastIndex` that
+    // must not leak state across invocations (a stale `lastIndex` from a
+    // previous, shorter string silently skips matches in the next one).
+    const re = new RegExp(REF_CALL_PATTERN.source, 'g');
+    let match;
+    while ((match = re.exec(value)) !== null) {
+      into.add(match[1]);
+    }
+    return into;
+  }
+  if (Array.isArray(value)) {
+    value.forEach(item => collectRefNames(item, into));
+    return into;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach(item => collectRefNames(item, into));
+    return into;
+  }
+  return into;
+}
+
+/**
+ * Every ref name a single insight's working state (props + interactions)
+ * references. `insightState` is an `explorerInsightStates[name]` entry
+ * (`{ props, interactions }`) — tolerates `null`/`undefined`.
+ */
+export function collectInsightRefNames(insightState) {
+  const names = new Set();
+  if (!insightState) return names;
+  collectRefNames(insightState.props, names);
+  (insightState.interactions || []).forEach(interaction => {
+    collectRefNames(interaction && interaction.value, names);
+  });
+  return names;
+}
+
+/**
+ * For each name in `names`, how many of `insightNames` (looked up in
+ * `insightStates`) reference it (across props or interactions)? Returns a
+ * `Map<name, count>` — the data behind the query chip's referenced-by badge
+ * (⛓n — "2 draft insights reference this query", 01-ux-spec.md §3;
+ * successor to `ModelTabBar`'s boolean referenced ring).
+ */
+export function countReferencingInsights(names, insightNames, insightStates) {
+  const counts = new Map((names || []).map(name => [name, 0]));
+  for (const insightName of insightNames || []) {
+    const refs = collectInsightRefNames((insightStates || {})[insightName]);
+    for (const name of counts.keys()) {
+      if (refs.has(name)) counts.set(name, counts.get(name) + 1);
+    }
+  }
+  return counts;
+}

--- a/viewer/src/utils/refWalk.test.js
+++ b/viewer/src/utils/refWalk.test.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-template-curly-in-string -- test fixtures are literal Visivo ref-string syntax, not JS template interpolation */
+import { collectRefNames, collectInsightRefNames, countReferencingInsights } from './refWalk';
+
+describe('collectRefNames', () => {
+  test('finds a bare ref() in a string', () => {
+    expect(collectRefNames('${ref(orders_q)}')).toEqual(new Set(['orders_q']));
+  });
+
+  test('finds a ref().field in a string', () => {
+    expect(collectRefNames('?{${ref(orders_q).amount}}')).toEqual(new Set(['orders_q']));
+  });
+
+  test('finds a ref() nested inside a function call expression', () => {
+    expect(collectRefNames('sum(ref(orders_q).amount)')).toEqual(new Set(['orders_q']));
+  });
+
+  test('finds multiple distinct refs across a string', () => {
+    const names = collectRefNames('${ref(a).x} + ${ref(b).y}');
+    expect(names).toEqual(new Set(['a', 'b']));
+  });
+
+  test('walks nested objects and arrays', () => {
+    const value = {
+      x: '${ref(model_a).col}',
+      nested: { y: '${ref(model_b).col}' },
+      list: ['${ref(model_c)}', 42, null],
+    };
+    expect(collectRefNames(value)).toEqual(new Set(['model_a', 'model_b', 'model_c']));
+  });
+
+  test('returns an empty set for a value with no refs', () => {
+    expect(collectRefNames('plain text')).toEqual(new Set());
+    expect(collectRefNames(null)).toEqual(new Set());
+    expect(collectRefNames(undefined)).toEqual(new Set());
+    expect(collectRefNames(42)).toEqual(new Set());
+  });
+
+  test('accumulates into a passed-in Set across repeated calls', () => {
+    const into = new Set(['seed']);
+    collectRefNames('${ref(a)}', into);
+    collectRefNames('${ref(b)}', into);
+    expect(into).toEqual(new Set(['seed', 'a', 'b']));
+  });
+
+  test('does not leak regex lastIndex state across calls (repeat call finds matches again)', () => {
+    // A stale `lastIndex` from a previous call on a LONGER string would cause
+    // a subsequent call on a SHORTER string to miss matches near the start.
+    collectRefNames('${ref(a)} ${ref(b)} ${ref(c)} ${ref(d)}');
+    expect(collectRefNames('${ref(a)}')).toEqual(new Set(['a']));
+  });
+});
+
+describe('collectInsightRefNames', () => {
+  test('collects refs from both props and interactions', () => {
+    const insightState = {
+      props: { x: '${ref(orders_q).cohort}', y: '${ref(orders_q).churned}' },
+      interactions: [{ value: '${ref(region_input).value}' }],
+    };
+    expect(collectInsightRefNames(insightState)).toEqual(
+      new Set(['orders_q', 'region_input'])
+    );
+  });
+
+  test('tolerates a null/undefined insight state', () => {
+    expect(collectInsightRefNames(null)).toEqual(new Set());
+    expect(collectInsightRefNames(undefined)).toEqual(new Set());
+  });
+
+  test('tolerates missing props/interactions', () => {
+    expect(collectInsightRefNames({})).toEqual(new Set());
+  });
+});
+
+describe('countReferencingInsights', () => {
+  const insightStates = {
+    churn_by_cohort: { props: { x: '${ref(orders_q).cohort}' }, interactions: [] },
+    revenue_by_region: {
+      props: { x: '${ref(orders_q).region}', y: '${ref(cohort_q).amount}' },
+      interactions: [],
+    },
+    unrelated: { props: { x: '${ref(cohort_q).amount}' }, interactions: [] },
+  };
+  const insightNames = ['churn_by_cohort', 'revenue_by_region', 'unrelated'];
+
+  test('counts how many named insights reference each name', () => {
+    const counts = countReferencingInsights(['orders_q', 'cohort_q'], insightNames, insightStates);
+    expect(counts.get('orders_q')).toBe(2);
+    expect(counts.get('cohort_q')).toBe(2);
+  });
+
+  test('a name with zero referencing insights counts as 0, not absent', () => {
+    const counts = countReferencingInsights(['never_referenced'], insightNames, insightStates);
+    expect(counts.get('never_referenced')).toBe(0);
+  });
+
+  test('only counts insights actually in insightNames (chart-attached), not every insightState', () => {
+    const counts = countReferencingInsights(['cohort_q'], ['unrelated'], insightStates);
+    expect(counts.get('cohort_q')).toBe(1);
+  });
+
+  test('tolerates empty/undefined inputs', () => {
+    expect(countReferencingInsights([], [], {}).size).toBe(0);
+    expect(countReferencingInsights(['a'], undefined, undefined).get('a')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3a of Explore 2.0 (specs/plan/explorer-workspace-unification/03-delivery-plan.md): the Library gains a source → table → column drill-down, the exploration surface's DnD unifies onto the shell's single `WorkspaceDndContext`, and `ModelTabBar` is replaced by compact query chips — scoped to the exploration surface only, per-concern commits:

1. **`fc9551ff`** — shared `useInlineRename` hook + `refWalk` util (B16), adopted in the Home-card rename + `ExplorationPane`'s SubBar pencil.
2. **`2e9dcde8`** — Library drag-payload extension: metric/dimension rows carry `parentModel`/`expression`, input rows carry `inputType` (closes the "payload gap," 02-architecture.md §4). A new `explorationDragSource` flag marks source/metric/dimension/insight as exploration drag sources, kept independent of the existing `droppable` (canvas-item) flag.
3. **`f88379f0`** — Library source drill-down (D9 / B10): `LibrarySourceRow` renders source → table → columns lazily, on the SAME shared `useSourceOutline` hook the right-rail Data tab already uses. Compact rows (h-6, text-[12px]), type glyphs, hover-revealed drag handles, session-only expand memory.
4. **`691faeba`** — `ExplorationQueryChips`: run-status dot, referenced-by badge (⛓n, a count now — successor to `ModelTabBar`'s boolean ring), active-chip `⋮` menu (rename / delete-with-dependent-warning).
5. **`5d4fa61c`** — DnD unification (D7): `ExplorerDndContext` is deleted from the `ExplorationWorkbench` nesting (and `ExplorerLeftPanel` alongside it); `routeExplorationDragEnd` ports the legacy zone-resolution logic verbatim into `WorkspaceDndContext`'s router, plus a new `sql-editor-drop` target (table → seeds a query, column → inserts at the Monaco cursor). The canvas-insert branch gains a `DROPPABLE_TYPES` guard so the newly-draggable exploration-only Library rows can never build a bogus dashboard item.

## Judgment calls (flagged for the orchestrator)

- **Standalone `/explorer` kept fully alive, not just its behavior.** The delivery plan's Phase 3a bullet reads "Delete `ExplorerLeftPanel`" / "delete `ExplorerDndContext`," but this task's own Test Strategy explicitly requires "Standalone `/explorer` legacy stories must keep passing untouched." Since `ExplorerPage.jsx` (the standalone route) still directly renders `ExplorerLeftPanel` + `SourceBrowser` + `ExplorerDndContext` + `ModelTabBar`, I read the delivery-plan phrasing as describing the Phase 3b END STATE (when the route itself is redirected away), not a Phase 3a file deletion, and kept all four files alive — only their USE inside the new `ExplorationWorkbench` is removed. Flagging this explicitly since it's a real tension between two docs, resolved in favor of the more specific, more recent test-compat directive.
- **Library click routing is unchanged** — clicking a Model/Insight/etc. row still opens that object's own edit form in the right rail, even while an exploration tab is active. The legacy `ExplorerLeftPanel`'s "click a Model row to load its SQL into a query tab" capability has no replacement in this phase (D9's spec only names drag-out for existing object rows, not a click-to-load-into-exploration mode). Noted as a known gap, not silently dropped — no e2e story in this phase's gate depends on it.
- **`LibrarySourceRow` doesn't yet have the flip/kebab context menu** (Show lineage / Open in new tab / Delete…) that plain `LibraryRow` has — primary click-to-open still works. Deferred; not exercised by `library-source-drilldown.spec.mjs`'s gate.
- **Schema/table-level column → computed-column popover drop** (named in 01-ux-spec §3a) is out of scope this phase — `AddComputedColumnPopover` is a manual, non-droppable widget today, and building a new droppable for it edges toward the right-panel rebuild explicitly reserved for Phase 3b. Column → SQL cursor and column → prop slot (via the existing `property-zone`/`axis-zone`) are both implemented and covered.
- **Source/metric/dimension/insight Library rows are now ALWAYS draggable** (not gated to "only while an exploration tab is active") — the `DROPPABLE_TYPES` guard on the canvas-insert branch makes this safe (dropping one on a dashboard canvas is a no-op), and it avoids context-detection complexity. Minor UX side effect: their drag-handle dots now show on hover everywhere, not just inside explorations.
- **Table-seed SQL is unquoted** (`SELECT * FROM <table>`, literal per 01-ux-spec §3a) — no dialect-aware identifier quoting. Matches the spec text; flagging in case a table name needs quoting in practice.

## Suite counts

- `bash scripts/viewer-check.sh` (from the worktree root): **330 test suites / 5459 passed / 2 skipped / 0 failed**, lint clean. Run twice (once before the final commit, once after) — both green.
- New unit tests added this phase: `useInlineRename.test.js` (6), `refWalk.test.js` (16), `LibrarySourceRow.test.jsx` (10), `ExplorationQueryChips.test.jsx` (13), plus new/extended cases in `useLibraryData.test.js`, `LibraryRow.test.jsx`, `Library.test.jsx`, `WorkspaceDndContext.test.jsx` (canvas-insert guard + full `routeExplorationDragEnd` coverage), `SQLEditor.test.jsx`, `CenterPanel.test.jsx`, `explorerStore.test.js` (`seedModelTabFromTable`), `ExplorationWorkbench.test.jsx` (rewritten for the reduced composition).
- New e2e stories (**written only, not run** per this task's instructions — orchestrator gates at merge): `library-source-drilldown.spec.mjs`, `exploration-dnd-pull-in.spec.mjs`, `exploration-query-chips.spec.mjs`.
- No Python/backend changes in this phase — schema regen not applicable.

## Ledger rows touched (05-e2e-ledger.md)

- `explorer-source-browser.spec.mjs` → successor `library-source-drilldown.spec.mjs` written.
- `explorer-dnd.spec.mjs` (DnD mechanics half) + `explorer-interaction-dnd.spec.mjs` (DnD half) → successor `exploration-dnd-pull-in.spec.mjs` written.
- Orchestrator resolution #3 (query-chip CRUD successor) → `exploration-query-chips.spec.mjs` written, including the delete-with-dependents case (successor to `explorer-insight-survives-model-close.spec.mjs`'s regression class).
- `explorer-tab-management.spec.mjs` / `explorer-multi-model.spec.mjs` (create/switch/rename/no-duplicate-names) — covered by the same new `exploration-query-chips.spec.mjs`.

## Left for the orchestrator

- Run the three new e2e stories against a live sandbox (they were written, not executed, per this task's instructions).
- The known gaps above (click-to-load-model-into-query, source-row context menu, computed-column-popover drop) — decide whether any need to be pulled into this phase or explicitly deferred in the plan docs.
- Full standalone `/explorer` legacy suite should be re-verified green at the integration gate (unaffected by this diff, but worth confirming given the file-retention judgment call above).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX