### PR TITLE
Explore 2.0 Phase 6: cleanup + acceptance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 env/
 venv/
 venv12/
+venv14/
 cli_venv/
 api_venv/
 ENV/
@@ -45,6 +46,9 @@ htmlcov/
 .netlify
 .qodo
 .visivo_cache
+# Exploration workbench repository (Explore 2.0) — runtime state under any
+# test-projects/*/.visivo/, never checked in (analogous to target/).
+test-projects/*/.visivo/
 mk_docs.log
 visivo.spec
 

--- a/tests/server/views/test_commit_views.py
+++ b/tests/server/views/test_commit_views.py
@@ -5,6 +5,12 @@ from flask import Flask
 from visivo.server.views.commit_views import register_commit_views
 from visivo.server.managers.object_manager import ObjectStatus
 
+# TestExplorationCommitExclusion below intentionally uses the REAL
+# integration_client/integration_app fixtures (tests/server/conftest.py) —
+# both commit_views and exploration_views are registered on that same real
+# FlaskApp, which is exactly the "is an exploration ever visible to the
+# commit surfaces" question this class pins.
+
 
 class TestCommitViews:
     """Test suite for commit API endpoints."""
@@ -357,3 +363,91 @@ class TestCommitViews:
         assert response.status_code == 200
         assert response.get_json()["discarded_count"] == 1
         app.flask_app.dashboard_manager.clear_cache.assert_called_once()
+
+
+class TestExplorationCommitExclusion:
+    """e2e-gap-review.md #14 [MEDIUM·CONFIRMED_GAP]: explorations are
+    deliberately NOT part of the Project DAG / commit surfaces
+    (02-architecture.md: "Deliberately NOT part of the Project DAG... must
+    not appear in... git diffs"), but that guarantee has only ever held by
+    OMISSION — commit_views.py's `change_managers` (get_project_changes) and
+    every pending/commit/discard loop hardcode exactly 13 non-exploration
+    managers and simply never reference an exploration_manager. Nothing
+    previously asserted this; a future "add exploration_manager for
+    consistency with every other object type" refactor could silently fold
+    explorations into the commit surfaces with no test catching it.
+
+    Mirrors tests/server/test_run_views.py's `TestExplorationRunIsolation`
+    pattern (the same "prove absence via the real integration app" shape for
+    a different surface) using the shared `integration_client`/`integration_app`
+    fixtures (tests/server/conftest.py) — both commit_views and
+    exploration_views are registered on that one real FlaskApp.
+    """
+
+    def test_exploration_type_never_appears_in_project_changes(self, integration_client):
+        # A dirty exploration (create + draft edit + rename) sits alongside a
+        # genuinely dirty model, so /changes/'s response is non-trivial and
+        # this isn't just "the endpoint returns an empty list either way".
+        integration_client.post("/api/models/exploration_gap_model/", json={"sql": "select 1"})
+
+        created = integration_client.post("/api/explorations/", json={"name": "Scratch"}).get_json()
+        integration_client.post(
+            f"/api/explorations/{created['id']}/",
+            json={"draft": {"queries": [{"name": "q", "sql": "SELECT 1"}]}},
+        )
+        integration_client.post(f"/api/explorations/{created['id']}/", json={"name": "Renamed"})
+
+        resp = integration_client.get("/api/projects/proj1/changes/")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        types = {entry["type"] for entry in data["to_publish"] + data["to_remove"]}
+        assert "exploration" not in types
+        # Sanity: the model IS present, so the exploration's absence above is
+        # a real exclusion, not an artifact of an empty response.
+        assert "model" in types
+
+        integration_client.delete(f"/api/explorations/{created['id']}/")
+
+    def test_create_update_rename_delete_exploration_leaves_pending_empty_throughout(
+        self, integration_client
+    ):
+        def pending_count():
+            resp = integration_client.get("/api/commit/pending/")
+            assert resp.status_code == 200
+            return resp.get_json()["count"]
+
+        assert pending_count() == 0
+
+        created = integration_client.post("/api/explorations/", json={"name": "Scratch"}).get_json()
+        assert pending_count() == 0
+
+        integration_client.post(
+            f"/api/explorations/{created['id']}/",
+            json={"draft": {"queries": [{"name": "q", "sql": "SELECT 1"}]}},
+        )
+        assert pending_count() == 0
+
+        integration_client.post(f"/api/explorations/{created['id']}/", json={"name": "Renamed"})
+        assert pending_count() == 0
+
+        integration_client.delete(f"/api/explorations/{created['id']}/")
+        assert pending_count() == 0
+
+    def test_commit_status_unaffected_by_exploration_mutations(self, integration_client):
+        assert (
+            integration_client.get("/api/commit/status/").get_json()["has_unpublished_changes"]
+            is False
+        )
+
+        created = integration_client.post("/api/explorations/", json={"name": "Scratch"}).get_json()
+        integration_client.post(
+            f"/api/explorations/{created['id']}/",
+            json={"draft": {"queries": [{"name": "q", "sql": "SELECT 1"}]}},
+        )
+
+        assert (
+            integration_client.get("/api/commit/status/").get_json()["has_unpublished_changes"]
+            is False
+        )
+
+        integration_client.delete(f"/api/explorations/{created['id']}/")

--- a/tests/server/views/test_exploration_views.py
+++ b/tests/server/views/test_exploration_views.py
@@ -323,3 +323,48 @@ class TestRecordPromotion:
             json={"promoted": [], "name": "x"},
         )
         assert len(resp.get_json()["promoted"]) == 1
+
+
+class TestReturnTo:
+    """e2e-gap-review.md D12 [LOW·PARTIAL]: `return_to.dashboard` is persisted
+    with ZERO existence validation against the project's real dashboards —
+    `ReturnToRef` (visivo/models/exploration.py) is pure shape typing (a dict
+    with a `dashboard: str` field), and neither `ExplorationRepository.create`/
+    `update` nor this view cross-checks it against any dashboard list. This is
+    documented-permissive by design (07-exploration-api-contract.md;
+    exploration_views.py's own module docstring: "draft CONTENT is
+    intentionally never validated at rest") — Phase 4/5's eventual
+    `dashboardExists` consumption (ExplorationPromoteModal.jsx) is what
+    actually reacts to a missing dashboard, not creation-time validation. These
+    tests lock in and document today's intentional permissiveness; they are
+    NOT a bug fix.
+    """
+
+    def test_create_with_nonexistent_dashboard_return_to_succeeds_and_persists_verbatim(
+        self, client
+    ):
+        resp = client.post(
+            "/api/explorations/",
+            json={"return_to": {"dashboard": "definitely-does-not-exist", "slot": "r1-i1"}},
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["return_to"] == {"dashboard": "definitely-does-not-exist", "slot": "r1-i1"}
+
+        # Survives a re-fetch — persisted, not just echoed in the response.
+        refetched = client.get(f"/api/explorations/{data['id']}/").get_json()
+        assert refetched["return_to"] == {"dashboard": "definitely-does-not-exist", "slot": "r1-i1"}
+
+    def test_update_to_a_nonexistent_dashboard_return_to_also_succeeds(self, client):
+        created = client.post("/api/explorations/", json={}).get_json()
+        assert created["return_to"] is None
+
+        resp = client.post(
+            f"/api/explorations/{created['id']}/",
+            json={"return_to": {"dashboard": "another-ghost-dashboard"}},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["return_to"] == {
+            "dashboard": "another-ghost-dashboard",
+            "slot": None,
+        }

--- a/venv12
+++ b/venv12
@@ -1,1 +1,0 @@
-/Users/jaredjesionek/visivo/Product/visivo/venv12

--- a/viewer/e2e/stories/chart-legend-layout.spec.mjs
+++ b/viewer/e2e/stories/chart-legend-layout.spec.mjs
@@ -1,0 +1,134 @@
+/**
+ * Story: Chart legend structural layout (P5-D6 ledger gap closure,
+ * e2e-gap-review.md "Final delta pass").
+ *
+ * 05-e2e-ledger.md verdicts `explorer-chart-legend-visual.spec.mjs`
+ * (horizontal-below-plot legend default, non-zero bottom margin, no
+ * legend/plot overlap) PORT — "Chart.jsx rendering is carried forward"
+ * (02-architecture.md §9) — but that old file was deleted at the Phase 3b
+ * cutover with no e2e successor anywhere in the final suite (confirmed:
+ * `grep -rli legend viewer/e2e/stories/` was empty before this file).
+ * `Chart.test.jsx` already unit-tests the CONFIG-level defaults
+ * (`legend: { orientation: 'h', y: -0.2, x: 0 }`, non-zero bottom margin)
+ * against a MOCKED Plotly — this file closes the residual gap: proving that
+ * same default config actually reaches a REAL, live-data Plotly render
+ * against the sandbox (not just a mock), plus a best-effort real-geometry
+ * check on any chart Plotly actually chooses to draw a legend for (Plotly
+ * only draws `.legend` when there's something to show one for — 2+ traces —
+ * so this dashboard's mix of single- and multi-trace charts makes a strict
+ * "must find one" assertion a source of flakiness un-related to the
+ * capability under test; the config-equality assertion below is the load-
+ * bearing one and is deterministic).
+ *
+ * Precondition: sandbox running (integration project) on the standard
+ * :3001/:8001 ports.
+ *
+ * Read-only (no exploration mutation) — registered in the default
+ * `parallel` project, no special isolation needed.
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const DASHBOARD = 'insights-dashboard';
+
+test.describe('Chart legend structural layout (P5-D6)', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  test('every real rendered chart resolves Chart.jsx\'s default horizontal below-plot legend config and a non-zero bottom margin', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace/dashboard/${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('workspace-middle-dashboard-canvas')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Every chart on this dashboard leaves `layout.legend` unset in its own
+    // config, so Chart.jsx's default (Chart.jsx: `if (!l.legend) l.legend =
+    // { orientation: 'h', y: -0.2, x: 0 }`) applies uniformly — assert it
+    // reached the REAL Plotly instance's resolved `_fullLayout`, not just a
+    // mock (Chart.test.jsx's own coverage), on every drawn plot.
+    const configs = await page.evaluate(() => {
+      const plots = [...document.querySelectorAll('.js-plotly-plot')];
+      return plots
+        .map(p => p._fullLayout)
+        .filter(Boolean)
+        .map(l => ({ legend: l.legend, marginBottom: l.margin?.b }));
+    });
+
+    expect(configs.length).toBeGreaterThan(0);
+    // Not every chart type resolves a `legend` layout field (e.g. an
+    // Indicator has none) — restrict the default-config assertion to the
+    // ones that do, but require at least one (this dashboard has several
+    // XY scatter/bar charts, none of which set an explicit `legend`).
+    const withLegend = configs.filter(c => c.legend);
+    expect(withLegend.length).toBeGreaterThan(0);
+    for (const cfg of withLegend) {
+      expect(cfg.legend).toMatchObject({ orientation: 'h', y: -0.2, x: 0 });
+    }
+    // Non-zero bottom margin on every chart — the space Chart.jsx's default
+    // margin (`{ t: 40, r: 20, b: 80, l: 60 }`) reserves is never clipped.
+    for (const cfg of configs) {
+      expect(cfg.marginBottom).toBeGreaterThan(0);
+    }
+  });
+
+  test('a chart whose data actually draws a legend renders it below the plot area with no overlap', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/workspace/dashboard/${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.js-plotly-plot svg.main-svg').first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Best-effort: Plotly only draws a `.legend` group for charts with 2+
+    // traces (or an explicitly-named single trace) — poll for one to exist
+    // among this dashboard's charts, but don't treat "none drawn yet" within
+    // the budget as a hard failure of THIS test's real subject (the config
+    // assertion above already proves the capability deterministically);
+    // skip gracefully if none appears so this test never flakes on lazy
+    // row-visibility timing unrelated to legend geometry itself.
+    let legendGeometry = null;
+    try {
+      await expect
+        .poll(
+          async () => {
+            legendGeometry = await page.evaluate(() => {
+              const plots = [...document.querySelectorAll('.js-plotly-plot')];
+              for (const plot of plots) {
+                const legend = plot.querySelector('g.legend');
+                const plotArea =
+                  plot.querySelector('g.plotbg') || plot.querySelector('.bglayer > rect');
+                if (legend && plotArea) {
+                  const legendRect = legend.getBoundingClientRect();
+                  const plotRect = plotArea.getBoundingClientRect();
+                  return {
+                    legendTop: legendRect.top,
+                    legendBottom: legendRect.bottom,
+                    plotTop: plotRect.top,
+                    plotBottom: plotRect.bottom,
+                    overlaps: legendRect.top < plotRect.bottom && legendRect.bottom > plotRect.top,
+                  };
+                }
+              }
+              return null;
+            });
+            return legendGeometry;
+          },
+          { timeout: 20000, intervals: [500, 1000, 2000] }
+        )
+        .not.toBeNull();
+    } catch {
+      test.skip(true, 'No chart on this dashboard drew a legend within the polling budget');
+    }
+
+    expect(legendGeometry.legendTop).toBeGreaterThanOrEqual(legendGeometry.plotTop);
+    expect(legendGeometry.overlaps).toBe(false);
+  });
+});

--- a/viewer/e2e/stories/cross-tab-soft-reload-project-runs.spec.mjs
+++ b/viewer/e2e/stories/cross-tab-soft-reload-project-runs.spec.mjs
@@ -1,0 +1,167 @@
+/**
+ * Story: Commit-broadcast reload symmetry across /workspace, /project, and
+ * /runs (Explore 2.0 e2e-gap-review.md D7 — "VIS-1087's remaining half").
+ *
+ * `commit_views.py`'s `commit_changes()` calls
+ * `hot_reload_server.socketio.emit('reload')` — an UNSCOPED broadcast to
+ * every connected socket (unchanged by this fix; see hot_reload_server.py).
+ * The injected `/hot-reload.js` (baked into every served index.html) only
+ * skips the hard `window.location.reload()` when
+ * `window.__VISIVO_SOFT_RELOAD__` is true, and that flag is set by
+ * `useProjectChangeListener()` (viewer/src/components/views/workspace/
+ * useProjectChangeListener.js). Before this fix, ONLY `Workspace.jsx` ever
+ * called that hook — so `/project` (Project.jsx) and `/runs` (RunsView.jsx),
+ * which mount OUTSIDE the Workspace shell (LocalRouter.jsx), hard-reloaded on
+ * every commit fired from any `/workspace/...` tab. The fix mounts the SAME
+ * hook in `Project.jsx`/`RunsView.jsx` too — mechanical, behavior-preserving,
+ * does not retire or fold `/project` into the Workspace (03-delivery-plan.md's
+ * "Resolved questions" §1 keeps it the separate "consumer surface").
+ *
+ * This story proves the asymmetry is GONE: all three routes set the
+ * soft-reload flag, and a real commit fired from `/workspace` never hard-
+ * reloads a `/project` or `/runs` tab (asserted via a `window`-scoped marker
+ * that only a hard `window.location.reload()` would wipe).
+ *
+ * Mutates test-projects/integration/project.visivo.yml via a REAL commit —
+ * snapshots + byte-restores it, same pattern as build-mode-publish.spec.mjs /
+ * external-edit-banner.spec.mjs. Runs in the isolated 'workspace-publish'
+ * playwright project (serial, no retries) since it fires a real
+ * `POST /api/commit/` against shared sandbox state.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8051 VISIVO_SANDBOX_FRONTEND_PORT=3051 \
+ *   VISIVO_SANDBOX_NAME=vis806 bash scripts/sandbox.sh start
+ *   # then: VIS_PUBLISH_BASE=http://localhost:3051 npx playwright test cross-tab-soft-reload
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const BASE =
+  process.env.VIS_PUBLISH_BASE || process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+const WAIT = 20000;
+// The commit broadcast is near-instant (a bare socket.io emit); this just
+// gives every page's socket + hot-reload.js handler time to run before we
+// poll for the marker's survival.
+const SETTLE_WAIT = 8000;
+
+const PROJECT_YML = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../test-projects/integration/project.visivo.yml'
+);
+
+const MODEL_NAME = `e2e_d7_model_${Date.now()}`;
+
+/** Mark the page's CURRENT JS context. A hard `window.location.reload()`
+ * creates a brand-new JS context (this marker is gone); a soft refresh
+ * (refetch + re-render in place) never touches an unrelated `window`
+ * property, so the marker survives untouched either way. */
+const markAlive = page =>
+  page.evaluate(() => {
+    window.__E2E_D7_ALIVE_MARKER__ = 'still-alive';
+  });
+
+const isStillAlive = page =>
+  page.evaluate(() => window.__E2E_D7_ALIVE_MARKER__ === 'still-alive').catch(() => false);
+
+const softReloadFlagIsSet = page =>
+  page.evaluate(() => window.__VISIVO_SOFT_RELOAD__ === true).catch(() => false);
+
+// This test drives its own manually-created `browser.newContext()` (three
+// real tabs sharing one profile) rather than the fixture-managed default
+// `page`/`context` — tracing that ad-hoc context alongside the unused
+// default one hit a Playwright trace-artifact housekeeping error (ENOENT on
+// an internal recording file) in this environment that has nothing to do
+// with this story's own assertions (which all pass before the error surfaces
+// at context teardown). Trace/screenshot aren't needed here — every
+// assertion is a plain boolean read off `window`, not a visual one.
+test.use({ trace: 'off', screenshot: 'off' });
+
+test.describe('Commit-broadcast reload symmetry across /workspace, /project, /runs (D7)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  let originalYaml;
+
+  test.beforeAll(async ({ request }) => {
+    originalYaml = fs.readFileSync(PROJECT_YML, 'utf8');
+    await request.post(`${BASE}/api/commit/discard/`).catch(() => {});
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.post(`${BASE}/api/commit/discard/`).catch(() => {});
+    if (originalYaml !== undefined && fs.readFileSync(PROJECT_YML, 'utf8') !== originalYaml) {
+      fs.writeFileSync(PROJECT_YML, originalYaml);
+      // Let the file watcher's recompile settle before the next test file
+      // touches the sandbox (mirrors build-mode-publish.spec.mjs /
+      // external-edit-banner.spec.mjs's identical restore wait).
+      await new Promise(resolve => setTimeout(resolve, 4000));
+    }
+  });
+
+  test('all three routes set the soft-reload flag, and a commit from /workspace never hard-reloads /project or /runs', async ({
+    browser,
+  }) => {
+    // A single shared context (three real OS-level browser tabs in one
+    // profile), not three independent `browser.newPage()` contexts — matches
+    // #13's own note on the closest-analogous multi-page pattern in this
+    // suite, and avoids a Playwright trace-recording collision observed
+    // across three simultaneously-traced AD-HOC contexts in this project's
+    // global `trace: 'retain-on-failure'` config.
+    const context = await browser.newContext();
+    const pageWorkspace = await context.newPage();
+    const pageProject = await context.newPage();
+    const pageRuns = await context.newPage();
+
+    await pageWorkspace.goto(`${BASE}/workspace`);
+    await pageWorkspace.waitForLoadState('networkidle');
+    await expect(pageWorkspace.getByTestId('workspace-route-root')).toBeVisible({ timeout: WAIT });
+
+    await pageProject.goto(`${BASE}/project`);
+    await pageProject.waitForLoadState('networkidle');
+
+    await pageRuns.goto(`${BASE}/runs`);
+    await pageRuns.waitForLoadState('networkidle');
+
+    // Precondition (the fix itself): before D7, only /workspace ever set
+    // this flag — /project and /runs never did.
+    await expect.poll(() => softReloadFlagIsSet(pageWorkspace), { timeout: WAIT }).toBe(true);
+    await expect.poll(() => softReloadFlagIsSet(pageProject), { timeout: WAIT }).toBe(true);
+    await expect.poll(() => softReloadFlagIsSet(pageRuns), { timeout: WAIT }).toBe(true);
+
+    await markAlive(pageWorkspace);
+    await markAlive(pageProject);
+    await markAlive(pageRuns);
+
+    // A real dirty change + a real commit, fired from the /workspace tab —
+    // exactly the scenario D7 describes (User A commits from /workspace;
+    // User B, or the same user's second tab, sits on /project or /runs).
+    const dirtyRes = await pageWorkspace.request.post(`${apiBase}/api/models/${MODEL_NAME}/`, {
+      data: { sql: 'select 1' },
+    });
+    expect(dirtyRes.ok()).toBe(true);
+    const commitRes = await pageWorkspace.request.post(`${apiBase}/api/commit/`);
+    expect(commitRes.ok()).toBe(true);
+
+    await pageProject.waitForTimeout(SETTLE_WAIT);
+
+    // The marker survives on ALL THREE pages — none of them hard-reloaded.
+    // Before the D7 fix, /project and /runs would have hard-navigated here
+    // (window.location.reload()), wiping this marker.
+    expect(await isStillAlive(pageWorkspace)).toBe(true);
+    expect(await isStillAlive(pageProject)).toBe(true);
+    expect(await isStillAlive(pageRuns)).toBe(true);
+
+    await context.close();
+  });
+});

--- a/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
+++ b/viewer/e2e/stories/dashboard-newchart-roundtrip.spec.mjs
@@ -364,4 +364,108 @@ test.describe('Dashboard round-trip completion (Explore 2.0 Phase 5 — VIS-1068
     const dashboard = await fetchDashboard(page, dashboardName);
     expect(dashboardReferencesChart(dashboard, chartName)).toBe(false);
   });
+
+  // e2e-gap-review.md P5-D3 [MEDIUM · CONFIRMED_GAP]: `dashboardExists`
+  // (ExplorationPromoteModal.jsx) disables "Place in <dashboard>" with a
+  // tooltip once the return_to target is gone — but no test ever minted a
+  // real return_to, then actually removed the target dashboard, then reached
+  // promote success to observe the disabled state. This test drives exactly
+  // that, backend-asserted throughout.
+  //
+  // The target is a THROWAWAY, never-committed draft dashboard (created via
+  // the backend save-to-cache endpoint the app's own "+ New Dashboard" flow
+  // uses) rather than the shared `simple-dashboard` fixture every other test
+  // in this file reads — deleting a SHARED fixture mid-suite would corrupt
+  // concurrently-running specs against the same sandbox. Honest note: no
+  // live in-app UI currently exposes deleting a dashboard — grep confirms
+  // `DashboardEditForm.jsx` (the only component with a "Delete dashboard"
+  // affordance) is never rendered anywhere outside its own tests; the
+  // Workspace's Right Rail edit view for a dashboard (`RightRailEditPanel.jsx`)
+  // only supports row-level edits. This test drives the deletion through the
+  // same backend endpoint `deleteDashboard()` (dashboardStore.js) would call
+  // if that UI existed, which is the closest honest equivalent available today.
+  test('a dashboard deleted before promote disables "Place in <name>" with a tooltip; "Not now" still cleanly consumes return_to', async ({
+    page,
+  }) => {
+    const throwawayDashboard = `e2e_p5d3_throwaway_${Date.now()}`;
+    // A genuinely zero-row dashboard renders `project-canvas` at 0 height in
+    // this layout (a real, if unrelated, CSS quirk root-caused via live
+    // reproduction against the sandbox) — seed one empty row so the canvas
+    // has real size, matching every real (non-empty) dashboard the other
+    // tests in this file use.
+    const createRes = await page.request.post(
+      `${apiBase}/api/dashboards/${encodeURIComponent(throwawayDashboard)}/`,
+      { data: { name: throwawayDashboard, type: 'internal', rows: [{ height: 'medium', items: [] }] } }
+    );
+    expect(createRes.ok()).toBe(true);
+
+    await openDashboardCanvas(page, throwawayDashboard);
+
+    const id = await newChartFromLibrary(page);
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to?.dashboard).toBe(throwawayDashboard);
+    }).toPass({ timeout: 15000 });
+
+    // Delete the target dashboard NOW, before promoting — see the file-level
+    // note above on why this goes through the backend endpoint directly.
+    // Never having been committed, this fully removes it from
+    // `/api/dashboards/` (mark-for-deletion on a purely-cached, never-
+    // published draft drops it from the listing entirely — see
+    // dashboard_manager.py's `get_all_dashboards_with_status`), rather than
+    // leaving a "deleted" stub entry a name-only lookup could still match.
+    const deleteRes = await page.request.delete(
+      `${apiBase}/api/dashboards/${encodeURIComponent(throwawayDashboard)}/delete/`
+    );
+    expect(deleteRes.ok()).toBe(true);
+
+    // Reload so the client's `dashboards` store state (fetched once at
+    // Workspace mount) genuinely reflects the deletion — mirrors the "hard
+    // reload between opening the intent-carrying exploration and promoting"
+    // test above, which already proves a reload here is safe for return_to.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_p5d3_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await promoteEverything(page);
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    // The offer still renders (return_to is still set on the exploration
+    // record — deleting the dashboard never touches it), but "Place in
+    // <name>" is disabled with the explanatory tooltip once `dashboardExists`
+    // correctly resolves false.
+    const placeOffer = page.getByTestId('exploration-promote-return-to-offer');
+    await expect(placeOffer).toBeVisible({ timeout: 10000 });
+    const placeButton = page.getByTestId('exploration-promote-place-in-dashboard');
+    await expect(placeButton).toBeDisabled();
+    await expect(placeButton).toHaveAttribute('title', `"${throwawayDashboard}" no longer exists`);
+
+    // "Not now" still cleanly consumes return_to even though the dashboard
+    // is gone — the decline path never depended on the target existing.
+    await page.getByTestId('exploration-promote-decline-placement').click();
+    await expect(placeOffer).not.toBeVisible({ timeout: 10000 });
+
+    await expect(async () => {
+      const exploration = await fetchExploration(page, id);
+      expect(exploration.return_to).toBeNull();
+    }).toPass({ timeout: 15000 });
+  });
 });

--- a/viewer/e2e/stories/exploration-build-rail.spec.mjs
+++ b/viewer/e2e/stories/exploration-build-rail.spec.mjs
@@ -356,11 +356,24 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     await expect(valueSlot).not.toContainText('SUM');
 
     // The slice survives the aggregate-function rewrite in the persisted
-    // value...
-    await waitForBackendDraft(page, id, draft =>
-      (draft.insights || []).some(
-        insight => insight.props?.value === `?{avg(\${ref(${queryName}).${columnName}})}[0]`
-      )
+    // value... This is the SECOND sequential debounce+backend round trip in
+    // this test (the first already paid the ~1.6s debounce + real
+    // request/response cost above) — under concurrent-worker/shared-sandbox
+    // load (this project runs alongside 'parallel' and 'workspace-publish'),
+    // the default 15s budget was observed to occasionally run out here
+    // specifically (two full round trips compounding real backend latency),
+    // even though the underlying behavior is correct and settles quickly in
+    // isolation. A more generous timeout absorbs that queueing delay without
+    // loosening what's asserted — mirrors exploration-dnd-pull-in.spec.mjs's
+    // identical "generous timeout absorbs warm-up cost" precedent.
+    await waitForBackendDraft(
+      page,
+      id,
+      draft =>
+        (draft.insights || []).some(
+          insight => insight.props?.value === `?{avg(\${ref(${queryName}).${columnName}})}[0]`
+        ),
+      30000
     );
     // ...and SliceBadge still reads correctly afterward — never reset/blanked
     // by the pill's own label/type change underneath it.

--- a/viewer/e2e/stories/exploration-build-rail.spec.mjs
+++ b/viewer/e2e/stories/exploration-build-rail.spec.mjs
@@ -304,4 +304,67 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     await expect(page.getByTestId('slice-option-range')).toBeDisabled();
     await expect(page.getByTestId('slice-option-all')).toBeDisabled();
   });
+
+  // e2e-gap-review.md D4 [MEDIUM, Phase 3b delta]: toggling a PillMenu
+  // preset on a slot that already carries an authored slice is untested —
+  // `handleSelectPreset` -> `handleQueryChange` re-wraps the NEW aggregate
+  // body with the CURRENT `slice` closure value (PropertyRow.jsx), so `[0]`
+  // should survive an aggregate-function rewrite, but nothing asserts the
+  // resulting persisted value, nor that SliceBadge still reads correctly
+  // afterward. Extends the slice-on-drop test above with a SUM -> AVG
+  // preset toggle on the SAME pill.
+  test('toggling a preset (SUM -> AVG) on a slot with an authored slice preserves the slice, both in the persisted value and in SliceBadge', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const queryName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+    await pickSelectOption(page, `insight-type-select-${insightName}`, 'Indicator');
+
+    const tableRow = await expandSourceTable(page);
+    const { locator: column, name: columnName } = await firstNumericColumn(page, tableRow);
+    const valueSlot = page.locator('[data-testid*="droppable-property-value"]').first();
+    await expect(valueSlot).toBeVisible({ timeout: 15000 });
+    await dragAndDrop(page, column, valueSlot);
+
+    // The scalar-only slot auto-applies the default slice on drop (same
+    // fixture as the test above).
+    await expect(page.getByTestId('slice-banner')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('slice-banner-first').click();
+    const badge = page.getByTestId('slice-badge');
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    await expect(badge).toContainText('First (0)');
+
+    await waitForBackendDraft(page, id, draft =>
+      (draft.insights || []).some(
+        insight => insight.props?.value === `?{sum(\${ref(${queryName}).${columnName}})}[0]`
+      )
+    );
+
+    // Toggle the SAME pill's preset SUM -> AVG.
+    await valueSlot.getByTestId('pill-menu-trigger').click();
+    await expect(page.getByTestId('pill-menu')).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('pill-menu-preset-avg').click();
+
+    await expect(valueSlot).toContainText('AVG');
+    await expect(valueSlot).not.toContainText('SUM');
+
+    // The slice survives the aggregate-function rewrite in the persisted
+    // value...
+    await waitForBackendDraft(page, id, draft =>
+      (draft.insights || []).some(
+        insight => insight.props?.value === `?{avg(\${ref(${queryName}).${columnName}})}[0]`
+      )
+    );
+    // ...and SliceBadge still reads correctly afterward — never reset/blanked
+    // by the pill's own label/type change underneath it.
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('First (0)');
+  });
 });

--- a/viewer/e2e/stories/exploration-computed-columns.spec.mjs
+++ b/viewer/e2e/stories/exploration-computed-columns.spec.mjs
@@ -1,0 +1,163 @@
+/**
+ * Story: Computed columns on the exploration surface (P5-D6 ledger gap
+ * closure, e2e-gap-review.md "Final delta pass").
+ *
+ * 05-e2e-ledger.md verdicts `explorer-computed-columns.spec.mjs` (US-5/6/7/8:
+ * add/remove metric AND dimension computed columns via the popover,
+ * invalid-expression validation) PORT — `AddComputedColumnPopover` +
+ * `useExplorerDuckDB` are explicitly "carried forward (restyled, not
+ * rewritten)" per 02-architecture.md §9. That capability has solid UNIT
+ * coverage (`AddComputedColumnPopover.test.jsx`, `useExplorerDuckDB.test.js`,
+ * `DataSectionToolbar.test.jsx`) but zero end-to-end successor anywhere in
+ * the final suite — this file closes that residual gap with a real,
+ * sandbox-backed pass through the actual UI.
+ *
+ * Precondition: sandbox running (integration project) on the standard
+ * :3001/:8001 ports (`bash scripts/sandbox.sh start`).
+ *
+ * Read-only against the exploration's DRAFT DuckDB grid (computed columns
+ * are a client-side, ephemeral concept until promote — 02-architecture.md's
+ * "computed-column promote -> metric/dimension born bound" is a SEPARATE,
+ * already-tested flow in exploration-promote.spec.mjs) — this file asserts
+ * DOM/grid state, matching the unit tests' own treatment of this surface,
+ * not a backend exploration draft shape.
+ *
+ * Runs in playwright.config.mjs's `exploration-mutations` project (serial,
+ * no retries) — mints a real exploration record via the shared
+ * `.visivo/explorations/` repository, same isolation need as every other
+ * exploration-mutating spec.
+ */
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+test.describe('Exploration computed columns (P5-D6 ledger gap closure)', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('US-5/6: adding a metric-shaped (aggregate) computed column shows it as a pill and in the results grid', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, 'SELECT 1 AS a, 2 AS b');
+    await runQuery(page);
+
+    await expect(page.getByTestId('data-section-toolbar')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('add-computed-column-btn').click();
+    await expect(page.getByTestId('add-computed-column-popover')).toBeVisible();
+
+    await page.getByTestId('computed-col-name').fill('total_ab');
+    await page.getByTestId('computed-col-expression').fill('SUM(a + b)');
+
+    // Debounced (750ms) client-side validation.
+    await expect(page.getByTestId('validation-result')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('detected-type-badge')).toHaveText('Metric', { timeout: 5000 });
+
+    await page.getByTestId('add-btn').click();
+
+    await expect(page.getByTestId('computed-pill-total_ab')).toBeVisible({ timeout: 10000 });
+    // The new column must actually appear as data in the results grid, not
+    // just as a toolbar pill — the whole point of a computed column.
+    await expect(page.getByText('total_ab', { exact: false }).first()).toBeVisible();
+  });
+
+  test('US-5/6: adding a dimension-shaped (non-aggregate) computed column detects "Dimension"', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, "SELECT 'x' AS a, 'y' AS b");
+    await runQuery(page);
+
+    await expect(page.getByTestId('data-section-toolbar')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('add-computed-column-btn').click();
+    await page.getByTestId('computed-col-name').fill('combined_label');
+    await page.getByTestId('computed-col-expression').fill('a || b');
+
+    await expect(page.getByTestId('validation-result')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('detected-type-badge')).toHaveText('Dimension', { timeout: 5000 });
+
+    await page.getByTestId('add-btn').click();
+    await expect(page.getByTestId('computed-pill-combined_label')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('US-8: an invalid expression surfaces an inline validation error instead of silently accepting it', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, 'SELECT 1 AS a');
+    await runQuery(page);
+
+    await expect(page.getByTestId('data-section-toolbar')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('add-computed-column-btn').click();
+    await page.getByTestId('computed-col-name').fill('bad_col');
+    // Malformed SQL — unbalanced parens / nonexistent function.
+    await page.getByTestId('computed-col-expression').fill('NOT_A_REAL_FUNCTION(a');
+
+    const result = page.getByTestId('validation-result');
+    await expect(result).toBeVisible({ timeout: 5000 });
+    await expect(result).not.toHaveClass(/text-green-600/);
+    await expect(page.getByTestId('detected-type-badge')).not.toBeVisible();
+  });
+
+  test('US-7: removing a computed column clears its pill', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await typeSql(page, 'SELECT 1 AS a');
+    await runQuery(page);
+
+    await expect(page.getByTestId('data-section-toolbar')).toBeVisible({ timeout: 15000 });
+    await page.getByTestId('add-computed-column-btn').click();
+    await page.getByTestId('computed-col-name').fill('doubled_a');
+    await page.getByTestId('computed-col-expression').fill('a * 2');
+    await expect(page.getByTestId('validation-result')).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('add-btn').click();
+
+    const pill = page.getByTestId('computed-pill-doubled_a');
+    await expect(pill).toBeVisible({ timeout: 10000 });
+
+    await pill.getByTestId('pill-remove').click();
+    await expect(pill).not.toBeVisible();
+  });
+});

--- a/viewer/e2e/stories/exploration-cross-tab-concurrency.spec.mjs
+++ b/viewer/e2e/stories/exploration-cross-tab-concurrency.spec.mjs
@@ -1,0 +1,178 @@
+/**
+ * Story: Same exploration open in two independent browser contexts —
+ * documented last-write-wins is never actually tested end-to-end
+ * (e2e-gap-review.md #19 [MEDIUM · PARTIAL]).
+ *
+ * `ExplorationRepository.update()` (visivo/server/repositories/
+ * exploration_repository.py) is a bare read-mutate-write with no version
+ * check — `07-exploration-api-contract.md` documents this as intentional
+ * last-write-wins ("409 reserved for future optimistic concurrency (not in
+ * v1)"). `exploration-lifecycle.spec.mjs`'s two-tab isolation test only ever
+ * switches between two DIFFERENT exploration ids in ONE browser
+ * context/Zustand singleton — it never opens the SAME exploration id in two
+ * genuinely independent browser contexts (two separate Zustand stores, each
+ * with its own restore + debounce cycle). This story drives that exact
+ * scenario end to end and asserts:
+ *   1. Both contexts independently restore the same base draft.
+ *   2. The later writer's edit wins server-side (last-write-wins, as
+ *      documented).
+ *   3. Neither context's syncStatus ever surfaces as 'error' from this.
+ *   4. The LOSING context isn't left stuck — a reload cleanly picks up the
+ *      winner's SQL, and a further edit from the (reloaded) loser persists
+ *      normally afterward.
+ *
+ * Uses TWO independent `browser.newContext()`s (genuinely separate Zustand
+ * stores, unlike two tabs in one context) per the finding's own
+ * recommendation.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+/** `typeSql` + a verify-and-retry guard (mirrors exploration-lifecycle.spec.mjs's
+ * identical helper) — under concurrent-load contention, typing before the
+ * active model is genuinely bound can silently vanish. */
+async function typeSqlReliably(page, sql) {
+  await typeSql(page, sql);
+  const landed = await page.evaluate(expected => {
+    const s = window.useStore.getState();
+    const name = s.explorerActiveModelName;
+    return !!name && s.explorerModelStates[name]?.sql === expected;
+  }, sql);
+  if (!landed) {
+    await typeSql(page, sql);
+  }
+}
+
+// 30s (not a flat 15s) mirrors exploration-lifecycle.spec.mjs's own
+// documented reasoning: this file runs concurrently with `parallel`'s many
+// workers against the same :8001 Flask dev server, and this specific story
+// opens TWO independent browser contexts at once — real combined-load
+// contention, not just a correctness dependency.
+async function waitForBackendDraftSql(page, id, expectedSql, timeout = 30000) {
+  await expect(async () => {
+    const res = await page.request.get(`${API}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    const sql = data?.draft?.queries?.[0]?.sql;
+    expect(sql).toBe(expectedSql);
+  }).toPass({ timeout });
+}
+
+async function openExploration(page, id) {
+  await page.goto(`${BASE_URL}/workspace/exploration/${id}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  // Mirrors exploration-lifecycle.spec.mjs's `newExploration()` guard: typing
+  // before the legacy explorerStore singleton's restore effect has actually
+  // bound an active model silently no-ops (`setActiveModelSql` no-ops with no
+  // active model) — wait for a real active model first, both on first open
+  // AND after a reload.
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 15000,
+  });
+}
+
+const syncStatus = (page, id) =>
+  page.evaluate(eid => window.useStore.getState().workspaceExplorations?.byId?.[eid]?.syncStatus, id);
+
+// This story drives two manually-created `browser.newContext()`s (genuinely
+// independent Zustand stores — the whole point of the test) rather than the
+// fixture-managed default `page`/`context`. Tracing those ad-hoc contexts
+// alongside the unused default one intermittently hits a Playwright
+// trace-artifact housekeeping error (ENOENT on an internal recording file)
+// in this environment, unrelated to this story's own assertions — same as
+// cross-tab-soft-reload-project-runs.spec.mjs / workspace-cross-tab-tabset.spec.mjs.
+test.use({ trace: 'off', screenshot: 'off' });
+
+test.describe('Same exploration open in two independent browser contexts (#19)', () => {
+  test.setTimeout(90000);
+
+  let explorationId;
+
+  test.beforeEach(async ({ request }) => {
+    const res = await request.post(`${API}/api/explorations/`, {
+      data: {
+        name: 'Cross-tab concurrency test',
+        draft: { queries: [{ name: 'query_1', sql: 'SELECT 0 AS base_marker' }] },
+      },
+    });
+    expect(res.ok(), 'exploration create must succeed before the test body runs').toBe(true);
+    const created = await res.json();
+    explorationId = created.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (explorationId) {
+      await request.delete(`${API}/api/explorations/${explorationId}/`).catch(() => {});
+    }
+  });
+
+  test('last write wins server-side; neither context errors; the losing context recovers cleanly on reload', async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    await openExploration(pageA, explorationId);
+    await openExploration(pageB, explorationId);
+
+    // Both contexts independently restored the SAME base draft.
+    await expect(pageA.locator('.view-lines').first()).toContainText('SELECT 0 AS base_marker', {
+      timeout: 10000,
+    });
+    await expect(pageB.locator('.view-lines').first()).toContainText('SELECT 0 AS base_marker', {
+      timeout: 10000,
+    });
+
+    // Context A edits first...
+    await typeSqlReliably(pageA, 'SELECT 1 AS marker_a');
+    // ...Context B edits shortly after (B is the deterministic last writer —
+    // enough of a gap that A's debounce chain has almost certainly already
+    // fired at least once by the time B's own settles).
+    await pageA.waitForTimeout(400);
+    await typeSqlReliably(pageB, 'SELECT 2 AS marker_b');
+
+    // The backend settles on B's edit — last-write-wins, as documented.
+    await waitForBackendDraftSql(pageB, explorationId, 'SELECT 2 AS marker_b');
+
+    // Give A's own (now-losing) debounced write every chance to also land
+    // before asserting the FINAL state — the backend must still show B's
+    // SQL afterward, not flip back to A's.
+    await pageA.waitForTimeout(2000);
+    await waitForBackendDraftSql(pageA, explorationId, 'SELECT 2 AS marker_b');
+
+    // Neither context's local syncStatus ever surfaced as an outright error
+    // from this race — last-write-wins is a silent overwrite, not a failure.
+    expect(await syncStatus(pageA, explorationId)).not.toBe('error');
+    expect(await syncStatus(pageB, explorationId)).not.toBe('error');
+
+    // The LOSING context (A) isn't left stuck: reloading it cleanly picks up
+    // the winner's SQL — not stale, not crashed, not a not-found state.
+    await pageA.reload();
+    await pageA.waitForLoadState('networkidle');
+    await expect(pageA.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await expect(pageA.getByTestId('workspace-middle-exploration-not-found')).not.toBeVisible();
+    await expect(pageA.locator('.view-lines').first()).toContainText('SELECT 2 AS marker_b', {
+      timeout: 10000,
+    });
+    await pageA.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+      timeout: 10000,
+    });
+
+    // And a further edit from the reloaded loser persists normally
+    // afterward — proving it's genuinely recovered, not permanently wedged.
+    await typeSqlReliably(pageA, 'SELECT 3 AS marker_recovered');
+    await waitForBackendDraftSql(pageA, explorationId, 'SELECT 3 AS marker_recovered');
+    expect(await syncStatus(pageA, explorationId)).not.toBe('error');
+
+    await contextA.close();
+    await contextB.close();
+  });
+});

--- a/viewer/e2e/stories/exploration-cross-tab-dnd-isolation.spec.mjs
+++ b/viewer/e2e/stories/exploration-cross-tab-dnd-isolation.spec.mjs
@@ -1,0 +1,265 @@
+/**
+ * Story: Two-exploration isolation for Phase 3a's DnD-authored ref pills and
+ * multi-query-chip state (e2e-gap-review.md #22 [MEDIUM · PARTIAL]).
+ *
+ * `exploration-lifecycle.spec.mjs`'s "two explorations opened in two tabs
+ * never bleed state into each other" test only ever types plain SQL marker
+ * text into a SINGLE query chip per exploration — no second chip, no DnD, no
+ * insight-prop ref pill. `exploration-dnd-pull-in.spec.mjs`'s ref-pill test
+ * and `exploration-query-chips.spec.mjs`'s multi-chip CRUD tests each operate
+ * within ONE exploration only. This story combines all three patterns:
+ * exploration A gets a SECOND query chip AND a DnD-authored ref pill, then B
+ * is built up independently, then switching back to A proves (through the
+ * BACKEND draft, not just the DOM) that A's full chip set + ref pill survive
+ * byte-for-byte — never merged/overwritten by B's restore or the shared
+ * WorkspaceDndContext's `activeDrag` state.
+ *
+ * Note on auto-generated chip names: `generateUniqueName` scopes uniqueness
+ * to the CURRENT exploration's own working state only (matching the shared
+ * review's own P4-D2 observation) — so A's and B's auto-named chips can
+ * coincidentally share the exact same string (e.g. both mint "model"). Every
+ * assertion here that must be unambiguous across the two explorations goes
+ * through the BACKEND, keyed by each exploration's own distinct id — never a
+ * bare chip-name string, which name collisions would make ambiguous.
+ *
+ * A SEPARATE, orthogonal defect surfaced while writing this test (documented
+ * here, not asserted on, since it's outside #22's own scope — reported
+ * separately): creating a SECOND (or later) exploration in the same page
+ * session mints an extra phantom auto-created query chip (repro: React
+ * StrictMode — confirmed enabled in src/index.jsx — double-invokes
+ * `useExplorerWorkbenchInit.js`'s auto-create-model-tab `useLayoutEffect`,
+ * which has no cleanup function; both invocations see `modelTabs.length===0`
+ * off a stale closure and each call `createModelTab()`, minting two
+ * auto-named tabs instead of one once `explorerSources` is already cached
+ * from an earlier exploration in the same session). This test does NOT
+ * assert an exact chip count for exploration B for exactly that reason —
+ * B's own internal auto-create correctness is a different bug from the
+ * cross-exploration isolation this test targets; asserting a fixed chip
+ * count here would make this test fail on an unrelated pre-existing defect.
+ *
+ * Reuses `dragAndDrop`/`expandSourceTable`/`waitForBackendDraft` verbatim
+ * from `exploration-dnd-pull-in.spec.mjs`, and the `chips()` locator +
+ * `query-chip-add` pattern from `exploration-query-chips.spec.mjs`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+/** Verbatim from exploration-dnd-pull-in.spec.mjs. */
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Verbatim from exploration-query-chips.spec.mjs / exploration-dnd-pull-in.spec.mjs. */
+const chips = page => page.locator('[data-testid^="query-chip-"][data-active]');
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  // Idempotent, unlike the sibling helper this is copied from: this test
+  // calls `expandSourceTable` TWICE in one session (once per exploration),
+  // and the Library rail's row-expansion state is NOT reset between
+  // explorations — a second unconditional click would TOGGLE the row
+  // closed again instead of opening it.
+  if (!(await tableRow.isVisible().catch(() => false))) {
+    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  }
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstColumnNameAndLocator(page, tableRow) {
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  // Idempotent for the same reason as `expandSourceTable` above — the second
+  // call in this test (for exploration B) can find the table already
+  // expanded from A's earlier pass.
+  if (!(await col.isVisible().catch(() => false))) {
+    await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  }
+  await expect(col).toBeVisible({ timeout: 10000 });
+  const name = await col
+    .getAttribute('data-testid')
+    .then(t => t.replace(`library-source-column-${SOURCE}-${TABLE}-`, ''));
+  return { col, name };
+}
+
+/** Verbatim shape from exploration-dnd-pull-in.spec.mjs. */
+async function waitForBackendDraft(page, id, predicate, timeout = 20000) {
+  await expect(async () => {
+    const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(predicate(data.draft)).toBe(true);
+  }).toPass({ timeout });
+}
+
+test.describe('Two-exploration isolation for DnD ref pills + multi-chip state (#22)', () => {
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test("A's two-chip set and DnD-authored ref pill survive a full park (B) and resume, byte-for-byte through the backend", async ({
+    page,
+  }) => {
+    // ---- Build exploration A: 2 chips + a real DnD ref pill on chip 1 ----
+    await gotoExplorerHome(page);
+    const idA = await newExploration(page);
+    const queryA1 = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    await page.getByTestId('query-chip-add').click();
+    await expect(chips(page)).toHaveCount(2);
+    const queryA2 = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    expect(queryA2).not.toBe(queryA1);
+
+    // Switch back to A's FIRST chip so the ref pill binds to queryA1.
+    await page.getByTestId(`query-chip-${queryA1}`).click();
+    await expect(page.getByTestId(`query-chip-${queryA1}`)).toHaveAttribute('data-active', 'true');
+
+    const tableRowA = await expandSourceTable(page);
+    const { col: columnA, name: columnNameA } = await firstColumnNameAndLocator(page, tableRowA);
+    const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+    await expect(xSlot).toBeVisible({ timeout: 15000 });
+    await dragAndDrop(page, columnA, xSlot);
+    await expect(xSlot).toContainText(columnNameA);
+
+    const aHasExpectedDraft = draft => {
+      const chipNames = (draft.queries || []).map(q => q.name);
+      return (
+        chipNames.includes(queryA1) &&
+        chipNames.includes(queryA2) &&
+        (draft.insights || []).some(insight =>
+          Object.values(insight.props || {}).some(
+            v => typeof v === 'string' && v.includes(`ref(${queryA1}).${columnNameA}`)
+          )
+        )
+      );
+    };
+
+    // Confirm A's full state (2 chips + the ref pill on queryA1) actually
+    // persisted server-side before we ever touch exploration B.
+    await waitForBackendDraft(page, idA, aHasExpectedDraft);
+
+    // ---- Park A, build exploration B with its OWN chip + a DIFFERENT DnD
+    // ref pill (bound to B's own active query, on the 'y' prop rather than
+    // 'x' so even a coincidental chip-name collision with A can never make
+    // the two ref pills look alike). B's own chip-count correctness is
+    // deliberately NOT asserted here — see the file docstring's note on the
+    // separate, pre-existing StrictMode-related double-auto-create defect
+    // this test surfaced but is out of scope to fix/assert on. ----
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId('explorer-home-gallery')).toBeVisible();
+    const idB = await newExploration(page);
+    const queryB1 = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+
+    const tableRowB = await expandSourceTable(page);
+    const { col: columnB, name: columnNameB } = await firstColumnNameAndLocator(page, tableRowB);
+    const ySlot = page.locator('[data-testid*="droppable-property-y"]').first();
+    await expect(ySlot).toBeVisible({ timeout: 15000 });
+    await dragAndDrop(page, columnB, ySlot);
+    await expect(ySlot).toContainText(columnNameB);
+
+    const bHasExpectedDraft = draft => {
+      const chipNames = (draft.queries || []).map(q => q.name);
+      return (
+        chipNames.includes(queryB1) &&
+        (draft.insights || []).some(insight =>
+          Object.values(insight.props || {}).some(
+            v => typeof v === 'string' && v.includes(`ref(${queryB1}).${columnNameB}`)
+          )
+        )
+      );
+    };
+    await waitForBackendDraft(page, idB, bHasExpectedDraft);
+
+    // ---- Switch BACK to A via its tab (not Home) — the two-tab isolation
+    // pattern exploration-lifecycle.spec.mjs establishes for plain SQL,
+    // exercised here for chips + a DnD ref pill instead. ----
+    await page.getByTestId(`workspace-tab-select-exploration:${idA}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+
+    // A's OWN two chips are BOTH still present (the actual isolation
+    // guarantee this test targets) — whatever B's own internal chip count
+    // turned out to be is irrelevant to A's own state.
+    await expect(page.getByTestId(`query-chip-${queryA1}`)).toBeVisible();
+    await expect(page.getByTestId(`query-chip-${queryA2}`)).toBeVisible();
+
+    // A's x-slot ref pill is exactly as left — not cleared, not overwritten
+    // by B's y-slot pill, not showing raw ref syntax.
+    await page.getByTestId(`query-chip-${queryA1}`).click();
+    const xSlotAgain = page.locator('[data-testid*="droppable-property-x"]').first();
+    await expect(xSlotAgain).toContainText(columnNameA);
+    await expect(xSlotAgain).not.toContainText('?{');
+
+    // Final, authoritative check: BOTH explorations' backend drafts are
+    // exactly as each was left — neither merged into nor overwritten by the
+    // other, despite sharing one WorkspaceDndContext and one legacy
+    // explorerStore singleton across the park/resume cycle.
+    await waitForBackendDraft(page, idA, aHasExpectedDraft);
+    await waitForBackendDraft(page, idB, bHasExpectedDraft);
+  });
+});

--- a/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
+++ b/viewer/e2e/stories/exploration-dnd-pull-in.spec.mjs
@@ -267,4 +267,57 @@ test.describe('Exploration DnD pull-in (Explore 2.0 Phase 3a — D9)', () => {
       )
     );
   });
+
+  // e2e-gap-review.md #27 [LOW·PARTIAL]: a query chip created via Library
+  // drag-and-drop, then immediately renamed before its own draft-sync
+  // round-trip lands, is never proven to serialize correctly under the
+  // RENAMED name. Chains the DnD-seeded chip creation directly into an
+  // immediate rename — faster than the ~1.6s live-sync + backend-POST
+  // window this file's other tests deliberately wait out — and verifies the
+  // FINAL persisted draft through the backend, not just the DOM.
+  test('a chip created via Library DnD, renamed before its own draft-sync settles, persists under the RENAMED name with its DnD-derived SQL intact', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const existingChips = await chips(page).count();
+
+    const tableRow = await expandSourceTable(page);
+    const dropZone = page.getByTestId('sql-editor-drop-zone');
+    await dragAndDrop(page, tableRow, dropZone);
+
+    await expect(chips(page)).toHaveCount(existingChips + 1, { timeout: 10000 });
+    const seededName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+    await expect(page.locator('.view-lines').first()).toContainText(`SELECT * FROM ${TABLE}`, {
+      timeout: 10000,
+    });
+
+    // Rename IMMEDIATELY — no wait for the dirty dot, no backend poll first —
+    // before the DnD-seeded chip's own draft-sync round trip has any chance
+    // to settle.
+    await page.getByTestId(`query-chip-${seededName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${seededName}-rename-action`).click();
+    const input = page.getByTestId(`query-chip-${seededName}-rename-input`);
+    await input.fill('orders_from_dnd');
+    await input.press('Enter');
+
+    await expect(page.getByTestId('query-chip-orders_from_dnd')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId(`query-chip-${seededName}`)).not.toBeVisible();
+
+    // The FINAL persisted draft reflects the RENAMED chip, carrying the
+    // DnD-derived SQL — not a race between the DnD-creation's own draft-sync
+    // and the rename's effect on the same `explorerModelTabs` slice.
+    await waitForBackendDraft(page, id, draft =>
+      (draft.queries || []).some(
+        q => q.name === 'orders_from_dnd' && (q.sql || '').includes(`SELECT * FROM ${TABLE}`)
+      )
+    );
+    await waitForBackendDraft(
+      page,
+      id,
+      draft => !(draft.queries || []).some(q => q.name === seededName)
+    );
+  });
 });

--- a/viewer/e2e/stories/exploration-duplicate.spec.mjs
+++ b/viewer/e2e/stories/exploration-duplicate.spec.mjs
@@ -1,0 +1,269 @@
+/**
+ * Story: Exploration Duplicate — happy path + reload-race (e2e-gap-review.md
+ * #18 [MEDIUM·PARTIAL]).
+ *
+ * Distinct from `exploration-duplicate-race.spec.mjs`, which only covers
+ * RAPID-DOUBLE-CLICK races on the Duplicate button (VIS-1086's in-flight
+ * guard) — this file covers content-fidelity (does the duplicate actually
+ * carry the source's LATEST edit, byte for byte, not a stale pre-debounce
+ * draft?) and the RELOAD-TIMING race `handleDuplicate`'s own two-step
+ * sequence sits on:
+ *
+ *   `ExplorationPane.jsx`'s `handleDuplicate` is `await flushExplorationSync(id)`
+ *   THEN `await duplicateExploration(id)` THEN `openWorkspaceTab(...)`. Every
+ *   write goes through a plain `fetch()` (`viewer/src/api/utils.js`) with no
+ *   `keepalive: true` and no `beforeunload` guard anywhere in `viewer/src/` —
+ *   a hard reload in the narrow window between either leg's request being
+ *   SENT and its response LANDING can abort that specific request before it
+ *   completes.
+ *
+ * Two reload-race variants below drive both halves of that window
+ * deterministically via `page.route()` (which pauses a request BEFORE it is
+ * ever dispatched to the real network/server — releasing the gate is what
+ * lets it actually go out): reload while LEG 1 (the pre-duplicate flush) is
+ * held, and reload while LEG 2 (the duplicate's own create) is held. Both
+ * document CURRENT behavior (regression-armor, not a bug fix — see the
+ * conversation's task list, which scopes #18 to coverage only): a request
+ * held by `page.route()` and then torn down by a reload never reaches the
+ * real backend, so neither variant can ever mint an orphaned duplicate —
+ * the only question each answers is "what happens to the exploration that
+ * was already open."
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=explorationDuplicate VISIVO_SANDBOX_BACKEND_PORT=8056 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3056 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3056 npx playwright test exploration-duplicate
+ *
+ * Mints real backend exploration records — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** `typeSql` + a verify-and-retry guard (mirrors exploration-lifecycle.spec.mjs's
+ * `typeSqlReliably` verbatim — same cold-load "auto-create model tab" race). */
+async function typeSqlReliably(page, sql) {
+  await typeSql(page, sql);
+  const landed = await page.evaluate(expected => {
+    const s = window.useStore.getState();
+    const name = s.explorerActiveModelName;
+    return !!name && s.explorerModelStates[name]?.sql === expected;
+  }, sql);
+  if (!landed) {
+    await typeSql(page, sql);
+  }
+}
+
+/** Poll the BACKEND record until its persisted draft's first query's `sql`
+ * matches (mirrors exploration-lifecycle.spec.mjs's `waitForBackendDraftSql`). */
+async function waitForBackendDraftSql(page, id, expectedSql, timeout = 15000) {
+  await expect(async () => {
+    const res = await page.request.get(`${API}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(data?.draft?.queries?.[0]?.sql).toBe(expectedSql);
+  }).toPass({ timeout });
+}
+
+/**
+ * Wait for this exploration's SLICE-LEVEL `draft` (workspaceExplorationsStore.js,
+ * NOT the legacy explorerStore.js working copy) to actually contain
+ * `expectedSql`. This is NOT a cosmetic wait: `ExplorationPane`'s own 600ms
+ * "live sync" effect is what calls `updateExplorationDraft` — the thing that
+ * both updates this exploration's SLICE-level `draft` and arms the ~1s
+ * backend-POST debounce `flushExplorationSync` flushes. Clicking Duplicate
+ * with truly ZERO delay after typing races AHEAD of that first 600ms stage:
+ * `duplicateExploration` would then read a STALE slice-level draft (the
+ * edit never reached the slice at all yet) and `flushExplorationSync` would
+ * be a pure no-op (no timer armed to flush).
+ *
+ * Deliberately polls the DRAFT CONTENT itself, not `syncStatus === 'saving'`
+ * — `syncStatus` flips to 'saving' on EVERY live-sync tick, including an
+ * earlier, unrelated one from the exploration's own cold-start auto-create
+ * (empty SQL) that can still be settling when this test's typing lands;
+ * waiting on the status string alone can catch that earlier cycle instead of
+ * the one this edit actually armed. The draft's own content is the precise,
+ * unambiguous signal that THIS edit has reached the slice.
+ */
+async function waitForSliceDraftSql(page, id, expectedSql, timeout = 10000) {
+  await page.waitForFunction(
+    ({ id, expectedSql }) =>
+      window.useStore.getState().workspaceExplorations.byId[id]?.draft?.queries?.[0]?.sql ===
+      expectedSql,
+    { id, expectedSql },
+    { timeout }
+  );
+}
+
+test.describe('Exploration Duplicate — happy path + reload race (e2e-gap-review.md #18)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unroute('**/api/explorations/').catch(() => {});
+    await page.unroute('**/api/explorations/**').catch(() => {});
+    const idsAfterTest = await listExplorationIds(page);
+    const createdIds = idsAfterTest.filter(id => !idsBeforeTest.includes(id));
+    for (const id of createdIds) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test("duplicate flushes the latest edit and opens the new exploration's tab, with byte-identical content (zero-timing-tricks happy path)", async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const idA = await newExploration(page);
+
+    // Type, then click Duplicate as soon as the edit has genuinely reached
+    // the slice — NOT a flat wait for the backend POST to settle (that's
+    // what `handleDuplicate`'s own flush exists to short-circuit). See
+    // `waitForSliceDraftSql`'s docstring for why zero delay would race ahead
+    // of the mechanism this test is actually about.
+    await typeSqlReliably(page, 'SELECT 999 AS pane_dup_marker');
+    await waitForSliceDraftSql(page, idA, 'SELECT 999 AS pane_dup_marker');
+    await expect(page.getByTestId('exploration-duplicate-button')).toBeEnabled();
+    await page.getByTestId('exploration-duplicate-button').click();
+
+    // A new tab opens for a DIFFERENT exploration id.
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 15000 })
+      .not.toBe(`/workspace/exploration/${idA}`);
+    const idB = new URL(page.url()).pathname.split('/').pop();
+    expect(idB).not.toBe(idA);
+    expect(idB).toMatch(/^exp_/);
+
+    // The pre-duplicate flush landed — the SOURCE reflects the latest edit.
+    await waitForBackendDraftSql(page, idA, 'SELECT 999 AS pane_dup_marker');
+    // The duplicate seeded from that same up-to-date draft, not a stale
+    // pre-debounce one — byte-identical content.
+    await waitForBackendDraftSql(page, idB, 'SELECT 999 AS pane_dup_marker');
+  });
+
+  test('reloading right as the pre-duplicate flush is sent (before its response lands) never orphans a duplicate', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 1 AS reload_leg1_marker');
+    await waitForSliceDraftSql(page, id, 'SELECT 1 AS reload_leg1_marker');
+
+    let notifyIntercepted;
+    const intercepted = new Promise(resolve => {
+      notifyIntercepted = resolve;
+    });
+    // Hold LEG 1 (the pre-duplicate flush, POST /api/explorations/<id>/)
+    // before it ever reaches the real network — never call route.continue(),
+    // so this specific write can never land server-side.
+    await page.route(`**/api/explorations/${id}/`, async route => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      notifyIntercepted();
+      // Deliberately never continue — the impending reload tears this down.
+    });
+
+    const before = await listExplorationIds(page);
+    await page.getByTestId('exploration-duplicate-button').click();
+    await intercepted;
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.unroute(`**/api/explorations/${id}/`).catch(() => {});
+
+    // The held flush request never reached the real backend, so this
+    // specific edit is lost — the CURRENT, documented behavior (this test is
+    // coverage/regression-armor, not a fix; see the file docstring). Nothing
+    // is corrupted: the app reloads cleanly onto the source exploration with
+    // its last successfully-flushed content, never a crash or a stuck state.
+    // Polled (not a one-shot check) — settling right after a hard reload can
+    // take a beat under load, same reasoning as `waitForBackendDraftSql`.
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await expect(async () => {
+      const res = await page.request.get(`${API}/api/explorations/${id}/`);
+      expect(res.ok()).toBe(true);
+      const data = await res.json();
+      expect(data?.draft?.queries?.[0]?.sql || '').not.toContain('reload_leg1_marker');
+    }).toPass({ timeout: 10000 });
+
+    // `duplicateExploration` is never reached (the chain never got past its
+    // first await) — no orphaned duplicate record exists.
+    const after = await listExplorationIds(page);
+    expect(after.filter(x => !before.includes(x))).toHaveLength(0);
+  });
+
+  test('reloading right as the duplicate create request is sent (after the flush already landed) leaves the source flushed and never orphans a duplicate', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 1 AS reload_leg2_marker');
+    await waitForSliceDraftSql(page, id, 'SELECT 1 AS reload_leg2_marker');
+
+    let notifyIntercepted;
+    const intercepted = new Promise(resolve => {
+      notifyIntercepted = resolve;
+    });
+    // Hold LEG 2 (the duplicate's own create, POST /api/explorations/) —
+    // LEG 1's own update endpoint (/api/explorations/<id>/) is a DIFFERENT
+    // URL and is left completely unintercepted, so it completes normally
+    // before this route ever fires.
+    await page.route('**/api/explorations/', async route => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      notifyIntercepted();
+      // Deliberately never continue.
+    });
+
+    const before = await listExplorationIds(page);
+    await page.getByTestId('exploration-duplicate-button').click();
+    await intercepted;
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.unroute('**/api/explorations/').catch(() => {});
+
+    // LEG 1 (the flush) was never intercepted, so it already completed by
+    // the time LEG 2's create request was even issued — the source's edit
+    // landed regardless of the reload.
+    await waitForBackendDraftSql(page, id, 'SELECT 1 AS reload_leg2_marker');
+
+    // The duplicate's create request never reached the real backend (held,
+    // then torn down by the reload) — no orphan record was minted.
+    const after = await listExplorationIds(page);
+    expect(after.filter(x => !before.includes(x))).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/stories/exploration-lifecycle.spec.mjs
+++ b/viewer/e2e/stories/exploration-lifecycle.spec.mjs
@@ -67,6 +67,11 @@ async function typeSqlReliably(page, sql) {
   }
 }
 
+// Playwright runs on the same host as the browser, so process.platform picks
+// the right modifier for the page's navigator-based detection (mirrors
+// workspace-tabs-shortcuts.spec.mjs's own MOD constant).
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
 const BASE_URL =
   process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
 // Explorations are S3'd to a single file-backed repository shared by every
@@ -302,5 +307,212 @@ test.describe('Exploration lifecycle (Explore 2.0 Phase 2)', () => {
       timeout: 15000,
     });
     await expect(page.getByText(/doesn't exist/i)).toBeVisible();
+  });
+
+  // e2e-gap-review.md #3 [HIGH·PARTIAL]: the existing lossless-park test above
+  // deliberately waits for the dirty dot to CLEAR before closing (its own
+  // comment: "the contract is only that sync has SETTLED before we close") —
+  // it never drives a close while the REAL syncStatus pipeline (not a
+  // manually-flipped flag) is genuinely mid-debounce. `requestCloseWorkspaceTab`
+  // (workspaceStore.js) has exactly one behavior for a dirty tab: it ALWAYS
+  // raises TabCloseConfirmDialog — there is no "close directly while dirty"
+  // door in the UI, so driving a real close through this exact interruption
+  // means going through "Close without saving", which (VIS-1081,
+  // `discardExploration`) deliberately reverts to the pre-session snapshot
+  // BEFORE `ExplorationPane`'s own unmount-cleanup flush re-persists whatever
+  // the (now-reverted) legacy store holds. This test proves that interaction
+  // is safe even when the debounce is a REAL, in-flight one (not a
+  // synthetic/settled one): the discard-revert wins cleanly, the in-flight
+  // autosave never races back in to resurrect the discarded edit, and the tab
+  // reactivates cleanly afterward with no stuck 'saving'/'error' state.
+  test('closing a tab mid-debounce (real syncStatus, via the confirm dialog\'s "Close without saving") reverts cleanly and never resurrects the discarded edit', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+
+    await typeSqlReliably(page, 'SELECT 1 AS marker_v1');
+    // Poll the REAL store (not a manual flag) until the debounce has
+    // genuinely armed — `syncStatus` only flips to 'saving' once
+    // ExplorationPane's 600ms live-sync timer has ALREADY fired and called
+    // `updateExplorationDraft`, so catching it here guarantees a real
+    // backend POST is either in flight or about to be scheduled.
+    await page.waitForFunction(
+      id => window.useStore.getState().workspaceExplorations.byId[id]?.syncStatus === 'saving',
+      id,
+      { timeout: 5000 }
+    );
+
+    const closeBtn = page.getByTestId(`workspace-tab-close-exploration:${id}`);
+    await closeBtn.hover();
+    await closeBtn.click();
+
+    // Genuinely dirty at click time -> the confirm dialog, not a direct close.
+    const dialog = page.getByTestId('tab-close-confirm-dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('tab-close-confirm-close').click();
+
+    await expect(dialog).not.toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
+    await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible();
+
+    // The discard reverted to the pre-session (empty SQL) snapshot — the
+    // in-flight autosave's own stale write must never race back in and
+    // resurrect 'marker_v1' server-side.
+    await expect(async () => {
+      const res = await page.request.get(`${API}/api/explorations/${id}/`);
+      expect(res.ok()).toBe(true);
+      const data = await res.json();
+      expect(data?.draft?.queries?.[0]?.sql || '').not.toContain('marker_v1');
+    }).toPass({ timeout: 10000 });
+
+    // Reopening reactivates cleanly — no stuck syncStatus, no crash, no
+    // duplicate tab.
+    await expect(async () => {
+      const card = page.getByTestId(`exploration-card-${id}-open`);
+      if (await card.isVisible()) await card.click();
+      await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 4000 });
+    }).toPass({ timeout: 30000 });
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toHaveCount(1);
+    const syncStatus = await page.evaluate(
+      id => window.useStore.getState().workspaceExplorations.byId[id]?.syncStatus,
+      id
+    );
+    expect(syncStatus).not.toBe('error');
+  });
+
+  // e2e-gap-review.md #17 [MEDIUM·PARTIAL]: `activateWorkspaceView`
+  // (workspaceStore.js) unconditionally nulls `workspaceActiveTabId` on every
+  // view click — including re-clicking a document tab's OWN destination —
+  // parking it (still open, just unfocused) rather than closing it. Clicking
+  // back into Explorer's OWN view lands on ExplorerHomePane's gallery, never
+  // back on the parked tab directly; the only way back to the tab itself is
+  // its own Home card's "Open" action. This exercises exactly that path,
+  // deliberately WITHOUT waiting for the dirty dot to clear first (the gap
+  // the other two lifecycle tests in this file don't hit) — a real edit is
+  // still plausibly in flight when the reopen happens.
+  test("park via view-switch (not close), then reopen from Home's own card — reactivates the SAME tab, no duplicate, edit survives", async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 999 AS reopen_marker');
+
+    // Park via a VIEW SWITCH, not a close — no dirty-confirm dialog gates
+    // this path at all (activateWorkspaceView doesn't check `dirty`).
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible({ timeout: 15000 });
+    // Still open, just unfocused.
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+
+    // Re-clicking Explorer's OWN view lands on the gallery, not the tab.
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId('explorer-home-gallery')).toBeVisible({ timeout: 15000 });
+
+    // Reopen from the exploration's OWN Home card while it's still parked
+    // (and plausibly still mid-debounce) elsewhere in the strip.
+    await expect(async () => {
+      const card = page.getByTestId(`exploration-card-${id}-open`);
+      if (await card.isVisible()) await card.click();
+      await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 4000 });
+    }).toPass({ timeout: 30000 });
+
+    // The SAME tab reactivated — no duplicate tab was minted for it.
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toHaveCount(1);
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    // The restore-on-activate effect never clobbered the in-flight edit.
+    await expect(page.locator('.view-lines').first()).toContainText('SELECT 999 AS reopen_marker', {
+      timeout: 10000,
+    });
+    await waitForBackendDraftSql(page, id, 'SELECT 999 AS reopen_marker');
+  });
+
+  // e2e-gap-review.md #21 [MEDIUM·PARTIAL]: reloading at a BARE view URL
+  // (e.g. /workspace/semantic-layer) while a document tab sits parked behind
+  // it in restored localStorage is never exercised — view-switcher.spec.mjs's
+  // own bare-URL-reload test opens zero tabs first, and this file's other
+  // reload test always reloads with the exploration tab itself ACTIVE. This
+  // drives the three-way race directly: the parked view must render from the
+  // URL (not resurrect onto the parked tab), and the parked tab must survive
+  // the reload with its content intact.
+  test('reload at a bare view URL restores that view (not the parked tab), and the parked exploration tab survives with its content intact', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 99 AS parked_marker');
+    const dirtyDot = page.getByTestId(`workspace-tab-dirty-exploration:${id}`);
+    await expect(dirtyDot).not.toBeVisible({ timeout: 10000 });
+    await waitForBackendDraftSql(page, id, 'SELECT 99 AS parked_marker');
+
+    // Park behind Semantic Layer (not Project — the reviewer's own example).
+    await page.getByTestId('workspace-view-switcher-semantic-layer').click();
+    await expect(page.getByTestId('workspace-middle-semantic-layer')).toBeVisible({
+      timeout: 15000,
+    });
+    expect(new URL(page.url()).pathname).toBe('/workspace/semantic-layer');
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+
+    // Hard-reload AT this exact bare view URL.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // The correct view renders straight from the URL — never resurrected
+    // onto the parked document tab.
+    await expect(page.getByTestId('workspace-middle-semantic-layer')).toBeVisible({
+      timeout: 30000,
+    });
+    expect(new URL(page.url()).pathname).toBe('/workspace/semantic-layer');
+    await expect(page.getByTestId('workspace-view-switcher-semantic-layer')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // The parked tab survived the reload (restored from localStorage) with
+    // its persisted content intact.
+    const parkedTab = page.getByTestId(`workspace-tab-exploration:${id}`);
+    await expect(parkedTab).toBeVisible({ timeout: 10000 });
+    await page.getByTestId(`workspace-tab-select-exploration:${id}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.view-lines').first()).toContainText('SELECT 99 AS parked_marker', {
+      timeout: 10000,
+    });
+  });
+
+  // e2e-gap-review.md #29 [LOW·PARTIAL]: only the mouse-× path has ever been
+  // proven safe for a real exploration tab's lossless park/reopen guarantee —
+  // Cmd/Ctrl+W (`useWorkspaceTabShortcuts.js`) routes through the exact same
+  // `requestCloseWorkspaceTab` primitive, but no test ever drives the
+  // keyboard shortcut against a real, backend-synced exploration.
+  test(`${MOD}+W closes an exploration tab and reopening it is lossless, same as the mouse ×`, async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 999 AS kbd_marker');
+
+    const dirtyDot = page.getByTestId(`workspace-tab-dirty-exploration:${id}`);
+    await expect(dirtyDot).not.toBeVisible({ timeout: 10000 });
+    await waitForBackendDraftSql(page, id, 'SELECT 999 AS kbd_marker');
+
+    // Move focus OFF the Monaco editor first — `handleTabShortcut` suppresses
+    // every shortcut while an editable target has focus.
+    await page.getByTestId('workspace-tab-strip').click();
+    await page.keyboard.press(`${MOD}+w`);
+
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).not.toBeVisible();
+    await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible();
+
+    await expect(async () => {
+      const card = page.getByTestId(`exploration-card-${id}-open`);
+      if (await card.isVisible()) await card.click();
+      await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 4000 });
+    }).toPass({ timeout: 30000 });
+    await expect(page.locator('.view-lines').first()).toContainText('SELECT 999 AS kbd_marker', {
+      timeout: 10000,
+    });
   });
 });

--- a/viewer/e2e/stories/exploration-query-chips.spec.mjs
+++ b/viewer/e2e/stories/exploration-query-chips.spec.mjs
@@ -55,6 +55,20 @@ async function newExploration(page) {
  */
 const chips = page => page.locator('[data-testid^="query-chip-"][data-active]');
 
+/** Poll the BACKEND record (mirrors exploration-lifecycle.spec.mjs's
+ * `waitForBackendDraftSql` / exploration-dnd-pull-in.spec.mjs's
+ * `waitForBackendDraft`) until `predicate(draft)` is true — a hard reload or
+ * promote only ever sees what's actually persisted, never the optimistic
+ * client-side store. */
+async function waitForBackendDraft(page, id, predicate, timeout = 15000) {
+  await expect(async () => {
+    const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    expect(predicate(data.draft)).toBe(true);
+  }).toPass({ timeout });
+}
+
 test.describe('Exploration query chips (Explore 2.0 Phase 3a)', () => {
   let idsBeforeTest = [];
 
@@ -195,5 +209,116 @@ test.describe('Exploration query chips (Explore 2.0 Phase 3a)', () => {
     await page.getByTestId(`query-chip-${onlyName}-menu-trigger`).click();
     await expect(page.getByTestId(`query-chip-${onlyName}-delete-action`)).not.toBeVisible();
     await expect(page.getByTestId(`query-chip-${onlyName}-rename-action`)).toBeVisible();
+  });
+
+  // e2e-gap-review.md #26 [LOW·PARTIAL]: a focus-stealing interruption
+  // mid-rename (starting a drag, clicking a different chip, a
+  // destination-switch shortcut) fires the shared InlineRenameInput's native
+  // `onBlur` handler, which cannot distinguish "the user clicked the
+  // checkmark" from "an unrelated gesture stole focus" — it commits whatever
+  // partial text is present. This is CONFIRMED-INTENTIONAL design
+  // (InlineRenameInput.test.jsx's "blur commits (matching Enter behavior)"
+  // locks this in, mirroring Finder/Sheets-style rename UX) — this test is
+  // documentation/regression-armor for that behavior on the query-chip
+  // surface specifically, not a bug fix.
+  test('an unrelated gesture (clicking a different chip) mid-rename commits the half-typed name — an interruption, not a confirmation', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const originalName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+
+    // A sibling chip to click as the interrupting gesture.
+    await page.getByTestId('query-chip-add').click();
+    const secondName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+
+    // Re-activate the first chip and open its rename UI.
+    await page.getByTestId(`query-chip-${originalName}`).click();
+    await page.getByTestId(`query-chip-${originalName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${originalName}-rename-action`).click();
+    const input = page.getByTestId(`query-chip-${originalName}-rename-input`);
+    // Deliberately partial/incomplete — never Enter, never the ✓/✕ buttons.
+    await input.fill('anal');
+
+    // The interruption: click the SIBLING chip mid-rename. Clicking any
+    // OTHER element steals focus via a native blur first — the same class of
+    // gesture as starting a drag or a destination-switch shortcut, neither
+    // of which InlineRenameInput's onBlur can distinguish from an
+    // intentional commit.
+    await page.getByTestId(`query-chip-${secondName}`).click();
+
+    // Blur committed the partial text — the chip is renamed, not reverted
+    // and not left stuck in edit mode.
+    await expect(page.getByTestId('query-chip-anal')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId(`query-chip-${originalName}`)).not.toBeVisible();
+
+    await waitForBackendDraft(page, id, draft => (draft.queries || []).some(q => q.name === 'anal'));
+  });
+
+  // e2e-gap-review.md #4 [HIGH·PARTIAL]: a query-chip delete-with-confirm
+  // dialog held open across a live-sync debounce tick is never raced against
+  // the debounce it sits on top of — does a stale PRE-delete draft-sync
+  // write (which genuinely completes server-side WHILE the confirm dialog
+  // sits open) get silently resurrected once the delete's own (later) write
+  // lands? VIS-1085's write-queue (`enqueueWrite`) serializes every write for
+  // a given exploration id in ENQUEUE order, so the delete's own write —
+  // enqueued strictly after the pre-delete tick's — should always be the one
+  // that survives; this drives that exact race end-to-end and verifies it
+  // through the backend, not just the DOM.
+  test('deleting a referenced query while a stale pre-delete live-sync write has already landed does not resurrect it server-side', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const queryName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+
+    // Establish a real referrer, exactly as the delete-with-dependents test
+    // above does.
+    await page.evaluate(name => {
+      const s = window.useStore.getState();
+      const insightName = s.explorerActiveInsightName;
+      if (insightName) s.setInsightProp(insightName, 'x', `?{\${ref(${name}).x}}`);
+    }, queryName);
+
+    // Creating the second chip arms the live-sync debounce for the
+    // PRE-delete (2-chip) draft.
+    await page.getByTestId('query-chip-add').click();
+    const secondName = await page.evaluate(
+      () => window.useStore.getState().explorerActiveModelName
+    );
+
+    // Re-activate the referenced chip and open its delete-confirm dialog
+    // WITHOUT waiting for the pre-delete tick to settle first — the dialog
+    // sits open across the debounce boundary.
+    await page.getByTestId(`query-chip-${queryName}`).click();
+    await page.getByTestId(`query-chip-${queryName}-menu-trigger`).click();
+    await page.getByTestId(`query-chip-${queryName}-delete-action`).click();
+    const confirmDialog = page.getByTestId(`query-chip-${queryName}-delete-confirm`);
+    await expect(confirmDialog).toBeVisible({ timeout: 5000 });
+
+    // Leave the dialog open long enough (well past the ~1.6s live-sync +
+    // backend-POST window: 600ms compute debounce + 1000ms backend
+    // debounce) for the PRE-delete (2-chip) draft to genuinely reach the
+    // backend WHILE the dialog still sits open.
+    await waitForBackendDraft(page, id, draft => (draft.queries || []).length === 2, 10000);
+    await expect(confirmDialog).toBeVisible();
+
+    // Now confirm the delete.
+    await page.getByTestId(`query-chip-${queryName}-delete-confirm-confirm`).click();
+    await expect(page.getByTestId(`query-chip-${queryName}`)).not.toBeVisible();
+
+    // The delete's own (later-enqueued) write must win — the backend must
+    // settle on the POST-delete (1-chip) state, never resurrecting the
+    // deleted chip via the stale pre-delete write racing back in.
+    await waitForBackendDraft(page, id, draft => {
+      const names = (draft.queries || []).map(q => q.name);
+      return names.length === 1 && names[0] === secondName;
+    }, 15000);
   });
 });

--- a/viewer/e2e/stories/explorer-home.spec.mjs
+++ b/viewer/e2e/stories/explorer-home.spec.mjs
@@ -238,4 +238,74 @@ test.describe('Explorer Home gallery (Explore 2.0 Phase 2)', () => {
     await expect(page.getByTestId(tabTestId)).not.toBeVisible();
     await expect(page.getByText(/was deleted/i)).toBeVisible({ timeout: 5000 });
   });
+
+  // e2e-gap-review.md #23 [MEDIUM · PARTIAL]: the test above only ever has
+  // ONE exploration in play — this proves a SIBLING parked exploration
+  // survives untouched (tab strip presence, backend-persisted draft, and
+  // clean re-openability) when a DIFFERENT parked exploration is deleted
+  // from Home.
+  test("deleting one parked exploration from Home leaves a SIBLING parked exploration's tab and persisted draft untouched, and its own slot un-reactivatable", async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+
+    // Exploration A: create, park it (switch to Project without closing).
+    await page.getByTestId('explorer-home-new-exploration').click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const explorationIdA = new URL(page.url()).pathname.split('/').pop();
+    const tabTestIdA = `workspace-tab-exploration:${explorationIdA}`;
+    await expect(page.getByTestId(tabTestIdA)).toBeVisible();
+
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await expect(page.getByTestId(tabTestIdA)).toHaveAttribute('data-active', 'false');
+
+    // Exploration B: a SIBLING, created and parked the same way, so BOTH
+    // sit parked in the strip simultaneously.
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId('explorer-home-gallery')).toBeVisible();
+    await page.getByTestId('explorer-home-new-exploration').click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const explorationIdB = new URL(page.url()).pathname.split('/').pop();
+    const tabTestIdB = `workspace-tab-exploration:${explorationIdB}`;
+    await expect(page.getByTestId(tabTestIdB)).toBeVisible();
+
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await expect(page.getByTestId(tabTestIdA)).toBeVisible();
+    await expect(page.getByTestId(tabTestIdA)).toHaveAttribute('data-active', 'false');
+    await expect(page.getByTestId(tabTestIdB)).toBeVisible();
+    await expect(page.getByTestId(tabTestIdB)).toHaveAttribute('data-active', 'false');
+
+    // Delete A from Home while BOTH A and B sit parked in the strip.
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await page.getByTestId(`exploration-card-${explorationIdA}-menu`).click();
+    await page.getByTestId(`exploration-card-${explorationIdA}-delete-action`).click();
+    await page.getByTestId('exploration-delete-confirm-confirm').click();
+
+    // A's parked tab is force-closed with a toast, as the single-exploration
+    // test above already proves...
+    await expect(page.getByTestId(tabTestIdA)).not.toBeVisible();
+    await expect(page.getByText(/was deleted/i)).toBeVisible({ timeout: 5000 });
+
+    // ...but B's SIBLING parked tab is completely undisturbed — still
+    // present in the strip, unfocused (deleting A never re-fires B's
+    // restore or activates it).
+    await expect(page.getByTestId(tabTestIdB)).toBeVisible();
+    await expect(page.getByTestId(tabTestIdB)).toHaveAttribute('data-active', 'false');
+
+    // B's backend record survived untouched.
+    const backendCheckB = await page.request.get(`${API}/api/explorations/${explorationIdB}/`);
+    expect(backendCheckB.ok()).toBe(true);
+
+    // A's record is genuinely gone — its slot cannot be reactivated (no
+    // stray tab, no card) — while B still opens cleanly from its own tab.
+    const backendCheckA = await page.request.get(`${API}/api/explorations/${explorationIdA}/`);
+    expect(backendCheckA.status()).toBe(404);
+    await expect(page.getByTestId(`exploration-card-${explorationIdA}-name`)).not.toBeVisible();
+
+    await page.getByTestId(`workspace-tab-select-exploration:${explorationIdB}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId(tabTestIdB)).toHaveAttribute('data-active', 'true');
+  });
 });

--- a/viewer/e2e/stories/pill-aggregation.spec.mjs
+++ b/viewer/e2e/stories/pill-aggregation.spec.mjs
@@ -269,6 +269,56 @@ test.describe('Pill aggregation grammar (Explore 2.0 Phase 3b — D10)', () => {
     );
   });
 
+  // e2e-gap-review.md D11 [LOW, Phase 3b delta]: the opaque-expression
+  // "never silently rewritten" guarantee is only proven above via a
+  // same-exploration RELOAD — the Duplicate code path (a completely
+  // different server-side/client-side construction of the new record's
+  // draft) is never exercised. Extends the same fixture with a
+  // Duplicate-instead-of-reload variant, backend-asserted on the NEW
+  // exploration's own copy of the prop.
+  test('an opaque custom expression survives Duplicate byte-for-byte (not just a same-exploration reload)', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const raw = `count(distinct \${ref(${queryName}).x}) / count(*)`;
+
+    const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+    await expect(xSlot).toBeVisible({ timeout: 15000 });
+    await xSlot.getByRole('button', { name: 'query string' }).click();
+    const editable = xSlot.locator('[data-testid="ref-textarea-editable"]');
+    await editable.click();
+    await page.keyboard.type(raw, { delay: 5 });
+    await editable.blur();
+
+    await expect(xSlot.getByTestId('pill-menu-trigger')).not.toBeVisible();
+    await waitForBackendDraft(page, id, draft =>
+      (draft.insights || []).some(insight => insight.props?.x === `?{${raw}}`)
+    );
+
+    // Duplicate — not reload.
+    await expect(page.getByTestId('exploration-duplicate-button')).toBeEnabled();
+    await page.getByTestId('exploration-duplicate-button').click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 15000 })
+      .not.toBe(`/workspace/exploration/${id}`);
+    const duplicateId = new URL(page.url()).pathname.split('/').pop();
+    expect(duplicateId).not.toBe(id);
+
+    // The duplicate's OWN copy of the prop is byte-identical — never
+    // re-normalized, re-parsed, or rewritten by whatever constructs the
+    // duplicate's draft.
+    await waitForBackendDraft(page, duplicateId, draft =>
+      (draft.insights || []).some(insight => insight.props?.x === `?{${raw}}`)
+    );
+    // The source exploration's own copy is untouched by the duplication.
+    await waitForBackendDraft(page, id, draft =>
+      (draft.insights || []).some(insight => insight.props?.x === `?{${raw}}`)
+    );
+  });
+
   test('no raw ?{ or ${ syntax ever appears in the rendered Build rail, even after several drops', async ({
     page,
   }) => {

--- a/viewer/e2e/stories/workspace-back-forward-exploration.spec.mjs
+++ b/viewer/e2e/stories/workspace-back-forward-exploration.spec.mjs
@@ -1,0 +1,219 @@
+/**
+ * Story: Browser Back/Forward across destinations and exploration tabs
+ * (e2e-gap-review.md finding #15).
+ *
+ * `Workspace.jsx`'s URL→store `useEffect` (keyed on `syncedTargetRef`) is
+ * the ONLY code path that reacts to browser back/forward and deep links —
+ * its own comment says so verbatim: "still needed for browser back/forward
+ * and deep links, which never call [openWorkspaceTab/openWorkspaceView]".
+ * Every INTERACTIVE transition (a click, a keyboard shortcut) double-writes
+ * the store directly AND the URL synchronously (the VIS-1050 fix), so this
+ * effect is normally just re-confirming state that's already correct. A
+ * real `page.goBack()`/`page.goForward()` is the one gesture that has never
+ * exercised this effect being the SOLE writer, end to end, against a real
+ * sandbox — confirmed absent from the suite (grep for `goBack`/`goForward`
+ * across every spec file returns nothing prior to this file).
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=backForward VISIVO_SANDBOX_BACKEND_PORT=8048 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3048 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3048 npx playwright test workspace-back-forward-exploration
+ *
+ * Runs in playwright.config.mjs's `exploration-mutations` project (serial,
+ * no retries) — mints real backend exploration records, same reasoning as
+ * exploration-lifecycle.spec.mjs.
+ */
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function typeSqlReliably(page, sql) {
+  await typeSql(page, sql);
+  const landed = await page.evaluate(expected => {
+    const s = window.useStore.getState();
+    const name = s.explorerActiveModelName;
+    return !!name && s.explorerModelStates[name]?.sql === expected;
+  }, sql);
+  if (!landed) {
+    await typeSql(page, sql);
+  }
+}
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+async function waitForBackendDraftSql(page, id, expectedSql, timeout = 30000) {
+  await expect(async () => {
+    const res = await page.request.get(`${API}/api/explorations/${id}/`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    const sql = data?.draft?.queries?.[0]?.sql;
+    expect(sql).toBe(expectedSql);
+  }).toPass({ timeout });
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+test.describe('Browser Back/Forward walks destinations + exploration tabs (Explore 2.0)', () => {
+  // exploration-lifecycle.spec.mjs's own file header explains why: this
+  // project runs concurrently with `parallel`'s many workers against the
+  // same :8001 Flask dev server, so a slow debounced-sync round-trip under
+  // combined load needs real headroom, not a tight guess — mirrors that
+  // file's identical rationale for its own multi-step tests.
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfter = await listExplorationIds(page);
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('Back/Forward walks Explorer Home -> exploration -> Project -> chart tab and never loses exploration state', async ({
+    page,
+  }) => {
+    // History entry 0: Explorer Home (initial goto).
+    await gotoExplorerHome(page);
+
+    // History entry 1: a real exploration, with a distinctive persisted edit.
+    const id = await newExploration(page);
+    await typeSqlReliably(page, 'SELECT 111 AS back_forward_marker');
+    await expect(page.getByTestId(`workspace-tab-dirty-exploration:${id}`)).not.toBeVisible({
+      timeout: 10000,
+    });
+    await waitForBackendDraftSql(page, id, 'SELECT 111 AS back_forward_marker');
+
+    // History entry 2: switch to Project (parks the exploration tab, open
+    // but unfocused).
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible();
+    await page.waitForURL('**/workspace', { timeout: 10000 });
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+
+    // History entry 3: open a Library chart tab.
+    const chartHeader = page.getByTestId('library-subsection-chart-header');
+    const chartRow = page.getByTestId('library-row-chart-simple-scatter-chart');
+    if (!(await chartRow.isVisible().catch(() => false))) {
+      await chartHeader.hover();
+      await chartHeader.click();
+    }
+    await expect(chartRow).toBeVisible({ timeout: 10000 });
+    await chartRow.click();
+    await expect(page.getByTestId('workspace-tab-chart:simple-scatter-chart')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    await page.waitForURL(/[?&]edit=chart%3Asimple-scatter-chart/, { timeout: 10000 });
+
+    // --- Walk BACK through history: 3 -> 2 -> 1 -> 0 ---
+
+    // Back to entry 2: Project, exploration still parked (open, unfocused).
+    await page.goBack();
+    await page.waitForURL('**/workspace', { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible();
+    await expect(page.getByTestId('workspace-view-switcher-project')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+
+    // Back to entry 1: the exploration re-activates, SQL intact — the ONE
+    // thing the URL→store effect (and nothing else) drives here.
+    await page.goBack();
+    await page.waitForURL(new RegExp(`/workspace/exploration/${id}$`), { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.view-lines').first()).toContainText('back_forward_marker', {
+      timeout: 10000,
+    });
+    const activeViewAfterBack = await page.evaluate(
+      () => window.useStore.getState().workspaceActiveView
+    );
+    expect(activeViewAfterBack).toBe('explorer');
+
+    // Back to entry 0: bare Explorer Home gallery.
+    await page.goBack();
+    await page.waitForURL(/\/workspace\/exploration$/, { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 15000 });
+
+    // --- Walk FORWARD back through history: 0 -> 1 -> 2 -> 3 ---
+
+    await page.goForward();
+    await page.waitForURL(new RegExp(`/workspace/exploration/${id}$`), { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.view-lines').first()).toContainText('back_forward_marker', {
+      timeout: 10000,
+    });
+
+    await page.goForward();
+    await page.waitForURL('**/workspace', { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible();
+
+    await page.goForward();
+    await page.waitForURL(/[?&]edit=chart%3Asimple-scatter-chart/, { timeout: 10000 });
+    await expect(page.getByTestId('workspace-tab-chart:simple-scatter-chart')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    // The exploration tab is still there, just parked — round-tripping
+    // through the whole history never dropped it from the strip.
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+  });
+
+  test('pressing browser Back while a dirty-close confirmation is pending dismisses it, not orphans it (combines with #5)', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await typeSql(page, 'SELECT 222 AS marker');
+    await expect(page.getByTestId(`workspace-tab-dirty-exploration:${id}`)).toBeVisible({
+      timeout: 3000,
+    });
+
+    const closeBtn = page.getByTestId(`workspace-tab-close-exploration:${id}`);
+    await closeBtn.hover();
+    await closeBtn.click();
+    await expect(page.getByTestId('tab-close-confirm-dialog')).toBeVisible();
+
+    // Browser Back — a control no keydown/click handler can intercept —
+    // instead of clicking "Keep editing"/"Close without saving".
+    await page.goBack();
+    await page.waitForURL(/\/workspace\/exploration$/, { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 15000 });
+
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+    await expect(page.getByTestId('tab-close-confirm-backdrop')).not.toBeVisible();
+    const pending = await page.evaluate(() => window.useStore.getState().workspacePendingCloseTabId);
+    expect(pending).toBeNull();
+  });
+});

--- a/viewer/e2e/stories/workspace-cross-tab-tabset.spec.mjs
+++ b/viewer/e2e/stories/workspace-cross-tab-tabset.spec.mjs
@@ -1,0 +1,211 @@
+/**
+ * Story: Cross-tab workspace tab-set clobbering (e2e-gap-review.md #13
+ * [MEDIUM · CONFIRMED_GAP]).
+ *
+ * Workspace.jsx persists the OPEN-TAB SET (+ active view) to ONE shared
+ * per-project localStorage key (`visivo.workspace.tabs.<project>`) — not
+ * per-browser-tab. Each real browser tab's `Workspace` instance:
+ *   1. Restores from that key EXACTLY ONCE, at its own mount (a
+ *      component-local `tabsRestored` ref — scoped to THIS JS runtime, with
+ *      no awareness of any other tab).
+ *   2. Re-serializes the FULL `{tabs, activeView}` blob back to the SAME key
+ *      on every subsequent change to its own `workspaceTabs`/
+ *      `workspaceActiveView`.
+ *
+ * There is no `window.addEventListener('storage', ...)` anywhere — so if Tab
+ * B mounted BEFORE Tab A opened an exploration, Tab B's own restored
+ * snapshot never learned about it, and the very next time Tab B's persist
+ * effect fires (any unrelated change, e.g. switching destinations), it
+ * clobbers the shared key with a tab-set that never included Tab A's
+ * exploration. Reloading Tab A afterward silently loses that tab from the
+ * restored strip — the exploration record itself stays safe on the backend
+ * (this bug is purely about the localStorage-persisted UI tab-set), but the
+ * user has to rediscover it via Explorer Home.
+ *
+ * Uses a SINGLE `browser.newContext()` (shared localStorage, exactly like
+ * two real OS-level browser tabs in one profile) with TWO independent
+ * `page`s from it — per the finding's own note, this is the one config no
+ * other spec in this suite uses.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+/** Every `visivo.workspace.tabs.<project>` key currently in localStorage —
+ * there's exactly one live project in the sandbox, but reading by prefix
+ * avoids hardcoding the project's display name (Workspace.jsx derives it
+ * from `project.project_json?.name || project.name || 'project'`). */
+const tabsStorageEntries = page =>
+  page.evaluate(() => {
+    const out = {};
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('visivo.workspace.tabs.')) {
+        try {
+          out[key] = JSON.parse(localStorage.getItem(key));
+        } catch {
+          out[key] = null;
+        }
+      }
+    }
+    return out;
+  });
+
+const clearTabsStorage = page =>
+  page.evaluate(() => {
+    Object.keys(localStorage)
+      .filter(k => k.startsWith('visivo.workspace.tabs.'))
+      .forEach(k => localStorage.removeItem(k));
+  });
+
+const anyEntryHasTabId = (entries, tabId) =>
+  Object.values(entries).some(v => (v?.tabs || []).some(t => t.id === tabId));
+
+// This story drives its own manually-created `browser.newContext()` (two
+// real tabs sharing one profile — the whole point of the test) rather than
+// the fixture-managed default `page`/`context`. Tracing that ad-hoc context
+// alongside the unused default one hits a Playwright trace-artifact
+// housekeeping error (ENOENT on an internal recording file) in this
+// environment unrelated to this story's own assertions — see the identical
+// note in cross-tab-soft-reload-project-runs.spec.mjs.
+test.use({ trace: 'off', screenshot: 'off' });
+
+test.describe('Cross-tab workspace tab-set clobbering (#13)', () => {
+  test.setTimeout(60000);
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfter = await listExplorationIds(page);
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test("a stale second browser tab clobbers the first tab's exploration entry in the shared workspace tab-set key (no cross-tab storage sync)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+
+    // Start from a known-empty shared tab-set key (a fresh profile) so this
+    // test's assertions aren't polluted by whatever a prior run/session left
+    // behind.
+    const bootstrap = await context.newPage();
+    await bootstrap.goto(`${BASE_URL}/workspace`);
+    await bootstrap.waitForLoadState('networkidle');
+    await clearTabsStorage(bootstrap);
+    await bootstrap.close();
+
+    // Tab B mounts FIRST, on the bare /workspace root — its own one-time
+    // localStorage restore (Workspace.jsx's `tabsRestored` effect) captures
+    // the shared key as genuinely EMPTY. Nothing about the exploration Tab A
+    // is about to create exists yet.
+    const pageB = await context.newPage();
+    await pageB.goto(`${BASE_URL}/workspace`);
+    await pageB.waitForLoadState('networkidle');
+    await expect(pageB.getByTestId('workspace-view-switcher')).toBeVisible({ timeout: 15000 });
+
+    // Tab A opens SECOND (same shared context/localStorage) and creates a
+    // real exploration — its persist effect writes the shared key with this
+    // exploration's tab entry.
+    const pageA = await context.newPage();
+    await pageA.goto(`${BASE_URL}/workspace/exploration`);
+    await pageA.waitForLoadState('networkidle');
+    await expect(pageA.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 15000 });
+    await pageA.getByTestId('explorer-home-new-exploration').click();
+    await expect(pageA.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await pageA.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const explorationId = new URL(pageA.url()).pathname.split('/').pop();
+    const tabId = `exploration:${explorationId}`;
+
+    // Confirm Tab A's write really landed in the SHARED key (read via pageB
+    // — same context, same storage) before Tab B does anything.
+    await expect
+      .poll(async () => anyEntryHasTabId(await tabsStorageEntries(pageB), tabId), { timeout: 10000 })
+      .toBe(true);
+
+    // Tab A parks its own exploration (switches to the Project destination,
+    // matching explorer-home.spec.mjs's own "park via view-switch" pattern)
+    // — the tab stays in ITS OWN strip, just unfocused. This ALSO re-fires
+    // Tab A's OWN persist effect (workspaceActiveView changed), which still
+    // correctly includes the exploration tab (Tab A's own in-memory state
+    // was never touched by anything Tab B does) — a realistic "keep
+    // working, switch destinations" step before Tab B's stale write lands.
+    await pageA.getByTestId('workspace-view-switcher-project').click();
+    await expect(pageA.getByTestId(`workspace-tab-exploration:${explorationId}`)).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+    // Under heavy concurrent load, `openWorkspaceView`'s `history.pushState`
+    // navigation can lag behind the store update above — wait for the URL
+    // itself to have genuinely left the exploration's own deep-link before
+    // the later reload, so that reload can't race a still-in-flight
+    // navigation and land back on the exploration's own self-healing URL
+    // (which would reintroduce the tab via `activateWorkspaceTab`,
+    // independent of anything localStorage says — see the reload comment
+    // below for why that specific URL is deliberately avoided).
+    await pageA.waitForFunction(
+      () => !window.location.pathname.includes('/workspace/exploration/'),
+      { timeout: 10000 }
+    );
+    await expect
+      .poll(async () => anyEntryHasTabId(await tabsStorageEntries(pageA), tabId), { timeout: 10000 })
+      .toBe(true);
+
+    // Tab B does something totally unrelated to Tab A's exploration — switch
+    // destinations. This is enough to fire Workspace.jsx's persist effect
+    // (keyed on `[workspaceTabs, workspaceActiveView, tabsStorageKey]`) using
+    // Tab B's OWN in-memory state, which never learned about Tab A's tab.
+    await pageB.getByTestId('workspace-view-switcher-semantic-layer').click();
+    await expect(pageB.getByTestId('workspace-view-switcher-semantic-layer')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // The shared key is now clobbered: Tab A's exploration tab is gone from
+    // EVERY entry (there is exactly one project's worth of entries in this
+    // sandbox) — Tab B's write overwrote it with a tab-set that never
+    // included it.
+    await expect
+      .poll(async () => anyEntryHasTabId(await tabsStorageEntries(pageB), tabId), { timeout: 10000 })
+      .toBe(false);
+
+    // Reload Tab A at its CURRENT (Project / bare workspace-root) URL — NOT
+    // the exploration's own deep-link URL. Reloading AT the exploration's
+    // own `/workspace/exploration/:id` URL would self-heal the tab back in
+    // via the URL->store sync effect's `activateWorkspaceTab` regardless of
+    // what localStorage says (that's exactly why
+    // exploration-lifecycle.spec.mjs's "reload while the exploration tab is
+    // ACTIVE" test passes even with this bug present). This test targets the
+    // DIFFERENT, genuinely-broken case #13 describes: a PARKED tab, reloaded
+    // from a non-tab (view) URL — nothing reintroduces it once the shared
+    // localStorage key no longer carries it.
+    await pageA.reload();
+    await pageA.waitForLoadState('networkidle');
+    await expect(pageA.getByTestId('workspace-route-root')).toBeVisible({ timeout: 15000 });
+    await expect(pageA.getByTestId(`workspace-tab-exploration:${explorationId}`)).not.toBeVisible({
+      timeout: 5000,
+    });
+
+    // The exploration RECORD itself is untouched on the backend — only its
+    // open/parked UI tab-strip state was lost. Reopening it via Explorer
+    // Home still works.
+    const backendCheck = await pageA.request.get(`${API}/api/explorations/${explorationId}/`);
+    expect(backendCheck.ok()).toBe(true);
+
+    await context.close();
+  });
+});

--- a/viewer/e2e/stories/workspace-dnd-mid-drag-destination-switch.spec.mjs
+++ b/viewer/e2e/stories/workspace-dnd-mid-drag-destination-switch.spec.mjs
@@ -1,0 +1,205 @@
+/**
+ * Story: Switching destination mid-drag (e2e-gap-review.md finding #16).
+ * Companion to `exploration-dnd-pull-in.spec.mjs` — reuses its manual
+ * mouse-driven drag pattern, split into explicit `mouse.down`/`mouse.move`
+ * steps WITHOUT `mouse.up()` so a keyboard shortcut can fire mid-drag.
+ *
+ * `WorkspaceDndContext` (VIS-802 / G-1) is mounted exactly ONCE at
+ * `WorkspaceShell`, wrapping `MiddlePane` — it never unmounts on a
+ * destination switch. `MiddlePane`'s dispatch is a plain conditional swap:
+ * switching destination while `ExplorationPane` is mounted unmounts it (and
+ * every `useDroppable` registration inside it, including
+ * `sql-editor-drop-zone`) in favor of `DestinationHome`, but the DnD
+ * context's `activeDrag` state + `<DragOverlay>` survive untouched, since
+ * they live one level up. `routeWorkspaceDragEnd`/`routeExplorationDragEnd`
+ * dispatch purely by payload SHAPE (dragData/dropData), with no check that
+ * the drop's surface matches the drag's origin surface — this story drives
+ * the actual release and confirms the outcome is a graceful no-op (no
+ * crash, no corrupted exploration state, no stuck DnD context), not a
+ * silent misroute.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=dndMidDrag VISIVO_SANDBOX_BACKEND_PORT=8049 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3049 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3049 npx playwright test workspace-dnd-mid-drag-destination-switch
+ *
+ * Runs in playwright.config.mjs's `exploration-mutations` project (serial,
+ * no retries) — mints a real backend exploration record, same reasoning as
+ * exploration-dnd-pull-in.spec.mjs.
+ */
+import { test, expect } from '@playwright/test';
+
+// Tall viewport — same rationale as exploration-dnd-pull-in.spec.mjs: keeps
+// every drop target comfortably away from any auto-scroll edge.
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+const chips = page => page.locator('[data-testid^="query-chip-"][data-active]');
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+test.describe('Switching destination mid-drag (Explore 2.0 cross-feature #518 x #520)', () => {
+  // Headroom for combined-load contention against the shared sandbox
+  // (mirrors exploration-lifecycle.spec.mjs's own rationale).
+  test.describe.configure({ timeout: 60000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfter = await listExplorationIds(page);
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('Cmd/Ctrl+1 mid-drag switches destination without crashing; the drag ends as a clean no-op and the exploration is untouched', async ({
+    page,
+  }) => {
+    // Track uncaught JS exceptions (a real crash) and any 4xx/5xx from an
+    // ACTUAL api call — deliberately NOT a blanket "no console.error"
+    // check, which would also flag incidental static-asset 404s
+    // (favicons/icons) unrelated to the drag interruption this test cares
+    // about.
+    const pageErrors = [];
+    page.on('pageerror', err => pageErrors.push(err.message));
+    const apiFailures = [];
+    page.on('response', res => {
+      if (res.status() >= 400 && res.url().includes('/api/')) {
+        apiFailures.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    const existingChips = await chips(page).count();
+
+    const tableRow = await expandSourceTable(page);
+    const dropZone = page.getByTestId('sql-editor-drop-zone');
+    const sourceBox = await tableRow.boundingBox();
+    const targetBox = await dropZone.boundingBox();
+    expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+    const sourceX = sourceBox.x + sourceBox.width / 2;
+    const sourceY = sourceBox.y + sourceBox.height / 2;
+    const targetX = targetBox.x + targetBox.width / 2;
+    const targetY = targetBox.y + targetBox.height / 2;
+
+    // Manual drag, split into explicit steps — NO mouse.up() yet, so the
+    // gesture is genuinely mid-flight when the keyboard shortcut fires.
+    await page.mouse.move(sourceX, sourceY);
+    await page.mouse.down();
+    await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+    await page.waitForTimeout(100);
+    await page.mouse.move((sourceX + targetX) / 2, (sourceY + targetY) / 2, { steps: 8 });
+    await page.waitForTimeout(100);
+
+    // Confirm the drag is genuinely live before doing anything else.
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible({ timeout: 5000 });
+
+    // Mid-drag destination switch — mouse button is still physically held.
+    const isMac = process.platform === 'darwin';
+    await page.keyboard.press(isMac ? 'Meta+1' : 'Control+1');
+
+    // The destination switch happens; ExplorationPane (and its
+    // sql-editor-drop-zone) unmounts in favor of Project Home, but the
+    // DragOverlay survives (WorkspaceDndContext is shell-level).
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('library-drag-preview')).toBeVisible();
+
+    // Release over whatever's now under the cursor in the NEW destination —
+    // move onto the Project pane's body first, matching the recommended
+    // story's "release over whatever's now under the cursor" step.
+    const projectBox = await page.getByTestId('workspace-middle-project').boundingBox();
+    await page.mouse.move(
+      projectBox.x + projectBox.width / 2,
+      projectBox.y + projectBox.height / 2,
+      { steps: 6 }
+    );
+    await page.waitForTimeout(100);
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    // The drag ends cleanly — no lingering overlay, no crash, destination
+    // unchanged (no forced bounce back to Explorer).
+    await expect(page.getByTestId('library-drag-preview')).not.toBeVisible();
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible();
+
+    expect(pageErrors, 'no uncaught JS exceptions from the interrupted drag').toEqual([]);
+    expect(apiFailures, 'no failed API calls from the interrupted drag').toEqual([]);
+
+    // The exploration itself is untouched — no phantom/garbage query chip
+    // was created by the orphaned drop, and the source table drag never
+    // reached a valid target.
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await page.getByTestId(`workspace-tab-select-exploration:${id}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 15000 });
+    await expect(chips(page)).toHaveCount(existingChips);
+
+    // The DnD context isn't left in a stuck "always dragging" state — a
+    // FRESH, complete drag-and-drop still works normally afterward.
+    const freshDropZone = page.getByTestId('sql-editor-drop-zone');
+    const tableRow2 = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+    const src2 = await tableRow2.boundingBox();
+    const tgt2 = await freshDropZone.boundingBox();
+    await page.mouse.move(src2.x + src2.width / 2, src2.y + src2.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(src2.x + src2.width / 2 + 10, src2.y + src2.height / 2, { steps: 3 });
+    await page.waitForTimeout(100);
+    await page.mouse.move(tgt2.x + tgt2.width / 2, tgt2.y + tgt2.height / 2, { steps: 12 });
+    await page.mouse.move(tgt2.x + tgt2.width / 2, tgt2.y + tgt2.height / 2, { steps: 4 });
+    await page.waitForTimeout(150);
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    await expect(chips(page)).toHaveCount(existingChips + 1, { timeout: 10000 });
+  });
+});

--- a/viewer/e2e/stories/workspace-tab-close-dialog-navigation.spec.mjs
+++ b/viewer/e2e/stories/workspace-tab-close-dialog-navigation.spec.mjs
@@ -1,0 +1,243 @@
+/**
+ * Story: Tab-close confirmation survives navigation away (cross-PR #518 x
+ * #519, e2e-gap-review.md finding #5).
+ *
+ * `requestCloseWorkspaceTab` parks a dirty tab's id in
+ * `workspacePendingCloseTabId` so `TabCloseConfirmDialog` (mounted at the
+ * shell level, inside `TabStrip.jsx` — never swapped by `MiddlePane`) can
+ * ask "Keep editing / Close without saving" first. Before the fix landed
+ * alongside this story, ONLY `confirmCloseWorkspaceTab`/
+ * `cancelCloseWorkspaceTab`/`closeWorkspaceTab`'s own id-match guard ever
+ * cleared that pending id — `activateWorkspaceTab`/`activateWorkspaceView`
+ * (the write path behind every OTHER navigation: a ViewSwitcher click, a
+ * Library row open, a tab click, Cmd+1/2/3) never touched it. Navigating
+ * away while the dialog was pending left it floating over whatever new
+ * destination/tab the user landed on next.
+ *
+ * TWO corrections to the finding's literal scenario, made after checking
+ * the CURRENT source/DOM (not just the doc, whose reviewer traced an
+ * earlier commit):
+ *
+ *   1. Cmd/Ctrl+1/2/3 while the dialog is open is suppressed ENTIRELY
+ *      today by `useWorkspaceTabShortcuts.js`'s `hasBlockingModal()` guard
+ *      (added for the unrelated P4-D1 gate — it checks for ANY
+ *      `[aria-modal="true"]` element, which `TabCloseConfirmDialog` is).
+ *      So Cmd+2 is a documented no-op, not a live reproduction — see the
+ *      third test below, which locks in that (separate, already-correct)
+ *      behavior instead of asserting a false reproduction.
+ *
+ *   2. A literal mouse `.click()` on a Library row or ViewSwitcher row
+ *      ALSO cannot reach it: `TabCloseConfirmDialog`'s backdrop is
+ *      `fixed inset-0 z-[90]` (a real full-viewport overlay, portaled onto
+ *      `document.body`, with no z-index anywhere in the shell above it) —
+ *      Playwright (and a real mouse) hit-tests the backdrop first, which
+ *      calls `cancelClose()` on its own `onPointerDown`. That's a
+ *      reasonable incidental mitigation for pointer users, but the dialog
+ *      has NO FOCUS TRAP (no keydown/Tab interception at all), so a
+ *      keyboard-focused control BEHIND the backdrop still fires its own
+ *      click/keydown handler directly — no coordinate hit-test involved.
+ *      That's the genuinely still-live reproduction this file drives:
+ *      `.focus()` (however focus got there — Tab navigation, assistive
+ *      tech, a remembered focus target) + Enter/Space activates the
+ *      control underneath, exactly as the finding describes the RESULT
+ *      (`activateWorkspaceTab`/`activateWorkspaceView` firing while the
+ *      dialog is still parked) even though the literal INPUT differs from
+ *      "click a Library row". Browser Back/Forward — genuinely unblocked
+ *      by both the backdrop and the keyboard-shortcut guard — is covered
+ *      separately in `workspace-back-forward-exploration.spec.mjs`.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=tabCloseDialogNav VISIVO_SANDBOX_BACKEND_PORT=8047 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3047 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3047 npx playwright test workspace-tab-close-dialog-navigation
+ *
+ * Runs in playwright.config.mjs's `exploration-mutations` project (serial,
+ * no retries) — mints a real backend exploration record, same reasoning as
+ * exploration-lifecycle.spec.mjs.
+ */
+import { test, expect } from '@playwright/test';
+import { typeSql } from '../helpers/explorer.mjs';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function typeSqlReliably(page, sql) {
+  await typeSql(page, sql);
+  const landed = await page.evaluate(expected => {
+    const s = window.useStore.getState();
+    const name = s.explorerActiveModelName;
+    return !!name && s.explorerModelStates[name]?.sql === expected;
+  }, sql);
+  if (!landed) {
+    await typeSql(page, sql);
+  }
+}
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Arm a REAL dirty-close confirmation on exploration `id`: type SQL, wait
+ * for the store's real syncStatus to flip dirty, then trigger the × so
+ * `requestCloseWorkspaceTab` parks the dialog (never a manually-flipped
+ * flag — mirrors the recommended story's own emphasis on a genuine
+ * mid-debounce dirty tab). */
+async function armDirtyCloseDialog(page, id, sql) {
+  await typeSqlReliably(page, sql);
+  await expect(page.getByTestId(`workspace-tab-dirty-exploration:${id}`)).toBeVisible({
+    timeout: 3000,
+  });
+  const closeBtn = page.getByTestId(`workspace-tab-close-exploration:${id}`);
+  await closeBtn.hover();
+  await closeBtn.click();
+  await expect(page.getByTestId('tab-close-confirm-dialog')).toBeVisible();
+}
+
+/** Activate a control BEHIND the dialog's full-viewport backdrop via
+ * keyboard focus + Enter — see the file header's correction #2. A plain
+ * `.click()` here hits the backdrop instead (no focus trap needed to
+ * explain that: it's pure pointer-event hit-testing), so this is the
+ * actual reachable path today, not a testing artifice. */
+async function focusAndActivate(locator) {
+  await locator.focus();
+  await locator.press('Enter');
+}
+
+test.describe('Tab-close confirmation survives navigation away (cross-PR #518 x #519)', () => {
+  // Headroom for combined-load contention against the shared sandbox
+  // (mirrors exploration-lifecycle.spec.mjs's own rationale) — each test
+  // mints/arms 2-3 explorations in sequence.
+  test.describe.configure({ timeout: 60000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfter = await listExplorationIds(page);
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('activating the ViewSwitcher (destination switch) behind the open dialog dismisses it, not orphans it', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await armDirtyCloseDialog(page, id, 'SELECT 1 AS one');
+
+    const semanticRow = page.getByTestId('workspace-view-switcher-semantic-layer');
+    await focusAndActivate(semanticRow);
+
+    // The new destination is showing...
+    await expect(page.getByTestId('workspace-middle-semantic-layer')).toBeVisible();
+    // ...and the dialog must NOT be floating over it.
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+    await expect(page.getByTestId('tab-close-confirm-backdrop')).not.toBeVisible();
+
+    // The store's pending-close id is genuinely cleared, not just visually
+    // hidden behind something else.
+    const pending = await page.evaluate(() => window.useStore.getState().workspacePendingCloseTabId);
+    expect(pending).toBeNull();
+
+    // The tab itself is untouched — still open, still dirty (the dialog
+    // was dismissed by navigation, not by "Close without saving").
+    await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
+    await expect(page.getByTestId(`workspace-tab-dirty-exploration:${id}`)).toBeVisible();
+  });
+
+  test('activating a Library row (opening a different tab) behind the open dialog dismisses it, not orphans it', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await armDirtyCloseDialog(page, id, 'SELECT 2 AS two');
+
+    // Navigate to Project first (behind the dialog) so the Library's chart
+    // rows are on-screen underneath it.
+    await focusAndActivate(page.getByTestId('workspace-view-switcher-project'));
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+    await expect(page.getByTestId('workspace-middle-project')).toBeVisible();
+
+    // Re-arm the dialog on a fresh dirty exploration tab, then activate a
+    // Library chart row — the actual "click a Library row to open a
+    // different tab" scenario from the finding, reached via keyboard focus
+    // (see file header for why a literal click can't reach it).
+    await focusAndActivate(page.getByTestId('workspace-view-switcher-explorer'));
+    const id2 = await newExploration(page);
+    await armDirtyCloseDialog(page, id2, 'SELECT 3 AS three');
+
+    await focusAndActivate(page.getByTestId('workspace-view-switcher-project'));
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+
+    const header = page.getByTestId('library-subsection-chart-header');
+    const row = page.getByTestId('library-row-chart-simple-scatter-chart');
+    if (!(await row.isVisible().catch(() => false))) {
+      await header.hover();
+      await header.click();
+    }
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // Re-arm the dialog one more time so THIS activation is the one under
+    // test, then activate the chart row via focus + Enter (the row's own
+    // onKeyDown handles Enter/Space directly, per LibraryRow.jsx).
+    await focusAndActivate(page.getByTestId('workspace-view-switcher-explorer'));
+    const id3 = await newExploration(page);
+    await armDirtyCloseDialog(page, id3, 'SELECT 4 AS four');
+    await focusAndActivate(row);
+
+    await expect(page.getByTestId('workspace-tab-chart:simple-scatter-chart')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+    await expect(page.getByTestId('tab-close-confirm-backdrop')).not.toBeVisible();
+    const pending = await page.evaluate(() => window.useStore.getState().workspacePendingCloseTabId);
+    expect(pending).toBeNull();
+  });
+
+  test('Cmd+2 while the dialog is open is suppressed entirely (hasBlockingModal) — documents the current, already-correct guard', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const id = await newExploration(page);
+    await armDirtyCloseDialog(page, id, 'SELECT 5 AS five');
+
+    const isMac = process.platform === 'darwin';
+    await page.keyboard.press(isMac ? 'Meta+2' : 'Control+2');
+
+    // Nothing changed — the shortcut was swallowed by hasBlockingModal, so
+    // the dialog is still up over the SAME exploration tab (no destination
+    // switch actually happened).
+    await expect(page.getByTestId('tab-close-confirm-dialog')).toBeVisible();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible();
+
+    // Clean up via the dialog's own safe action so the test leaves no
+    // pending-close state behind.
+    await page.getByTestId('tab-close-confirm-cancel').click();
+    await expect(page.getByTestId('tab-close-confirm-dialog')).not.toBeVisible();
+  });
+});

--- a/viewer/e2e/stories/workspace-tab-phantom-exploration.spec.mjs
+++ b/viewer/e2e/stories/workspace-tab-phantom-exploration.spec.mjs
@@ -1,0 +1,248 @@
+/**
+ * Story: Tab-strip position shortcuts (Cmd+4-9) and drag-reorder against a
+ * "phantom" exploration tab — one whose backend record was deleted OUT OF
+ * BAND (e2e-gap-review.md finding #25).
+ *
+ * `restoreWorkspaceTabs` (workspaceStore.js) only sanitizes SHAPE (drops
+ * nulls, dedupes by id, scrubs workspace-view chrome types) — it performs
+ * ZERO cross-check against `workspaceExplorations.byId` or a fetched list.
+ * A tab set restored from a prior session's localStorage snapshot can
+ * therefore contain an `exploration` tab whose backend record is gone
+ * (deleted from a different session, or a session killed before its own
+ * `deleteExploration`'s force-close/toast round-trip completed). This story
+ * simulates exactly that: seed `visivo.workspace.tabs.<project>` with a real
+ * (still-live) exploration AND a fabricated phantom exploration id that was
+ * never created, then verify the tab strip's power features (position
+ * shortcuts, drag-reorder, label fallback, landing on the phantom tab)
+ * degrade gracefully — never a crash.
+ *
+ * Deliberately a NEW dedicated file rather than extending
+ * `workspace-tabs-shortcuts.spec.mjs`: that file's existing tests are all
+ * registered in the PARALLEL Playwright project (no backend exploration
+ * mutations); mixing a real exploration-delete in would force the WHOLE
+ * file to move to the serial `exploration-mutations` project, a bigger
+ * blast radius than this small dedicated file.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=phantomTab VISIVO_SANDBOX_BACKEND_PORT=8050 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3050 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3050 npx playwright test workspace-tab-phantom-exploration
+ *
+ * Runs in playwright.config.mjs's `exploration-mutations` project (serial,
+ * no retries) — mints/deletes a real backend exploration record, same
+ * reasoning as exploration-lifecycle.spec.mjs.
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const API = BASE_URL.replace(':3001', ':8001');
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  return ((await res.json().catch(() => [])) || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Seed the persisted tab-set localStorage key exactly as
+ * `Workspace.jsx`'s restore effect reads it (`{ tabs, activeView }`),
+ * mirroring a prior session's snapshot that includes a tab whose backend
+ * record has since vanished. `projectName` matches the integration
+ * project's real name so the storage key lines up with what the app itself
+ * would compute.
+ *
+ * Uses `page.addInitScript` (runs before ANY page script on the next
+ * navigation) rather than a live `page.evaluate` write — the latter races
+ * `Workspace.jsx`'s own "persist the tab set on every change" effect, which
+ * can re-fire (e.g. on an unrelated background poll/re-render) and clobber
+ * a live write with the CURRENTLY-mounted app's own (still just
+ * `[realTab]`) state before the reload actually happens. An init script
+ * applies strictly before the reloaded document's own JS boots, so there's
+ * no live app instance left to race. */
+async function seedTabSet(page, projectName, tabs, activeView = 'explorer') {
+  await page.addInitScript(
+    ({ key, tabs, activeView }) => {
+      window.localStorage.setItem(key, JSON.stringify({ tabs, activeView }));
+    },
+    { key: `visivo.workspace.tabs.${projectName}`, tabs, activeView }
+  );
+}
+
+async function getProjectName(page) {
+  return page.evaluate(() => {
+    const p = window.useStore.getState().project;
+    return p?.project_json?.name || p?.name || 'project';
+  });
+}
+
+test.describe('Tab-strip power features against a phantom exploration tab (#25)', () => {
+  // Headroom for combined-load contention against the shared sandbox
+  // (mirrors exploration-lifecycle.spec.mjs's own rationale) — each test
+  // reloads the page at least once.
+  test.describe.configure({ timeout: 60000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfter = await listExplorationIds(page);
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('a phantom exploration tab restored from localStorage: label falls back to the raw id, and landing on it (click) reaches a clean not-found state', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const realId = await newExploration(page);
+    const projectName = await getProjectName(page);
+
+    // Delete the real exploration's backend record directly (out-of-band —
+    // never routed through THIS session's own `deleteExploration`, which is
+    // the only path that force-closes + toasts). The tab stays in the
+    // client's in-memory strip until a reload re-reads the persisted set.
+    const phantomId = 'exp_phantom_never_created_0001';
+    await page.request.delete(`${API}/api/explorations/${realId}/`);
+
+    // Seed the persisted tab-set as if a PRIOR session had this exploration
+    // (now deleted) open, plus the never-created phantom id — simulating
+    // restoreWorkspaceTabs blindly restoring a stale snapshot with zero
+    // cross-check against the fetched workspaceExplorations list.
+    await seedTabSet(page, projectName, [
+      { id: `exploration:${realId}`, type: 'exploration', name: realId },
+      { id: `exploration:${phantomId}`, type: 'exploration', name: phantomId },
+    ]);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Both tabs restored into the strip — restoreWorkspaceTabs sanitizes
+    // shape only, no existence cross-check.
+    const realTab = page.getByTestId(`workspace-tab-exploration:${realId}`);
+    const phantomTab = page.getByTestId(`workspace-tab-exploration:${phantomId}`);
+    await expect(realTab).toBeVisible({ timeout: 15000 });
+    await expect(phantomTab).toBeVisible();
+
+    // Label fallback (TabStrip.jsx's explorationDisplayName): neither
+    // record resolves via workspaceExplorations.byId (both are gone/never
+    // existed), so the tab falls back to displaying the raw backend id.
+    await expect(phantomTab).toContainText(phantomId);
+    await expect(realTab).toContainText(realId);
+
+    // Landing on the phantom tab via a click reaches a clean not-found
+    // state — never a crash.
+    await page.getByTestId(`workspace-tab-select-exploration:${phantomId}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration-not-found')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByText(/doesn't exist/i)).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe(`/workspace/exploration/${phantomId}`);
+
+    // The tab strip itself is still fully functional — the real (now also
+    // deleted) tab is still selectable without crashing the app either.
+    await page.getByTestId(`workspace-tab-select-exploration:${realId}`).click();
+    await expect(page.getByTestId('workspace-middle-exploration-not-found')).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('Cmd/Ctrl+4-9 position shortcuts and drag-reorder are type/record-agnostic — landing on a phantom tab by POSITION reaches the same clean not-found state', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const realId = await newExploration(page);
+    const projectName = await getProjectName(page);
+
+    const phantomId = 'exp_phantom_position_0002';
+    await seedTabSet(page, projectName, [
+      { id: `exploration:${realId}`, type: 'exploration', name: realId },
+      { id: `exploration:${phantomId}`, type: 'exploration', name: phantomId },
+    ]);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId(`workspace-tab-exploration:${realId}`)).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId(`workspace-tab-exploration:${phantomId}`)).toBeVisible();
+
+    // Cmd/Ctrl+4 -> first tab position (real), Cmd/Ctrl+5 -> second tab
+    // position (phantom) — useWorkspaceTabShortcuts.js's `switchWorkspaceTab`
+    // is a plain array-index lookup, agnostic to whether the tab's backend
+    // record actually exists.
+    const isMac = process.platform === 'darwin';
+    await page.keyboard.press(isMac ? 'Meta+5' : 'Control+5');
+
+    // Poll the STORE (not an immediate `page.url()` read, which can catch
+    // the URL mid-navigation) for the expected active tab, then confirm the
+    // URL followed suit.
+    await page.waitForFunction(
+      expectedId => window.useStore.getState().workspaceActiveTabId === expectedId,
+      `exploration:${phantomId}`,
+      { timeout: 10000 }
+    );
+    await page.waitForURL(new RegExp(`/workspace/exploration/${phantomId}$`), { timeout: 10000 });
+    await expect(page.getByTestId('workspace-middle-exploration-not-found')).toBeVisible({
+      timeout: 15000,
+    });
+    expect(new URL(page.url()).pathname).toBe(`/workspace/exploration/${phantomId}`);
+
+    // Cmd/Ctrl+4 switches back to the real (first-position) tab without
+    // incident — the shortcut layer never distinguishes phantom from real.
+    await page.keyboard.press(isMac ? 'Meta+4' : 'Control+4');
+    await expect(page.getByTestId(`workspace-tab-exploration:${realId}`)).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    // Drag-reorder the phantom tab ahead of the real one — reorderWorkspaceTabs
+    // is a plain id/array-index operation with no type/record awareness, so
+    // this must succeed exactly like reordering any other pair of tabs
+    // (workspace-tabs-shortcuts.spec.mjs's own "drag-to-reorder tabs with a
+    // real cursor" is the reference gesture this mirrors).
+    // Real pointer drag, mirroring workspace-tabs-shortcuts.spec.mjs's own
+    // "drag-to-reorder tabs with a real cursor" reference geometry: glide
+    // onto the target's LEFT THIRD so closestCenter resolves to it.
+    const phantomWrapper = page.getByTestId(`workspace-tab-wrapper-exploration:${phantomId}`);
+    const realWrapper = page.getByTestId(`workspace-tab-wrapper-exploration:${realId}`);
+    const phantomBox = await phantomWrapper.boundingBox();
+    const realBox = await realWrapper.boundingBox();
+
+    await page.mouse.move(phantomBox.x + phantomBox.width / 2, phantomBox.y + phantomBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(realBox.x + realBox.width / 3, realBox.y + realBox.height / 2, {
+      steps: 12,
+    });
+    await page.mouse.move(realBox.x + realBox.width / 3, realBox.y + realBox.height / 2, {
+      steps: 4,
+    });
+    await page.mouse.up();
+
+    // Reorder succeeded (no crash) — the phantom tab is now in the FIRST
+    // position, confirmed by Cmd/Ctrl+4 now landing on IT instead of the
+    // real tab.
+    await page.keyboard.press(isMac ? 'Meta+4' : 'Control+4');
+    const activeTabId = await page.evaluate(() => window.useStore.getState().workspaceActiveTabId);
+    expect(activeTabId).toBe(`exploration:${phantomId}`);
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -31,6 +31,11 @@ export default defineConfig({
       testIgnore: [
         '**/build-mode-publish.spec.mjs',
         '**/external-edit-banner.spec.mjs',
+        // Phase 6 D7 (VIS-1087's remaining half): fires a real POST
+        // /api/commit/ against shared sandbox state — same isolation need
+        // as the two files above (registered in the 'workspace-publish'
+        // project's testMatch).
+        '**/cross-tab-soft-reload-project-runs.spec.mjs',
         '**/library-inline-create.spec.mjs',
         '**/validation-as-save.spec.mjs',
         // VIS-993 regression: canvas edits must persist to the DRAFT CACHE
@@ -86,6 +91,19 @@ export default defineConfig({
         '**/explore-this-flywheel.spec.mjs',
         '**/dashboard-newchart-roundtrip.spec.mjs',
         '**/exploration-staleness.spec.mjs',
+        // Phase 6 (VIS-1073-1076/VIS-1088-1090 armor + P5-D6/P5-D-final-
+        // delta gap closures): same shared `.visivo/explorations/`
+        // repository isolation need — each mints (and most delete) real
+        // backend exploration records.
+        '**/exploration-computed-columns.spec.mjs',
+        '**/workspace-tab-close-dialog-navigation.spec.mjs',
+        '**/workspace-back-forward-exploration.spec.mjs',
+        '**/workspace-dnd-mid-drag-destination-switch.spec.mjs',
+        '**/workspace-tab-phantom-exploration.spec.mjs',
+        '**/exploration-duplicate.spec.mjs',
+        '**/workspace-cross-tab-tabset.spec.mjs',
+        '**/exploration-cross-tab-concurrency.spec.mjs',
+        '**/exploration-cross-tab-dnd-isolation.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -112,7 +130,14 @@ export default defineConfig({
       // YAML restore and see phantom pending changes). Targets its own
       // sandbox via VIS_PUBLISH_BASE.
       name: 'workspace-publish',
-      testMatch: ['**/build-mode-publish.spec.mjs', '**/external-edit-banner.spec.mjs'],
+      testMatch: [
+        '**/build-mode-publish.spec.mjs',
+        '**/external-edit-banner.spec.mjs',
+        // Phase 6 D7 (VIS-1087's remaining half): fires a real POST
+        // /api/commit/ against shared sandbox state — same isolation need
+        // as the two files above.
+        '**/cross-tab-soft-reload-project-runs.spec.mjs',
+      ],
       fullyParallel: false,
       workers: 1,
       retries: 0,
@@ -174,6 +199,18 @@ export default defineConfig({
         '**/explore-this-flywheel.spec.mjs',
         '**/dashboard-newchart-roundtrip.spec.mjs',
         '**/exploration-staleness.spec.mjs',
+        // Phase 6 additions (VIS-1073-1076/VIS-1088-1090 armor + P5-D6/
+        // P5-D-final-delta gap closures) — see the 'parallel' project's
+        // testIgnore entry for the same files for why.
+        '**/exploration-computed-columns.spec.mjs',
+        '**/workspace-tab-close-dialog-navigation.spec.mjs',
+        '**/workspace-back-forward-exploration.spec.mjs',
+        '**/workspace-dnd-mid-drag-destination-switch.spec.mjs',
+        '**/workspace-tab-phantom-exploration.spec.mjs',
+        '**/exploration-duplicate.spec.mjs',
+        '**/workspace-cross-tab-tabset.spec.mjs',
+        '**/exploration-cross-tab-concurrency.spec.mjs',
+        '**/exploration-cross-tab-dnd-isolation.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/components/RunsView.jsx
+++ b/viewer/src/components/RunsView.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import useStore from '../stores/store';
 import { fetchRuns, fetchRunLog } from '../api/branching';
 import AnsiText from './common/AnsiText';
+import useProjectChangeListener from './views/workspace/useProjectChangeListener';
 
 // queued/running are the only non-terminal states — while active a run is still
 // building, so the detail panel tail-polls the log.
@@ -75,10 +76,25 @@ function RunDetail({ run }) {
  * Shared shape with the cloud: backed by the same fetchRuns/fetchRunLog +
  * /api/projects/<id>/run/ + /api/runs/<id>/logs/ contract (local serve
  * implements it via RunManager).
+ *
+ * e2e-gap-review.md D7 ("VIS-1087's remaining half"): `/runs` mounts OUTSIDE
+ * the Workspace shell, so — before this hook was added here — a commit fired
+ * from any `/workspace/...` tab hard-reloaded a tab sitting on `/runs` too
+ * (the commit broadcast's `reload` socket event only skips
+ * `window.location.reload()` when `window.__VISIVO_SOFT_RELOAD__` is true,
+ * which only `useProjectChangeListener` sets, and only the Workspace called
+ * it). A hard reload here silently loses which run row was expanded
+ * (`expandedId`, purely local state) for no reason — mounting the same hook
+ * Workspace.jsx already uses is a small, mechanical fix that changes nothing
+ * else about this view's own behavior or data-fetching.
  */
 export default function RunsView() {
   const projectId = useStore(state => state.project?.id);
   const [expandedId, setExpandedId] = useState(null);
+
+  // D7: soft-refresh on backend `project_changed` events instead of a hard
+  // page reload — see the module docstring above.
+  useProjectChangeListener();
   const {
     data: runs = [],
     isLoading,

--- a/viewer/src/components/RunsView.test.jsx
+++ b/viewer/src/components/RunsView.test.jsx
@@ -13,6 +13,14 @@ jest.mock('../api/branching', () => ({
   fetchRunLog: jest.fn(),
 }));
 
+// D7 (e2e-gap-review.md): RunsView now mounts the same H-2 project-change
+// socket listener the Workspace uses (useProjectChangeListener) — stub the
+// socket client so jsdom never attempts a real polling connection (mirrors
+// Workspace.test.jsx's identical stub).
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => ({ on: jest.fn(), close: jest.fn() })),
+}));
+
 // RunsView and the expanded RunDetail each call useQuery; dispatch on the key so
 // the runs list and a run's log can be controlled independently.
 const mockQueries = ({ runs, log }) =>

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -61,6 +61,32 @@ const MAX_PROMOTED_POLL_ATTEMPTS = 15;
  * own `promoted[]` trail (`workspaceExplorations.byId[activeExplorationId]`)
  * actually recorded promoting an insight of that name.
  *
+ * PROMOTED-DATA FRESHNESS (P5-D1, e2e-gap-review.md "Final delta pass"): the
+ * promoted-lane switch above was a ONE-WAY RATCHET — once `promotedNames`
+ * included a name and `insightJobs[name].data` existed, every future render
+ * kept preferring the real key forever, even after the user kept editing
+ * that insight's props/interactions post-promote ("promote early, keep
+ * refining" silently broke: the chart froze on the promote-moment snapshot).
+ * `promotedDataSignatureRef` below remembers, per name, the insight-state
+ * signature (type/props/interactions) that was live the LAST time we saw a
+ * given `insightJobs[name].data` reference — i.e. "what the real data is
+ * believed to represent." A promoted name only resolves to the real key when
+ * the CURRENT signature still matches that captured one; any edit since
+ * diverges the signature and falls back to the draft-namespaced key, which
+ * resumes the normal live draft-compile preview immediately (never waits on
+ * a re-run). Re-promoting and a fresh run completing lands a NEW `data`
+ * reference, which re-captures the (now current, unedited) signature and
+ * flips back to the real key — no stale lock survives a genuine edit, and no
+ * manual reset is needed on re-promote.
+ *
+ * (Residual, out of scope for this pass: two DIFFERENT explorations that
+ * both hold a draft insight literally named the same as a just-(re)promoted
+ * insight can still observe each other's fresh data for that name — real
+ * cross-exploration isolation would require scoping `insightJobs` itself per
+ * exploration, a larger change to the shared run/dashboard rendering
+ * pipeline. Tracked as a follow-up; this fix closes the reported "stuck
+ * forever" symptom, which is the common case.)
+ *
  * PER-INSIGHT LOADING/ERROR (VIS-1092): `isLoading`/`error` handed to
  * `<ChartPreview>` (which gates the WHOLE chart render on them) are computed
  * ONLY over the insights still in the draft lane — an already-promoted
@@ -141,18 +167,43 @@ const ExplorerChartPreview = () => {
     useInsightsData(projectId, promotedNames, undefined, { cacheKey: pollTick }) || {};
   const promotedPollFailed = hasPromotedWithoutRealData && (pollExhausted || !!promotedFetchError);
 
+  // P5-D1 — signature-freshness cache backing the promoted-lane switch below.
+  // Ref (not state): purely a "what did the current real data last look like
+  // for this name" memo, mutated in-render (an accepted pattern for this
+  // shape of derived comparison, matching `pollAttemptsRef` elsewhere in this
+  // file) — it never itself triggers a re-render, only informs this render's
+  // own key resolution.
+  const promotedDataSignatureRef = useRef({});
+  const insightSignature = name => {
+    const s = insightStates[name];
+    return JSON.stringify({ type: s?.type, props: s?.props, interactions: s?.interactions });
+  };
+
   // Per-insight lane: the REAL name once its real data has actually landed
-  // (never just because it's promoted — avoids a flash of empty/error chart
-  // state in the gap between promote and the run finishing); the draft-
-  // namespaced key otherwise.
+  // AND the insight hasn't been edited since that data was captured (never
+  // just because it's promoted — avoids both a flash of empty/error chart
+  // state in the gap between promote and the run finishing, and a stale
+  // snapshot surviving edits made after promotion); the draft-namespaced key
+  // otherwise.
   const previewInsightKeys = useMemo(
     () =>
-      chartInsightNames.map(name =>
-        promotedNames.includes(name) && storeInsightJobs?.[name]?.data
-          ? name
-          : draftInsightKey(name)
-      ),
-    [chartInsightNames, promotedNames, storeInsightJobs]
+      chartInsightNames.map(name => {
+        if (!promotedNames.includes(name)) return draftInsightKey(name);
+        const data = storeInsightJobs?.[name]?.data;
+        if (!data) return draftInsightKey(name);
+
+        const cache = promotedDataSignatureRef.current[name];
+        const currentSig = insightSignature(name);
+        if (!cache || cache.data !== data) {
+          // New (or first-seen) real data for this name — capture what the
+          // insight looks like right now as the signature it represents.
+          promotedDataSignatureRef.current[name] = { data, signature: currentSig };
+          return name;
+        }
+        return cache.signature === currentSig ? name : draftInsightKey(name);
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chartInsightNames, promotedNames, storeInsightJobs, insightStates]
   );
 
   // VIS-1092 — `<ChartPreview>` (unlike `Chart.jsx`) gates its ENTIRE render

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -320,6 +320,84 @@ describe('ExplorerChartPreview', () => {
         JSON.stringify(['__draft__:ins_1'])
       );
     });
+
+    // P5-D1 — the sticky promoted-lane lock: editing a promoted insight must
+    // resume live draft rendering immediately, never freeze on the
+    // promote-moment snapshot ("promote early, keep refining").
+    describe('promoted-data freshness (P5-D1)', () => {
+      it('falls back to the draft key once the promoted insight is edited after promotion', () => {
+        const data = [{ x: 1 }];
+        useStore.setState({ insights: [{ name: 'ins_1' }], insightJobs: { ins_1: { name: 'ins_1', data } } });
+        markPromoted(['ins_1']);
+        const { rerender } = render(<ExplorerChartPreview />);
+        // First render: real data just landed, current insight state is what
+        // it represents — resolves to the real key.
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
+
+        // User edits the (still-promoted) insight's props post-promote — the
+        // SAME `data` object is still sitting in insightJobs (no new run yet).
+        act(() => {
+          useStore.setState({
+            explorerInsightStates: {
+              ins_1: { type: 'scatter', props: { x: '?{${ref(sales).new_col}}' }, interactions: [] },
+            },
+          });
+        });
+        rerender(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
+          JSON.stringify(['__draft__:ins_1'])
+        );
+      });
+
+      it('flips back to the real key once a fresh promote/run lands new data matching the current state', () => {
+        const staleData = [{ x: 1 }];
+        useStore.setState({
+          insights: [{ name: 'ins_1' }],
+          insightJobs: { ins_1: { name: 'ins_1', data: staleData } },
+        });
+        markPromoted(['ins_1']);
+        const { rerender } = render(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
+
+        // Edit — falls back to draft, as proven above.
+        act(() => {
+          useStore.setState({
+            explorerInsightStates: {
+              ins_1: { type: 'scatter', props: { x: '?{${ref(sales).new_col}}' }, interactions: [] },
+            },
+          });
+        });
+        rerender(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
+          JSON.stringify(['__draft__:ins_1'])
+        );
+
+        // Re-promote completes and a fresh run lands a NEW data reference —
+        // captured as representing the (current, just-repromoted) state.
+        const freshData = [{ x: 2 }];
+        act(() => {
+          useStore.setState({ insightJobs: { ins_1: { name: 'ins_1', data: freshData } } });
+        });
+        rerender(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
+      });
+
+      it('never flickers to draft on a render where insightJobs is unchanged and the insight is untouched', () => {
+        const data = [{ x: 1 }];
+        useStore.setState({ insights: [{ name: 'ins_1' }], insightJobs: { ins_1: { name: 'ins_1', data } } });
+        markPromoted(['ins_1']);
+        const { rerender } = render(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
+
+        // An unrelated re-render (e.g. chart layout edit) with no insight or
+        // data change must stay on the real key.
+        act(() => {
+          useStore.setState({ explorerChartLayout: { title: 'x' } });
+        });
+        rerender(<ExplorerChartPreview />);
+        expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(JSON.stringify(['ins_1']));
+      });
+    });
   });
 
   // VIS-1093 — the promoted-poll bridge's bounded lifetime + failure path.

--- a/viewer/src/components/onboarding/OnboardingChecklist.jsx
+++ b/viewer/src/components/onboarding/OnboardingChecklist.jsx
@@ -5,6 +5,7 @@ import './onboarding.css';
 import { hasCompletedOnboarding, readOnboardingState, writeOnboardingState } from './onboardingState';
 import { fireEvent } from './telemetry';
 import useChecklistProgress from './useChecklistProgress';
+import useStore from '../../stores/store';
 
 const CHECKLIST_WIDTH = 320;
 const VIEWPORT_PAD = 8;
@@ -34,6 +35,7 @@ function readPersistedPosition() {
 
 export default function OnboardingChecklist() {
   const navigate = useNavigate();
+  const createExploration = useStore(s => s.createExploration);
   const [collapsed, setCollapsed] = useState(false);
   const [dismissed, setDismissed] = useState(readDismissed());
 
@@ -136,7 +138,7 @@ export default function OnboardingChecklist() {
   if (!hasCompletedOnboarding()) return null;
   if (total > 0 && completed === total) return null;
 
-  const handleItemClick = it => {
+  const handleItemClick = async it => {
     if (it.done) return;
     fireEvent('onboarding_checklist_item_clicked', { item_id: it.id });
     // Clicking a checklist row is a reset for the Coach — even if the
@@ -147,6 +149,22 @@ export default function OnboardingChecklist() {
     const dismissed = (persisted.coach_dismissed || []).filter(id => id !== it.id);
     if (dismissed.length !== (persisted.coach_dismissed || []).length) {
       writeOnboardingState({ ...persisted, coach_dismissed: dismissed });
+    }
+    // D8 (e2e-gap-review.md delta pass): `it.route` for `mintsExploration`
+    // items (e.g. `build_model`) is the bare Explorer Home gallery — its
+    // first coach-mark target only exists INSIDE an open exploration tab.
+    // Mint one first (mirrors `DashboardExplorerRedirect` in
+    // LocalRouter.jsx: create via `createExploration`, then navigate
+    // straight to `/workspace/exploration/:id`) so the row always lands
+    // somewhere the target genuinely exists. Fails open to the bare route
+    // if the mint itself fails (network/API error), same contract as
+    // `DashboardExplorerRedirect`.
+    if (it.mintsExploration && typeof createExploration === 'function') {
+      const result = await createExploration();
+      if (result?.success && result.id) {
+        navigate(`/workspace/exploration/${result.id}`);
+        return;
+      }
     }
     navigate(it.route);
   };

--- a/viewer/src/components/onboarding/OnboardingChecklist.test.jsx
+++ b/viewer/src/components/onboarding/OnboardingChecklist.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import OnboardingChecklist from './OnboardingChecklist';
@@ -60,6 +60,60 @@ describe('OnboardingChecklist', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/workspace/exploration');
     const events = getEventBuffer().map(e => e.event);
     expect(events).toContain('onboarding_checklist_item_clicked');
+  });
+
+  // D8 (e2e-gap-review.md delta pass): `build_model`'s first coach-mark
+  // target (`query-chip-add`) only exists inside an open exploration tab,
+  // never on the bare `/workspace/exploration` gallery route. These tests
+  // lock in the mint-then-navigate fix on `handleItemClick`.
+  describe('mintsExploration items (D8 fix)', () => {
+    test('clicking build_model mints a fresh exploration and navigates straight to its own route', async () => {
+      writeOnboardingState({ completed_at: '2026-01-01' });
+      const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_abc123' });
+      useStore.mockImplementation(selector =>
+        selector({
+          project: { project_json: { dashboards: [], sources: [] } },
+          createExploration,
+        })
+      );
+      renderChecklist();
+      fireEvent.click(screen.getByTestId('onb-checklist-build_model'));
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith('/workspace/exploration/exp_abc123')
+      );
+      expect(createExploration).toHaveBeenCalled();
+      // Never navigated to the bare gallery route in this success path.
+      expect(mockNavigate).not.toHaveBeenCalledWith('/workspace/exploration');
+    });
+
+    test('clicking build_model fails open to the bare gallery route when minting fails', async () => {
+      writeOnboardingState({ completed_at: '2026-01-01' });
+      const createExploration = jest.fn().mockResolvedValue({ success: false, error: 'boom' });
+      useStore.mockImplementation(selector =>
+        selector({
+          project: { project_json: { dashboards: [], sources: [] } },
+          createExploration,
+        })
+      );
+      renderChecklist();
+      fireEvent.click(screen.getByTestId('onb-checklist-build_model'));
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/workspace/exploration'));
+    });
+
+    test('clicking a non-mintsExploration item (connect_source) never calls createExploration', () => {
+      writeOnboardingState({ completed_at: '2026-01-01' });
+      const createExploration = jest.fn();
+      useStore.mockImplementation(selector =>
+        selector({
+          project: { project_json: { dashboards: [], sources: [] } },
+          createExploration,
+        })
+      );
+      renderChecklist();
+      fireEvent.click(screen.getByTestId('onb-checklist-connect_source'));
+      expect(mockNavigate).toHaveBeenCalledWith('/editor');
+      expect(createExploration).not.toHaveBeenCalled();
+    });
   });
 
   test('clicking the empty circle manually marks the row done', () => {

--- a/viewer/src/components/onboarding/OnboardingCoach.jsx
+++ b/viewer/src/components/onboarding/OnboardingCoach.jsx
@@ -32,9 +32,18 @@ export default function OnboardingCoach() {
     setDismissedSet(readDismissed());
   }, [location.pathname]);
 
+  // D8 (e2e-gap-review.md delta pass): a route match must also cover a
+  // deeper sub-path of `currentItem.route`, not just an exact string match —
+  // `build_model` (and `create_insight`) advertise the bare
+  // `/workspace/exploration` gallery route, but `OnboardingChecklist`'s
+  // `mintsExploration` handling (see its `handleItemClick`) now lands the
+  // user on `/workspace/exploration/:id` instead, so the Coach must still
+  // recognize itself as "on route" there. Generalizes the pre-existing
+  // `/project` special case (a dashboard sub-route) into the same rule
+  // rather than special-casing `/workspace/exploration` a second time.
   const onRoute = currentItem
     ? location.pathname === currentItem.route ||
-      (currentItem.route === '/project' && location.pathname.startsWith('/project'))
+      location.pathname.startsWith(`${currentItem.route}/`)
     : false;
 
   // For multi-step macro items, the Coach points at the active step

--- a/viewer/src/components/onboarding/onboardingManifest.js
+++ b/viewer/src/components/onboarding/onboardingManifest.js
@@ -64,6 +64,17 @@ export const CHECKLIST_ITEMS = [
     route: '/workspace/exploration',
     target: 'query-chip-add',
     weight: 20,
+    // D8 (e2e-gap-review.md delta pass): `query-chip-add` only exists
+    // INSIDE an already-open exploration tab, never on the bare
+    // `/workspace/exploration` gallery `route` above points at — a
+    // first-time user clicking this row would land on an empty Home with
+    // no coach-mark and no indication anything was wrong.
+    // `OnboardingChecklist.handleItemClick` checks this flag and, instead
+    // of a bare `navigate(route)`, mints a fresh exploration first
+    // (mirroring `DashboardExplorerRedirect` in LocalRouter.jsx) and
+    // navigates straight to `/workspace/exploration/:id` — the one place
+    // `query-chip-add` is guaranteed to be mounted.
+    mintsExploration: true,
     // Multi-step flow: the Coach walks the user through creating a tab,
     // typing SQL, and running the query before the row checks off.
     // Each step's `done` reads a per-action flag tapped by the host

--- a/viewer/src/components/project/Project.jsx
+++ b/viewer/src/components/project/Project.jsx
@@ -8,14 +8,33 @@ import { Container } from '../styled/Container';
 import { HiTemplate } from 'react-icons/hi';
 import DashboardSection from '../project/DashboardSection';
 import FilterBar from '../project/FilterBar';
+import useProjectChangeListener from '../views/workspace/useProjectChangeListener';
 
 /**
  * Project - Container component for the new project view
  * Fetches data from stores and passes to Dashboard
  * Reads dashboards from the store instead of a project_json blob
+ *
+ * e2e-gap-review.md D7 ("VIS-1087's remaining half"): `/project` (this
+ * component) and `/runs` (RunsView.jsx) render OUTSIDE the Workspace shell —
+ * per `03-delivery-plan.md`'s "Resolved questions" §1, `/project` is
+ * deliberately the separate "consumer surface" and stays that way. Before
+ * this hook was mounted here, committing from any `/workspace/...` tab hard-
+ * reloaded every OTHER open tab sitting on `/project` or `/runs` (they never
+ * set `window.__VISIVO_SOFT_RELOAD__`, so the injected `/hot-reload.js`
+ * treated the commit-broadcast `reload` event as a real navigation and
+ * called `window.location.reload()`), wiping any live client-side state
+ * there. Mounting the SAME hook the Workspace already uses is a mechanical,
+ * behavior-preserving fix: it only sets a window flag + refetches the shared
+ * store's collections on a backend recompile — it does not change `/project`
+ * itself, retire it, or fold it into the Workspace.
  */
 function Project() {
   const { dashboardName } = useParams();
+
+  // D7: soft-refresh on backend `project_changed` events instead of a hard
+  // page reload — see the module docstring above.
+  useProjectChangeListener();
 
   // Positioned root the View-mode flip layer (VIS-788 / I-1) measures + delegates
   // pointer events against, so its flip buttons land over the dashboard's slots.

--- a/viewer/src/components/project/Project.test.jsx
+++ b/viewer/src/components/project/Project.test.jsx
@@ -6,6 +6,14 @@ import useStore from '../../stores/store';
 
 jest.mock('../../stores/store');
 
+// D7 (e2e-gap-review.md): Project now mounts the same H-2 project-change
+// socket listener the Workspace uses (useProjectChangeListener) — stub the
+// socket client so jsdom never attempts a real polling connection (mirrors
+// Workspace.test.jsx's identical stub).
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => ({ on: jest.fn(), close: jest.fn() })),
+}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(),

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -238,6 +238,28 @@ export function PropertyRow({
     pillState.kind !== 'custom' &&
     !forceRawEdit;
 
+  // D3 (e2e-gap-review.md delta pass): "Custom aggregation…" is otherwise a
+  // ONE-WAY RATCHET into raw-text mode — `forceRawEdit` is only ever reset
+  // by the `useEffect` above, keyed on `path` (stable for the row's whole
+  // mount), so even retyping the EXACT original recognized shape (e.g.
+  // `sum(${ref(q).amount})`, which `pillGrammar.parse` reclassifies as a
+  // clean `aggregate` pill) left the slot stuck in raw text until an
+  // unrelated remount. `pillState` already re-parses the CURRENT raw body
+  // on every change regardless of `forceRawEdit` (it only gates whether the
+  // pill RENDERS, not whether it's computed) — so whenever the user is in
+  // raw-edit mode AND the current text re-parses as a recognized, non-
+  // opaque/custom shape, offer an explicit, safe way back: a pure view-mode
+  // toggle that never mutates the underlying value (the raw text is already
+  // valid; `onClick` just flips `forceRawEdit` back to `false` so the SAME
+  // value renders as a pill instead of text).
+  const canReturnToPill =
+    droppable &&
+    currentMode === 'query' &&
+    isQueryFormValue &&
+    forceRawEdit &&
+    pillState.kind !== 'opaque' &&
+    pillState.kind !== 'custom';
+
   const pillType = pillState.kind === 'aggregate' || pillState.kind === 'metricRef' ? 'metric' : 'dimension';
   const pillLabel =
     pillState.kind === 'aggregate'
@@ -380,16 +402,30 @@ export function PropertyRow({
                   }
                 />
               ) : (
-                <RefTextArea
-                  value={body}
-                  onChange={handleQueryChange}
-                  label=""
-                  rows={2}
-                  helperText={description}
-                  disabled={disabled}
-                  allowedTypes={['model', 'dimension', 'metric', 'input']}
-                  restrictBrackets
-                />
+                <>
+                  <RefTextArea
+                    value={body}
+                    onChange={handleQueryChange}
+                    label=""
+                    rows={2}
+                    helperText={description}
+                    disabled={disabled}
+                    allowedTypes={['model', 'dimension', 'metric', 'input']}
+                    restrictBrackets
+                  />
+                  {canReturnToPill && (
+                    <button
+                      type="button"
+                      onClick={() => setForceRawEdit(false)}
+                      disabled={disabled}
+                      data-testid={`property-${path}-back-to-pill`}
+                      title="This expression matches a recognized shape again — switch back to the pill view."
+                      className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-primary-600 hover:text-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      ◂ Back to pill
+                    </button>
+                  )}
+                </>
               )}
             </div>
             {showSliceBadge && (

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -630,6 +630,112 @@ describe('PropertyRow', () => {
       expect(screen.getByTestId('ref-input')).toHaveValue('${ref(orders_q).amount}');
     });
 
+    // D3 (e2e-gap-review.md delta pass): the "Custom aggregation…" escape
+    // hatch used to be a one-way ratchet — no way back to pill rendering
+    // short of an unrelated remount, even once the raw text re-parses as a
+    // clean, recognized shape. These three tests lock in the "Back to pill"
+    // affordance's exact contract.
+    describe('"Back to pill" return path (D3)', () => {
+      test('the affordance is ABSENT immediately after "Custom aggregation…" while the raw text is still opaque/custom-shaped', () => {
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{count(distinct ${ref(orders_q).id})}"
+            droppable
+          />
+        );
+        // This value is already opaque (never rendered as a pill at all),
+        // so RefTextArea is the fallback from the start — no custom-aggregation
+        // click needed to reach raw-edit mode here.
+        expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+        expect(screen.queryByTestId('property-x-back-to-pill')).not.toBeInTheDocument();
+      });
+
+      test('the affordance APPEARS once the raw text re-parses as a recognized (non-opaque/custom) shape', () => {
+        // PropertyRow is a controlled component (`body` derives from the
+        // `value` prop) — mirrors the slice-badge tests' `rerender()`
+        // pattern to simulate the parent pushing the edited value back in,
+        // rather than relying on the mocked RefTextArea's onChange to
+        // mutate anything itself.
+        const { rerender } = render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{${ref(orders_q).amount}}"
+            droppable
+          />
+        );
+        fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+        fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+        // Still the exact original recognized shape — RefTextArea is showing
+        // (forceRawEdit is true) but the affordance should already be visible
+        // since the raw text re-parses as a clean 'dimension' pill.
+        expect(screen.getByTestId('property-x-back-to-pill')).toBeInTheDocument();
+
+        // Parent pushes an edited, OPAQUE value back in — the affordance
+        // must disappear (forceRawEdit stays true; only the affordance
+        // reacts to the reparse).
+        rerender(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{count(distinct ${ref(orders_q).id})}"
+            droppable
+          />
+        );
+        expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+        expect(screen.queryByTestId('property-x-back-to-pill')).not.toBeInTheDocument();
+
+        // Parent pushes an edited value back matching a recognized
+        // (aggregate) shape — the affordance returns.
+        rerender(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{sum(${ref(orders_q).amount})}"
+            droppable
+          />
+        );
+        expect(screen.getByTestId('property-x-back-to-pill')).toBeInTheDocument();
+      });
+
+      test('clicking the affordance returns to pill rendering with the value UNCHANGED', () => {
+        const onChange = jest.fn();
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{${ref(orders_q).amount}}"
+            droppable
+            onChange={onChange}
+          />
+        );
+        fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+        fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+        expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('property-x-back-to-pill'));
+
+        // Back to the pill — same dimension label as before the escape hatch.
+        expect(screen.getByText('orders_q ▸ amount')).toBeInTheDocument();
+        expect(screen.queryByTestId('ref-text-area')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('property-x-back-to-pill')).not.toBeInTheDocument();
+        // Purely a view-mode toggle — onChange is never called by it.
+        expect(onChange).not.toHaveBeenCalled();
+      });
+    });
+
     test('a bare ref matching a known Metric renders a metricRef pill (Σ-style, plain name)', () => {
       useStore.setState({ metrics: [{ name: 'churn_rate', parentModel: 'orders_q' }] });
       render(

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PiCheckCircle, PiXCircle, PiCircleNotch } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import { buildPromoteChecklist } from '../../../stores/promoteChecklist';
@@ -57,6 +57,8 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const [promotedThisRun, setPromotedThisRun] = useState(null);
   const [placing, setPlacing] = useState(false);
   const [placeError, setPlaceError] = useState(null);
+  const [declining, setDeclining] = useState(false);
+  const [declineError, setDeclineError] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,6 +134,18 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
 
   const totalRows = rows.length;
 
+  // P5-D2 (e2e-gap-review.md "Final delta pass") — partial promotion is
+  // documented as "normal" (handlePromote's own error-branch above handles
+  // it), so `promotedThisRun.success` (== every row succeeded) must NOT gate
+  // whether the succeeded rows' offers render. `promotedChart`/`promotedField`
+  // below already scope to per-row success; the success banner + both offer
+  // banners key off `promotedThisRun` existing and the relevant row(s) having
+  // actually succeeded, never overall-batch success.
+  const succeededCount = useMemo(
+    () => (promotedThisRun?.results || []).filter(r => r.success).length,
+    [promotedThisRun]
+  );
+
   // VIS-1068 — the chart promoted THIS RUN (return_to placement only makes
   // sense for a run that actually promoted a chart; older promotes in a
   // prior session don't retroactively offer placement).
@@ -144,28 +158,40 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     [returnTo, dashboards]
   );
 
+  // P5-D4 (e2e-gap-review.md "Final delta pass") — `disabled={placing}` alone
+  // is not a sufficient double-click guard: a real double-click can dispatch
+  // both click events before React re-renders the button disabled (the exact
+  // bug class VIS-1084/VIS-1086 fixed for ExplorationPane's handleDuplicate,
+  // via `duplicatingRef` above). Mirrors that same synchronous-ref pattern.
+  const placingRef = useRef(false);
+
   const handlePlaceInDashboard = useCallback(async () => {
+    if (placingRef.current) return;
     if (!returnTo?.dashboard || !promotedChart || !placeChartInDashboardSlot) return;
+    placingRef.current = true;
     setPlacing(true);
     setPlaceError(null);
-    const placeResult = await placeChartInDashboardSlot(
-      returnTo.dashboard,
-      promotedChart.name,
-      returnTo.slot
-    );
-    if (!placeResult?.success) {
+    try {
+      const placeResult = await placeChartInDashboardSlot(
+        returnTo.dashboard,
+        promotedChart.name,
+        returnTo.slot
+      );
+      if (!placeResult?.success) {
+        setPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
+        return;
+      }
+      await consumeExplorationReturnTo?.(explorationId);
+      openWorkspaceTab?.({
+        id: `dashboard:${returnTo.dashboard}`,
+        type: 'dashboard',
+        name: returnTo.dashboard,
+      });
+      onClose?.();
+    } finally {
+      placingRef.current = false;
       setPlacing(false);
-      setPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
-      return;
     }
-    await consumeExplorationReturnTo?.(explorationId);
-    setPlacing(false);
-    openWorkspaceTab?.({
-      id: `dashboard:${returnTo.dashboard}`,
-      type: 'dashboard',
-      name: returnTo.dashboard,
-    });
-    onClose?.();
   }, [
     returnTo,
     promotedChart,
@@ -178,8 +204,23 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
 
   // "Declining also consumes" (01-ux-spec.md §5) — an explicit choice, never
   // silent accretion of an ever-growing pile of dead placement intents.
-  const handleDeclinePlacement = useCallback(() => {
-    consumeExplorationReturnTo?.(explorationId);
+  //
+  // P5-D5 (e2e-gap-review.md "Final delta pass") — this used to be a bare,
+  // un-awaited fire-and-forget call: no loading/disabled state of its own, no
+  // error surfaced on failure, so a failed consume-return-to (network blip,
+  // or a concurrent write conflict on the same on-disk record — the exact
+  // unlocked read-modify-write risk `consumeExplorationReturnTo`'s own
+  // docstring calls out) silently left the offer able to resurface later
+  // with none of the accept path's rigor. Mirrors `handlePlaceInDashboard`'s
+  // own async/error-surfacing shape.
+  const handleDeclinePlacement = useCallback(async () => {
+    setDeclining(true);
+    setDeclineError(null);
+    const result = await consumeExplorationReturnTo?.(explorationId);
+    setDeclining(false);
+    if (!result?.success) {
+      setDeclineError(result?.error || 'Could not dismiss the placement offer');
+    }
   }, [consumeExplorationReturnTo, explorationId]);
 
   // VIS-1069 — the first metric/dimension promoted THIS RUN (mirrors
@@ -312,13 +353,13 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
           </p>
         )}
 
-        {promotedThisRun?.success && reclassificationOffers.length === 0 && (
+        {promotedThisRun && succeededCount > 0 && reclassificationOffers.length === 0 && (
           <p
             data-testid="exploration-promote-success"
             className="mt-3 text-xs text-green-700 bg-green-50 border border-green-200 rounded-md px-2.5 py-1.5"
           >
-            Promoted {promotedThisRun.results.filter(r => r.success).length} object
-            {promotedThisRun.results.filter(r => r.success).length === 1 ? '' : 's'}.
+            Promoted {succeededCount} object
+            {succeededCount === 1 ? '' : 's'}.
           </p>
         )}
 
@@ -330,7 +371,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
             return_to whose dashboard no longer exists renders the offer
             DISABLED with a tooltip rather than hiding it (04-bug-inventory.md
             D12's validation nit). */}
-        {promotedThisRun?.success && returnTo?.dashboard && promotedChart && (
+        {promotedThisRun && returnTo?.dashboard && promotedChart && (
           <div
             data-testid="exploration-promote-return-to-offer"
             className="mt-3 flex items-center justify-between gap-2 rounded-md border border-primary-200 bg-primary-50 px-2.5 py-2"
@@ -344,16 +385,16 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
                 type="button"
                 data-testid="exploration-promote-decline-placement"
                 onClick={handleDeclinePlacement}
-                disabled={placing}
+                disabled={placing || declining}
                 className="rounded-md px-2 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100 disabled:opacity-50"
               >
-                Not now
+                {declining ? 'Dismissing…' : 'Not now'}
               </button>
               <button
                 type="button"
                 data-testid="exploration-promote-place-in-dashboard"
                 onClick={handlePlaceInDashboard}
-                disabled={placing || !dashboardExists}
+                disabled={placing || declining || !dashboardExists}
                 title={!dashboardExists ? `"${returnTo.dashboard}" no longer exists` : undefined}
                 className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
@@ -372,10 +413,19 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
           </p>
         )}
 
+        {declineError && (
+          <p
+            data-testid="exploration-promote-decline-error"
+            className="mt-2 text-xs text-highlight-600 bg-highlight-50 border border-highlight-200 rounded-md px-2.5 py-1.5"
+          >
+            {declineError}
+          </p>
+        )}
+
         {/* VIS-1069 — Semantic Layer reciprocal: promoting a metric/dimension
             offers a one-click jump to the ERD, focused on that field's
             parent model node. */}
-        {promotedThisRun?.success && promotedField && (
+        {promotedThisRun && promotedField && (
           <div
             data-testid="exploration-promote-semantic-layer-offer"
             className="mt-3 flex items-center justify-between gap-2 rounded-md border border-primary-200 bg-primary-50 px-2.5 py-2"

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -180,6 +180,50 @@ describe('ExplorationPromoteModal', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  // P5-D2 (e2e-gap-review.md "Final delta pass") — a partial-failure promote
+  // must not forfeit the succeeded rows' own success messaging: the error and
+  // success banners are independent, not mutually exclusive.
+  test('a partial failure still shows the success banner for the rows that DID succeed', async () => {
+    buildPromoteChecklist.mockResolvedValue([row(), row({ name: 'flaky' })]);
+    const promoteExploration = jest.fn().mockResolvedValue({
+      success: false,
+      results: [
+        { type: 'model', name: 'orders_q', success: true, error: null },
+        { type: 'model', name: 'flaky', success: false, error: 'server rejected it' },
+      ],
+      reclassificationOffers: [],
+    });
+    useStore.setState({ promoteExploration });
+    render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+    await screen.findByTestId('exploration-promote-error');
+    // Both banners coexist — the failure of 'flaky' must never hide that
+    // 'orders_q' really did promote.
+    expect(screen.getByTestId('exploration-promote-success')).toHaveTextContent('Promoted 1 object');
+  });
+
+  // Overall success===false but zero rows actually succeeded — the success
+  // banner (which would otherwise read "Promoted 0 objects") must stay hidden.
+  test('a total failure (zero succeeded rows) shows only the error banner, never "Promoted 0 objects"', async () => {
+    buildPromoteChecklist.mockResolvedValue([row({ name: 'flaky' })]);
+    const promoteExploration = jest.fn().mockResolvedValue({
+      success: false,
+      results: [{ type: 'model', name: 'flaky', success: false, error: 'server rejected it' }],
+      reclassificationOffers: [],
+    });
+    useStore.setState({ promoteExploration });
+    render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+    await screen.findByTestId('exploration-promote-error');
+    expect(screen.queryByTestId('exploration-promote-success')).not.toBeInTheDocument();
+  });
+
   test('a reclassification offer stays open and renders the FieldSwapOfferBanner', async () => {
     buildPromoteChecklist.mockResolvedValue([row({ tier: 'field', type: 'metric' })]);
     const promoteExploration = jest.fn().mockResolvedValue({
@@ -337,6 +381,62 @@ describe('ExplorationPromoteModal', () => {
       expect(screen.getByTestId('exploration-promote-decline-placement')).toBeEnabled();
     });
 
+    // P5-D2 — the offer must key on the CHART row's own success, never on
+    // whether every selected row promoted (a sibling model/metric failing is
+    // "normal" partial promotion, per handlePromote's own docstring).
+    test('a partial-failure promote that includes a successfully-promoted chart still renders the Place-in-dashboard offer', async () => {
+      seedReturnTo({ dashboard: 'sales', slot: 'r1-i1' });
+      buildPromoteChecklist.mockResolvedValue([
+        row({ tier: 'chart', type: 'chart', name: 'churn_chart' }),
+        row({ name: 'flaky' }),
+      ]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: false,
+          results: [
+            { type: 'chart', name: 'churn_chart', success: true, error: null },
+            { type: 'model', name: 'flaky', success: false, error: 'server rejected it' },
+          ],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const offer = await screen.findByTestId('exploration-promote-return-to-offer');
+      expect(offer).toHaveTextContent('churn_chart');
+      // The error for the sibling failure coexists, not either/or.
+      expect(screen.getByTestId('exploration-promote-error')).toHaveTextContent('server rejected it');
+    });
+
+    // P5-D5 — declining is no longer a bare fire-and-forget: a failed
+    // consume-return-to must surface an error and keep the button re-clickable
+    // rather than silently letting the offer resurface with no feedback.
+    test('a failed decline surfaces an inline error and leaves the offer re-declinable', async () => {
+      seedReturnTo(
+        { dashboard: 'sales' },
+        { consumeExplorationReturnTo: jest.fn().mockResolvedValue({ success: false, error: 'network blip' }) }
+      );
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-return-to-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-decline-placement'));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('exploration-promote-decline-error')).toHaveTextContent('network blip')
+      );
+      // The offer itself is still present (return_to was never actually
+      // cleared server-side) and the decline button is re-clickable, not
+      // stuck disabled.
+      expect(screen.getByTestId('exploration-promote-return-to-offer')).toBeInTheDocument();
+      expect(screen.getByTestId('exploration-promote-decline-placement')).toBeEnabled();
+    });
+
     test('a placement failure shows an inline error and does not consume return_to or close', async () => {
       seedReturnTo({ dashboard: 'sales' }, {
         placeChartInDashboardSlot: jest.fn().mockResolvedValue({ success: false, error: 'slot taken' }),
@@ -356,6 +456,29 @@ describe('ExplorationPromoteModal', () => {
       );
       expect(useStore.getState().consumeExplorationReturnTo).not.toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
+    });
+
+    // P5-D4 — a real double-click can dispatch both events before React
+    // re-renders the button `disabled`; the synchronous `placingRef` guard
+    // must stop the second call regardless (mirrors ExplorationPane's
+    // `duplicatingRef`, VIS-1084/VIS-1086).
+    test('rapid double-click on Place-in-dashboard fires exactly one placement', async () => {
+      seedReturnTo({ dashboard: 'sales', slot: 'r1-i1' });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-return-to-offer');
+
+      const button = screen.getByTestId('exploration-promote-place-in-dashboard');
+      fireEvent.click(button);
+      fireEvent.click(button);
+
+      await waitFor(() =>
+        expect(useStore.getState().consumeExplorationReturnTo).toHaveBeenCalledTimes(1)
+      );
+      expect(useStore.getState().placeChartInDashboardSlot).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -384,6 +507,31 @@ describe('ExplorationPromoteModal', () => {
       expect(
         screen.queryByTestId('exploration-promote-semantic-layer-offer')
       ).not.toBeInTheDocument();
+    });
+
+    // P5-D2 — same offer-keys-on-row-success fix as the dashboard offer above.
+    test('a partial-failure promote that includes a successfully-promoted field still renders the View-in-Semantic-Layer offer', async () => {
+      buildPromoteChecklist.mockResolvedValue([
+        row({ tier: 'field', type: 'metric', name: 'churn_rate' }),
+        row({ name: 'flaky' }),
+      ]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: false,
+          results: [
+            { type: 'metric', name: 'churn_rate', success: true, error: null },
+            { type: 'model', name: 'flaky', success: false, error: 'server rejected it' },
+          ],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const offer = await screen.findByTestId('exploration-promote-semantic-layer-offer');
+      expect(offer).toHaveTextContent('churn_rate');
+      expect(screen.getByTestId('exploration-promote-error')).toHaveTextContent('server rejected it');
     });
 
     test('promoting a metric offers "View in Semantic Layer"; accepting sets the focus intent, opens the tab, and closes', async () => {

--- a/viewer/src/components/views/workspace/ExplorationQueryChips.jsx
+++ b/viewer/src/components/views/workspace/ExplorationQueryChips.jsx
@@ -6,6 +6,17 @@ import { useConfirm } from '../../common/ConfirmDialog';
 import InlineRenameInput from './InlineRenameInput';
 import useInlineRename from '../../../hooks/useInlineRename';
 import { countReferencingInsights } from '../../../utils/refWalk';
+import { getTypeColors } from '../common/objectTypeConfigs';
+
+// P5-D7 (e2e-gap-review.md final delta pass): the referenced-by badge is a
+// reference COUNT on a query/model object, so `model`'s token family (never
+// a hand-rolled `bg-teal-*`/`text-teal-*` pair) is the right source —
+// mirrors how `DraggableColumnHeader.jsx`/`AddComputedColumnPopover.jsx`
+// were migrated off hardcoded cyan/teal in the Phase 5 restyle sweep
+// (commit befa20a4, B9). `OBJECT_TYPES` is a module-scope constant, so this
+// lookup is stable and safe to hoist out of the component (matches
+// `WorkspaceDndContext.jsx`'s `DASH_COLORS` precedent).
+const REF_BADGE_COLORS = getTypeColors('model');
 
 /**
  * ExplorationQueryChips — Explore 2.0 Phase 3a (01-ux-spec.md §3).
@@ -145,7 +156,7 @@ const QueryChip = ({
         <span
           data-testid={`query-chip-${name}-ref-badge`}
           title={`${referencedCount} draft insight${referencedCount === 1 ? '' : 's'} reference this query`}
-          className="ml-0.5 inline-flex items-center gap-0.5 rounded bg-teal-100 px-1 py-0.5 text-[9px] font-semibold text-teal-700"
+          className={`ml-0.5 inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[9px] font-semibold ${REF_BADGE_COLORS.bg} ${REF_BADGE_COLORS.text}`}
         >
           <PiLink className="h-2.5 w-2.5" aria-hidden="true" />
           {referencedCount}

--- a/viewer/src/components/views/workspace/ExplorationQueryChips.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationQueryChips.test.jsx
@@ -94,6 +94,27 @@ describe('ExplorationQueryChips', () => {
     expect(screen.queryByTestId('query-chip-orders_q-ref-badge')).not.toBeInTheDocument();
   });
 
+  // P5-D7 (e2e-gap-review.md final delta pass): the badge must source its
+  // color from objectTypeConfigs' `model` token family (amber), never a
+  // hand-rolled teal/cyan class — the one hit the Phase 5 restyle sweep
+  // (befa20a4, B9) missed.
+  test('the referenced-by badge uses objectTypeConfigs "model" tokens, never hand-rolled teal/cyan classes', () => {
+    act(() => {
+      useStore.getState().createModelTab('orders_q');
+      useStore.setState({
+        explorerChartInsightNames: ['churn_by_cohort'],
+        explorerInsightStates: {
+          churn_by_cohort: { props: { x: '${ref(orders_q).cohort}' }, interactions: [] },
+        },
+      });
+    });
+    render(<ExplorationQueryChips />);
+    const badge = screen.getByTestId('query-chip-orders_q-ref-badge');
+    expect(badge.className).toContain('bg-amber-100');
+    expect(badge.className).toContain('text-amber-800');
+    expect(badge.className).not.toMatch(/\bteal-|\bcyan-/);
+  });
+
   describe('rename (active chip only)', () => {
     test('the ⋮ menu Rename action swaps the chip for an inline input; committing renames the tab', () => {
       act(() => {

--- a/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorationCard.jsx
@@ -155,13 +155,31 @@ const ExplorationCard = ({
         )}
       </div>
 
-      {exploration.seededFrom && (
+      {(exploration.seededFrom || exploration.returnTo?.dashboard) && (
         <div className="mb-3 flex flex-wrap items-center gap-1.5">
-          <FieldPill
-            type={exploration.seededFrom.type}
-            name={exploration.seededFrom.name}
-            label={`from ${exploration.seededFrom.type}: ${exploration.seededFrom.name}`}
-          />
+          {exploration.seededFrom && (
+            <FieldPill
+              type={exploration.seededFrom.type}
+              name={exploration.seededFrom.name}
+              label={`from ${exploration.seededFrom.type}: ${exploration.seededFrom.name}`}
+            />
+          )}
+          {/* D10 (e2e-gap-review.md "Final delta pass"): a minted `return_to`
+              placement intent was previously invisible everywhere in the UI —
+              this exploration's own card looked identical to a throwaway
+              scratch query. `type="dashboard"` pulls the same rose palette
+              every other dashboard surface uses (objectTypeConfigs.js), so
+              this reads as "destined for a dashboard", not a hand-rolled
+              color. */}
+          {exploration.returnTo?.dashboard && (
+            <FieldPill
+              type="dashboard"
+              name={exploration.returnTo.dashboard}
+              label={`→ ${exploration.returnTo.dashboard}`}
+              title={`Destined for dashboard: ${exploration.returnTo.dashboard}`}
+              data-testid={`exploration-card-${exploration.id}-return-to`}
+            />
+          )}
         </div>
       )}
 

--- a/viewer/src/components/views/workspace/homes/ExplorationCard.test.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorationCard.test.jsx
@@ -92,6 +92,56 @@ describe('ExplorationCard', () => {
     expect(screen.queryByText(/from /i)).not.toBeInTheDocument();
   });
 
+  // D10 (e2e-gap-review.md "Final delta pass"): a minted `return_to`
+  // placement intent was previously invisible everywhere in the UI — this
+  // card looked identical to a throwaway scratch exploration.
+  describe('return_to placement-intent chip (D10)', () => {
+    test('renders a "→ <dashboard>" chip when return_to is set', () => {
+      render(
+        <ExplorationCard
+          exploration={exploration({ returnTo: { dashboard: 'sales', slot: 'r1-i1' } })}
+          onOpen={jest.fn()}
+          onRename={jest.fn()}
+          onDuplicate={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      );
+      const chip = screen.getByTestId('exploration-card-exp_1-return-to');
+      expect(chip).toHaveTextContent('sales');
+      expect(chip).toHaveAttribute('title', expect.stringContaining('sales'));
+    });
+
+    test('does not render the return_to chip when return_to is null', () => {
+      render(
+        <ExplorationCard
+          exploration={exploration({ returnTo: null })}
+          onOpen={jest.fn()}
+          onRename={jest.fn()}
+          onDuplicate={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      );
+      expect(screen.queryByTestId('exploration-card-exp_1-return-to')).not.toBeInTheDocument();
+    });
+
+    test('renders BOTH the seededFrom and return_to chips together when both are set', () => {
+      render(
+        <ExplorationCard
+          exploration={exploration({
+            seededFrom: { type: 'model', name: 'orders' },
+            returnTo: { dashboard: 'sales' },
+          })}
+          onOpen={jest.fn()}
+          onRename={jest.fn()}
+          onDuplicate={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      );
+      expect(screen.getByText(/from model: orders/i)).toBeInTheDocument();
+      expect(screen.getByTestId('exploration-card-exp_1-return-to')).toHaveTextContent('sales');
+    });
+  });
+
   test('Open calls onOpen with the exploration id', () => {
     const onOpen = jest.fn();
     render(

--- a/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Position } from 'reactflow';
 import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
 import { NodeHandle } from '../../../styled/NodeHandle';
@@ -27,26 +27,57 @@ const FieldPills = ({ label, names, type }) => {
   const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
 
+  // P5-D4 (e2e-gap-review.md): a rapid double-click used to mint TWO
+  // exploration records — this pill had neither a `disabled` state nor an
+  // in-flight ref, unlike `ExplorationPane.jsx`'s `handleDuplicate`
+  // (`duplicatingRef`), which documents exactly why `disabled` alone is
+  // insufficient: a real double-click can dispatch both click events before
+  // React re-renders the button disabled. Mirrors that pattern here — a
+  // synchronous, per-field-name in-flight ref checked-and-set BEFORE the
+  // async `createExploration()` call, cleared in a `finally`. Keyed by name
+  // (not a single boolean) so exploring one field never blocks a DIFFERENT
+  // field's own pill in the same section. `disabled` state is layered on
+  // top purely as the visible affordance.
+  const exploringRef = useRef(new Set());
+  const [exploringNames, setExploringNames] = useState(() => new Set());
+
   const handleExploreField = useCallback(
     name => {
       if (!createExploration) return;
+      if (exploringRef.current.has(name)) return;
+      exploringRef.current.add(name);
+      setExploringNames(new Set(exploringRef.current));
       const seed = { type, name };
       const legacyStateOverride = buildExplorationSeedState
         ? buildExplorationSeedState(seed)
         : null;
-      createExploration(seed, null, legacyStateOverride).then(result => {
-        if (result?.success && openWorkspaceTab) {
-          openWorkspaceTab({
-            id: `exploration:${result.id}`,
-            type: 'exploration',
-            name: result.id,
-          });
-          emitWorkspaceEvent('explore_this_used', { source_type: type });
-        }
-      });
+      createExploration(seed, null, legacyStateOverride)
+        .then(result => {
+          if (result?.success && openWorkspaceTab) {
+            openWorkspaceTab({
+              id: `exploration:${result.id}`,
+              type: 'exploration',
+              name: result.id,
+            });
+            emitWorkspaceEvent('explore_this_used', { source_type: type });
+          }
+        })
+        .finally(() => {
+          exploringRef.current.delete(name);
+          setExploringNames(new Set(exploringRef.current));
+        });
     },
     [type, createExploration, buildExplorationSeedState, openWorkspaceTab]
   );
+
+  // A remount (e.g. the model's field list changing identity) must never
+  // leave a stale name stuck disabled forever.
+  useEffect(() => {
+    const inFlight = exploringRef.current;
+    return () => {
+      inFlight.clear();
+    };
+  }, []);
 
   if (!names || names.length === 0) return null;
   const colors = getTypeColors(type);
@@ -64,6 +95,7 @@ const FieldPills = ({ label, names, type }) => {
             type="button"
             data-testid={`erd-${type}-pill-${name}`}
             title={`Explore ${name}`}
+            disabled={exploringNames.has(name)}
             onPointerDown={e => e.stopPropagation()}
             onClick={e => {
               e.stopPropagation();
@@ -71,7 +103,7 @@ const FieldPills = ({ label, names, type }) => {
             }}
             className={[
               'inline-flex max-w-[120px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors',
-              'cursor-pointer hover:ring-1 hover:ring-inset',
+              'cursor-pointer hover:ring-1 hover:ring-inset disabled:cursor-not-allowed disabled:opacity-60',
               colors.bg,
               colors.text,
             ].join(' ')}

--- a/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.test.jsx
+++ b/viewer/src/components/views/workspace/relations/SemanticLayerErdModelNode.test.jsx
@@ -1,0 +1,143 @@
+/* eslint-disable no-template-curly-in-string -- N/A here, kept for parity with sibling test files */
+/**
+ * SemanticLayerErdModelNode (Explore 2.0 Phase 5 — VIS-1069) — the ERD
+ * model card's "Explore this" field-pill back-link.
+ *
+ * e2e-gap-review.md P5-D4 [MEDIUM, "Final delta pass"]: `handleExploreField`
+ * had NO in-flight guard at all (no `disabled`, no ref) — a rapid
+ * double-click could dispatch both click events before React ever re-renders
+ * a `disabled` button, minting two exploration records for the same field.
+ * Fixed with the same synchronous in-flight ref pattern `ExplorationPane.jsx`'s
+ * `handleDuplicate` uses (`duplicatingRef`), keyed per field NAME (not a
+ * single boolean) so exploring one field never blocks a sibling field's own
+ * pill.
+ */
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { ReactFlowProvider } from 'reactflow';
+import SemanticLayerErdModelNode from './SemanticLayerErdModelNode';
+import useStore from '../../../../stores/store';
+
+const data = {
+  name: 'orders',
+  columns: ['id', 'amount'],
+  metrics: ['total_revenue'],
+  dimensions: ['order_status', 'region'],
+};
+
+const seed = (extra = {}) => {
+  act(() => {
+    useStore.setState({
+      createExploration: jest.fn().mockResolvedValue({ success: true, id: 'exp_1' }),
+      buildExplorationSeedState: jest.fn(() => null),
+      openWorkspaceTab: jest.fn(),
+      ...extra,
+    });
+  });
+};
+
+const renderNode = (props = {}) =>
+  render(
+    <ReactFlowProvider>
+      <SemanticLayerErdModelNode data={data} selected={false} {...props} />
+    </ReactFlowProvider>
+  );
+
+describe('SemanticLayerErdModelNode — field pill "Explore this" back-link', () => {
+  test('clicking a metric pill mints an exploration seeded from that field and opens its tab', async () => {
+    const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_1' });
+    const openWorkspaceTab = jest.fn();
+    seed({ createExploration, openWorkspaceTab });
+    renderNode();
+
+    fireEvent.click(screen.getByTestId('erd-metric-pill-total_revenue'));
+    await waitFor(() => expect(openWorkspaceTab).toHaveBeenCalled());
+
+    expect(createExploration).toHaveBeenCalledWith(
+      { type: 'metric', name: 'total_revenue' },
+      null,
+      null
+    );
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'exploration:exp_1',
+      type: 'exploration',
+      name: 'exp_1',
+    });
+  });
+
+  // P5-D4 — the core regression-armor assertion: exactly one exploration
+  // gets minted from a rapid double-click.
+  test('double-clicking the SAME field pill mints exactly ONE exploration (P5-D4)', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    const openWorkspaceTab = jest.fn();
+    seed({ createExploration, openWorkspaceTab });
+    renderNode();
+
+    const pill = screen.getByTestId('erd-metric-pill-total_revenue');
+    fireEvent.click(pill);
+    fireEvent.click(pill); // fires before the first call resolves
+
+    await waitFor(() => expect(createExploration).toHaveBeenCalledTimes(1));
+    expect(pill).toBeDisabled();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_1' });
+    });
+    await waitFor(() => expect(pill).not.toBeDisabled());
+    expect(openWorkspaceTab).toHaveBeenCalledTimes(1);
+  });
+
+  test('the pill re-enables (and the guard clears) once the in-flight create resolves', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    seed({ createExploration });
+    renderNode();
+
+    const pill = screen.getByTestId('erd-metric-pill-total_revenue');
+    fireEvent.click(pill);
+    expect(pill).toBeDisabled();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_1' });
+    });
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    // A SUBSEQUENT click (after the first fully resolved) must still work —
+    // the guard isn't permanently stuck.
+    fireEvent.click(pill);
+    await waitFor(() => expect(createExploration).toHaveBeenCalledTimes(2));
+  });
+
+  // The in-flight guard is keyed PER FIELD NAME — a different field's own
+  // pill must never be blocked by a sibling field's in-flight create.
+  test('exploring one field does not disable a DIFFERENT field pill in the same section', async () => {
+    let resolveCreate;
+    const createExploration = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveCreate = resolve;
+        })
+    );
+    seed({ createExploration });
+    renderNode();
+
+    fireEvent.click(screen.getByTestId('erd-dimension-pill-order_status'));
+    expect(screen.getByTestId('erd-dimension-pill-order_status')).toBeDisabled();
+    expect(screen.getByTestId('erd-dimension-pill-region')).not.toBeDisabled();
+
+    await act(async () => {
+      resolveCreate({ success: true, id: 'exp_1' });
+    });
+  });
+});

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -351,4 +351,59 @@ describe('dashboardStore placeChartInDashboardSlot', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // e2e-gap-review.md P5-D3 [MEDIUM·CONFIRMED_GAP]: `dashboardExists`
+  // (ExplorationPromoteModal.jsx) and `placeChartInDashboardSlot` here both
+  // resolve their target by a BARE NAME match — neither has any notion of
+  // dashboard IDENTITY. Delete dashboard 'A' and create a brand-new,
+  // unrelated dashboard also named 'A' (or rename a different dashboard TO
+  // 'A') between minting a `return_to` intent and promoting, and both checks
+  // silently treat the NEW 'A' as the ORIGINAL target. A `slot` captured
+  // against the ORIGINAL A's row layout is now almost certainly stale
+  // against the NEW A's (probably very different) rows — `slotToInsertTarget`
+  // gracefully falls back to a "between rows" append rather than erroring,
+  // so the chart silently lands in the wrong (if same-named) dashboard
+  // object with zero signal that identity ever changed underneath the offer.
+  //
+  // This test LOCKS IN AND DOCUMENTS that defect — it does not fix it. A real
+  // fix (comparing dashboard identity, not just name) is a larger change,
+  // explicitly out of scope for this pass per the review's own recommendation.
+  test('P5-D3: a slot captured against the ORIGINAL "A" still applies via the between-rows fallback after "A" is deleted and a different dashboard is created with the SAME name — no identity check exists', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    // Original "A": 2 rows — a slot captured against it (row index 1) would
+    // have been a normal, in-range "append to row 1" placement.
+    seedPlace(
+      [
+        {
+          name: 'A',
+          config: {
+            rows: [{ items: [{ chart: 'ref(old1)' }] }, { items: [{ chart: 'ref(old2)' }] }],
+          },
+        },
+      ],
+      saveDashboard
+    );
+    const capturedSlot = '1:end'; // captured against the ORIGINAL A (2 rows)
+
+    // Simulate "delete A, then create a brand-new, unrelated dashboard also
+    // named A" — a totally different (empty) config under the SAME name, as
+    // if the exploration's `return_to.dashboard` name now resolves to a
+    // different underlying object. Nothing about `dashboards` here carries
+    // any id/version the store could have compared against the original.
+    seedPlace([{ name: 'A', config: { rows: [] } }], saveDashboard);
+
+    await act(async () => {
+      await useStore.getState().placeChartInDashboardSlot('A', 'orphaned_chart', capturedSlot);
+    });
+
+    // Silently "succeeds" — no error, no signal that the target dashboard's
+    // identity changed. slotToInsertTarget's out-of-range fallback (row index
+    // 1 doesn't exist in the NEW A's empty rows) lands the chart via a plain
+    // "between rows" append into whatever is now named "A".
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+    const [name, nextConfig] = saveDashboard.mock.calls[0];
+    expect(name).toBe('A');
+    expect(nextConfig.rows).toHaveLength(1);
+    expect(nextConfig.rows[0].items[0].chart).toBe('ref(orphaned_chart)');
+  });
 });

--- a/viewer/src/stores/explorerStore.snapshotIdentity.test.js
+++ b/viewer/src/stores/explorerStore.snapshotIdentity.test.js
@@ -1,0 +1,173 @@
+/* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
+/**
+ * Snapshot object-identity regression armor (e2e-gap-review.md #28 —
+ * LOW·PARTIAL: "draft.legacyState's nested objects are captured by reference,
+ * never proven safe across many park/resume cycles").
+ *
+ * `snapshotExplorerWorkingState()`/`restoreExplorerWorkingState()`
+ * (explorerStore.js) capture nested objects — `explorerInsightStates`, and
+ * each model's `computedColumns` array — BY REFERENCE, not deep-cloned, when
+ * a snapshot is embedded into an exploration's cached
+ * `draft.legacyState` (explorationLegacyBridge.js's `legacyStateToDraft`).
+ * This is currently safe ONLY because every mutator in explorerStore.js is
+ * copy-on-write (spread — `{...state.x, [k]: ...}` / `[...arr, item]` — never
+ * `.push()`/`.splice()`/direct assignment): switching to a different
+ * exploration REPOINTS the live store at a brand-new object rather than
+ * mutating the old one in place, so a PARKED exploration's already-cached
+ * snapshot is never reachable from the live store again.
+ *
+ * No prior test pinned this invariant across MANY park/resume cycles between
+ * two explorations — this is a pure object-IDENTITY concern, not
+ * DOM-observable, so it's a unit test here rather than an e2e story. It locks
+ * in the invariant so a future accidental in-place mutation on
+ * `explorerInsightStates`/`computedColumns` fails loudly here instead of
+ * silently corrupting a parked exploration's cached draft (e.g. the Home
+ * gallery's "n queries · n insights" summary silently drifting whenever a
+ * DIFFERENT exploration is edited afterward).
+ */
+import { act } from '@testing-library/react';
+import useStore from './store';
+import { legacyStateToDraft } from '../components/views/workspace/explorationLegacyBridge';
+
+/** Snapshot the CURRENT live working state and project it into the shape a
+ * real park (ExplorationPane's unmount cleanup -> updateExplorationDraft)
+ * would cache under `workspaceExplorations.byId[id].draft`. */
+const park = () => legacyStateToDraft(useStore.getState().snapshotExplorerWorkingState());
+
+describe('draft.legacyState snapshot object identity across many park/resume cycles (#28)', () => {
+  beforeEach(() => {
+    act(() => {
+      useStore.setState({
+        explorerModelTabs: [],
+        explorerModelStates: {},
+        explorerActiveModelName: null,
+        explorerInsightStates: {},
+        explorerChartInsightNames: [],
+        explorerActiveInsightName: null,
+        explorerChartName: null,
+        explorerChartLayout: {},
+        // Cross-type name-collision guard (assertNameUnique) reads these
+        // cached-object collections too — keep them empty/deterministic so
+        // this test's fixture names never collide with real project state
+        // some other test file may have left behind.
+        models: [],
+        insights: [],
+        sources: [],
+        charts: [],
+        inputs: [],
+        metrics: [],
+        dimensions: [],
+        relations: [],
+        tables: [],
+        dashboards: [],
+      });
+    });
+  });
+
+  test("mutating exploration B many cycles after A last parked never mutates A's already-cached draft.legacyState object", () => {
+    const byId = {};
+
+    // ---- Cycle 0: build + park exploration A ----
+    act(() => {
+      useStore.getState().restoreExplorerWorkingState(null);
+      useStore.getState().createModelTab('a_query');
+      useStore.getState().addActiveModelComputedColumn({ name: 'a_col_1', expression: '1+1' });
+      useStore.getState().createInsight('a_insight');
+      useStore.getState().setInsightProp('a_insight', 'x', '${ref(a_query).a_col_1}');
+    });
+    byId.A = park();
+
+    // Sanity check on the PREMISE itself (captured by reference, not a bug to
+    // fix): the cached draft's `insightStates` really is the SAME object as
+    // whatever the live store held at park time.
+    expect(byId.A.legacyState.insightStates).toBe(useStore.getState().explorerInsightStates);
+
+    // A snapshot of A's cached draft's CONTENT right after it first parked —
+    // diffed against itself after 3 more full A<->B round trips below.
+    const draftAAfterFirstPark = JSON.parse(JSON.stringify(byId.A));
+
+    // ---- Cycle 0: switch to B (a hard reset, matching a real activate-a-
+    // different-tab restore), build + park B ----
+    act(() => {
+      useStore.getState().restoreExplorerWorkingState(null);
+      useStore.getState().createModelTab('b_query');
+      useStore.getState().addActiveModelComputedColumn({ name: 'b_col_1', expression: '2+2' });
+      useStore.getState().createInsight('b_insight');
+      useStore.getState().setInsightProp('b_insight', 'y', '${ref(b_query).b_col_1}');
+    });
+    byId.B = park();
+
+    // ---- 3 more park/resume cycles, alternating A -> B -> A -> B, each one
+    // resuming from the OTHER exploration's own cached legacyState (exactly
+    // what ExplorationPane's restore-on-activate does) and mutating further.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      act(() => {
+        useStore.getState().restoreExplorerWorkingState(byId.A.legacyState);
+        useStore.getState().addActiveModelComputedColumn({
+          name: `a_extra_${cycle}`,
+          expression: `${cycle}`,
+        });
+        useStore.getState().setInsightProp('a_insight', `extra_${cycle}`, `val_${cycle}`);
+      });
+      byId.A = park();
+
+      act(() => {
+        useStore.getState().restoreExplorerWorkingState(byId.B.legacyState);
+        useStore.getState().addActiveModelComputedColumn({
+          name: `b_extra_${cycle}`,
+          expression: `${cycle}`,
+        });
+        useStore.getState().setInsightProp('b_insight', `extra_${cycle}`, `val_${cycle}`);
+      });
+      byId.B = park();
+    }
+
+    // The FIRST cached snapshot's content (captured before any of the above)
+    // is untouched by object reference — proving none of B's many later
+    // mutations (nor A's own later re-parks, which repoint `byId.A` at a
+    // brand-new draft object rather than mutating the first one) ever
+    // reached back through the shared `insightStates`/`computedColumns`
+    // references to corrupt an already-parked snapshot.
+    expect(JSON.parse(JSON.stringify(draftAAfterFirstPark))).toEqual(draftAAfterFirstPark);
+    expect(draftAAfterFirstPark.legacyState.insightStates.a_insight.props).toEqual({
+      x: '${ref(a_query).a_col_1}',
+    });
+    expect(
+      draftAAfterFirstPark.legacyState.modelStates.a_query.computedColumns.map(c => c.name)
+    ).toEqual(['a_col_1']);
+
+    // A's LATEST cached draft reflects every one of A's OWN edits, and NONE
+    // of B's — proving the shared-reference risk never actually bled state
+    // across explorations despite being captured by reference at every park.
+    const finalA = byId.A;
+    expect(Object.keys(finalA.legacyState.insightStates)).toEqual(['a_insight']);
+    expect(finalA.legacyState.insightStates.a_insight.props).toEqual({
+      x: '${ref(a_query).a_col_1}',
+      extra_0: 'val_0',
+      extra_1: 'val_1',
+      extra_2: 'val_2',
+    });
+    expect(
+      finalA.legacyState.modelStates.a_query.computedColumns.map(c => c.name)
+    ).toEqual(['a_col_1', 'a_extra_0', 'a_extra_1', 'a_extra_2']);
+
+    const finalB = byId.B;
+    expect(Object.keys(finalB.legacyState.insightStates)).toEqual(['b_insight']);
+    expect(finalB.legacyState.insightStates.b_insight.props).toEqual({
+      y: '${ref(b_query).b_col_1}',
+      extra_0: 'val_0',
+      extra_1: 'val_1',
+      extra_2: 'val_2',
+    });
+    expect(
+      finalB.legacyState.modelStates.b_query.computedColumns.map(c => c.name)
+    ).toEqual(['b_col_1', 'b_extra_0', 'b_extra_1', 'b_extra_2']);
+
+    // And, critically, A's final draft carries NO trace of B's names/values
+    // (the actual "cross-exploration bleed" failure mode #28 worries about).
+    expect(finalA.legacyState.insightStates.b_insight).toBeUndefined();
+    expect(finalA.legacyState.modelStates.b_query).toBeUndefined();
+    expect(finalB.legacyState.insightStates.a_insight).toBeUndefined();
+    expect(finalB.legacyState.modelStates.a_query).toBeUndefined();
+  });
+});

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -296,6 +296,18 @@ const createWorkspaceSlice = (set, get) => ({
     const activeObject = { type: tab.type, name: tab.name };
     const keyReset = outlineKeyResetFor(state.workspaceActiveObject, activeObject);
     const owningView = viewForDocumentType(tab.type);
+    // Cross-PR gap fix (#5, e2e-gap-review.md): ANY selection change must
+    // dismiss a pending tab-close confirmation — `requestCloseWorkspaceTab`
+    // parks `workspacePendingCloseTabId` so `TabCloseConfirmDialog` can ask
+    // first, but that dialog lives at the shell level (`TabStrip.jsx`), not
+    // inside the tab/view it was raised for. Before this fix, only
+    // `confirmCloseWorkspaceTab`/`cancelCloseWorkspaceTab`/
+    // `closeWorkspaceTab`'s own id-match guard ever cleared it — navigating
+    // away via ANY other path (a Library row, a switcher click, a keyboard
+    // shortcut) left the dialog mounted and rendered on top of whatever the
+    // user landed on next. Clearing it here (and in `activateWorkspaceView`
+    // below) makes every selection change dismiss the stale confirmation,
+    // exactly like actually closing the tab would have.
     if (existing) {
       if (state.workspaceActiveTabId !== id) {
         emitWorkspaceEvent('tab_switched', { id, type: tab.type, name: tab.name, via: 'open' });
@@ -304,6 +316,7 @@ const createWorkspaceSlice = (set, get) => ({
         workspaceActiveTabId: id,
         workspaceActiveObject: activeObject,
         workspaceActiveView: owningView,
+        workspacePendingCloseTabId: null,
         ...keyReset,
       });
       return id;
@@ -314,6 +327,7 @@ const createWorkspaceSlice = (set, get) => ({
       workspaceActiveTabId: id,
       workspaceActiveObject: activeObject,
       workspaceActiveView: owningView,
+      workspacePendingCloseTabId: null,
       ...keyReset,
     });
     return id;
@@ -333,7 +347,16 @@ const createWorkspaceSlice = (set, get) => ({
     if (state.workspaceActiveView !== view || state.workspaceActiveTabId) {
       emitWorkspaceEvent('view_activated', { view });
     }
-    set({ workspaceActiveView: view, workspaceActiveTabId: null, workspaceActiveObject: null });
+    // See the matching comment in `activateWorkspaceTab` — a destination
+    // switch must dismiss a pending tab-close confirmation too (#5,
+    // e2e-gap-review.md), or the dialog is left floating over the
+    // just-activated destination's Home.
+    set({
+      workspaceActiveView: view,
+      workspaceActiveTabId: null,
+      workspaceActiveObject: null,
+      workspacePendingCloseTabId: null,
+    });
   },
 
   /**

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -364,6 +364,43 @@ describe('workspace store slice', () => {
     expect(useStore.getState().workspacePendingCloseTabId).toBeNull();
   });
 
+  // Cross-PR gap fix (#5, e2e-gap-review.md): navigating away (a different
+  // tab, or a destination switch) while a tab-close confirmation is pending
+  // must dismiss the dialog too — previously ONLY confirm/cancel/the closed
+  // tab's own id-match guard ever cleared `workspacePendingCloseTabId`, so
+  // it stayed parked and the dialog kept rendering over whatever the user
+  // navigated to next.
+  test('activating a DIFFERENT tab while a close is pending clears the pending id (dialog does not orphan over the new tab)', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+      useStore.getState().setWorkspaceTabDirty('chart:c1', true);
+      useStore.getState().requestCloseWorkspaceTab('chart:c1');
+    });
+    expect(useStore.getState().workspacePendingCloseTabId).toBe('chart:c1');
+    act(() => {
+      useStore.getState().activateWorkspaceTab({ type: 'dashboard', name: 'd1' });
+    });
+    const s = useStore.getState();
+    expect(s.workspacePendingCloseTabId).toBeNull();
+    // The pending tab itself is untouched (still open, still dirty) — only
+    // the confirmation dialog's pending state is dismissed, not the tab.
+    expect(s.workspaceTabs.map((t) => t.id)).toContain('chart:c1');
+  });
+
+  test('activating a view (destination switch) while a close is pending clears the pending id', () => {
+    act(() => {
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'c1' });
+      useStore.getState().setWorkspaceTabDirty('chart:c1', true);
+      useStore.getState().requestCloseWorkspaceTab('chart:c1');
+    });
+    expect(useStore.getState().workspacePendingCloseTabId).toBe('chart:c1');
+    act(() => {
+      useStore.getState().activateWorkspaceView('semantic-layer');
+    });
+    expect(useStore.getState().workspacePendingCloseTabId).toBeNull();
+  });
+
   test('setWorkspaceTabDirty toggles the dirty flag without touching others', () => {
     act(() => {
       useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });


### PR DESCRIPTION
## Summary

Resumes and finalizes Explore 2.0 Phase 6 (cleanup + acceptance) after a machine crash killed the previous session mid-verification. This PR:

1. Coherence-reviewed the uncommitted diff left by the crashed session (three parallel sub-agents' armor work), fixing one real double-registration gap the review surfaced.
2. Committed the work in 3 logical commits (e2e armor suite, source closures, backend tests + zombie sweep).
3. Ran the full backend pytest suite, full viewer unit+lint suite, and the full 31-spec/113-test exploration & workspace e2e story suite against a live sandbox — 3 consecutive green runs.
4. Finalized the acceptance report with a per-item disposition table.

## Commits

- `1058b33a` — test(e2e): Phase 6 armor suite (VIS-1088/1089/1090 + P5-D3/D6 e2e closures + playwright.config.mjs double-registration fix)
- `a32a05c0` — fix(explorer): Phase 6 delta-pass source closures (onboarding D8, P5-D4/D7, cross-PR #5/#28)
- `80ebb073` — test(backend): exploration commit-surface exclusion + return_to permissiveness (#14/D12); zombie sweep

(on top of `733f2d2f`, already on the branch pre-crash: P5-D1/D2/D4-half/D5)

## Coherence-review finding fixed before any test run

`cross-tab-soft-reload-project-runs.spec.mjs` (new, D7/VIS-1087) was registered in the `workspace-publish` project's `testMatch` but missing from the `parallel` project's `testIgnore` — it would have run TWICE (once serially, correctly, and once concurrently inside the ~150-spec `parallel` project against the same sandbox it fires a real `POST /api/commit/` against). This is precisely the cross-spec interference failure mode called out as having hit this project twice before. Fixed and grep-verified every new mutating spec now appears exactly twice in the config.

## Disposition table

### Final-delta-pass findings (P5-D1..D7)

| Item | Severity | Disposition |
|---|---|---|
| P5-D1 sticky promoted-lane lock | HIGH | FIXED (commit `733f2d2f`, pre-crash) |
| P5-D2 partial-failure promote forfeits offers | HIGH | FIXED (commit `733f2d2f`) |
| P5-D3 dashboard delete/rename identity | MEDIUM | COVERED — documents the bare-name-match defect (unit test) + drives a real delete-before-promote e2e scenario against the existing `dashboardExists` guard; not fixed (identity-based matching is a larger change, out of scope per the finding's own recommendation) |
| P5-D4 double-click guards (2 surfaces) | MEDIUM | FIXED — Promote-modal half in `733f2d2f`; ERD "Explore this" half this pass (`SemanticLayerErdModelNode.jsx`) |
| P5-D5 decline-placement fire-and-forget | MEDIUM | FIXED (commit `733f2d2f`) |
| P5-D6 legend + computed-columns e2e gap | MEDIUM | FIXED — 2 new spec files restore both lost 05-e2e-ledger PORT-verdict capabilities |
| P5-D7 hardcoded badge color | LOW | FIXED — `ExplorationQueryChips.jsx` badge now sources `objectTypeConfigs` |

### VIS-1088/1089/1090 armor umbrellas

**VIS-1088 (navigation × dialog × history) — 9/9 covered.** #5, #15, #16, #17/#21/#26/#29, #25, plus Phase-3b-delta D3 (custom-aggregation ratchet) and D8 (onboarding cold-start) — all fixed/covered, new stories + unit tests.

**VIS-1089 (mid-flight interruption matrix) — 7/8 covered, 1 accepted gap.** #3/#4, #18, #27, D4/D11, and P5-D4's other half — fixed/covered. **#30** (Explorer-Home concurrent first-visit seed race) is NOT covered this pass — LOW severity, narrow precondition (two tabs racing the very first seed on a genuinely-empty project), cosmetic-only impact (duplicate card label, no data loss/crash/corruption per the finding's own text). Deferred as a follow-up rather than rushed.

**VIS-1090 (multi-session/state integrity) — 8/8 covered.** #13, #19, #22, #23, #28 (unit), #14 (backend), D7/VIS-1087 remainder, D10, D12 — all fixed/covered.

### Other items

- **Unadjudicated verifier claim** ("exploration chart section renders in-progress state"): resolved without a new test — `ExplorerChartPreview.test.jsx`'s pre-existing `forwards isLoading/error from useDraftInsightPreview via perInsight` test (plus the VIS-1092 mixed-lane describe block) already exercises this render path; confirmed still green in this pass's full viewer-test run.
- **VIS-726** ("Explorer tab activation breaks query running") — reverified against the live sandbox: does not repro, `ModelTabBar` (where the bug lived) no longer exists. Closing with comment.
- **VIS-662** ("Explorer page expands to size of model list") — reverified: `document.documentElement.scrollHeight` stays pinned to viewport height at both tall and short viewports; Library's own list scrolls internally. Closing with comment.
- **Zombie sweep**: removed a stray tracked `venv12` symlink (blob committed pre-existing its own `.gitignore` entry — directory-only patterns don't match a tracked symlink file); added this worktree's `venv14` to `.gitignore`; added `test-projects/*/.visivo/` ignore for the exploration workbench's runtime state.
- **www/ marketing claims** (report-only, no edits): Explore 2.0 isn't on `main` yet, so nothing is currently inaccurate. `posts/visivo-release-v1-0-81.mdx` will need a copy update once this ships (declares "there is only one Explorer now" — superseded once Explorer is one of three Workspace destinations). `posts/sql-editor-in-bi-power-users.mdx` has a minor precision drift. Flagging a **naming collision** (not stale, but worth fixing before new copy): `productData.js`/`ExplorerFlagship.jsx` already use "Explorer" for the unrelated Inputs feature.

## Test evidence

- Backend: `PYTHONPATH=$(pwd) ./venv14/bin/python -m pytest tests/ -x --tb=short -q` → **2134 passed, 2 skipped, 5 xfailed, 1 xpassed, 0 failed**
- `./venv14/bin/black --check --target-version py312 .` → **509 files unchanged, clean**
- Viewer: `bash scripts/viewer-check.sh` → **338 suites / 5674 passed, 2 skipped, 0 failed; lint clean**
- No `visivo/models/` changes in this pass — schema regen not needed.
- E2E: 31 spec files / 113 tests (the exploration + workspace mutation suite, covering VIS-1088/1089/1090 + P5-D3/D6 + the pre-existing gate set) run against a live sandbox serving this worktree's code (`venv14/bin/visivo serve --port 8001`, viewer on `:3001`, confirmed via `lsof` on the listening PID).
  - **Run 1:** 109 passed, 1 skipped (expected — `chart-legend-layout.spec.mjs`'s own best-effort geometry test gracefully skips), 3 failed — all `waitForBackendDraft`/`toPass` timeouts (15-25s) in tests spread across unrelated files (one new, one pre-existing/untouched, one new), no shared code path.
  - **Isolated re-verification** (same 3 spec files, 19 tests, single worker, zero concurrent projects): **19/19 passed**, including the exact 3 previously-timed-out tests (19.7s timeout → 8.3s pass; 19.8s timeout → 6.1s pass; wrong-URL failure → clean pass at 8.9s) — confirmed resource contention from 3 concurrent Playwright projects sharing one sandbox, not a product regression.
  - **Run 2:** killed at 49/113 clean once the pattern was confirmed — re-hit the SAME single test's second `waitForBackendDraft` timeout (D4 preset+slice, exploration-build-rail.spec.mjs), nothing else. Fixed by bumping that one call's timeout 15s → 30s (commit `62c870be`) — same "generous timeout absorbs real concurrent-load latency" precedent already used elsewhere in this suite. The assertion itself is unchanged.
  - **Run 3 (green 1/3):** 112 passed, 1 skipped (expected), 0 failed.
  - **Run 4 (green 2/3):** 112 passed, 1 skipped (expected), 0 failed. All three previously-flaky tests passed cleanly again.
  - **Run 5 (green 3/3):** 112 passed, 1 skipped (expected), 0 failed (11.5m). Three consecutive fully green full-suite runs achieved — acceptance gate met.

## Not done / could not confirm

- VIS-1089 #30 — see disposition table above; tracked as an explicit follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX
