### PR TITLE
Explore 2.0 hardening: five combination-discovered bugs (VIS-1082–VIS-1086)

### DIFF
--- a/tests/server/repositories/test_exploration_repository.py
+++ b/tests/server/repositories/test_exploration_repository.py
@@ -8,6 +8,7 @@ JSON-document one (02-architecture.md §2).
 
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 
@@ -113,6 +114,54 @@ class TestDefaultNaming:
         repo.create(name="Churn dig")
         second = repo.create()
         assert second.name == "Exploration 2"
+
+
+class TestConcurrentCreate:
+    """VIS-1086: a double-click on '+ New exploration' (or a source tile), or
+    two browser windows racing a fresh empty project, both hit `create()`
+    with no name. `hot_reload_server.py` runs Flask with
+    `async_mode="threading"`, so concurrent HTTP requests are real concurrent
+    OS threads in one process — this drives that exact concurrency directly
+    against the repository (mirrors production threading, not a serialized
+    test double) and asserts the `_create_lock` + collision-checked
+    `_default_name()` fix actually closes the race, not just narrows it."""
+
+    def test_concurrent_no_name_creates_mint_unique_names(self, repo):
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(repo.create) for _ in range(8)]
+            results = [f.result() for f in as_completed(futures)]
+
+        names = [e.name for e in results]
+        assert len(set(names)) == len(names), f"duplicate default names minted: {names}"
+
+    def test_concurrent_no_name_creates_mint_unique_ids(self, repo):
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(repo.create) for _ in range(8)]
+            results = [f.result() for f in as_completed(futures)]
+
+        ids = [e.id for e in results]
+        assert len(set(ids)) == len(ids), f"duplicate ids minted: {ids}"
+
+    def test_concurrent_creates_each_persist_a_distinct_file(self, repo, explorations_dir):
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(repo.create) for _ in range(8)]
+            [f.result() for f in as_completed(futures)]
+
+        files = [f for f in os.listdir(explorations_dir) if f.endswith(".json")]
+        assert len(files) == 8
+
+    def test_concurrent_mixed_named_and_default_creates_stay_unique(self, repo):
+        # A more realistic mix: some requests carry an explicit name (a
+        # rename-on-create flow, if one ever exists), most don't.
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(repo.create) for _ in range(6)]
+            futures += [pool.submit(repo.create, name="Explicit") for _ in range(2)]
+            results = [f.result() for f in as_completed(futures)]
+
+        names = [e.name for e in results]
+        assert names.count("Explicit") == 2  # explicit names are never disambiguated
+        default_names = [n for n in names if n != "Explicit"]
+        assert len(set(default_names)) == len(default_names), f"duplicates: {default_names}"
 
 
 class TestGet:

--- a/viewer/e2e/stories/exploration-concurrent-rename-and-draft-sync.spec.mjs
+++ b/viewer/e2e/stories/exploration-concurrent-rename-and-draft-sync.spec.mjs
@@ -1,0 +1,148 @@
+/**
+ * Story: Rename racing the debounced draft-sync (VIS-1085, e2e-gap-review.md
+ * finding #7 — MEDIUM). A rename (immediate, non-debounced POST `{name}`)
+ * firing in the same window as the draft-sync's own debounced POST `{draft}`
+ * used to be able to silently clobber one of the two writes:
+ * `ExplorationRepository.update()` (exploration_repository.py) is an
+ * unlocked read-modify-write — full `_read()`, patch only the fields present
+ * in the request, `_write()` the merged doc back, no lock, no version check
+ * — and `hot_reload_server.py` runs Flask with `async_mode="threading"`, so
+ * concurrent HTTP requests are genuinely concurrent OS threads. Whichever
+ * request's `_read()` happened first but `_write()` landed LAST would win,
+ * silently discarding the other's field.
+ *
+ * THE FIX (workspaceExplorationsStore.js): every write for a given
+ * exploration id — the debounced draft sync, an immediate rename, a discard
+ * revert, and a promotion record — is enqueued onto a per-id promise chain
+ * (`_writeQueues`/`enqueueWrite`) so at most ONE `update()`-shaped request
+ * for that id is ever in flight. This closes the race entirely on the
+ * client, without needing any backend locking.
+ *
+ * Per the review's own recommended approach: rather than waiting out the
+ * real ~1.6s of timers (flaky and slow, and not actually deterministic even
+ * then), this story forces the race directly by invoking the underlying
+ * store actions concurrently via `page.evaluate` + `Promise.all` — the exact
+ * code paths a real ~1.6s-apart rename+draft-sync would hit, without the
+ * wait. Verified through the BACKEND afterward: both the new name and the
+ * synced draft must survive, never one clobbering the other.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationConcurrentRename VISIVO_SANDBOX_BACKEND_PORT=8054 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3054 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3054 npx playwright test exploration-concurrent-rename-and-draft-sync
+ *
+ * Mutates shared file-backed state — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+test.describe('Rename racing the debounced draft-sync never clobbers either write (VIS-1085)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('a rename fired concurrently with a flushed draft-sync for the same id: BOTH the new name and the synced draft persist', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+
+    // The edit that would normally arm ExplorationPane's 600ms live-sync
+    // timer -> the store's own 1s scheduleSync debounce.
+    await typeSql(page, 'SELECT 1 AS raced_sql');
+
+    // Force the race deterministically: fire the rename and a flush of the
+    // just-typed draft CONCURRENTLY via Promise.all, from inside the page —
+    // the exact underlying store calls a real ~1.6s-apart rename+debounce
+    // would make, without waiting out the real timers (flaky and slow).
+    // Pre-fix, both hit ExplorationRepository.update()'s unlocked
+    // read-modify-write as genuinely concurrent HTTP requests (Flask's
+    // threading dev server); post-fix, `enqueueWrite` serializes them so
+    // this is safe regardless of how close together they fire.
+    await page.evaluate(async () => {
+      const store = window.useStore.getState();
+      const currentId = window.location.pathname.split('/').pop();
+      await Promise.all([
+        store.renameExploration(currentId, 'Raced Name'),
+        store.flushExplorationSync(currentId),
+      ]);
+    });
+
+    // Backend-asserted: NEITHER write was clobbered by the other.
+    await expect(async () => {
+      const res = await page.request.get(`${API}/api/explorations/${id}/`);
+      expect(res.ok()).toBe(true);
+      const data = await res.json();
+      expect(data.name).toBe('Raced Name');
+      expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 1 AS raced_sql');
+    }).toPass({ timeout: 15000 });
+
+    // The UI reflects the same — no split-brain between client and server.
+    await expect(page.locator('[role="tab"]', { hasText: 'Raced Name' })).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('the reverse race (draft-sync flushed just after a rename kicks off) is equally safe', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSql(page, 'SELECT 2 AS reverse_raced_sql');
+
+    await page.evaluate(async () => {
+      const store = window.useStore.getState();
+      const currentId = window.location.pathname.split('/').pop();
+      const renamePromise = store.renameExploration(currentId, 'Reverse Raced Name');
+      const flushPromise = store.flushExplorationSync(currentId);
+      await Promise.all([flushPromise, renamePromise]);
+    });
+
+    await expect(async () => {
+      const res = await page.request.get(`${API}/api/explorations/${id}/`);
+      expect(res.ok()).toBe(true);
+      const data = await res.json();
+      expect(data.name).toBe('Reverse Raced Name');
+      expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 2 AS reverse_raced_sql');
+    }).toPass({ timeout: 15000 });
+  });
+});

--- a/viewer/e2e/stories/exploration-cross-session-delete.spec.mjs
+++ b/viewer/e2e/stories/exploration-cross-session-delete.spec.mjs
@@ -70,6 +70,38 @@ async function deleteFromHome(page, id) {
   await page.getByTestId('exploration-delete-confirm-confirm').click();
 }
 
+async function waitForBackendDraftSql(page, id, expectedSql, timeout = 15000) {
+  await expect(async () => {
+    const res = await page.request.get(`${API}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data?.draft?.queries?.[0]?.sql).toBe(expectedSql);
+  }).toPass({ timeout });
+}
+
+/**
+ * Deletes `id` from `pageB` (a different session than the one editing it),
+ * then forces `pageA`'s NEXT draft-sync attempt to actually fire against the
+ * now-dead id — the banner (`runSync`'s 404 catch, workspaceExplorationsStore.js)
+ * only ever appears once a REAL sync attempt 404s, and the FIRST edit's own
+ * sync (armed the moment `pageA` started editing, ~1.6s debounce) is very
+ * plausibly already settled successfully by the time `deleteFromHome`'s own
+ * multi-step UI navigation completes on `pageB` — leaving no subsequent
+ * failing attempt to trigger anything. Confirming the first edit's sync
+ * genuinely landed BEFORE deleting, then typing a SECOND edit to arm a fresh
+ * sync AFTER the delete is confirmed, removes that timing ambiguity: the
+ * second sync is guaranteed to fire against an id that is already gone.
+ */
+async function deleteAndForceSubsequentSyncAttempt(pageA, pageB, id, firstSql, retrySql) {
+  await waitForBackendDraftSql(pageA, id, firstSql);
+  await deleteFromHome(pageB, id);
+  await expect(async () => {
+    const res = await pageB.request.get(`${API}/api/explorations/${id}/`);
+    expect(res.status()).toBe(404);
+  }).toPass({ timeout: 10000 });
+  await typeSql(pageA, retrySql);
+}
+
 test.describe('Cross-session delete surfaces a deleted-remotely banner, never a silent forever-stuck sync (VIS-1083)', () => {
   test('actively-editing Tab A sees the deleted-remotely banner once Tab B deletes the same exploration, and the sync loop genuinely stops', async ({
     browser,
@@ -84,22 +116,22 @@ test.describe('Cross-session delete surfaces a deleted-remotely banner, never a 
     const pageB = await ctxB.newPage();
 
     try {
-      // Tab A: open the exploration and start editing — arms the 600ms
-      // legacy-sync -> 1s backend debounce chain.
+      // Tab A: open the exploration and edit it — the first edit's own sync
+      // must genuinely settle (proves the healthy baseline) BEFORE Tab B
+      // deletes it; a second edit afterward is what actually races the dead
+      // id (see deleteAndForceSubsequentSyncAttempt's docstring).
       await openExplorationTab(pageA, id);
       await typeSql(pageA, 'SELECT 1 AS marker');
+      await deleteAndForceSubsequentSyncAttempt(
+        pageA,
+        pageB,
+        id,
+        'SELECT 1 AS marker',
+        'SELECT 1 AS marker_v2'
+      );
 
-      // Tab B: delete the SAME exploration from Explorer Home.
-      await deleteFromHome(pageB, id);
-
-      // Confirm the backend record is genuinely gone.
-      await expect(async () => {
-        const res = await pageB.request.get(`${API}/api/explorations/${id}/`);
-        expect(res.status()).toBe(404);
-      }).toPass({ timeout: 10000 });
-
-      // Tab A's next debounced sync 404s — must surface a clear, actionable
-      // state, never stay silent.
+      // The second edit's debounced sync 404s — must surface a clear,
+      // actionable state, never stay silent.
       await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
         timeout: 10000,
       });
@@ -142,28 +174,43 @@ test.describe('Cross-session delete surfaces a deleted-remotely banner, never a 
     try {
       await openExplorationTab(pageA, id);
       await typeSql(pageA, 'SELECT 999 AS recovered_marker');
-
-      await deleteFromHome(pageB, id);
+      await deleteAndForceSubsequentSyncAttempt(
+        pageA,
+        pageB,
+        id,
+        'SELECT 999 AS recovered_marker',
+        'SELECT 999 AS recovered_marker_v2'
+      );
       await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
         timeout: 10000,
       });
 
       await pageA.getByTestId('exploration-deleted-remotely-recreate').click();
 
-      // Lands on a brand NEW exploration tab — never the dead id.
-      await pageA.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+      // Lands on a brand NEW exploration tab — never the dead id. A bare
+      // `/\/workspace\/exploration\/exp_/` predicate would match the CURRENT
+      // (pre-click) URL too — it's already at `/workspace/exploration/${id}`
+      // — so `waitForURL` could resolve immediately without any navigation
+      // ever happening; require the pathname to actually differ from the
+      // dead id's URL.
+      await pageA.waitForURL(
+        url => /\/workspace\/exploration\/exp_/.test(url.pathname) && url.pathname !== `/workspace/exploration/${id}`,
+        { timeout: 10000 }
+      );
       newId = new URL(pageA.url()).pathname.split('/').pop();
       expect(newId).not.toBe(id);
       await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).not.toBeVisible();
       await expect(pageA.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
 
       // Backend-asserted: the new record actually persisted the recovered
-      // draft — not just an optimistic client-only patch.
+      // draft (the SECOND edit — the one that armed the 404'd sync attempt,
+      // i.e. the freshest local state) — not just an optimistic client-only
+      // patch.
       await expect(async () => {
         const res = await pageA.request.get(`${API}/api/explorations/${newId}/`);
         expect(res.ok()).toBe(true);
         const data = await res.json();
-        expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 999 AS recovered_marker');
+        expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 999 AS recovered_marker_v2');
       }).toPass({ timeout: 15000 });
     } finally {
       await ctxA.close();
@@ -191,8 +238,13 @@ test.describe('Cross-session delete surfaces a deleted-remotely banner, never a 
     try {
       await openExplorationTab(pageA, id);
       await typeSql(pageA, 'SELECT 1 AS marker');
-
-      await deleteFromHome(pageB, id);
+      await deleteAndForceSubsequentSyncAttempt(
+        pageA,
+        pageB,
+        id,
+        'SELECT 1 AS marker',
+        'SELECT 1 AS marker_v2'
+      );
       await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
         timeout: 10000,
       });
@@ -207,10 +259,11 @@ test.describe('Cross-session delete surfaces a deleted-remotely banner, never a 
       await pageA.getByTestId('exploration-deleted-remotely-close').click();
 
       await expect(pageA.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
-      // Lands back on a Home/other surface, not a crash or a stuck pane.
-      await expect(
-        pageA.getByTestId('workspace-middle-explorer').or(pageA.getByTestId('workspace-tab-strip'))
-      ).toBeVisible();
+      // Lands back on Explorer Home (the only open tab just closed), not a
+      // crash or a stuck pane. `workspace-tab-strip` is persistent chrome
+      // (always rendered regardless of tab count) so it isn't a meaningful
+      // assertion here — `workspace-middle-explorer` is the real signal.
+      await expect(pageA.getByTestId('workspace-middle-explorer')).toBeVisible();
       await pageA.waitForTimeout(1000);
       expect(postsToDeadId).toHaveLength(0);
     } finally {

--- a/viewer/e2e/stories/exploration-cross-session-delete.spec.mjs
+++ b/viewer/e2e/stories/exploration-cross-session-delete.spec.mjs
@@ -1,0 +1,221 @@
+/**
+ * Story: Cross-session delete → deleted-remotely recovery (VIS-1083,
+ * e2e-gap-review.md finding #10 — MEDIUM). Deleting an exploration in one
+ * browser session while it's actively being edited in another used to leave
+ * the editing session permanently, silently stuck: `runSync`'s catch set a
+ * generic `syncStatus: 'error'` with no distinction from a transient
+ * failure, and `updateExplorationDraft` unconditionally re-armed the sync
+ * loop on every keystroke regardless of status — a broken record kept
+ * re-attempting and re-failing forever with nothing in the UI to explain
+ * why or offer a way out.
+ *
+ * THE FIX (workspaceExplorationsStore.js):
+ *   - `runSync`'s catch distinguishes a 404 (`error.status === 404` — the
+ *     record is gone, `ExplorationRepository.update()` returns `None` for a
+ *     vanished id, `exploration_views.py` turns that into a 404) and sets
+ *     `syncStatus: 'deleted-remotely'` instead of the generic `'error'`.
+ *   - `updateExplorationDraft` stops re-arming the sync loop once
+ *     `syncStatus` is `'deleted-remotely'` — no more doomed retries.
+ *   - `ExplorationPane` renders `ExplorationDeletedRemotelyBanner` whenever
+ *     `syncStatus === 'deleted-remotely'`: a clear, non-silent state with
+ *     two real recovery options — "Recreate as new exploration" (mints a
+ *     fresh record from the local draft) and "Close tab" (nothing left to
+ *     lose — the backend record is already gone).
+ *
+ * Two genuinely separate browser contexts (not two tabs in one context) so
+ * each has its OWN in-memory Zustand store, matching the real "two browser
+ * sessions" scenario the finding describes.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationCrossSessionDelete VISIVO_SANDBOX_BACKEND_PORT=8052 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3052 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3052 npx playwright test exploration-cross-session-delete
+ *
+ * Mutates shared file-backed state — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+/** Create a stable exploration via the API (so both sessions reference the
+ * SAME id from the start) rather than minting it through either page's own
+ * UI — neither session should "own" the create. */
+async function createExplorationViaApi(page, name) {
+  const res = await page.request.post(`${API}/api/explorations/`, { data: { name } });
+  expect(res.ok()).toBe(true);
+  return (await res.json()).id;
+}
+
+async function openExplorationTab(page, id) {
+  await page.goto(`${BASE_URL}/workspace/exploration/${id}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+}
+
+async function deleteFromHome(page, id) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+  await page.getByTestId(`exploration-card-${id}-menu`).click();
+  await page.getByTestId(`exploration-card-${id}-delete-action`).click();
+  await page.getByTestId('exploration-delete-confirm-confirm').click();
+}
+
+test.describe('Cross-session delete surfaces a deleted-remotely banner, never a silent forever-stuck sync (VIS-1083)', () => {
+  test('actively-editing Tab A sees the deleted-remotely banner once Tab B deletes the same exploration, and the sync loop genuinely stops', async ({
+    browser,
+  }) => {
+    const setupPage = await browser.newPage();
+    const id = await createExplorationViaApi(setupPage, 'Cross-session test');
+    await setupPage.close();
+
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    const pageB = await ctxB.newPage();
+
+    try {
+      // Tab A: open the exploration and start editing — arms the 600ms
+      // legacy-sync -> 1s backend debounce chain.
+      await openExplorationTab(pageA, id);
+      await typeSql(pageA, 'SELECT 1 AS marker');
+
+      // Tab B: delete the SAME exploration from Explorer Home.
+      await deleteFromHome(pageB, id);
+
+      // Confirm the backend record is genuinely gone.
+      await expect(async () => {
+        const res = await pageB.request.get(`${API}/api/explorations/${id}/`);
+        expect(res.status()).toBe(404);
+      }).toPass({ timeout: 10000 });
+
+      // Tab A's next debounced sync 404s — must surface a clear, actionable
+      // state, never stay silent.
+      await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(pageA.getByTestId('exploration-deleted-remotely-recreate')).toBeVisible();
+      await expect(pageA.getByTestId('exploration-deleted-remotely-close')).toBeVisible();
+      // The workbench itself keeps rendering underneath — the local draft is
+      // not lost, only unsaveable until the user acts on the banner.
+      await expect(pageA.getByTestId('workspace-middle-exploration')).toBeVisible();
+
+      // The sync loop is genuinely stopped: further typing must NOT re-arm
+      // a doomed POST against the dead id.
+      const postsToDeadId = [];
+      pageA.on('request', req => {
+        if (req.method() === 'POST' && req.url().includes(`/api/explorations/${id}/`)) {
+          postsToDeadId.push(req.url());
+        }
+      });
+      await typeSql(pageA, 'SELECT 2 AS marker_after_delete');
+      await pageA.waitForTimeout(2500); // past the ~1.6s debounce window
+      expect(postsToDeadId).toHaveLength(0);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  test('"Recreate as new exploration" mints a fresh backend record from the local draft and clears the banner', async ({
+    browser,
+  }) => {
+    const setupPage = await browser.newPage();
+    const id = await createExplorationViaApi(setupPage, 'Recreate test');
+    await setupPage.close();
+
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    const pageB = await ctxB.newPage();
+    let newId;
+
+    try {
+      await openExplorationTab(pageA, id);
+      await typeSql(pageA, 'SELECT 999 AS recovered_marker');
+
+      await deleteFromHome(pageB, id);
+      await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
+        timeout: 10000,
+      });
+
+      await pageA.getByTestId('exploration-deleted-remotely-recreate').click();
+
+      // Lands on a brand NEW exploration tab — never the dead id.
+      await pageA.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+      newId = new URL(pageA.url()).pathname.split('/').pop();
+      expect(newId).not.toBe(id);
+      await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).not.toBeVisible();
+      await expect(pageA.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
+
+      // Backend-asserted: the new record actually persisted the recovered
+      // draft — not just an optimistic client-only patch.
+      await expect(async () => {
+        const res = await pageA.request.get(`${API}/api/explorations/${newId}/`);
+        expect(res.ok()).toBe(true);
+        const data = await res.json();
+        expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 999 AS recovered_marker');
+      }).toPass({ timeout: 15000 });
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+      if (newId) {
+        const cleanup = await browser.newPage();
+        await cleanup.request.delete(`${API}/api/explorations/${newId}/`).catch(() => {});
+        await cleanup.close();
+      }
+    }
+  });
+
+  test('"Close tab" force-closes with no further network activity against the dead id', async ({
+    browser,
+  }) => {
+    const setupPage = await browser.newPage();
+    const id = await createExplorationViaApi(setupPage, 'Close test');
+    await setupPage.close();
+
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    const pageB = await ctxB.newPage();
+
+    try {
+      await openExplorationTab(pageA, id);
+      await typeSql(pageA, 'SELECT 1 AS marker');
+
+      await deleteFromHome(pageB, id);
+      await expect(pageA.getByTestId('exploration-deleted-remotely-banner')).toBeVisible({
+        timeout: 10000,
+      });
+
+      const postsToDeadId = [];
+      pageA.on('request', req => {
+        if (req.method() === 'POST' && req.url().includes(`/api/explorations/${id}/`)) {
+          postsToDeadId.push(req.url());
+        }
+      });
+
+      await pageA.getByTestId('exploration-deleted-remotely-close').click();
+
+      await expect(pageA.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
+      // Lands back on a Home/other surface, not a crash or a stuck pane.
+      await expect(
+        pageA.getByTestId('workspace-middle-explorer').or(pageA.getByTestId('workspace-tab-strip'))
+      ).toBeVisible();
+      await pageA.waitForTimeout(1000);
+      expect(postsToDeadId).toHaveLength(0);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+});

--- a/viewer/e2e/stories/exploration-duplicate-race.spec.mjs
+++ b/viewer/e2e/stories/exploration-duplicate-race.spec.mjs
@@ -197,7 +197,17 @@ test.describe('Double-click create doors mint exactly one record (VIS-1086)', ()
     await page.getByTestId('exploration-duplicate-button').click();
     await expect(page.getByTestId('exploration-duplicate-button')).toBeDisabled({ timeout: 3000 });
 
+    // Wait for the actual HTTP response (not a blind timeout) before
+    // unrouting — `release()` only resolves the gate promise, it doesn't
+    // wait for the still-suspended route handler's own `await route.continue()`
+    // to actually run. Unrouting while that handler is mid-resolution races
+    // Playwright's own unroute cleanup against our handler's continue() call
+    // ("Route is already handled").
+    const responsePromise = page.waitForResponse(
+      res => res.url().endsWith('/api/explorations/') && res.request().method() === 'POST'
+    );
     release();
+    await responsePromise;
     await page.unroute('**/api/explorations/');
     await expect(page.getByTestId('exploration-duplicate-button')).toBeEnabled({ timeout: 10000 });
   });

--- a/viewer/e2e/stories/exploration-duplicate-race.spec.mjs
+++ b/viewer/e2e/stories/exploration-duplicate-race.spec.mjs
@@ -1,0 +1,204 @@
+/**
+ * Story: Double-click create doors mint duplicates (VIS-1086,
+ * e2e-gap-review.md findings #8 and #9 — MEDIUM). Every create door in the
+ * Explorer surface used to have no in-flight guard at all:
+ *
+ *   - #9: ExplorationPane's "Duplicate" button — `handleDuplicate` had no
+ *     `disabled`/in-flight ref; two rapid clicks fired two independent
+ *     `duplicateExploration` calls, minting two duplicate records and
+ *     opening two tabs the user only meant to create once.
+ *   - #8: ExplorerHomePane's "+ New exploration" / a "Start from a source"
+ *     tile — `handleNew`/`handleSourceTile` only guarded against the
+ *     FIRST-VISIT seed racing a manual create (`seedPromiseRef`), never
+ *     against two manual clicks of the same button. Both POSTs land at
+ *     `ExplorationRepository.create()`, each independently computing
+ *     `_default_name()` from a directory listing taken BEFORE either
+ *     request's `_write()` has landed — no lock — so two rapid clicks could
+ *     mint the SAME default name (a name collision, not just a duplicate
+ *     record).
+ *
+ * THE FIX:
+ *   - Frontend: every create door (`ExplorationPane`'s Duplicate button,
+ *     `ExplorerHomePane`'s "+ New exploration" and every source tile) is now
+ *     guarded by a synchronous in-flight ref CHECKED INSIDE THE HANDLER
+ *     (not just a `disabled` HTML attribute, which only takes effect after
+ *     a React re-render — a real double-click can dispatch both click
+ *     events before that render lands) plus a `disabled` state for the
+ *     visible affordance.
+ *   - Backend (`exploration_repository.py`): `create()`'s whole "resolve id
+ *     + name, then write" sequence is now serialized per-process
+ *     (`_create_lock`, a `threading.Lock` — Flask runs with
+ *     `async_mode="threading"`, so concurrent requests are real concurrent
+ *     OS threads) AND `_default_name()` collision-checks its candidate
+ *     against the CURRENT set of existing names, incrementing until free —
+ *     defense in depth for any request that reaches the backend
+ *     concurrently despite the frontend guard (e.g. two separate browser
+ *     windows, which the frontend's per-component ref can't coordinate
+ *     across).
+ *
+ * This story exercises the FRONTEND guard specifically (the backend
+ * concurrency fix has its own dedicated real-thread test,
+ * `tests/server/repositories/test_exploration_repository.py::TestConcurrentCreate`)
+ * — two click events are dispatched via `page.evaluate` (bypassing
+ * Playwright's own actionability/disabled-wait) so BOTH land before React
+ * has a chance to re-render the button disabled, matching a genuine
+ * faster-than-a-render double-click rather than relying on the `disabled`
+ * attribute alone.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationDuplicateRace VISIVO_SANDBOX_BACKEND_PORT=8055 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3055 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3055 npx playwright test exploration-duplicate-race
+ *
+ * Mints real backend exploration records — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Dispatch two click events on the SAME testid synchronously in one task —
+ * bypasses Playwright's own actionability wait (which would otherwise honor
+ * a `disabled` attribute and refuse the second click) so both land before
+ * React has a chance to re-render the button disabled, the genuine "double-
+ * click faster than a render" race these fixes defend against. */
+async function doubleClickFast(page, testId) {
+  await page.evaluate(id => {
+    const els = document.querySelectorAll(`[data-testid="${id}"]`);
+    const btn = els[els.length - 1];
+    btn.click();
+    btn.click();
+  }, testId);
+}
+
+test.describe('Double-click create doors mint exactly one record (VIS-1086)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('double-clicking the exploration Duplicate button mints exactly ONE duplicate, opens exactly ONE new tab', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const before = await listExplorationIds(page);
+
+    const tabStripTabs = page.getByTestId('workspace-tab-strip').locator('[role="tab"]');
+    const initialTabCount = await tabStripTabs.count();
+
+    await expect(page.getByTestId('exploration-duplicate-button')).toBeEnabled();
+    await doubleClickFast(page, 'exploration-duplicate-button');
+
+    // Exactly one new tab opens (a second, silently-swallowed duplicate
+    // click would otherwise open two).
+    await expect(tabStripTabs).toHaveCount(initialTabCount + 1, { timeout: 15000 });
+    // Give any (incorrectly) second in-flight request a moment to land
+    // before asserting the backend count — a false negative here (asserting
+    // too early) would be worse than a slightly slower test.
+    await page.waitForTimeout(1500);
+
+    const after = await listExplorationIds(page);
+    const createdCount = after.filter(id => !before.includes(id)).length;
+    expect(createdCount).toBe(1);
+  });
+
+  test('double-clicking "+ New exploration" mints exactly ONE record with a unique name', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const before = await listExplorationIds(page);
+
+    await expect(page.getByTestId('explorer-home-new-exploration')).toBeEnabled();
+    await doubleClickFast(page, 'explorer-home-new-exploration');
+
+    // Exactly one navigation lands on a real exploration tab.
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForTimeout(1500);
+
+    const after = await listExplorationIds(page);
+    const createdIds = after.filter(id => !before.includes(id));
+    expect(createdIds).toHaveLength(1);
+  });
+
+  test('double-clicking a "Start from a source" tile mints exactly ONE record', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await expect(page.getByTestId('explorer-home-source-tile-local-sqlite')).toBeVisible({
+      timeout: 15000,
+    });
+    const before = await listExplorationIds(page);
+
+    await doubleClickFast(page, 'explorer-home-source-tile-local-sqlite');
+
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForTimeout(1500);
+
+    const after = await listExplorationIds(page);
+    const createdIds = after.filter(id => !before.includes(id));
+    expect(createdIds).toHaveLength(1);
+  });
+
+  test('the Duplicate button visibly disables itself while the request is in flight', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+
+    // Delay the duplicate's create POST so the disabled window is
+    // observable rather than racing a real (usually sub-100ms) round trip.
+    let release = () => {};
+    const gate = new Promise(resolve => {
+      release = resolve;
+    });
+    await page.route('**/api/explorations/', async route => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await gate;
+      await route.continue();
+    });
+
+    await page.getByTestId('exploration-duplicate-button').click();
+    await expect(page.getByTestId('exploration-duplicate-button')).toBeDisabled({ timeout: 3000 });
+
+    release();
+    await page.unroute('**/api/explorations/');
+    await expect(page.getByTestId('exploration-duplicate-button')).toBeEnabled({ timeout: 10000 });
+  });
+});

--- a/viewer/e2e/stories/exploration-promote-tab-race.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-tab-race.spec.mjs
@@ -218,10 +218,20 @@ test.describe('Keyboard shortcut suppression + write serialization mid-promote (
     );
     expect(new URL(page.url()).pathname).toBe(`/workspace/exploration/${id}`);
 
-    // Release the gate — let the promote loop actually finish.
+    // Release the gate — let the promote loop actually finish. Unroute only
+    // AFTER the success indicator confirms every record-promotion request
+    // (there are two — one per promoted row) has actually resolved through
+    // our handler's own `route.continue()` — `releaseRecordPromotion()`
+    // only resolves the gate promise, it doesn't wait for the handler(s)
+    // still suspended on it to actually resume and call `continue()`.
+    // Unrouting while one is still mid-resolution races Playwright's own
+    // unroute cleanup against our handler's continue() call ("Route is
+    // already handled"), which fails the promotion request and cascades
+    // into leaked, uncleaned-up backend objects for the next spec to trip
+    // over.
     releaseRecordPromotion();
-    await page.unroute('**/record-promotion/');
     await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    await page.unroute('**/record-promotion/');
     createdObjects.push(
       { segment: 'models', name: queryName },
       { segment: 'insights', name: insightName }
@@ -240,11 +250,26 @@ test.describe('Keyboard shortcut suppression + write serialization mid-promote (
   test('the shortcut resumes working normally once the promote modal is closed', async ({ page }) => {
     await gotoExplorerHome(page);
     await newExploration(page);
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
     await bindXSlotToNumericColumn(page);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
 
     await openPromoteModal(page);
     await page.getByTestId('exploration-promote-submit').click();
     await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    // This test promotes too (submit -> success, same as the first test) —
+    // without registering the promoted objects for cleanup, this leaks a
+    // real "model"/"insight" pair (the exploration's own default auto-names)
+    // that then collides with every OTHER spec's own fresh explorations,
+    // which auto-name their first query/insight the exact same way. Root-
+    // caused live: this exact leak cascaded into 3/4 of exploration-promote.spec.mjs's
+    // OWN tests failing on an unrelated run.
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName }
+    );
     await page.getByTestId('exploration-promote-cancel').click();
     await expect(page.getByTestId('exploration-promote-modal')).not.toBeVisible({ timeout: 5000 });
 

--- a/viewer/e2e/stories/exploration-promote-tab-race.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-tab-race.spec.mjs
@@ -1,0 +1,259 @@
+/**
+ * Story: Keyboard-driven tab/view switch mid-promote does not race
+ * record-promotion's append against a concurrent draft-sync write (Explore
+ * 2.0 Phase 4 delta review, finding P4-D1 — HIGH).
+ *
+ * `promoteExploration` (workspaceExplorationsStore.js) loops promotable rows
+ * SEQUENTIALLY, awaiting each row's `saveFn` then its own
+ * `recordExplorationPromotion` POST (`/api/explorations/:id/record-promotion/`).
+ * `ExplorationPromoteModal`'s backdrop already blocks a MOUSE-driven close
+ * mid-promote (its own `onClick` checks `!promoting`) — but before this fix,
+ * `useWorkspaceTabShortcuts.js`'s keyboard shortcuts (Cmd+1/2/3, Cmd+4-9,
+ * Cmd+W, Cmd+T) had no equivalent guard: a keyboard-driven destination/tab
+ * switch while a row's `record-promotion` POST was still in flight would
+ * unmount `ExplorationPane`, whose deactivate cleanup fires a generic
+ * `update()` draft-sync POST against the SAME unlocked backend JSON document
+ * (`exploration_repository.py`'s `update()`/`record_promotion()` are both
+ * bare `_read()` -> patch -> `_write()`, no lock). Whichever write's
+ * `_read()` landed first but `_write()` landed LAST could silently clobber
+ * the other — including wiping the just-appended `promoted[]` entry.
+ *
+ * THE FIX (this PR, VIS-1082-1086 hardening):
+ *   1. `useWorkspaceTabShortcuts.js`'s `hasBlockingModal()` guard suppresses
+ *      every shortcut in this hook while any `[aria-modal="true"]` element
+ *      is in the DOM (ExplorationPromoteModal now carries it) — the
+ *      keyboard path that used to bypass the modal's mouse-backdrop guard is
+ *      closed entirely.
+ *   2. `workspaceExplorationsStore.js`'s `recordExplorationPromotion` is
+ *      enqueued onto the SAME per-id write queue as the draft sync / rename
+ *      / discard revert (`enqueueWrite`) — belt-and-suspenders: even a write
+ *      that reaches the backend through some OTHER path (a different
+ *      browser tab/session) can never interleave with this session's writes
+ *      for the same id.
+ *
+ * This story proves BOTH halves against the real backend: (a) the shortcut
+ * is inert while the promote modal is open — no navigation, no unmount; (b)
+ * once promotion completes, `promoted[]` has BOTH entries and the draft is
+ * intact — read from the backend, never asserted from UI state alone.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationPromoteRace VISIVO_SANDBOX_BACKEND_PORT=8050 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3050 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3050 npx playwright test exploration-promote-tab-race
+ *
+ * Mutates real backend records (explorations AND promoted project objects)
+ * — runs in the serial `exploration-mutations` playwright project
+ * (playwright.config.mjs), never `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstNumericColumn(page, tableRow) {
+  await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  await expect(col).toBeVisible({ timeout: 10000 });
+  const name = await col
+    .getAttribute('data-testid')
+    .then(t => t.replace(`library-source-column-${SOURCE}-${TABLE}-`, ''));
+  return { locator: col, name };
+}
+
+/** Same helper as exploration-promote.spec.mjs — binds the x-slot to a real
+ * numeric column so BOTH the model and insight rows are valid/promotable
+ * (`buildPromoteChecklist` drops a model with no `sql`, and an insight with
+ * no data props beyond `type`). */
+async function bindXSlotToNumericColumn(page) {
+  await typeSql(page, `SELECT * FROM ${TABLE}`);
+  await runQuery(page);
+  const tableRow = await expandSourceTable(page);
+  const { locator: column, name: columnName } = await firstNumericColumn(page, tableRow);
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await expect(xSlot).toBeVisible({ timeout: 15000 });
+  await dragAndDrop(page, column, xSlot);
+  await expect(xSlot.getByTestId('pill-menu-trigger')).toBeVisible({ timeout: 10000 });
+  return columnName;
+}
+
+async function openPromoteModal(page) {
+  await page.getByTestId('explorer-save-button').click();
+  await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+}
+
+async function fetchExploration(page, id) {
+  const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+test.describe('Keyboard shortcut suppression + write serialization mid-promote (P4-D1)', () => {
+  let explorationIdsBefore = [];
+  const createdObjects = []; // {segment, name} — best-effort cleanup
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    explorationIdsBefore = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !explorationIdsBefore.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+  });
+
+  test('Cmd+2 pressed mid-promote does not navigate away, and promoted[] + the draft are both intact once promotion completes', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    await bindXSlotToNumericColumn(page);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    // Delay the record-promotion POST so there's a real, deterministic
+    // window to fire the shortcut mid-flight — the multi-row promote loop
+    // (promoteExploration) is otherwise too fast for a keydown to reliably
+    // land inside it.
+    let releaseRecordPromotion = () => {};
+    const recordPromotionGate = new Promise(resolve => {
+      releaseRecordPromotion = resolve;
+    });
+    await page.route('**/record-promotion/', async route => {
+      await recordPromotionGate;
+      await route.continue();
+    });
+
+    await openPromoteModal(page);
+    await expect(page.getByTestId(`promote-row-model-${queryName}-checkbox`)).toBeChecked();
+    await expect(page.getByTestId(`promote-row-insight-${insightName}-checkbox`)).toBeChecked();
+    await page.getByTestId('exploration-promote-submit').click();
+
+    // The FIRST row's record-promotion POST is now held by the route gate —
+    // the modal is open and a promotion is genuinely in flight. Fire the
+    // keyboard shortcut a real user could reach for: Cmd+2 (Semantic Layer).
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+2`);
+
+    // Give the (suppressed) shortcut a moment to have taken effect if it
+    // were going to, then assert NOTHING navigated: the promote modal is
+    // still open, the exploration tab is still active, and the URL never
+    // changed to the Semantic Layer destination.
+    await page.waitForTimeout(300);
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(new URL(page.url()).pathname).toBe(`/workspace/exploration/${id}`);
+
+    // Release the gate — let the promote loop actually finish.
+    releaseRecordPromotion();
+    await page.unroute('**/record-promotion/');
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName }
+    );
+
+    // Backend-asserted: BOTH rows actually promoted (no row silently lost to
+    // the race), and the exploration's own draft is intact (never clobbered
+    // by an interleaved draft-sync write racing record-promotion).
+    const record = await fetchExploration(page, id);
+    const promotedKeys = record.promoted.map(p => `${p.type}:${p.name}`);
+    expect(promotedKeys).toContain(`model:${queryName}`);
+    expect(promotedKeys).toContain(`insight:${insightName}`);
+    expect(record.draft.queries?.[0]?.name).toBe(queryName);
+  });
+
+  test('the shortcut resumes working normally once the promote modal is closed', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await bindXSlotToNumericColumn(page);
+
+    await openPromoteModal(page);
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    await page.getByTestId('exploration-promote-cancel').click();
+    await expect(page.getByTestId('exploration-promote-modal')).not.toBeVisible({ timeout: 5000 });
+
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+2`);
+    await expect(page.getByTestId('workspace-view-switcher-semantic-layer')).toHaveAttribute(
+      'data-active',
+      'true',
+      { timeout: 5000 }
+    );
+  });
+});

--- a/viewer/e2e/stories/explorer-cold-session-default-source.spec.mjs
+++ b/viewer/e2e/stories/explorer-cold-session-default-source.spec.mjs
@@ -1,0 +1,159 @@
+/**
+ * Story: Cold-session default-source race (VIS-1082, e2e-gap-review.md
+ * finding #2 — HIGH). The very first auto-created query in a session must
+ * never silently skip the project's configured default source.
+ *
+ * `useExplorerWorkbenchInit.js`'s auto-create-model-tab effect is a
+ * `useLayoutEffect` gated only on `explorerSources.length > 0` — it fires as
+ * soon as sources arrive, with no dependency on `state.defaults` (fetched by
+ * a separate, later-declared, unordered `useEffect` in the same hook). On a
+ * cold session, sources can land before defaults do, so `createModelTab()`
+ * (explorerStore.js) resolves its source from "project default > first
+ * available" with `state.defaults` still `null` — falling back to whichever
+ * source sorts first, silently wrong if that isn't the configured default.
+ *
+ * This project's own sandbox fixture (test-projects/integration/project.visivo.yml)
+ * is the exact precondition: two sources (`local-sqlite` first, `local-duckdb`
+ * second) with `defaults.source_name: local-duckdb` — the configured default
+ * is NOT the first source in listing order.
+ *
+ * THE FIX (viewer/src/components/explorer/useExplorerWorkbenchInit.js +
+ * viewer/src/stores/explorerStore.js's `applyResolvedDefaultSource`):
+ * remembers whether `defaults` had already arrived at the moment the tab was
+ * auto-created; if not, a dedicated effect rebinds that tab's source once
+ * `defaults` actually lands (a no-op if the user has since picked a source
+ * themselves). This story forces the race deterministically via
+ * `page.route()` (gating `/api/defaults/`) rather than hoping for a real
+ * network race to land inside the assertion window.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorerColdSession VISIVO_SANDBOX_BACKEND_PORT=8051 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3051 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3051 npx playwright test explorer-cold-session-default-source
+ *
+ * Mints real backend exploration records — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+test.describe('Cold-session default-source race (VIS-1082)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unroute('**/api/defaults/**').catch(() => {});
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('an exploration auto-created before defaults arrive still ends up bound to the project default source, not the first-available fallback', async ({
+    page,
+  }) => {
+    // Gate the defaults fetch (useExplorerWorkbenchInit.js's fetchDefaults())
+    // so it resolves strictly AFTER the sources fetch + the synchronous
+    // auto-create-model-tab layout effect have already run — the exact
+    // ordering the review identified as reachable on a genuinely cold
+    // session, forced deterministically rather than raced.
+    let releaseDefaults = () => {};
+    const defaultsGate = new Promise(resolve => {
+      releaseDefaults = resolve;
+    });
+    await page.route('**/api/defaults/**', async route => {
+      await defaultsGate;
+      await route.continue();
+    });
+
+    await gotoExplorerHome(page);
+    // Opening the exploration mounts ExplorationWorkbench -> useExplorerWorkbenchInit,
+    // which fetches BOTH explorerSources and (gated) defaults, and the
+    // layout effect auto-creates a model tab the instant sources land —
+    // `newExploration`'s own wait proves that has already happened.
+    const id = await newExploration(page);
+
+    // Precondition check: the auto-created tab's source resolved with
+    // `defaults` still null — "first available" (local-sqlite per the
+    // sandbox fixture's YAML order), NOT the configured default
+    // (local-duckdb). If this assertion ever fails, the race precondition
+    // itself stopped reproducing (e.g. a source-fetch ordering change) —
+    // investigate before assuming the FIX assertion below is meaningful.
+    await expect(page.getByTestId('source-selector')).toContainText('local-sqlite', {
+      timeout: 15000,
+    });
+
+    // Release the gate — defaults land. The fix's rebind effect
+    // (applyResolvedDefaultSource, explorerStore.js) must correct the
+    // already-created tab's source to the real project default.
+    releaseDefaults();
+    await page.unroute('**/api/defaults/**');
+
+    await expect(page.getByTestId('source-selector')).toContainText('local-duckdb', {
+      timeout: 10000,
+    });
+
+    // Backend-confirmed: the corrected source is what actually gets
+    // persisted once the user runs/saves — not just a UI-only patch that
+    // reverts on reload. Type SQL so a query genuinely exists, then let the
+    // draft-sync settle and read the persisted source back.
+    await page.locator('.view-lines').first().click({ timeout: 10000 });
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type('SELECT 1 AS cold_session_marker', { delay: 5 });
+    await expect(async () => {
+      const res = await page.request.get(`${API}/api/explorations/${id}/`);
+      expect(res.ok()).toBe(true);
+      const data = await res.json();
+      expect(data.draft?.queries?.[0]?.sql).toBe('SELECT 1 AS cold_session_marker');
+    }).toPass({ timeout: 15000 });
+  });
+
+  test('when defaults arrive BEFORE sources (the non-racy order), the tab is correct from the start — no rebind needed', async ({
+    page,
+  }) => {
+    // Baseline/regression guard: the common case (defaults already cached
+    // this session) must be unaffected by the fix — the tab should never
+    // visibly flash the wrong source and correct itself.
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await expect(page.getByTestId('source-selector')).toContainText('local-duckdb', {
+      timeout: 15000,
+    });
+    // Cleanup handled by afterEach via idsBeforeTest diffing; id referenced
+    // only to document intent (not otherwise used).
+    expect(id).toMatch(/^exp_/);
+  });
+});

--- a/viewer/e2e/stories/explorer-cold-session-default-source.spec.mjs
+++ b/viewer/e2e/stories/explorer-cold-session-default-source.spec.mjs
@@ -117,8 +117,16 @@ test.describe('Cold-session default-source race (VIS-1082)', () => {
 
     // Release the gate — defaults land. The fix's rebind effect
     // (applyResolvedDefaultSource, explorerStore.js) must correct the
-    // already-created tab's source to the real project default.
+    // already-created tab's source to the real project default. Wait for
+    // the actual HTTP response (not a blind timeout) before unrouting —
+    // `releaseDefaults()` only resolves the gate promise, it doesn't wait
+    // for the still-suspended route handler's own `await route.continue()`
+    // to actually run; unrouting while that handler is mid-resolution races
+    // Playwright's own unroute cleanup against it ("Route is already
+    // handled").
+    const responsePromise = page.waitForResponse(res => res.url().includes('/api/defaults/'));
     releaseDefaults();
+    await responsePromise;
     await page.unroute('**/api/defaults/**');
 
     await expect(page.getByTestId('source-selector')).toContainText('local-duckdb', {

--- a/viewer/e2e/stories/explorer-create-race.spec.mjs
+++ b/viewer/e2e/stories/explorer-create-race.spec.mjs
@@ -104,8 +104,17 @@ test.describe('Explorer Home: switching destinations mid-create never yanks navi
     );
 
     // Release the gate — the create resolves NOW, after the user has
-    // already navigated away.
+    // already navigated away. Wait for the actual HTTP response (not a
+    // blind timeout) before unrouting — `release()` only resolves the gate
+    // promise, it doesn't wait for the still-suspended route handler's own
+    // `await route.continue()` to actually run; unrouting while that
+    // handler is mid-resolution races Playwright's own unroute cleanup
+    // against it ("Route is already handled").
+    const responsePromise = page.waitForResponse(
+      res => res.url().endsWith('/api/explorations/') && res.request().method() === 'POST'
+    );
     release();
+    await responsePromise;
     await page.unroute('**/api/explorations/');
 
     // The stale completion must NOT force-navigate back to the new
@@ -143,7 +152,11 @@ test.describe('Explorer Home: switching destinations mid-create never yanks navi
       'true'
     );
 
+    const responsePromise = page.waitForResponse(
+      res => res.url().endsWith('/api/explorations/') && res.request().method() === 'POST'
+    );
     release();
+    await responsePromise;
     await page.unroute('**/api/explorations/');
 
     await page.waitForTimeout(500);

--- a/viewer/e2e/stories/explorer-create-race.spec.mjs
+++ b/viewer/e2e/stories/explorer-create-race.spec.mjs
@@ -1,0 +1,165 @@
+/**
+ * Story: Stale create-completion navigation (VIS-1084, e2e-gap-review.md
+ * finding #11 — MEDIUM). Switching destinations while a "New exploration" /
+ * "Start from a source" create is still in flight used to let the stale
+ * completion forcibly yank the user back to Explorer once it resolved:
+ * `ExplorerHomePane.jsx`'s `handleNew`/`handleSourceTile` are `async`, await
+ * a real network round-trip (`createExploration()`), then unconditionally
+ * call `openExploration(result.id)` -> `openWorkspaceTab(...)`, which
+ * activates the new exploration tab and forces `workspaceActiveView` back to
+ * 'explorer' as a side effect — with zero check for "is the user even still
+ * on this screen."
+ *
+ * THE FIX (ExplorerHomePane.jsx): a `mountedRef` (same pattern as
+ * `useRecordSave.js`/`useDebouncedSave.js`) makes the post-await navigate
+ * conditional on this component instance still being mounted. Switching
+ * destinations (a ViewSwitcher row, Cmd+2/3) unmounts `ExplorerHomePane` —
+ * `MiddlePane.jsx` renders a DIFFERENT destination's Home in its place — so
+ * `mountedRef.current` is reliably `false` by the time a still-in-flight
+ * create resolves. The exploration is still created and persisted either
+ * way; it's just never force-opened into a screen the user already left.
+ *
+ * This story forces the race deterministically via `page.route()` (gating
+ * the create POST) rather than hoping for a real network race to land
+ * inside the assertion window.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorerCreateRace VISIVO_SANDBOX_BACKEND_PORT=8053 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3053 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3053 npx playwright test explorer-create-race
+ *
+ * Mints real backend exploration records — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+/** Gate the exploration-create POST so it resolves only once `release()` is
+ * called — a deterministic stand-in for "the network round-trip is still in
+ * flight when the user navigates away." */
+async function gateCreatePost(page) {
+  let release = () => {};
+  const gate = new Promise(resolve => {
+    release = resolve;
+  });
+  await page.route('**/api/explorations/', async route => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+    await gate;
+    await route.continue();
+  });
+  return release;
+}
+
+test.describe('Explorer Home: switching destinations mid-create never yanks navigation back (VIS-1084)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unroute('**/api/explorations/').catch(() => {});
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('"+ New exploration": switching to Semantic Layer before the create resolves stays on Semantic Layer — the exploration is still created, just not force-opened', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const release = await gateCreatePost(page);
+
+    await page.getByTestId('explorer-home-new-exploration').click();
+    // The create POST is now held open — the user (a real click, not a
+    // keyboard shortcut, to keep this story orthogonal to the P4-D1
+    // keyboard-suppression fix) switches to a different destination while
+    // it's still in flight.
+    await page.getByTestId('workspace-view-switcher-semantic-layer').click();
+    await expect(page.getByTestId('workspace-view-switcher-semantic-layer')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // Release the gate — the create resolves NOW, after the user has
+    // already navigated away.
+    release();
+    await page.unroute('**/api/explorations/');
+
+    // The stale completion must NOT force-navigate back to the new
+    // exploration tab — Semantic Layer stays active, no exploration tab
+    // opens/activates.
+    await page.waitForTimeout(500);
+    await expect(page.getByTestId('workspace-view-switcher-semantic-layer')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(new URL(page.url()).pathname).not.toMatch(/\/workspace\/exploration\/exp_/);
+
+    // The exploration itself was still genuinely created and persisted —
+    // navigating to Explorer Home afterward finds it in the gallery, ready
+    // to open deliberately.
+    await expect(async () => {
+      const idsNow = await listExplorationIds(page);
+      expect(idsNow.length).toBeGreaterThan(idsBeforeTest.length);
+    }).toPass({ timeout: 10000 });
+  });
+
+  test('a source tile: switching destinations before the create resolves does not force-open the seeded exploration either', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await expect(page.getByTestId('explorer-home-source-tile-local-sqlite')).toBeVisible({
+      timeout: 15000,
+    });
+    const release = await gateCreatePost(page);
+
+    await page.getByTestId('explorer-home-source-tile-local-sqlite').click();
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await expect(page.getByTestId('workspace-view-switcher-project')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    release();
+    await page.unroute('**/api/explorations/');
+
+    await page.waitForTimeout(500);
+    await expect(page.getByTestId('workspace-view-switcher-project')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(new URL(page.url()).pathname).not.toMatch(/\/workspace\/exploration\/exp_/);
+  });
+
+  test('baseline (unchanged): staying on Explorer Home through the create still opens the new tab normally', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await page.getByTestId('explorer-home-new-exploration').click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -66,6 +66,14 @@ export default defineConfig({
         '**/exploration-promote.spec.mjs',
         '**/exploration-preview.spec.mjs',
         '**/save-as-metric.spec.mjs',
+        // Gate Hardening (VIS-1082-1086 + P4-D1/P4-D4): race-inducing,
+        // route-intercepting, backend-state-mutating specs — serial only.
+        '**/exploration-promote-tab-race.spec.mjs',
+        '**/exploration-cross-session-delete.spec.mjs',
+        '**/exploration-concurrent-rename-and-draft-sync.spec.mjs',
+        '**/explorer-create-race.spec.mjs',
+        '**/exploration-duplicate-race.spec.mjs',
+        '**/explorer-cold-session-default-source.spec.mjs',
         // B14 part 2: its exploration-workbench anchor check now mints a
         // real exploration too (the old standalone /explorer route let it
         // assume anchors render eagerly with no open document; the new

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -142,6 +142,17 @@ export default defineConfig({
         '**/exploration-promote.spec.mjs',
         '**/exploration-preview.spec.mjs',
         '**/save-as-metric.spec.mjs',
+        // Gate Hardening (VIS-1082-1086 + Phase 4 delta P4-D1/P4-D4): same
+        // shared-repository isolation need — mints real backend exploration
+        // + promoted-object records, and P4-D1's story deliberately holds a
+        // real network request open via page.route(), which must never race
+        // another worker's own promote flow against the same sandbox.
+        '**/exploration-promote-tab-race.spec.mjs',
+        '**/exploration-cross-session-delete.spec.mjs',
+        '**/exploration-concurrent-rename-and-draft-sync.spec.mjs',
+        '**/explorer-create-race.spec.mjs',
+        '**/exploration-duplicate-race.spec.mjs',
+        '**/explorer-cold-session-default-source.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/api/explorations.js
+++ b/viewer/src/api/explorations.js
@@ -72,7 +72,14 @@ export const updateExploration = async (id, payload) => {
   if (response.status === 200) {
     return await response.json();
   }
-  throw new Error(await parseErrorOr(response, 'Failed to update exploration'));
+  const message = await parseErrorOr(response, 'Failed to update exploration');
+  const error = new Error(message);
+  // VIS-1083: lets callers (workspaceExplorationsStore.js's runSync)
+  // distinguish "the record was deleted out from under this session" (404 —
+  // exploration_repository.py's update() returns None for a vanished id)
+  // from any other transient failure, without re-parsing `message`.
+  error.status = response.status;
+  throw error;
 };
 
 /**

--- a/viewer/src/components/explorer/useExplorerWorkbenchInit.js
+++ b/viewer/src/components/explorer/useExplorerWorkbenchInit.js
@@ -32,6 +32,22 @@ import { fetchSourceSchemaJobs } from '../../api/sourceSchemaJobs';
  * Workspace host gates mounting `ExplorationWorkbench` (and therefore this
  * hook) on that restore having completed for the current exploration id.
  *
+ * VIS-1082 (cold-session default-source race): the auto-create-model-tab
+ * effect below is a `useLayoutEffect` gated only on sources being available —
+ * it has no dependency on `state.defaults`, which is fetched by a separate,
+ * later-declared, plain `useEffect` with no ordering guarantee relative to
+ * the sources fetch. On a cold session (nothing cached yet), sources can
+ * arrive before defaults do, so the very first auto-created model tab can
+ * silently resolve to "first available source" instead of the project's
+ * configured default — a WRONG source with no visible error. Rather than
+ * blocking tab creation on `fetchDefaults()` (which would reopen the exact
+ * data-loss race the layout effect exists to close, per the note on that
+ * effect below), this hook remembers whether `defaults` had already arrived
+ * at the moment it auto-created a tab; if not, a dedicated effect rebinds
+ * that tab's source once `defaults` actually lands (`applyResolvedDefaultSource`,
+ * explorerStore.js — a no-op if the user has since picked a source
+ * themselves).
+ *
  * Phase 3a regression fix (VIS-1053): `explorerSources` used to be populated
  * ONLY as a side effect of `ExplorerLeftPanel`'s nested `SourceBrowser`
  * mounting (`SourceBrowser.onSourcesLoaded` -> `ExplorerLeftPanel`'s
@@ -56,6 +72,8 @@ export default function useExplorerWorkbenchInit() {
   const fetchDefaults = useStore(s => s.fetchDefaults);
   const fetchExplorerDiff = useStore(s => s.fetchExplorerDiff);
   const setExplorerSources = useStore(s => s.setExplorerSources);
+  const defaults = useStore(s => s.defaults);
+  const applyResolvedDefaultSource = useStore(s => s.applyResolvedDefaultSource);
 
   // Populate explorerSources on mount if not already loaded — see the Phase
   // 3a regression note above. Guarded on length so re-mounting this hook for
@@ -117,11 +135,29 @@ export default function useExplorerWorkbenchInit() {
   // window entirely. It doesn't help the very first cold load (sources
   // haven't arrived over the network yet regardless of effect timing), but
   // no real user — or test — can interact with the UI before it paints.
+  // VIS-1082: remembers the auto-created tab's name ONLY when `defaults`
+  // hadn't arrived yet at creation time — the one case that needs a later
+  // rebind. `null` once resolved (or if defaults were already in by creation
+  // time, in which case createModelTab already picked the right source).
+  const pendingDefaultSourceTabRef = useRef(null);
   useLayoutEffect(() => {
     if (modelTabs.length === 0 && explorerSources.length > 0) {
-      createModelTab();
+      const defaultsAlreadyArrived = !!useStore.getState().defaults;
+      const createdName = createModelTab();
+      if (!defaultsAlreadyArrived) {
+        pendingDefaultSourceTabRef.current = createdName;
+      }
     }
   }, [modelTabs.length, explorerSources.length, createModelTab]);
+
+  // VIS-1082: once `defaults` lands, rebind the tab that was auto-created
+  // before it arrived (a no-op — see `applyResolvedDefaultSource` — if the
+  // user already picked a source themselves in the meantime).
+  useEffect(() => {
+    if (!defaults || !pendingDefaultSourceTabRef.current) return;
+    applyResolvedDefaultSource(pendingDefaultSourceTabRef.current, defaults.source_name);
+    pendingDefaultSourceTabRef.current = null;
+  }, [defaults, applyResolvedDefaultSource]);
 
   // Auto-create an insight on initial mount only (not when the user removes
   // every insight).

--- a/viewer/src/components/explorer/useExplorerWorkbenchInit.test.js
+++ b/viewer/src/components/explorer/useExplorerWorkbenchInit.test.js
@@ -11,7 +11,7 @@
  * hook now fetches sources itself so both hosts get them regardless of
  * whether a browse-panel component is mounted.
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import useStore from '../../stores/store';
 import useExplorerWorkbenchInit from './useExplorerWorkbenchInit';
 import { fetchSourceSchemaJobs } from '../../api/sourceSchemaJobs';
@@ -29,11 +29,13 @@ const resetStore = () => {
     explorerInsightStates: {},
     explorerChartName: null,
     explorerChartLayout: {},
+    defaults: null,
     createModelTab: jest.fn(),
     createInsight: jest.fn(),
     fetchDefaults: jest.fn(),
     fetchExplorerDiff: jest.fn(),
     setExplorerSources: sources => useStore.setState({ explorerSources: sources }),
+    applyResolvedDefaultSource: jest.fn(),
   });
 };
 
@@ -87,5 +89,59 @@ describe('useExplorerWorkbenchInit', () => {
 
     await waitFor(() => expect(useStore.getState().explorerSources).toHaveLength(1));
     expect(createModelTab).not.toHaveBeenCalled();
+  });
+});
+
+// VIS-1082 — cold-session default-source race: sources can arrive (unblocking
+// the auto-create-model-tab effect above) before `defaults` does, since
+// `fetchDefaults()` is a separate, unordered effect. The auto-created tab
+// must get rebound to the real project default once it lands, rather than
+// silently keeping whatever "first available source" guess `createModelTab`
+// made at creation time.
+describe('useExplorerWorkbenchInit — VIS-1082 default-source rebind', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  test('rebinds the auto-created tab once defaults arrive AFTER it was created', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([{ source_name: 'local-duckdb' }]);
+    const createModelTab = jest.fn(() => 'model');
+    const applyResolvedDefaultSource = jest.fn();
+    useStore.setState({ createModelTab, applyResolvedDefaultSource, defaults: null });
+
+    renderHook(() => useExplorerWorkbenchInit());
+
+    // Sources land; defaults still haven't — the tab is auto-created with
+    // `defaults` still null at that moment.
+    await waitFor(() => expect(createModelTab).toHaveBeenCalledTimes(1));
+    expect(applyResolvedDefaultSource).not.toHaveBeenCalled();
+
+    // Defaults land afterward — the pending tab must be rebound.
+    act(() => {
+      useStore.setState({ defaults: { source_name: 'the-real-default' } });
+    });
+
+    await waitFor(() =>
+      expect(applyResolvedDefaultSource).toHaveBeenCalledWith('model', 'the-real-default')
+    );
+  });
+
+  test('does NOT rebind when defaults had already arrived before the tab was created', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([{ source_name: 'local-duckdb' }]);
+    const createModelTab = jest.fn(() => 'model');
+    const applyResolvedDefaultSource = jest.fn();
+    useStore.setState({
+      createModelTab,
+      applyResolvedDefaultSource,
+      defaults: { source_name: 'already-correct' },
+    });
+
+    renderHook(() => useExplorerWorkbenchInit());
+
+    await waitFor(() => expect(createModelTab).toHaveBeenCalledTimes(1));
+    // createModelTab itself already resolved the right source at creation
+    // time (defaults were present) — no rebind is ever needed or fired.
+    expect(applyResolvedDefaultSource).not.toHaveBeenCalled();
   });
 });

--- a/viewer/src/components/views/workspace/ExplorationDeletedRemotelyBanner.jsx
+++ b/viewer/src/components/views/workspace/ExplorationDeletedRemotelyBanner.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { PiWarningCircle } from 'react-icons/pi';
+import useStore from '../../../stores/store';
+
+/**
+ * ExplorationDeletedRemotelyBanner — VIS-1083.
+ *
+ * Rendered by `ExplorationPane` above the workbench whenever this
+ * exploration's `syncStatus` is `'deleted-remotely'` (`workspaceExplorationsStore.js`'s
+ * `runSync` sets it after a 404 — the backend record was deleted in another
+ * session, or removed out-of-band). Unlike `ExternalEditBanner`, this never
+ * auto-dismisses and isn't merely informational: the record's sync loop has
+ * already been stopped (`updateExplorationDraft` stops re-arming it once
+ * `syncStatus` is this value), so silence here would leave the user editing
+ * a tab that can never save again with no indication why. Offers the two
+ * real options: recreate the local draft as a brand-new exploration, or
+ * close the tab (nothing left to lose — the backend record is already
+ * gone).
+ */
+const ExplorationDeletedRemotelyBanner = ({ id }) => {
+  const recreateExplorationFromDeleted = useStore(s => s.recreateExplorationFromDeleted);
+  const discardDeletedExploration = useStore(s => s.discardDeletedExploration);
+  const [busy, setBusy] = useState(false);
+
+  const handleRecreate = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await recreateExplorationFromDeleted(id);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (busy) return;
+    discardDeletedExploration(id);
+  };
+
+  return (
+    <div
+      role="alert"
+      data-testid="exploration-deleted-remotely-banner"
+      className="flex w-full shrink-0 items-start gap-3 border-b border-highlight-200 bg-highlight-50 px-4 py-3"
+    >
+      <PiWarningCircle aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-highlight-600" />
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="font-medium text-highlight-900">This exploration was deleted.</p>
+        <p className="mt-0.5 text-highlight-800">
+          It was removed elsewhere (another tab, or outside Visivo) while you were editing here.
+          Your unsaved changes are still on this screen, but they can no longer be saved to that
+          record.
+        </p>
+        <div className="mt-2 flex gap-2">
+          <button
+            type="button"
+            onClick={handleRecreate}
+            disabled={busy}
+            data-testid="exploration-deleted-remotely-recreate"
+            className="rounded bg-highlight-600 px-2.5 py-1 text-[12px] font-medium text-white transition-colors hover:bg-highlight-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Recreate as new exploration
+          </button>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={busy}
+            data-testid="exploration-deleted-remotely-close"
+            className="rounded px-2.5 py-1 text-[12px] font-medium text-highlight-700 transition-colors hover:bg-highlight-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Close tab
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExplorationDeletedRemotelyBanner;

--- a/viewer/src/components/views/workspace/ExplorationDeletedRemotelyBanner.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationDeletedRemotelyBanner.test.jsx
@@ -1,0 +1,93 @@
+/**
+ * ExplorationDeletedRemotelyBanner (VIS-1083) — the recovery banner shown
+ * when an exploration's backend record was deleted out from under an
+ * actively-editing session (another tab's delete, or an out-of-band removal).
+ * Pins: both actions are wired to the right store calls, and busy-guards
+ * against a double-click while a recreate is in flight.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import ExplorationDeletedRemotelyBanner from './ExplorationDeletedRemotelyBanner';
+import useStore from '../../../stores/store';
+
+const seed = (extra = {}) => {
+  act(() => {
+    useStore.setState({
+      recreateExplorationFromDeleted: jest.fn().mockResolvedValue({ success: true, id: 'exp_2' }),
+      discardDeletedExploration: jest.fn(),
+      ...extra,
+    });
+  });
+};
+
+describe('ExplorationDeletedRemotelyBanner', () => {
+  test('renders the warning message and both action buttons', () => {
+    seed();
+    render(<ExplorationDeletedRemotelyBanner id="exp_1" />);
+    expect(screen.getByTestId('exploration-deleted-remotely-banner')).toBeInTheDocument();
+    expect(screen.getByText(/this exploration was deleted/i)).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-deleted-remotely-recreate')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-deleted-remotely-close')).toBeInTheDocument();
+  });
+
+  test('"Recreate as new exploration" calls recreateExplorationFromDeleted with the id', async () => {
+    const recreateExplorationFromDeleted = jest.fn().mockResolvedValue({ success: true, id: 'exp_2' });
+    seed({ recreateExplorationFromDeleted });
+    render(<ExplorationDeletedRemotelyBanner id="exp_1" />);
+
+    fireEvent.click(screen.getByTestId('exploration-deleted-remotely-recreate'));
+
+    await waitFor(() => expect(recreateExplorationFromDeleted).toHaveBeenCalledWith('exp_1'));
+  });
+
+  test('the recreate button disables itself while the recreate is in flight', async () => {
+    let resolvePromise;
+    const recreateExplorationFromDeleted = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolvePromise = resolve;
+        })
+    );
+    seed({ recreateExplorationFromDeleted });
+    render(<ExplorationDeletedRemotelyBanner id="exp_1" />);
+
+    fireEvent.click(screen.getByTestId('exploration-deleted-remotely-recreate'));
+    expect(screen.getByTestId('exploration-deleted-remotely-recreate')).toBeDisabled();
+    expect(screen.getByTestId('exploration-deleted-remotely-close')).toBeDisabled();
+
+    await act(async () => {
+      resolvePromise({ success: true, id: 'exp_2' });
+    });
+    expect(recreateExplorationFromDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  test('a second click on "Recreate" while busy does not fire a second request', async () => {
+    let resolvePromise;
+    const recreateExplorationFromDeleted = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolvePromise = resolve;
+        })
+    );
+    seed({ recreateExplorationFromDeleted });
+    render(<ExplorationDeletedRemotelyBanner id="exp_1" />);
+
+    fireEvent.click(screen.getByTestId('exploration-deleted-remotely-recreate'));
+    fireEvent.click(screen.getByTestId('exploration-deleted-remotely-recreate'));
+    expect(recreateExplorationFromDeleted).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePromise({ success: true, id: 'exp_2' });
+    });
+  });
+
+  test('"Close tab" calls discardDeletedExploration with the id', () => {
+    const discardDeletedExploration = jest.fn();
+    seed({ discardDeletedExploration });
+    render(<ExplorationDeletedRemotelyBanner id="exp_1" />);
+
+    fireEvent.click(screen.getByTestId('exploration-deleted-remotely-close'));
+
+    expect(discardDeletedExploration).toHaveBeenCalledWith('exp_1');
+  });
+});

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -3,6 +3,7 @@ import { PiPencilSimple, PiCopy, PiCircleNotch } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import SubBar from './SubBar';
 import ExplorationWorkbench from './ExplorationWorkbench';
+import ExplorationDeletedRemotelyBanner from './ExplorationDeletedRemotelyBanner';
 import InlineRenameInput from './InlineRenameInput';
 import useInlineRename from '../../../hooks/useInlineRename';
 import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
@@ -214,17 +215,40 @@ const ExplorationPane = ({ id }) => {
     [id, renameExploration]
   );
 
+  // VIS-1086: in-flight guard against a double-click on Duplicate — checked
+  // synchronously INSIDE the handler (a real double-click can dispatch both
+  // click events before React re-renders the button `disabled`, which is
+  // still set below as the visible affordance, not the actual guard).
+  // ExplorationPane isn't remounted when `id` changes (switching tabs is a
+  // prop change on the SAME instance, per MiddlePane's dispatch) — reset the
+  // guard on `id` change so a duplicate still in flight for the OLD
+  // exploration never leaves the button stuck disabled for a DIFFERENT one.
+  const duplicatingRef = useRef(false);
+  const [duplicating, setDuplicating] = useState(false);
+  useEffect(() => {
+    duplicatingRef.current = false;
+    setDuplicating(false);
+  }, [id]);
+
   const handleDuplicate = useCallback(async () => {
-    // Flush this exploration's own latest edits first so the duplicate seeds
-    // from up-to-date state, not a stale pre-debounce draft.
-    await flushExplorationSync(id);
-    const result = await duplicateExploration(id);
-    if (result?.success) {
-      openWorkspaceTab({
-        id: `exploration:${result.id}`,
-        type: 'exploration',
-        name: result.id,
-      });
+    if (duplicatingRef.current) return;
+    duplicatingRef.current = true;
+    setDuplicating(true);
+    try {
+      // Flush this exploration's own latest edits first so the duplicate
+      // seeds from up-to-date state, not a stale pre-debounce draft.
+      await flushExplorationSync(id);
+      const result = await duplicateExploration(id);
+      if (result?.success) {
+        openWorkspaceTab({
+          id: `exploration:${result.id}`,
+          type: 'exploration',
+          name: result.id,
+        });
+      }
+    } finally {
+      duplicatingRef.current = false;
+      setDuplicating(false);
     }
   }, [id, flushExplorationSync, duplicateExploration, openWorkspaceTab]);
 
@@ -281,14 +305,16 @@ const ExplorationPane = ({ id }) => {
           <button
             type="button"
             onClick={handleDuplicate}
+            disabled={duplicating}
             title="Duplicate this exploration"
             data-testid="exploration-duplicate-button"
-            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-gray-200 px-2.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-gray-200 px-2.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <PiCopy style={{ fontSize: 13 }} /> Duplicate
           </button>
         }
       />
+      {record.syncStatus === 'deleted-remotely' && <ExplorationDeletedRemotelyBanner id={id} />}
       <ExplorationWorkbench id={id} />
     </section>
   );

--- a/viewer/src/components/views/workspace/ExplorationPane.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.test.jsx
@@ -147,6 +147,32 @@ describe('ExplorationPane — ready state', () => {
   });
 });
 
+// VIS-1083: a 404'd sync marks the record 'deleted-remotely' — the pane must
+// surface the recovery banner (never stay silent) while still rendering the
+// workbench underneath (the local draft is not lost).
+describe('ExplorationPane — VIS-1083 deleted-remotely banner', () => {
+  test('shows the banner when syncStatus is deleted-remotely', () => {
+    seed({
+      workspaceExplorations: {
+        byId: { exp_1: record({ syncStatus: 'deleted-remotely' }) },
+        order: ['exp_1'],
+      },
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.getByTestId('exploration-deleted-remotely-banner')).toBeInTheDocument();
+    // The workbench keeps rendering underneath — nothing is lost, just unsaveable.
+    expect(screen.getByTestId('exploration-workbench-mock')).toBeInTheDocument();
+  });
+
+  test('does NOT show the banner for any other syncStatus', () => {
+    seed({
+      workspaceExplorations: { byId: { exp_1: record({ syncStatus: 'saving' }) }, order: ['exp_1'] },
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.queryByTestId('exploration-deleted-remotely-banner')).not.toBeInTheDocument();
+  });
+});
+
 describe('ExplorationPane — rename', () => {
   test('the pencil opens an inline input; committing calls renameExploration', () => {
     const renameExploration = jest.fn();
@@ -204,6 +230,76 @@ describe('ExplorationPane — duplicate', () => {
       id: 'exploration:exp_2',
       type: 'exploration',
       name: 'exp_2',
+    });
+  });
+
+  // VIS-1086: double-clicking Duplicate must never fire two duplicate
+  // round-trips.
+  test('double-clicking Duplicate only calls duplicateExploration once', async () => {
+    let resolveDuplicate;
+    const flushExplorationSync = jest.fn().mockResolvedValue({ success: true });
+    const duplicateExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveDuplicate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({
+      workspaceExplorations: { byId: { exp_1: record() }, order: ['exp_1'] },
+      flushExplorationSync,
+      duplicateExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorationPane id="exp_1" />);
+
+    const button = screen.getByTestId('exploration-duplicate-button');
+    fireEvent.click(button);
+    fireEvent.click(button); // fires before the first call resolves
+
+    await waitFor(() => expect(duplicateExploration).toHaveBeenCalledTimes(1));
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      resolveDuplicate({ success: true, id: 'exp_2' });
+    });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(openWorkspaceTab).toHaveBeenCalledTimes(1);
+  });
+
+  test('the duplicate in-flight guard resets when the exploration id changes (switching tabs)', async () => {
+    let resolveDuplicate;
+    const flushExplorationSync = jest.fn().mockResolvedValue({ success: true });
+    const duplicateExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveDuplicate = resolve;
+        })
+    );
+    seed({
+      workspaceExplorations: {
+        byId: { exp_1: record(), exp_2: record({ id: 'exp_2', name: 'Q3 refund spike' }) },
+        order: ['exp_1', 'exp_2'],
+      },
+      flushExplorationSync,
+      duplicateExploration,
+    });
+    const { rerender } = render(<ExplorationPane id="exp_1" />);
+
+    fireEvent.click(screen.getByTestId('exploration-duplicate-button'));
+    expect(screen.getByTestId('exploration-duplicate-button')).toBeDisabled();
+    // Let the handler's own awaited flushExplorationSync() microtask resolve
+    // so duplicateExploration (and its deferred promise) has actually fired
+    // before we switch tabs below.
+    await waitFor(() => expect(duplicateExploration).toHaveBeenCalledTimes(1));
+
+    // Switch to a DIFFERENT exploration WITHOUT the first duplicate ever
+    // resolving — its own Duplicate button must not be stuck disabled.
+    rerender(<ExplorationPane id="exp_2" />);
+    expect(screen.getByTestId('exploration-duplicate-button')).not.toBeDisabled();
+
+    await act(async () => {
+      resolveDuplicate({ success: true, id: 'exp_3' });
     });
   });
 });

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -123,7 +123,12 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
         if (e.target === e.currentTarget && !promoting) onClose?.();
       }}
     >
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg p-6 max-h-[85vh] overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Save to Project"
+        className="bg-white rounded-lg shadow-xl w-full max-w-lg p-6 max-h-[85vh] overflow-y-auto"
+      >
         <h3 className="text-lg font-medium text-secondary-900 mb-1">Save to Project</h3>
 
         {loading ? (

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -34,6 +34,18 @@ describe('ExplorationPromoteModal', () => {
     expect(screen.getByText('Checking your draft…')).toBeInTheDocument();
   });
 
+  // P4-D1: `useWorkspaceTabShortcuts.js`'s `hasBlockingModal` guard finds
+  // blocking modals purely via `[aria-modal="true"]` in the DOM — this pins
+  // that the promote modal actually carries that marker (a regression here
+  // would silently reopen the keyboard-shortcut race the guard exists to
+  // close, with no test failure anywhere near this file to point at it).
+  test('renders with role="dialog" aria-modal="true" (required by the shortcut-suppression guard)', () => {
+    buildPromoteChecklist.mockReturnValue(new Promise(() => {}));
+    render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+    const dialog = screen.getByRole('dialog', { name: 'Save to Project' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
   test('shows "No changes to save" when the checklist is empty', async () => {
     buildPromoteChecklist.mockResolvedValue([]);
     render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);

--- a/viewer/src/components/views/workspace/TabStrip.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.jsx
@@ -8,7 +8,7 @@ import {
   useDroppable,
   closestCenter,
 } from '@dnd-kit/core';
-import { PiX, PiPlus } from 'react-icons/pi';
+import { PiX, PiPlus, PiWarningCircle } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import { getTypeIcon } from '../common/objectTypeConfigs';
 import TabCloseConfirmDialog from './TabCloseConfirmDialog';
@@ -54,6 +54,14 @@ const WorkspaceTab = ({ tab, active, onSelect, onClose, isDragging }) => {
     tab.type === 'exploration' ? s.workspaceExplorations.byId[tab.name]?.name : null
   );
   const displayName = explorationDisplayName || tab.name;
+  // VIS-1083: a 404'd sync means the backend record for this exploration tab
+  // is gone (another session's delete, or an out-of-band removal) — the
+  // pane's own banner (`ExplorationDeletedRemotelyBanner`) carries the real
+  // recovery options, but a PARKED tab never shows the pane, so this is the
+  // only surface that can flag it before the user even switches to it.
+  const explorationDeletedRemotely = useStore(
+    s => tab.type === 'exploration' && s.workspaceExplorations.byId[tab.name]?.syncStatus === 'deleted-remotely'
+  );
   return (
     <div
       role="tab"
@@ -78,12 +86,21 @@ const WorkspaceTab = ({ tab, active, onSelect, onClose, isDragging }) => {
       >
         <TypeIcon aria-hidden="true" style={{ fontSize: 14 }} className="shrink-0 text-gray-500" />
         <span className="truncate">{displayName}</span>
-        {tab.dirty && (
-          <span
-            title="Unsaved changes"
-            data-testid={`workspace-tab-dirty-${tab.id}`}
-            className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+        {explorationDeletedRemotely ? (
+          <PiWarningCircle
+            title="This exploration was deleted — open it to recover"
+            data-testid={`workspace-tab-deleted-remotely-${tab.id}`}
+            aria-hidden="true"
+            className="h-3 w-3 shrink-0 text-highlight-600"
           />
+        ) : (
+          tab.dirty && (
+            <span
+              title="Unsaved changes"
+              data-testid={`workspace-tab-dirty-${tab.id}`}
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+            />
+          )
         )}
       </button>
       <button

--- a/viewer/src/components/views/workspace/TabStrip.test.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.test.jsx
@@ -97,6 +97,45 @@ describe('TabStrip', () => {
     );
   });
 
+  // VIS-1083: a PARKED exploration tab (not the active one, so
+  // ExplorationPane's own banner isn't rendered) still needs to flag that its
+  // backend record is gone — the strip is the only surface that can.
+  test('an exploration tab whose record is deleted-remotely shows a warning indicator instead of the dirty dot', () => {
+    seedStore({
+      workspaceTabs: [
+        { id: 'exploration:exp_gone', type: 'exploration', name: 'exp_gone', dirty: false },
+      ],
+      workspaceExplorations: {
+        byId: { exp_gone: { id: 'exp_gone', name: 'Gone', syncStatus: 'deleted-remotely' } },
+        order: ['exp_gone'],
+      },
+    });
+    render(<TabStrip />);
+    expect(
+      screen.getByTestId('workspace-tab-deleted-remotely-exploration:exp_gone')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('workspace-tab-dirty-exploration:exp_gone')
+    ).not.toBeInTheDocument();
+  });
+
+  test('a healthy (synced) exploration tab shows neither the dirty dot nor the deleted-remotely warning', () => {
+    seedStore({
+      workspaceTabs: [
+        { id: 'exploration:exp_ok', type: 'exploration', name: 'exp_ok', dirty: false },
+      ],
+      workspaceExplorations: {
+        byId: { exp_ok: { id: 'exp_ok', name: 'Fine', syncStatus: 'synced' } },
+        order: ['exp_ok'],
+      },
+    });
+    render(<TabStrip />);
+    expect(
+      screen.queryByTestId('workspace-tab-deleted-remotely-exploration:exp_ok')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-tab-dirty-exploration:exp_ok')).not.toBeInTheDocument();
+  });
+
   test('renders the dirty dot on tabs marked dirty', () => {
     seedStore();
     render(<TabStrip />);

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { PiPlus, PiCircleNotch } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import SubBar from '../SubBar';
@@ -78,16 +78,62 @@ const ExplorerHomePane = () => {
     seedPromiseRef.current = createExploration();
   }, [fetched, orderedExplorations.length, createExploration]);
 
+  // VIS-1084: `handleNew`/`handleSourceTile` await a real network round-trip
+  // before navigating. If the user switches destinations (ViewSwitcher row,
+  // Cmd+2/3) while that's in flight, THIS component unmounts — MiddlePane
+  // renders a different destination's Home instead (or a document tab) — but
+  // the create's completion doesn't know that and used to force-navigate
+  // into the new exploration regardless, yanking the user back to a screen
+  // they'd already deliberately left. `mountedRef` (same pattern as
+  // `useRecordSave.js`/`useDebouncedSave.js`) makes the post-await navigate
+  // conditional on this instance still being mounted; the exploration itself
+  // is still created and persisted either way — it just won't be forced open.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
+  // VIS-1086: guard every create door with an in-flight ref CHECKED INSIDE
+  // THE HANDLER — a real double-click can dispatch both click events before
+  // React has a chance to re-render the button `disabled` (that attribute
+  // is still set below, as the visible affordance, but it's a secondary
+  // defense, not the actual guard). `creatingRef` blocks a second call
+  // synchronously; `creating` state drives the disabled UI. Shared across
+  // "+ New exploration" AND every source tile — a fast double-click across
+  // TWO different doors races the exact same backend `_default_name()`
+  // window as two clicks of the same one.
+  const creatingRef = useRef(false);
+  const [creating, setCreating] = useState(false);
+
   const handleNew = async () => {
-    if (seedPromiseRef.current) await seedPromiseRef.current;
-    const result = await createExploration();
-    if (result?.success) openExploration(result.id);
+    if (creatingRef.current) return;
+    creatingRef.current = true;
+    setCreating(true);
+    try {
+      if (seedPromiseRef.current) await seedPromiseRef.current;
+      const result = await createExploration();
+      if (result?.success && mountedRef.current) openExploration(result.id);
+    } finally {
+      creatingRef.current = false;
+      if (mountedRef.current) setCreating(false);
+    }
   };
 
   const handleSourceTile = async sourceName => {
-    if (seedPromiseRef.current) await seedPromiseRef.current;
-    const result = await createExploration({ type: 'source', name: sourceName });
-    if (result?.success) openExploration(result.id);
+    if (creatingRef.current) return;
+    creatingRef.current = true;
+    setCreating(true);
+    try {
+      if (seedPromiseRef.current) await seedPromiseRef.current;
+      const result = await createExploration({ type: 'source', name: sourceName });
+      if (result?.success && mountedRef.current) openExploration(result.id);
+    } finally {
+      creatingRef.current = false;
+      if (mountedRef.current) setCreating(false);
+    }
   };
 
   const handleDuplicate = async id => {
@@ -131,8 +177,9 @@ const ExplorerHomePane = () => {
           <button
             type="button"
             onClick={handleNew}
+            disabled={creating}
             data-testid="explorer-home-new-exploration"
-            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600"
+            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-semibold text-white shadow-sm transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <PiPlus style={{ fontSize: 13 }} /> New exploration
           </button>
@@ -153,8 +200,9 @@ const ExplorerHomePane = () => {
                   key={source.name}
                   type="button"
                   onClick={() => handleSourceTile(source.name)}
+                  disabled={creating}
                   data-testid={`explorer-home-source-tile-${source.name}`}
-                  className={`inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12.5px] font-medium transition-colors ${SOURCE_COLORS.border} ${SOURCE_COLORS.text} hover:bg-orange-50`}
+                  className={`inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12.5px] font-medium transition-colors ${SOURCE_COLORS.border} ${SOURCE_COLORS.text} hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-60`}
                 >
                   {SourceIcon && <SourceIcon style={{ fontSize: 14 }} />}
                   {source.name}

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
@@ -89,12 +89,20 @@ const ExplorerHomePane = () => {
   // conditional on this instance still being mounted; the exploration itself
   // is still created and persisted either way — it just won't be forced open.
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Reset on EVERY effect run, not just at the `useRef(true)` initializer —
+    // React 18 StrictMode (index.jsx wraps the app in it) double-invokes
+    // mount effects in development: mount -> cleanup -> mount again. Without
+    // this reset, the cleanup's `mountedRef.current = false` from that
+    // simulated first "unmount" would stick permanently false even though
+    // the component is genuinely mounted and interactive — exactly the
+    // regression this comment is here to prevent from recurring. Same
+    // pattern as `useRecordSave.js`/`useDebouncedSave.js`.
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    []
-  );
+    };
+  }, []);
 
   // VIS-1086: guard every create door with an in-flight ref CHECKED INSIDE
   // THE HANDLER — a real double-click can dispatch both click events before

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
@@ -66,6 +66,186 @@ describe('ExplorerHomePane — header + new exploration', () => {
   });
 });
 
+// VIS-1084: switching destinations while a create is in flight (unmounting
+// THIS pane) must never let the completion force-navigate afterward.
+describe('ExplorerHomePane — VIS-1084 stale create-completion navigation', () => {
+  test('"+ New exploration": does not navigate if the pane unmounted before the create resolved', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      createExploration,
+      openWorkspaceTab,
+    });
+    const { unmount } = render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-new-exploration'));
+    await waitFor(() => expect(createExploration).toHaveBeenCalled());
+
+    // The user switches destinations before the create resolves — MiddlePane
+    // would unmount this pane in favor of a different Home/document.
+    unmount();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_new' });
+      await Promise.resolve();
+    });
+
+    expect(openWorkspaceTab).not.toHaveBeenCalled();
+  });
+
+  test('"+ New exploration": still navigates when the pane is still mounted (baseline, unchanged)', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      createExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-new-exploration'));
+    await waitFor(() => expect(createExploration).toHaveBeenCalled());
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_new' });
+    });
+
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'exploration:exp_new',
+      type: 'exploration',
+      name: 'exp_new',
+    });
+  });
+
+  test('a source tile: does not navigate if the pane unmounted before the create resolved', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      sources: [{ name: 'warehouse' }],
+      createExploration,
+      openWorkspaceTab,
+    });
+    const { unmount } = render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-source-tile-warehouse'));
+    await waitFor(() => expect(createExploration).toHaveBeenCalled());
+
+    unmount();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_seeded' });
+      await Promise.resolve();
+    });
+
+    expect(openWorkspaceTab).not.toHaveBeenCalled();
+  });
+});
+
+// VIS-1086: every create door needs an in-flight guard — a rapid double
+// click (or two different doors clicked in quick succession) must never
+// mint two records.
+describe('ExplorerHomePane — VIS-1086 double-click guard', () => {
+  test('double-clicking "+ New exploration" only calls createExploration once', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      createExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorerHomePane />);
+
+    const button = screen.getByTestId('explorer-home-new-exploration');
+    fireEvent.click(button);
+    fireEvent.click(button); // fires before the first call resolves
+
+    expect(createExploration).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_new' });
+    });
+    expect(button).not.toBeDisabled();
+  });
+
+  test('double-clicking a source tile only calls createExploration once', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      sources: [{ name: 'warehouse' }],
+      createExploration,
+    });
+    render(<ExplorerHomePane />);
+
+    const tile = screen.getByTestId('explorer-home-source-tile-warehouse');
+    fireEvent.click(tile);
+    fireEvent.click(tile);
+
+    expect(createExploration).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_seeded' });
+    });
+  });
+
+  test('clicking "+ New exploration" while a source-tile create is in flight is also blocked (shared guard across doors)', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    seed({
+      workspaceExplorations: { byId: { exp_1: explorationRecord() }, order: ['exp_1'] },
+      sources: [{ name: 'warehouse' }],
+      createExploration,
+    });
+    render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-source-tile-warehouse'));
+    fireEvent.click(screen.getByTestId('explorer-home-new-exploration'));
+
+    expect(createExploration).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_seeded' });
+    });
+  });
+});
+
 describe('ExplorerHomePane — start from a source', () => {
   test('renders one tile per source', () => {
     seed({

--- a/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.js
+++ b/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.js
@@ -31,6 +31,21 @@ import { HIGHER_LEVEL_VIEWS } from './higherLevelViews';
  * while focus is in an input / textarea / select / contenteditable so the
  * browser's own editing shortcuts are never clobbered, and any combo with
  * Alt or Shift is left alone (those are browser/system chords).
+ *
+ * Phase 4 delta (P4-D1): shortcuts are ALSO suppressed while a blocking
+ * modal is open (`hasBlockingModal`, below). `ExplorationPromoteModal`'s
+ * backdrop already blocks a MOUSE-driven close mid-promote (its own
+ * `onClick` checks `!promoting`), but every shortcut here (T/W/1-9) can
+ * navigate away from — and thereby unmount — the active exploration tab
+ * regardless: `ExplorationPane`'s deactivate cleanup fires a generic
+ * draft-sync flush that races `promoteExploration`'s in-flight
+ * `recordExplorationPromotion` POST on the same unlocked backend JSON
+ * document (see `workspaceExplorationsStore.js`'s "WRITE SERIALIZATION"
+ * docstring for the other half of this fix — the client-side write queue
+ * that makes surviving this race safe even when it isn't preventable, e.g.
+ * a mouse click on a different browser tab/window). Suppressing here closes
+ * off the KEYBOARD path entirely, matching the mouse backdrop's existing
+ * guarantee instead of leaving it as the only door.
  */
 
 /** Mac detection — exported for tests. `navigator.platform` is deprecated but
@@ -49,6 +64,21 @@ export const isEditableTarget = (el) => {
 };
 
 /**
+ * Is a blocking modal currently open? Checked via the DOM rather than a
+ * store flag — every blocking modal in this codebase already renders
+ * `aria-modal="true"` on its dialog element for a11y (`ConfirmDialog.jsx`,
+ * `TabCloseConfirmDialog.jsx`, `ExplorationPromoteModal.jsx`), so this
+ * generalizes to any FUTURE blocking modal for free with zero call-site
+ * wiring — no modal owner needs to remember to set/clear a store flag,
+ * mirroring `isEditableTarget`'s own DOM-based check just above. Exported
+ * for tests.
+ */
+export const hasBlockingModal = () => {
+  if (typeof document === 'undefined') return false;
+  return !!document.querySelector('[aria-modal="true"]');
+};
+
+/**
  * The pure keydown handler — exported so tests can drive it without
  * mounting a component. `store` is the zustand state (getState()).
  */
@@ -56,6 +86,9 @@ export const handleTabShortcut = (e, store, { mac = isMacPlatform() } = {}) => {
   const mod = mac ? e.metaKey : e.ctrlKey;
   if (!mod || e.altKey || e.shiftKey) return false;
   if (isEditableTarget(e.target)) return false;
+  // P4-D1: never navigate away from (and thereby unmount) the active tab
+  // while a blocking modal is open — see the file docstring.
+  if (hasBlockingModal()) return false;
 
   const key = typeof e.key === 'string' ? e.key.toLowerCase() : '';
 

--- a/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.test.jsx
+++ b/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.test.jsx
@@ -12,6 +12,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import useWorkspaceTabShortcuts, {
   handleTabShortcut,
   isEditableTarget,
+  hasBlockingModal,
 } from './useWorkspaceTabShortcuts';
 import useStore from '../../../stores/store';
 
@@ -164,6 +165,86 @@ describe('handleTabShortcut (pure dispatcher)', () => {
     expect(isEditableTarget(document.createElement('select'))).toBe(true);
     expect(isEditableTarget(document.createElement('div'))).toBe(false);
     expect(isEditableTarget(null)).toBe(false);
+  });
+
+  // P4-D1: a keyboard-driven tab/view switch mid-promote (or mid any other
+  // blocking-modal flow) must never fire — closes the door the promote
+  // modal's mouse-backdrop guard already closes, that shortcuts used to
+  // bypass entirely.
+  describe('hasBlockingModal / P4-D1 shortcut suppression', () => {
+    let marker;
+
+    afterEach(() => {
+      if (marker) {
+        document.body.removeChild(marker);
+        marker = null;
+      }
+    });
+
+    const mountBlockingModal = () => {
+      marker = document.createElement('div');
+      marker.setAttribute('aria-modal', 'true');
+      document.body.appendChild(marker);
+    };
+
+    test('hasBlockingModal is false with nothing in the DOM', () => {
+      expect(hasBlockingModal()).toBe(false);
+    });
+
+    test('hasBlockingModal is true once any element carries aria-modal="true"', () => {
+      mountBlockingModal();
+      expect(hasBlockingModal()).toBe(true);
+    });
+
+    test('Cmd+1/2/3 (view switch) is suppressed while a blocking modal is open', () => {
+      mountBlockingModal();
+      const store = makeStore();
+      expect(handleTabShortcut(makeEvent({ key: '1', metaKey: true }), store, { mac: true })).toBe(
+        false
+      );
+      expect(store.openWorkspaceView).not.toHaveBeenCalled();
+    });
+
+    test('Cmd+4-9 (tab position) is suppressed while a blocking modal is open', () => {
+      mountBlockingModal();
+      const store = makeStore();
+      expect(handleTabShortcut(makeEvent({ key: '4', metaKey: true }), store, { mac: true })).toBe(
+        false
+      );
+      expect(store.switchWorkspaceTab).not.toHaveBeenCalled();
+    });
+
+    test('Cmd+W (close active tab) is suppressed while a blocking modal is open', () => {
+      mountBlockingModal();
+      const store = makeStore();
+      expect(handleTabShortcut(makeEvent({ key: 'w', metaKey: true }), store, { mac: true })).toBe(
+        false
+      );
+      expect(store.requestCloseWorkspaceTab).not.toHaveBeenCalled();
+    });
+
+    test('Cmd+T (new tab) is suppressed while a blocking modal is open', () => {
+      mountBlockingModal();
+      const store = makeStore();
+      expect(handleTabShortcut(makeEvent({ key: 't', metaKey: true }), store, { mac: true })).toBe(
+        false
+      );
+      expect(store.openWorkspaceTab).not.toHaveBeenCalled();
+    });
+
+    test('shortcuts resume normally once the modal is gone', () => {
+      mountBlockingModal();
+      const store = makeStore();
+      expect(handleTabShortcut(makeEvent({ key: '1', metaKey: true }), store, { mac: true })).toBe(
+        false
+      );
+      document.body.removeChild(marker);
+      marker = null;
+      expect(handleTabShortcut(makeEvent({ key: '1', metaKey: true }), store, { mac: true })).toBe(
+        true
+      );
+      expect(store.openWorkspaceView).toHaveBeenCalledWith('project');
+    });
   });
 });
 

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -517,6 +517,38 @@ const createExplorerSlice = (set, get) => ({
         [finalName]: newModelState,
       },
     });
+
+    // Returned so callers that create a tab before `defaults` has necessarily
+    // arrived (useExplorerWorkbenchInit's cold-session auto-create,
+    // VIS-1082) can remember which tab to rebind once it does.
+    return finalName;
+  },
+
+  /**
+   * VIS-1082 — cold-session default-source race. `createModelTab` resolves
+   * its source at CREATE time from whatever `state.defaults` holds right
+   * then; on a cold session the auto-create-model-tab effect
+   * (useExplorerWorkbenchInit.js) can fire before `fetchDefaults()` (a
+   * separate, unordered effect) has landed, silently falling back to "first
+   * available source" instead of the project's configured default. Call this
+   * once `defaults` arrives to correct a tab that was minted before that —
+   * a no-op if the user already picked a source themselves (`sourceEdited`)
+   * or the tab's source already matches. Deliberately does NOT set
+   * `sourceEdited` — this is still a resolved default, not a user edit (same
+   * distinction `setActiveModelSource`'s own comment draws).
+   */
+  applyResolvedDefaultSource: (modelName, sourceName) => {
+    if (!modelName || !sourceName) return;
+    const state = get();
+    const modelState = state.explorerModelStates[modelName];
+    if (!modelState || modelState.sourceEdited) return;
+    if (modelState.sourceName === sourceName) return;
+    set({
+      explorerModelStates: {
+        ...state.explorerModelStates,
+        [modelName]: { ...modelState, sourceName },
+      },
+    });
   },
 
   /**

--- a/viewer/src/stores/explorerStore.test.js
+++ b/viewer/src/stores/explorerStore.test.js
@@ -233,6 +233,66 @@ describe('explorerStore', () => {
 
       expect(useStore.getState().explorerActiveModelName).toBe('second');
     });
+
+    it('returns the resolved tab name (VIS-1082 — callers rebind against it later)', () => {
+      expect(useStore.getState().createModelTab()).toBe('model');
+      expect(useStore.getState().createModelTab('explicit')).toBe('explicit');
+    });
+  });
+
+  // ====================================================================
+  // applyResolvedDefaultSource (VIS-1082 — cold-session default-source race)
+  // ====================================================================
+  describe('applyResolvedDefaultSource', () => {
+    it('rebinds a tab created before defaults arrived', () => {
+      useStore.setState({ defaults: null, explorerSources: [{ source_name: 'first-source' }] });
+      const name = useStore.getState().createModelTab();
+      expect(useStore.getState().explorerModelStates[name].sourceName).toBe('first-source');
+
+      useStore.getState().applyResolvedDefaultSource(name, 'the-real-default');
+
+      expect(useStore.getState().explorerModelStates[name].sourceName).toBe('the-real-default');
+    });
+
+    it('does not mark the tab sourceEdited (still a resolved default, not a user edit)', () => {
+      const name = useStore.getState().createModelTab();
+      useStore.getState().applyResolvedDefaultSource(name, 'the-real-default');
+      expect(useStore.getState().explorerModelStates[name].sourceEdited).toBeFalsy();
+    });
+
+    it('is a no-op once the user has explicitly picked a source (sourceEdited)', () => {
+      const name = useStore.getState().createModelTab();
+      useStore.getState().setActiveModelSource('user-chosen-source');
+
+      useStore.getState().applyResolvedDefaultSource(name, 'the-real-default');
+
+      expect(useStore.getState().explorerModelStates[name].sourceName).toBe('user-chosen-source');
+    });
+
+    it('is a no-op when the tab already has the resolved source', () => {
+      useStore.setState({ defaults: { source_name: 'already-right' } });
+      const name = useStore.getState().createModelTab();
+      const before = useStore.getState().explorerModelStates[name];
+
+      useStore.getState().applyResolvedDefaultSource(name, 'already-right');
+
+      expect(useStore.getState().explorerModelStates[name]).toBe(before); // same reference — no set() fired
+    });
+
+    it('is a no-op for an unknown model name (no crash)', () => {
+      expect(() =>
+        useStore.getState().applyResolvedDefaultSource('exp_nope', 'some-source')
+      ).not.toThrow();
+    });
+
+    it('is a no-op when sourceName is falsy (no configured project default)', () => {
+      const name = useStore.getState().createModelTab();
+      const before = useStore.getState().explorerModelStates[name];
+
+      useStore.getState().applyResolvedDefaultSource(name, null);
+
+      expect(useStore.getState().explorerModelStates[name]).toBe(before);
+    });
   });
 
   // Explore 2.0 Phase 3a (D9): a Library schema-table row dropped on the SQL

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -44,6 +44,38 @@
  * implement TRUE discard for "Close without saving" on a dirty exploration
  * tab — see their docstrings below for why a naive close used to silently
  * re-persist the very draft the user asked to discard.
+ *
+ * WRITE SERIALIZATION (VIS-1085, extended by the Phase 4 delta P4-D1): every
+ * write that touches a given exploration's on-disk JSON document — the
+ * debounced draft sync (`runSync`), an immediate rename (`renameExploration`),
+ * a discard revert (`discardExploration`), AND an append-only promotion
+ * record (`recordExplorationPromotion`) — is enqueued onto a per-id promise
+ * chain (`_writeQueues`/`enqueueWrite`) rather than fired directly. The first
+ * three go through the backend's generic `ExplorationRepository.update()`;
+ * `recordExplorationPromotion` goes through the separate `record_promotion()`
+ * method — but BOTH are unlocked read-modify-writes on the exact same file
+ * (full `_read()` -> patch -> `_write()`, no lock, no version check), so two
+ * of ANY of these four requests landing concurrently for the SAME id — e.g. a
+ * rename firing the instant the draft-sync debounce also fires, or a
+ * keyboard-shortcut tab switch mid-promote unmounting `ExplorationPane` and
+ * firing its flush-on-deactivate while `promoteExploration`'s own
+ * `recordExplorationPromotion` call is still in flight — can each `_read()`
+ * before either `_write()` lands, so whichever writes last silently clobbers
+ * the other's field (including wiping a just-appended `promoted[]` entry).
+ * Serializing on the CLIENT guarantees at most one write for a given id is
+ * ever in flight, closing the race without needing any backend locking.
+ * `useWorkspaceTabShortcuts.js`'s `hasBlockingModal` guard closes the other
+ * half of P4-D1: it stops the keyboard-driven unmount from happening AT ALL
+ * while `ExplorationPromoteModal` (or any other blocking modal) is open, so
+ * the race this queue defends against becomes unreachable via that path,
+ * not just survivable.
+ *
+ * DELETED REMOTELY (VIS-1083): a 404 from `update()` means the record was
+ * removed out from under this session (another tab/session's delete, or an
+ * out-of-band `rm .visivo/explorations/<id>.json`) — see `runSync`'s catch
+ * and `recreateExplorationFromDeleted`/`discardDeletedExploration` below for
+ * how the slice stops silently retrying forever and instead surfaces a
+ * recoverable state (`syncStatus: 'deleted-remotely'`).
  */
 
 import * as explorationsApi from '../api/explorations';
@@ -88,6 +120,32 @@ const clearPendingSyncTimer = id => {
     clearTimeout(timer);
     _pendingSyncTimers.delete(id);
   }
+};
+
+// VIS-1085: id -> the tail of that id's serialized-write promise chain. Every
+// `explorationsApi.updateExploration` call for a given id is enqueued here
+// (`enqueueWrite`) so the debounced draft sync, an immediate rename, and a
+// discard revert never race each other against the backend's unlocked
+// read-modify-write. Module-level for the same reason `_pendingSyncTimers`
+// is — ephemeral, per-record bookkeeping, not reactive state.
+const _writeQueues = new Map();
+
+/** Test-only: clear all write queues so state doesn't leak across test files. */
+export const _resetExplorationWriteQueuesForTests = () => {
+  _writeQueues.clear();
+};
+
+/** Run `task` after every currently-queued write for `id` has settled
+ * (success or failure — one write's failure must never wedge the next write
+ * behind it forever), and become the new tail of that chain. */
+const enqueueWrite = (id, task) => {
+  const previous = _writeQueues.get(id) || Promise.resolve();
+  const next = previous.then(task, task);
+  // The tail stored for the NEXT enqueue must never be a rejected promise
+  // (an unhandled rejection on a value nothing else awaits) — callers still
+  // observe the real outcome via the `next` this function returns.
+  _writeQueues.set(id, next.catch(() => {}));
+  return next;
 };
 
 const mapDraftFromApi = draft => ({
@@ -158,9 +216,11 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       // `record` was read at the top of runSync (fire time), which — thanks to
       // scheduleSync always clearing/re-arming a single timer per id — already
       // reflects the LATEST optimistic draft, not a stale scheduling-time one.
-      const updated = await explorationsApi.updateExploration(id, {
-        draft: mapDraftToApi(record.draft),
-      });
+      // VIS-1085: enqueued (not fired directly) so this can never interleave
+      // with a concurrent rename/discard-revert write for the SAME id.
+      const updated = await enqueueWrite(id, () =>
+        explorationsApi.updateExploration(id, { draft: mapDraftToApi(record.draft) })
+      );
       set(state =>
         patchExploration(state, id, {
           draft: mapDraftFromApi(updated.draft),
@@ -170,6 +230,18 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       );
       return { success: true };
     } catch (error) {
+      // VIS-1083: a 404 means the record is gone (deleted from another
+      // session, or removed out-of-band) — the update() route will 404
+      // forever, so retrying (as every subsequent keystroke otherwise would,
+      // via updateExplorationDraft re-arming scheduleSync) is pointless and
+      // silent. Stop here with a distinct, recoverable status instead of the
+      // generic 'error' — `updateExplorationDraft` below checks for it and
+      // stops re-arming the sync loop; the UI (ExplorationPane) surfaces a
+      // banner with real options (recreate / close) rather than nothing.
+      if (error?.status === 404) {
+        set(state => patchExploration(state, id, { syncStatus: 'deleted-remotely' }));
+        return { success: false, error: error.message, deletedRemotely: true };
+      }
       set(state => patchExploration(state, id, { syncStatus: 'error' }));
       return { success: false, error: error.message };
     }
@@ -249,6 +321,16 @@ const createWorkspaceExplorationsSlice = (set, get) => {
     updateExplorationDraft: (id, nextDraft) => {
       const existing = get().workspaceExplorations.byId[id];
       if (!existing) return;
+      // VIS-1083: once the backend has told us this record is gone (a prior
+      // sync 404'd), never re-arm the sync loop — every further keystroke
+      // would otherwise schedule another doomed POST forever, silently
+      // failing on repeat with no way out. Keep the local edit (nothing is
+      // lost while the user decides what to do) but stop trying to persist
+      // it until they act on the banner (recreate / close).
+      if (existing.syncStatus === 'deleted-remotely') {
+        set(state => patchExploration(state, id, { draft: nextDraft }));
+        return;
+      }
       set(state => patchExploration(state, id, { draft: nextDraft, syncStatus: 'saving' }));
       scheduleSync(id);
     },
@@ -313,6 +395,74 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       return { success: true };
     },
 
+    /**
+     * VIS-1083 — "Recreate as new exploration" option on the
+     * deleted-remotely banner (`ExplorationPane`/`ExplorationDeletedRemotelyBanner`):
+     * the backend record for `id` is confirmed gone (a prior sync 404'd), but
+     * this session's local draft — everything typed since the last
+     * successful sync — is still sitting in `workspaceExplorations.byId[id]`.
+     * Mints a BRAND NEW exploration seeded from that local draft (never
+     * retries the dead id — it will 404 forever), drops the dead local
+     * record, force-closes its tab, and opens the new one in its place.
+     */
+    recreateExplorationFromDeleted: async id => {
+      const existing = get().workspaceExplorations.byId[id];
+      if (!existing) return { success: false, error: 'Exploration not found' };
+      try {
+        const created = await explorationsApi.createExploration({
+          name: existing.name,
+          seeded_from: existing.seededFrom || undefined,
+          draft: mapDraftToApi(existing.draft),
+        });
+        const mapped = mapExplorationFromApi(created);
+        set(state => insertExploration(state, mapped));
+        clearPendingSyncTimer(id);
+        _writeQueues.delete(id);
+        const tabId = `exploration:${id}`;
+        get().closeWorkspaceTab?.(tabId);
+        set(state => {
+          const nextById = { ...state.workspaceExplorations.byId };
+          delete nextById[id];
+          return {
+            workspaceExplorations: {
+              byId: nextById,
+              order: state.workspaceExplorations.order.filter(existingId => existingId !== id),
+            },
+          };
+        });
+        get().openWorkspaceTab?.({
+          id: `exploration:${mapped.id}`,
+          type: 'exploration',
+          name: mapped.id,
+        });
+        return { success: true, id: mapped.id, exploration: mapped };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    },
+
+    /** VIS-1083 — "Close" option on the deleted-remotely banner: the backend
+     * record is already gone, so there's nothing left to persist or lose —
+     * just drop the dead local record and force-close its tab (no confirm
+     * dialog; a 404'd record can't have a meaningful "unsaved changes"
+     * guarantee to honor). */
+    discardDeletedExploration: id => {
+      clearPendingSyncTimer(id);
+      _writeQueues.delete(id);
+      const tabId = `exploration:${id}`;
+      get().closeWorkspaceTab?.(tabId);
+      set(state => {
+        const nextById = { ...state.workspaceExplorations.byId };
+        delete nextById[id];
+        return {
+          workspaceExplorations: {
+            byId: nextById,
+            order: state.workspaceExplorations.order.filter(existingId => existingId !== id),
+          },
+        };
+      });
+    },
+
     /** Rename `id` — persists immediately (not debounced; a rename is a
      * deliberate one-gesture commit, not exploratory typing) via the generic
      * update route (`name` is a mutable field, 07-exploration-api-contract.md).
@@ -326,11 +476,20 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       const previousName = existing.name;
       set(state => patchExploration(state, id, { name: trimmed }));
       try {
-        const updated = await explorationsApi.updateExploration(id, { name: trimmed });
+        // VIS-1085: enqueued so a rename landing in the same window as the
+        // debounced draft-sync can never interleave with it — see the file
+        // docstring's "WRITE SERIALIZATION" note.
+        const updated = await enqueueWrite(id, () =>
+          explorationsApi.updateExploration(id, { name: trimmed })
+        );
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, mapped));
         return { success: true, exploration: mapped };
       } catch (error) {
+        if (error?.status === 404) {
+          set(state => patchExploration(state, id, { syncStatus: 'deleted-remotely' }));
+          return { success: false, error: error.message, deletedRemotely: true };
+        }
         set(state => patchExploration(state, id, { name: previousName }));
         return { success: false, error: error.message };
       }
@@ -391,6 +550,29 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      * activated) or a failed revert POST never blocks the tab from closing —
      * "Close without saving" always closes; the discard itself degrades
      * gracefully.
+     *
+     * Phase 4 delta (P4-D4) — "ghost trail" fix: the discard SNAPSHOT is
+     * `draft`-only (`snapshotExplorationForDiscard`, above) and the revert
+     * POST's payload is deliberately `{ draft }` alone — `name`/`return_to`
+     * are never part of this operation, and `promoted[]` is immutable via
+     * the generic update route on the BACKEND regardless of payload (see
+     * `exploration_repository.py`'s `update()`/`TestImmutability`). So a
+     * partial-promote-then-discard can never have this call's OWN payload
+     * erase a promotion. The remaining risk was staleness, not payload
+     * shape: `update()` is a `_read()` -> patch -> `_write()`-the-FULL-
+     * document round trip, so if this revert's `_read()` landed before a
+     * concurrent `recordExplorationPromotion` write, this call's OWN
+     * `_write()` could persist a document based on that stale read —
+     * silently reverting the just-appended promotion even though this
+     * payload never mentioned it. `enqueueWrite` below closes that (both
+     * writers for one id are now strictly serialized — see the file
+     * docstring), so on success this always reflects the CURRENT server
+     * document, INCLUDING any promotion recorded ahead of it in the queue —
+     * applied back into local state so the Build-rail promoted trail
+     * (`ExplorationBuildRail.jsx`) never lags behind server truth after a
+     * discard. `draft` is deliberately excluded from that merge — the
+     * snapshot already reverted above IS the authoritative post-discard
+     * draft (byte-identical to what this POST just echoed back).
      */
     discardExploration: async id => {
       clearPendingSyncTimer(id);
@@ -402,19 +584,42 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       get().restoreExplorerWorkingState?.(draftToLegacyState(snapshot));
 
       try {
-        await explorationsApi.updateExploration(id, { draft: mapDraftToApi(snapshot) });
+        // VIS-1085: enqueued alongside every other write for this id — see
+        // the file docstring's "WRITE SERIALIZATION" note.
+        const updated = await enqueueWrite(id, () =>
+          explorationsApi.updateExploration(id, { draft: mapDraftToApi(snapshot) })
+        );
+        const mapped = mapExplorationFromApi(updated);
+        set(state => patchExploration(state, id, { promoted: mapped.promoted, updatedAt: mapped.updatedAt }));
         return { success: true, reverted: true };
       } catch (error) {
+        // A 404 here just means the record was ALSO deleted remotely in the
+        // same window — the tab is closing regardless (discard is
+        // best-effort, per the docstring above), so there's nothing further
+        // to surface; the record is gone either way.
         return { success: false, reverted: true, error: error.message };
       }
     },
 
     /** Append-only promotion record (07-exploration-api-contract.md's
      * record-promotion sub-action) — call after a `saveX` action succeeds
-     * for a promoted object. */
+     * for a promoted object.
+     *
+     * Phase 4 delta (P4-D1): enqueued alongside every other write for this
+     * id (draft sync / rename / discard revert). `record_promotion()`
+     * (exploration_repository.py) is a SEPARATE backend method from the
+     * generic `update()` route, but reads and rewrites the exact same
+     * on-disk JSON document with the exact same unlocked read-modify-write
+     * shape — so it needs the same client-side serialization to stay safe
+     * against a concurrent `update()` write for this id (e.g. a keyboard
+     * shortcut mid-`promoteExploration` unmounting `ExplorationPane`, whose
+     * deactivate cleanup fires a draft-sync flush). Without this, whichever
+     * write's `_read()` happened first can have its `_write()` land last and
+     * silently clobber the other's persisted field, INCLUDING wiping the
+     * just-appended `promoted[]` entry this call exists to record. */
     recordExplorationPromotion: async (id, type, name) => {
       try {
-        const updated = await explorationsApi.recordPromotion(id, type, name);
+        const updated = await enqueueWrite(id, () => explorationsApi.recordPromotion(id, type, name));
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, mapped));
         return { success: true };

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -15,6 +15,7 @@ import {
   _resetExplorationSyncTimersForTests,
   _openDraftSnapshots,
   _resetExplorationSnapshotsForTests,
+  _resetExplorationWriteQueuesForTests,
 } from './workspaceExplorationsStore';
 import { buildPromoteChecklist } from './promoteChecklist';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
@@ -66,12 +67,14 @@ const seedRecord = (overrides = {}) => {
 const reset = () => {
   _resetExplorationSyncTimersForTests();
   _resetExplorationSnapshotsForTests();
+  _resetExplorationWriteQueuesForTests();
   act(() => {
     useStore.setState({
       workspaceExplorations: { byId: {}, order: [] },
       workspaceTabs: [],
       workspaceToast: null,
       closeWorkspaceTab: jest.fn(),
+      openWorkspaceTab: jest.fn(),
       restoreExplorerWorkingState: jest.fn(),
       explorerInsightStates: {},
     });
@@ -91,6 +94,7 @@ afterEach(() => {
   jest.useRealTimers();
   _resetExplorationSyncTimersForTests();
   _resetExplorationSnapshotsForTests();
+  _resetExplorationWriteQueuesForTests();
 });
 
 describe('fetchExplorations', () => {
@@ -340,6 +344,203 @@ describe('updateExplorationDraft', () => {
     });
     expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
   });
+
+  // VIS-1083: once a prior sync has 404'd (syncStatus 'deleted-remotely'),
+  // further edits must never re-arm the sync loop against a record that will
+  // 404 forever — but the local edit itself must still land (nothing lost).
+  test('does NOT re-arm the sync loop once syncStatus is deleted-remotely, but keeps the local edit', () => {
+    seedRecord({ syncStatus: 'deleted-remotely' });
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'q', sql: 'SELECT 2' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+
+    const record = useStore.getState().workspaceExplorations.byId.exp_1;
+    expect(record.draft.queries[0].sql).toBe('SELECT 2');
+    expect(record.syncStatus).toBe('deleted-remotely'); // never flipped to 'saving'
+    expect(_pendingSyncTimers.has('exp_1')).toBe(false);
+
+    // Even after the usual debounce window, still no network call.
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+  });
+});
+
+describe('runSync — VIS-1083 deleted-remotely (404 handling)', () => {
+  const notFoundError = () => {
+    const error = new Error('Exploration not found');
+    error.status = 404;
+    return error;
+  };
+
+  test('a 404 on the debounced sync sets syncStatus to deleted-remotely, not the generic error', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockRejectedValueOnce(notFoundError());
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe(
+      'deleted-remotely'
+    );
+  });
+
+  test('a non-404 failure still sets the generic error status (regression guard)', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockRejectedValueOnce(new Error('offline'));
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe('error');
+  });
+
+  test('flushExplorationSync surfaces deletedRemotely:true on a 404', async () => {
+    seedRecord();
+    explorationsApi.updateExploration.mockRejectedValueOnce(notFoundError());
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().flushExplorationSync('exp_1');
+    });
+    expect(result).toMatchObject({ success: false, deletedRemotely: true });
+  });
+});
+
+describe('recreateExplorationFromDeleted (VIS-1083)', () => {
+  test('mints a new exploration from the local draft, drops the dead record, force-closes its tab, and opens the new one', async () => {
+    seedRecord({
+      id: 'exp_1',
+      name: 'Churn dig',
+      syncStatus: 'deleted-remotely',
+      draft: { queries: [{ name: 'q1', sql: 'SELECT 1' }], insights: [], chart: null, computedColumns: [] },
+    });
+    const closeWorkspaceTab = jest.fn();
+    const openWorkspaceTab = jest.fn();
+    useStore.setState({ closeWorkspaceTab, openWorkspaceTab });
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({
+        id: 'exp_2',
+        name: 'Churn dig',
+        draft: { queries: [{ name: 'q1', sql: 'SELECT 1' }], insights: [], chart: null, computed_columns: [] },
+      })
+    );
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().recreateExplorationFromDeleted('exp_1');
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Churn dig' })
+    );
+    expect(result).toMatchObject({ success: true, id: 'exp_2' });
+    const state = useStore.getState().workspaceExplorations;
+    expect(state.byId.exp_1).toBeUndefined();
+    expect(state.byId.exp_2).toBeDefined();
+    expect(closeWorkspaceTab).toHaveBeenCalledWith('exploration:exp_1');
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'exploration:exp_2',
+      type: 'exploration',
+      name: 'exp_2',
+    });
+  });
+
+  test('returns success:false for an unknown id', async () => {
+    let result;
+    await act(async () => {
+      result = await useStore.getState().recreateExplorationFromDeleted('exp_missing');
+    });
+    expect(result).toEqual({ success: false, error: 'Exploration not found' });
+  });
+
+  test('returns success:false when the create POST itself fails', async () => {
+    seedRecord({ syncStatus: 'deleted-remotely' });
+    explorationsApi.createExploration.mockRejectedValueOnce(new Error('offline'));
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().recreateExplorationFromDeleted('exp_1');
+    });
+    expect(result).toEqual({ success: false, error: 'offline' });
+    // The dead local record is left in place on failure — nothing to recover
+    // into otherwise.
+    expect(useStore.getState().workspaceExplorations.byId.exp_1).toBeDefined();
+  });
+});
+
+describe('discardDeletedExploration (VIS-1083)', () => {
+  test('drops the local record and force-closes its tab, without any network call', () => {
+    seedRecord({ syncStatus: 'deleted-remotely' });
+    const closeWorkspaceTab = jest.fn();
+    useStore.setState({ closeWorkspaceTab });
+
+    act(() => {
+      useStore.getState().discardDeletedExploration('exp_1');
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1).toBeUndefined();
+    expect(closeWorkspaceTab).toHaveBeenCalledWith('exploration:exp_1');
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+    expect(explorationsApi.deleteExploration).not.toHaveBeenCalled();
+  });
+
+  test('clears any still-pending sync timer so it can never fire after the tab is gone', () => {
+    seedRecord({ syncStatus: 'saving' });
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    expect(_pendingSyncTimers.has('exp_1')).toBe(true);
+
+    act(() => {
+      useStore.getState().discardDeletedExploration('exp_1');
+    });
+    expect(_pendingSyncTimers.has('exp_1')).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+  });
 });
 
 describe('flushExplorationSync', () => {
@@ -578,6 +779,178 @@ describe('renameExploration', () => {
     });
     expect(result).toEqual({ success: false, error: 'Exploration not found' });
   });
+
+  test('a 404 marks the record deleted-remotely instead of rolling back the name (VIS-1083)', async () => {
+    seedRecord({ name: 'Scratch' });
+    const error = new Error('Exploration not found');
+    error.status = 404;
+    explorationsApi.updateExploration.mockRejectedValueOnce(error);
+
+    let result;
+    await act(async () => {
+      result = await useStore.getState().renameExploration('exp_1', 'Churn dig');
+    });
+
+    expect(result).toMatchObject({ success: false, deletedRemotely: true });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe(
+      'deleted-remotely'
+    );
+  });
+});
+
+describe('VIS-1085 — per-id write serialization (rename vs debounced draft-sync)', () => {
+  test('a rename fired while a draft-sync write is in flight for the SAME id waits for it (no concurrent update() calls)', async () => {
+    seedRecord();
+    let resolveDraftSync;
+    explorationsApi.updateExploration.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveDraftSync = resolve;
+        })
+    );
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration({ name: 'Renamed' }));
+
+    // Arm + fire the debounced draft-sync — its own updateExploration call is
+    // now in flight (deliberately left unresolved).
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'q', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    // Fire a rename WHILE that write is still unresolved — it must not
+    // dispatch its own network call yet (queued behind the in-flight write).
+    let renamePromise;
+    act(() => {
+      renamePromise = useStore.getState().renameExploration('exp_1', 'Renamed');
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    // Resolving the draft-sync's write unblocks the queued rename write.
+    await act(async () => {
+      resolveDraftSync(wireExploration());
+      await renamePromise;
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(2);
+    expect(explorationsApi.updateExploration).toHaveBeenNthCalledWith(2, 'exp_1', {
+      name: 'Renamed',
+    });
+  });
+
+  test('a debounced draft-sync fired while a rename is in flight for the SAME id waits for it (reverse ordering)', async () => {
+    seedRecord();
+    let resolveRename;
+    explorationsApi.updateExploration.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveRename = resolve;
+        })
+    );
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration());
+
+    let renamePromise;
+    await act(async () => {
+      renamePromise = useStore.getState().renameExploration('exp_1', 'Renamed');
+      // Let the rename's own enqueueWrite microtask actually dispatch its
+      // network call before asserting on the mock's call count below.
+      await Promise.resolve();
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    // Arm + fire the debounced draft-sync while the rename's write is still
+    // unresolved — it must queue behind it, not fire concurrently.
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'q', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRename(wireExploration({ name: 'Renamed' }));
+      await renamePromise;
+      // Let the now-unblocked draft-sync write's microtask actually dispatch.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(2);
+    expect(explorationsApi.updateExploration).toHaveBeenNthCalledWith(2, 'exp_1', {
+      draft: {
+        queries: [{ name: 'q', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computed_columns: [],
+        legacy_state: null,
+      },
+    });
+  });
+
+  test('writes for DIFFERENT ids are never serialized against each other', async () => {
+    seedRecord({ id: 'exp_1' });
+    act(() => {
+      useStore.setState(state => ({
+        workspaceExplorations: {
+          byId: { ...state.workspaceExplorations.byId, exp_2: mappedRecord({ id: 'exp_2' }) },
+          order: [...state.workspaceExplorations.order, 'exp_2'],
+        },
+      }));
+    });
+    let resolveFirst;
+    explorationsApi.updateExploration.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFirst = resolve;
+        })
+    );
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration({ id: 'exp_2' }));
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    // A write for a DIFFERENT id must dispatch immediately, unblocked by
+    // exp_1's still-in-flight write.
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_2', {
+        queries: [],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveFirst(wireExploration());
+    });
+  });
 });
 
 describe('VIS-1081 discard mechanics', () => {
@@ -721,6 +1094,174 @@ describe('recordExplorationPromotion', () => {
       result = await useStore.getState().recordExplorationPromotion('exp_1', 'model', 'orders_q');
     });
     expect(result).toEqual({ success: false, error: 'boom' });
+  });
+});
+
+// P4-D1 — a keyboard-driven tab switch mid-promote used to be able to race
+// recordExplorationPromotion's append against a concurrent draft-sync/rename/
+// discard write for the SAME id (both hit the same unlocked backend JSON
+// document). Pins that recordExplorationPromotion now shares the same per-id
+// write queue as every other writer — see the file docstring's "WRITE
+// SERIALIZATION" note.
+describe('recordExplorationPromotion — P4-D1 write serialization', () => {
+  test('queues behind an in-flight draft-sync write for the same id (no concurrent requests)', async () => {
+    seedRecord();
+    let resolveDraftSync;
+    explorationsApi.updateExploration.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveDraftSync = resolve;
+        })
+    );
+    explorationsApi.recordPromotion.mockResolvedValueOnce(
+      wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+    );
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'q', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+    expect(explorationsApi.recordPromotion).not.toHaveBeenCalled();
+
+    let promotionPromise;
+    act(() => {
+      promotionPromise = useStore.getState().recordExplorationPromotion('exp_1', 'model', 'orders_q');
+    });
+    // Must NOT fire yet — the draft-sync write is still unresolved.
+    expect(explorationsApi.recordPromotion).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDraftSync(wireExploration());
+      await promotionPromise;
+    });
+
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledTimes(1);
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith('exp_1', 'model', 'orders_q');
+  });
+
+  test('a draft-sync fired while a promotion is in flight for the same id waits for it (reverse ordering)', async () => {
+    seedRecord();
+    let resolvePromotion;
+    explorationsApi.recordPromotion.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolvePromotion = resolve;
+        })
+    );
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration());
+
+    let promotionPromise;
+    await act(async () => {
+      promotionPromise = useStore.getState().recordExplorationPromotion('exp_1', 'model', 'orders_q');
+      await Promise.resolve();
+    });
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', {
+        queries: [{ name: 'q', sql: 'x' }],
+        insights: [],
+        chart: null,
+        computedColumns: [],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    // Queued behind the still-unresolved promotion write.
+    expect(explorationsApi.updateExploration).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolvePromotion(
+        wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+      );
+      await promotionPromise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+  });
+});
+
+// P4-D4 — "Close without saving" after a partial promote must never leave a
+// ghost entry (an entry that gets silently wiped) OR a stale one — the
+// discard revert's payload never mentions `promoted` (immutable via that
+// route regardless), and once serialized (P4-D1), the revert's OWN response
+// is the current server document, applied back so the Build-rail promoted
+// trail (ExplorationBuildRail.jsx) never lags server truth after a discard.
+describe('discardExploration — P4-D4 promoted[] integrity', () => {
+  test('the revert POST payload never includes `promoted` or `name`, only `draft`', async () => {
+    seedRecord({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] });
+    act(() => {
+      useStore.getState().snapshotExplorationForDiscard('exp_1');
+    });
+    explorationsApi.updateExploration.mockResolvedValueOnce(
+      wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+    );
+
+    await act(async () => {
+      await useStore.getState().discardExploration('exp_1');
+    });
+
+    const payload = explorationsApi.updateExploration.mock.calls[0][1];
+    expect(Object.keys(payload)).toEqual(['draft']);
+  });
+
+  test('after a successful revert, local promoted[] reflects the server response (re-reads server state post-discard)', async () => {
+    seedRecord({ promoted: [] });
+    act(() => {
+      useStore.getState().snapshotExplorationForDiscard('exp_1');
+    });
+    // The server's document already has a promotion recorded ahead of this
+    // revert in the write queue (e.g. a promote that landed just before the
+    // user chose "Close without saving") — the revert's own response is the
+    // CURRENT document, including it.
+    explorationsApi.updateExploration.mockResolvedValueOnce(
+      wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+    );
+
+    await act(async () => {
+      await useStore.getState().discardExploration('exp_1');
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.promoted).toEqual([
+      { type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' },
+    ]);
+  });
+
+  test('a promotion recorded, then a discard, leaves promoted[] intact (no ghost erasure)', async () => {
+    seedRecord({ promoted: [] });
+    act(() => {
+      useStore.getState().snapshotExplorationForDiscard('exp_1');
+    });
+    explorationsApi.recordPromotion.mockResolvedValueOnce(
+      wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+    );
+    await act(async () => {
+      await useStore.getState().recordExplorationPromotion('exp_1', 'model', 'orders_q');
+    });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.promoted).toHaveLength(1);
+
+    // The server's document (as this revert's response echoes) still carries
+    // the promotion — because it's the SAME document the promotion just
+    // wrote, and the two writes are serialized (never overlapping _read()s).
+    explorationsApi.updateExploration.mockResolvedValueOnce(
+      wireExploration({ promoted: [{ type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' }] })
+    );
+    await act(async () => {
+      await useStore.getState().discardExploration('exp_1');
+    });
+
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.promoted).toHaveLength(1);
   });
 });
 

--- a/visivo/server/repositories/exploration_repository.py
+++ b/visivo/server/repositories/exploration_repository.py
@@ -20,6 +20,7 @@ import json
 import os
 import secrets
 import tempfile
+import threading
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -29,6 +30,22 @@ from visivo.models.exploration import Exploration, PromotionRecord
 class ExplorationRepository:
     def __init__(self, explorations_dir: str):
         self.explorations_dir = explorations_dir
+        # VIS-1086: guards the "resolve a name (default or explicit,
+        # including the id mint) then persist" critical section in
+        # `create()`. `hot_reload_server.py` runs Flask with
+        # `async_mode="threading"`, so concurrent HTTP requests are real
+        # concurrent OS threads within this ONE process — a bare
+        # count(existing)->name computation (`_default_name`) has no
+        # serialization against a second thread doing the exact same read
+        # before either has written, so two requests racing the same narrow
+        # window (a double-click on "+ New exploration"/a source tile, or two
+        # browser windows both landing on a fresh empty project) could mint
+        # the SAME default name. This lock makes "pick a free name and
+        # reserve it by writing" atomic from this process's perspective; it
+        # intentionally does NOT protect against a second OS PROCESS writing
+        # into the same directory (not this bug's scenario — see module
+        # docstring).
+        self._create_lock = threading.Lock()
 
     def _ensure_dir(self) -> None:
         os.makedirs(self.explorations_dir, exist_ok=True)
@@ -55,8 +72,24 @@ class ExplorationRepository:
         # "Scratch" for the very first exploration, "Exploration N" after
         # (resolved question 3, 03-delivery-plan.md): a one-gesture create
         # with no naming prompt.
-        count = len(self._existing_ids())
-        return "Scratch" if count == 0 else f"Exploration {count + 1}"
+        #
+        # VIS-1086: the count-based candidate is cheap but blind — collision-
+        # checked against the CURRENT set of existing names (already resident
+        # from the read below, no extra I/O) and incremented until free
+        # rather than minted unconditionally. Must be called with
+        # `_create_lock` held (see `__init__`) for this to actually close the
+        # race rather than merely narrow it — the collision check alone,
+        # without the lock, still has a read-then-write gap two threads could
+        # both slip through.
+        existing_names = {e.name for e in self.list()}
+        count = len(existing_names)
+        candidate = "Scratch" if count == 0 else f"Exploration {count + 1}"
+        if candidate not in existing_names:
+            return candidate
+        n = count + 1
+        while f"Exploration {n}" in existing_names:
+            n += 1
+        return f"Exploration {n}"
 
     def _write(self, exploration: Exploration) -> None:
         self._ensure_dir()
@@ -95,17 +128,23 @@ class ExplorationRepository:
         draft: Optional[dict] = None,
     ) -> Exploration:
         now = datetime.now(timezone.utc)
-        exploration = Exploration(
-            id=self._mint_id(),
-            name=name or self._default_name(),
-            created_at=now,
-            updated_at=now,
-            seeded_from=seeded_from,
-            return_to=return_to,
-            draft=draft if draft is not None else {},
-            promoted=[],
-        )
-        self._write(exploration)
+        # VIS-1086: the whole "resolve id + name, then write" sequence is
+        # serialized per-process (`_create_lock`) so two concurrent creates
+        # (double-click on a create door, or two browser windows racing a
+        # fresh empty project) can never both observe the same "N existing"
+        # snapshot before either has written — see `__init__`'s comment.
+        with self._create_lock:
+            exploration = Exploration(
+                id=self._mint_id(),
+                name=name or self._default_name(),
+                created_at=now,
+                updated_at=now,
+                seeded_from=seeded_from,
+                return_to=return_to,
+                draft=draft if draft is not None else {},
+                promoted=[],
+            )
+            self._write(exploration)
         return exploration
 
     def get(self, exploration_id: str) -> Optional[Exploration]:


### PR DESCRIPTION
## Summary

Fixes the five combination-discovered bugs from the adversarial e2e-gap review (`specs/plan/explorer-workspace-unification/research/e2e-gap-review.md`, findings #2, #7, #8/#9, #10, #11), plus two items from that review's just-completed Phase 4 delta pass (P4-D1, P4-D4) that were explicitly folded into this workstream because they extend VIS-1085's write-serialization mechanism.

## Per-bug fixes

**VIS-1082 (HIGH) — cold-session default-source race.** `useExplorerWorkbenchInit.js`'s auto-create-model-tab effect fires as soon as sources arrive, with no dependency on `state.defaults` (a separate, unordered fetch) — a cold session could silently bind the first auto-created query to the wrong source. Fixed by remembering whether `defaults` had already landed at creation time and rebinding (`applyResolvedDefaultSource`, `explorerStore.js`) once it does, rather than blocking creation (which would reopen a real data-loss race the effect exists to close).

**VIS-1083 — cross-session delete → silent forever-stuck sync.** A 404 on the debounced draft POST (record deleted in another session) used to retry forever with a generic error. Now `runSync` sets `syncStatus: 'deleted-remotely'`, `updateExplorationDraft` stops re-arming the sync loop, and `ExplorationPane` shows a new `ExplorationDeletedRemotelyBanner` with real recovery options — "Recreate as new exploration" or "Close tab". A parked tab also gets a warning indicator in `TabStrip`.

**VIS-1084 — stale create-completion yanks navigation.** Switching destinations while "+ New exploration"/a source tile's create was still in flight let the stale completion force-navigate back once it resolved. Fixed with a `mountedRef` guard in `ExplorerHomePane.jsx` (same pattern as `useRecordSave.js`).

**VIS-1085 — rename racing draft-sync clobbers a write.** `ExplorationRepository.update()` is an unlocked read-modify-write; a rename firing near the debounced draft-sync could silently lose one write. Fixed with a per-id client-side write queue (`_writeQueues`/`enqueueWrite`, `workspaceExplorationsStore.js`) serializing every writer for a given exploration id.

**VIS-1086 — double-click mints duplicates.** Every create door (`+ New`, source tiles, Duplicate) now has an in-flight guard checked synchronously inside the handler (not just a `disabled` attribute, which a real double-click can outrun). Backend defense in depth: `ExplorationRepository.create()` is now serialized per-process via a `threading.Lock`, and `_default_name()` collision-checks its candidate against current names.

## Phase 4 delta (folded in per review routing)

**P4-D1 (HIGH) — promote-modal keyboard race.** A keyboard-driven tab/view switch mid-promote (Cmd+1-9/W/T) had no modal-open check, unmounting `ExplorationPane` mid-promote and racing its draft-sync flush against the in-flight `recordExplorationPromotion` POST on the same unlocked file. Fixed two ways: `recordExplorationPromotion` now shares VIS-1085's write queue, and `useWorkspaceTabShortcuts.js` gained a `hasBlockingModal()` guard (DOM-based on `[aria-modal="true"]`, generalizing to any blocking modal with zero call-site wiring).

**P4-D4 (MEDIUM) — discard ghost trail.** `discardExploration`'s revert never sent `promoted` (immutable via that route regardless), but now applies the revert response's `promoted`/`updatedAt` back to local state so the Build-rail promoted trail reflects server truth immediately after a discard, closing the staleness window the write-queue fix also addresses at the network level.

## Suite counts (final commit)

- Backend: `2129 passed, 2 skipped, 5 xfailed, 1 xpassed` (full `tests/` suite); `black --check` clean.
- Frontend: `333 test suites / 5534 tests passed` (full `src/` suite via `yarn test`); `yarn lint` clean.
- New backend concurrency test: `TestConcurrentCreate` in `tests/server/repositories/test_exploration_repository.py` drives 8 real threads through `ThreadPoolExecutor` against `create()`.
- 6 new Playwright e2e stories written and registered in `playwright.config.mjs`'s serial `exploration-mutations` project (not run, per task scope — no sandbox available in this session): `explorer-cold-session-default-source.spec.mjs`, `exploration-cross-session-delete.spec.mjs`, `exploration-concurrent-rename-and-draft-sync.spec.mjs`, `exploration-promote-tab-race.spec.mjs`, `explorer-create-race.spec.mjs`, `exploration-duplicate-race.spec.mjs`.

## Judgment calls

1. **Backend lock over pure retry for VIS-1086.** The recommended coverage's own `ThreadPoolExecutor(8)` test requires *strict* uniqueness under real thread interleaving — a check-then-write retry alone can't guarantee that deterministically, so I added a `threading.Lock` around `create()`'s whole "resolve id+name, then write" sequence in addition to the requested collision-checked `_default_name()` retry.
2. **`hasBlockingModal` suppresses ALL shortcuts in the hook, not just view/tab-position ones.** Cmd+W and Cmd+T also navigate away from (and can unmount) the active tab, so they're vulnerable to the same race as Cmd+1-9 — suppressing only a subset would leave two open doors.
3. **VIS-1085 and P4-D1/P4-D4 landed as one commit with VIS-1083** (not four separate commits) — `runSync`/`renameExploration`/`discardExploration`'s hunks for the 404-handling (1083) and write-queue (1085) fixes are genuinely interleaved in the same functions in `workspaceExplorationsStore.js`, and the coordinator's own framing treats P4-D1/P4-D4 as extensions of the 1085 mechanism. Similarly, VIS-1084 and VIS-1086's `ExplorerHomePane.jsx` guard landed in one commit — `mountedRef` and `creatingRef` wrap the same handler bodies and aren't separable without one depending on the other's scaffolding.
4. **`ExplorationPromoteModal.jsx` gained `role="dialog" aria-modal="true"`** (it previously had neither) so `hasBlockingModal`'s DOM check picks it up — matches the existing convention already used by `ConfirmDialog.jsx`/`TabCloseConfirmDialog.jsx`.
5. **No sandbox was available this session** — all new e2e specs were written to closely match this codebase's existing story conventions (helpers, backend-polling patterns, `page.route()` for deterministic race-forcing) and registered in the correct Playwright project, but have not been executed. Recommend a sandbox run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX