### PR TITLE
Explore 2.0 Phase 5: flywheel entry points, round-trips, preview-lane fixes, polish (VIS-1067–VIS-1072, VIS-1091–VIS-1095)

### DIFF
--- a/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
+++ b/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
@@ -177,6 +177,26 @@ test.describe('Dashboard round-trip completion (Explore 2.0 Phase 5 — VIS-1068
     for (const { segment, name } of createdObjects.splice(0)) {
       await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
     }
+    // Root-caused via live reproduction against the sandbox (integration-gate
+    // fix cycle): the happy-path and hard-reload tests place the promoted
+    // chart into a REAL, SHARED dashboard (`placeChartInDashboardSlot`
+    // appends a brand-new row via its cache-level `saveDashboard`, per
+    // 04-bug-inventory.md D12's "first free slot" fallback). Deleting the
+    // chart above removes the object but NOT that dashboard row, leaving a
+    // permanently dangling `${ref(<deleted chart>)}` item cached on the
+    // dashboard — every subsequent test in the WHOLE gate run that resolves
+    // the full project DAG (e.g. `/api/insight-compile-draft/`'s
+    // `build_draft_overlay` -> `project.dag()`, which eagerly dereferences
+    // every ref in the project, not just the ones relevant to the insight
+    // being compiled) then 400s on an item that has nothing to do with it.
+    // This is exactly what corrupted the live sandbox and cascaded into
+    // `exploration-preview.spec.mjs`'s entire preview-lane cluster across
+    // an unrelated spec file. Discarding this story's own cached-but-never-
+    // published edits (mirrors `canvas-editing.spec.mjs` /
+    // `validation-as-save.spec.mjs`'s existing `/api/commit/discard/`
+    // cleanup precedent) reverts the dashboard back to its published state,
+    // undoing the placement along with everything else this test cached.
+    await page.request.post(`${apiBase}/api/commit/discard/`).catch(() => {});
   });
 
   test('happy path: promote → "Place in <dashboard>" → chart lands in the dashboard, return_to consumed', async ({

--- a/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
+++ b/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
@@ -1,0 +1,347 @@
+/**
+ * Story: Dashboard round-trip completion — "+ New Chart" → promote →
+ * "Place in <dashboard>" (Explore 2.0 Phase 5 — VIS-1068, 01-ux-spec.md §5,
+ * 02-architecture.md §5).
+ *
+ *   1. The Library's "+ New" → Chart, scoped to an open dashboard tab, mints
+ *      an exploration carrying `return_to: {dashboard}` and opens its tab.
+ *   2. After a promote that includes a chart, the success state offers
+ *      "Place in <dashboard>". Accepting places the promoted chart into the
+ *      dashboard (via the existing placeChartInDashboardSlot canvas-add
+ *      path), consumes return_to (server nulls it), and navigates to the
+ *      dashboard tab — asserted through the BACKEND (never a frontend string
+ *      comparison), including after a reload.
+ *   3. A hard reload BETWEEN opening the intent-carrying exploration and
+ *      promoting must preserve the intent (return_to survives — it's
+ *      persisted on the record and re-fetched from the backend on every
+ *      Workspace mount, never a local-only snapshot).
+ *   4. Declining the offer ALSO consumes return_to (explicit choice, no
+ *      accretion of orphaned placement intents) — the chart is NOT placed.
+ *
+ * Precondition: sandbox running (integration project — has ≥1 real
+ * dashboard, e.g. `simple-dashboard`), e.g.
+ *   VISIVO_SANDBOX_NAME=dashboardRoundtrip VISIVO_SANDBOX_BACKEND_PORT=8053 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3053 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3053 npx playwright test dashboard-newchart-roundtrip
+ *
+ * Mutates real backend records (explorations, models, insights, charts, AND
+ * a real dashboard's config) — runs in the serial `exploration-mutations`
+ * playwright project (playwright.config.mjs), never `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function getRealDashboardName(page) {
+  const res = await page.request.get(`${apiBase}/api/dashboards/`);
+  expect(res.ok()).toBe(true);
+  const { dashboards } = await res.json();
+  expect(dashboards.length).toBeGreaterThan(0);
+  return dashboards[0].name;
+}
+
+async function openDashboardCanvas(page, name) {
+  await page.goto(`${BASE_URL}/workspace/dashboard/${name}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: 30000 });
+  await expect(page.getByTestId(`dashboard_${name}`)).toBeVisible({ timeout: 30000 });
+}
+
+/** The Library's "+ New" → Chart, scoped to the currently-open dashboard tab
+ * — mints an exploration carrying `return_to: {dashboard}` and opens its tab
+ * (Library.jsx's `handleCreate`'s `typeKey === 'chart' && scope.dashboardName`
+ * branch). */
+async function newChartFromLibrary(page) {
+  await page.getByTestId('library-new-object-button').click();
+  await expect(page.getByTestId('library-new-object-menu')).toBeVisible({ timeout: 5000 });
+  await page.getByTestId('library-new-object-chart').click();
+
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstNumericColumn(page, tableRow) {
+  await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  await expect(col).toBeVisible({ timeout: 10000 });
+  return col;
+}
+
+/** Bind the active insight's x prop to a real numeric column, running the
+ * active query first — buildPromoteChecklist drops the whole model tier
+ * without SQL (see exploration-promote.spec.mjs's identical helper). */
+async function bindXSlotToNumericColumn(page) {
+  await typeSql(page, `SELECT * FROM ${TABLE}`);
+  await runQuery(page);
+  const tableRow = await expandSourceTable(page);
+  const column = await firstNumericColumn(page, tableRow);
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await expect(xSlot).toBeVisible({ timeout: 15000 });
+  await dragAndDrop(page, column, xSlot);
+  await expect(xSlot.getByTestId('pill-menu-trigger')).toBeVisible({ timeout: 10000 });
+}
+
+async function promoteEverything(page) {
+  await page.getByTestId('explorer-save-button').click();
+  await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+  await page.getByTestId('exploration-promote-submit').click();
+  await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+}
+
+async function fetchExploration(page, id) {
+  const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+async function fetchDashboard(page, name) {
+  const res = await page.request.get(`${apiBase}/api/dashboards/${encodeURIComponent(name)}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+function dashboardReferencesChart(dashboard, chartName) {
+  const rows = dashboard?.config?.rows || [];
+  return rows.some(row =>
+    (row.items || []).some(item => (item.chart || '').includes(chartName))
+  );
+}
+
+test.describe('Dashboard round-trip completion (Explore 2.0 Phase 5 — VIS-1068)', () => {
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+  const createdObjects = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+  });
+
+  test('happy path: promote → "Place in <dashboard>" → chart lands in the dashboard, return_to consumed', async ({
+    page,
+  }) => {
+    const dashboardName = await getRealDashboardName(page);
+    await openDashboardCanvas(page, dashboardName);
+
+    const id = await newChartFromLibrary(page);
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to?.dashboard).toBe(dashboardName);
+    }).toPass({ timeout: 15000 });
+
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_roundtrip_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await promoteEverything(page);
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    const placeOffer = page.getByTestId('exploration-promote-return-to-offer');
+    await expect(placeOffer).toBeVisible({ timeout: 10000 });
+    await expect(placeOffer).toContainText(chartName);
+    await expect(placeOffer).toContainText(dashboardName);
+
+    await page.getByTestId('exploration-promote-place-in-dashboard').click();
+
+    // Navigates to the dashboard tab.
+    await expect(page.getByTestId(`dashboard_${dashboardName}`)).toBeVisible({ timeout: 20000 });
+
+    // Asserted through the BACKEND after a reload — never a frontend string
+    // comparison (feedback_backend_diffing.md).
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(async () => {
+      const dashboard = await fetchDashboard(page, dashboardName);
+      expect(dashboardReferencesChart(dashboard, chartName)).toBe(true);
+    }).toPass({ timeout: 20000 });
+
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to).toBeNull();
+    }).toPass({ timeout: 15000 });
+  });
+
+  test('a hard reload between opening the intent-carrying exploration and promoting preserves return_to', async ({
+    page,
+  }) => {
+    const dashboardName = await getRealDashboardName(page);
+    await openDashboardCanvas(page, dashboardName);
+
+    const id = await newChartFromLibrary(page);
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to?.dashboard).toBe(dashboardName);
+    }).toPass({ timeout: 15000 });
+
+    // Reload BEFORE ever promoting — return_to is persisted on the record
+    // and re-fetched from the backend on every Workspace mount, never a
+    // local-only (e.g. in-memory or localStorage) snapshot.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+
+    const exploration = await fetchExploration(page, id);
+    expect(exploration.return_to?.dashboard).toBe(dashboardName);
+
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_roundtrip_reload_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await promoteEverything(page);
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    // The offer still appears post-reload — the intent was never lost.
+    await expect(page.getByTestId('exploration-promote-return-to-offer')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByTestId('exploration-promote-place-in-dashboard').click();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(async () => {
+      const dashboard = await fetchDashboard(page, dashboardName);
+      expect(dashboardReferencesChart(dashboard, chartName)).toBe(true);
+    }).toPass({ timeout: 20000 });
+  });
+
+  test('declining the offer ALSO consumes return_to (explicit choice, no accretion) — the chart is never placed', async ({
+    page,
+  }) => {
+    const dashboardName = await getRealDashboardName(page);
+    await openDashboardCanvas(page, dashboardName);
+
+    const id = await newChartFromLibrary(page);
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_roundtrip_decline_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await promoteEverything(page);
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    await expect(page.getByTestId('exploration-promote-return-to-offer')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByTestId('exploration-promote-decline-placement').click();
+
+    // The offer disappears (return_to is now null, reactively) — the modal
+    // itself stays open (decline is not a promote-modal dismissal).
+    await expect(page.getByTestId('exploration-promote-return-to-offer')).not.toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible();
+
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to).toBeNull();
+    }).toPass({ timeout: 15000 });
+
+    // The chart was published (it's still a normal promote), but never
+    // placed into the dashboard.
+    const dashboard = await fetchDashboard(page, dashboardName);
+    expect(dashboardReferencesChart(dashboard, chartName)).toBe(false);
+  });
+});

--- a/viewer/e2e/stories/exploration-preview.spec.mjs
+++ b/viewer/e2e/stories/exploration-preview.spec.mjs
@@ -385,4 +385,257 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
       expect(realEntry?.data).toBeTruthy();
     }).toPass({ timeout: 20000 });
   });
+
+  // Explore 2.0 Phase 5 preview-lane fixes (VIS-1091–1095, absorbed from the
+  // Phase 4 delta review) ---------------------------------------------------
+
+  test('VIS-1091: a same-named real insight promoted by a DIFFERENT exploration is never treated as promoted by THIS one', async ({
+    page,
+  }) => {
+    // Exploration A: bind + promote its (default-auto-named) first insight.
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+    const tableRowA = await expandSourceTable(page);
+    const { locator: columnA } = await firstNumericColumn(page, tableRowA);
+    const xSlotA = page.locator('[data-testid*="droppable-property-x"]').first();
+    await dragAndDrop(page, columnA, xSlotA);
+    const insightNameA = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+    const queryNameA = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryNameA },
+      { segment: 'insights', name: insightNameA }
+    );
+
+    // Exploration B: a FRESH, UNRELATED exploration. `generateUniqueName`
+    // scopes auto-naming to each exploration's OWN state, so B's first
+    // insight is very likely named identically to A's — assert the
+    // collision precondition explicitly rather than assuming it.
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+    const tableRowB = await expandSourceTable(page);
+    const { locator: columnB } = await firstNumericColumn(page, tableRowB);
+    const xSlotB = page.locator('[data-testid*="droppable-property-x"]').first();
+    await dragAndDrop(page, columnB, xSlotB);
+    const insightNameB = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+    expect(insightNameB).toBe(insightNameA);
+
+    // The SAME browser session/store still holds A's REAL data under
+    // `insightJobs[insightNameA]` (nothing clears it on tab switch) — this
+    // is exactly the precondition the bug needed. B must resolve its OWN
+    // lane regardless: replicate ExplorerChartPreview.jsx's exact
+    // exploration-scoped predicate against the live store.
+    await expect(async () => {
+      const treatedAsPromoted = await page.evaluate(name => {
+        const state = window.useStore.getState();
+        const activeId =
+          state.workspaceActiveObject?.type === 'exploration'
+            ? state.workspaceActiveObject.name
+            : null;
+        const promoted = state.workspaceExplorations?.byId?.[activeId]?.promoted || [];
+        const isRealInsight = (state.insights || []).some(i => i.name === name);
+        const isPromotedByThisExploration = promoted.some(
+          p => p.type === 'insight' && p.name === name
+        );
+        return isRealInsight && isPromotedByThisExploration;
+      }, insightNameB);
+      expect(treatedAsPromoted).toBe(false);
+    }).toPass({ timeout: 10000 });
+
+    // B's own draft still renders live, on its own draft-namespaced lane.
+    await ensureChartTabVisible(page);
+    const data = await waitForDraftInsightData(page, insightNameB);
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test('VIS-1092: an already-promoted insight is never blanked by a sibling DRAFT insight erroring', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+
+    const tableRow = await expandSourceTable(page);
+    const { locator: column } = await firstNumericColumn(page, tableRow);
+    const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+    await dragAndDrop(page, column, xSlot);
+    await ensureChartTabVisible(page);
+
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    await waitForDraftInsightData(page, insightName);
+    await expect(page.getByTestId('chart-preview')).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName }
+    );
+    await page.getByTestId('exploration-promote-cancel').click();
+
+    // Wait for the promoted insight's REAL data (the poll bridge) so the
+    // chart is genuinely in the "already rendering, promoted" state before
+    // introducing the erroring sibling.
+    await expect(async () => {
+      const real = await page.evaluate(
+        name => window.useStore.getState().insightJobs[name],
+        insightName
+      );
+      expect(real?.data).toBeTruthy();
+    }).toPass({ timeout: 20000 });
+    await expect(page.getByTestId('chart-preview')).toBeVisible({ timeout: 15000 });
+
+    // Add a SECOND insight with a permanently dangling ref — its compile
+    // pass will keep erroring.
+    await page.getByTestId('right-panel-add-insight').click();
+    const insightNames = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames
+    );
+    const badInsightName = insightNames[insightNames.length - 1];
+    const ySlot = page
+      .locator(
+        `[data-testid="insight-build-section-${badInsightName}"] [data-testid*="droppable-property-y"]`
+      )
+      .first();
+    await ySlot.getByRole('button', { name: 'query string' }).click();
+    const editable = ySlot.locator('[data-testid="ref-textarea-editable"]');
+    await editable.click();
+    await page.keyboard.type('${ref(totally_made_up_model_xyz).amount}', { delay: 5 });
+    // No blur/commit — see the sibling "not-yet-promoted input" test above
+    // for why that races the pill swap and hangs.
+
+    // The bad insight's compile pass fails after the debounce — give it
+    // room to settle, then assert the ALREADY-GOOD chart is untouched: never
+    // regressed to the whole-chart error/loading screens.
+    await page.waitForTimeout(2500);
+    await expect(page.getByTestId('chart-preview')).toBeVisible();
+    await expect(page.getByTestId('chart-preview-error')).not.toBeVisible();
+    await expect(page.getByTestId('chart-preview-loading')).not.toBeVisible();
+  });
+
+  test('VIS-1093: the promoted-poll bridge has a bounded lifetime — it surfaces a failure banner instead of spinning forever', async ({
+    page,
+  }) => {
+    test.setTimeout(75000);
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+
+    const tableRow = await expandSourceTable(page);
+    const { locator: column } = await firstNumericColumn(page, tableRow);
+    const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+    await dragAndDrop(page, column, xSlot);
+    await ensureChartTabVisible(page);
+
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    await waitForDraftInsightData(page, insightName);
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push({ segment: 'models', name: queryName });
+    await page.getByTestId('exploration-promote-cancel').click();
+
+    // Delete the promoted insight IMMEDIATELY — its real data can now never
+    // land, so the poll bridge is chasing an object that's already gone.
+    // (Already removed from `createdObjects` since we're deleting it here.)
+    await page.request.delete(`${apiBase}/api/insights/${encodeURIComponent(insightName)}/`);
+
+    // ~30s (15 x 2s) polling budget, plus margin.
+    await expect(page.getByTestId('chart-preview-promoted-poll-failed')).toBeVisible({
+      timeout: 45000,
+    });
+  });
+
+  test('VIS-1095: a dedup-offer slot hand-edited before Apply is skipped, not blindly overwritten', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+
+    const tableRow = await expandSourceTable(page);
+    const { locator: column } = await firstNumericColumn(page, tableRow);
+
+    // Insight A (active by default): bind x to a SUM(col) pill.
+    const xSlotA = page.locator('[data-testid*="droppable-property-x"]').first();
+    await dragAndDrop(page, column, xSlotA);
+    await expect(xSlotA).toContainText('SUM', { timeout: 10000 });
+
+    // Insight B: a SECOND insight whose OWN x slot gets the IDENTICAL
+    // SUM(col) expression (same source column, same drag) — the
+    // match-and-replace dedup detector's target.
+    await page.getByTestId('right-panel-add-insight').click();
+    const insightNames = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames
+    );
+    const insightB = insightNames[insightNames.length - 1];
+    const xSlotB = page
+      .locator(`[data-testid="insight-build-section-${insightB}"] [data-testid*="droppable-property-x"]`)
+      .first();
+    await dragAndDrop(page, column, xSlotB);
+    await expect(xSlotB).toContainText('SUM', { timeout: 10000 });
+
+    // Promote A's x-slot to a named metric via "Save as metric" — its
+    // match-and-replace dedup scan finds B's identical slot and offers a swap.
+    await xSlotA.getByTestId('pill-menu-trigger').click();
+    await expect(page.getByTestId('pill-menu')).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('pill-menu-save-as-metric').click();
+    await expect(page.getByTestId('save-as-metric-prompt')).toBeVisible({ timeout: 5000 });
+    const metricName = `e2e_dedup_stale_${Date.now()}`;
+    await page.getByTestId('save-as-metric-name-input').fill(metricName);
+    await page.getByTestId('save-as-metric-submit').click();
+    await expect(page.getByTestId('save-as-metric-prompt')).not.toBeVisible({ timeout: 15000 });
+    createdObjects.push({ segment: 'metrics', name: metricName });
+
+    const offerBanner = page.getByTestId('field-swap-offer-banner');
+    await expect(offerBanner).toBeVisible({ timeout: 10000 });
+
+    // BEFORE accepting, hand-edit B's slot to something else entirely —
+    // simulating the user continuing to work underneath the non-blocking
+    // (non-modal) banner.
+    const staleGuardValue = '?{${ref(totally_different_model).other_col}}';
+    await page.evaluate(
+      ({ insightB, staleGuardValue }) => {
+        window.useStore.getState().setInsightProp(insightB, 'x', staleGuardValue);
+      },
+      { insightB, staleGuardValue }
+    );
+
+    await offerBanner.getByRole('button', { name: /Update \d+ reference/ }).click();
+
+    // B's slot was NOT overwritten by the stale offer — the manual edit survived.
+    const finalValue = await page.evaluate(
+      name => window.useStore.getState().explorerInsightStates[name]?.props?.x,
+      insightB
+    );
+    expect(finalValue).toBe(staleGuardValue);
+
+    // A toast informed the user the reference had changed and was skipped.
+    await expect(page.getByText(/changed since this offer was made/i)).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/viewer/e2e/stories/exploration-preview.spec.mjs
+++ b/viewer/e2e/stories/exploration-preview.spec.mjs
@@ -552,17 +552,34 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
     const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
     await waitForDraftInsightData(page, insightName);
 
+    // The promoted-poll bridge's own data-fetch (`/api/insight-jobs/`) must
+    // never succeed for the rest of this test. Root-caused via live
+    // reproduction against the sandbox (integration-gate fix cycle): the
+    // ORIGINAL approach here — promote, then immediately DELETE the
+    // promoted Insight object — does NOT reliably reproduce "data can never
+    // land". The run-on-save pipeline promote triggers already finishes and
+    // writes real output files (per `ExplorerChartPreview.jsx`'s own
+    // docstring, "typically finishes in well under a second") well before
+    // even a single network round-trip to delete the object can land; a
+    // live trace showed the REAL (un-namespaced) `insightJobs` entry
+    // arriving with genuine data seconds after the delete request resolved.
+    // Deleting the object doesn't delete its already-produced job output.
+    // Forcing the fetch itself to fail is the only deterministic way to
+    // exercise the bounded-lifetime/failure path — mirrors
+    // `exploration-promote-tab-race.spec.mjs`'s `page.route()` precedent for
+    // gating a real in-flight request. Installed BEFORE promoting so it's in
+    // effect for every attempt the poll bridge makes once it starts.
+    await page.route('**/api/insight-jobs/**', route => route.abort('failed'));
+
     await page.getByTestId('explorer-save-button').click();
     await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
     await page.getByTestId('exploration-promote-submit').click();
     await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
-    createdObjects.push({ segment: 'models', name: queryName });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName }
+    );
     await page.getByTestId('exploration-promote-cancel').click();
-
-    // Delete the promoted insight IMMEDIATELY — its real data can now never
-    // land, so the poll bridge is chasing an object that's already gone.
-    // (Already removed from `createdObjects` since we're deleting it here.)
-    await page.request.delete(`${apiBase}/api/insights/${encodeURIComponent(insightName)}/`);
 
     // ~30s (15 x 2s) polling budget, plus margin.
     await expect(page.getByTestId('chart-preview-promoted-poll-failed')).toBeVisible({
@@ -581,14 +598,37 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
     const tableRow = await expandSourceTable(page);
     const { locator: column } = await firstNumericColumn(page, tableRow);
 
-    // Insight A (active by default): bind x to a SUM(col) pill.
-    const xSlotA = page.locator('[data-testid*="droppable-property-x"]').first();
+    const insightA = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    // Insight A (active by default): bind x to a SUM(col) pill. Scoped to
+    // A's OWN section testid (never a bare `.first()` across the whole
+    // page) — see the "Explore this" comment below for why.
+    const xSlotA = page
+      .locator(`[data-testid="insight-build-section-${insightA}"] [data-testid*="droppable-property-x"]`)
+      .first();
     await dragAndDrop(page, column, xSlotA);
     await expect(xSlotA).toContainText('SUM', { timeout: 10000 });
 
     // Insight B: a SECOND insight whose OWN x slot gets the IDENTICAL
     // SUM(col) expression (same source column, same drag) — the
-    // match-and-replace dedup detector's target.
+    // match-and-replace dedup detector's target. Creating it activates AND
+    // EXPANDS it, collapsing A (`ExplorationBuildRail.jsx`'s
+    // `isExpanded={name === activeInsightName}` — correct, intentional
+    // product behavior: a newly-added insight is focused). `InsightBuildSection.
+    // jsx`'s `{isExpanded && (...)}` UNMOUNTS a collapsed section's content
+    // entirely — its droppable-property-x/pill-menu-trigger simply leave the
+    // DOM, not just CSS-hidden. Root-caused via live reproduction against
+    // the sandbox (integration-gate fix cycle): the ORIGINAL test captured
+    // `xSlotA` via a bare page-wide `.first()` locator BEFORE B existed;
+    // once A collapsed, that lazily-re-evaluated locator silently
+    // re-resolved to B's OWN droppable/pill-menu-trigger, so the "Save as
+    // metric" flow below ran against B instead of A — the dedup/stale-guard
+    // logic itself behaved correctly for whichever insight it actually ran
+    // against, this was purely a test locator-scoping bug. Every reference
+    // to A's elements below is now scoped to A's own section testid, and A
+    // is explicitly re-expanded before being touched again.
     await page.getByTestId('right-panel-add-insight').click();
     const insightNames = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames
@@ -599,6 +639,11 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
       .first();
     await dragAndDrop(page, column, xSlotB);
     await expect(xSlotB).toContainText('SUM', { timeout: 10000 });
+
+    // Re-expand A (collapsed the instant B was created/activated above) —
+    // its droppable/pill-menu elements are unmounted until it is.
+    await page.getByTestId(`insight-toggle-${insightA}`).click();
+    await expect(xSlotA).toContainText('SUM', { timeout: 5000 });
 
     // Promote A's x-slot to a named metric via "Save as metric" — its
     // match-and-replace dedup scan finds B's identical slot and offers a swap.
@@ -614,6 +659,7 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
 
     const offerBanner = page.getByTestId('field-swap-offer-banner');
     await expect(offerBanner).toBeVisible({ timeout: 10000 });
+    await expect(offerBanner).toContainText(metricName);
 
     // BEFORE accepting, hand-edit B's slot to something else entirely —
     // simulating the user continuing to work underneath the non-blocking

--- a/viewer/e2e/stories/exploration-staleness.spec.mjs
+++ b/viewer/e2e/stories/exploration-staleness.spec.mjs
@@ -1,0 +1,207 @@
+/**
+ * Story: Exploration staleness (Explore 2.0 Phase 5 — VIS-1070,
+ * 02-architecture.md §8, 01-ux-spec.md §2's "⚠ stale (orders changed)"
+ * end-state).
+ *
+ * `computeExplorationStaleness` re-runs the SAME advisory ref-target check
+ * (`checkRefTargets`) the Build rail already runs continuously while typing,
+ * at two moments nothing else covers: on RESUME (`ExplorationPane`'s
+ * activate effect) and on the Explorer Home gallery (every card, once per
+ * render).
+ *
+ *   1. A draft with a ref to an object that doesn't exist shows the "stale"
+ *      badge on its Explorer Home card.
+ *   2. Reopening that exploration shows the non-blocking "re-check
+ *      references" banner, naming the dangling ref.
+ *   3. Dismiss hides the banner without touching the draft.
+ *   4. "Re-check references" re-runs the check live — once the referenced
+ *      object actually gets published, the banner clears without a reload.
+ *   5. A clean draft (no dangling refs) never shows either affordance.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationStaleness VISIVO_SANDBOX_BACKEND_PORT=8054 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3054 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3054 npx playwright test exploration-staleness
+ *
+ * Mutates real backend records (explorations, and one model in the
+ * "re-check clears live" test) — runs in the serial `exploration-mutations`
+ * playwright project (playwright.config.mjs), never `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Type a raw `${ref(...)}` directly into the x-slot's query-string field —
+ * the exact pattern exploration-preview.spec.mjs's "not-yet-promoted input"
+ * test already proves works for typing a syntactically-complete single ref.
+ * No blur/commit afterward: a complete single ref swaps RefTextArea for a
+ * pill mid-keystroke (PropertyRow.jsx's `showPill`), so blurring the by-then
+ * -unmounted node hangs for the full test timeout. */
+async function typeDanglingRefIntoXSlot(page, refName) {
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await xSlot.getByRole('button', { name: 'query string' }).click();
+  const editable = xSlot.locator('[data-testid="ref-textarea-editable"]');
+  await editable.click();
+  await page.keyboard.type(`\${ref(${refName}).amount}`, { delay: 5 });
+}
+
+/** Park the active exploration tab (switches destinations without closing
+ * it) — triggers ExplorationPane's deactivate flush, so the just-typed
+ * draft edit lands in workspaceExplorations.byId BEFORE Explorer Home reads
+ * it for the staleness badge. */
+async function parkActiveTab(page) {
+  await page.getByTestId('workspace-view-switcher-project').click();
+}
+
+async function waitForBackendDraftContains(page, id, needle, timeout = 15000) {
+  await expect(async () => {
+    const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(JSON.stringify(data.draft)).toContain(needle);
+  }).toPass({ timeout });
+}
+
+test.describe('Exploration staleness (Explore 2.0 Phase 5 — VIS-1070)', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let idsBeforeTest = [];
+  const createdObjects = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+  });
+
+  test('a dangling ref shows the Home card badge, and the resume banner names it', async ({
+    page,
+  }) => {
+    const danglingRef = `e2e_stale_ref_${Date.now()}`;
+
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeDanglingRefIntoXSlot(page, danglingRef);
+    await waitForBackendDraftContains(page, id, danglingRef);
+
+    await parkActiveTab(page);
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId('explorer-home-gallery')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId(`exploration-card-${id}-stale`)).toBeVisible({ timeout: 20000 });
+
+    // Reopening surfaces the non-blocking resume banner, naming the ref.
+    await page.getByTestId(`exploration-card-${id}-open`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    const banner = page.getByTestId('exploration-staleness-banner');
+    await expect(banner).toBeVisible({ timeout: 15000 });
+    await expect(banner).toContainText(danglingRef);
+  });
+
+  test('Dismiss hides the banner without touching the draft', async ({ page }) => {
+    const danglingRef = `e2e_stale_dismiss_${Date.now()}`;
+
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeDanglingRefIntoXSlot(page, danglingRef);
+    await waitForBackendDraftContains(page, id, danglingRef);
+    await parkActiveTab(page);
+
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await page.getByTestId(`exploration-card-${id}-open`).click();
+    await expect(page.getByTestId('exploration-staleness-banner')).toBeVisible({ timeout: 15000 });
+
+    await page.getByTestId('exploration-staleness-dismiss').click();
+    await expect(page.getByTestId('exploration-staleness-banner')).not.toBeVisible();
+
+    // The draft itself is untouched — the ref is still there (dismiss is
+    // purely a UI affordance, never a silent edit).
+    await waitForBackendDraftContains(page, id, danglingRef);
+  });
+
+  test('"Re-check references" clears the banner live, once the referenced object is actually published', async ({
+    page,
+  }) => {
+    // A NAME the exploration will reference — published mid-test, not
+    // up front, so the first check genuinely observes it dangling.
+    const modelName = `e2e_stale_recheck_${Date.now()}`;
+
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeDanglingRefIntoXSlot(page, modelName);
+    await waitForBackendDraftContains(page, id, modelName);
+    await parkActiveTab(page);
+
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await page.getByTestId(`exploration-card-${id}-open`).click();
+    await expect(page.getByTestId('exploration-staleness-banner')).toBeVisible({ timeout: 15000 });
+
+    // Publish a REAL model under that exact name directly via the API.
+    const res = await page.request.post(`${apiBase}/api/models/${encodeURIComponent(modelName)}/`, {
+      data: { sql: 'SELECT 1 AS amount', source: '${ref(local-duckdb)}' },
+    });
+    expect(res.ok()).toBe(true);
+    createdObjects.push({ segment: 'models', name: modelName });
+    // The client's own cached `state.models` won't see it until refetched —
+    // the same reason save-as-metric.spec.mjs's collision test refetches
+    // after a raw API create.
+    await page.evaluate(() => window.useStore.getState().fetchModels());
+
+    await page.getByTestId('exploration-staleness-recheck').click();
+    await expect(page.getByTestId('exploration-staleness-banner')).not.toBeVisible({ timeout: 15000 });
+  });
+
+  test('a clean draft (no dangling refs) never shows the badge or the banner', async ({ page }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    // Deliberately leave the draft untouched (no data props at all) — the
+    // baseline "nothing to be stale about" case.
+    await parkActiveTab(page);
+
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId('explorer-home-gallery')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId(`exploration-card-${id}-name`)).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId(`exploration-card-${id}-stale`)).not.toBeVisible();
+
+    await page.getByTestId(`exploration-card-${id}-open`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId('exploration-staleness-banner')).not.toBeVisible();
+  });
+});

--- a/viewer/e2e/stories/explore-this-flywheel.spec.mjs
+++ b/viewer/e2e/stories/explore-this-flywheel.spec.mjs
@@ -1,0 +1,212 @@
+/**
+ * Story: The "Explore this" flywheel loop (Explore 2.0 Phase 5 — VIS-1067
+ * context-menu entry points + VIS-1069 Semantic Layer reciprocals,
+ * 01-ux-spec.md §5, 02-architecture.md).
+ *
+ * Closes the full round trip in one flow:
+ *
+ *   1. "Explore this" from a real MODEL's Library row context menu mints a
+ *      NEW exploration pre-wired with a query against that model
+ *      (`seeded_from: {type:'model', name}`, `buildExplorationSeedState`).
+ *   2. A computed column marked as a metric, promoted via "Save to Project",
+ *      publishes a real Metric — the promote success state offers
+ *      "View in Semantic Layer".
+ *   3. Accepting sets the one-shot `workspaceSemanticLayerFocusIntent`,
+ *      navigates to the Semantic Layer, and the ERD consumes (self-clears)
+ *      the intent to focus the metric's parent model node.
+ *   4. Clicking the metric's own field pill on the ERD ("Explore this" back-
+ *      link) mints YET ANOTHER exploration, seeded from that metric.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=exploreThisFlywheel VISIVO_SANDBOX_BACKEND_PORT=8052 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3052 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3052 npx playwright test explore-this-flywheel
+ *
+ * Mutates real backend records (explorations, models, metrics) — runs in the
+ * serial `exploration-mutations` playwright project (playwright.config.mjs),
+ * never `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const TABLE = 'test_table';
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function waitForObjectPublished(page, segment, name, timeout = 20000) {
+  await expect(async () => {
+    const res = await page.request.get(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`);
+    expect(res.ok()).toBe(true);
+  }).toPass({ timeout });
+}
+
+async function fetchExploration(page, id) {
+  const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+test.describe('The "Explore this" flywheel loop (Explore 2.0 Phase 5)', () => {
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+  const createdObjects = []; // {segment, name} — best-effort cleanup
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+  });
+
+  test('seed from model → promote a metric → View in Semantic Layer focuses the node → Explore this from the ERD back', async ({
+    page,
+  }) => {
+    // --- Step 0: publish a real MODEL to seed from (via the normal promote
+    // path — the same one exploration-promote.spec.mjs already proves works).
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const defaultQueryName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+    const modelName = `e2e_flywheel_model_${Date.now()}`;
+    await page.evaluate(
+      ({ defaultQueryName, modelName }) =>
+        window.useStore.getState().renameModelTab(defaultQueryName, modelName),
+      { defaultQueryName, modelName }
+    );
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId(`promote-row-model-${modelName}-checkbox`)).toBeChecked();
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push({ segment: 'models', name: modelName });
+    await waitForObjectPublished(page, 'models', modelName);
+
+    // --- Step 1: "Explore this" from the model's Library row. ---
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => window.useStore.getState().fetchModels?.());
+
+    const modelHeader = page.getByTestId('library-subsection-model-header');
+    const modelBody = page.getByTestId('library-subsection-model-body');
+    if (!(await modelBody.isVisible().catch(() => false))) await modelHeader.click();
+    const modelRow = page.getByTestId(`library-row-model-${modelName}`);
+    await expect(modelRow).toBeVisible({ timeout: 15000 });
+    await modelRow.click({ button: 'right' });
+    const modelCtxMenu = page.getByTestId(`library-row-model-${modelName}-context-menu`);
+    await expect(modelCtxMenu).toBeVisible({ timeout: 5000 });
+    await modelCtxMenu.getByText('Explore this').click();
+
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const explorationId2 = new URL(page.url()).pathname.split('/').pop();
+
+    // Seed provenance + the pre-wired query referencing the model (the
+    // buildExplorationSeedState "model" branch — `SELECT * FROM ${ref(model)}`).
+    await expect(async () => {
+      const exploration = await fetchExploration(page, explorationId2);
+      expect(exploration.seeded_from).toEqual({ type: 'model', name: modelName });
+      expect((exploration.draft.queries || [])[0]?.sql || '').toContain(modelName);
+    }).toPass({ timeout: 15000 });
+
+    // --- Step 2: run the seeded query, add a computed METRIC column, promote it. ---
+    await runQuery(page);
+    const firstColumn = page.locator('[data-testid^="draggable-col-"]').first();
+    await expect(firstColumn).toBeVisible({ timeout: 15000 });
+    const colName = await firstColumn
+      .getAttribute('data-testid')
+      .then(t => t.replace('draggable-col-', ''));
+
+    await page.getByTestId('add-computed-column-btn').click();
+    const metricName = `e2e_flywheel_metric_${Date.now()}`;
+    await page.getByTestId('computed-col-name').fill(metricName);
+    await page.getByTestId('computed-col-expression').fill(`SUM(${colName})`);
+    await expect(page.getByTestId('detected-type-badge')).toContainText('Metric', { timeout: 10000 });
+    await page.getByTestId('add-btn').click();
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId(`promote-row-metric-${metricName}-checkbox`)).toBeChecked({
+      timeout: 10000,
+    });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: 'query_1' }, // the seeded scratch query itself also promotes
+      { segment: 'metrics', name: metricName }
+    );
+    await waitForObjectPublished(page, 'metrics', metricName);
+
+    // --- Step 3: "View in Semantic Layer" offer appears; accepting focuses the node. ---
+    const semanticLayerOffer = page.getByTestId('exploration-promote-semantic-layer-offer');
+    await expect(semanticLayerOffer).toBeVisible({ timeout: 10000 });
+    await expect(semanticLayerOffer).toContainText(metricName);
+    await page.getByTestId('exploration-promote-view-in-semantic-layer').click();
+
+    await expect(page.getByTestId('semantic-layer-erd')).toBeVisible({ timeout: 20000 });
+    const metricPill = page.getByTestId(`erd-metric-pill-${metricName}`);
+    await expect(metricPill).toBeVisible({ timeout: 15000 });
+    // The one-shot focus intent self-clears once the ERD consumes it.
+    await expect(async () => {
+      const intent = await page.evaluate(
+        () => window.useStore.getState().workspaceSemanticLayerFocusIntent
+      );
+      expect(intent).toBeNull();
+    }).toPass({ timeout: 10000 });
+
+    // --- Step 4: "Explore this" back-link from the ERD pill closes the loop. ---
+    await metricPill.click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const explorationId3 = new URL(page.url()).pathname.split('/').pop();
+
+    await expect(async () => {
+      const exploration = await fetchExploration(page, explorationId3);
+      expect(exploration.seeded_from).toEqual({ type: 'metric', name: metricName });
+    }).toPass({ timeout: 15000 });
+
+    // The two round-trip explorations are genuinely distinct records.
+    expect(explorationId3).not.toBe(explorationId2);
+  });
+});

--- a/viewer/e2e/stories/explore-this-flywheel.spec.mjs
+++ b/viewer/e2e/stories/explore-this-flywheel.spec.mjs
@@ -142,12 +142,22 @@ test.describe('The "Explore this" flywheel loop (Explore 2.0 Phase 5)', () => {
     await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
     const explorationId2 = new URL(page.url()).pathname.split('/').pop();
 
-    // Seed provenance + the pre-wired query referencing the model (the
-    // buildExplorationSeedState "model" branch — `SELECT * FROM ${ref(model)}`).
+    // Seed provenance + the pre-wired query. `buildExplorationSeedState`'s
+    // "model" branch reuses the model's OWN literal SQL (never a
+    // `${ref(model)}` context-string expression) — the scratch SQL editor's
+    // execution pipeline (`useModelQueryJob` -> `/api/model-query-jobs/`)
+    // sends the query text VERBATIM to the source with zero ref-resolution,
+    // so an unresolved `${ref(...)}` reaches DuckDB and fails to parse.
+    // Root-caused via live reproduction against the sandbox (integration-
+    // gate fix cycle): the model's own SQL (`SELECT * FROM ${TABLE}`) is
+    // exactly what the model was published with in Step 0 above, so
+    // asserting it contains the real table name proves the seed is both
+    // genuinely runnable AND tied to this model — `seeded_from` is the
+    // provenance record, not the query text.
     await expect(async () => {
       const exploration = await fetchExploration(page, explorationId2);
       expect(exploration.seeded_from).toEqual({ type: 'model', name: modelName });
-      expect((exploration.draft.queries || [])[0]?.sql || '').toContain(modelName);
+      expect((exploration.draft.queries || [])[0]?.sql || '').toContain(TABLE);
     }).toPass({ timeout: 15000 });
 
     // --- Step 2: run the seeded query, add a computed METRIC column, promote it. ---

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -79,6 +79,13 @@ export default defineConfig({
         // assume anchors render eagerly with no open document; the new
         // Explorer Home doesn't).
         '**/onboarding-coach-anchors.spec.mjs',
+        // Phase 5 (VIS-1067–1072/VIS-1091-1095): same shared-repository
+        // isolation need — each mints real backend exploration records
+        // (and, for the flywheel/dashboard specs, real models/metrics/
+        // insights/charts and a real dashboard's config).
+        '**/explore-this-flywheel.spec.mjs',
+        '**/dashboard-newchart-roundtrip.spec.mjs',
+        '**/exploration-staleness.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -161,6 +168,12 @@ export default defineConfig({
         '**/explorer-create-race.spec.mjs',
         '**/exploration-duplicate-race.spec.mjs',
         '**/explorer-cold-session-default-source.spec.mjs',
+        // Phase 5 additions (VIS-1067-1072/VIS-1091-1095) — see the
+        // 'parallel' project's testIgnore entry for the same three files
+        // for why.
+        '**/explore-this-flywheel.spec.mjs',
+        '**/dashboard-newchart-roundtrip.spec.mjs',
+        '**/exploration-staleness.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/components/explorer/AddComputedColumnPopover.jsx
+++ b/viewer/src/components/explorer/AddComputedColumnPopover.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { PiPlus, PiX, PiCheckCircle, PiWarningCircle, PiSpinner } from 'react-icons/pi';
 import { recordOnboardingAction } from '../onboarding/onboardingState';
+import { getTypeColors } from '../views/common/objectTypeConfigs';
 
 const DEBOUNCE_MS = 750;
 
@@ -237,11 +238,7 @@ const AddComputedColumnPopover = ({
                   Valid expression
                   {detectedType && (
                     <span
-                      className={`ml-1.5 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${
-                        detectedType === 'metric'
-                          ? 'bg-cyan-100 text-cyan-700'
-                          : 'bg-teal-100 text-teal-700'
-                      }`}
+                      className={`ml-1.5 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${getTypeColors(detectedType).bg} ${getTypeColors(detectedType).text}`}
                       data-testid="detected-type-badge"
                     >
                       {detectedType === 'metric' ? 'Metric' : 'Dimension'}

--- a/viewer/src/components/explorer/AddComputedColumnPopover.test.jsx
+++ b/viewer/src/components/explorer/AddComputedColumnPopover.test.jsx
@@ -102,6 +102,25 @@ describe('AddComputedColumnPopover', () => {
     });
   });
 
+  // B9 (04-bug-inventory.md) / VIS-1071: the detected-type badge derives its
+  // color from objectTypeConfigs — never hand-rolled cyan/teal classes.
+  it('the detected-type badge uses the canonical objectTypeConfigs metric/dimension classes', async () => {
+    renderPopover();
+    fireEvent.click(screen.getByTestId('add-computed-column-btn'));
+    fireEvent.change(screen.getByTestId('computed-col-name'), { target: { value: 'total_revenue' } });
+    fireEvent.change(screen.getByTestId('computed-col-expression'), {
+      target: { value: 'SUM(amount)' },
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(750);
+    });
+
+    const badge = await screen.findByTestId('detected-type-badge');
+    expect(badge).toHaveTextContent('Metric');
+    expect(badge.className).toContain('bg-cyan-100');
+    expect(badge.className).toContain('text-cyan-800');
+  });
+
   it('shows duplicate name error when name exists in existingNames Set', () => {
     renderPopover({ existingNames: new Set(['revenue']) });
     fireEvent.click(screen.getByTestId('add-computed-column-btn'));

--- a/viewer/src/components/explorer/DataSectionToolbar.jsx
+++ b/viewer/src/components/explorer/DataSectionToolbar.jsx
@@ -93,7 +93,7 @@ const DataSectionToolbar = () => {
                     : `Click to edit ${col.name}`
                 }
                 className={
-                  isFailed ? 'bg-red-50 text-red-800 border-red-200' : ''
+                  isFailed ? 'bg-highlight-50 text-highlight-800 border-highlight-200' : ''
                 }
               />
             </span>

--- a/viewer/src/components/explorer/DataSectionToolbar.test.jsx
+++ b/viewer/src/components/explorer/DataSectionToolbar.test.jsx
@@ -238,7 +238,9 @@ describe('DataSectionToolbar', () => {
     expect(pill.dataset.objectType).toBe('dimension');
   });
 
-  it('failed columns have red styling via className override', () => {
+  // B9 (04-bug-inventory.md) / VIS-1071: failed columns use the shared
+  // `highlight-*` tokens, never raw `red-*`.
+  it('failed columns have highlight (not red) styling via className override', () => {
     setupStore({
       explorerModelStates: {
         model_a: {
@@ -250,8 +252,9 @@ describe('DataSectionToolbar', () => {
     });
     render(<DataSectionToolbar />);
     const pill = screen.getByTestId('pill-dimension-bad_col');
-    expect(pill.className).toContain('bg-red-50');
-    expect(pill.className).toContain('border-red-200');
+    expect(pill.className).toContain('bg-highlight-50');
+    expect(pill.className).toContain('border-highlight-200');
+    expect(pill.className).not.toMatch(/\bred-/);
   });
 
   it('clicking pill opens edit mode (sets editColumn)', () => {

--- a/viewer/src/components/explorer/DraggableColumnHeader.jsx
+++ b/viewer/src/components/explorer/DraggableColumnHeader.jsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import DataTableHeader from '../common/DataTableHeader';
+import { getTypeColors } from '../views/common/objectTypeConfigs';
 
-const COMPUTED_STYLES = {
-  metric: 'border-t-2 border-t-cyan-500 bg-cyan-50/50',
-  dimension: 'border-t-2 border-t-teal-500 bg-teal-50/50',
+// B9 (04-bug-inventory.md) / VIS-1071 restyle sweep: metric/dimension
+// border-top + tint now derive from the canonical `objectTypeConfigs`
+// palette instead of hand-rolled cyan/teal classes (the fork the CLAUDE.md
+// "always use objectTypeConfigs" rule exists to prevent — a future palette
+// change would otherwise silently desync this file). Tailwind can't compose
+// a dynamic `border-t-{color}-500` class from a runtime value, so the
+// border-top COLOR is an inline style sourced from `connectionHandle` (the
+// same hex `objectTypeConfigs` already exposes for ERD connection handles);
+// the background tint uses the config's own `bg` token directly. The error
+// state uses the shared `highlight-*` tokens, not raw `red-*` (B9's other
+// half).
+const ERROR_CLASS_NAME = 'border-t-2 border-t-highlight-500 bg-highlight-50/50';
+
+const computedHeaderStyle = column => {
+  if (column.computedError) return { className: ERROR_CLASS_NAME };
+  if (!column.computedType) return { className: '' };
+  const colors = getTypeColors(column.computedType);
+  return {
+    className: `border-t-2 ${colors.bg}`,
+    style: { borderTopColor: colors.connectionHandle },
+  };
 };
-
-const ERROR_STYLE = 'border-t-2 border-t-red-500 bg-red-50/50';
 
 const DraggableColumnHeader = ({ column, sorting, onSortChange, onInfoClick }) => {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -15,18 +32,15 @@ const DraggableColumnHeader = ({ column, sorting, onSortChange, onInfoClick }) =
     data: { name: column.name, type: 'column', sourceType: 'data-table' },
   });
 
-  const computedStyle = column.computedError
-    ? ERROR_STYLE
-    : column.computedType
-      ? COMPUTED_STYLES[column.computedType] || ''
-      : '';
+  const { className: computedClassName, style: computedStyle } = computedHeaderStyle(column);
 
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
-      className={`cursor-grab active:cursor-grabbing ${isDragging ? 'opacity-50' : ''} ${computedStyle}`}
+      className={`cursor-grab active:cursor-grabbing ${isDragging ? 'opacity-50' : ''} ${computedClassName}`}
+      style={computedStyle}
       data-testid={`draggable-col-${column.name}`}
       title={column.computedError || undefined}
     >

--- a/viewer/src/components/explorer/DraggableColumnHeader.test.jsx
+++ b/viewer/src/components/explorer/DraggableColumnHeader.test.jsx
@@ -37,33 +37,42 @@ describe('DraggableColumnHeader', () => {
     expect(wrapper.dataset.draggableId).toBe('column-order_id');
   });
 
-  it('applies metric styling for metric computed columns', () => {
+  // B9 (04-bug-inventory.md) / VIS-1071: metric/dimension styling now
+  // derives from `objectTypeConfigs` (a `bg-*` class + an inline
+  // `borderTopColor` sourced from the same `connectionHandle` hex the ERD
+  // uses) instead of hand-rolled `cyan`/`teal` classes.
+  it('applies metric styling (from objectTypeConfigs) for metric computed columns', () => {
     const metricColumn = { name: 'total_revenue', normalizedType: 'number', computedType: 'metric' };
     render(<DraggableColumnHeader column={metricColumn} />);
 
     const wrapper = screen.getByTestId('draggable-col-total_revenue');
-    expect(wrapper.className).toContain('border-t-cyan-500');
-    expect(wrapper.className).toContain('bg-cyan-50/50');
+    expect(wrapper.className).toContain('border-t-2');
+    expect(wrapper.className).toContain('bg-cyan-100');
+    expect(wrapper.style.borderTopColor).toBe('#06b6d4');
   });
 
-  it('applies dimension styling for dimension computed columns', () => {
+  it('applies dimension styling (from objectTypeConfigs) for dimension computed columns', () => {
     const dimColumn = { name: 'order_month', normalizedType: 'string', computedType: 'dimension' };
     render(<DraggableColumnHeader column={dimColumn} />);
 
     const wrapper = screen.getByTestId('draggable-col-order_month');
-    expect(wrapper.className).toContain('border-t-teal-500');
-    expect(wrapper.className).toContain('bg-teal-50/50');
+    expect(wrapper.className).toContain('border-t-2');
+    expect(wrapper.className).toContain('bg-teal-100');
+    expect(wrapper.style.borderTopColor).toBe('#14b8a6');
   });
 
   it('does not apply computed styling for regular columns', () => {
     render(<DraggableColumnHeader column={mockColumn} />);
 
     const wrapper = screen.getByTestId('draggable-col-order_id');
-    expect(wrapper.className).not.toContain('border-t-cyan');
-    expect(wrapper.className).not.toContain('border-t-teal');
+    expect(wrapper.className).not.toContain('bg-cyan');
+    expect(wrapper.className).not.toContain('bg-teal');
+    expect(wrapper.style.borderTopColor).toBeFalsy();
   });
 
-  it('applies error styling for failed computed columns', () => {
+  // B9's other half: the error state uses the shared `highlight-*` tokens,
+  // never raw `red-*`.
+  it('applies highlight (not red) error styling for failed computed columns', () => {
     const failedColumn = {
       name: 'formatted_date',
       normalizedType: 'string',
@@ -73,8 +82,9 @@ describe('DraggableColumnHeader', () => {
     render(<DraggableColumnHeader column={failedColumn} />);
 
     const wrapper = screen.getByTestId('draggable-col-formatted_date');
-    expect(wrapper.className).toContain('border-t-red-500');
-    expect(wrapper.className).toContain('bg-red-50/50');
+    expect(wrapper.className).toContain('border-t-highlight-500');
+    expect(wrapper.className).toContain('bg-highlight-50/50');
+    expect(wrapper.className).not.toMatch(/\bred-/);
   });
 
   it('error styling takes precedence over computed type styling', () => {
@@ -87,8 +97,9 @@ describe('DraggableColumnHeader', () => {
     render(<DraggableColumnHeader column={errorMetric} />);
 
     const wrapper = screen.getByTestId('draggable-col-bad_metric');
-    expect(wrapper.className).toContain('border-t-red-500');
-    expect(wrapper.className).not.toContain('border-t-cyan-500');
+    expect(wrapper.className).toContain('border-t-highlight-500');
+    expect(wrapper.className).not.toContain('bg-cyan-100');
+    expect(wrapper.style.borderTopColor).toBeFalsy();
   });
 
   it('shows error tooltip via title attribute', () => {

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { PiCircleNotch } from 'react-icons/pi';
 import ChartPreview from '../views/common/ChartPreview';
 import useDraftInsightPreview, { draftInsightKey } from '../../hooks/useDraftInsightPreview';
@@ -6,6 +6,18 @@ import { useInsightsData } from '../../hooks/useInsightsData';
 import { usePreviewInputDependencies } from '../views/workspace/usePreviewInputDependencies';
 import PreviewInputControls from '../views/workspace/PreviewInputControls';
 import useStore from '../../stores/store';
+
+// Stable empty-array reference (avoids a fresh `[]` literal defeating memoized
+// selectors/`useMemo` deps every render — see ExplorationBuildRail.jsx's
+// EMPTY_PROMOTED for the same convention).
+const EMPTY_PROMOTED = [];
+
+// VIS-1093 — a bounded polling budget for the promoted-insight bridge below:
+// ~30s at 2s intervals. The run-on-save pipeline typically finishes in well
+// under a second (verified via a live trace); this is generous headroom for
+// a slow run, past which we stop polling forever and surface a failure state
+// instead of silently spinning.
+const MAX_PROMOTED_POLL_ATTEMPTS = 15;
 
 /**
  * ExplorerChartPreview — Explore 2.0 Phase 4 (S2's resolved design, VIS-1026's
@@ -36,6 +48,23 @@ import useStore from '../../stores/store';
  * lifetime, for exactly the chart's insights that have a matching real
  * `state.insights` entry (refreshed by `saveInsight`'s own `fetchInsights()`
  * call immediately after a successful promote).
+ *
+ * EXPLORATION-SCOPED LANE DETECTION (VIS-1091, Phase 5 preview-lane fix): a
+ * bare NAME match against the project-global `state.insights` list is not
+ * enough — two independently-created scratch explorations very likely mint
+ * the same auto-name ("insight") for their first insight, so if EITHER ONE
+ * gets promoted, the OTHER (never-promoted) exploration would incorrectly
+ * treat its own still-draft insight as "promoted" the instant it renders,
+ * silently swapping in unrelated real data. `promotedNames` below requires
+ * BOTH a matching real `state.insights` entry AND that THIS exploration's
+ * own `promoted[]` trail (`workspaceExplorations.byId[activeExplorationId]`)
+ * actually recorded promoting an insight of that name.
+ *
+ * PER-INSIGHT LOADING/ERROR (VIS-1092): `isLoading`/`error` handed to
+ * `<ChartPreview>` (which gates the WHOLE chart render on them) are computed
+ * ONLY over the insights still in the draft lane — an already-promoted
+ * insight showing real data is excluded, so a sibling draft insight's error
+ * can never blank it.
  */
 const ExplorerChartPreview = () => {
   const chartLayout = useStore(s => s.explorerChartLayout);
@@ -46,31 +75,70 @@ const ExplorerChartPreview = () => {
   const insightStates = useStore(s => s.explorerInsightStates);
   const realInsights = useStore(s => s.insights);
   const storeInsightJobs = useStore(s => s.insightJobs);
+  // VIS-1091 — the ACTIVE exploration's own promoted[] trail. This component
+  // only ever mounts while an exploration tab is active (CenterPanel has no
+  // other caller), so `workspaceActiveObject` reliably names it.
+  const activeExplorationId = useStore(s =>
+    s.workspaceActiveObject?.type === 'exploration' ? s.workspaceActiveObject.name : null
+  );
+  const explorationPromoted = useStore(s =>
+    activeExplorationId
+      ? s.workspaceExplorations?.byId?.[activeExplorationId]?.promoted || EMPTY_PROMOTED
+      : EMPTY_PROMOTED
+  );
 
   const draftPreview = useDraftInsightPreview();
 
-  // Chart insights that are ALSO real, published objects (post-promote).
+  // Chart insights that are ALSO real, published objects THIS EXPLORATION
+  // ITSELF promoted (VIS-1091 — never a bare cross-exploration name match).
   const promotedNames = useMemo(
-    () => chartInsightNames.filter(name => (realInsights || []).some(i => i.name === name)),
-    [chartInsightNames, realInsights]
+    () =>
+      chartInsightNames.filter(name => {
+        const isRealInsight = (realInsights || []).some(i => i.name === name);
+        if (!isRealInsight) return false;
+        return explorationPromoted.some(p => p.type === 'insight' && p.name === name);
+      }),
+    [chartInsightNames, realInsights, explorationPromoted]
   );
 
   // Poll every 2s while any promoted insight is still missing its real data
   // — the run-on-save pipeline typically finishes in well under a second
   // (verified via a live trace), but nothing else on this surface would ever
   // ask again once the first attempt lands before the run does. Stops
-  // itself the instant every promoted name has data (or on unmount).
+  // itself the instant every promoted name has data, on unmount, OR once
+  // MAX_PROMOTED_POLL_ATTEMPTS is exhausted (VIS-1093 — a run that never
+  // completes server-side used to spin this forever with no failure state).
   const [pollTick, setPollTick] = useState(0);
+  const [pollExhausted, setPollExhausted] = useState(false);
+  const pollAttemptsRef = useRef(0);
   const hasPromotedWithoutRealData = promotedNames.some(
     name => !storeInsightJobs?.[name]?.data
   );
+  const pollKey = promotedNames.join('|');
+  useEffect(() => {
+    // A NEW set of promoted-without-data names (e.g. a fresh promote) gets a
+    // fresh polling budget — it must not inherit exhaustion from a prior one.
+    pollAttemptsRef.current = 0;
+    setPollExhausted(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pollKey]);
   useEffect(() => {
     if (!hasPromotedWithoutRealData) return undefined;
-    const timer = setInterval(() => setPollTick(t => t + 1), 2000);
+    const timer = setInterval(() => {
+      pollAttemptsRef.current += 1;
+      if (pollAttemptsRef.current > MAX_PROMOTED_POLL_ATTEMPTS) {
+        setPollExhausted(true);
+        clearInterval(timer);
+        return;
+      }
+      setPollTick(t => t + 1);
+    }, 2000);
     return () => clearInterval(timer);
   }, [hasPromotedWithoutRealData]);
 
-  useInsightsData(projectId, promotedNames, undefined, { cacheKey: pollTick });
+  const { error: promotedFetchError } =
+    useInsightsData(projectId, promotedNames, undefined, { cacheKey: pollTick }) || {};
+  const promotedPollFailed = hasPromotedWithoutRealData && (pollExhausted || !!promotedFetchError);
 
   // Per-insight lane: the REAL name once its real data has actually landed
   // (never just because it's promoted — avoids a flash of empty/error chart
@@ -85,6 +153,37 @@ const ExplorerChartPreview = () => {
       ),
     [chartInsightNames, promotedNames, storeInsightJobs]
   );
+
+  // VIS-1092 — `<ChartPreview>` (unlike `Chart.jsx`) gates its ENTIRE render
+  // on `isLoading`/`error` — a single Plotly figure needs every insight's
+  // data to draw at all, so there's no such thing as "render just the good
+  // insight." The fix is therefore two-layered:
+  //   1. Only DRAFT-LANE insights (not already resolved to a real promoted
+  //      key) can even contribute a loading/error/blocked status — a
+  //      promoted insight's own real-data fetch is a separate lane entirely
+  //      (the poll bridge below), never this hook's concern.
+  //   2. Once ANY chart insight (promoted OR draft) already has data on
+  //      screen, suppress the whole-chart loading/error gate outright —
+  //      never regress an already-rendering chart back to a blank "Preview
+  //      Failed"/spinner screen because a background recompute is chasing a
+  //      sibling insight's edit. (`Chart.jsx`'s OWN `hasAllInsightData` gate
+  //      still applies underneath — it shows its own gentler generic
+  //      "Loading" state, never an alarming error, until every insight has
+  //      data again.)
+  const draftLaneNames = useMemo(
+    () => chartInsightNames.filter((name, idx) => previewInsightKeys[idx] === draftInsightKey(name)),
+    [chartInsightNames, previewInsightKeys]
+  );
+  const anyInsightAlreadyHasData = previewInsightKeys.some(key => storeInsightJobs?.[key]?.data != null);
+  const draftLaneIsLoading =
+    !anyInsightAlreadyHasData &&
+    draftLaneNames.some(name => draftPreview.perInsight?.[name]?.isLoading);
+  const draftLaneError = anyInsightAlreadyHasData
+    ? null
+    : draftLaneNames.map(name => draftPreview.perInsight?.[name]?.error).find(Boolean) || null;
+  const draftLaneBlockedStatus = anyInsightAlreadyHasData
+    ? null
+    : draftLaneNames.map(name => draftPreview.perInsight?.[name]).find(s => s?.blockedReason);
 
   // Config-fallback source for `usePreviewInputDependencies` (02 §6):
   // extracts referenced input names from props/interactions text directly —
@@ -126,8 +225,10 @@ const ExplorerChartPreview = () => {
   // Graceful "run the query first" state (S2's one known sub-gap): a raw-
   // column ref names a never-run scratch model with no schema anywhere —
   // neither a real schemas/<model>/schema.json NOR a client-supplied
-  // model_schemas override (no cached query result yet).
-  if (draftPreview.blockedReason === 'model_not_run') {
+  // model_schemas override (no cached query result yet). Scoped to the
+  // DRAFT LANE (VIS-1092) — a blocked still-draft sibling must not blank an
+  // already-rendering promoted insight either.
+  if (draftLaneBlockedStatus?.blockedReason === 'model_not_run') {
     return (
       <div
         className="flex flex-col items-center justify-center h-full bg-gray-50 gap-2 p-6 text-center"
@@ -135,7 +236,7 @@ const ExplorerChartPreview = () => {
       >
         <PiCircleNotch className="h-5 w-5 text-secondary-300" aria-hidden="true" />
         <span className="text-sm font-medium text-secondary-600">
-          Run the query{draftPreview.blockedModel ? ` for "${draftPreview.blockedModel}"` : ''}{' '}
+          Run the query{draftLaneBlockedStatus.blockedModel ? ` for "${draftLaneBlockedStatus.blockedModel}"` : ''}{' '}
           to preview this chart
         </span>
         <span className="text-xs text-secondary-400 max-w-sm">
@@ -157,6 +258,19 @@ const ExplorerChartPreview = () => {
           {unresolvedNames.map(n => `"${n}"`).join(', ')} — not yet promoted.
         </div>
       )}
+      {/* VIS-1093 — the promoted-poll bridge's failure path: surfaced as a
+          dismissible-by-nature banner (disappears once data lands or the
+          promoted set changes), never an infinite silent spinner. */}
+      {promotedPollFailed && (
+        <div
+          data-testid="chart-preview-promoted-poll-failed"
+          className="px-3 py-1.5 text-xs text-highlight-700 bg-highlight-50 border-b border-highlight-200"
+        >
+          Couldn&apos;t load the promoted chart&apos;s data
+          {promotedFetchError ? `: ${promotedFetchError.message || promotedFetchError}` : ' yet'}.
+          It may still be running server-side — try reopening this exploration.
+        </div>
+      )}
       <div className="flex-1 min-h-0">
         <ChartPreview
           chartConfig={chartConfig}
@@ -164,8 +278,8 @@ const ExplorerChartPreview = () => {
           projectId={projectId}
           onLayoutChange={syncPlotlyEdits}
           editableLayout={true}
-          isLoading={draftPreview.isLoading}
-          error={draftPreview.error}
+          isLoading={draftLaneIsLoading}
+          error={draftLaneError}
         />
       </div>
     </div>

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -6,6 +6,7 @@ import { useInsightsData } from '../../hooks/useInsightsData';
 import { usePreviewInputDependencies } from '../views/workspace/usePreviewInputDependencies';
 import PreviewInputControls from '../views/workspace/PreviewInputControls';
 import useStore from '../../stores/store';
+import { emitTimeToFirstChart } from '../views/workspace/telemetry';
 
 // Stable empty-array reference (avoids a fresh `[]` literal defeating memoized
 // selectors/`useMemo` deps every render — see ExplorationBuildRail.jsx's
@@ -184,6 +185,18 @@ const ExplorerChartPreview = () => {
   const draftLaneBlockedStatus = anyInsightAlreadyHasData
     ? null
     : draftLaneNames.map(name => draftPreview.perInsight?.[name]).find(s => s?.blockedReason);
+
+  // VIS-1072 — `time_to_first_chart`: fires the FIRST time any chart insight
+  // (draft or promoted) actually has data on screen for THIS exploration.
+  // `emitTimeToFirstChart` itself is idempotent per exploration id (a no-op
+  // on every subsequent render once fired), so this effect can just keep
+  // re-checking the condition on every relevant state change with no extra
+  // bookkeeping here.
+  useEffect(() => {
+    if (activeExplorationId && anyInsightAlreadyHasData) {
+      emitTimeToFirstChart(activeExplorationId);
+    }
+  }, [activeExplorationId, anyInsightAlreadyHasData]);
 
   // Config-fallback source for `usePreviewInputDependencies` (02 §6):
   // extracts referenced input names from props/interactions text directly —

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -5,6 +5,10 @@ import '@testing-library/jest-dom';
 import ExplorerChartPreview from './ExplorerChartPreview';
 import useStore from '../../stores/store';
 import useDraftInsightPreview from '../../hooks/useDraftInsightPreview';
+import {
+  markExplorationCreated,
+  setWorkspaceTelemetryListener,
+} from '../views/workspace/telemetry';
 
 // Explore 2.0 Phase 4: ExplorerChartPreview no longer builds the dead
 // context_objects preview-job request — it drives `useDraftInsightPreview`
@@ -382,6 +386,66 @@ describe('ExplorerChartPreview', () => {
         jest.advanceTimersByTime(15 * 2000 + 1000);
       });
       expect(screen.queryByTestId('chart-preview-promoted-poll-failed')).not.toBeInTheDocument();
+    });
+  });
+
+  // VIS-1072 — flywheel telemetry: time_to_first_chart fires the first time
+  // ANY chart insight (draft or promoted) actually has data on screen for
+  // the active exploration.
+  describe('time_to_first_chart telemetry (VIS-1072)', () => {
+    let events;
+    let unsubscribe;
+
+    beforeEach(() => {
+      events = [];
+      unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    });
+    afterEach(() => unsubscribe());
+
+    const chartEvents = () => events.filter(e => e.eventName === 'time_to_first_chart');
+
+    test('fires once real/draft data is on screen for the active (created-this-session) exploration', () => {
+      markExplorationCreated('exp_1');
+      useStore.setState({
+        insights: [{ name: 'ins_1' }],
+        insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 1 }] } },
+      });
+      useStore.setState({
+        workspaceExplorations: {
+          byId: { exp_1: { id: 'exp_1', promoted: [{ type: 'insight', name: 'ins_1' }] } },
+          order: ['exp_1'],
+        },
+      });
+      render(<ExplorerChartPreview />);
+      expect(chartEvents()).toHaveLength(1);
+    });
+
+    test('does not fire while nothing has data yet', () => {
+      markExplorationCreated('exp_1');
+      render(<ExplorerChartPreview />);
+      expect(chartEvents()).toHaveLength(0);
+    });
+
+    test('does not fire for an exploration this session never saw created (e.g. resumed after reload)', () => {
+      // A fresh, never-marked-created id — distinct from the other tests in
+      // this describe block, since `markExplorationCreated` bookkeeping is
+      // module-level and not reset between tests.
+      useStore.setState({
+        workspaceActiveObject: { type: 'exploration', name: 'exp_resumed_after_reload' },
+        insights: [{ name: 'ins_1' }],
+        insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 1 }] } },
+        workspaceExplorations: {
+          byId: {
+            exp_resumed_after_reload: {
+              id: 'exp_resumed_after_reload',
+              promoted: [{ type: 'insight', name: 'ins_1' }],
+            },
+          },
+          order: ['exp_resumed_after_reload'],
+        },
+      });
+      render(<ExplorerChartPreview />);
+      expect(chartEvents()).toHaveLength(0);
     });
   });
 });

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ExplorerChartPreview from './ExplorerChartPreview';
 import useStore from '../../stores/store';
@@ -55,6 +55,7 @@ const { usePreviewInputDependencies } = jest.requireMock(
 
 const defaultDraftPreview = {
   previewInsightKeys: ['__draft__:ins_1'],
+  perInsight: {},
   isLoading: false,
   error: null,
   blockedReason: null,
@@ -78,6 +79,11 @@ const defaultState = {
   // lane unless it explicitly opts into the promoted-lane-switch scenario.
   insights: [],
   insightJobs: {},
+  // VIS-1091 — lane detection is scoped to the ACTIVE exploration's own
+  // promoted[] trail. This component only ever mounts while an exploration
+  // tab is active, so every test seeds one (with an empty trail by default).
+  workspaceActiveObject: { type: 'exploration', name: 'exp_1' },
+  workspaceExplorations: { byId: { exp_1: { id: 'exp_1', promoted: [] } }, order: ['exp_1'] },
 };
 
 describe('ExplorerChartPreview', () => {
@@ -119,11 +125,14 @@ describe('ExplorerChartPreview', () => {
     expect(screen.getByTestId('cp-project-id')).toHaveTextContent('my-project-123');
   });
 
-  it('forwards isLoading/error from useDraftInsightPreview', () => {
+  // VIS-1092: the component reads `perInsight[name]` (draft-lane-scoped),
+  // not the hook's aggregate `isLoading`/`error` fields, so it can never
+  // blank an already-rendering promoted insight over a draft sibling's
+  // error — see the `mixed lane` describe block below for that guarantee.
+  it('forwards isLoading/error from useDraftInsightPreview via perInsight', () => {
     useDraftInsightPreview.mockReturnValue({
       ...defaultDraftPreview,
-      isLoading: true,
-      error: 'boom',
+      perInsight: { ins_1: { isLoading: true, error: 'boom', blockedReason: null, blockedModel: null } },
     });
     render(<ExplorerChartPreview />);
     expect(screen.getByTestId('cp-is-loading')).toHaveTextContent('true');
@@ -133,13 +142,47 @@ describe('ExplorerChartPreview', () => {
   it('renders the graceful "run the query first" state instead of ChartPreview on a model_not_run block', () => {
     useDraftInsightPreview.mockReturnValue({
       ...defaultDraftPreview,
-      blockedReason: 'model_not_run',
-      blockedModel: 'cohort_q',
+      perInsight: {
+        ins_1: { isLoading: false, error: null, blockedReason: 'model_not_run', blockedModel: 'cohort_q' },
+      },
     });
     render(<ExplorerChartPreview />);
     expect(screen.getByTestId('chart-preview-run-first')).toBeInTheDocument();
     expect(screen.getByTestId('chart-preview-run-first')).toHaveTextContent('cohort_q');
     expect(screen.queryByTestId('chart-preview-component')).not.toBeInTheDocument();
+  });
+
+  // VIS-1092 — the actual mixed-lane guarantee: a promoted insight with real
+  // data must never be blanked by a DRAFT sibling's error/loading, because
+  // the promoted one isn't even in the draft lane the aggregate is scoped to.
+  describe('mixed-lane isLoading/error scoping (VIS-1092)', () => {
+    it('an already-promoted insight with real data is never blanked by a draft sibling erroring', () => {
+      useStore.setState({
+        explorerChartInsightNames: ['promoted_ins', 'draft_ins'],
+        insights: [{ name: 'promoted_ins' }],
+        insightJobs: { promoted_ins: { name: 'promoted_ins', data: [{ x: 1 }] } },
+        workspaceExplorations: {
+          byId: { exp_1: { id: 'exp_1', promoted: [{ type: 'insight', name: 'promoted_ins' }] } },
+          order: ['exp_1'],
+        },
+      });
+      useDraftInsightPreview.mockReturnValue({
+        previewInsightKeys: ['promoted_ins', '__draft__:draft_ins'],
+        perInsight: {
+          draft_ins: { isLoading: false, error: 'draft_ins blew up', blockedReason: null, blockedModel: null },
+        },
+        isLoading: false,
+        error: 'draft_ins blew up', // the AGGREGATE still carries it — proves the fix reads perInsight, not this.
+        blockedReason: null,
+        blockedModel: null,
+      });
+      render(<ExplorerChartPreview />);
+      // promoted_ins renders through the normal ChartPreview path (not
+      // blanked by chart-preview-error / chart-preview-run-first).
+      expect(screen.getByTestId('chart-preview-component')).toBeInTheDocument();
+      expect(screen.getByTestId('cp-is-loading')).toHaveTextContent('false');
+      expect(screen.getByTestId('cp-error')).toBeEmptyDOMElement();
+    });
   });
 
   it('renders PreviewInputControls above the chart, driven by usePreviewInputDependencies', () => {
@@ -181,8 +224,26 @@ describe('ExplorerChartPreview', () => {
   // promoted (present in `state.insights`), and only SWITCHES the chart's
   // insightKeys over once that real data has actually landed.
   describe('promoted-lane switch', () => {
+    // Every "promoted" scenario below must seed BOTH a matching real
+    // `state.insights` entry AND the ACTIVE exploration's own `promoted[]`
+    // trail (VIS-1091) — a bare `state.insights` match alone is no longer
+    // sufficient.
+    const markPromoted = (names) =>
+      useStore.setState({
+        workspaceExplorations: {
+          byId: {
+            exp_1: {
+              id: 'exp_1',
+              promoted: names.map(name => ({ type: 'insight', name })),
+            },
+          },
+          order: ['exp_1'],
+        },
+      });
+
     it('stays on the draft-namespaced key while promoted but real data has not landed yet', () => {
       useStore.setState({ insights: [{ name: 'ins_1' }], insightJobs: {} });
+      markPromoted(['ins_1']);
       render(<ExplorerChartPreview />);
       expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
         JSON.stringify(['__draft__:ins_1'])
@@ -194,6 +255,7 @@ describe('ExplorerChartPreview', () => {
         insights: [{ name: 'ins_1' }],
         insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 1 }] } },
       });
+      markPromoted(['ins_1']);
       render(<ExplorerChartPreview />);
       expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
     });
@@ -209,6 +271,7 @@ describe('ExplorerChartPreview', () => {
         insights: [{ name: 'ins_1' }], // ins_2 is still a draft-only insight
         insightJobs: {},
       });
+      markPromoted(['ins_1']);
       render(<ExplorerChartPreview />);
       expect(useInsightsData).toHaveBeenCalledWith('proj-1', ['ins_1'], undefined, {
         cacheKey: 0,
@@ -221,6 +284,104 @@ describe('ExplorerChartPreview', () => {
       expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
         JSON.stringify(['__draft__:ins_1'])
       );
+    });
+
+    // VIS-1091 — the actual confirmed gap: a REAL insight named 'ins_1'
+    // exists (e.g. promoted by a DIFFERENT exploration, or pre-existing in
+    // the project) but THIS exploration's own promoted[] trail never
+    // recorded promoting it. Must stay on the draft-namespaced key — never
+    // silently swap in the unrelated real data.
+    it('a same-named real insight that THIS exploration never promoted is never treated as promoted (cross-exploration collision)', () => {
+      useStore.setState({
+        insights: [{ name: 'ins_1' }],
+        insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 99 }] } },
+      });
+      // workspaceExplorations.byId.exp_1.promoted stays [] — the default —
+      // simulating a DIFFERENT exploration having promoted 'ins_1', or a
+      // pre-existing project insight of the same auto-generated name.
+      render(<ExplorerChartPreview />);
+      expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
+        JSON.stringify(['__draft__:ins_1'])
+      );
+    });
+
+    it('no active exploration id (edge case) never treats anything as promoted', () => {
+      useStore.setState({
+        workspaceActiveObject: null,
+        insights: [{ name: 'ins_1' }],
+        insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 1 }] } },
+      });
+      render(<ExplorerChartPreview />);
+      expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
+        JSON.stringify(['__draft__:ins_1'])
+      );
+    });
+  });
+
+  // VIS-1093 — the promoted-poll bridge's bounded lifetime + failure path.
+  describe('promoted-poll bridge failure path (VIS-1093)', () => {
+    const { useInsightsData } = jest.requireMock('../../hooks/useInsightsData');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      // The default module mock resolves to `{}` (no error) — reset it
+      // explicitly since a prior test's `.mockReturnValue` override would
+      // otherwise leak (jest.clearAllMocks() clears call history, not a
+      // configured return value).
+      useInsightsData.mockReturnValue({});
+    });
+    afterEach(() => {
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+      jest.useRealTimers();
+    });
+
+    const markPromoted = (names) =>
+      useStore.setState({
+        workspaceExplorations: {
+          byId: { exp_1: { id: 'exp_1', promoted: names.map(name => ({ type: 'insight', name })) } },
+          order: ['exp_1'],
+        },
+      });
+
+    it('surfaces useInsightsData\'s error via a banner instead of silently discarding it', () => {
+      const { useInsightsData } = jest.requireMock('../../hooks/useInsightsData');
+      useInsightsData.mockReturnValue({ error: new Error('fetch failed') });
+      useStore.setState({ insights: [{ name: 'ins_1' }], insightJobs: {} });
+      markPromoted(['ins_1']);
+      render(<ExplorerChartPreview />);
+      expect(screen.getByTestId('chart-preview-promoted-poll-failed')).toHaveTextContent(
+        'fetch failed'
+      );
+    });
+
+    it('stops polling and shows the failure banner after the attempt budget is exhausted', () => {
+      useStore.setState({ insights: [{ name: 'ins_1' }], insightJobs: {} });
+      markPromoted(['ins_1']);
+      render(<ExplorerChartPreview />);
+      expect(screen.queryByTestId('chart-preview-promoted-poll-failed')).not.toBeInTheDocument();
+
+      // Exhaust the ~30s (15 x 2s) polling budget — advance comfortably past
+      // it so the exact attempt-count boundary doesn't make this test brittle.
+      act(() => {
+        jest.advanceTimersByTime(20 * 2000);
+      });
+
+      expect(screen.getByTestId('chart-preview-promoted-poll-failed')).toBeInTheDocument();
+    });
+
+    it('never shows the failure banner once real data actually lands', () => {
+      useStore.setState({
+        insights: [{ name: 'ins_1' }],
+        insightJobs: { ins_1: { name: 'ins_1', data: [{ x: 1 }] } },
+      });
+      markPromoted(['ins_1']);
+      render(<ExplorerChartPreview />);
+      act(() => {
+        jest.advanceTimersByTime(15 * 2000 + 1000);
+      });
+      expect(screen.queryByTestId('chart-preview-promoted-poll-failed')).not.toBeInTheDocument();
     });
   });
 });

--- a/viewer/src/components/views/common/CenteredFrameState.jsx
+++ b/viewer/src/components/views/common/CenteredFrameState.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * CenteredFrameState — Explore 2.0 Phase 5 (VIS-1071, 01-ux-spec.md §7's
+ * "Consolidate the three near-duplicate centered-card state components...
+ * into one shared component"). One shared "centered white card on a gray
+ * backdrop" empty/loading/error state, replacing FOUR near-identical
+ * hand-rolled copies (the spec names three; a fourth turned up during the
+ * sweep — `ExplorationPane.jsx` had its own separate `FrameState` with the
+ * same name as `ObjectCanvasFrame.jsx`'s, plus a `spin` prop neither of the
+ * other two had):
+ *
+ *   - `ObjectCanvasFrame.jsx`'s `FrameState`
+ *   - `ExplorationPane.jsx`'s (separately-defined, same-named) `FrameState`
+ *   - `RelationErdCanvas.jsx`'s `ErdEmptyState`
+ *   - `SourceErd.jsx`'s `FrameMessage`
+ *
+ * `icon` is optional (omit/pass `null` for a text-only card — matches the
+ * original `ErdEmptyState`, which never had one); `spin` adds
+ * `animate-spin` (matches `ExplorationPane`'s loading variant); `maxWidth`
+ * defaults to 420px (matches three of the four originals — `ErdEmptyState`
+ * used 360px, preserved via the prop at its call site).
+ */
+const CenteredFrameState = ({
+  testId,
+  title,
+  body,
+  icon: Icon = null,
+  spin = false,
+  maxWidth = 420,
+}) => (
+  <div
+    data-testid={testId}
+    className="flex flex-1 items-center justify-center bg-gray-50 p-12 text-center"
+  >
+    <div
+      data-testid={testId ? `${testId}-card` : undefined}
+      className="rounded-2xl border border-gray-200 bg-white p-8 shadow-sm"
+      style={{ maxWidth }}
+    >
+      {Icon && (
+        <Icon
+          className={`mx-auto mb-2 h-6 w-6 text-gray-300 ${spin ? 'animate-spin' : ''}`}
+          aria-hidden="true"
+        />
+      )}
+      <h2 className="text-[15px] font-semibold text-gray-900">{title}</h2>
+      {body && (
+        <p className="mx-auto mt-1.5 max-w-[320px] text-[13px] leading-relaxed text-gray-500">
+          {body}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+export default CenteredFrameState;

--- a/viewer/src/components/views/common/CenteredFrameState.test.jsx
+++ b/viewer/src/components/views/common/CenteredFrameState.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CenteredFrameState from './CenteredFrameState';
+
+const Icon = props => <svg data-testid="frame-state-icon" {...props} />;
+
+describe('CenteredFrameState', () => {
+  test('renders the testId, title, and body', () => {
+    render(<CenteredFrameState testId="my-state" title="Nothing here" body="Come back later." />);
+    expect(screen.getByTestId('my-state')).toBeInTheDocument();
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.getByText('Come back later.')).toBeInTheDocument();
+  });
+
+  test('renders no icon by default (matches the original ErdEmptyState, text-only)', () => {
+    render(<CenteredFrameState testId="my-state" title="Nothing here" />);
+    expect(screen.queryByTestId('frame-state-icon')).not.toBeInTheDocument();
+  });
+
+  test('exposes a stable "<testId>-card" testid for the inner card', () => {
+    render(<CenteredFrameState testId="my-state" title="Nothing here" />);
+    expect(screen.getByTestId('my-state-card')).toBeInTheDocument();
+  });
+
+  test('renders the given icon, without spin by default', () => {
+    render(<CenteredFrameState testId="my-state" title="Nothing here" icon={Icon} />);
+    const icon = screen.getByTestId('frame-state-icon');
+    expect(icon).toBeInTheDocument();
+    // SVG elements expose `className` as an SVGAnimatedString, not a plain
+    // string, in jsdom — read the attribute directly instead.
+    expect(icon.getAttribute('class')).not.toContain('animate-spin');
+  });
+
+  test('spin adds animate-spin to the icon', () => {
+    render(<CenteredFrameState testId="my-state" title="Loading…" icon={Icon} spin />);
+    expect(screen.getByTestId('frame-state-icon').getAttribute('class')).toContain('animate-spin');
+  });
+
+  test('omits the body paragraph entirely when none is given', () => {
+    render(<CenteredFrameState testId="my-state" title="Nothing here" />);
+    expect(screen.queryByText(/./, { selector: 'p' })).not.toBeInTheDocument();
+  });
+
+  test('maxWidth defaults to 420px and is overridable', () => {
+    const { rerender } = render(<CenteredFrameState testId="my-state" title="x" />);
+    expect(screen.getByTestId('my-state-card')).toHaveStyle({ maxWidth: '420px' });
+
+    rerender(<CenteredFrameState testId="my-state" title="x" maxWidth={360} />);
+    expect(screen.getByTestId('my-state-card')).toHaveStyle({ maxWidth: '360px' });
+  });
+});

--- a/viewer/src/components/views/common/pillFieldSwap.js
+++ b/viewer/src/components/views/common/pillFieldSwap.js
@@ -84,6 +84,7 @@ export function findReclassifiedSlots(promotedName, promotedType, insightStates)
       location: slot.location,
       key: slot.key,
       previousRef: slot.state.ref,
+      previousColumn: slot.state.column,
       previousAgg: slot.state.agg || null,
       swapTo: { kind: promotedType === 'metric' ? 'metricRef' : 'dimensionRef', ref: promotedName },
     }));
@@ -123,6 +124,7 @@ export function findMatchingExpressionSlots(
       location: slot.location,
       key: slot.key,
       previousRef: slot.state.ref,
+      previousColumn: slot.state.column,
       previousAgg: slot.state.agg || null,
       swapTo: { kind: promotedType === 'metric' ? 'metricRef' : 'dimensionRef', ref: promotedName },
     }));
@@ -132,4 +134,30 @@ export function findMatchingExpressionSlots(
  * the `?{...}` query-string form a prop/interaction value expects. */
 export function serializeSwapTarget(swapTo) {
   return `?{${pillGrammar.serialize({ kind: swapTo.kind, ref: swapTo.ref })}}`;
+}
+
+/**
+ * Re-read a slot's CURRENT live value (VIS-1095, Phase 5 preview-lane/offer-
+ * staleness fix). An offer's `slots` are a SNAPSHOT captured the instant the
+ * offer was created (right after a promote / "Save as metric"); by the time
+ * the user actually clicks "Update N references", the target insight may
+ * have been renamed/removed, or the SAME slot may have been hand-edited to
+ * something else entirely underneath the banner (it's a non-blocking inline
+ * element, not a modal — nothing stops continued editing while it's open).
+ *
+ * Returns `null` when the insight is gone or the slot's current value no
+ * longer parses as a column-ref-shaped (dimension/aggregate) value at all —
+ * `FieldSwapOfferBanner.applyOffer` treats a `null` (or any ref/column/agg
+ * mismatch against the offer's captured `previousRef`/`previousColumn`/
+ * `previousAgg`) as "changed since the offer was made" and skips that slot
+ * rather than blindly overwriting whatever is there now.
+ */
+export function readCurrentSlotState(insightStates, slot) {
+  const insightState = insightStates?.[slot.insightName];
+  if (!insightState) return null;
+  const rawValue =
+    slot.location === 'prop'
+      ? insightState.props?.[slot.key]
+      : insightState.interactions?.[slot.key]?.value;
+  return parseQueryBody(rawValue);
 }

--- a/viewer/src/components/views/common/pillFieldSwap.test.js
+++ b/viewer/src/components/views/common/pillFieldSwap.test.js
@@ -3,6 +3,7 @@ import {
   findReclassifiedSlots,
   findMatchingExpressionSlots,
   serializeSwapTarget,
+  readCurrentSlotState,
 } from './pillFieldSwap';
 
 describe('pillFieldSwap', () => {
@@ -116,6 +117,52 @@ describe('pillFieldSwap', () => {
         insightStates
       );
       expect(hits).toHaveLength(0);
+    });
+  });
+
+  describe('both detectors capture previousColumn (VIS-1095 accept-time re-validation)', () => {
+    test('findReclassifiedSlots', () => {
+      const insightStates = { a: { props: { y: '?{${ref(orders_q).region}}' }, interactions: [] } };
+      const hits = findReclassifiedSlots('region', 'dimension', insightStates);
+      expect(hits[0]).toMatchObject({ previousRef: 'orders_q', previousColumn: 'region', previousAgg: null });
+    });
+
+    test('findMatchingExpressionSlots', () => {
+      const insightStates = { a: { props: { y: '?{sum(${ref(orders_q).amount})}' }, interactions: [] } };
+      const hits = findMatchingExpressionSlots(
+        { promotedRef: 'orders_q', promotedColumn: 'amount', promotedAgg: 'sum', promotedName: 'x', promotedType: 'metric' },
+        insightStates
+      );
+      expect(hits[0]).toMatchObject({ previousRef: 'orders_q', previousColumn: 'amount', previousAgg: 'sum' });
+    });
+  });
+
+  describe('readCurrentSlotState (VIS-1095 accept-time re-validation)', () => {
+    test('reads and parses the CURRENT prop value at the slot key', () => {
+      const insightStates = {
+        a: { props: { y: '?{${ref(orders_q).region}}' }, interactions: [] },
+      };
+      const state = readCurrentSlotState(insightStates, { insightName: 'a', location: 'prop', key: 'y' });
+      expect(state).toMatchObject({ kind: 'dimension', ref: 'orders_q', column: 'region' });
+    });
+
+    test('reads and parses the CURRENT interaction value at the slot index', () => {
+      const insightStates = {
+        a: { props: {}, interactions: [{ type: 'sort', value: '?{sum(${ref(orders_q).amount})}' }] },
+      };
+      const state = readCurrentSlotState(insightStates, { insightName: 'a', location: 'interaction', key: 0 });
+      expect(state).toMatchObject({ kind: 'aggregate', agg: 'sum', ref: 'orders_q', column: 'amount' });
+    });
+
+    test('returns null when the insight no longer exists (renamed/removed since the offer was made)', () => {
+      const state = readCurrentSlotState({}, { insightName: 'gone', location: 'prop', key: 'y' });
+      expect(state).toBeNull();
+    });
+
+    test('returns null when the current value no longer parses as a column-ref shape', () => {
+      const insightStates = { a: { props: { y: 'not a ref at all' }, interactions: [] } };
+      const state = readCurrentSlotState(insightStates, { insightName: 'a', location: 'prop', key: 'y' });
+      expect(state).toBeNull();
     });
   });
 

--- a/viewer/src/components/views/lineage/LineageCanvas.jsx
+++ b/viewer/src/components/views/lineage/LineageCanvas.jsx
@@ -5,6 +5,7 @@ import OpenObjectContextMenu from '../workspace/OpenObjectContextMenu';
 import useStore from '../../../stores/store';
 import { useWorkspaceScope } from '../workspace/useWorkspaceScope';
 import { emitWorkspaceEvent } from '../workspace/telemetry';
+import { EXPLORE_THIS_TYPES, EXPLORATION_DRAG_TYPES } from '../workspace/library/LibraryRow';
 
 /**
  * LineageCanvas — VIS-E1 (VIS-779 / Track E).
@@ -34,6 +35,12 @@ const LineageCanvas = () => {
   const openWorkspaceTab = useStore((s) => s.openWorkspaceTab);
   const openWorkspaceTabBackground = useStore((s) => s.openWorkspaceTabBackground);
   const setWorkspaceLensIntent = useStore((s) => s.setWorkspaceLensIntent);
+  const createExploration = useStore((s) => s.createExploration);
+  const buildExplorationSeedState = useStore((s) => s.buildExplorationSeedState);
+  const addObjectToActiveExploration = useStore((s) => s.addObjectToActiveExploration);
+  // VIS-1067: only offer "Add to exploration" while an exploration tab is
+  // the ACTIVE one — see Library.jsx's identical gate for why.
+  const canAddToExploration = useStore((s) => s.workspaceActiveObject?.type === 'exploration');
 
   // Local "show full project" override. When active we force `*` regardless of
   // the derived scope — without touching the route. It auto-clears whenever the
@@ -138,6 +145,32 @@ const LineageCanvas = () => {
     [openWorkspaceTabBackground]
   );
 
+  // VIS-1067 — "Explore this" mints a new exploration seeded from the
+  // clicked DAG node (pre-wired per `buildExplorationSeedState`) and opens
+  // its tab; "Add to exploration" adds it into the currently active one.
+  const handleCtxExploreThis = useCallback(
+    (obj) => {
+      if (!createExploration || !openWorkspaceTab) return;
+      const seed = { type: obj.type, name: obj.name };
+      const legacyStateOverride = buildExplorationSeedState
+        ? buildExplorationSeedState(seed)
+        : null;
+      createExploration(seed, null, legacyStateOverride).then((result) => {
+        if (result?.success) {
+          openWorkspaceTab({ id: `exploration:${result.id}`, type: 'exploration', name: result.id });
+          emitWorkspaceEvent('explore_this_used', { source_type: obj.type });
+        }
+      });
+    },
+    [createExploration, openWorkspaceTab, buildExplorationSeedState]
+  );
+  const handleCtxAddToExploration = useCallback(
+    (obj) => {
+      addObjectToActiveExploration && addObjectToActiveExploration(obj);
+    },
+    [addObjectToActiveExploration]
+  );
+
   const chrome = (
     <div
       data-testid="lineage-canvas-scope-bar"
@@ -189,6 +222,14 @@ const LineageCanvas = () => {
           obj={ctxMenu.obj}
           onOpen={handleCtxOpen}
           onOpenInNewTab={handleCtxOpenInNewTab}
+          onExploreThis={
+            EXPLORE_THIS_TYPES.includes(ctxMenu.obj?.type) ? handleCtxExploreThis : undefined
+          }
+          onAddToExploration={
+            canAddToExploration && EXPLORATION_DRAG_TYPES.includes(ctxMenu.obj?.type)
+              ? handleCtxAddToExploration
+              : undefined
+          }
           onDismiss={dismissCtxMenu}
           testIdPrefix="lineage-node-ctx"
         />

--- a/viewer/src/components/views/lineage/LineageCanvas.test.jsx
+++ b/viewer/src/components/views/lineage/LineageCanvas.test.jsx
@@ -14,7 +14,7 @@
  * the contract without standing up React Flow.
  */
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import LineageCanvas from './LineageCanvas';
 import useStore from '../../../stores/store';
 import { setWorkspaceTelemetryListener } from '../workspace/telemetry';
@@ -56,6 +56,14 @@ jest.mock('./Lineage', () => {
           }
         >
           right-click node
+        </button>
+        <button
+          data-testid="simulate-node-contextmenu-insight"
+          onClick={(e) =>
+            onNodeContextMenu && onNodeContextMenu(e, { type: 'insight', name: 'revenue_growth' })
+          }
+        >
+          right-click insight node
         </button>
       </div>
     );
@@ -221,6 +229,71 @@ describe('LineageCanvas', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByTestId('lineage-node-ctx-menu')).not.toBeInTheDocument();
     expect(useStore.getState().workspaceTabs).toHaveLength(0);
+  });
+
+  // VIS-1067 — "Explore this" / "Add to exploration" from a DAG node.
+  describe('Explore this / Add to exploration', () => {
+    test('"Explore this" renders for a model node, mints a pre-wired exploration, and opens its tab', async () => {
+      const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+      const buildExplorationSeedState = jest.fn().mockReturnValue({ modelTabs: ['query_1'] });
+      setScope(DASHBOARD);
+      act(() => {
+        useStore.setState({ createExploration, buildExplorationSeedState });
+      });
+      render(<LineageCanvas />);
+      fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+      const exploreThis = screen.getByTestId('lineage-node-ctx-explore-this');
+      fireEvent.click(exploreThis);
+
+      expect(buildExplorationSeedState).toHaveBeenCalledWith({
+        type: 'model',
+        name: 'monthly_revenue',
+      });
+      await waitFor(() =>
+        expect(createExploration).toHaveBeenCalledWith(
+          { type: 'model', name: 'monthly_revenue' },
+          null,
+          { modelTabs: ['query_1'] }
+        )
+      );
+      await waitFor(() => {
+        expect(useStore.getState().workspaceActiveTabId).toBe('exploration:exp_new');
+      });
+      expect(screen.queryByTestId('lineage-node-ctx-menu')).not.toBeInTheDocument();
+    });
+
+    test('"Add to exploration" never renders for a model node (model is not an EXPLORATION_DRAG_TYPE), even with an exploration active', () => {
+      setScope(DASHBOARD);
+      act(() => {
+        useStore.setState({ workspaceActiveObject: { type: 'exploration', name: 'exp_1' } });
+      });
+      render(<LineageCanvas />);
+      fireEvent.click(screen.getByTestId('simulate-node-contextmenu'));
+      expect(screen.queryByTestId('lineage-node-ctx-add-to-exploration')).not.toBeInTheDocument();
+    });
+
+    test('"Add to exploration" renders for an insight node ONLY when an exploration tab is active, and calls addObjectToActiveExploration', () => {
+      const addObjectToActiveExploration = jest.fn();
+      setScope(DASHBOARD);
+      act(() => {
+        useStore.setState({ addObjectToActiveExploration, workspaceActiveObject: null });
+      });
+      render(<LineageCanvas />);
+      fireEvent.click(screen.getByTestId('simulate-node-contextmenu-insight'));
+      expect(screen.queryByTestId('lineage-node-ctx-add-to-exploration')).not.toBeInTheDocument();
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      act(() => {
+        useStore.setState({ workspaceActiveObject: { type: 'exploration', name: 'exp_1' } });
+      });
+      fireEvent.click(screen.getByTestId('simulate-node-contextmenu-insight'));
+      const addToExploration = screen.getByTestId('lineage-node-ctx-add-to-exploration');
+      fireEvent.click(addToExploration);
+      expect(addObjectToActiveExploration).toHaveBeenCalledWith({
+        type: 'insight',
+        name: 'revenue_growth',
+      });
+    });
   });
 
   test('manual selector input inside Lineage still works as an override', () => {

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -4,10 +4,12 @@ import useStore from '../../../stores/store';
 import SubBar from './SubBar';
 import ExplorationWorkbench from './ExplorationWorkbench';
 import ExplorationDeletedRemotelyBanner from './ExplorationDeletedRemotelyBanner';
+import ExplorationStalenessBanner from './ExplorationStalenessBanner';
 import InlineRenameInput from './InlineRenameInput';
 import useInlineRename from '../../../hooks/useInlineRename';
 import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import { legacyStateToDraft, draftToLegacyState } from './explorationLegacyBridge';
+import { computeExplorationStaleness } from './explorationStaleness';
 
 const ExplorationIcon = getTypeIcon('exploration');
 const EXPLORATION_COLORS = getTypeColors('exploration');
@@ -134,6 +136,12 @@ const ExplorationPane = ({ id }) => {
 
   const [readyId, setReadyId] = useState(null);
   const skipNextLiveSyncRef = useRef(false);
+  // VIS-1070 — resume-time staleness (02-architecture.md §8): computed ONCE
+  // per activation, not continuously (that's what the Build rail's own live
+  // advisory validation already does while editing) — see
+  // `explorationStaleness.js`'s docstring for what "stale" means here.
+  const [staleness, setStaleness] = useState(null);
+  const [stalenessDismissed, setStalenessDismissed] = useState(false);
 
   // Restore-on-activate / flush-on-deactivate. Deps are `[id, !!record]` —
   // NOT `record` itself: `record` is a fresh object on every optimistic
@@ -153,6 +161,12 @@ const ExplorationPane = ({ id }) => {
     // draft it just read. Not incorrect (idempotent), just wasted traffic.
     skipNextLiveSyncRef.current = true;
     setReadyId(id);
+    // VIS-1070 — re-run ref checks against CURRENT collections right at
+    // resume (a parked exploration may have sat while a referenced object
+    // was deleted elsewhere). A fresh activation always gets a fresh check —
+    // never carries over a previous session's dismissal.
+    setStaleness(computeExplorationStaleness(record, useStore.getState()));
+    setStalenessDismissed(false);
 
     return () => {
       const snapshot = snapshotExplorerWorkingState();
@@ -214,6 +228,17 @@ const ExplorationPane = ({ id }) => {
     },
     [id, renameExploration]
   );
+
+  // VIS-1070 — "Re-check references": re-runs the SAME staleness check
+  // against whatever the live store looks like RIGHT NOW (picks up an edit
+  // the user just made, or an object someone else just published) rather
+  // than only ever reflecting the moment-of-resume snapshot.
+  const handleRecheckStaleness = useCallback(() => {
+    const current = useStore.getState().workspaceExplorations?.byId?.[id];
+    if (!current) return;
+    setStaleness(computeExplorationStaleness(current, useStore.getState()));
+  }, [id]);
+  const handleDismissStaleness = useCallback(() => setStalenessDismissed(true), []);
 
   // VIS-1086: in-flight guard against a double-click on Duplicate — checked
   // synchronously INSIDE the handler (a real double-click can dispatch both
@@ -315,6 +340,13 @@ const ExplorationPane = ({ id }) => {
         }
       />
       {record.syncStatus === 'deleted-remotely' && <ExplorationDeletedRemotelyBanner id={id} />}
+      {!stalenessDismissed && staleness?.stale && (
+        <ExplorationStalenessBanner
+          danglingRefs={staleness.danglingRefs}
+          onRecheck={handleRecheckStaleness}
+          onDismiss={handleDismissStaleness}
+        />
+      )}
       <ExplorationWorkbench id={id} />
     </section>
   );

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -11,6 +11,7 @@ import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import { legacyStateToDraft, draftToLegacyState } from './explorationLegacyBridge';
 import { computeExplorationStaleness } from './explorationStaleness';
 import CenteredFrameState from '../common/CenteredFrameState';
+import { emitWorkspaceEvent } from './telemetry';
 
 const ExplorationIcon = getTypeIcon('exploration');
 const EXPLORATION_COLORS = getTypeColors('exploration');
@@ -151,6 +152,10 @@ const ExplorationPane = ({ id }) => {
     // never carries over a previous session's dismissal.
     setStaleness(computeExplorationStaleness(record, useStore.getState()));
     setStalenessDismissed(false);
+    // VIS-1072 — every activation (fresh create's immediate open, AND a
+    // later resume of a parked tab) counts as "opened"; `exploration_created`
+    // is the separate, narrower "minted a new record" signal.
+    emitWorkspaceEvent('exploration_opened', { id });
 
     return () => {
       const snapshot = snapshotExplorerWorkingState();

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -10,6 +10,7 @@ import useInlineRename from '../../../hooks/useInlineRename';
 import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import { legacyStateToDraft, draftToLegacyState } from './explorationLegacyBridge';
 import { computeExplorationStaleness } from './explorationStaleness';
+import CenteredFrameState from '../common/CenteredFrameState';
 
 const ExplorationIcon = getTypeIcon('exploration');
 const EXPLORATION_COLORS = getTypeColors('exploration');
@@ -19,23 +20,6 @@ const EXPLORATION_COLORS = getTypeColors('exploration');
 // already re-arms that internally on every call); this one just throttles
 // how often we bother computing a snapshot from the legacy store at all.
 const LIVE_SYNC_DEBOUNCE_MS = 600;
-
-const FrameState = ({ testId, title, body, icon: Icon = PiCircleNotch, spin = false }) => (
-  <div data-testid={testId} className="flex flex-1 items-center justify-center bg-gray-50 p-12">
-    <div className="max-w-[420px] rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-      <Icon
-        className={`mx-auto mb-2 h-6 w-6 text-gray-300 ${spin ? 'animate-spin' : ''}`}
-        aria-hidden="true"
-      />
-      <h2 className="text-[15px] font-semibold text-gray-900">{title}</h2>
-      {body && (
-        <p className="mx-auto mt-1.5 max-w-[320px] text-[13px] leading-relaxed text-gray-500">
-          {body}
-        </p>
-      )}
-    </div>
-  </div>
-);
 
 /**
  * RenameField — the SubBar's persistent-pencil rename affordance
@@ -285,7 +269,12 @@ const ExplorationPane = ({ id }) => {
           className="flex h-full w-full flex-col bg-gray-50"
         >
           <SubBar testId="workspace-subbar-exploration" left={<span className="text-[12px] text-gray-400">Loading…</span>} />
-          <FrameState testId="exploration-pane-loading" title="Loading exploration…" spin />
+          <CenteredFrameState
+            testId="exploration-pane-loading"
+            title="Loading exploration…"
+            icon={PiCircleNotch}
+            spin
+          />
         </section>
       );
     }
@@ -298,10 +287,11 @@ const ExplorationPane = ({ id }) => {
           testId="workspace-subbar-exploration"
           left={<span className="text-[12px] font-semibold text-gray-900">Exploration not found</span>}
         />
-        <FrameState
+        <CenteredFrameState
           testId="exploration-pane-not-found"
           title="This exploration doesn't exist"
           body="It may have been deleted. Head back to Explorer Home to start a new one."
+          icon={PiCircleNotch}
         />
       </section>
     );

--- a/viewer/src/components/views/workspace/ExplorationPane.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
 /**
  * ExplorationPane (Explore 2.0 Phase 2) — the MiddlePane branch for an
  * `exploration` document tab. Pins the not-found/loading states and the
@@ -170,6 +171,165 @@ describe('ExplorationPane — VIS-1083 deleted-remotely banner', () => {
     });
     render(<ExplorationPane id="exp_1" />);
     expect(screen.queryByTestId('exploration-deleted-remotely-banner')).not.toBeInTheDocument();
+  });
+});
+
+// VIS-1070 — resume-time staleness: re-runs ref checks against current
+// collections right at activation and offers a non-blocking "re-check"
+// banner (never a hard failure — the workbench keeps working regardless).
+describe('ExplorationPane — staleness banner (VIS-1070)', () => {
+  const withCollections = (extra = {}) => ({
+    models: [{ name: 'orders_q' }],
+    metrics: [],
+    dimensions: [],
+    sources: [{ name: 'warehouse' }],
+    insights: [],
+    charts: [],
+    tables: [],
+    markdowns: [],
+    inputs: [],
+    relations: [],
+    dashboards: [],
+    ...extra,
+  });
+
+  test('shows the banner + dangling ref when the draft references a deleted object', () => {
+    seed({
+      ...withCollections(),
+      workspaceExplorations: {
+        byId: {
+          exp_1: record({
+            draft: {
+              queries: [],
+              insights: [{ name: 'ins', props: { x: '?{${ref(deleted_model).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+        },
+        order: ['exp_1'],
+      },
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.getByTestId('exploration-staleness-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-staleness-banner')).toHaveTextContent('deleted_model');
+  });
+
+  test('does NOT show the banner for a draft with no dangling refs', () => {
+    seed({
+      ...withCollections(),
+      workspaceExplorations: {
+        byId: {
+          exp_1: record({
+            draft: {
+              queries: [{ name: 'orders_q', sql: 'SELECT 1', source: 'warehouse' }],
+              insights: [{ name: 'ins', props: { x: '?{${ref(orders_q).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+        },
+        order: ['exp_1'],
+      },
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.queryByTestId('exploration-staleness-banner')).not.toBeInTheDocument();
+  });
+
+  test('Dismiss hides the banner without touching the exploration draft', () => {
+    seed({
+      ...withCollections(),
+      workspaceExplorations: {
+        byId: {
+          exp_1: record({
+            draft: {
+              queries: [],
+              insights: [{ name: 'ins', props: { x: '?{${ref(gone).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+        },
+        order: ['exp_1'],
+      },
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.getByTestId('exploration-staleness-banner')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('exploration-staleness-dismiss'));
+    expect(screen.queryByTestId('exploration-staleness-banner')).not.toBeInTheDocument();
+  });
+
+  test('"Re-check references" re-runs the check and clears the banner once the ref resolves again', () => {
+    seed({
+      ...withCollections(),
+      workspaceExplorations: {
+        byId: {
+          exp_1: record({
+            draft: {
+              queries: [],
+              insights: [{ name: 'ins', props: { x: '?{${ref(orders_q).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+        },
+        order: ['exp_1'],
+      },
+      // Simulate the ref being dangling AT RESUME TIME by starting `models`
+      // without `orders_q`, then "publishing" it before Re-check.
+      models: [],
+    });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.getByTestId('exploration-staleness-banner')).toBeInTheDocument();
+
+    act(() => {
+      useStore.setState({ models: [{ name: 'orders_q' }] });
+    });
+    fireEvent.click(screen.getByTestId('exploration-staleness-recheck'));
+
+    expect(screen.queryByTestId('exploration-staleness-banner')).not.toBeInTheDocument();
+  });
+
+  test('switching to a DIFFERENT exploration gets its own fresh check, never carries over a dismissal', () => {
+    seed({
+      ...withCollections(),
+      workspaceExplorations: {
+        byId: {
+          exp_1: record({
+            draft: {
+              queries: [],
+              insights: [{ name: 'a', props: { x: '?{${ref(gone_1).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+          exp_2: record({
+            id: 'exp_2',
+            name: 'Second',
+            draft: {
+              queries: [],
+              insights: [{ name: 'b', props: { x: '?{${ref(gone_2).col}}' }, interactions: [] }],
+              chart: null,
+              computedColumns: [],
+              legacyState: null,
+            },
+          }),
+        },
+        order: ['exp_1', 'exp_2'],
+      },
+    });
+    const { rerender } = render(<ExplorationPane id="exp_1" />);
+    fireEvent.click(screen.getByTestId('exploration-staleness-dismiss'));
+    expect(screen.queryByTestId('exploration-staleness-banner')).not.toBeInTheDocument();
+
+    rerender(<ExplorationPane id="exp_2" />);
+    expect(screen.getByTestId('exploration-staleness-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-staleness-banner')).toHaveTextContent('gone_2');
   });
 });
 

--- a/viewer/src/components/views/workspace/ExplorationPane.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.test.jsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import ExplorationPane from './ExplorationPane';
 import useStore from '../../../stores/store';
+import { setWorkspaceTelemetryListener } from './telemetry';
 
 jest.mock('./ExplorationWorkbench', () => ({
   __esModule: true,
@@ -461,5 +462,36 @@ describe('ExplorationPane — duplicate', () => {
     await act(async () => {
       resolveDuplicate({ success: true, id: 'exp_3' });
     });
+  });
+});
+
+// VIS-1072 — flywheel telemetry.
+describe('ExplorationPane — exploration_opened telemetry (VIS-1072)', () => {
+  let events;
+  let unsubscribe;
+
+  beforeEach(() => {
+    events = [];
+    unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+  });
+  afterEach(() => unsubscribe());
+
+  test('fires exploration_opened on activation', () => {
+    seed({ workspaceExplorations: { byId: { exp_1: record() }, order: ['exp_1'] } });
+    render(<ExplorationPane id="exp_1" />);
+    expect(events.find(e => e.eventName === 'exploration_opened')?.payload).toEqual({ id: 'exp_1' });
+  });
+
+  test('fires again for a DIFFERENT exploration when switching tabs', () => {
+    seed({
+      workspaceExplorations: {
+        byId: { exp_1: record(), exp_2: record({ id: 'exp_2', name: 'Second' }) },
+        order: ['exp_1', 'exp_2'],
+      },
+    });
+    const { rerender } = render(<ExplorationPane id="exp_1" />);
+    rerender(<ExplorationPane id="exp_2" />);
+    const opened = events.filter(e => e.eventName === 'exploration_opened');
+    expect(opened.map(e => e.payload.id)).toEqual(['exp_1', 'exp_2']);
   });
 });

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -30,8 +30,20 @@ const rowKey = row => `${row.type}:${row.name}`;
  * updates the original (05-e2e-ledger.md resolution #1), never creates a
  * duplicate.
  */
+const EMPTY_DASHBOARDS = [];
+
 const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const promoteExploration = useStore(s => s.promoteExploration);
+  // VIS-1068 — dashboard round-trip completion: read the exploration's own
+  // one-shot `return_to` intent + the live dashboard list (for the disabled-
+  // with-tooltip case when the target dashboard no longer exists).
+  const returnTo = useStore(s =>
+    explorationId ? s.workspaceExplorations?.byId?.[explorationId]?.returnTo || null : null
+  );
+  const dashboards = useStore(s => s.dashboards || EMPTY_DASHBOARDS);
+  const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  const placeChartInDashboardSlot = useStore(s => s.placeChartInDashboardSlot);
+  const consumeExplorationReturnTo = useStore(s => s.consumeExplorationReturnTo);
 
   const [loading, setLoading] = useState(true);
   const [rows, setRows] = useState([]);
@@ -40,6 +52,8 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const [error, setError] = useState(null);
   const [reclassificationOffers, setReclassificationOffers] = useState([]);
   const [promotedThisRun, setPromotedThisRun] = useState(null);
+  const [placing, setPlacing] = useState(false);
+  const [placeError, setPlaceError] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -114,6 +128,56 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   }, []);
 
   const totalRows = rows.length;
+
+  // VIS-1068 — the chart promoted THIS RUN (return_to placement only makes
+  // sense for a run that actually promoted a chart; older promotes in a
+  // prior session don't retroactively offer placement).
+  const promotedChart = useMemo(
+    () => (promotedThisRun?.results || []).find(r => r.success && r.type === 'chart') || null,
+    [promotedThisRun]
+  );
+  const dashboardExists = useMemo(
+    () => !!returnTo?.dashboard && dashboards.some(d => d.name === returnTo.dashboard),
+    [returnTo, dashboards]
+  );
+
+  const handlePlaceInDashboard = useCallback(async () => {
+    if (!returnTo?.dashboard || !promotedChart || !placeChartInDashboardSlot) return;
+    setPlacing(true);
+    setPlaceError(null);
+    const placeResult = await placeChartInDashboardSlot(
+      returnTo.dashboard,
+      promotedChart.name,
+      returnTo.slot
+    );
+    if (!placeResult?.success) {
+      setPlacing(false);
+      setPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
+      return;
+    }
+    await consumeExplorationReturnTo?.(explorationId);
+    setPlacing(false);
+    openWorkspaceTab?.({
+      id: `dashboard:${returnTo.dashboard}`,
+      type: 'dashboard',
+      name: returnTo.dashboard,
+    });
+    onClose?.();
+  }, [
+    returnTo,
+    promotedChart,
+    placeChartInDashboardSlot,
+    consumeExplorationReturnTo,
+    explorationId,
+    openWorkspaceTab,
+    onClose,
+  ]);
+
+  // "Declining also consumes" (01-ux-spec.md §5) — an explicit choice, never
+  // silent accretion of an ever-growing pile of dead placement intents.
+  const handleDeclinePlacement = useCallback(() => {
+    consumeExplorationReturnTo?.(explorationId);
+  }, [consumeExplorationReturnTo, explorationId]);
 
   return (
     <div
@@ -229,6 +293,56 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
           >
             Promoted {promotedThisRun.results.filter(r => r.success).length} object
             {promotedThisRun.results.filter(r => r.success).length === 1 ? '' : 's'}.
+          </p>
+        )}
+
+        {/* VIS-1068 — dashboard round-trip completion. Only offered on a run
+            that actually promoted a chart while return_to is still set (a
+            reload between opening the intent-carrying exploration and
+            promoting preserves return_to — it's fetched from the backend on
+            every load, never derived from a mount-time snapshot here). A
+            return_to whose dashboard no longer exists renders the offer
+            DISABLED with a tooltip rather than hiding it (04-bug-inventory.md
+            D12's validation nit). */}
+        {promotedThisRun?.success && returnTo?.dashboard && promotedChart && (
+          <div
+            data-testid="exploration-promote-return-to-offer"
+            className="mt-3 flex items-center justify-between gap-2 rounded-md border border-primary-200 bg-primary-50 px-2.5 py-2"
+          >
+            <span className="text-xs text-primary-800">
+              Place <span className="font-medium">{promotedChart.name}</span> in{' '}
+              <span className="font-medium">{returnTo.dashboard}</span>?
+            </span>
+            <div className="flex shrink-0 gap-1.5">
+              <button
+                type="button"
+                data-testid="exploration-promote-decline-placement"
+                onClick={handleDeclinePlacement}
+                disabled={placing}
+                className="rounded-md px-2 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100 disabled:opacity-50"
+              >
+                Not now
+              </button>
+              <button
+                type="button"
+                data-testid="exploration-promote-place-in-dashboard"
+                onClick={handlePlaceInDashboard}
+                disabled={placing || !dashboardExists}
+                title={!dashboardExists ? `"${returnTo.dashboard}" no longer exists` : undefined}
+                className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {placing ? 'Placing…' : `Place in ${returnTo.dashboard}`}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {placeError && (
+          <p
+            data-testid="exploration-promote-place-error"
+            className="mt-2 text-xs text-highlight-600 bg-highlight-50 border border-highlight-200 rounded-md px-2.5 py-1.5"
+          >
+            {placeError}
           </p>
         )}
 

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -44,6 +44,9 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const placeChartInDashboardSlot = useStore(s => s.placeChartInDashboardSlot);
   const consumeExplorationReturnTo = useStore(s => s.consumeExplorationReturnTo);
+  // VIS-1069 — Semantic Layer reciprocal: "View in Semantic Layer" after
+  // promoting a metric/dimension.
+  const setWorkspaceSemanticLayerFocusIntent = useStore(s => s.setWorkspaceSemanticLayerFocusIntent);
 
   const [loading, setLoading] = useState(true);
   const [rows, setRows] = useState([]);
@@ -178,6 +181,29 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const handleDeclinePlacement = useCallback(() => {
     consumeExplorationReturnTo?.(explorationId);
   }, [consumeExplorationReturnTo, explorationId]);
+
+  // VIS-1069 — the first metric/dimension promoted THIS RUN (mirrors
+  // `promotedChart`'s "this run only" scoping above).
+  const promotedField = useMemo(
+    () =>
+      (promotedThisRun?.results || []).find(
+        r => r.success && (r.type === 'metric' || r.type === 'dimension')
+      ) || null,
+    [promotedThisRun]
+  );
+
+  const handleViewInSemanticLayer = useCallback(() => {
+    if (!promotedField) return;
+    setWorkspaceSemanticLayerFocusIntent?.({
+      objectKey: `${promotedField.type}:${promotedField.name}`,
+    });
+    openWorkspaceTab?.({
+      id: 'semantic-layer:semantic-layer',
+      type: 'semantic-layer',
+      name: 'semantic-layer',
+    });
+    onClose?.();
+  }, [promotedField, setWorkspaceSemanticLayerFocusIntent, openWorkspaceTab, onClose]);
 
   return (
     <div
@@ -344,6 +370,28 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
           >
             {placeError}
           </p>
+        )}
+
+        {/* VIS-1069 — Semantic Layer reciprocal: promoting a metric/dimension
+            offers a one-click jump to the ERD, focused on that field's
+            parent model node. */}
+        {promotedThisRun?.success && promotedField && (
+          <div
+            data-testid="exploration-promote-semantic-layer-offer"
+            className="mt-3 flex items-center justify-between gap-2 rounded-md border border-primary-200 bg-primary-50 px-2.5 py-2"
+          >
+            <span className="text-xs text-primary-800">
+              View <span className="font-medium">{promotedField.name}</span> in the Semantic Layer?
+            </span>
+            <button
+              type="button"
+              data-testid="exploration-promote-view-in-semantic-layer"
+              onClick={handleViewInSemanticLayer}
+              className="shrink-0 rounded-md bg-primary px-2 py-1 text-xs font-medium text-white hover:bg-primary-700"
+            >
+              View in Semantic Layer
+            </button>
+          </div>
         )}
 
         <div className="mt-4 pt-3 border-t border-secondary-100 flex justify-end gap-2">

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -358,4 +358,62 @@ describe('ExplorationPromoteModal', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
   });
+
+  // VIS-1069 — Semantic Layer reciprocal ("View in Semantic Layer").
+  describe('View in Semantic Layer', () => {
+    const promoteFieldResult = (extra = {}) => ({
+      success: true,
+      results: [{ type: 'metric', name: 'churn_rate', tier: 'field', success: true, error: null }],
+      reclassificationOffers: [],
+      ...extra,
+    });
+
+    test('no offer when nothing metric/dimension-shaped was promoted this run', async () => {
+      buildPromoteChecklist.mockResolvedValue([row()]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: true,
+          results: [{ type: 'model', name: 'orders_q', success: true, error: null }],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-success');
+      expect(
+        screen.queryByTestId('exploration-promote-semantic-layer-offer')
+      ).not.toBeInTheDocument();
+    });
+
+    test('promoting a metric offers "View in Semantic Layer"; accepting sets the focus intent, opens the tab, and closes', async () => {
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'field', type: 'metric', name: 'churn_rate' })]);
+      const setWorkspaceSemanticLayerFocusIntent = jest.fn();
+      const openWorkspaceTab = jest.fn();
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue(promoteFieldResult()),
+        setWorkspaceSemanticLayerFocusIntent,
+        openWorkspaceTab,
+      });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const offer = await screen.findByTestId('exploration-promote-semantic-layer-offer');
+      expect(offer).toHaveTextContent('churn_rate');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-view-in-semantic-layer'));
+
+      expect(setWorkspaceSemanticLayerFocusIntent).toHaveBeenCalledWith({
+        objectKey: 'metric:churn_rate',
+      });
+      expect(openWorkspaceTab).toHaveBeenCalledWith({
+        id: 'semantic-layer:semantic-layer',
+        type: 'semantic-layer',
+        name: 'semantic-layer',
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
 });

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -215,4 +215,147 @@ describe('ExplorationPromoteModal', () => {
     expect(onClose).toHaveBeenCalled();
     expect(promoteExploration).not.toHaveBeenCalled();
   });
+
+  // VIS-1068 — dashboard round-trip completion ("Place in <dashboard>").
+  describe('return_to / "Place in <dashboard>"', () => {
+    const seedReturnTo = (returnTo, extra = {}) => {
+      useStore.setState({
+        workspaceExplorations: {
+          byId: { exp_1: { id: 'exp_1', returnTo } },
+          order: ['exp_1'],
+        },
+        dashboards: [{ name: 'sales' }],
+        openWorkspaceTab: jest.fn(),
+        placeChartInDashboardSlot: jest.fn().mockResolvedValue({ success: true }),
+        consumeExplorationReturnTo: jest.fn().mockResolvedValue({ success: true }),
+        ...extra,
+      });
+    };
+
+    const promoteChartResult = (extra = {}) => ({
+      success: true,
+      results: [{ type: 'chart', name: 'churn_chart', tier: 'chart', success: true, error: null }],
+      reclassificationOffers: [],
+      ...extra,
+    });
+
+    test('no offer without a return_to on the exploration', async () => {
+      seedReturnTo(null);
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-success');
+      expect(screen.queryByTestId('exploration-promote-return-to-offer')).not.toBeInTheDocument();
+    });
+
+    test('no offer when return_to is set but no chart was promoted this run', async () => {
+      seedReturnTo({ dashboard: 'sales' });
+      buildPromoteChecklist.mockResolvedValue([row()]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: true,
+          results: [{ type: 'model', name: 'orders_q', success: true, error: null }],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-success');
+      expect(screen.queryByTestId('exploration-promote-return-to-offer')).not.toBeInTheDocument();
+    });
+
+    test('accepting places the chart, consumes return_to, navigates to the dashboard tab, and closes', async () => {
+      seedReturnTo({ dashboard: 'sales', slot: 'r1-i1' });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const offer = await screen.findByTestId('exploration-promote-return-to-offer');
+      expect(offer).toHaveTextContent('churn_chart');
+      expect(offer).toHaveTextContent('sales');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-place-in-dashboard'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInDashboardSlot).toHaveBeenCalledWith(
+          'sales',
+          'churn_chart',
+          'r1-i1'
+        )
+      );
+      await waitFor(() =>
+        expect(useStore.getState().consumeExplorationReturnTo).toHaveBeenCalledWith('exp_1')
+      );
+      await waitFor(() =>
+        expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'dashboard:sales',
+          type: 'dashboard',
+          name: 'sales',
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('declining consumes return_to (explicit choice), does not place or navigate, and does not close', async () => {
+      seedReturnTo({ dashboard: 'sales' });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-return-to-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-decline-placement'));
+
+      await waitFor(() =>
+        expect(useStore.getState().consumeExplorationReturnTo).toHaveBeenCalledWith('exp_1')
+      );
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
+      expect(useStore.getState().openWorkspaceTab).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test('a return_to whose dashboard no longer exists renders the offer DISABLED with a tooltip', async () => {
+      seedReturnTo({ dashboard: 'deleted-dashboard' }, { dashboards: [{ name: 'sales' }] });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const placeButton = await screen.findByTestId('exploration-promote-place-in-dashboard');
+      expect(placeButton).toBeDisabled();
+      expect(placeButton).toHaveAttribute('title', '"deleted-dashboard" no longer exists');
+      // Still consumable via decline even though placement is disabled.
+      expect(screen.getByTestId('exploration-promote-decline-placement')).toBeEnabled();
+    });
+
+    test('a placement failure shows an inline error and does not consume return_to or close', async () => {
+      seedReturnTo({ dashboard: 'sales' }, {
+        placeChartInDashboardSlot: jest.fn().mockResolvedValue({ success: false, error: 'slot taken' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-return-to-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-place-in-dashboard'));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('exploration-promote-place-error')).toHaveTextContent('slot taken')
+      );
+      expect(useStore.getState().consumeExplorationReturnTo).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/viewer/src/components/views/workspace/ExplorationStalenessBanner.jsx
+++ b/viewer/src/components/views/workspace/ExplorationStalenessBanner.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { PiArrowsClockwise, PiX } from 'react-icons/pi';
+
+/**
+ * ExplorationStalenessBanner — Explore 2.0 Phase 5 (VIS-1070,
+ * 02-architecture.md §8 / 01-ux-spec.md §2's "⚠ stale (orders changed)"
+ * end-state). Rendered by `ExplorationPane` above the workbench whenever the
+ * resume-time staleness check (`explorationStaleness.js`'s
+ * `computeExplorationStaleness`, run once on activate) finds a dangling ref.
+ *
+ * Deliberately NON-BLOCKING (unlike `ExplorationDeletedRemotelyBanner`,
+ * which reflects a hard failure state — the record can no longer save at
+ * all): a stale ref doesn't stop anything from working, it's informational
+ * with a one-click "re-check" action. Purely presentational — the parent
+ * owns the staleness computation/state so `onRecheck` can re-run it against
+ * the CURRENT live store without this component needing its own store
+ * wiring.
+ */
+const ExplorationStalenessBanner = ({ danglingRefs = [], onRecheck, onDismiss }) => (
+  <div
+    role="status"
+    data-testid="exploration-staleness-banner"
+    className="flex w-full shrink-0 items-start gap-3 border-b border-primary-200 bg-primary-50 px-4 py-2.5"
+  >
+    <PiArrowsClockwise aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-primary-600" />
+    <div className="min-w-0 flex-1 text-[12.5px]">
+      <p className="font-medium text-primary-900">Some referenced objects may have changed.</p>
+      {danglingRefs.length > 0 && (
+        <p className="mt-0.5 text-primary-800">
+          No longer resolves: <span className="font-mono">{danglingRefs.join(', ')}</span>
+        </p>
+      )}
+      <div className="mt-1.5 flex gap-2">
+        <button
+          type="button"
+          onClick={onRecheck}
+          data-testid="exploration-staleness-recheck"
+          className="rounded bg-primary-600 px-2.5 py-1 text-[12px] font-medium text-white transition-colors hover:bg-primary-700"
+        >
+          Re-check references
+        </button>
+      </div>
+    </div>
+    <button
+      type="button"
+      aria-label="Dismiss"
+      onClick={onDismiss}
+      data-testid="exploration-staleness-dismiss"
+      className="text-primary-400 transition-colors hover:text-primary-700"
+    >
+      <PiX size={14} />
+    </button>
+  </div>
+);
+
+export default ExplorationStalenessBanner;

--- a/viewer/src/components/views/workspace/ExplorationStalenessBanner.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationStalenessBanner.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExplorationStalenessBanner from './ExplorationStalenessBanner';
+
+describe('ExplorationStalenessBanner', () => {
+  test('renders the dangling refs and wires Re-check/Dismiss', () => {
+    const onRecheck = jest.fn();
+    const onDismiss = jest.fn();
+    render(
+      <ExplorationStalenessBanner
+        danglingRefs={['orders_q', 'revenue']}
+        onRecheck={onRecheck}
+        onDismiss={onDismiss}
+      />
+    );
+    const banner = screen.getByTestId('exploration-staleness-banner');
+    expect(banner).toHaveTextContent('orders_q, revenue');
+
+    fireEvent.click(screen.getByTestId('exploration-staleness-recheck'));
+    expect(onRecheck).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('exploration-staleness-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders without a dangling-refs line when the list is empty', () => {
+    render(<ExplorationStalenessBanner danglingRefs={[]} onRecheck={jest.fn()} onDismiss={jest.fn()} />);
+    expect(screen.getByTestId('exploration-staleness-banner')).not.toHaveTextContent('No longer resolves');
+  });
+});

--- a/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
+++ b/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
@@ -39,9 +39,11 @@ import ExplorationQueryChips from './ExplorationQueryChips';
  *     gated promote checklist that replaced the deleted `ExplorerSaveModal`/
  *     `saveExplorerObjects` (all-or-nothing, no per-object gate).
  *   - `useExplorerWorkbenchInit()` (the shared init hook) is unchanged.
- *   - No return-bar / `?return_to=` handling here — that's the dashboard
- *     round-trip intent, consumed at the Phase 3b cutover's redirect route,
- *     not this pane (02-architecture.md §5).
+ *   - No `?return_to=` QUERY-PARAM handling here — that dead param form was
+ *     replaced at the Phase 3b cutover's redirect route (02-architecture.md
+ *     §5). The `return_to` RECORD FIELD itself is consumed inside
+ *     `ExplorationPromoteModal`'s success state (VIS-1068's "Place in
+ *     <dashboard>" offer) — this pane just renders that modal, unchanged.
  *
  * The HOST (`ExplorationPane`) is responsible for gating this component's
  * mount on the per-exploration state restore having already landed — see

--- a/viewer/src/components/views/workspace/FieldSwapOfferBanner.jsx
+++ b/viewer/src/components/views/workspace/FieldSwapOfferBanner.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { PiArrowsClockwise, PiX } from 'react-icons/pi';
 import useStore from '../../../stores/store';
-import { serializeSwapTarget } from '../common/pillFieldSwap';
+import { serializeSwapTarget, readCurrentSlotState } from '../common/pillFieldSwap';
 
 /**
  * FieldSwapOfferBanner — Explore 2.0 Phase 4 (06 §4/§8, delta-review's
@@ -18,26 +18,68 @@ import { serializeSwapTarget } from '../common/pillFieldSwap';
  * banner is the one-click "Update N reference(s)" / "Dismiss" surface for
  * either. `offers`: `Array<{ promotedType, promotedName, slots }>`, the
  * exact shape `promoteExploration`/the Save-as-metric flow return.
+ *
+ * ACCEPT-TIME RE-VALIDATION (VIS-1095, Phase 5 preview-lane/offer-staleness
+ * fix): `offer.slots` is a SNAPSHOT captured the instant the offer was
+ * created. This banner is a non-blocking inline element (not a modal), so
+ * nothing stops the user continuing to edit the SAME slot — or renaming/
+ * removing the target insight entirely — before clicking "Update N
+ * references". `applyOffer` now re-reads each slot's CURRENT live value
+ * (`readCurrentSlotState`) and compares it against the offer's captured
+ * `previousRef`/`previousColumn`/`previousAgg` right before writing; a
+ * slot whose live value no longer matches (edited underneath the banner,
+ * or its insight is gone) is SKIPPED rather than blindly overwritten, and a
+ * toast summarizes how many were skipped.
  */
 const FieldSwapOfferBanner = ({ offers = [], onDismiss }) => {
   const setInsightProp = useStore(s => s.setInsightProp);
   const updateInsightInteraction = useStore(s => s.updateInsightInteraction);
+  const explorerInsightStates = useStore(s => s.explorerInsightStates);
+  const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
 
   const applyOffer = useCallback(
     offerIndex => {
       const offer = offers[offerIndex];
       if (!offer) return;
+      let appliedCount = 0;
+      let skippedCount = 0;
       offer.slots.forEach(slot => {
+        const current = readCurrentSlotState(explorerInsightStates, slot);
+        const unchanged =
+          !!current &&
+          current.ref === slot.previousRef &&
+          current.column === slot.previousColumn &&
+          (current.agg || null) === (slot.previousAgg || null);
+        if (!unchanged) {
+          skippedCount += 1;
+          return;
+        }
         const value = serializeSwapTarget(slot.swapTo);
         if (slot.location === 'prop') {
           setInsightProp(slot.insightName, slot.key, value);
         } else if (slot.location === 'interaction') {
           updateInsightInteraction(slot.insightName, slot.key, { value });
         }
+        appliedCount += 1;
       });
+      if (skippedCount > 0) {
+        const noun = `reference${skippedCount === 1 ? '' : 's'}`;
+        showWorkspaceToast?.(
+          appliedCount > 0
+            ? `Updated ${appliedCount} — ${skippedCount} ${noun} changed since this offer was made and ${skippedCount === 1 ? 'was' : 'were'} skipped`
+            : `Skipped — the ${noun} changed since this offer was made`
+        );
+      }
       onDismiss?.(offerIndex);
     },
-    [offers, setInsightProp, updateInsightInteraction, onDismiss]
+    [
+      offers,
+      explorerInsightStates,
+      setInsightProp,
+      updateInsightInteraction,
+      showWorkspaceToast,
+      onDismiss,
+    ]
   );
 
   if (offers.length === 0) return null;

--- a/viewer/src/components/views/workspace/FieldSwapOfferBanner.test.jsx
+++ b/viewer/src/components/views/workspace/FieldSwapOfferBanner.test.jsx
@@ -4,17 +4,39 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import FieldSwapOfferBanner from './FieldSwapOfferBanner';
 import useStore from '../../../stores/store';
 
+// VIS-1095: every offer slot now carries `previousRef`/`previousColumn`/
+// `previousAgg` — the snapshot `applyOffer` re-validates against the slot's
+// CURRENT live value at accept-time. Defaults here describe a slot bound to
+// `${ref(other_model).amount}` (a bare dimension ref, no aggregate).
 const offer = (overrides = {}) => ({
   promotedType: 'metric',
   promotedName: 'total_amount',
-  slots: [{ insightName: 'other_chart', location: 'prop', key: 'y', swapTo: { kind: 'metricRef', ref: 'total_amount' } }],
+  slots: [
+    {
+      insightName: 'other_chart',
+      location: 'prop',
+      key: 'y',
+      previousRef: 'other_model',
+      previousColumn: 'amount',
+      previousAgg: null,
+      swapTo: { kind: 'metricRef', ref: 'total_amount' },
+    },
+  ],
   ...overrides,
 });
+
+// The live `explorerInsightStates` matching `offer()`'s default slot
+// UNCHANGED — most tests want the "still matches, apply proceeds" case.
+const UNCHANGED_INSIGHT_STATES = {
+  other_chart: { props: { y: '?{${ref(other_model).amount}}' }, interactions: [] },
+};
 
 beforeEach(() => {
   useStore.setState({
     setInsightProp: jest.fn(),
     updateInsightInteraction: jest.fn(),
+    showWorkspaceToast: jest.fn(),
+    explorerInsightStates: UNCHANGED_INSIGHT_STATES,
   });
 });
 
@@ -56,13 +78,26 @@ describe('FieldSwapOfferBanner', () => {
 
   test('clicking Apply rewrites an affected INTERACTION slot via updateInsightInteraction', () => {
     const updateInsightInteraction = jest.fn();
-    useStore.setState({ updateInsightInteraction });
+    useStore.setState({
+      updateInsightInteraction,
+      explorerInsightStates: {
+        a: { props: {}, interactions: [{ type: 'filter', value: '?{${ref(orders_q).region}}' }] },
+      },
+    });
     render(
       <FieldSwapOfferBanner
         offers={[
           offer({
             slots: [
-              { insightName: 'a', location: 'interaction', key: 0, swapTo: { kind: 'dimensionRef', ref: 'region' } },
+              {
+                insightName: 'a',
+                location: 'interaction',
+                key: 0,
+                previousRef: 'orders_q',
+                previousColumn: 'region',
+                previousAgg: null,
+                swapTo: { kind: 'dimensionRef', ref: 'region' },
+              },
             ],
           }),
         ]}
@@ -88,5 +123,110 @@ describe('FieldSwapOfferBanner', () => {
     fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-dismiss'));
     expect(setInsightProp).not.toHaveBeenCalled();
     expect(onDismiss).toHaveBeenCalledWith(0);
+  });
+
+  // VIS-1095 — accept-time re-validation: the offer's captured slot snapshot
+  // is re-checked against the CURRENT live value right before writing.
+  describe('accept-time re-validation (VIS-1095)', () => {
+    test('a slot hand-edited to a DIFFERENT column since the offer was made is skipped, not overwritten', () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({
+        setInsightProp,
+        showWorkspaceToast,
+        // The user retyped the pill to a DIFFERENT column underneath the
+        // (non-modal) banner between offer-creation and clicking Apply.
+        explorerInsightStates: {
+          other_chart: { props: { y: '?{${ref(other_model).total_revenue}}' }, interactions: [] },
+        },
+      });
+      render(<FieldSwapOfferBanner offers={[offer()]} onDismiss={jest.fn()} />);
+      fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-apply'));
+      expect(setInsightProp).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringContaining('changed'));
+    });
+
+    test('a slot whose insight was renamed/removed since the offer was made is skipped, not overwritten', () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({
+        setInsightProp,
+        showWorkspaceToast,
+        explorerInsightStates: {}, // other_chart no longer exists
+      });
+      render(<FieldSwapOfferBanner offers={[offer()]} onDismiss={jest.fn()} />);
+      fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-apply'));
+      expect(setInsightProp).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringContaining('changed'));
+    });
+
+    test('a slot that still matches applies normally with no toast', () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ setInsightProp, showWorkspaceToast });
+      render(<FieldSwapOfferBanner offers={[offer()]} onDismiss={jest.fn()} />);
+      fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-apply'));
+      expect(setInsightProp).toHaveBeenCalledWith('other_chart', 'y', '?{${ref(total_amount)}}');
+      expect(showWorkspaceToast).not.toHaveBeenCalled();
+    });
+
+    test('a mixed offer applies the unchanged slots and skips only the changed one, with a partial-success toast', () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({
+        setInsightProp,
+        showWorkspaceToast,
+        explorerInsightStates: {
+          unchanged_chart: { props: { y: '?{${ref(other_model).amount}}' }, interactions: [] },
+          // changed_chart's slot now points at a DIFFERENT ref entirely.
+          changed_chart: { props: { y: '?{${ref(different_model).amount}}' }, interactions: [] },
+        },
+      });
+      render(
+        <FieldSwapOfferBanner
+          offers={[
+            offer({
+              slots: [
+                {
+                  insightName: 'unchanged_chart',
+                  location: 'prop',
+                  key: 'y',
+                  previousRef: 'other_model',
+                  previousColumn: 'amount',
+                  previousAgg: null,
+                  swapTo: { kind: 'metricRef', ref: 'total_amount' },
+                },
+                {
+                  insightName: 'changed_chart',
+                  location: 'prop',
+                  key: 'y',
+                  previousRef: 'other_model',
+                  previousColumn: 'amount',
+                  previousAgg: null,
+                  swapTo: { kind: 'metricRef', ref: 'total_amount' },
+                },
+              ],
+            }),
+          ]}
+          onDismiss={jest.fn()}
+        />
+      );
+      fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-apply'));
+      expect(setInsightProp).toHaveBeenCalledTimes(1);
+      expect(setInsightProp).toHaveBeenCalledWith(
+        'unchanged_chart',
+        'y',
+        '?{${ref(total_amount)}}'
+      );
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringContaining('Updated 1'));
+    });
+
+    test('still dismisses the offer even when every slot was skipped (no lingering stale offer)', () => {
+      const onDismiss = jest.fn();
+      useStore.setState({ explorerInsightStates: {} });
+      render(<FieldSwapOfferBanner offers={[offer()]} onDismiss={onDismiss} />);
+      fireEvent.click(screen.getByTestId('field-swap-offer-total_amount-apply'));
+      expect(onDismiss).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/viewer/src/components/views/workspace/ModelPreview.jsx
+++ b/viewer/src/components/views/workspace/ModelPreview.jsx
@@ -283,7 +283,7 @@ const ModelPreview = ({ activeObject, record: providedRecord }) => {
         ) : error ? (
           <div
             data-testid="model-preview-error"
-            className="rounded bg-red-50 p-3 font-mono text-sm text-red-700"
+            className="rounded bg-highlight-50 p-3 font-mono text-sm text-highlight-700"
           >
             {typeof error === 'string' ? error : error?.message || String(error)}
           </div>

--- a/viewer/src/components/views/workspace/ObjectCanvasFrame.jsx
+++ b/viewer/src/components/views/workspace/ObjectCanvasFrame.jsx
@@ -18,6 +18,7 @@ import LineageCanvas from '../lineage/LineageCanvas';
 import { getCanvasDescriptor } from './objectCanvasRegistry';
 import { useCanvasRecord } from './useCanvasRecord';
 import { COLLECTION_KEY } from './collectionKeys';
+import CenteredFrameState from '../common/CenteredFrameState';
 
 /**
  * ObjectCanvasFrame — the shared shell for every per-object Workspace canvas
@@ -66,22 +67,8 @@ const safeAvailable = key => {
   }
 };
 
-const FrameState = ({ testId, title, body, icon: Icon = PiCircleDuotone }) => (
-  <div
-    data-testid={testId}
-    className="flex flex-1 items-center justify-center bg-gray-50 p-12"
-  >
-    <div className="max-w-[420px] rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-      <Icon className="mx-auto mb-2 h-6 w-6 text-gray-300" aria-hidden="true" />
-      <h2 className="text-[15px] font-semibold text-gray-900">{title}</h2>
-      {body && (
-        <p className="mx-auto mt-1.5 max-w-[320px] text-[13px] leading-relaxed text-gray-500">
-          {body}
-        </p>
-      )}
-    </div>
-  </div>
-);
+// VIS-1071 (01-ux-spec.md §7): local FrameState replaced by the shared
+// CenteredFrameState (viewer/src/components/views/common/CenteredFrameState.jsx).
 
 const ObjectCanvasFrame = ({ activeObject, projectId }) => {
   const name = activeObject?.name || '(unnamed)';
@@ -284,7 +271,7 @@ const CanvasBody = ({ type, lens, lensMeta, descriptor, activeObject, projectId 
   return (
     <div data-testid={`workspace-middle-${type}-${lens}`} className="flex flex-1 min-h-0 min-w-0">
       {unavailable ? (
-        <FrameState
+        <CenteredFrameState
           testId="canvas-unavailable"
           icon={PiLockSimple}
           title="Available with visivo serve"
@@ -292,7 +279,9 @@ const CanvasBody = ({ type, lens, lensMeta, descriptor, activeObject, projectId 
         />
       ) : (
         <React.Suspense
-          fallback={<FrameState testId="canvas-loading" title="Loading canvas…" />}
+          fallback={
+            <CenteredFrameState testId="canvas-loading" title="Loading canvas…" icon={PiCircleDuotone} />
+          }
         >
           <Body activeObject={activeObject} projectId={projectId} record={config} lens={lens} />
         </React.Suspense>

--- a/viewer/src/components/views/workspace/OpenObjectContextMenu.jsx
+++ b/viewer/src/components/views/workspace/OpenObjectContextMenu.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { PiArrowSquareOut, PiArrowRight } from 'react-icons/pi';
+import { PiArrowSquareOut, PiArrowRight, PiCompass, PiPlusCircle } from 'react-icons/pi';
 import { getTypeIcon } from '../common/objectTypeConfigs';
 
 /**
- * OpenObjectContextMenu — VIS-811 / Track O O-2.
+ * OpenObjectContextMenu — VIS-811 / Track O O-2 (+ VIS-1067 flywheel entries).
  *
  * The shared right-click menu for "openable" workspace objects. Mounted by
  * surfaces that don't already own a context menu (lineage nodes, Project
- * Editor tiles); the canvas and Library menus integrate the same two actions
+ * Editor tiles); the canvas and Library menus integrate the same actions
  * into their existing menus instead.
  *
  *   - Open             → replaces the current workspace context
@@ -18,6 +18,14 @@ import { getTypeIcon } from '../common/objectTypeConfigs';
  *                        joins the strip ready to click. This matches the
  *                        Track O spec ("creates a new tab; clicking the tab
  *                        switches the workspace context").
+ *   - Explore this     → (VIS-1067, optional — only rendered when the
+ *                        consumer passes `onExploreThis`) mints a new
+ *                        exploration seeded from this object and opens it.
+ *   - Add to exploration → (VIS-1067, optional — only rendered when the
+ *                        consumer passes `onAddToExploration`, which callers
+ *                        gate on an exploration tab actually being open)
+ *                        adds this object into the active exploration's
+ *                        draft without leaving the current tab.
  *
  * Rendered through a portal at a fixed viewport position (`x`/`y` are
  * clientX/clientY) so it escapes any overflow-clipping ancestor (the lineage
@@ -44,7 +52,17 @@ const MenuItem = ({ testid, icon: Icon, label, onClick }) => (
   </button>
 );
 
-const OpenObjectContextMenu = ({ x, y, obj, onOpen, onOpenInNewTab, onDismiss, testIdPrefix }) => {
+const OpenObjectContextMenu = ({
+  x,
+  y,
+  obj,
+  onOpen,
+  onOpenInNewTab,
+  onExploreThis,
+  onAddToExploration,
+  onDismiss,
+  testIdPrefix,
+}) => {
   const menuRef = useRef(null);
   const prefix = testIdPrefix || 'open-object-ctx';
   const TypeIcon = obj?.type ? getTypeIcon(obj.type) : null;
@@ -103,6 +121,28 @@ const OpenObjectContextMenu = ({ x, y, obj, onOpen, onOpenInNewTab, onDismiss, t
           onDismiss && onDismiss();
         }}
       />
+      {onExploreThis && (
+        <MenuItem
+          testid={`${prefix}-explore-this`}
+          icon={PiCompass}
+          label="Explore this"
+          onClick={() => {
+            onExploreThis(obj);
+            onDismiss && onDismiss();
+          }}
+        />
+      )}
+      {onAddToExploration && (
+        <MenuItem
+          testid={`${prefix}-add-to-exploration`}
+          icon={PiPlusCircle}
+          label="Add to exploration"
+          onClick={() => {
+            onAddToExploration(obj);
+            onDismiss && onDismiss();
+          }}
+        />
+      )}
       <span
         aria-hidden="true"
         className="pointer-events-none absolute -left-px top-2 h-4 w-[3px] rounded-r"

--- a/viewer/src/components/views/workspace/OpenObjectContextMenu.test.jsx
+++ b/viewer/src/components/views/workspace/OpenObjectContextMenu.test.jsx
@@ -94,4 +94,36 @@ describe('OpenObjectContextMenu', () => {
     fireEvent.click(screen.getByTestId('test-ctx-open'));
     expect(hostClick).not.toHaveBeenCalled();
   });
+
+  // VIS-1067 — "Explore this" / "Add to exploration" are optional, only
+  // rendered when the consumer passes a handler.
+  describe('Explore this / Add to exploration (VIS-1067)', () => {
+    test('neither item renders when no handler is passed', () => {
+      renderMenu();
+      expect(screen.queryByTestId('test-ctx-explore-this')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('test-ctx-add-to-exploration')).not.toBeInTheDocument();
+    });
+
+    test('"Explore this" renders and fires onExploreThis with the object, then dismisses', () => {
+      const onExploreThis = jest.fn();
+      const onDismiss = jest.fn();
+      renderMenu({ onExploreThis, onDismiss });
+      const item = screen.getByTestId('test-ctx-explore-this');
+      expect(item).toHaveTextContent('Explore this');
+      fireEvent.click(item);
+      expect(onExploreThis).toHaveBeenCalledWith(OBJ);
+      expect(onDismiss).toHaveBeenCalled();
+    });
+
+    test('"Add to exploration" only renders when passed, and fires onAddToExploration', () => {
+      const onAddToExploration = jest.fn();
+      const onDismiss = jest.fn();
+      renderMenu({ onAddToExploration, onDismiss });
+      const item = screen.getByTestId('test-ctx-add-to-exploration');
+      expect(item).toHaveTextContent('Add to exploration');
+      fireEvent.click(item);
+      expect(onAddToExploration).toHaveBeenCalledWith(OBJ);
+      expect(onDismiss).toHaveBeenCalled();
+    });
+  });
 });

--- a/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
+++ b/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
@@ -436,7 +436,7 @@ const SourceOutlineTreePanel = ({ sourceName }) => {
             {generating ? 'Generating…' : 'Generate schema'}
           </button>
           {error && (
-            <p className="mt-2 inline-flex items-center gap-1 text-[10.5px] text-red-600">
+            <p className="mt-2 inline-flex items-center gap-1 text-[10.5px] text-highlight-600">
               <PiWarningCircle aria-hidden="true" className="h-3.5 w-3.5" />
               {error}
             </p>

--- a/viewer/src/components/views/workspace/explorationStaleness.js
+++ b/viewer/src/components/views/workspace/explorationStaleness.js
@@ -1,0 +1,75 @@
+import { checkRefTargets } from './refPreflight';
+
+/**
+ * explorationStaleness — Explore 2.0 Phase 5 (VIS-1070, 02-architecture.md
+ * §8 / 01-ux-spec.md §2's "⚠ stale (orders changed)" end-state).
+ *
+ * "Re-run ref checks against current collections" reuses the SAME advisory
+ * tool (`checkRefTargets`) the Build rail already runs continuously while an
+ * exploration is open (InsightBuildSection.jsx's live per-keystroke
+ * validation) — this module is the ONE-SHOT version of that same check, run
+ * against a whole exploration's `draft` at two additional moments the live
+ * check never covers on its own:
+ *
+ *   1. On RESUME (`ExplorationPane.jsx`'s activate effect) — the exploration
+ *      may have sat parked while its refs' targets were deleted elsewhere;
+ *      the live advisory check only starts running once the Build rail
+ *      mounts and a field is expanded, so a snapshot taken right at resume
+ *      is what drives the non-blocking "re-check references" banner.
+ *   2. On the Explorer Home gallery (`ExplorationCard.jsx`'s staleness
+ *      badge) — a card is never "opened" at all, so nothing else ever runs
+ *      this check for it.
+ *
+ * Scope (a deliberate, documented reduction from the UX spec's literal
+ * "orders changed" copy): without a persisted fingerprint of what a draft's
+ * referenced objects looked like at last-sync time, distinguishing "the
+ * referenced model's OWN definition changed" from "the ref no longer
+ * resolves at all" isn't computable client-side today. This treats BOTH as
+ * one unified "stale" signal — a dangling ref, exactly what `checkRefTargets`
+ * already detects — which is the same simplification 02 §8's own prose names
+ * as the mechanism ("re-run ref checks... (checkRefTargets)"). A true
+ * changed-vs-deleted distinction would need a `ref_fingerprint` persisted on
+ * the Exploration record — noted as follow-up work, not implemented here.
+ */
+
+/**
+ * @param {object} exploration - a mapped workspaceExplorations record (or
+ *   `null`/`undefined`, tolerated for a not-yet-loaded card).
+ * @param {object} state - `useStore.getState()` (or an equivalent plain
+ *   object exposing the same collection arrays `checkRefTargets` reads).
+ * @returns {{stale: boolean, danglingRefs: string[]}}
+ */
+export function computeExplorationStaleness(exploration, state) {
+  const draft = exploration?.draft;
+  if (!draft) return { stale: false, danglingRefs: [] };
+
+  // Splice the draft's OWN scratch query names into `models` (mirrors
+  // InsightBuildSection.jsx's synthetic-state pattern) so a ref to one of
+  // THIS exploration's not-yet-promoted queries is never flagged as
+  // dangling — only refs to something genuinely gone from the project.
+  const draftQueryStubs = (draft.queries || [])
+    .filter(q => q?.name)
+    .map(q => ({ name: q.name }));
+  const syntheticState = {
+    ...state,
+    models: [...(state?.models || []), ...draftQueryStubs],
+  };
+
+  // Walk the WHOLE draft (queries' SQL, insights, chart, computed columns) —
+  // `checkRefTargets` is shape-agnostic, it just scans every string for
+  // `${ref(...)}` / bare `ref(...)` occurrences.
+  const result = checkRefTargets(draft, syntheticState);
+  if (result.skipped || result.valid) return { stale: false, danglingRefs: [] };
+
+  const danglingRefs = [
+    ...new Set(
+      result.errors
+        .map(e => {
+          const match = e.message.match(/ref '([^']+)' does not match/);
+          return match ? match[1] : null;
+        })
+        .filter(Boolean)
+    ),
+  ];
+  return { stale: danglingRefs.length > 0, danglingRefs };
+}

--- a/viewer/src/components/views/workspace/explorationStaleness.test.js
+++ b/viewer/src/components/views/workspace/explorationStaleness.test.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
+import { computeExplorationStaleness } from './explorationStaleness';
+
+const baseState = {
+  models: [{ name: 'orders_q' }],
+  metrics: [{ name: 'revenue' }],
+  dimensions: [{ name: 'region' }],
+  sources: [{ name: 'warehouse' }],
+  insights: [],
+  charts: [],
+  tables: [],
+  markdowns: [],
+  inputs: [],
+  relations: [],
+  dashboards: [],
+};
+
+describe('computeExplorationStaleness', () => {
+  it('is not stale for a draft with no dangling refs', () => {
+    const exploration = {
+      draft: {
+        queries: [{ name: 'orders_q', sql: 'SELECT * FROM t', source: 'warehouse' }],
+        insights: [
+          { name: 'ins', props: { x: '?{${ref(orders_q).region}}', y: '?{${ref(revenue)}}' } },
+        ],
+      },
+    };
+    expect(computeExplorationStaleness(exploration, baseState)).toEqual({
+      stale: false,
+      danglingRefs: [],
+    });
+  });
+
+  it('flags a ref whose target no longer exists in any collection', () => {
+    const exploration = {
+      draft: {
+        queries: [{ name: 'q1', sql: 'SELECT 1', source: 'warehouse' }],
+        insights: [{ name: 'ins', props: { x: '?{${ref(deleted_model).col}}' } }],
+      },
+    };
+    const result = computeExplorationStaleness(exploration, baseState);
+    expect(result.stale).toBe(true);
+    expect(result.danglingRefs).toEqual(['deleted_model']);
+  });
+
+  it('never flags a ref to the draft\'s OWN not-yet-promoted scratch query', () => {
+    const exploration = {
+      draft: {
+        queries: [{ name: 'scratch_q', sql: 'SELECT 1', source: 'warehouse' }],
+        insights: [{ name: 'ins', props: { x: '?{${ref(scratch_q).col}}' } }],
+      },
+    };
+    expect(computeExplorationStaleness(exploration, baseState).stale).toBe(false);
+  });
+
+  it('dedupes repeated dangling refs across multiple insights', () => {
+    const exploration = {
+      draft: {
+        queries: [],
+        insights: [
+          { name: 'a', props: { x: '?{${ref(gone).col}}' } },
+          { name: 'b', props: { y: '?{${ref(gone).col2}}' } },
+        ],
+      },
+    };
+    const result = computeExplorationStaleness(exploration, baseState);
+    expect(result.danglingRefs).toEqual(['gone']);
+  });
+
+  it('is not stale for a missing/empty draft', () => {
+    expect(computeExplorationStaleness(null, baseState)).toEqual({ stale: false, danglingRefs: [] });
+    expect(computeExplorationStaleness({}, baseState)).toEqual({ stale: false, danglingRefs: [] });
+  });
+
+  it('fails open (never stale) when no collection is populated at all', () => {
+    const exploration = {
+      draft: { queries: [], insights: [{ name: 'ins', props: { x: '?{${ref(anything).col}}' } }] },
+    };
+    expect(computeExplorationStaleness(exploration, {}).stale).toBe(false);
+  });
+});

--- a/viewer/src/components/views/workspace/fields/DimensionInspector.jsx
+++ b/viewer/src/components/views/workspace/fields/DimensionInspector.jsx
@@ -274,14 +274,14 @@ const DimensionInspector = ({ activeObject, record: providedRecord }) => {
         ) : error ? (
           <div
             data-testid="dimension-inspector-error"
-            className="rounded bg-red-50 p-3 font-mono text-sm text-red-700"
+            className="rounded bg-highlight-50 p-3 font-mono text-sm text-highlight-700"
           >
             {typeof error === 'string' ? error : error?.message || String(error)}
           </div>
         ) : profileError ? (
           <div
             data-testid="dimension-inspector-error"
-            className="rounded bg-red-50 p-3 font-mono text-sm text-red-700"
+            className="rounded bg-highlight-50 p-3 font-mono text-sm text-highlight-700"
           >
             {profileError}
           </div>

--- a/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { PiDotsThreeVertical, PiPencilSimple, PiCopy, PiTrash } from 'react-icons/pi';
+import {
+  PiDotsThreeVertical,
+  PiPencilSimple,
+  PiCopy,
+  PiTrash,
+  PiWarningCircle,
+} from 'react-icons/pi';
 import Dropdown from '../../../common/Dropdown';
 import FieldPill from '../../common/FieldPill';
 import InlineRenameInput from '../InlineRenameInput';
@@ -10,17 +16,30 @@ import { draftSummary } from '../explorationLegacyBridge';
 /**
  * ExplorationCard — one "Recent explorations" gallery card (01-ux-spec.md
  * §2): name, relative edit time, draft summary ("n queries · n insights"),
- * a provenance chip when `seededFrom` is set, and Open / ⋮ (rename ·
- * duplicate · delete).
+ * a provenance chip when `seededFrom` is set, a staleness badge, and
+ * Open / ⋮ (rename · duplicate · delete).
  *
  * Promotion count (Explore 2.0 Phase 4, 01-ux-spec.md §2's "promotion count
  * arrives in Phase 4" note): read straight off the exploration's real
  * `promoted[]` trail (empty for an exploration that's never promoted
  * anything) — no separate fetch, `workspaceExplorationsStore.js` already
- * mirrors it locally after every `promoteExploration` call. Staleness badge
- * stays out of this card (Phase 5).
+ * mirrors it locally after every `promoteExploration` call.
+ *
+ * Staleness badge (Explore 2.0 Phase 5, VIS-1070, 01-ux-spec.md §2's
+ * "⚠ stale (orders changed)" end-state): `stale`/`danglingRefs` are computed
+ * by the PARENT (`ExplorerHomePane.jsx`, via `computeExplorationStaleness`)
+ * for every card at once, not per-card here — this component just renders
+ * whatever it's handed.
  */
-const ExplorationCard = ({ exploration, onOpen, onRename, onDuplicate, onDelete }) => {
+const ExplorationCard = ({
+  exploration,
+  onOpen,
+  onRename,
+  onDuplicate,
+  onDelete,
+  stale = false,
+  danglingRefs = [],
+}) => {
   // B16 (04-bug-inventory.md): the shared "am I editing this name" toggle —
   // see useInlineRename's docstring for why this hook exists.
   const rename = useInlineRename({ onCommit: nextName => onRename(exploration.id, nextName) });
@@ -108,16 +127,32 @@ const ExplorationCard = ({ exploration, onOpen, onRename, onDuplicate, onDelete 
 
       <div
         data-testid={`exploration-card-${exploration.id}-summary`}
-        className="mb-3 text-[12px] text-gray-500"
+        className="mb-3 flex flex-wrap items-center gap-1.5 text-[12px] text-gray-500"
       >
-        {[
-          editedLabel,
-          `${queryCount} ${queryCount === 1 ? 'query' : 'queries'}`,
-          `${insightCount} ${insightCount === 1 ? 'insight' : 'insights'}`,
-          promotedCount > 0 ? `${promotedCount} promoted` : null,
-        ]
-          .filter(Boolean)
-          .join(' · ')}
+        <span>
+          {[
+            editedLabel,
+            `${queryCount} ${queryCount === 1 ? 'query' : 'queries'}`,
+            `${insightCount} ${insightCount === 1 ? 'insight' : 'insights'}`,
+            promotedCount > 0 ? `${promotedCount} promoted` : null,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        </span>
+        {stale && (
+          <span
+            data-testid={`exploration-card-${exploration.id}-stale`}
+            title={
+              danglingRefs.length > 0
+                ? `References that no longer resolve: ${danglingRefs.join(', ')}`
+                : 'This exploration references objects that may have changed'
+            }
+            className="inline-flex items-center gap-1 rounded-full bg-highlight-50 px-1.5 py-0.5 text-[10.5px] font-medium text-highlight-700"
+          >
+            <PiWarningCircle style={{ fontSize: 11 }} aria-hidden="true" />
+            stale
+          </span>
+        )}
       </div>
 
       {exploration.seededFrom && (

--- a/viewer/src/components/views/workspace/homes/ExplorationCard.test.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorationCard.test.jsx
@@ -161,4 +161,39 @@ describe('ExplorationCard', () => {
 
     expect(onRename).toHaveBeenCalledWith('exp_1', 'Renamed');
   });
+
+  // VIS-1070 — staleness badge (01-ux-spec.md §2's "⚠ stale (orders
+  // changed)" end-state). `stale`/`danglingRefs` are computed by the PARENT
+  // (ExplorerHomePane) and just rendered here.
+  describe('staleness badge (VIS-1070)', () => {
+    test('no badge by default', () => {
+      render(
+        <ExplorationCard
+          exploration={exploration()}
+          onOpen={jest.fn()}
+          onRename={jest.fn()}
+          onDuplicate={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      );
+      expect(screen.queryByTestId('exploration-card-exp_1-stale')).not.toBeInTheDocument();
+    });
+
+    test('renders the badge with dangling refs in the tooltip when stale', () => {
+      render(
+        <ExplorationCard
+          exploration={exploration()}
+          onOpen={jest.fn()}
+          onRename={jest.fn()}
+          onDuplicate={jest.fn()}
+          onDelete={jest.fn()}
+          stale
+          danglingRefs={['deleted_model']}
+        />
+      );
+      const badge = screen.getByTestId('exploration-card-exp_1-stale');
+      expect(badge).toHaveTextContent('stale');
+      expect(badge).toHaveAttribute('title', expect.stringContaining('deleted_model'));
+    });
+  });
 });

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
@@ -5,6 +5,7 @@ import SubBar from '../SubBar';
 import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
 import { useConfirm } from '../../../common/ConfirmDialog';
 import ExplorationCard from './ExplorationCard';
+import { computeExplorationStaleness } from '../explorationStaleness';
 
 const ExplorerIcon = getTypeIcon('explorer');
 const EXPLORER_COLORS = getTypeColors('explorer');
@@ -30,8 +31,8 @@ const SOURCE_COLORS = getTypeColors('source');
  *     empty (after the fetch has settled — never race a real list) so the
  *     first visit is never empty.
  *
- * Promotion count (Phase 4) and the staleness badge (Phase 5) are
- * intentionally absent from the card — the mock depicts the end state.
+ * Promotion count (Phase 4) and the staleness badge (Phase 5,
+ * `computeExplorationStaleness`) are both wired now — the mock's end state.
  */
 const ExplorerHomePane = () => {
   const explorations = useStore(s => s.workspaceExplorations);
@@ -49,6 +50,19 @@ const ExplorerHomePane = () => {
     () => (explorations.order || []).map(id => explorations.byId[id]).filter(Boolean),
     [explorations]
   );
+
+  // VIS-1070 — staleness badge (01-ux-spec.md §2's "⚠ stale (orders
+  // changed)" end-state). Computed once per card here (not inside
+  // ExplorationCard itself) so the check runs against a SINGLE consistent
+  // state snapshot for the whole gallery rather than N independent reads.
+  const stalenessById = useMemo(() => {
+    const state = useStore.getState();
+    const map = {};
+    orderedExplorations.forEach(exploration => {
+      map[exploration.id] = computeExplorationStaleness(exploration, state);
+    });
+    return map;
+  }, [orderedExplorations]);
 
   const openExploration = id => {
     openWorkspaceTab({ id: `exploration:${id}`, type: 'exploration', name: id });
@@ -246,6 +260,8 @@ const ExplorerHomePane = () => {
                   onRename={handleRename}
                   onDuplicate={handleDuplicate}
                   onDelete={handleDelete}
+                  stale={!!stalenessById[exploration.id]?.stale}
+                  danglingRefs={stalenessById[exploration.id]?.danglingRefs || []}
                 />
               ))}
             </div>

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
 /**
  * ExplorerHomePane (Explore 2.0 Phase 2 — replaces the Phase 0 placeholder):
  * header + "+ New exploration", "Start from a source" tiles, "Recent
@@ -390,5 +391,44 @@ describe('ExplorerHomePane — delete flow', () => {
     fireEvent.click(screen.getByTestId('exploration-delete-confirm-cancel'));
 
     expect(deleteExploration).not.toHaveBeenCalled();
+  });
+});
+
+// VIS-1070 — the gallery computes staleness once per card (via
+// computeExplorationStaleness) and passes it down; this pins the wiring,
+// not the detection logic itself (covered by explorationStaleness.test.js).
+describe('ExplorerHomePane — staleness badges (VIS-1070)', () => {
+  test('flags a card whose draft references a deleted object, leaves an unaffected card clean', () => {
+    seed({
+      models: [{ name: 'orders_q' }],
+      workspaceExplorations: {
+        byId: {
+          exp_1: explorationRecord({
+            id: 'exp_1',
+            name: 'Stale one',
+            draft: {
+              queries: [],
+              insights: [{ name: 'a', props: { x: '?{${ref(deleted_model).col}}' } }],
+              chart: null,
+              computedColumns: [],
+            },
+          }),
+          exp_2: explorationRecord({
+            id: 'exp_2',
+            name: 'Clean one',
+            draft: {
+              queries: [{ name: 'orders_q', sql: 'SELECT 1', source: 'warehouse' }],
+              insights: [{ name: 'b', props: { x: '?{${ref(orders_q).col}}' } }],
+              chart: null,
+              computedColumns: [],
+            },
+          }),
+        },
+        order: ['exp_1', 'exp_2'],
+      },
+    });
+    render(<ExplorerHomePane />);
+    expect(screen.getByTestId('exploration-card-exp_1-stale')).toBeInTheDocument();
+    expect(screen.queryByTestId('exploration-card-exp_2-stale')).not.toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -65,6 +65,12 @@ const Library = () => {
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const openWorkspaceTabBackground = useStore(s => s.openWorkspaceTabBackground);
   const createExploration = useStore(s => s.createExploration);
+  const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
+  const addObjectToActiveExploration = useStore(s => s.addObjectToActiveExploration);
+  // VIS-1067: "Add to exploration" is only offered while an exploration tab
+  // is the ACTIVE one — that's the exploration whose live legacy working
+  // state `addObjectToActiveExploration` actually mutates.
+  const canAddToExploration = useStore(s => s.workspaceActiveObject?.type === 'exploration');
   const toggleLeftCollapsed = useStore(s => s.toggleWorkspaceLeftCollapsed);
   const setLibrarySubsectionCollapsed = useStore(s => s.setLibrarySubsectionCollapsed);
 
@@ -220,8 +226,9 @@ const Library = () => {
         name: obj.name,
         action,
       });
-      // VIS-811 / O-2: the open actions are live; the rest (wrapInChart,
-      // showLineage, delete) stay telemetry-only until their tracks wire them.
+      // VIS-811 / O-2: the open actions are live; `wrapInChart`/`showLineage`/
+      // `delete` stay telemetry-only until their tracks wire them. VIS-1067
+      // wires `exploreThis`/`addToExploration`.
       const type = routeType(obj);
       if (action === 'edit' && openWorkspaceTab) {
         openWorkspaceTab({ id: `${type}:${obj.name}`, type, name: obj.name });
@@ -231,9 +238,28 @@ const Library = () => {
           type,
           name: obj.name,
         });
+      } else if (action === 'exploreThis' && createExploration && openWorkspaceTab) {
+        const seed = { type, name: obj.name };
+        const legacyStateOverride = buildExplorationSeedState
+          ? buildExplorationSeedState(seed)
+          : null;
+        createExploration(seed, null, legacyStateOverride).then(result => {
+          if (result?.success) {
+            openWorkspaceTab({ id: `exploration:${result.id}`, type: 'exploration', name: result.id });
+            emitWorkspaceEvent('explore_this_used', { source_type: type });
+          }
+        });
+      } else if (action === 'addToExploration' && addObjectToActiveExploration) {
+        addObjectToActiveExploration({ type, name: obj.name, parentModel: obj.parentModel });
       }
     },
-    [openWorkspaceTab, openWorkspaceTabBackground]
+    [
+      openWorkspaceTab,
+      openWorkspaceTabBackground,
+      createExploration,
+      buildExplorationSeedState,
+      addObjectToActiveExploration,
+    ]
   );
 
   const handleCreate = useCallback(
@@ -414,6 +440,7 @@ const Library = () => {
             selectedRowId={selectedRowId}
             onRowClick={handleRowClick}
             onContextAction={handleContextAction}
+            canAddToExploration={canAddToExploration}
           />
         ))}
         {renderedTypes.length === 0 && (

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -377,6 +377,64 @@ describe('Library', () => {
     unsubscribe();
   });
 
+  // VIS-1067 — "Explore this" / "Add to exploration" context-menu entries.
+  describe('Explore this / Add to exploration', () => {
+    test('"Explore this" mints an exploration seeded + pre-wired via buildExplorationSeedState, then opens its tab', async () => {
+      const openWorkspaceTab = jest.fn();
+      const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+      const buildExplorationSeedState = jest.fn().mockReturnValue({ modelTabs: ['query_1'] });
+      seedStore({ openWorkspaceTab, createExploration, buildExplorationSeedState });
+      renderLibrary();
+
+      fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+      const menu = screen.getByTestId('library-row-insight-revenue_growth-context-menu');
+      fireEvent.click(within(menu).getByText('Explore this'));
+
+      expect(buildExplorationSeedState).toHaveBeenCalledWith({ type: 'insight', name: 'revenue_growth' });
+      await waitFor(() =>
+        expect(createExploration).toHaveBeenCalledWith(
+          { type: 'insight', name: 'revenue_growth' },
+          null,
+          { modelTabs: ['query_1'] }
+        )
+      );
+      await waitFor(() =>
+        expect(openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'exploration:exp_new',
+          type: 'exploration',
+          name: 'exp_new',
+        })
+      );
+    });
+
+    test('"Add to exploration" is offered only when the active tab is an exploration, and calls addObjectToActiveExploration', () => {
+      const addObjectToActiveExploration = jest.fn();
+      seedStore({
+        workspaceActiveObject: { type: 'exploration', name: 'exp_1' },
+        addObjectToActiveExploration,
+      });
+      renderLibrary();
+
+      fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+      const menu = screen.getByTestId('library-row-insight-revenue_growth-context-menu');
+      fireEvent.click(within(menu).getByText('Add to exploration'));
+
+      expect(addObjectToActiveExploration).toHaveBeenCalledWith({
+        type: 'insight',
+        name: 'revenue_growth',
+        parentModel: undefined,
+      });
+    });
+
+    test('"Add to exploration" does not render when no exploration tab is active', () => {
+      seedStore({ workspaceActiveObject: { type: 'model', name: 'monthly_revenue' } });
+      renderLibrary();
+      fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+      const menu = screen.getByTestId('library-row-insight-revenue_growth-context-menu');
+      expect(within(menu).queryByText('Add to exploration')).not.toBeInTheDocument();
+    });
+  });
+
   test('clicking a dashboard row scopes the workspace to that dashboard (VIS-824)', () => {
     const openWorkspaceTab = jest.fn();
     seedStore({ openWorkspaceTab });

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -7,6 +7,8 @@ import {
   PiPencil,
   PiArrowSquareOut,
   PiTrash,
+  PiCompass,
+  PiPlusCircle,
 } from 'react-icons/pi';
 import { ObjectStatus } from '../../../../stores/store';
 import { getTypeByValue, getTypeIcon } from '../../common/objectTypeConfigs';
@@ -58,6 +60,16 @@ export const DROPPABLE_TYPES = ['chart', 'table', 'markdown', 'input'];
 // these types — stay unchanged: a Library row being an exploration drag
 // source is orthogonal to it being a valid DASHBOARD canvas item.
 export const EXPLORATION_DRAG_TYPES = ['source', 'metric', 'dimension', 'insight'];
+
+// Explore 2.0 Phase 5 (VIS-1067): types a right-click "Explore this" can mint
+// a brand-new, pre-wired exploration from (`explorerStore.js`'s
+// `buildExplorationSeedState`) — broader than `EXPLORATION_DRAG_TYPES`
+// because minting a NEW exploration (rather than adding into an already-open
+// one) also makes sense for `model` and `chart`, which have no meaningful
+// "drop into an existing exploration" analog (a model is queried, not
+// bound to a slot; a chart already IS the top-level draft, not a value that
+// fits inside one).
+export const EXPLORE_THIS_TYPES = ['source', 'model', 'metric', 'dimension', 'insight', 'chart'];
 
 // Every type except `relation` supports inline create (a draft with a
 // minimal valid config — see stores/inlineCreateStore.js). A relation can't
@@ -148,8 +160,10 @@ const MenuDivider = () => (
   />
 );
 
-const ContextMenu = ({ obj, onAction, onDismiss }) => {
+const ContextMenu = ({ obj, onAction, onDismiss, canAddToExploration = false }) => {
   const isInsight = obj.type === 'insight';
+  const canExploreThis = EXPLORE_THIS_TYPES.includes(obj.type);
+  const canAddThisToExploration = canAddToExploration && EXPLORATION_DRAG_TYPES.includes(obj.type);
   const handle = action => () => {
     onAction && onAction(action, obj);
     onDismiss && onDismiss();
@@ -196,6 +210,25 @@ const ContextMenu = ({ obj, onAction, onDismiss }) => {
             onClick={handle('showLineage')}
           />
         </li>
+        {(canExploreThis || canAddThisToExploration) && <MenuDivider />}
+        {canExploreThis && (
+          <li>
+            <ContextMenuItem
+              icon={PiCompass}
+              label="Explore this"
+              onClick={handle('exploreThis')}
+            />
+          </li>
+        )}
+        {canAddThisToExploration && (
+          <li>
+            <ContextMenuItem
+              icon={PiPlusCircle}
+              label="Add to exploration"
+              onClick={handle('addToExploration')}
+            />
+          </li>
+        )}
         <MenuDivider />
         <li>
           <ContextMenuItem
@@ -211,7 +244,15 @@ const ContextMenu = ({ obj, onAction, onDismiss }) => {
   );
 };
 
-const LibraryRow = ({ obj, selected = false, draggable = true, onClick, onContextAction, testId }) => {
+const LibraryRow = ({
+  obj,
+  selected = false,
+  draggable = true,
+  onClick,
+  onContextAction,
+  canAddToExploration = false,
+  testId,
+}) => {
   const [hovered, setHovered] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -414,7 +455,12 @@ const LibraryRow = ({ obj, selected = false, draggable = true, onClick, onContex
         />
       )}
       {menuOpen && (
-        <ContextMenu obj={obj} onAction={onContextAction} onDismiss={handleMenuDismiss} />
+        <ContextMenu
+          obj={obj}
+          onAction={onContextAction}
+          onDismiss={handleMenuDismiss}
+          canAddToExploration={canAddToExploration}
+        />
       )}
     </div>
   );

--- a/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
@@ -156,6 +156,60 @@ describe('LibraryRow', () => {
     expect(menu).toHaveTextContent('⌫');
   });
 
+  // VIS-1067 — "Explore this" / "Add to exploration" context-menu entries.
+  describe('Explore this / Add to exploration (VIS-1067)', () => {
+    test('a model row offers "Explore this" but never "Add to exploration" (model is not an EXPLORATION_DRAG_TYPE)', () => {
+      render(withDnd(<LibraryRow obj={MODEL} canAddToExploration />));
+      fireEvent.mouseEnter(screen.getByTestId('library-row-model-monthly_revenue'));
+      fireEvent.click(screen.getByTestId('library-row-model-monthly_revenue-kebab'));
+      const menu = screen.getByTestId('library-row-model-monthly_revenue-context-menu');
+      expect(menu).toHaveTextContent('Explore this');
+      expect(menu).not.toHaveTextContent('Add to exploration');
+    });
+
+    test('an insight row offers "Add to exploration" only when canAddToExploration is true', () => {
+      const { rerender } = render(withDnd(<LibraryRow obj={INSIGHT} canAddToExploration={false} />));
+      fireEvent.mouseEnter(screen.getByTestId('library-row-insight-revenue_growth'));
+      fireEvent.click(screen.getByTestId('library-row-insight-revenue_growth-kebab'));
+      expect(
+        screen.getByTestId('library-row-insight-revenue_growth-context-menu')
+      ).not.toHaveTextContent('Add to exploration');
+
+      // Re-render with the flag flipped WITHOUT re-toggling the kebab — the
+      // menu (internal `menuOpen` state) stays open across the prop change,
+      // clicking the kebab again would just close it.
+      rerender(withDnd(<LibraryRow obj={INSIGHT} canAddToExploration />));
+      expect(
+        screen.getByTestId('library-row-insight-revenue_growth-context-menu')
+      ).toHaveTextContent('Add to exploration');
+    });
+
+    test('"Explore this" fires onContextAction("exploreThis", obj) and dismisses the menu', () => {
+      const onContextAction = jest.fn();
+      render(withDnd(<LibraryRow obj={INSIGHT} onContextAction={onContextAction} />));
+      fireEvent.mouseEnter(screen.getByTestId('library-row-insight-revenue_growth'));
+      fireEvent.click(screen.getByTestId('library-row-insight-revenue_growth-kebab'));
+      fireEvent.click(screen.getByText('Explore this'));
+      expect(onContextAction).toHaveBeenCalledWith('exploreThis', INSIGHT);
+      expect(
+        screen.queryByTestId('library-row-insight-revenue_growth-context-menu')
+      ).not.toBeInTheDocument();
+    });
+
+    test('"Add to exploration" fires onContextAction("addToExploration", obj)', () => {
+      const onContextAction = jest.fn();
+      render(
+        withDnd(
+          <LibraryRow obj={INSIGHT} canAddToExploration onContextAction={onContextAction} />
+        )
+      );
+      fireEvent.mouseEnter(screen.getByTestId('library-row-insight-revenue_growth'));
+      fireEvent.click(screen.getByTestId('library-row-insight-revenue_growth-kebab'));
+      fireEvent.click(screen.getByText('Add to exploration'));
+      expect(onContextAction).toHaveBeenCalledWith('addToExploration', INSIGHT);
+    });
+  });
+
   test('right-click opens the context menu (preventing the native one)', () => {
     render(withDnd(<LibraryRow obj={CHART} />));
     const row = screen.getByTestId('library-row-chart-waterfall');

--- a/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
@@ -36,6 +36,7 @@ const LibrarySubsection = ({
   selectedRowId = null,
   onRowClick,
   onContextAction,
+  canAddToExploration = false,
 }) => {
   const def = getTypeDef(typeKey);
   const Icon = def.icon;
@@ -120,6 +121,7 @@ const LibrarySubsection = ({
                       draggable={def.droppable || def.explorationDragSource}
                       onClick={onRowClick}
                       onContextAction={onContextAction}
+                      canAddToExploration={canAddToExploration}
                     />
                   </li>
                 )

--- a/viewer/src/components/views/workspace/relations/RelationErdCanvas.jsx
+++ b/viewer/src/components/views/workspace/relations/RelationErdCanvas.jsx
@@ -21,6 +21,7 @@ import AddModelMention from './AddModelMention';
 import RelationLinkEdge from './RelationLinkEdge';
 import { mergeById } from './erdNodeMerge';
 import ErdTidyButton from './ErdTidyButton';
+import CenteredFrameState from '../../common/CenteredFrameState';
 
 /**
  * RelationErdCanvas — the Relations ERD builder (VIS-1006).
@@ -31,20 +32,9 @@ import ErdTidyButton from './ErdTidyButton';
  *
  * data-testid: `relation-erd`.
  */
-const ErdEmptyState = () => (
-  <div
-    data-testid="relation-erd-empty"
-    className="flex flex-1 items-center justify-center bg-gray-50 p-12 text-center"
-  >
-    <div className="max-w-[360px] rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
-      <h2 className="text-[15px] font-semibold text-gray-900">No models to relate yet</h2>
-      <p className="mt-1.5 text-[13px] leading-relaxed text-gray-500">
-        Add at least two models, then drag a column from one card onto a column of another to
-        author a relation.
-      </p>
-    </div>
-  </div>
-);
+// VIS-1071 (01-ux-spec.md §7): local ErdEmptyState replaced by the shared
+// CenteredFrameState — rendered inline at its call site below (maxWidth={360}
+// preserves this state's original narrower card).
 
 const RelationErdCanvasInner = ({ activeObject = null, scopeAll = false }) => {
   const fetchModels = useStore(s => s.fetchModels);
@@ -272,7 +262,12 @@ const RelationErdCanvasInner = ({ activeObject = null, scopeAll = false }) => {
       </div>
 
       {!hasModels ? (
-        <ErdEmptyState />
+        <CenteredFrameState
+          testId="relation-erd-empty"
+          title="No models to relate yet"
+          body="Add at least two models, then drag a column from one card onto a column of another to author a relation."
+          maxWidth={360}
+        />
       ) : (
         <div ref={setDropRef} data-testid="relation-erd-dropzone" className="relative flex-1">
           <ReactFlow

--- a/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.jsx
@@ -10,7 +10,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import useStore from '../../../../stores/store';
-import { useRelationErdDag } from './useRelationErdDag';
+import { useRelationErdDag, ERD_NODE_ID } from './useRelationErdDag';
 import { useModelColumns } from './useModelColumns';
 import { groupFieldsByModel } from './semanticFields';
 import SemanticLayerErdModelNode from './SemanticLayerErdModelNode';
@@ -65,7 +65,15 @@ const SemanticLayerCanvasInner = () => {
   const getRelationByName = useStore(s => s.getRelationByName);
   const savedPositions = erdLayout.nodes;
 
-  const { fitView } = useReactFlow();
+  // VIS-1069 — one-shot node-focus intent (mirrors `workspaceLensIntent`):
+  // promoting a metric/dimension's "View in Semantic Layer" offer sets this
+  // one statement before navigating here.
+  const focusIntent = useStore(s => s.workspaceSemanticLayerFocusIntent);
+  const clearWorkspaceSemanticLayerFocusIntent = useStore(
+    s => s.clearWorkspaceSemanticLayerFocusIntent
+  );
+
+  const { fitView, setCenter } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
 
   // Hydrate every collection the project ERD reads from.
@@ -162,6 +170,47 @@ const SemanticLayerCanvasInner = () => {
     // The version bump reseeds rfNodes; fit after the reseed settles.
     setTimeout(() => fitView({ padding: 0.2, maxZoom: 1.2 }), 0);
   }, [clearErdLayout, fitView]);
+
+  // VIS-1069 — metrics/dimensions have no ERD node of their own (they're
+  // folded into their parent model's card, `fieldsByModel`); resolve a
+  // field name to the model card it lives on.
+  const resolveFieldParentModel = useCallback(
+    (type, name) => {
+      const key = type === 'metric' ? 'metrics' : 'dimensions';
+      for (const [modelName, buckets] of Object.entries(fieldsByModel)) {
+        if (buckets[key]?.includes(name)) return modelName;
+      }
+      return null;
+    },
+    [fieldsByModel]
+  );
+
+  // Consume the one-shot focus intent once its target node is actually on
+  // the canvas — pans/centers on it, then self-clears (never lingers to
+  // hijack a later, unrelated visit). A `model` intent targets its own node
+  // directly; a `metric`/`dimension` intent targets its parent model's node
+  // (fields have no node of their own). An unresolvable target is still
+  // consumed (cleared) rather than left dangling forever.
+  useEffect(() => {
+    if (!focusIntent?.objectKey || rfNodes.length === 0) return;
+    const sepIndex = focusIntent.objectKey.indexOf(':');
+    const type = focusIntent.objectKey.slice(0, sepIndex);
+    const name = focusIntent.objectKey.slice(sepIndex + 1);
+    const targetModelName =
+      type === 'metric' || type === 'dimension' ? resolveFieldParentModel(type, name) : name;
+    const node = targetModelName
+      ? rfNodes.find(n => n.id === ERD_NODE_ID(targetModelName))
+      : null;
+    if (node) {
+      const width = node.width || node.layoutSize?.width || 260;
+      const height = node.height || node.layoutSize?.height || 120;
+      setCenter(node.position.x + width / 2, node.position.y + height / 2, {
+        zoom: 1,
+        duration: 400,
+      });
+    }
+    clearWorkspaceSemanticLayerFocusIntent?.();
+  }, [focusIntent, rfNodes, resolveFieldParentModel, setCenter, clearWorkspaceSemanticLayerFocusIntent]);
 
   const hasEdits = Object.keys(savedPositions || {}).length > 0;
 

--- a/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.test.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.test.jsx
@@ -5,6 +5,7 @@ import SemanticLayerCanvas from './SemanticLayerCanvas';
 import useStore from '../../../../stores/store';
 import { useRelationErdDag } from './useRelationErdDag';
 import { useModelColumns } from './useModelColumns';
+import { setWorkspaceTelemetryListener } from '../telemetry';
 
 jest.mock('../../../../stores/store');
 jest.mock('./useRelationErdDag', () => ({
@@ -211,6 +212,26 @@ describe('SemanticLayerCanvas', () => {
           name: 'exp_new',
         })
       );
+    });
+
+    // VIS-1072 — flywheel telemetry.
+    it('fires explore_this_used{source_type} on a successful mint', async () => {
+      const events = [];
+      const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+      const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+      const openWorkspaceTab = jest.fn();
+      mockStore({ ...modelWithFields(), createExploration, openWorkspaceTab });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+      fireEvent.click(screen.getByTestId('erd-dimension-pill-status'));
+
+      await waitFor(() =>
+        expect(events.find(e => e.eventName === 'explore_this_used')?.payload).toEqual({
+          source_type: 'dimension',
+        })
+      );
+      unsubscribe();
     });
 
     it('does not open a tab when creation fails', async () => {

--- a/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.test.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerCanvas.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import SemanticLayerCanvas from './SemanticLayerCanvas';
 import useStore from '../../../../stores/store';
 import { useRelationErdDag } from './useRelationErdDag';
@@ -31,6 +31,7 @@ jest.mock('./JoinOperatorPopover', () => ({
 
 const rfProps = { current: null };
 const mockFitView = jest.fn();
+const mockSetCenter = jest.fn();
 
 jest.mock('reactflow', () => {
   const MockReactFlow = props => {
@@ -73,7 +74,7 @@ jest.mock('reactflow', () => {
         const change = changes.find(c => c.id === node.id && c.position);
         return change ? { ...node, position: change.position } : node;
       }),
-    useReactFlow: () => ({ fitView: mockFitView, screenToFlowPosition: p => p }),
+    useReactFlow: () => ({ fitView: mockFitView, setCenter: mockSetCenter, screenToFlowPosition: p => p }),
     useNodesInitialized: () => true,
     // RelationLinkEdge module-level imports (it's required transitively).
     BaseEdge: () => null,
@@ -157,6 +158,151 @@ describe('SemanticLayerCanvas', () => {
     expect(screen.getByTestId('semantic-erd-model-node-orders')).toBeInTheDocument();
     expect(screen.getByTestId('erd-metric-pill-total')).toBeInTheDocument();
     expect(screen.getByTestId('erd-dimension-pill-status')).toBeInTheDocument();
+  });
+
+  // VIS-1069 — Semantic Layer field pills gain "Explore this" back-links.
+  describe('"Explore this" field pills', () => {
+    const modelWithFields = () => ({
+      models: [
+        {
+          name: 'orders',
+          config: {
+            metrics: [{ name: 'total' }],
+            dimensions: [{ name: 'status' }],
+          },
+        },
+      ],
+    });
+
+    const nodesWithFields = () => ({
+      nodes: [
+        {
+          id: 'erd-model-orders',
+          type: 'erdModelNode',
+          position: { x: 0, y: 0 },
+          data: { name: 'orders', columns: ['id'], metrics: ['total'], dimensions: ['status'] },
+        },
+      ],
+      edges: [],
+    });
+
+    it('clicking a metric pill mints a pre-wired exploration and opens its tab', async () => {
+      const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+      const buildExplorationSeedState = jest.fn().mockReturnValue({ modelTabs: ['query_1'] });
+      const openWorkspaceTab = jest.fn();
+      mockStore({ ...modelWithFields(), createExploration, buildExplorationSeedState, openWorkspaceTab });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+      fireEvent.click(screen.getByTestId('erd-metric-pill-total'));
+
+      expect(buildExplorationSeedState).toHaveBeenCalledWith({ type: 'metric', name: 'total' });
+      await waitFor(() =>
+        expect(createExploration).toHaveBeenCalledWith(
+          { type: 'metric', name: 'total' },
+          null,
+          { modelTabs: ['query_1'] }
+        )
+      );
+      await waitFor(() =>
+        expect(openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'exploration:exp_new',
+          type: 'exploration',
+          name: 'exp_new',
+        })
+      );
+    });
+
+    it('does not open a tab when creation fails', async () => {
+      const createExploration = jest.fn().mockResolvedValue({ success: false, error: 'boom' });
+      const openWorkspaceTab = jest.fn();
+      mockStore({ ...modelWithFields(), createExploration, openWorkspaceTab });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+      fireEvent.click(screen.getByTestId('erd-dimension-pill-status'));
+
+      await waitFor(() => expect(createExploration).toHaveBeenCalled());
+      expect(openWorkspaceTab).not.toHaveBeenCalled();
+    });
+  });
+
+  // VIS-1069 — one-shot ERD node-focus intent (mirrors workspaceLensIntent).
+  describe('workspaceSemanticLayerFocusIntent', () => {
+    const modelWithFields = () => ({
+      models: [
+        {
+          name: 'orders',
+          config: { metrics: [{ name: 'total' }], dimensions: [{ name: 'status' }] },
+        },
+      ],
+    });
+
+    const nodesWithFields = () => ({
+      nodes: [
+        {
+          id: 'erd-model-orders',
+          type: 'erdModelNode',
+          position: { x: 40, y: 20 },
+          data: { name: 'orders', columns: ['id'], metrics: ['total'], dimensions: ['status'] },
+        },
+      ],
+      edges: [],
+    });
+
+    it('a model-targeted intent centers on that node and self-clears', async () => {
+      const clearWorkspaceSemanticLayerFocusIntent = jest.fn();
+      mockStore({
+        ...modelWithFields(),
+        workspaceSemanticLayerFocusIntent: { objectKey: 'model:orders' },
+        clearWorkspaceSemanticLayerFocusIntent,
+      });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+
+      await waitFor(() =>
+        expect(mockSetCenter).toHaveBeenCalledWith(40 + 130, 20 + 60, { zoom: 1, duration: 400 })
+      );
+      expect(clearWorkspaceSemanticLayerFocusIntent).toHaveBeenCalled();
+    });
+
+    it('a metric-targeted intent resolves to its PARENT MODEL node (fields have no node of their own)', async () => {
+      const clearWorkspaceSemanticLayerFocusIntent = jest.fn();
+      mockStore({
+        ...modelWithFields(),
+        workspaceSemanticLayerFocusIntent: { objectKey: 'metric:total' },
+        clearWorkspaceSemanticLayerFocusIntent,
+      });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+
+      await waitFor(() => expect(mockSetCenter).toHaveBeenCalledWith(170, 80, { zoom: 1, duration: 400 }));
+      expect(clearWorkspaceSemanticLayerFocusIntent).toHaveBeenCalled();
+    });
+
+    it('an unresolvable intent still self-clears (never lingers)', async () => {
+      const clearWorkspaceSemanticLayerFocusIntent = jest.fn();
+      mockStore({
+        ...modelWithFields(),
+        workspaceSemanticLayerFocusIntent: { objectKey: 'metric:does_not_exist' },
+        clearWorkspaceSemanticLayerFocusIntent,
+      });
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+
+      render(<SemanticLayerCanvas />);
+
+      await waitFor(() => expect(clearWorkspaceSemanticLayerFocusIntent).toHaveBeenCalled());
+      expect(mockSetCenter).not.toHaveBeenCalled();
+    });
+
+    it('no intent set never calls setCenter', () => {
+      mockStore(modelWithFields());
+      useRelationErdDag.mockReturnValue(nodesWithFields());
+      render(<SemanticLayerCanvas />);
+      expect(mockSetCenter).not.toHaveBeenCalled();
+    });
   });
 
   it('renders a relation as its own node + two link edges', () => {

--- a/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
@@ -3,6 +3,7 @@ import { Position } from 'reactflow';
 import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
 import { NodeHandle } from '../../../styled/NodeHandle';
 import useStore from '../../../../stores/store';
+import { emitWorkspaceEvent } from '../telemetry';
 
 /**
  * SemanticLayerErdModelNode — the model card for the project-wide Semantic Layer
@@ -40,6 +41,7 @@ const FieldPills = ({ label, names, type }) => {
             type: 'exploration',
             name: result.id,
           });
+          emitWorkspaceEvent('explore_this_used', { source_type: type });
         }
       });
     },

--- a/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Position } from 'reactflow';
 import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
 import { NodeHandle } from '../../../styled/NodeHandle';
+import useStore from '../../../../stores/store';
 
 /**
  * SemanticLayerErdModelNode — the model card for the project-wide Semantic Layer
@@ -12,8 +13,39 @@ import { NodeHandle } from '../../../styled/NodeHandle';
  *
  * All colours/icons come from objectTypeConfigs (model = amber, metric = cyan,
  * dimension = teal); no hand-rolled tones.
+ *
+ * Pills are clickable "Explore this" back-links (VIS-1069, 01-ux-spec.md §5) —
+ * mints a new exploration seeded from that field, pre-wired against its
+ * parent model via `buildExplorationSeedState`, and opens its tab. Buttons
+ * (not spans) so the affordance is keyboard-reachable; `stopPropagation` on
+ * both mouse and pointer events keeps the click from also firing React
+ * Flow's node click/drag handling on the card underneath.
  */
 const FieldPills = ({ label, names, type }) => {
+  const createExploration = useStore(s => s.createExploration);
+  const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
+  const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+
+  const handleExploreField = useCallback(
+    name => {
+      if (!createExploration) return;
+      const seed = { type, name };
+      const legacyStateOverride = buildExplorationSeedState
+        ? buildExplorationSeedState(seed)
+        : null;
+      createExploration(seed, null, legacyStateOverride).then(result => {
+        if (result?.success && openWorkspaceTab) {
+          openWorkspaceTab({
+            id: `exploration:${result.id}`,
+            type: 'exploration',
+            name: result.id,
+          });
+        }
+      });
+    },
+    [type, createExploration, buildExplorationSeedState, openWorkspaceTab]
+  );
+
   if (!names || names.length === 0) return null;
   const colors = getTypeColors(type);
   const Icon = getTypeIcon(type);
@@ -25,18 +57,25 @@ const FieldPills = ({ label, names, type }) => {
       </div>
       <div className="flex flex-wrap gap-1">
         {names.map(name => (
-          <span
+          <button
             key={name}
+            type="button"
             data-testid={`erd-${type}-pill-${name}`}
-            title={name}
+            title={`Explore ${name}`}
+            onPointerDown={e => e.stopPropagation()}
+            onClick={e => {
+              e.stopPropagation();
+              handleExploreField(name);
+            }}
             className={[
-              'inline-flex max-w-[120px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-medium',
+              'inline-flex max-w-[120px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors',
+              'cursor-pointer hover:ring-1 hover:ring-inset',
               colors.bg,
               colors.text,
             ].join(' ')}
           >
             {name}
-          </span>
+          </button>
         ))}
       </div>
     </div>

--- a/viewer/src/components/views/workspace/saveAsMetricFlow.js
+++ b/viewer/src/components/views/workspace/saveAsMetricFlow.js
@@ -2,6 +2,7 @@ import { translateExpressions } from '../../../api/expressions';
 import * as pillGrammar from '../common/pillGrammar';
 import { findMatchingExpressionSlots } from '../common/pillFieldSwap';
 import { serializeQueryString } from '../../../utils/queryString';
+import { emitWorkspaceEvent } from './telemetry';
 
 /**
  * saveAsMetricFlow — Explore 2.0 Phase 4 (06-pill-aggregation-grammar.md §4
@@ -120,6 +121,9 @@ export const saveAsMetric = async ({
     getState().explorerInsightStates || {},
     { excludeInsightName: insightName, excludeLocation: 'prop', excludeKey: path }
   );
+
+  // VIS-1072 — flywheel telemetry.
+  emitWorkspaceEvent('save_as_metric_used', { name: trimmed, dedupOfferSlots: matches.length });
 
   return {
     success: true,

--- a/viewer/src/components/views/workspace/saveAsMetricFlow.test.js
+++ b/viewer/src/components/views/workspace/saveAsMetricFlow.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
 import { saveAsMetric, suggestMetricName } from './saveAsMetricFlow';
 import { translateExpressions } from '../../../api/expressions';
+import { setWorkspaceTelemetryListener } from './telemetry';
 
 jest.mock('../../../api/expressions', () => ({ translateExpressions: jest.fn() }));
 
@@ -213,5 +214,46 @@ describe('saveAsMetric', () => {
       ]),
     });
     expect(result.dedupOffer.slots).toHaveLength(2);
+  });
+
+  // VIS-1072 — flywheel telemetry.
+  describe('save_as_metric_used telemetry (VIS-1072)', () => {
+    let events;
+    let unsubscribe;
+
+    beforeEach(() => {
+      events = [];
+      unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    });
+    afterEach(() => unsubscribe());
+
+    test('fires on a successful save, with the dedup-offer slot count', async () => {
+      const state = baseState({
+        explorerInsightStates: {
+          other_chart: { props: { y: '?{sum(${ref(orders_q).amount})}' }, interactions: [] },
+        },
+      });
+      await saveAsMetric({
+        pillState: pillState(),
+        name: 'total_amount',
+        insightName: 'churn_by_cohort',
+        path: 'y',
+        getState: () => state,
+      });
+      const fired = events.find(e => e.eventName === 'save_as_metric_used');
+      expect(fired.payload).toEqual({ name: 'total_amount', dedupOfferSlots: 1 });
+    });
+
+    test('does not fire on a blocked/failed save', async () => {
+      const state = baseState({ saveMetric: jest.fn().mockResolvedValue({ success: false, error: 'boom' }) });
+      await saveAsMetric({
+        pillState: pillState(),
+        name: 'total_amount',
+        insightName: 'i',
+        path: 'y',
+        getState: () => state,
+      });
+      expect(events.find(e => e.eventName === 'save_as_metric_used')).toBeUndefined();
+    });
   });
 });

--- a/viewer/src/components/views/workspace/source/ErdTableContextMenu.jsx
+++ b/viewer/src/components/views/workspace/source/ErdTableContextMenu.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { PiPlusCircle, PiCopySimple } from 'react-icons/pi';
+import { PiPlusCircle, PiCopySimple, PiCompass } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import { getTypeIcon } from '../../common/objectTypeConfigs';
 import { formatRefExpression } from '../../../../utils/refString';
 import { generateUniqueName } from '../../../../utils/uniqueName';
+import { emitWorkspaceEvent } from '../telemetry';
 
 /**
  * ErdTableContextMenu — right-click menu for a Source-ERD table node (VIS-1005).
@@ -13,6 +14,10 @@ import { generateUniqueName } from '../../../../utils/uniqueName';
  *   - "Create a model to query this table" — builds `SELECT * FROM <schema>.<table>`,
  *     mints a unique model name, saves a SqlModel (`source: ${ref(<sourceName>)}`)
  *     via the model store, then opens it as a workspace tab.
+ *   - "Explore this" (VIS-1067) — mints a new exploration with one scratch
+ *     query pre-wired to the SAME `SELECT * FROM <schema>.<table>` + source,
+ *     and opens its tab (the D9 "start from a table" round trip, without
+ *     first publishing a real model).
  *   - "Copy qualified name" — copies the dotted qualified name to the clipboard.
  *
  * The SELECT string is CONSTRUCTED in JS (trivial identifier quoting) — this is
@@ -67,6 +72,8 @@ const ErdTableContextMenu = ({ x, y, sourceName, target, onDismiss }) => {
   const models = useStore(s => s.models);
   const saveModel = useStore(s => s.saveModel);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
+  const createExploration = useStore(s => s.createExploration);
+  const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
   const SourceIcon = getTypeIcon('source');
 
   useEffect(() => {
@@ -113,6 +120,20 @@ const ErdTableContextMenu = ({ x, y, sourceName, target, onDismiss }) => {
     }
   };
 
+  const handleExploreThis = async () => {
+    if (!createExploration) return;
+    const sql = buildSelectStar(target);
+    const seed = { type: 'table', name: qualifiedName };
+    const legacyStateOverride = buildExplorationSeedState
+      ? buildExplorationSeedState(seed, { sql, source: sourceName })
+      : null;
+    const result = await createExploration(seed, null, legacyStateOverride);
+    if (result?.success && openWorkspaceTab) {
+      openWorkspaceTab({ id: `exploration:${result.id}`, type: 'exploration', name: result.id });
+      emitWorkspaceEvent('explore_this_used', { source_type: 'table' });
+    }
+  };
+
   const handleCopyQualifiedName = () => {
     try {
       navigator?.clipboard?.writeText?.(qualifiedName);
@@ -142,6 +163,15 @@ const ErdTableContextMenu = ({ x, y, sourceName, target, onDismiss }) => {
         label="Create a model to query this table"
         onClick={async () => {
           await handleCreateModel();
+          onDismiss && onDismiss();
+        }}
+      />
+      <MenuItem
+        testid="erd-table-ctx-explore-this"
+        icon={PiCompass}
+        label="Explore this"
+        onClick={async () => {
+          await handleExploreThis();
           onDismiss && onDismiss();
         }}
       />

--- a/viewer/src/components/views/workspace/source/ErdTableContextMenu.test.jsx
+++ b/viewer/src/components/views/workspace/source/ErdTableContextMenu.test.jsx
@@ -35,16 +35,22 @@ describe('buildSelectStar / buildQualifiedName', () => {
 describe('ErdTableContextMenu', () => {
   let saveModel;
   let openWorkspaceTab;
+  let createExploration;
+  let buildExplorationSeedState;
   let state;
 
   beforeEach(() => {
     jest.clearAllMocks();
     saveModel = jest.fn().mockResolvedValue({ success: true });
     openWorkspaceTab = jest.fn();
+    createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_1' });
+    buildExplorationSeedState = jest.fn().mockReturnValue({ modelTabs: ['query_1'] });
     state = {
       models: [{ name: 'orders_model' }], // forces the unique-name suffix
       saveModel,
       openWorkspaceTab,
+      createExploration,
+      buildExplorationSeedState,
     };
     useStore.mockImplementation(selector =>
       typeof selector === 'function' ? selector(state) : state
@@ -62,10 +68,46 @@ describe('ErdTableContextMenu', () => {
       />
     );
 
-  test('renders both actions', () => {
+  test('renders all three actions', () => {
     renderMenu();
     expect(screen.getByTestId('erd-table-ctx-create-model')).toBeInTheDocument();
+    expect(screen.getByTestId('erd-table-ctx-explore-this')).toBeInTheDocument();
     expect(screen.getByTestId('erd-table-ctx-copy-name')).toBeInTheDocument();
+  });
+
+  // VIS-1067 — "Explore this" mints an exploration pre-wired with the same
+  // SELECT * FROM <schema>.<table> + source, then opens its tab.
+  describe('Explore this', () => {
+    test('mints an exploration with the qualified name as seed provenance and the SELECT/source as build hints', async () => {
+      renderMenu();
+      fireEvent.click(screen.getByTestId('erd-table-ctx-explore-this'));
+
+      await waitFor(() => expect(createExploration).toHaveBeenCalledTimes(1));
+      expect(buildExplorationSeedState).toHaveBeenCalledWith(
+        { type: 'table', name: 'public.orders' },
+        { sql: 'SELECT * FROM public.orders', source: 'analytics_db' }
+      );
+      const [seed, returnTo, legacyStateOverride] = createExploration.mock.calls[0];
+      expect(seed).toEqual({ type: 'table', name: 'public.orders' });
+      expect(returnTo).toBeNull();
+      expect(legacyStateOverride).toEqual({ modelTabs: ['query_1'] });
+
+      await waitFor(() =>
+        expect(openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'exploration:exp_1',
+          type: 'exploration',
+          name: 'exp_1',
+        })
+      );
+    });
+
+    test('does NOT open a tab when creation fails', async () => {
+      createExploration.mockResolvedValue({ success: false, error: 'boom' });
+      renderMenu();
+      fireEvent.click(screen.getByTestId('erd-table-ctx-explore-this'));
+      await waitFor(() => expect(createExploration).toHaveBeenCalled());
+      expect(openWorkspaceTab).not.toHaveBeenCalled();
+    });
   });
 
   test('create-model builds the SELECT, saves with a ref() source, and opens a tab', async () => {

--- a/viewer/src/components/views/workspace/source/SourceErd.jsx
+++ b/viewer/src/components/views/workspace/source/SourceErd.jsx
@@ -13,6 +13,7 @@ import { computeLayout } from '../../lineage/useLineageDag';
 import { useSourceErdDag } from './useSourceErdDag';
 import TableErdNode from './TableErdNode';
 import ErdTableContextMenu from './ErdTableContextMenu';
+import CenteredFrameState from '../../common/CenteredFrameState';
 
 /**
  * SourceErd — the Source object's Canvas lens (VIS-1005).
@@ -38,22 +39,8 @@ const NODE_BASE_HEIGHT = 44; // header
 const NODE_ROW_HEIGHT = 24; // per visible column row
 const MAX_LAYOUT_ROWS = 12; // matches TableErdNode's column cap
 
-const FrameMessage = ({ testId, title, body }) => (
-  <div
-    data-testid={testId}
-    className="flex flex-1 items-center justify-center bg-gray-50 p-12"
-  >
-    <div className="max-w-[420px] rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-      <PiGraph className="mx-auto mb-2 h-6 w-6 text-gray-300" aria-hidden="true" />
-      <h2 className="text-[15px] font-semibold text-gray-900">{title}</h2>
-      {body && (
-        <p className="mx-auto mt-1.5 max-w-[320px] text-[13px] leading-relaxed text-gray-500">
-          {body}
-        </p>
-      )}
-    </div>
-  </div>
-);
+// VIS-1071 (01-ux-spec.md §7): local FrameMessage replaced by the shared
+// CenteredFrameState (icon={PiGraph} at every call site below).
 
 const nodeTypes = { tableErdNode: TableErdNode };
 
@@ -196,43 +183,47 @@ const SourceErdCanvas = ({ activeObject }) => {
   // --- Non-graph states ---------------------------------------------------
   if (!available) {
     return (
-      <FrameMessage
+      <CenteredFrameState
         testId="source-erd-unavailable"
         title="Available with visivo serve"
         body="Run `visivo serve` locally to explore this source's tables as an ERD."
+        icon={PiGraph}
       />
     );
   }
   if (status === 'loading' && !entry) {
-    return <FrameMessage testId="source-erd-loading" title="Loading tables…" />;
+    return <CenteredFrameState testId="source-erd-loading" title="Loading tables…" icon={PiGraph} />;
   }
   if (status === 'connection_failed' || status === 'missing') {
     return (
-      <FrameMessage
+      <CenteredFrameState
         testId="source-erd-connection-failed"
         title="No tables to show"
         body={
           error ||
           "This source's schema hasn't been generated yet. Generate its schema from the Data tab to see its tables."
         }
+        icon={PiGraph}
       />
     );
   }
   if (status === 'error') {
     return (
-      <FrameMessage
+      <CenteredFrameState
         testId="source-erd-connection-failed"
         title="Couldn't load tables"
         body={error || "The source's cached schema could not be loaded."}
+        icon={PiGraph}
       />
     );
   }
   if (nodes.length === 0) {
     return (
-      <FrameMessage
+      <CenteredFrameState
         testId="source-erd-empty"
         title="No tables found"
         body="This source has no tables to diagram."
+        icon={PiGraph}
       />
     );
   }

--- a/viewer/src/components/views/workspace/telemetry.js
+++ b/viewer/src/components/views/workspace/telemetry.js
@@ -109,3 +109,35 @@ export function emitFirstPublishTelemetry() {
     msSinceBuildModeEntered: buildModeEnteredAt ? Date.now() - buildModeEnteredAt : null,
   });
 }
+
+/**
+ * `time_to_first_chart` (VIS-1072, Explore 2.0 Phase 5's flywheel metric) —
+ * mirrors `markBuildModeEntered`/`emitFirstPublishTelemetry`'s "mark an
+ * entry moment, fire once on the first qualifying event after it" shape,
+ * generalized to a Map since (unlike Build mode, a single ongoing session)
+ * many explorations can be "in flight" at once across open tabs.
+ *
+ * `markExplorationCreated(id)` — call right after `createExploration`
+ * succeeds. `emitTimeToFirstChart(id)` — call the first time a draft chart
+ * preview actually renders data for that exploration; a no-op for any
+ * SUBSEQUENT call for the same id (re-editing after the first successful
+ * render doesn't re-fire), and a no-op if this session never saw the
+ * creation (e.g. the exploration was resumed from a page that loaded after
+ * creation, or across a hard reload) — there's nothing honest to measure.
+ */
+const explorationCreatedAt = new Map();
+const firstChartEmittedFor = new Set();
+
+export function markExplorationCreated(id) {
+  if (!id) return;
+  explorationCreatedAt.set(id, Date.now());
+  firstChartEmittedFor.delete(id);
+}
+
+export function emitTimeToFirstChart(id) {
+  if (!id || firstChartEmittedFor.has(id)) return;
+  const createdAt = explorationCreatedAt.get(id);
+  if (createdAt == null) return;
+  firstChartEmittedFor.add(id);
+  emitWorkspaceEvent('time_to_first_chart', { ms: Date.now() - createdAt });
+}

--- a/viewer/src/components/views/workspace/telemetry.test.js
+++ b/viewer/src/components/views/workspace/telemetry.test.js
@@ -13,6 +13,8 @@ import {
   setWorkspaceTelemetryListener,
   markBuildModeEntered,
   emitFirstPublishTelemetry,
+  markExplorationCreated,
+  emitTimeToFirstChart,
 } from './telemetry';
 import { postWorkspaceEvent } from '../../../api/workspaceTelemetry';
 
@@ -153,5 +155,60 @@ describe('time_to_first_publish_in_build_mode (VIS-806 / H-1)', () => {
       e => e.eventName === 'time_to_first_publish_in_build_mode'
     );
     expect(publishEvents).toHaveLength(2);
+  });
+});
+
+describe('time_to_first_chart (VIS-1072)', () => {
+  let events;
+  let unsubscribe;
+
+  beforeEach(() => {
+    events = [];
+    unsubscribe = setWorkspaceTelemetryListener(evt => events.push(evt));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  const chartEvents = () => events.filter(e => e.eventName === 'time_to_first_chart');
+
+  test('emits once per exploration, with elapsed ms', () => {
+    markExplorationCreated('exp_1');
+    emitTimeToFirstChart('exp_1');
+    emitTimeToFirstChart('exp_1'); // a second render — no second event
+
+    expect(chartEvents()).toHaveLength(1);
+    expect(chartEvents()[0].payload.ms).toEqual(expect.any(Number));
+    expect(chartEvents()[0].payload.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test('tracks multiple explorations independently', () => {
+    markExplorationCreated('exp_1');
+    markExplorationCreated('exp_2');
+    emitTimeToFirstChart('exp_2');
+    emitTimeToFirstChart('exp_1');
+
+    expect(chartEvents()).toHaveLength(2);
+  });
+
+  test('never fires for an id this session never saw created (e.g. resumed after a reload)', () => {
+    emitTimeToFirstChart('exp_never_created');
+    expect(chartEvents()).toHaveLength(0);
+  });
+
+  test('re-creating the SAME id re-arms the metric', () => {
+    markExplorationCreated('exp_1');
+    emitTimeToFirstChart('exp_1');
+    markExplorationCreated('exp_1');
+    emitTimeToFirstChart('exp_1');
+
+    expect(chartEvents()).toHaveLength(2);
+  });
+
+  test('no-ops (never throws) for a missing id', () => {
+    expect(() => markExplorationCreated(null)).not.toThrow();
+    expect(() => emitTimeToFirstChart(null)).not.toThrow();
+    expect(chartEvents()).toHaveLength(0);
   });
 });

--- a/viewer/src/hooks/useDraftInsightPreview.js
+++ b/viewer/src/hooks/useDraftInsightPreview.js
@@ -49,6 +49,8 @@ const extractInputDependencies = (query, staticProps) => {
   return [...names];
 };
 
+const EMPTY_INSIGHT_STATUS = { isLoading: false, error: null, blockedReason: null, blockedModel: null };
+
 /**
  * useDraftInsightPreview — Explore 2.0 Phase 4 (S2's resolved design). Live,
  * client-side preview for the exploration surface's UNSAVED chart/insight
@@ -61,8 +63,31 @@ const extractInputDependencies = (query, staticProps) => {
  * docstring) rather than taking props, so any Build-rail edit is picked up
  * automatically.
  *
+ * PER-INSIGHT STATE (VIS-1092, Phase 5 preview-lane fix): loading/error/
+ * blocked state is tracked PER CHART INSIGHT (`perInsight`, keyed by insight
+ * NAME), not as one flag shared across the whole debounce pass. A mixed-lane
+ * chart (one insight already promoted with real data, one still a draft)
+ * used to let the STILL-DRAFT insight's error/loading state blank the
+ * ENTIRE chart — including the already-rendering promoted insight — because
+ * the whole loop shared one `isLoading`/`error` pair that
+ * `ExplorerChartPreview.jsx` forwarded straight to `<ChartPreview>`'s
+ * whole-chart-gating props. The aggregate `isLoading`/`error`/`blockedReason`
+ * /`blockedModel` fields below are still returned for simple (single- or
+ * uniform-insight) callers, but a caller that needs mixed-lane correctness
+ * should read `perInsight[name]` instead — see `ExplorerChartPreview.jsx`.
+ *
+ * REQUEST-ORDERING GUARD (VIS-1094): each debounce fire is stamped with a
+ * monotonic generation number (`compileGenerationRef`). A rapid second edit
+ * arms a NEW debounce cycle whose fired pass increments the generation
+ * BEFORE the first pass's still-in-flight network/DuckDB chain can resolve;
+ * every write this hook makes (`updateInsightJob`/`removeInsightJob`/
+ * `setPerInsight`) is guarded by "is my generation still the current one" —
+ * a slower, stale pass's response is silently dropped rather than
+ * clobbering the faster, newer pass's already-applied result.
+ *
  * @returns {{
  *   previewInsightKeys: string[],
+ *   perInsight: Record<string, {isLoading: boolean, error: string|null, blockedReason: string|null, blockedModel: string|null}>,
  *   isLoading: boolean,
  *   error: string|null,
  *   blockedReason: 'model_not_run'|null,
@@ -78,13 +103,22 @@ const useDraftInsightPreview = () => {
   const updateInsightJob = useStore(s => s.updateInsightJob);
   const removeInsightJob = useStore(s => s.removeInsightJob);
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [blocked, setBlocked] = useState({ reason: null, model: null });
+  // { [insightName]: { isLoading, error, blockedReason, blockedModel } }
+  const [perInsight, setPerInsight] = useState({});
+
+  const setInsightStatus = (name, patch) =>
+    setPerInsight(prev => ({
+      ...prev,
+      [name]: { ...EMPTY_INSIGHT_STATUS, ...prev[name], ...patch },
+    }));
 
   const debounceRef = useRef(null);
   const registeredTablesRef = useRef(new Map()); // model_hash -> row-count fingerprint
   const seenDraftKeysRef = useRef(new Set());
+  // VIS-1094 — bumped once per debounce FIRE (not per render); every write
+  // below checks its own captured generation against the current one before
+  // touching the store, so a stale (slower, out-of-order) pass never wins.
+  const compileGenerationRef = useRef(0);
 
   const previewInsightKeys = useMemo(
     () => chartInsightNames.map(draftInsightKey),
@@ -119,23 +153,41 @@ const useDraftInsightPreview = () => {
         seenDraftKeysRef.current.delete(key);
       }
     });
+    setPerInsight(prev => {
+      const currentNames = new Set(chartInsightNames);
+      const next = {};
+      let changed = false;
+      Object.keys(prev).forEach(name => {
+        if (currentNames.has(name)) next[name] = prev[name];
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
 
     if (!db || chartInsightNames.length === 0) return undefined;
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(async () => {
-      setIsLoading(true);
-      setError(null);
-      setBlocked({ reason: null, model: null });
-      let sawBlocked = null;
-      let sawError = null;
+      // VIS-1094 — this pass's identity. Any write below whose captured
+      // generation no longer matches `compileGenerationRef.current` (a
+      // NEWER debounce fire has since started) is stale and skipped.
+      const myGeneration = ++compileGenerationRef.current;
+      const isStale = () => compileGenerationRef.current !== myGeneration;
 
       for (const name of chartInsightNames) {
         const state = insightStates[name];
-        if (!state) continue;
         const draftKey = draftInsightKey(name);
+        if (!state) {
+          setInsightStatus(name, EMPTY_INSIGHT_STATUS);
+          continue;
+        }
         const hasDataProps = Object.keys(state.props || {}).some(k => state.props[k] !== undefined && state.props[k] !== '');
-        if (!hasDataProps) continue;
+        if (!hasDataProps) {
+          setInsightStatus(name, EMPTY_INSIGHT_STATUS);
+          continue;
+        }
+
+        setInsightStatus(name, { isLoading: true, error: null, blockedReason: null, blockedModel: null });
 
         const expandedProps = expandDotNotationProps(state.props);
         const backendInteractions = (state.interactions || [])
@@ -170,6 +222,7 @@ const useDraftInsightPreview = () => {
             draftModels,
             modelSchemas,
           });
+          if (isStale()) continue;
 
           // Register each dependent model's ALREADY-FETCHED rows (the
           // SQL/results lane, `modelStates[name].queryResult`) as a DuckDB
@@ -193,26 +246,32 @@ const useDraftInsightPreview = () => {
             await db.dropFile(tempFile);
             registeredTablesRef.current.set(model.name_hash, fingerprint);
           }
+          if (isStale()) continue;
 
           const requiredInputs = extractInputDependencies(compiled.post_query, compiled.static_props);
           const missingInputs = requiredInputs.filter(inputName => !inputJobs[inputName]);
 
           if (missingInputs.length > 0) {
-            updateInsightJob(draftKey, {
-              name: draftKey,
-              data: null,
-              props_mapping: compiled.props_mapping,
-              static_props: compiled.static_props,
-              props_slices: compiled.props_slices,
-              split_key: compiled.split_key,
-              type: compiled.type,
-              pendingInputs: missingInputs,
-              inputDependencies: requiredInputs,
-            });
+            if (!isStale()) {
+              updateInsightJob(draftKey, {
+                name: draftKey,
+                data: null,
+                props_mapping: compiled.props_mapping,
+                static_props: compiled.static_props,
+                props_slices: compiled.props_slices,
+                split_key: compiled.split_key,
+                type: compiled.type,
+                pendingInputs: missingInputs,
+                inputDependencies: requiredInputs,
+              });
+              seenDraftKeysRef.current.add(draftKey);
+              setInsightStatus(name, EMPTY_INSIGHT_STATUS);
+            }
           } else {
             const preparedQuery = prepPostQuery({ query: compiled.post_query }, inputJobs);
             // eslint-disable-next-line no-await-in-loop
             const arrowResult = await runDuckDBQuery(db, preparedQuery, 2, 300);
+            if (isStale()) continue;
             const rows = processArrowResult(arrowResult);
             updateInsightJob(draftKey, {
               name: draftKey,
@@ -225,24 +284,32 @@ const useDraftInsightPreview = () => {
               pendingInputs: null,
               inputDependencies: requiredInputs,
             });
+            seenDraftKeysRef.current.add(draftKey);
+            setInsightStatus(name, EMPTY_INSIGHT_STATUS);
           }
-          seenDraftKeysRef.current.add(draftKey);
         } catch (err) {
+          if (isStale()) continue;
           if (err?.errorType === 'model_not_run') {
-            sawBlocked = { reason: 'model_not_run', model: err.modelName || null };
             removeInsightJob(draftKey);
             seenDraftKeysRef.current.delete(draftKey);
+            setInsightStatus(name, {
+              isLoading: false,
+              error: null,
+              blockedReason: 'model_not_run',
+              blockedModel: err.modelName || null,
+            });
           } else {
-            sawError = err?.message || String(err);
             removeInsightJob(draftKey);
             seenDraftKeysRef.current.delete(draftKey);
+            setInsightStatus(name, {
+              isLoading: false,
+              error: err?.message || String(err),
+              blockedReason: null,
+              blockedModel: null,
+            });
           }
         }
       }
-
-      setIsLoading(false);
-      setError(sawError);
-      setBlocked(sawBlocked || { reason: null, model: null });
     }, COMPILE_DEBOUNCE_MS);
 
     return () => {
@@ -267,12 +334,22 @@ const useDraftInsightPreview = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Aggregate fields — backward-compatible for a single-insight (or uniform-
+  // status) caller. A caller on a MIXED-lane chart (VIS-1092) should read
+  // `perInsight[name]` per key instead of these, which collapse every
+  // insight's status into one shared flag again by construction.
+  const statuses = chartInsightNames.map(name => perInsight[name] || EMPTY_INSIGHT_STATUS);
+  const isLoading = statuses.some(s => s.isLoading);
+  const errorStatus = statuses.find(s => s.error);
+  const blockedStatus = statuses.find(s => s.blockedReason);
+
   return {
     previewInsightKeys,
+    perInsight,
     isLoading,
-    error,
-    blockedReason: blocked.reason,
-    blockedModel: blocked.model,
+    error: errorStatus?.error || null,
+    blockedReason: blockedStatus?.blockedReason || null,
+    blockedModel: blockedStatus?.blockedModel || null,
   };
 };
 

--- a/viewer/src/hooks/useDraftInsightPreview.test.js
+++ b/viewer/src/hooks/useDraftInsightPreview.test.js
@@ -201,6 +201,141 @@ describe('useDraftInsightPreview', () => {
     expect(useStore.getState().insightJobs[draftInsightKey('my_insight')]).toBeUndefined();
   });
 
+  // VIS-1092 — per-insight state: a mixed-lane chart (one insight succeeds,
+  // one errors) must never let the erroring insight's status contaminate
+  // the succeeding insight's status.
+  test('mixed-lane chart: one insight succeeding does not get contaminated by a sibling insight erroring', async () => {
+    seedState({
+      explorerChartInsightNames: ['ins_ok', 'ins_bad'],
+      explorerInsightStates: {
+        ins_ok: {
+          type: 'scatter',
+          props: { x: '?{${ref(orders_q).region}}' },
+          interactions: [],
+        },
+        ins_bad: {
+          type: 'scatter',
+          props: { x: '?{${ref(orders_q).region}}' },
+          interactions: [],
+        },
+      },
+    });
+    compileDraftInsight
+      .mockResolvedValueOnce({
+        post_query: 'SELECT 1',
+        static_props: {},
+        props_mapping: {},
+        props_slices: {},
+        split_key: null,
+        type: 'scatter',
+        models: [],
+      })
+      .mockRejectedValueOnce(new Error('ins_bad blew up'));
+    runDuckDBQuery.mockResolvedValueOnce({ fake: 'arrow-result' });
+    processArrowResult.mockReturnValueOnce([{ a: 1 }]);
+
+    const { result } = renderHook(() => useDraftInsightPreview());
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // ins_ok rendered fine — its own entry landed and its per-insight status
+    // carries no error/loading, regardless of ins_bad's fate.
+    expect(useStore.getState().insightJobs[draftInsightKey('ins_ok')]?.data).toEqual([{ a: 1 }]);
+    expect(result.current.perInsight.ins_ok).toMatchObject({
+      isLoading: false,
+      error: null,
+      blockedReason: null,
+    });
+
+    // ins_bad's OWN status carries the error — it never leaks onto ins_ok.
+    expect(result.current.perInsight.ins_bad).toMatchObject({
+      isLoading: false,
+      error: 'ins_bad blew up',
+    });
+    expect(useStore.getState().insightJobs[draftInsightKey('ins_bad')]).toBeUndefined();
+  });
+
+  // VIS-1094 — request-ordering guard: a slower FIRST compile chain must
+  // never clobber a faster SECOND chain's already-applied write, even
+  // though the first one was triggered earlier.
+  test('a slower first compile chain does not clobber a faster second chain (out-of-order resolution guard)', async () => {
+    let resolveFirstCompile;
+    let resolveSecondCompile;
+    compileDraftInsight
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirstCompile = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveSecondCompile = resolve; }));
+
+    const compiledBase = {
+      post_query: 'SELECT 1',
+      static_props: {},
+      props_mapping: {},
+      props_slices: {},
+      split_key: null,
+      type: 'scatter',
+      models: [],
+    };
+    runDuckDBQuery.mockResolvedValue({ fake: 'arrow-result' });
+    processArrowResult.mockReturnValue([{ value: 'FRESH_SECOND' }]);
+
+    const { rerender } = renderHook(() => useDraftInsightPreview());
+
+    // Generation 1 fires; its compile call is left pending.
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(compileDraftInsight).toHaveBeenCalledTimes(1);
+
+    // A rapid second edit (still before generation 1 resolves) arms + fires
+    // generation 2.
+    act(() => {
+      useStore.setState(s => ({
+        explorerInsightStates: {
+          my_insight: {
+            ...s.explorerInsightStates.my_insight,
+            props: { ...s.explorerInsightStates.my_insight.props, x: '?{${ref(orders_q).other}}' },
+          },
+        },
+      }));
+    });
+    rerender();
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(compileDraftInsight).toHaveBeenCalledTimes(2);
+
+    // Generation 2 (the NEWER pass) resolves and completes its full chain
+    // FIRST — this is the realistic "second edit's response comes back
+    // faster" case.
+    await act(async () => {
+      resolveSecondCompile(compiledBase);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(useStore.getState().insightJobs[draftInsightKey('my_insight')]?.data).toEqual([
+      { value: 'FRESH_SECOND' },
+    ]);
+
+    // Generation 1 (the STALE, slower pass) FINALLY resolves — the guard
+    // must stop it BEFORE it ever writes: its own downstream pipeline
+    // short-circuits once it notices it's stale (processArrowResult/
+    // updateInsightJob are never called a second time), so generation 2's
+    // already-applied result is left untouched.
+    await act(async () => {
+      resolveFirstCompile(compiledBase);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(processArrowResult).toHaveBeenCalledTimes(1);
+    expect(useStore.getState().insightJobs[draftInsightKey('my_insight')]?.data).toEqual([
+      { value: 'FRESH_SECOND' },
+    ]);
+  });
+
   test('unmount cleans up every synthetic entry it wrote', async () => {
     compileDraftInsight.mockResolvedValue({
       post_query: 'SELECT 1',

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { generateUniqueName } from '../utils/uniqueName';
+import { legacyStateForSeed } from '../components/views/workspace/explorationLegacyBridge';
+import { formatRefExpression } from '../utils/refString';
 
 /**
  * Thrown by create/rename actions when the proposed name collides with any
@@ -1364,6 +1366,216 @@ const createExplorerSlice = (set, get) => ({
     for (const modelName of loadedModels) {
       autoLoadModelData(modelName, get, set);
     }
+  },
+
+  /**
+   * "Explore this" (VIS-1067) — build a legacy working-state snapshot seeded
+   * from a real project object, WITHOUT touching the live explorer working
+   * state (a PURE read of `get()`, unlike `addExistingInsightToChart`, which
+   * mutates the active exploration). Passed to `createExploration`'s
+   * `legacyStateOverride` param so a brand-new exploration opens pre-wired.
+   * Returns `null` when the object can't be resolved — the caller falls back
+   * to a bare `seeded_from`-only exploration (still records provenance).
+   *
+   *   - `source`   → one empty query tab bound to the source (existing
+   *                  `legacyStateForSeed` behavior, untouched).
+   *   - `table`    → one query tab with the given SQL/source (Source ERD's
+   *                  "Explore this" — `opts: {sql, source}`).
+   *   - `model`    → one query tab `SELECT * FROM ${ref(model)}`.
+   *   - `metric`/`dimension` → one query tab against the field's parent
+   *                  model (best-effort; `null` if unresolvable).
+   *   - `insight`  → copies the insight config into a draft insight of the
+   *                  SAME NAME (+ auto-loads its referenced models), so
+   *                  promoting it later updates the ORIGINAL insight via the
+   *                  ordinary update-by-name semantics `promoteExploration`
+   *                  already has (01-ux-spec.md §5).
+   *   - `chart`    → copies the chart (same name) + every one of its
+   *                  insights (same names) + their referenced models.
+   */
+  buildExplorationSeedState: (obj, opts = {}) => {
+    const state = get();
+    if (!obj || !obj.type || !obj.name) return null;
+
+    const blankSnapshot = () => ({
+      modelTabs: [],
+      activeModelName: null,
+      modelStates: {},
+      chartName: null,
+      chartLayout: {},
+      chartInsightNames: [],
+      activeInsightName: null,
+      insightStates: {},
+      leftNavCollapsed: false,
+      centerMode: 'split',
+      isEditorCollapsed: false,
+    });
+
+    const oneQuerySnapshot = ({ sql, sourceName, sourceEdited = false }) => {
+      const modelName = 'query_1';
+      return {
+        ...blankSnapshot(),
+        modelTabs: [modelName],
+        activeModelName: modelName,
+        modelStates: {
+          [modelName]: {
+            ...createEmptyModelState(true),
+            sql,
+            sourceName: sourceName || null,
+            sourceEdited,
+          },
+        },
+      };
+    };
+
+    const resolveModelsForInsights = insightObjs => {
+      const allInputNames = new Set((state.inputs || []).map(i => i.name));
+      const modelNames = new Set();
+      insightObjs.forEach(insight => {
+        const searchStr = JSON.stringify(insight.config || {});
+        for (const match of searchStr.matchAll(/ref\(([^.)]+)\)/g)) {
+          if (!allInputNames.has(match[1])) modelNames.add(match[1]);
+        }
+      });
+      const modelTabs = [];
+      const modelStates = {};
+      modelNames.forEach(modelName => {
+        const modelObj = (state.models || []).find(m => m.name === modelName);
+        if (!modelObj) return;
+        modelTabs.push(modelName);
+        modelStates[modelName] = buildModelStateFromObject(modelObj, state);
+      });
+      return { modelTabs, modelStates };
+    };
+
+    if (obj.type === 'source') {
+      return legacyStateForSeed({ type: 'source', name: obj.name });
+    }
+
+    if (obj.type === 'table') {
+      return oneQuerySnapshot({
+        sql: opts.sql || `SELECT * FROM ${obj.name}`,
+        sourceName: opts.source || null,
+        sourceEdited: !!opts.source,
+      });
+    }
+
+    if (obj.type === 'model') {
+      const modelObj = (state.models || []).find(m => m.name === obj.name);
+      if (!modelObj) return null;
+      const base = buildModelStateFromObject(modelObj, state);
+      return oneQuerySnapshot({
+        sql: `SELECT * FROM ${formatRefExpression(obj.name)}`,
+        sourceName: base.sourceName,
+      });
+    }
+
+    if (obj.type === 'metric' || obj.type === 'dimension') {
+      const collection = obj.type === 'metric' ? state.metrics : state.dimensions;
+      const fieldObj = (collection || []).find(f => f.name === obj.name);
+      const rawParent = fieldObj?.parentModel || fieldObj?.config?.model;
+      const parentModelName =
+        typeof rawParent === 'string' ? rawParent.replace(/^ref\((.+)\)$/, '$1') : null;
+      const modelObj = parentModelName
+        ? (state.models || []).find(m => m.name === parentModelName)
+        : null;
+      if (!modelObj) return null;
+      const base = buildModelStateFromObject(modelObj, state);
+      return oneQuerySnapshot({
+        sql: `SELECT * FROM ${formatRefExpression(parentModelName)}`,
+        sourceName: base.sourceName,
+      });
+    }
+
+    if (obj.type === 'insight') {
+      const insight = (state.insights || []).find(i => i.name === obj.name);
+      if (!insight) return null;
+      const { modelTabs, modelStates } = resolveModelsForInsights([insight]);
+      return {
+        ...blankSnapshot(),
+        modelTabs,
+        modelStates,
+        activeModelName: modelTabs[0] || null,
+        chartName: generateUniqueName('chart', []),
+        chartInsightNames: [obj.name],
+        activeInsightName: obj.name,
+        insightStates: { [obj.name]: transformInsightToUiState(insight) },
+      };
+    }
+
+    if (obj.type === 'chart') {
+      const chart = (state.charts || []).find(c => c.name === obj.name);
+      if (!chart) return null;
+      const insightRefs = chart.config?.insights || [];
+      const insightNames = insightRefs
+        .map(ref => {
+          const match = typeof ref === 'string' ? ref.match(/ref\(([^)]+)\)/) : null;
+          return match ? match[1].trim() : ref;
+        })
+        .filter(Boolean);
+      const insightObjs = insightNames
+        .map(name => (state.insights || []).find(i => i.name === name))
+        .filter(Boolean);
+      const { modelTabs, modelStates } = resolveModelsForInsights(insightObjs);
+      const insightStates = {};
+      insightObjs.forEach(insight => {
+        insightStates[insight.name] = transformInsightToUiState(insight);
+      });
+      return {
+        ...blankSnapshot(),
+        modelTabs,
+        modelStates,
+        activeModelName: modelTabs[0] || null,
+        chartName: obj.name,
+        chartLayout: chart.config?.layout ? JSON.parse(JSON.stringify(chart.config.layout)) : {},
+        chartInsightNames: insightNames,
+        activeInsightName: insightNames[0] || null,
+        insightStates,
+      };
+    }
+
+    return null;
+  },
+
+  /**
+   * "Add to exploration" (VIS-1067) — context-menu equivalent of dragging a
+   * Library row onto the active exploration (`routeExplorationDragEnd` in
+   * `WorkspaceDndContext.jsx`), for the same `EXPLORATION_DRAG_TYPES` set,
+   * when there's no specific drop target to aim at. Operates on the ACTIVE
+   * exploration's live legacy working state — callers must gate visibility
+   * on `workspaceActiveObject?.type === 'exploration'` first (the pane's
+   * mount effect keeps this state in sync with that exploration's draft).
+   */
+  addObjectToActiveExploration: obj => {
+    if (!obj || !obj.type || !obj.name) {
+      return { success: false, error: 'Invalid object' };
+    }
+
+    if (obj.type === 'insight') {
+      get().addExistingInsightToChart(obj.name);
+      return { success: true };
+    }
+
+    if (obj.type === 'source') {
+      if (!get().explorerActiveModelName) {
+        get().createModelTab();
+      }
+      get().setActiveModelSource(obj.name);
+      return { success: true };
+    }
+
+    if (obj.type === 'metric' || obj.type === 'dimension') {
+      const refExpr = obj.parentModel
+        ? formatRefExpression(obj.parentModel, obj.name)
+        : formatRefExpression(obj.name);
+      get().createInsight();
+      const newInsightName = get().explorerActiveInsightName;
+      if (newInsightName) {
+        get().setInsightProp(newInsightName, 'y', `?{${refExpr}}`);
+      }
+      return { success: true };
+    }
+
+    return { success: false, error: `Cannot add type "${obj.type}" to an exploration` };
   },
 
   handleTableSelect: ({ sourceName, table }) => {

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -1464,7 +1464,19 @@ const createExplorerSlice = (set, get) => ({
       if (!modelObj) return null;
       const base = buildModelStateFromObject(modelObj, state);
       return oneQuerySnapshot({
-        sql: `SELECT * FROM ${formatRefExpression(obj.name)}`,
+        // Reuse the model's OWN literal SQL — never a `${ref(...)}`
+        // context-string expression. The scratch SQL editor's execution
+        // pipeline (`SQLEditor.jsx` -> `useModelQueryJob` ->
+        // `/api/model-query-jobs/` -> `execute_model_query_job`) sends this
+        // text VERBATIM to the source with zero ref-resolution — it's a raw
+        // pass-through, not the full-project compile pipeline that resolves
+        // `${ref(...)}` via SQLGlot — so a `${ref(...)}` string here reaches
+        // DuckDB unresolved and fails to parse (root-caused via live
+        // reproduction against the sandbox, integration-gate fix cycle:
+        // `SELECT * FROM ${ref(model)}` sent verbatim errored with "syntax
+        // error at or near \"$\""). `base.sql` is the same already-runnable
+        // text `buildModelStateFromObject` loads for every other model tab.
+        sql: base.sql || '',
         sourceName: base.sourceName,
       });
     }
@@ -1481,7 +1493,9 @@ const createExplorerSlice = (set, get) => ({
       if (!modelObj) return null;
       const base = buildModelStateFromObject(modelObj, state);
       return oneQuerySnapshot({
-        sql: `SELECT * FROM ${formatRefExpression(parentModelName)}`,
+        // Same fix as the "model" branch above — reuse the parent model's
+        // own literal SQL, never an unresolved `${ref(...)}` expression.
+        sql: base.sql || '',
         sourceName: base.sourceName,
       });
     }

--- a/viewer/src/stores/explorerStore.test.js
+++ b/viewer/src/stores/explorerStore.test.js
@@ -1629,22 +1629,27 @@ describe('explorerStore', () => {
       });
     });
 
-    it('model: seeds a query tab referencing the model via ${ref(model)}', () => {
+    it('model: seeds a query tab with the model\'s OWN literal SQL (never an unresolved ${ref(...)} expression)', () => {
+      // The scratch SQL editor's execution pipeline (`useModelQueryJob` ->
+      // `/api/model-query-jobs/`) sends this text VERBATIM to the source
+      // with zero ref-resolution, so a `${ref(...)}` context string reaches
+      // DuckDB unresolved and fails to parse — root-caused via live
+      // reproduction against the sandbox (integration-gate fix cycle).
       useStore.setState({
         models: [{ name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } }],
       });
       const snapshot = useStore.getState().buildExplorationSeedState({ type: 'model', name: 'orders' });
-      expect(snapshot.modelStates.query_1.sql).toBe('SELECT * FROM ${ref(orders)}');
+      expect(snapshot.modelStates.query_1.sql).toBe('SELECT 1');
       expect(snapshot.modelStates.query_1.sourceName).toBe('pg');
     });
 
-    it('metric/dimension: seeds a query against the field\'s parent model', () => {
+    it('metric/dimension: seeds a query with the parent model\'s OWN literal SQL', () => {
       useStore.setState({
         models: [{ name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } }],
         metrics: [{ name: 'revenue', parentModel: 'orders', config: { model: 'ref(orders)' } }],
       });
       const snapshot = useStore.getState().buildExplorationSeedState({ type: 'metric', name: 'revenue' });
-      expect(snapshot.modelStates.query_1.sql).toBe('SELECT * FROM ${ref(orders)}');
+      expect(snapshot.modelStates.query_1.sql).toBe('SELECT 1');
     });
 
     it('metric with no resolvable parent model returns null', () => {

--- a/viewer/src/stores/explorerStore.test.js
+++ b/viewer/src/stores/explorerStore.test.js
@@ -1588,6 +1588,224 @@ describe('explorerStore', () => {
     });
   });
 
+  // VIS-1067 — "Explore this" seed-bridge extension: a pure state builder
+  // (no set() calls) so a caller can hand its result to
+  // `createExploration`'s `legacyStateOverride` param without touching the
+  // live explorer working state.
+  describe('buildExplorationSeedState', () => {
+    beforeEach(() => {
+      useStore.setState({
+        models: [],
+        insights: [],
+        charts: [],
+        metrics: [],
+        dimensions: [],
+        inputs: [],
+        explorerSources: [{ source_name: 'pg' }],
+      });
+    });
+
+    it('returns null for an unresolvable object', () => {
+      expect(useStore.getState().buildExplorationSeedState({ type: 'model', name: 'missing' })).toBeNull();
+      expect(useStore.getState().buildExplorationSeedState(null)).toBeNull();
+    });
+
+    it('source: mirrors legacyStateForSeed (one empty query tab bound to the source)', () => {
+      const snapshot = useStore.getState().buildExplorationSeedState({ type: 'source', name: 'pg' });
+      expect(snapshot.modelTabs).toEqual(['query_1']);
+      expect(snapshot.modelStates.query_1).toMatchObject({ sql: '', sourceName: 'pg' });
+    });
+
+    it('table: seeds one query tab with the given SQL + source hints', () => {
+      const snapshot = useStore.getState().buildExplorationSeedState(
+        { type: 'table', name: 'public.orders' },
+        { sql: 'SELECT * FROM public.orders', source: 'pg' }
+      );
+      expect(snapshot.modelTabs).toEqual(['query_1']);
+      expect(snapshot.modelStates.query_1).toMatchObject({
+        sql: 'SELECT * FROM public.orders',
+        sourceName: 'pg',
+        sourceEdited: true,
+      });
+    });
+
+    it('model: seeds a query tab referencing the model via ${ref(model)}', () => {
+      useStore.setState({
+        models: [{ name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } }],
+      });
+      const snapshot = useStore.getState().buildExplorationSeedState({ type: 'model', name: 'orders' });
+      expect(snapshot.modelStates.query_1.sql).toBe('SELECT * FROM ${ref(orders)}');
+      expect(snapshot.modelStates.query_1.sourceName).toBe('pg');
+    });
+
+    it('metric/dimension: seeds a query against the field\'s parent model', () => {
+      useStore.setState({
+        models: [{ name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } }],
+        metrics: [{ name: 'revenue', parentModel: 'orders', config: { model: 'ref(orders)' } }],
+      });
+      const snapshot = useStore.getState().buildExplorationSeedState({ type: 'metric', name: 'revenue' });
+      expect(snapshot.modelStates.query_1.sql).toBe('SELECT * FROM ${ref(orders)}');
+    });
+
+    it('metric with no resolvable parent model returns null', () => {
+      useStore.setState({ metrics: [{ name: 'orphan', config: {} }] });
+      expect(
+        useStore.getState().buildExplorationSeedState({ type: 'metric', name: 'orphan' })
+      ).toBeNull();
+    });
+
+    it('insight: copies the insight config into a draft insight of the SAME name + auto-loads its model', () => {
+      useStore.setState({
+        insights: [
+          {
+            name: 'churn_by_cohort',
+            config: {
+              type: 'bar',
+              props: { x: '?{${ref(orders).month}}', y: '?{${ref(orders).total}}' },
+              interactions: [],
+            },
+          },
+        ],
+        models: [{ name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } }],
+      });
+      const snapshot = useStore
+        .getState()
+        .buildExplorationSeedState({ type: 'insight', name: 'churn_by_cohort' });
+
+      // SAME name preserved — promoting it later updates the ORIGINAL via
+      // ordinary update-by-name semantics.
+      expect(snapshot.chartInsightNames).toEqual(['churn_by_cohort']);
+      expect(snapshot.activeInsightName).toBe('churn_by_cohort');
+      expect(snapshot.insightStates.churn_by_cohort.type).toBe('bar');
+      expect(snapshot.insightStates.churn_by_cohort.isNew).toBe(false);
+      expect(snapshot.modelTabs).toEqual(['orders']);
+      // A fresh chart name is fine — there's no original chart to preserve.
+      expect(snapshot.chartName).toBeTruthy();
+    });
+
+    it('chart: copies the chart (same name) + every insight (same names) + their models', () => {
+      useStore.setState({
+        charts: [
+          {
+            name: 'revenue_dashboard_chart',
+            config: { layout: { 'title.text': 'Revenue' }, insights: ['${ref(ins_a)}', '${ref(ins_b)}'] },
+          },
+        ],
+        insights: [
+          {
+            name: 'ins_a',
+            config: { type: 'bar', props: { x: '?{${ref(orders).month}}' }, interactions: [] },
+          },
+          {
+            name: 'ins_b',
+            config: { type: 'line', props: { x: '?{${ref(revenue).date}}' }, interactions: [] },
+          },
+        ],
+        models: [
+          { name: 'orders', config: { sql: 'SELECT 1', source: 'ref(pg)' } },
+          { name: 'revenue', config: { sql: 'SELECT 1', source: 'ref(pg)' } },
+        ],
+      });
+      const snapshot = useStore
+        .getState()
+        .buildExplorationSeedState({ type: 'chart', name: 'revenue_dashboard_chart' });
+
+      expect(snapshot.chartName).toBe('revenue_dashboard_chart');
+      expect(snapshot.chartLayout).toEqual({ 'title.text': 'Revenue' });
+      expect(snapshot.chartInsightNames).toEqual(['ins_a', 'ins_b']);
+      expect(Object.keys(snapshot.insightStates)).toEqual(['ins_a', 'ins_b']);
+      expect(snapshot.modelTabs.sort()).toEqual(['orders', 'revenue']);
+    });
+
+    it('chart: returns null for an unresolvable chart name', () => {
+      expect(
+        useStore.getState().buildExplorationSeedState({ type: 'chart', name: 'missing' })
+      ).toBeNull();
+    });
+  });
+
+  // VIS-1067 — "Add to exploration": the context-menu equivalent of dragging
+  // a Library row onto the active exploration, for the same
+  // EXPLORATION_DRAG_TYPES set.
+  describe('addObjectToActiveExploration', () => {
+    beforeEach(() => {
+      useStore.setState({
+        explorerChartInsightNames: [],
+        explorerInsightStates: {},
+        explorerActiveInsightName: null,
+        explorerModelTabs: [],
+        explorerModelStates: {},
+        explorerActiveModelName: null,
+        insights: [],
+        models: [],
+        inputs: [],
+        metrics: [],
+        dimensions: [],
+        explorerSources: [{ source_name: 'pg' }],
+      });
+    });
+
+    it('insight: adds the existing insight to the active chart', () => {
+      useStore.setState({
+        insights: [{ name: 'ins', config: { type: 'bar', props: {}, interactions: [] } }],
+      });
+      const result = useStore.getState().addObjectToActiveExploration({ type: 'insight', name: 'ins' });
+      expect(result).toEqual({ success: true });
+      expect(useStore.getState().explorerChartInsightNames).toEqual(['ins']);
+    });
+
+    it('source: creates a query tab if none is active, then binds the source', () => {
+      const result = useStore.getState().addObjectToActiveExploration({ type: 'source', name: 'pg' });
+      expect(result).toEqual({ success: true });
+      const state = useStore.getState();
+      expect(state.explorerActiveModelName).toBeTruthy();
+      const activeModel = state.explorerModelStates[state.explorerActiveModelName];
+      expect(activeModel.sourceName).toBe('pg');
+    });
+
+    it('source: reuses the already-active query tab', () => {
+      useStore.getState().createModelTab('existing_q');
+      const result = useStore.getState().addObjectToActiveExploration({ type: 'source', name: 'pg' });
+      expect(result).toEqual({ success: true });
+      const state = useStore.getState();
+      expect(state.explorerActiveModelName).toBe('existing_q');
+      expect(state.explorerModelStates.existing_q.sourceName).toBe('pg');
+    });
+
+    it('metric/dimension: creates a new insight and binds the field into its y prop', () => {
+      const result = useStore
+        .getState()
+        .addObjectToActiveExploration({ type: 'metric', name: 'revenue', parentModel: 'orders' });
+      expect(result).toEqual({ success: true });
+      const state = useStore.getState();
+      const newInsightName = state.explorerActiveInsightName;
+      expect(newInsightName).toBeTruthy();
+      expect(state.explorerInsightStates[newInsightName].props.y).toBe(
+        '?{${ref(orders).revenue}}'
+      );
+    });
+
+    it('metric/dimension without a parentModel falls back to a bare ref', () => {
+      useStore.getState().addObjectToActiveExploration({ type: 'dimension', name: 'region' });
+      const state = useStore.getState();
+      const newInsightName = state.explorerActiveInsightName;
+      expect(state.explorerInsightStates[newInsightName].props.y).toBe('?{${ref(region)}}');
+    });
+
+    it('rejects a type with no meaningful "add to exploration" action', () => {
+      const result = useStore.getState().addObjectToActiveExploration({ type: 'dashboard', name: 'kpis' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Cannot add type/);
+    });
+
+    it('rejects an invalid object', () => {
+      expect(useStore.getState().addObjectToActiveExploration(null)).toEqual({
+        success: false,
+        error: 'Invalid object',
+      });
+    });
+  });
+
   describe('handleTableSelect', () => {
     it('sets SQL and source on the active model when SQL is empty', () => {
       useStore.getState().createModelTab('my_model');

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -301,12 +301,19 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      * §5) is a one-shot placement intent `{ dashboard, slot? }`: the
      * `/workspace/dashboard/:name/explorer` composed route mints a fresh
      * exploration carrying it so "Place in <dashboard>" can consume it later
-     * (Phase 4/5) via the existing `consumeReturnTo` endpoint. */
-    createExploration: async (seed = null, returnTo = null) => {
+     * (Phase 4/5) via the existing `consumeReturnTo` endpoint.
+     *
+     * `legacyStateOverride` (optional, Explore 2.0 Phase 5 — VIS-1067) lets a
+     * caller hand in a fully-built legacy working-state snapshot (see
+     * `explorerStore.js`'s `buildExplorationSeedState`) instead of relying on
+     * `legacyStateForSeed`'s `type === 'source'`-only bridge — the "Explore
+     * this" context-menu action's pre-wired query for models/tables and its
+     * name-preserving copy for insights/charts both go through this. */
+    createExploration: async (seed = null, returnTo = null, legacyStateOverride = null) => {
       try {
         const payload = seed ? { seeded_from: seed } : {};
         if (returnTo) payload.return_to = returnTo;
-        const seedLegacyState = seed ? legacyStateForSeed(seed) : null;
+        const seedLegacyState = legacyStateOverride || (seed ? legacyStateForSeed(seed) : null);
         if (seedLegacyState) payload.draft = mapDraftToApi(legacyStateToDraft(seedLegacyState));
         const created = await explorationsApi.createExploration(payload);
         const mapped = mapExplorationFromApi(created);

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -87,6 +87,7 @@ import {
 import { buildPromoteChecklist } from './promoteChecklist';
 import { SAVE_ACTION } from '../components/views/workspace/collectionKeys';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
+import { emitWorkspaceEvent, markExplorationCreated } from '../components/views/workspace/telemetry';
 
 const SYNC_DEBOUNCE_MS = 1000;
 
@@ -318,6 +319,13 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         const created = await explorationsApi.createExploration(payload);
         const mapped = mapExplorationFromApi(created);
         set(state => insertExploration(state, mapped));
+        // VIS-1072 — flywheel telemetry: the create moment + the
+        // time_to_first_chart clock start together.
+        markExplorationCreated(mapped.id);
+        emitWorkspaceEvent('exploration_created', {
+          seededFromType: seed?.type || null,
+          hasReturnTo: !!returnTo,
+        });
         return { success: true, id: mapped.id, exploration: mapped };
       } catch (error) {
         return { success: false, error: error.message };
@@ -365,6 +373,12 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         });
         const mapped = mapExplorationFromApi(created);
         set(state => insertExploration(state, mapped));
+        // VIS-1072 — "branch" gets its own time_to_first_chart clock too,
+        // same as a fresh create (the copy's own draft may still need its
+        // first successful preview render, even though the SOURCE
+        // exploration already had one).
+        markExplorationCreated(mapped.id);
+        emitWorkspaceEvent('exploration_branched', { sourceId: id });
         return { success: true, id: mapped.id, exploration: mapped };
       } catch (error) {
         return { success: false, error: error.message };
@@ -586,6 +600,10 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       const snapshot = _openDraftSnapshots.get(id);
       if (snapshot === undefined) return { success: true, reverted: false };
       _openDraftSnapshots.delete(id);
+      // VIS-1072 — fired once we know a real revert is happening (never for
+      // the no-op "discard invoked before the pane ever activated" case
+      // above, which returned early).
+      emitWorkspaceEvent('exploration_discarded', { id });
 
       set(state => patchExploration(state, id, { draft: snapshot, syncStatus: 'synced' }));
       get().restoreExplorerWorkingState?.(draftToLegacyState(snapshot));
@@ -743,6 +761,29 @@ const createWorkspaceExplorationsSlice = (set, get) => {
             });
           }
         }
+      }
+
+      // VIS-1072 — `object_counts` (per-type, successful promotions only) +
+      // `update_vs_new` (status is carried on the CHECKLIST row, not the
+      // result — re-key `toPromote` by "type:name" to look it up per
+      // successful result without a second buildPromoteChecklist pass).
+      const rowByKey = new Map(toPromote.map(row => [`${row.type}:${row.name}`, row]));
+      const objectCounts = {};
+      const updateVsNew = { updated: 0, new: 0 };
+      results
+        .filter(r => r.success)
+        .forEach(r => {
+          objectCounts[r.type] = (objectCounts[r.type] || 0) + 1;
+          const row = rowByKey.get(`${r.type}:${r.name}`);
+          if (row?.status === 'modified') updateVsNew.updated += 1;
+          else updateVsNew.new += 1;
+        });
+      if (results.length > 0) {
+        emitWorkspaceEvent('exploration_promoted', {
+          id,
+          objectCounts,
+          updateVsNew,
+        });
       }
 
       return {

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -608,6 +608,30 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       }
     },
 
+    /**
+     * consumeExplorationReturnTo(id) — VIS-1068 dashboard round-trip
+     * completion. Calls the consume-return-to endpoint (server nulls
+     * `return_to`, idempotently) and mirrors the result into the local
+     * record. Enqueued alongside every other write for this id (draft sync /
+     * rename / discard revert / record-promotion) — see the file docstring's
+     * "WRITE SERIALIZATION" note; consuming return_to is one more unlocked
+     * read-modify-write against the same on-disk document.
+     *
+     * Called BOTH when the user accepts "Place in <dashboard>" (after the
+     * chart has actually been placed) and when they decline it (01-ux-spec.md
+     * §5: "Declining also consumes — explicit choice, no accretion").
+     */
+    consumeExplorationReturnTo: async id => {
+      try {
+        const updated = await enqueueWrite(id, () => explorationsApi.consumeReturnTo(id));
+        const mapped = mapExplorationFromApi(updated);
+        set(state => patchExploration(state, id, { returnTo: mapped.returnTo }));
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    },
+
     /** Append-only promotion record (07-exploration-api-contract.md's
      * record-promotion sub-action) — call after a `saveX` action succeeds
      * for a promoted object.

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -1128,6 +1128,69 @@ describe('recordExplorationPromotion', () => {
   });
 });
 
+// VIS-1068 — dashboard round-trip completion: consuming the one-shot
+// return_to intent (both on accept, after placement, and on decline).
+describe('consumeExplorationReturnTo', () => {
+  test('nulls return_to via the endpoint and mirrors it locally', async () => {
+    seedRecord({ returnTo: { dashboard: 'sales' } });
+    explorationsApi.consumeReturnTo.mockResolvedValueOnce(wireExploration({ return_to: null }));
+    let result;
+    await act(async () => {
+      result = await useStore.getState().consumeExplorationReturnTo('exp_1');
+    });
+    expect(result).toEqual({ success: true });
+    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1');
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.returnTo).toBeNull();
+  });
+
+  test('returns success:false on failure and leaves the local record untouched', async () => {
+    seedRecord({ returnTo: { dashboard: 'sales' } });
+    explorationsApi.consumeReturnTo.mockRejectedValueOnce(new Error('offline'));
+    let result;
+    await act(async () => {
+      result = await useStore.getState().consumeExplorationReturnTo('exp_1');
+    });
+    expect(result).toEqual({ success: false, error: 'offline' });
+    expect(useStore.getState().workspaceExplorations.byId.exp_1.returnTo).toEqual({
+      dashboard: 'sales',
+    });
+  });
+
+  test('is enqueued alongside other writers for the same id (waits for an in-flight draft-sync)', async () => {
+    seedRecord({ returnTo: { dashboard: 'sales' } });
+    let resolveDraftSync;
+    explorationsApi.updateExploration.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveDraftSync = resolve;
+        })
+    );
+    explorationsApi.consumeReturnTo.mockResolvedValueOnce(wireExploration({ return_to: null }));
+
+    act(() => {
+      useStore.getState().updateExplorationDraft('exp_1', { queries: [], insights: [], chart: null });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(1);
+
+    let consumePromise;
+    act(() => {
+      consumePromise = useStore.getState().consumeExplorationReturnTo('exp_1');
+    });
+    // The draft-sync write is still in flight — consume-return-to must not
+    // have fired its POST yet.
+    expect(explorationsApi.consumeReturnTo).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDraftSync(wireExploration());
+      await consumePromise;
+    });
+    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1');
+  });
+});
+
 // P4-D1 — a keyboard-driven tab switch mid-promote used to be able to race
 // recordExplorationPromotion's append against a concurrent draft-sync/rename/
 // discard write for the SAME id (both hit the same unlocked backend JSON

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -18,6 +18,7 @@ import {
   _resetExplorationWriteQueuesForTests,
 } from './workspaceExplorationsStore';
 import { buildPromoteChecklist } from './promoteChecklist';
+import { setWorkspaceTelemetryListener } from '../components/views/workspace/telemetry';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
 
 jest.mock('../api/explorations');
@@ -1546,5 +1547,132 @@ describe('promoteExploration', () => {
       result = await useStore.getState().promoteExploration('exp_1', []);
     });
     expect(result).toEqual({ success: false, results: [], reclassificationOffers: [] });
+  });
+
+  // VIS-1072 — flywheel telemetry: exploration_promoted's object_counts
+  // (per-type, successes only) + update_vs_new (from the checklist row's
+  // OWN status, not re-derived).
+  describe('exploration_promoted telemetry (VIS-1072)', () => {
+    let events;
+    let unsubscribe;
+
+    beforeEach(() => {
+      events = [];
+      unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    });
+    afterEach(() => unsubscribe());
+
+    test('reports per-type object_counts and update_vs_new for successful rows only', async () => {
+      buildPromoteChecklist.mockResolvedValue([
+        checklistRow({ status: 'new' }),
+        checklistRow({
+          type: 'insight',
+          tier: 'insight',
+          name: 'churn',
+          status: 'modified',
+          config: { props: { type: 'scatter' } },
+        }),
+        checklistRow({ type: 'insight', tier: 'insight', name: 'flaky', status: 'new', config: {} }),
+      ]);
+      seedRecord();
+      act(() => {
+        useStore.setState({
+          saveModel: jest.fn().mockResolvedValue({ success: true }),
+          saveInsight: jest
+            .fn()
+            .mockImplementation(async name =>
+              name === 'flaky' ? { success: false, error: 'boom' } : { success: true }
+            ),
+        });
+      });
+      explorationsApi.recordPromotion.mockResolvedValue(wireExploration());
+
+      await act(async () => {
+        await useStore.getState().promoteExploration('exp_1', [
+          { type: 'model', name: 'orders_q' },
+          { type: 'insight', name: 'churn' },
+          { type: 'insight', name: 'flaky' },
+        ]);
+      });
+
+      const promoted = events.find(e => e.eventName === 'exploration_promoted');
+      expect(promoted.payload.id).toBe('exp_1');
+      // 'flaky' failed — excluded from every count.
+      expect(promoted.payload.objectCounts).toEqual({ model: 1, insight: 1 });
+      expect(promoted.payload.updateVsNew).toEqual({ updated: 1, new: 1 });
+    });
+
+    test('does not fire when nothing was actually attempted (empty selection)', async () => {
+      buildPromoteChecklist.mockResolvedValue([checklistRow()]);
+      seedRecord();
+      await act(async () => {
+        await useStore.getState().promoteExploration('exp_1', []);
+      });
+      expect(events.find(e => e.eventName === 'exploration_promoted')).toBeUndefined();
+    });
+  });
+});
+
+// VIS-1072 — flywheel telemetry for createExploration/duplicateExploration/
+// discardExploration (promoteExploration's own event is covered above,
+// alongside the checklist fixtures it needs).
+describe('flywheel telemetry (VIS-1072)', () => {
+  let events;
+  let unsubscribe;
+
+  beforeEach(() => {
+    events = [];
+    unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+  });
+  afterEach(() => unsubscribe());
+
+  test('createExploration fires exploration_created with the seed type', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ seeded_from: { type: 'source', name: 'pg' } })
+    );
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'source', name: 'pg' });
+    });
+    const created = events.find(e => e.eventName === 'exploration_created');
+    expect(created.payload).toEqual({ seededFromType: 'source', hasReturnTo: false });
+  });
+
+  test('createExploration with no seed reports seededFromType: null', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(wireExploration());
+    await act(async () => {
+      await useStore.getState().createExploration();
+    });
+    const created = events.find(e => e.eventName === 'exploration_created');
+    expect(created.payload.seededFromType).toBeNull();
+  });
+
+  test('duplicateExploration fires exploration_branched with the source id', async () => {
+    seedRecord();
+    explorationsApi.createExploration.mockResolvedValueOnce(wireExploration({ id: 'exp_2' }));
+    await act(async () => {
+      await useStore.getState().duplicateExploration('exp_1');
+    });
+    const branched = events.find(e => e.eventName === 'exploration_branched');
+    expect(branched.payload).toEqual({ sourceId: 'exp_1' });
+  });
+
+  test('discardExploration fires exploration_discarded only on a real revert', async () => {
+    seedRecord();
+    act(() => {
+      useStore.getState().snapshotExplorationForDiscard('exp_1');
+    });
+    explorationsApi.updateExploration.mockResolvedValueOnce(wireExploration());
+    await act(async () => {
+      await useStore.getState().discardExploration('exp_1');
+    });
+    expect(events.find(e => e.eventName === 'exploration_discarded')?.payload).toEqual({ id: 'exp_1' });
+  });
+
+  test('discardExploration does NOT fire when there was never a snapshot to revert (no-op path)', async () => {
+    seedRecord();
+    await act(async () => {
+      await useStore.getState().discardExploration('exp_1');
+    });
+    expect(events.find(e => e.eventName === 'exploration_discarded')).toBeUndefined();
   });
 });

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -184,6 +184,37 @@ describe('createExploration', () => {
     });
   });
 
+  // VIS-1067 — "Explore this" hands in a fully-built legacy snapshot
+  // (`explorerStore.js`'s `buildExplorationSeedState`) instead of relying on
+  // `legacyStateForSeed`'s `type === 'source'`-only bridge.
+  test('legacyStateOverride wins over legacyStateForSeed and is mapped into the draft', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ seeded_from: { type: 'model', name: 'orders' } })
+    );
+
+    const override = {
+      modelTabs: ['query_1'],
+      activeModelName: 'query_1',
+      modelStates: { query_1: { sql: 'SELECT * FROM ${ref(orders)}', sourceName: 'pg', isNew: true } },
+      chartName: null,
+      chartLayout: {},
+      chartInsightNames: [],
+      activeInsightName: null,
+      insightStates: {},
+    };
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'model', name: 'orders' }, null, override);
+    });
+
+    const payload = explorationsApi.createExploration.mock.calls[0][0];
+    expect(payload.seeded_from).toEqual({ type: 'model', name: 'orders' });
+    expect(payload.draft.queries).toEqual([
+      { name: 'query_1', sql: 'SELECT * FROM ${ref(orders)}', source: 'pg' },
+    ]);
+    expect(payload.draft.legacy_state).toEqual(override);
+  });
+
   // Explore 2.0 Phase 3b cutover (02-architecture.md §5): the dashboard-scoped
   // `/workspace/dashboard/:name/explorer` route mints a fresh exploration
   // carrying a return_to placement intent.

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -135,6 +135,15 @@ const createWorkspaceSlice = (set, get) => ({
   // so it can never leak to a later selection. The consuming pane clears it.
   workspaceLensIntent: null, // { objectKey: 'type:name', lens: 'lineage' } | null
 
+  // One-shot Semantic Layer ERD node-focus request (VIS-1069, mirrors
+  // `workspaceLensIntent`'s shape/lifecycle exactly). Promoting a
+  // metric/dimension's "View in Semantic Layer" offer sets this ONE
+  // statement before navigating to the semantic-layer view; the ERD
+  // (`SemanticLayerCanvas.jsx`) reads it once, pans/centers on the field's
+  // parent model node, and self-clears — never a lingering focus request
+  // that would hijack a later, unrelated ERD visit.
+  workspaceSemanticLayerFocusIntent: null, // { objectKey: 'type:name' } | null
+
   // Pivot playground draft (table `build` lens, VIS-1008) --------------------
   // The in-flight pivot config the drag-to-shelf builder owns while the user
   // composes it: `{ tableName, columns, rows, values }`. `columns`/`rows` are
@@ -599,6 +608,16 @@ const createWorkspaceSlice = (set, get) => ({
 
   clearWorkspaceLensIntent: () => {
     set({ workspaceLensIntent: null });
+  },
+
+  // VIS-1069 — see `workspaceSemanticLayerFocusIntent`'s declaration above.
+  setWorkspaceSemanticLayerFocusIntent: (intent) => {
+    if (intent && !intent.objectKey) return;
+    set({ workspaceSemanticLayerFocusIntent: intent || null });
+  },
+
+  clearWorkspaceSemanticLayerFocusIntent: () => {
+    set({ workspaceSemanticLayerFocusIntent: null });
   },
 
   // ------------------------------------------------------------------------

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -676,6 +676,27 @@ describe('workspace store slice', () => {
     expect(useStore.getState().workspaceLensIntent).toBeNull();
   });
 
+  test('workspaceSemanticLayerFocusIntent: set, validate, and clear (VIS-1069)', () => {
+    act(() => {
+      useStore.getState().setWorkspaceSemanticLayerFocusIntent({ objectKey: 'metric:revenue' });
+    });
+    expect(useStore.getState().workspaceSemanticLayerFocusIntent).toEqual({
+      objectKey: 'metric:revenue',
+    });
+    // An invalid shape (no objectKey) is rejected without clobbering the
+    // current intent — mirrors `setWorkspaceLensIntent`'s guard.
+    act(() => {
+      useStore.getState().setWorkspaceSemanticLayerFocusIntent({});
+    });
+    expect(useStore.getState().workspaceSemanticLayerFocusIntent).toEqual({
+      objectKey: 'metric:revenue',
+    });
+    act(() => {
+      useStore.getState().clearWorkspaceSemanticLayerFocusIntent();
+    });
+    expect(useStore.getState().workspaceSemanticLayerFocusIntent).toBeNull();
+  });
+
   // Outline tree (VIS-793 / Track F F-3) ------------------------------------
 
   test('setWorkspaceOutlineSelectedKey updates the selection key', () => {


### PR DESCRIPTION
## Summary

Final build phase of Explore 2.0. Eight per-concern commits, each independently reviewable:

1. **VIS-1067 — "Explore this" / "Add to exploration" everywhere.** `OpenObjectContextMenu` (mounted by `LineageCanvas`), `LibraryRow`, and `ErdTableContextMenu` gain both actions. New `buildExplorationSeedState` (explorerStore.js) seed bridge: source/table/model/metric/dimension pre-wire a scratch query; insight/chart copy into the draft under the **same name** so promoting later updates the original via the existing update-by-name `saveX` semantics. New `addObjectToActiveExploration` mirrors `WorkspaceDndContext`'s DnD routing for the same `EXPLORATION_DRAG_TYPES` set when there's no drop target to aim at. `createExploration` gained an optional `legacyStateOverride` param.
2. **VIS-1068 — Dashboard round-trip completion.** `ExplorationPromoteModal`'s success state offers "Place in `<dashboard>`" when a promote included a chart while `return_to` is set: accept places the chart via the already-built (previously zero-caller) `placeChartInDashboardSlot`, consumes `return_to` (new `consumeExplorationReturnTo` action wired to the Phase 1 endpoint), and navigates to the dashboard tab; decline also consumes (explicit choice, no accretion). A `return_to` whose dashboard no longer exists renders the offer **disabled with a tooltip** (04-bug-inventory.md D12's validation nit). Reload-survival needed **no code change** — Workspace.jsx already re-fetches explorations from the backend on every mount.
3. **VIS-1069 — Semantic Layer reciprocals.** New one-shot `workspaceSemanticLayerFocusIntent` (mirrors `workspaceLensIntent`'s set-then-navigate/self-clear lifecycle exactly). Promoting a metric/dimension offers "View in Semantic Layer"; `SemanticLayerCanvas` consumes the intent and pans/centers the ERD on the field's parent model node (metrics/dimensions have no node of their own). Semantic Layer field pills (`SemanticLayerErdModelNode`) are now clickable "Explore this" back-links. Caught and fixed a real bug while writing tests: the field→parent-model resolver called `Set.has()` on what `groupFieldsByModel` actually returns (plain arrays) — would have thrown at runtime on first use.
4. **VIS-1091–1095 — preview-lane correctness** (Phase 4 delta review, absorbed into this phase):
   - **(a)** Lane detection now requires both a real `state.insights` match **and** the *active exploration's own* `promoted[]` trail recording it — closes the cross-exploration same-auto-name collision.
   - **(b)** `useDraftInsightPreview` tracks loading/error/blocked **per insight** (`perInsight`), and `ExplorerChartPreview` additionally suppresses the whole-chart gate entirely once *any* insight already has data on screen — `ChartPreview` has no partial-render mode (Plotly needs every insight's data to draw at all), so "never blank an already-rendering insight" means stale-while-revalidate, not a partial chart.
   - **(c)** The promoted-poll bridge is now bounded (~30s/15 attempts) and surfaces `useInsightsData`'s error (previously discarded) via a dismissible-by-nature banner instead of polling forever.
   - **(d)** A monotonic generation token per debounce fire guards every store write in the compile lane — a slower, out-of-order response is dropped rather than clobbering a newer one.
   - **(e)** `FieldSwapOfferBanner.applyOffer` re-reads each slot's live value against the offer's captured snapshot before writing; a slot edited (or its insight renamed/removed) since the offer was made is skipped with a toast, never blindly overwritten. Added `previousColumn` to both offer-detector return shapes to make the re-validation possible.
5. **VIS-1070 — Staleness.** New `computeExplorationStaleness` re-runs `checkRefTargets` (the same tool the Build rail's live advisory validation already uses) against a whole exploration's draft on resume (new non-blocking `ExplorationStalenessBanner`, "Re-check references") and on the Explorer Home gallery (new "stale" badge). See judgment calls below for the changed-vs-deleted scope reduction.
6. **VIS-1071 — Restyle sweep (B9).** `DraggableColumnHeader`/`AddComputedColumnPopover` now derive metric/dimension styling from `objectTypeConfigs` instead of hand-rolled cyan/teal. Raw `red-*` → `highlight-*` across the exploration surface (5 files). New shared `CenteredFrameState` replaces **four** near-duplicate hand-rolled empty/loading/error cards (a fourth — `ExplorationPane`'s own separately-defined `FrameState` — turned up during the sweep, beyond the three the spec named). Every existing `data-testid` preserved at each call site.
7. **VIS-1072 — Telemetry.** `exploration_created/opened/branched/promoted/discarded`, `save_as_metric_used`, `explore_this_used{source_type}`, `time_to_first_chart` — all through the existing `emitWorkspaceEvent` relay (never the onboarding shim), snake_case, no event renamed. New `markExplorationCreated`/`emitTimeToFirstChart` pair in `telemetry.js` mirrors the existing `markBuildModeEntered`/`emitFirstPublishTelemetry` pattern, generalized to a Map (multiple explorations can be in flight).
8. **Tests.** New e2e: `explore-this-flywheel.spec.mjs`, `dashboard-newchart-roundtrip.spec.mjs` (+ reload-mid-flow + decline-consumes cases), `exploration-staleness.spec.mjs`; `exploration-preview.spec.mjs` extended with VIS-1091/1092/1093/1095 assertions (VIS-1094 deliberately not duplicated at e2e — see judgment calls). All three new spec files double-registered in `playwright.config.mjs` (verified via grep — each appears exactly twice).

## Taxonomy diff (specs working tree — NOT committed, per instructions; orchestrator to push)

Appended one bullet to `specs/marketing-relaunch/event-taxonomy.md` §4 "Activation — `surface: cli | viewer`", after the existing "Role-flow activation" bullet:

```
- **Explore 2.0 flywheel (VIS-1067–VIS-1072, viewer — `workspace/telemetry.js` `emitWorkspaceEvent`, not the onboarding shim; no client-side `surface` prop needed, the local Flask relay attaches it server-side):** `exploration_created` · `exploration_opened` · `exploration_branched` · `exploration_promoted{object_counts, update_vs_new}` · `exploration_discarded` · `save_as_metric_used` · `explore_this_used{source_type}` · `time_to_first_chart{ms}`
```

The `specs/` working tree also has substantial *unrelated* pending changes from other sessions (dashboard-building docs, deleted cofounder-mockups, etc.) — untouched by this PR, flagging only so the orchestrator isn't surprised by `git status` there.

## Suite counts

- **Unit (viewer):** `bash scripts/viewer-check.sh` — **336 test suites / 5647 passed, 2 skipped, 5649 total** — green after every commit, re-verified at the end.
- **Lint:** `eslint src --ext .js,.jsx,.ts,.tsx` — 0 errors/warnings, re-verified at the end.
- **Backend:** no Python files touched this phase (confirmed via `git diff --stat -- visivo/` against the base) — pytest/black gate not applicable.
- **E2E:** 4 files, 17 tests (1 new + 3 new + 4 new + 9 pre-existing-in-that-file across `explore-this-flywheel.spec.mjs` / `dashboard-newchart-roundtrip.spec.mjs` / `exploration-staleness.spec.mjs` / `exploration-preview.spec.mjs`). Verified structurally with `npx playwright test --list` (17 discovered correctly under `exploration-mutations`, 0 under `parallel` — confirms the testMatch/testIgnore split is correct) and the double-registration grep. **Per this task's "NO sandbox use" instruction, these were never run against a live sandbox** — that's the one gate item left for the orchestrator/CI before merge.

## Judgment calls (please review)

- **VIS-1067 "Add to exploration" type coverage:** scoped to `EXPLORATION_DRAG_TYPES` (source/metric/dimension/insight), matching the existing DnD-routing precedent. For metric/dimension (no specific drop target from a context menu), it creates a new insight and binds the field into its `y` prop — a reasonable default, not literally specified anywhere.
- **VIS-1067 seed bridge for metric/dimension "Explore this":** pre-wires a query against the field's *parent model* (bonus, beyond the prompt's explicit "models/tables" pre-wiring requirement) rather than leaving it unwired.
- **VIS-1068 "first free slot":** `placeChartInDashboardSlot`'s existing fallback (already-built, zero prior callers) is "append a new row at the end", not "scan for the first empty existing slot" — no such scan existed anywhere in the codebase; writing one was out of scope for this pass. Documented in the promote-modal's inline comment.
- **VIS-1070 staleness scope:** "changed" vs "deleted" refs collapse into one dangling-ref signal (no persisted fingerprint of referenced objects to diff against exists yet) — matches 02-architecture.md §8's own literal mechanism (`checkRefTargets`). A true changed-vs-deleted distinction needs a `ref_fingerprint` on the `Exploration` record — noted as follow-up, not implemented.
- **VIS-1092 fix shape:** "never blank an already-rendering insight" is implemented as stale-while-revalidate (suppress the whole-chart gate once anything has data), not a partial-chart render — Plotly fundamentally can't render one insight's trace without every insight's data.
- **VIS-1094 e2e coverage:** deliberately not duplicated in e2e (network-timing assertions are inherently flaky there); it's precisely covered by `useDraftInsightPreview.test.js`'s new out-of-order-resolution unit test instead.
- **E2E specs are unverified against a live sandbox** (see above) — structurally validated only.

## Anything left for the orchestrator

1. Run the 3 new + 1 extended e2e spec files against a real sandbox before merge (never run this session, per instructions).
2. Push the `specs/marketing-relaunch/event-taxonomy.md` diff (quoted above) from the specs working tree — not committed by this session.
3. Core Django twin (`core/api`) untouched — this phase was viewer-only per its scope; no cloud-side work needed for VIS-1067–1072.
4. `05-e2e-ledger.md` / Phase 6 cleanup pass (deleting dead code, final ledger reconciliation) is explicitly out of this phase's scope per `03-delivery-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX