### PR TITLE
Phase 6c-T1: preview integrity & states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ env/
 venv/
 venv12/
 venv14/
+# ...and the bare-symlink form: a trailing-slash rule matches directories
+# only, so a `venv14 -> /path/to/poetry-env` symlink slipped past it and got
+# committed by a `git add -A` (Wave 1), clobbering worktree venvs on checkout.
+/venv14
+/venv12
 cli_venv/
 api_venv/
 ENV/

--- a/tests/server/views/test_exploration_views.py
+++ b/tests/server/views/test_exploration_views.py
@@ -84,7 +84,11 @@ class TestCreate:
             json={"seeded_from": {"type": "model", "name": "orders"}},
         )
         assert resp.status_code == 201
-        assert resp.get_json()["seeded_from"] == {"type": "model", "name": "orders"}
+        assert resp.get_json()["seeded_from"] == {
+            "type": "model",
+            "name": "orders",
+            "content_signature": None,
+        }
 
     def test_create_with_draft(self, client):
         resp = client.post(
@@ -195,7 +199,11 @@ class TestUpdate:
         data = resp.get_json()
         assert data["id"] == created["id"]
         assert data["created_at"] == created["created_at"]
-        assert data["seeded_from"] == {"type": "model", "name": "orders"}
+        assert data["seeded_from"] == {
+            "type": "model",
+            "name": "orders",
+            "content_signature": None,
+        }
         assert data["promoted"] == []
         assert data["name"] == "Renamed"
 

--- a/venv14
+++ b/venv14
@@ -1,1 +1,0 @@
-/tmp/poetry-987-cache/virtualenvs/visivo-A-6GcZOt-py3.12

--- a/venv14
+++ b/venv14
@@ -1,0 +1,1 @@
+/tmp/poetry-987-cache/virtualenvs/visivo-A-6GcZOt-py3.12

--- a/viewer/e2e/stories/exploration-lifecycle.spec.mjs
+++ b/viewer/e2e/stories/exploration-lifecycle.spec.mjs
@@ -468,6 +468,13 @@ test.describe('Exploration lifecycle (Explore 2.0 Phase 2)', () => {
     await expect(page.getByTestId('workspace-middle-semantic-layer')).toBeVisible({
       timeout: 15000,
     });
+    // Wave-1 composed gate: the middle pane can commit a frame before the URL
+    // write lands under load (observed 1-in-3), so sampling `page.url()` at
+    // this exact instant is racy. Wait for the URL to BECOME the bare view
+    // route, then still assert the pathname exactly — same proof, not a
+    // weaker one. (That the pane can lead the URL at all is logged against
+    // 6c-T2 for a look at whether the write should be synchronous.)
+    await page.waitForURL('**/workspace/semantic-layer', { timeout: 10000 });
     expect(new URL(page.url()).pathname).toBe('/workspace/semantic-layer');
     await expect(page.getByTestId(`workspace-tab-exploration:${id}`)).toBeVisible();
 

--- a/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
@@ -1,0 +1,257 @@
+/**
+ * Story: the post-promote "add to a dashboard" offer, reached the way the
+ * adversarial UX audit's auditor actually walked the surface (Explore 2.0
+ * Phase 6c-T1 — ux-audit.md's "post-promote offers never appear" finding,
+ * ⚠ conflicts-with-e2e, promote-roundtrip #9).
+ *
+ * `dashboard-newchart-roundtrip.spec.mjs` already proves the
+ * `return_to`-driven "Place in <dashboard>" offer works — but ONLY through
+ * ONE specific entry point: the Library's "+ New" -> Chart button, used
+ * while a dashboard tab happens to be open. The audit's auditor (and
+ * `promote-roundtrip`'s own narrative) never went anywhere near a dashboard
+ * tab — they went Explorer home -> source tile -> query -> chart -> "Save
+ * to Project", the single most common path through this surface, and it
+ * never offered ANY next step toward a dashboard. This story reproduces
+ * EXACTLY that ordinary flow (no dashboard ever opened, no `return_to`
+ * ever armed) and asserts the fix: `ExplorationPromoteModal`'s new
+ * fallback offer (`exploration-promote-fallback-dashboard-offer`), which
+ * reuses the same `placeChartInDashboardSlot` plumbing the return_to-driven
+ * offer does.
+ *
+ * Precondition: sandbox running (integration project — has ≥1 real
+ * dashboard), e.g.
+ *   VISIVO_SANDBOX_NAME=fallbackOffer VISIVO_SANDBOX_BACKEND_PORT=8055 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3055 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3055 npx playwright test exploration-promote-fallback-dashboard-offer
+ *
+ * Mutates real backend records (explorations, models, insights, charts, AND
+ * a real dashboard's config) — runs in the serial `exploration-mutations`
+ * playwright project (playwright.config.mjs), never `parallel`. See the
+ * DOUBLE-REGISTRATION RULE note in playwright.config.mjs: this filename
+ * must appear in BOTH `exploration-mutations`'s `testMatch` AND
+ * `parallel`'s `testIgnore`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+/** Pick an option from the brand `<Select>` (react-select, not a native
+ * `<select>` — exploration-build-rail.spec.mjs's established pattern). The
+ * dashboard-picker Select here is `isSearchable={false}` (a handful of
+ * options at most), so this skips the type-to-filter step that pattern
+ * uses for a searchable instance. */
+async function pickSelectOption(page, testId, optionLabel) {
+  const container = page.getByTestId(testId);
+  await container.click();
+  const option = page
+    .locator('.vis-select__option', { hasText: new RegExp(`^${optionLabel}$`, 'i') })
+    .first();
+  await option.waitFor({ timeout: 5000 });
+  await option.click();
+}
+
+async function getRealDashboardName(page) {
+  const res = await page.request.get(`${apiBase}/api/dashboards/`);
+  expect(res.ok()).toBe(true);
+  const { dashboards } = await res.json();
+  expect(dashboards.length).toBeGreaterThan(0);
+  return dashboards[0].name;
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+/** The AUDIT'S OWN entry point — a source tile on Explorer home — never a
+ * dashboard-scoped "+ New Chart" click. This is the whole point of this
+ * spec: no `return_to` is ever armed anywhere in this flow. */
+async function startFromSourceTile(page) {
+  const tile = page.getByTestId(`explorer-home-source-tile-${SOURCE}`);
+  await expect(tile).toBeVisible({ timeout: 20000 });
+  await tile.click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstNumericColumn(page, tableRow) {
+  await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  await expect(col).toBeVisible({ timeout: 10000 });
+  return col;
+}
+
+async function bindXSlotToNumericColumn(page) {
+  await typeSql(page, `SELECT * FROM ${TABLE}`);
+  await runQuery(page);
+  const tableRow = await expandSourceTable(page);
+  const column = await firstNumericColumn(page, tableRow);
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await expect(xSlot).toBeVisible({ timeout: 15000 });
+  await dragAndDrop(page, column, xSlot);
+  await expect(xSlot.getByTestId('pill-menu-trigger')).toBeVisible({ timeout: 10000 });
+}
+
+async function fetchDashboard(page, name) {
+  const res = await page.request.get(`${apiBase}/api/dashboards/${encodeURIComponent(name)}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+function dashboardReferencesChart(dashboard, chartName) {
+  const rows = dashboard?.config?.rows || [];
+  return rows.some(row => (row.items || []).some(item => (item.chart || '').includes(chartName)));
+}
+
+test.describe('Post-promote fallback dashboard offer, reached through the ordinary Save-to-Project flow', () => {
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+  const createdObjects = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+    // Same dangling-dashboard-row cleanup precedent as
+    // dashboard-newchart-roundtrip.spec.mjs's afterEach — the placement
+    // below appends a real row to a SHARED dashboard.
+    await page.request.post(`${apiBase}/api/commit/discard/`).catch(() => {});
+  });
+
+  test('promoting from a plain source-tile-started exploration (no dashboard ever opened) offers to add the chart to a dashboard', async ({
+    page,
+  }) => {
+    const dashboardName = await getRealDashboardName(page);
+
+    // The audit's actual walkthrough: land on Explorer home, click a source
+    // tile — NEVER a dashboard canvas, NEVER the Library's dashboard-scoped
+    // "+ New Chart" button. `return_to` is never armed anywhere in this test.
+    await gotoExplorerHome(page);
+    const id = await startFromSourceTile(page);
+
+    const exploration = await (await page.request.get(`${apiBase}/api/explorations/${id}/`)).json();
+    expect(exploration.return_to).toBeFalsy();
+
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_fallback_offer_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    // The return_to-specific offer never appears (no return_to was ever
+    // armed) — but the fallback DOES, closing the audit's "the round-trip
+    // to a dashboard cannot even begin from here" gap.
+    await expect(page.getByTestId('exploration-promote-return-to-offer')).not.toBeVisible();
+    const fallbackOffer = page.getByTestId('exploration-promote-fallback-dashboard-offer');
+    await expect(fallbackOffer).toBeVisible({ timeout: 10000 });
+    await expect(fallbackOffer).toContainText(chartName);
+
+    await pickSelectOption(page, 'exploration-promote-fallback-dashboard-select', dashboardName);
+    await page.getByTestId('exploration-promote-fallback-place').click();
+
+    // Navigates to the dashboard tab.
+    await expect(page.getByTestId(`dashboard_${dashboardName}`)).toBeVisible({ timeout: 20000 });
+
+    // Backend-asserted after a reload — never a frontend string comparison
+    // (feedback_backend_diffing.md).
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(async () => {
+      const dashboard = await fetchDashboard(page, dashboardName);
+      expect(dashboardReferencesChart(dashboard, chartName)).toBe(true);
+    }).toPass({ timeout: 20000 });
+  });
+
+  test('the fallback offer never appears when nothing was promoted this run', async ({ page }) => {
+    await gotoExplorerHome(page);
+    const id = await startFromSourceTile(page);
+    // No query typed, nothing run, nothing to save — open Save to Project
+    // directly (the empty-checklist path).
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    // Nothing to save — the modal's own empty state; no fallback offer.
+    await expect(page.getByText('No changes to save.')).toBeVisible({ timeout: 10000 });
+    expect(await page.getByTestId('exploration-promote-fallback-dashboard-offer').count()).toBe(0);
+    await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+  });
+});

--- a/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
@@ -249,8 +249,15 @@ test.describe('Post-promote fallback dashboard offer, reached through the ordina
     // directly (the empty-checklist path).
     await page.getByTestId('explorer-save-button').click();
     await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
-    // Nothing to save — the modal's own empty state; no fallback offer.
-    await expect(page.getByText('No changes to save.')).toBeVisible({ timeout: 10000 });
+    // NOTE (gate correction): the modal's "No changes to save." empty state is
+    // NOT reachable this way — a source-tile exploration is seeded with a
+    // query + insight + chart, so the checklist is never empty here. (That the
+    // untouched seed is offered for saving at all is its own finding, tracked
+    // for 6c-T5/T3.) The behavior under test is the OFFER, so drive the
+    // reachable negative path instead: dismiss without saving anything.
+    await page.getByTestId('exploration-promote-cancel').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeHidden({ timeout: 10000 });
+    // Nothing was promoted this run -> no fallback dashboard offer anywhere.
     expect(await page.getByTestId('exploration-promote-fallback-dashboard-offer').count()).toBe(0);
     await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
   });

--- a/viewer/e2e/stories/exploration-staleness-drift.spec.mjs
+++ b/viewer/e2e/stories/exploration-staleness-drift.spec.mjs
@@ -1,0 +1,268 @@
+/**
+ * Story: staleness DRIFT detection — the underlying insight is edited
+ * elsewhere after an exploration copied it (Explore 2.0 Phase 6c-T1 —
+ * ux-audit.md's "no staleness indication after the underlying insight is
+ * edited elsewhere" finding, ⚠ conflicts-with-e2e, existing-objects #8).
+ *
+ * `exploration-staleness.spec.mjs` already proves the DANGLING-REF case
+ * (a copy references an object that's been DELETED) works end-to-end — but
+ * that is a different, narrower check than what the audit's auditor
+ * expected: "I edited aggregated-bar-insight's description in the project
+ * editor, reopened the exploration that copied it, and got no signal at
+ * all." A ref that still RESOLVES but whose CONTENT changed was a genuine,
+ * documented scope gap (`explorationStaleness.js`'s old "Scope" note) — the
+ * dangling-ref check can never catch it. This story reaches the FIX
+ * (`seededFrom.contentSignature` captured at seed time,
+ * `computeSeedContentSignature` compared on resume) the way a user does:
+ *
+ *   1. Publish a real insight via the ordinary "Save to Project" flow.
+ *   2. "Explore this" from the insight's Library row — a real copy-until-
+ *      promote exploration, seeded provenance captured for real.
+ *   3. The ORIGINAL insight is edited (simulating "someone/something else
+ *      touched it") through the exact same `/api/insights/<name>/` endpoint
+ *      the project editor's own Save button calls — never a frontend store
+ *      shortcut.
+ *   4. Reopening the copy (Explorer Home -> card -> Open, mirroring
+ *      exploration-staleness.spec.mjs's own park/reopen convention) shows
+ *      the drift line, naming the insight.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=stalenessDrift VISIVO_SANDBOX_BACKEND_PORT=8056 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3056 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3056 npx playwright test exploration-staleness-drift
+ *
+ * Mutates real backend records (explorations, models, insights, charts) —
+ * runs in the serial `exploration-mutations` playwright project
+ * (playwright.config.mjs), never `parallel`. See the DOUBLE-REGISTRATION
+ * RULE note in playwright.config.mjs: this filename must appear in BOTH
+ * `exploration-mutations`'s `testMatch` AND `parallel`'s `testIgnore`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1280, height: 1600 } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+const apiBase = (() => {
+  try {
+    const u = new URL(BASE_URL);
+    return `${u.protocol}//${u.hostname}:8001`;
+  } catch {
+    return 'http://localhost:8001';
+  }
+})();
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstNumericColumn(page, tableRow) {
+  await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  await expect(col).toBeVisible({ timeout: 10000 });
+  return col;
+}
+
+async function bindXSlotToNumericColumn(page) {
+  await typeSql(page, `SELECT * FROM ${TABLE}`);
+  await runQuery(page);
+  const tableRow = await expandSourceTable(page);
+  const column = await firstNumericColumn(page, tableRow);
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await expect(xSlot).toBeVisible({ timeout: 15000 });
+  await dragAndDrop(page, column, xSlot);
+  await expect(xSlot.getByTestId('pill-menu-trigger')).toBeVisible({ timeout: 10000 });
+}
+
+async function fetchExploration(page, id) {
+  const res = await page.request.get(`${apiBase}/api/explorations/${id}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+async function fetchInsight(page, name) {
+  const res = await page.request.get(`${apiBase}/api/insights/${encodeURIComponent(name)}/`);
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+/** Edits the PUBLISHED insight through the exact same `/api/insights/<name>/`
+ * endpoint the project editor's own InsightEditForm "Save" button calls
+ * (`saveInsight` -> `insightsApi.saveInsight` -> `POST /api/insights/<name>/`
+ * with the full config as the body) — never a frontend store shortcut. This
+ * is the "someone/something else touched the source object" half of the
+ * story; every OTHER step in this file is a real UI gesture. */
+async function editInsightElsewhere(page, name) {
+  const current = await fetchInsight(page, name);
+  const nextConfig = {
+    ...current.config,
+    props: { ...(current.config.props || {}), name: `edited_elsewhere_${Date.now()}` },
+  };
+  const res = await page.request.post(`${apiBase}/api/insights/${encodeURIComponent(name)}/`, {
+    data: nextConfig,
+  });
+  expect(res.ok()).toBe(true);
+}
+
+test.describe('Exploration staleness — drift detection (Explore 2.0 Phase 6c-T1)', () => {
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+  const createdObjects = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+    for (const { segment, name } of createdObjects.splice(0)) {
+      await page.request.delete(`${apiBase}/api/${segment}/${encodeURIComponent(name)}/`).catch(() => {});
+    }
+  });
+
+  test('editing the seeded-from insight elsewhere surfaces the drift banner on reopen, naming the insight', async ({
+    page,
+  }) => {
+    // --- Step 1: publish a real insight (+ its model + chart) via the
+    // ordinary Save-to-Project flow. ---
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    await bindXSlotToNumericColumn(page);
+
+    const chartName = `e2e_drift_chart_${Date.now()}`;
+    const nameInput = page.getByTestId('chart-name-input');
+    await nameInput.click();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(chartName, { delay: 5 });
+    await nameInput.blur();
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    // --- Step 2: "Explore this" from the insight's Library row. ---
+    await page.goto(`${BASE_URL}/workspace`);
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => window.useStore.getState().fetchInsights?.());
+
+    const insightHeader = page.getByTestId('library-subsection-insight-header');
+    const insightBody = page.getByTestId('library-subsection-insight-body');
+    if (!(await insightBody.isVisible().catch(() => false))) await insightHeader.click();
+    const insightRow = page.getByTestId(`library-row-insight-${insightName}`);
+    await expect(insightRow).toBeVisible({ timeout: 15000 });
+    await insightRow.click({ button: 'right' });
+    const ctxMenu = page.getByTestId(`library-row-insight-${insightName}-context-menu`);
+    await expect(ctxMenu).toBeVisible({ timeout: 5000 });
+    await ctxMenu.getByText('Explore this').click();
+
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+    const copyId = new URL(page.url()).pathname.split('/').pop();
+
+    // Pins the fix's seed-time capture: a real content_signature was
+    // recorded, not just the bare {type, name} provenance.
+    await expect(async () => {
+      const exploration = await fetchExploration(page, copyId);
+      expect(exploration.seeded_from).toMatchObject({ type: 'insight', name: insightName });
+      expect(typeof exploration.seeded_from.content_signature).toBe('string');
+      expect(exploration.seeded_from.content_signature.length).toBeGreaterThan(0);
+    }).toPass({ timeout: 15000 });
+
+    // No drift yet — the copy was JUST seeded from the current content.
+    await page.getByTestId('workspace-view-switcher-project').click();
+    await page.getByTestId('workspace-view-switcher-explorer').click();
+    await expect(page.getByTestId(`exploration-card-${copyId}-name`)).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId(`exploration-card-${copyId}-stale`)).not.toBeVisible();
+
+    // --- Step 3: the ORIGINAL insight is edited elsewhere (real backend
+    // save, same endpoint the project editor's Save button hits). ---
+    await editInsightElsewhere(page, insightName);
+    await page.evaluate(() => window.useStore.getState().fetchInsights());
+
+    // --- Step 4: reopening the copy shows the drift banner, naming the
+    // insight — the audit's exact missing signal. ---
+    await page.getByTestId(`exploration-card-${copyId}-open`).click();
+    await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+    const banner = page.getByTestId('exploration-staleness-banner');
+    await expect(banner).toBeVisible({ timeout: 15000 });
+    const drift = page.getByTestId('exploration-staleness-drift');
+    await expect(drift).toBeVisible();
+    await expect(drift).toContainText(insightName);
+    // D11 / plain language — never the save-to-project pipeline's internal
+    // vocabulary leaking onto an unrelated banner.
+    await expect(banner).not.toContainText('promoted');
+
+    // Dismiss hides it without touching the draft (same UX contract the
+    // dangling-ref case already has).
+    await page.getByTestId('exploration-staleness-dismiss').click();
+    await expect(banner).not.toBeVisible();
+  });
+});

--- a/viewer/e2e/stories/explore-this-flywheel.spec.mjs
+++ b/viewer/e2e/stories/explore-this-flywheel.spec.mjs
@@ -156,7 +156,12 @@ test.describe('The "Explore this" flywheel loop (Explore 2.0 Phase 5)', () => {
     // provenance record, not the query text.
     await expect(async () => {
       const exploration = await fetchExploration(page, explorationId2);
-      expect(exploration.seeded_from).toEqual({ type: 'model', name: modelName });
+      // 6c-T1 added `content_signature` to SeedRef (staleness drift detection),
+      // so the shape is no longer exactly these two keys — assert the
+      // identity fields exactly AND that the signature was captured.
+      expect(exploration.seeded_from).toMatchObject({ type: 'model', name: modelName });
+      expect(typeof exploration.seeded_from.content_signature).toBe('string');
+      expect(exploration.seeded_from.content_signature.length).toBeGreaterThan(0);
       expect((exploration.draft.queries || [])[0]?.sql || '').toContain(TABLE);
     }).toPass({ timeout: 15000 });
 
@@ -213,7 +218,12 @@ test.describe('The "Explore this" flywheel loop (Explore 2.0 Phase 5)', () => {
 
     await expect(async () => {
       const exploration = await fetchExploration(page, explorationId3);
-      expect(exploration.seeded_from).toEqual({ type: 'metric', name: metricName });
+      // 6c-T1 added `content_signature` to SeedRef (staleness drift detection),
+      // so the shape is no longer exactly these two keys — assert the
+      // identity fields exactly AND that the signature was captured.
+      expect(exploration.seeded_from).toMatchObject({ type: 'metric', name: metricName });
+      expect(typeof exploration.seeded_from.content_signature).toBe('string');
+      expect(exploration.seeded_from.content_signature.length).toBeGreaterThan(0);
     }).toPass({ timeout: 15000 });
 
     // The two round-trip explorations are genuinely distinct records.

--- a/viewer/e2e/stories/explore-this-flywheel.spec.mjs
+++ b/viewer/e2e/stories/explore-this-flywheel.spec.mjs
@@ -222,8 +222,12 @@ test.describe('The "Explore this" flywheel loop (Explore 2.0 Phase 5)', () => {
       // so the shape is no longer exactly these two keys — assert the
       // identity fields exactly AND that the signature was captured.
       expect(exploration.seeded_from).toMatchObject({ type: 'metric', name: metricName });
-      expect(typeof exploration.seeded_from.content_signature).toBe('string');
-      expect(exploration.seeded_from.content_signature.length).toBeGreaterThan(0);
+      // 6c-T1's drift detection deliberately does NOT hash metric/dimension
+      // seeds (explorationStaleness.js's SIGNATURE_TYPES): a metric has no
+      // standalone content — it lives inside its model's config — so its
+      // signature is null BY DESIGN rather than guessed at. Asserted so the
+      // contract is documented, not silently assumed.
+      expect(exploration.seeded_from.content_signature).toBeNull();
     }).toPass({ timeout: 15000 });
 
     // The two round-trip explorations are genuinely distinct records.

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -104,6 +104,13 @@ export default defineConfig({
         '**/workspace-cross-tab-tabset.spec.mjs',
         '**/exploration-cross-tab-concurrency.spec.mjs',
         '**/exploration-cross-tab-dnd-isolation.spec.mjs',
+        // Phase 6c-T1 (ux-audit.md "post-promote offers never appear" /
+        // "no staleness indication" findings): each mints real backend
+        // exploration + model/insight/chart records via the same shared
+        // `.visivo/explorations/` repository — same isolation need as every
+        // other exploration-mutating spec above.
+        '**/exploration-promote-fallback-dashboard-offer.spec.mjs',
+        '**/exploration-staleness-drift.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -251,6 +258,10 @@ export default defineConfig({
         '**/workspace-cross-tab-tabset.spec.mjs',
         '**/exploration-cross-tab-concurrency.spec.mjs',
         '**/exploration-cross-tab-dnd-isolation.spec.mjs',
+        // Phase 6c-T1 additions — see the 'parallel' project's testIgnore
+        // entry for the same two files for why.
+        '**/exploration-promote-fallback-dashboard-offer.spec.mjs',
+        '**/exploration-staleness-drift.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
-import { PiCircleNotch } from 'react-icons/pi';
+import { PiCircleNotch, PiCursorClick } from 'react-icons/pi';
 import ChartPreview from '../views/common/ChartPreview';
 import useDraftInsightPreview, { draftInsightKey } from '../../hooks/useDraftInsightPreview';
 import { useInsightsData } from '../../hooks/useInsightsData';
@@ -285,9 +285,21 @@ const ExplorerChartPreview = () => {
     [chartInsightNames, insightStates]
   );
 
+  // ux-audit.md "unresolved-input misclassification" finding (cold-start #3,
+  // promote-roundtrip #3, pills #3): a model reference authored via the
+  // Build rail's own pill drops (`?{${ref(model).column}}`) is picked up by
+  // the SAME regex `extractInputDependenciesFromProps` uses to find real
+  // Input references — the two are textually indistinguishable without
+  // knowing what names are actually models. `usePreviewInputDependencies`
+  // excludes PUBLISHED model names on its own (`state.models`); draft/
+  // not-yet-promoted model tabs only exist here (`explorerModelStates`), so
+  // they're passed explicitly.
+  const extraModelNames = useMemo(() => Object.keys(modelStates || {}), [modelStates]);
+
   const { inputConfigs, unresolvedNames } = usePreviewInputDependencies(projectId, {
     insightNames: draftPreview.previewInsightKeys,
     configForFallback,
+    extraModelNames,
   });
 
   const chartConfig = useMemo(
@@ -323,11 +335,30 @@ const ExplorerChartPreview = () => {
       >
         <PiCircleNotch className="h-5 w-5 text-secondary-300" aria-hidden="true" />
         <span className="text-sm font-medium text-secondary-600">
-          Run the query{draftLaneBlockedStatus.blockedModel ? ` for "${draftLaneBlockedStatus.blockedModel}"` : ''}{' '}
-          to preview this chart
+          Run your query{draftLaneBlockedStatus.blockedModel ? ` for "${draftLaneBlockedStatus.blockedModel}"` : ''}{' '}
+          to see a preview
         </span>
         <span className="text-xs text-secondary-400 max-w-sm">
-          This insight references a column on a model that hasn&apos;t returned any rows yet.
+          This chart references a column on a model that hasn&apos;t returned any rows yet.
+        </span>
+      </div>
+    );
+  }
+
+  // ux-audit.md "infinite spinner" finding (cold-start #2, pills #3): nothing
+  // has been mapped to this insight yet (no x/y/etc.), so there is genuinely
+  // nothing to compile or load — a guided empty state, never a spinner that
+  // waits on a request that was never made.
+  if (draftLaneBlockedStatus?.blockedReason === 'no_data_props') {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full bg-gray-50 gap-2 p-6 text-center"
+        data-testid="chart-preview-empty-no-props"
+      >
+        <PiCursorClick className="h-5 w-5 text-secondary-300" aria-hidden="true" />
+        <span className="text-sm font-medium text-secondary-600">Nothing to preview yet</span>
+        <span className="text-xs text-secondary-400 max-w-sm">
+          Drag a column from the results grid onto a field (like x or y) to see a chart preview.
         </span>
       </div>
     );
@@ -341,8 +372,9 @@ const ExplorerChartPreview = () => {
           data-testid="chart-preview-unresolved-inputs"
           className="px-3 py-1.5 text-xs text-highlight-700 bg-highlight-50 border-b border-highlight-200"
         >
-          References input{unresolvedNames.length === 1 ? '' : 's'}{' '}
-          {unresolvedNames.map(n => `"${n}"`).join(', ')} — not yet promoted.
+          Input{unresolvedNames.length === 1 ? '' : 's'}{' '}
+          {unresolvedNames.map(n => `"${n}"`).join(', ')}{' '}
+          {unresolvedNames.length === 1 ? "isn't" : "aren't"} defined in this project yet.
         </div>
       )}
       {/* VIS-1093 — the promoted-poll bridge's failure path: surfaced as a

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -189,6 +189,23 @@ describe('ExplorerChartPreview', () => {
     expect(screen.queryByTestId('chart-preview-component')).not.toBeInTheDocument();
   });
 
+  // ux-audit.md "infinite spinner" finding (cold-start #2, pills #3): nothing
+  // mapped yet -> a guided empty state, never a spinner with no request in
+  // flight (Chart.jsx's own `hasAllInsightData` gate would otherwise spin
+  // forever waiting on data this hook never even tries to fetch).
+  it('renders a guided empty state instead of ChartPreview on a no_data_props block', () => {
+    useDraftInsightPreview.mockReturnValue({
+      ...defaultDraftPreview,
+      perInsight: {
+        ins_1: { isLoading: false, error: null, blockedReason: 'no_data_props', blockedModel: null },
+      },
+    });
+    render(<ExplorerChartPreview />);
+    expect(screen.getByTestId('chart-preview-empty-no-props')).toBeInTheDocument();
+    expect(screen.queryByTestId('chart-preview-component')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('chart-preview-loading')).not.toBeInTheDocument();
+  });
+
   // VIS-1092 — the actual mixed-lane guarantee: a promoted insight with real
   // data must never be blanked by a DRAFT sibling's error/loading, because
   // the promoted one isn't even in the draft lane the aggregate is scoped to.
@@ -228,14 +245,30 @@ describe('ExplorerChartPreview', () => {
     expect(screen.getByTestId('preview-input-controls')).toHaveTextContent('region');
   });
 
-  it('surfaces an explicit banner for a draft referencing a not-yet-promoted input (never a silent drop)', () => {
+  it('surfaces an explicit banner for a draft referencing a genuinely undefined input (never a silent drop)', () => {
     usePreviewInputDependencies.mockReturnValue({
       inputConfigs: [],
-      unresolvedNames: ['not_yet_promoted'],
+      unresolvedNames: ['not_defined_yet'],
     });
     render(<ExplorerChartPreview />);
-    expect(screen.getByTestId('chart-preview-unresolved-inputs')).toHaveTextContent(
-      'not_yet_promoted'
+    const banner = screen.getByTestId('chart-preview-unresolved-inputs');
+    expect(banner).toHaveTextContent('not_defined_yet');
+    // D11 / ux-audit.md "unresolved-input misclassification": plain
+    // language, never the "promoted" pipeline jargon a MODEL banner used to
+    // leak onto a genuine input.
+    expect(banner).not.toHaveTextContent('promoted');
+  });
+
+  // ux-audit.md "unresolved-input misclassification" (cold-start #3): the
+  // component must hand its own known draft model tab names to
+  // usePreviewInputDependencies so a model ref (e.g. the auto-created
+  // 'model' tab) is never misclassified as an unresolved input.
+  it('passes draft model tab names as extraModelNames to usePreviewInputDependencies', () => {
+    useStore.setState({ explorerModelStates: { orders_q: {}, model: {} } });
+    render(<ExplorerChartPreview />);
+    expect(usePreviewInputDependencies).toHaveBeenCalledWith(
+      'proj-1',
+      expect.objectContaining({ extraModelNames: expect.arrayContaining(['orders_q', 'model']) })
     );
   });
 

--- a/viewer/src/components/views/common/ChartPreview.jsx
+++ b/viewer/src/components/views/common/ChartPreview.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import Chart from '../../items/Chart';
 import CircularProgress from '@mui/material/CircularProgress';
+import { translatePreviewError } from '../../../utils/translatePreviewError';
 
 const EDITABLE_PLOTLY_CONFIG = {
   responsive: true,
@@ -102,16 +103,30 @@ const ChartPreview = ({
   }
 
   if (error) {
-    const errorMessage = typeof error === 'string' ? error : error?.message || String(error);
+    // ux-audit.md "error translation" finding: never surface a raw
+    // engine/compile message (hashed table names, DuckDB catalog "Did you
+    // mean pg_*" suggestions, DAG-internals jargon) as the prominent copy —
+    // translate to plain language, and keep the raw message available only
+    // behind a collapsed "technical details" disclosure.
+    const rawMessage = typeof error === 'string' ? error : error?.message || String(error);
+    const { headline, hint, technical } = translatePreviewError(rawMessage);
     return (
       <div
         className="flex flex-col items-center justify-center h-full p-8 text-center"
         data-testid="chart-preview-error"
       >
-        <h3 className="text-lg font-medium text-red-600 mb-2">Preview Failed</h3>
-        <p className="text-sm text-gray-700 max-w-sm font-mono bg-red-50 p-3 rounded">
-          {errorMessage}
-        </p>
+        <h3 className="text-lg font-medium text-red-600 mb-2">{headline}</h3>
+        <p className="text-sm text-gray-600 max-w-sm mb-2">{hint}</p>
+        {technical && (
+          <details className="mt-1 w-full max-w-sm text-left" data-testid="chart-preview-error-technical">
+            <summary className="cursor-pointer select-none text-xs text-gray-400 hover:text-gray-600">
+              Technical details
+            </summary>
+            <p className="mt-1 whitespace-pre-wrap break-words rounded bg-red-50 p-3 font-mono text-xs text-gray-700">
+              {technical}
+            </p>
+          </details>
+        )}
       </div>
     );
   }

--- a/viewer/src/components/views/common/ChartPreview.test.jsx
+++ b/viewer/src/components/views/common/ChartPreview.test.jsx
@@ -84,7 +84,7 @@ describe('ChartPreview (presentational)', () => {
     expect(screen.getByText('Running query')).toBeInTheDocument();
   });
 
-  it('shows error state when error prop is set', () => {
+  it('shows error state when error prop is set, with the raw message tucked behind technical details', () => {
     render(
       <ChartPreview
         chartConfig={chartConfig}
@@ -94,7 +94,61 @@ describe('ChartPreview (presentational)', () => {
       />
     );
     expect(screen.getByTestId('chart-preview-error')).toBeInTheDocument();
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('This preview failed to run.')).toBeInTheDocument();
+    expect(screen.getByTestId('chart-preview-error-technical')).toHaveTextContent(
+      'Something went wrong'
+    );
+  });
+
+  // ux-audit.md "error translation" finding (cold-start #1, promote-roundtrip
+  // #1/#2, pills #3): a hashed internal table name must never appear as the
+  // prominent headline — only inside the collapsed technical details.
+  it('translates a hashed-table catalog error to plain language, hiding the hash from the headline', () => {
+    render(
+      <ChartPreview
+        chartConfig={chartConfig}
+        insightKeys={['__preview__a']}
+        projectId="p"
+        error='Catalog Error: Table with name mfiawdybhqqkwzuxbjzfxqbvbaibc does not exist! Did you mean "pg_index"?'
+      />
+    );
+    // The headline and hint are exact, hash-free strings — the hash exists
+    // ONLY inside the collapsed technical-details block below.
+    expect(screen.getByText("This chart hasn't loaded any data yet.")).toBeInTheDocument();
+    expect(
+      screen.getByText('Run your query, then come back to this tab to see a preview.')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('chart-preview-error-technical')).toHaveTextContent(
+      'mfiawdybhqqkwzuxbjzfxqbvbaibc'
+    );
+  });
+
+  it('translates "has no dependent models" jargon to a plain drag-a-column hint', () => {
+    render(
+      <ChartPreview
+        chartConfig={chartConfig}
+        insightKeys={['__preview__a']}
+        projectId="p"
+        error="Insight 'insight' has no dependent models"
+      />
+    );
+    const errorPanel = screen.getByTestId('chart-preview-error');
+    expect(errorPanel).toHaveTextContent("isn't connected to any data yet");
+    expect(errorPanel).toHaveTextContent('Drag a column from the Library');
+  });
+
+  it('accepts an Error-shaped object (not just a string) for the error prop', () => {
+    render(
+      <ChartPreview
+        chartConfig={chartConfig}
+        insightKeys={['__preview__a']}
+        projectId="p"
+        error={new Error('boom from an Error object')}
+      />
+    );
+    expect(screen.getByTestId('chart-preview-error-technical')).toHaveTextContent(
+      'boom from an Error object'
+    );
   });
 
   it('shows empty state when insightKeys is empty', () => {

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -338,6 +338,7 @@ const ExplorationPane = ({ id }) => {
       {!stalenessDismissed && staleness?.stale && (
         <ExplorationStalenessBanner
           danglingRefs={staleness.danglingRefs}
+          driftedFrom={staleness.driftedFrom}
           onRecheck={handleRecheckStaleness}
           onDismiss={handleDismissStaleness}
         />

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -4,6 +4,7 @@ import useStore from '../../../stores/store';
 import { buildPromoteChecklist } from '../../../stores/promoteChecklist';
 import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
 import FieldSwapOfferBanner from './FieldSwapOfferBanner';
+import Select from '../../common/Select';
 
 const TIER_HEADING = { model: 'MODELS', field: 'FIELDS', insight: 'INSIGHTS', chart: 'CHART' };
 const TIER_ORDER = ['model', 'field', 'insight', 'chart'];
@@ -158,6 +159,56 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     [returnTo, dashboards]
   );
 
+  // ux-audit.md "post-promote offers never appear" finding (⚠
+  // conflicts-with-e2e — promote-roundtrip #9): the `return_to`-driven offer
+  // above is real and works — dashboard-newchart-roundtrip.spec.mjs proves
+  // it — but `return_to` is only ever armed by ONE specific entry point
+  // (Library "+ New" -> Chart, scoped to an already-open dashboard tab). The
+  // canonical build flow this audit walked through (Explorer home -> source
+  // tile -> query -> chart -> Save to Project) never sets it, so the
+  // flywheel's own advertised "promote -> place in dashboard" round-trip had
+  // NO exit ramp at all for the single most common path — a too-narrow
+  // condition on an otherwise-correct feature, not a bug in the feature
+  // itself. This fallback reuses the exact same `placeChartInDashboardSlot`
+  // plumbing for the common case: a chart was promoted this run, there's no
+  // `return_to` intent already offering placement, and at least one
+  // dashboard exists to place it in.
+  const showFallbackDashboardOffer = !!promotedChart && !returnTo?.dashboard && dashboards.length > 0;
+  const [fallbackDashboardName, setFallbackDashboardName] = useState('');
+  useEffect(() => {
+    if (showFallbackDashboardOffer && !fallbackDashboardName) {
+      setFallbackDashboardName(dashboards[0]?.name || '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showFallbackDashboardOffer, dashboards]);
+  const [fallbackPlacing, setFallbackPlacing] = useState(false);
+  const [fallbackPlaceError, setFallbackPlaceError] = useState(null);
+  const fallbackPlacingRef = useRef(false);
+
+  const handleFallbackPlace = useCallback(async () => {
+    if (fallbackPlacingRef.current) return;
+    if (!promotedChart || !fallbackDashboardName || !placeChartInDashboardSlot) return;
+    fallbackPlacingRef.current = true;
+    setFallbackPlacing(true);
+    setFallbackPlaceError(null);
+    try {
+      const placeResult = await placeChartInDashboardSlot(fallbackDashboardName, promotedChart.name);
+      if (!placeResult?.success) {
+        setFallbackPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
+        return;
+      }
+      openWorkspaceTab?.({
+        id: `dashboard:${fallbackDashboardName}`,
+        type: 'dashboard',
+        name: fallbackDashboardName,
+      });
+      onClose?.();
+    } finally {
+      fallbackPlacingRef.current = false;
+      setFallbackPlacing(false);
+    }
+  }, [promotedChart, fallbackDashboardName, placeChartInDashboardSlot, openWorkspaceTab, onClose]);
+
   // P5-D4 (e2e-gap-review.md "Final delta pass") — `disabled={placing}` alone
   // is not a sufficient double-click guard: a real double-click can dispatch
   // both click events before React re-renders the button disabled (the exact
@@ -258,12 +309,24 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     }
   }, [consumeExplorationReturnTo, explorationId]);
 
-  // VIS-1069 — the first metric/dimension promoted THIS RUN (mirrors
+  // VIS-1069 — the first metric/dimension/model promoted THIS RUN (mirrors
   // `promotedChart`'s "this run only" scoping above).
+  //
+  // ux-audit.md "post-promote offers never appear" finding (⚠
+  // conflicts-with-e2e — promote-roundtrip #9): this originally only
+  // considered `type === 'metric' || type === 'dimension'`, which is real
+  // and correct for ITS OWN narrow trigger (Save-as-metric on a pill) but is
+  // NEVER true for the single most common promote outcome — a plain
+  // query -> chart flow promotes a MODEL + an INSIGHT + a CHART, never a
+  // metric/dimension. A model is exactly as semantic-layer-visible as a
+  // metric/dimension (it's a node on the same ERD), so the same reciprocal
+  // "go look at what you just published" offer applies to it too — this was
+  // a too-narrow condition, not a discoverability gap in an otherwise-correct
+  // trigger.
   const promotedField = useMemo(
     () =>
       (promotedThisRun?.results || []).find(
-        r => r.success && (r.type === 'metric' || r.type === 'dimension')
+        r => r.success && (r.type === 'metric' || r.type === 'dimension' || r.type === 'model')
       ) || null,
     [promotedThisRun]
   );
@@ -445,6 +508,52 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
             className="mt-2 text-xs text-highlight-600 bg-highlight-50 border border-highlight-200 rounded-md px-2.5 py-1.5"
           >
             {placeError}
+          </p>
+        )}
+
+        {/* ux-audit.md "post-promote offers never appear" finding
+            (⚠ conflicts-with-e2e — promote-roundtrip #9): the fallback for
+            the common case — a chart was promoted but no return_to intent
+            was ever armed — so the promote -> dashboard round-trip still has
+            an exit ramp from the ordinary Save-to-Project flow, not just the
+            "+ New Chart from an open dashboard" entry point. */}
+        {promotedThisRun && showFallbackDashboardOffer && (
+          <div
+            data-testid="exploration-promote-fallback-dashboard-offer"
+            className="mt-3 flex items-center justify-between gap-2 rounded-md border border-primary-200 bg-primary-50 px-2.5 py-2"
+          >
+            <span className="flex min-w-0 items-center gap-1.5 text-xs text-primary-800">
+              Add <span className="font-medium">{promotedChart.name}</span> to
+              <Select
+                data-testid="exploration-promote-fallback-dashboard-select"
+                value={fallbackDashboardName}
+                onChange={setFallbackDashboardName}
+                disabled={fallbackPlacing}
+                size="sm"
+                isSearchable={false}
+                options={dashboards.map(d => ({ value: d.name, label: d.name }))}
+                className="min-w-[7rem]"
+              />
+              ?
+            </span>
+            <button
+              type="button"
+              data-testid="exploration-promote-fallback-place"
+              onClick={handleFallbackPlace}
+              disabled={fallbackPlacing || !fallbackDashboardName}
+              className="shrink-0 rounded-md bg-primary px-2 py-1 text-xs font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {fallbackPlacing ? 'Adding…' : 'Add'}
+            </button>
+          </div>
+        )}
+
+        {fallbackPlaceError && (
+          <p
+            data-testid="exploration-promote-fallback-place-error"
+            className="mt-2 text-xs text-highlight-600 bg-highlight-50 border border-highlight-200 rounded-md px-2.5 py-1.5"
+          >
+            {fallbackPlaceError}
           </p>
         )}
 

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -323,13 +323,21 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   // "go look at what you just published" offer applies to it too — this was
   // a too-narrow condition, not a discoverability gap in an otherwise-correct
   // trigger.
-  const promotedField = useMemo(
-    () =>
-      (promotedThisRun?.results || []).find(
-        r => r.success && (r.type === 'metric' || r.type === 'dimension' || r.type === 'model')
-      ) || null,
-    [promotedThisRun]
-  );
+  // Composed-gate correction: `find()` over the results scans them in PROMOTE
+  // order, which is dependency-ordered — the model a metric depends on is
+  // always promoted (and therefore found) first. Broadening to models above
+  // then meant a run that published a metric offered "View <its model> in the
+  // Semantic Layer", naming the incidental dependency instead of the thing
+  // the user just built. Prefer the most specific field, fall back to the
+  // model so the plain query -> chart flow still gets an offer.
+  const promotedField = useMemo(() => {
+    const succeeded = (promotedThisRun?.results || []).filter(r => r.success);
+    return (
+      succeeded.find(r => r.type === 'metric' || r.type === 'dimension') ||
+      succeeded.find(r => r.type === 'model') ||
+      null
+    );
+  }, [promotedThisRun]);
 
   const handleViewInSemanticLayer = useCallback(() => {
     if (!promotedField) return;

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -283,7 +283,13 @@ describe('ExplorationPromoteModal', () => {
       ...extra,
     });
 
-    test('no offer without a return_to on the exploration', async () => {
+    // ux-audit.md "post-promote offers never appear" finding (⚠
+    // conflicts-with-e2e — promote-roundtrip #9): without a return_to
+    // intent, the OLD offer stays absent, but the fix's fallback offer
+    // (reusing the same placement plumbing) now appears instead — the
+    // promote -> dashboard round-trip is never a dead end just because the
+    // user didn't enter through the one narrow "+New Chart" path.
+    test('no return_to-specific offer without a return_to on the exploration — the generic fallback offer appears instead', async () => {
       seedReturnTo(null);
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
       useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
@@ -292,6 +298,103 @@ describe('ExplorationPromoteModal', () => {
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
       await screen.findByTestId('exploration-promote-success');
       expect(screen.queryByTestId('exploration-promote-return-to-offer')).not.toBeInTheDocument();
+      const fallback = screen.getByTestId('exploration-promote-fallback-dashboard-offer');
+      expect(fallback).toHaveTextContent('churn_chart');
+    });
+
+    test('no fallback offer when no dashboards exist at all', async () => {
+      seedReturnTo(null, { dashboards: [] });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-success');
+      expect(
+        screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
+      ).not.toBeInTheDocument();
+    });
+
+    test('no fallback offer when no chart was promoted this run (even with no return_to)', async () => {
+      seedReturnTo(null);
+      buildPromoteChecklist.mockResolvedValue([row()]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: true,
+          results: [{ type: 'model', name: 'orders_q', success: true, error: null }],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-success');
+      expect(
+        screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
+      ).not.toBeInTheDocument();
+    });
+
+    test('the return_to-specific offer takes priority — the fallback never shows alongside it', async () => {
+      seedReturnTo({ dashboard: 'sales', slot: 'r1-i1' });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-return-to-offer');
+      expect(
+        screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
+      ).not.toBeInTheDocument();
+    });
+
+    test('accepting the fallback offer places the chart in the chosen dashboard, navigates, and closes', async () => {
+      seedReturnTo(null);
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInDashboardSlot).toHaveBeenCalledWith(
+          'sales',
+          'churn_chart'
+        )
+      );
+      await waitFor(() =>
+        expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'dashboard:sales',
+          type: 'dashboard',
+          name: 'sales',
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('a fallback placement failure shows an inline error and does not close', async () => {
+      seedReturnTo(null, {
+        placeChartInDashboardSlot: jest.fn().mockResolvedValue({ success: false, error: 'slot taken' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('exploration-promote-fallback-place-error')).toHaveTextContent(
+          'slot taken'
+        )
+      );
+      expect(onClose).not.toHaveBeenCalled();
     });
 
     test('no offer when return_to is set but no chart was promoted this run', async () => {
@@ -547,12 +650,34 @@ describe('ExplorationPromoteModal', () => {
       ...extra,
     });
 
-    test('no offer when nothing metric/dimension-shaped was promoted this run', async () => {
+    // ux-audit.md "post-promote offers never appear" finding
+    // (⚠ conflicts-with-e2e — promote-roundtrip #9): a MODEL is exactly as
+    // semantic-layer-visible as a metric/dimension (same ERD), so promoting
+    // one — the single most common promote-roundtrip outcome — now offers
+    // this too. This is the fix; see the too-narrow-condition note on
+    // `promotedField` in the component.
+    test('promoting a model (the common case — no metric/dimension involved) also offers "View in Semantic Layer"', async () => {
       buildPromoteChecklist.mockResolvedValue([row()]);
       useStore.setState({
         promoteExploration: jest.fn().mockResolvedValue({
           success: true,
           results: [{ type: 'model', name: 'orders_q', success: true, error: null }],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      const offer = await screen.findByTestId('exploration-promote-semantic-layer-offer');
+      expect(offer).toHaveTextContent('orders_q');
+    });
+
+    test('no offer when only an insight (no model/metric/dimension) was promoted this run', async () => {
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'insight', type: 'insight', name: 'my_insight' })]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: true,
+          results: [{ type: 'insight', name: 'my_insight', success: true, error: null }],
           reclassificationOffers: [],
         }),
       });

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -715,6 +715,34 @@ describe('ExplorationPromoteModal', () => {
       expect(screen.getByTestId('exploration-promote-error')).toHaveTextContent('server rejected it');
     });
 
+    test('a run that publishes BOTH a model and a metric names the METRIC, not the dependency-ordered model', async () => {
+      // Composed-gate regression: promote results are dependency-ordered, so a
+      // metric's own model is always first. A plain `find()` over "metric,
+      // dimension, or model" therefore named the incidental model rather than
+      // the field the user just built.
+      buildPromoteChecklist.mockResolvedValue([
+        row({ tier: 'model', type: 'model', name: 'orders_q' }),
+        row({ tier: 'field', type: 'metric', name: 'churn_rate' }),
+      ]);
+      useStore.setState({
+        promoteExploration: jest.fn().mockResolvedValue({
+          success: true,
+          results: [
+            { type: 'model', name: 'orders_q', success: true, error: null },
+            { type: 'metric', name: 'churn_rate', success: true, error: null },
+          ],
+          reclassificationOffers: [],
+        }),
+      });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+      const offer = await screen.findByTestId('exploration-promote-semantic-layer-offer');
+      expect(offer).toHaveTextContent('churn_rate');
+      expect(offer).not.toHaveTextContent('orders_q');
+    });
+
     test('promoting a metric offers "View in Semantic Layer"; accepting sets the focus intent, opens the tab, and closes', async () => {
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'field', type: 'metric', name: 'churn_rate' })]);
       const setWorkspaceSemanticLayerFocusIntent = jest.fn();

--- a/viewer/src/components/views/workspace/ExplorationStalenessBanner.jsx
+++ b/viewer/src/components/views/workspace/ExplorationStalenessBanner.jsx
@@ -16,7 +16,7 @@ import { PiArrowsClockwise, PiX } from 'react-icons/pi';
  * the CURRENT live store without this component needing its own store
  * wiring.
  */
-const ExplorationStalenessBanner = ({ danglingRefs = [], onRecheck, onDismiss }) => (
+const ExplorationStalenessBanner = ({ danglingRefs = [], driftedFrom = null, onRecheck, onDismiss }) => (
   <div
     role="status"
     data-testid="exploration-staleness-banner"
@@ -25,6 +25,16 @@ const ExplorationStalenessBanner = ({ danglingRefs = [], onRecheck, onDismiss })
     <PiArrowsClockwise aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-primary-600" />
     <div className="min-w-0 flex-1 text-[12.5px]">
       <p className="font-medium text-primary-900">Some referenced objects may have changed.</p>
+      {/* Phase 6c-T1 (ux-audit.md existing-objects #8): the drift line —
+          the seeded-from object still exists but was edited elsewhere since
+          this copy was made — is distinct from, and additive with, the
+          dangling-ref line below. */}
+      {driftedFrom && (
+        <p className="mt-0.5 text-primary-800" data-testid="exploration-staleness-drift">
+          <span className="font-mono">{driftedFrom.name}</span> changed in the project since this
+          copy was made.
+        </p>
+      )}
       {danglingRefs.length > 0 && (
         <p className="mt-0.5 text-primary-800">
           No longer resolves: <span className="font-mono">{danglingRefs.join(', ')}</span>

--- a/viewer/src/components/views/workspace/ExplorationStalenessBanner.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationStalenessBanner.test.jsx
@@ -27,4 +27,47 @@ describe('ExplorationStalenessBanner', () => {
     render(<ExplorationStalenessBanner danglingRefs={[]} onRecheck={jest.fn()} onDismiss={jest.fn()} />);
     expect(screen.getByTestId('exploration-staleness-banner')).not.toHaveTextContent('No longer resolves');
   });
+
+  // Phase 6c-T1 (ux-audit.md existing-objects #8): the drift line renders
+  // when the seeded-from object was edited elsewhere — distinct copy from
+  // the dangling-ref line, coexisting with it when both apply.
+  test('renders the drift line naming the seeded object, in plain language (no "promoted"/"input" jargon)', () => {
+    render(
+      <ExplorationStalenessBanner
+        danglingRefs={[]}
+        driftedFrom={{ type: 'insight', name: 'aggregated_bar' }}
+        onRecheck={jest.fn()}
+        onDismiss={jest.fn()}
+      />
+    );
+    const drift = screen.getByTestId('exploration-staleness-drift');
+    expect(drift).toHaveTextContent('aggregated_bar');
+    expect(drift).toHaveTextContent('changed in the project since this copy was made');
+    expect(drift).not.toHaveTextContent('promoted');
+  });
+
+  test('renders neither the drift nor dangling-refs line when driftedFrom is null and danglingRefs is empty', () => {
+    render(
+      <ExplorationStalenessBanner
+        danglingRefs={[]}
+        driftedFrom={null}
+        onRecheck={jest.fn()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.queryByTestId('exploration-staleness-drift')).not.toBeInTheDocument();
+  });
+
+  test('renders both the drift line and the dangling-refs line together when both apply', () => {
+    render(
+      <ExplorationStalenessBanner
+        danglingRefs={['deleted_model']}
+        driftedFrom={{ type: 'insight', name: 'aggregated_bar' }}
+        onRecheck={jest.fn()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('exploration-staleness-drift')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-staleness-banner')).toHaveTextContent('deleted_model');
+  });
 });

--- a/viewer/src/components/views/workspace/explorationStaleness.js
+++ b/viewer/src/components/views/workspace/explorationStaleness.js
@@ -20,28 +20,89 @@ import { checkRefTargets } from './refPreflight';
  *      badge) — a card is never "opened" at all, so nothing else ever runs
  *      this check for it.
  *
- * Scope (a deliberate, documented reduction from the UX spec's literal
- * "orders changed" copy): without a persisted fingerprint of what a draft's
- * referenced objects looked like at last-sync time, distinguishing "the
- * referenced model's OWN definition changed" from "the ref no longer
- * resolves at all" isn't computable client-side today. This treats BOTH as
- * one unified "stale" signal — a dangling ref, exactly what `checkRefTargets`
- * already detects — which is the same simplification 02 §8's own prose names
- * as the mechanism ("re-run ref checks... (checkRefTargets)"). A true
- * changed-vs-deleted distinction would need a `ref_fingerprint` persisted on
- * the Exploration record — noted as follow-up work, not implemented here.
+ * DRIFT DETECTION (Phase 6c-T1, ux-audit.md existing-objects #8, ⚠
+ * conflicts-with-e2e — "no staleness indication after the underlying insight
+ * is edited elsewhere"): the dangling-ref check above only catches a ref
+ * that stopped resolving ENTIRELY (deleted). The audit's actual complaint —
+ * "I edited aggregated-bar-insight's description in the project editor,
+ * reopened the exploration that copied it, and got no signal at all" — is a
+ * DIFFERENT case: the seeded-from object still resolves, its CONTENT just
+ * changed. This was a genuine, documented scope gap (see the removed
+ * "Scope" note this replaces): a bare dangling-ref check can never catch it,
+ * only a persisted fingerprint of the seeded object's content at seed time
+ * can. `workspaceExplorationsStore.js`'s `createExploration` now captures
+ * exactly that (`computeSeedContentSignature`, below) into
+ * `exploration.seededFrom.contentSignature` at seed time; this function
+ * recomputes the CURRENT signature for the same object and flags `stale`
+ * when they diverge — orthogonal to (and additive with) the dangling-ref
+ * check, never a replacement for it.
  */
+
+// Object types this exploration's seed provenance can point at whose
+// content is meaningfully hashable via the shared collections a mounted
+// Workspace already has loaded (`state.insights`/`state.models`/
+// `state.charts`). 'source'/'table'/'metric'/'dimension' seeds don't carry a
+// single canonical "content" the same way (a table is the source's schema,
+// not a project object; metrics/dimensions are scoped inside a model's own
+// config) — omitted rather than guessed at.
+const SIGNATURE_TYPES = { insight: 'insights', chart: 'charts', model: 'models' };
+
+/** Deterministic JSON stringify — recursively sorts object keys — so two
+ * reads of logically-identical config taken at different times (seed-time
+ * vs. a later recheck) never disagree merely because of incidental key
+ * insertion-order differences from the API layer. */
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** The live content a `{type, name}` seed ref currently points at, hashed
+ * into a stable signature string — `null` when the type isn't one of
+ * `SIGNATURE_TYPES`, the object can't be found in `state`, or it has no
+ * `config` to hash (all "can't determine drift" cases, never treated as
+ * drift themselves — that would double up with the dangling-ref check,
+ * which already owns "this doesn't resolve anymore").
+ *
+ * @param {{type: string, name: string}} seed
+ * @param {object} state - `useStore.getState()` (or an equivalent plain
+ *   object exposing `insights`/`models`/`charts`).
+ * @returns {string|null}
+ */
+export function computeSeedContentSignature(seed, state) {
+  if (!seed?.type || !seed?.name) return null;
+  const collectionKey = SIGNATURE_TYPES[seed.type];
+  if (!collectionKey) return null;
+  const obj = (state?.[collectionKey] || []).find(o => o.name === seed.name);
+  if (!obj || obj.config == null) return null;
+  return stableStringify(obj.config);
+}
 
 /**
  * @param {object} exploration - a mapped workspaceExplorations record (or
  *   `null`/`undefined`, tolerated for a not-yet-loaded card).
  * @param {object} state - `useStore.getState()` (or an equivalent plain
  *   object exposing the same collection arrays `checkRefTargets` reads).
- * @returns {{stale: boolean, danglingRefs: string[]}}
+ * @returns {{stale: boolean, danglingRefs: string[], driftedFrom: {type: string, name: string}|null}}
  */
 export function computeExplorationStaleness(exploration, state) {
+  const seed = exploration?.seededFrom;
+  let driftedFrom = null;
+  if (seed?.contentSignature) {
+    const currentSignature = computeSeedContentSignature(seed, state);
+    // `currentSignature` is `null` when the object is gone entirely — that
+    // case is the dangling-ref check's job (below), not drift's; only an
+    // object that STILL resolves but hashes differently counts as drifted.
+    if (currentSignature && currentSignature !== seed.contentSignature) {
+      driftedFrom = { type: seed.type, name: seed.name };
+    }
+  }
+
   const draft = exploration?.draft;
-  if (!draft) return { stale: false, danglingRefs: [] };
+  if (!draft) return { stale: !!driftedFrom, danglingRefs: [], driftedFrom };
 
   // Splice the draft's OWN scratch query names into `models` (mirrors
   // InsightBuildSection.jsx's synthetic-state pattern) so a ref to one of
@@ -59,7 +120,9 @@ export function computeExplorationStaleness(exploration, state) {
   // `checkRefTargets` is shape-agnostic, it just scans every string for
   // `${ref(...)}` / bare `ref(...)` occurrences.
   const result = checkRefTargets(draft, syntheticState);
-  if (result.skipped || result.valid) return { stale: false, danglingRefs: [] };
+  if (result.skipped || result.valid) {
+    return { stale: !!driftedFrom, danglingRefs: [], driftedFrom };
+  }
 
   const danglingRefs = [
     ...new Set(
@@ -71,5 +134,5 @@ export function computeExplorationStaleness(exploration, state) {
         .filter(Boolean)
     ),
   ];
-  return { stale: danglingRefs.length > 0, danglingRefs };
+  return { stale: danglingRefs.length > 0 || !!driftedFrom, danglingRefs, driftedFrom };
 }

--- a/viewer/src/components/views/workspace/explorationStaleness.test.js
+++ b/viewer/src/components/views/workspace/explorationStaleness.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
-import { computeExplorationStaleness } from './explorationStaleness';
+import { computeExplorationStaleness, computeSeedContentSignature } from './explorationStaleness';
 
 const baseState = {
   models: [{ name: 'orders_q' }],
@@ -28,6 +28,7 @@ describe('computeExplorationStaleness', () => {
     expect(computeExplorationStaleness(exploration, baseState)).toEqual({
       stale: false,
       danglingRefs: [],
+      driftedFrom: null,
     });
   });
 
@@ -68,8 +69,16 @@ describe('computeExplorationStaleness', () => {
   });
 
   it('is not stale for a missing/empty draft', () => {
-    expect(computeExplorationStaleness(null, baseState)).toEqual({ stale: false, danglingRefs: [] });
-    expect(computeExplorationStaleness({}, baseState)).toEqual({ stale: false, danglingRefs: [] });
+    expect(computeExplorationStaleness(null, baseState)).toEqual({
+      stale: false,
+      danglingRefs: [],
+      driftedFrom: null,
+    });
+    expect(computeExplorationStaleness({}, baseState)).toEqual({
+      stale: false,
+      danglingRefs: [],
+      driftedFrom: null,
+    });
   });
 
   it('fails open (never stale) when no collection is populated at all', () => {
@@ -77,5 +86,130 @@ describe('computeExplorationStaleness', () => {
       draft: { queries: [], insights: [{ name: 'ins', props: { x: '?{${ref(anything).col}}' } }] },
     };
     expect(computeExplorationStaleness(exploration, {}).stale).toBe(false);
+  });
+
+  // Phase 6c-T1 (ux-audit.md existing-objects #8, ⚠ conflicts-with-e2e — "no
+  // staleness indication after the underlying insight is edited elsewhere"):
+  // a copy-until-promote exploration whose seeded-from object's CONTENT
+  // changed (still resolves, just edited) must be flagged, distinctly from
+  // the dangling-ref case above.
+  describe('drift detection (seededFrom.contentSignature)', () => {
+    const driftState = {
+      ...baseState,
+      insights: [{ name: 'aggregated_bar', config: { props: { type: 'bar' }, description: 'v2' } }],
+    };
+
+    it('is not stale when the seeded object still matches its recorded signature', () => {
+      const signature = computeSeedContentSignature(
+        { type: 'insight', name: 'aggregated_bar' },
+        driftState
+      );
+      const exploration = {
+        draft: { queries: [], insights: [] },
+        seededFrom: { type: 'insight', name: 'aggregated_bar', contentSignature: signature },
+      };
+      const result = computeExplorationStaleness(exploration, driftState);
+      expect(result.stale).toBe(false);
+      expect(result.driftedFrom).toBeNull();
+    });
+
+    it('flags drift when the seeded insight was edited elsewhere since the copy was made', () => {
+      const staleSignature = computeSeedContentSignature(
+        { type: 'insight', name: 'aggregated_bar' },
+        { ...driftState, insights: [{ name: 'aggregated_bar', config: { props: { type: 'bar' }, description: 'v1' } }] }
+      );
+      const exploration = {
+        draft: { queries: [], insights: [] },
+        seededFrom: { type: 'insight', name: 'aggregated_bar', contentSignature: staleSignature },
+      };
+      const result = computeExplorationStaleness(exploration, driftState);
+      expect(result.stale).toBe(true);
+      expect(result.driftedFrom).toEqual({ type: 'insight', name: 'aggregated_bar' });
+    });
+
+    it('flags drift for a seeded MODEL too, not just insights', () => {
+      const modelState = {
+        ...baseState,
+        models: [{ name: 'orders_q', config: { sql: 'SELECT 1' } }],
+      };
+      const staleSignature = computeSeedContentSignature(
+        { type: 'model', name: 'orders_q' },
+        { ...modelState, models: [{ name: 'orders_q', config: { sql: 'SELECT 2' } }] }
+      );
+      const exploration = {
+        draft: { queries: [], insights: [] },
+        seededFrom: { type: 'model', name: 'orders_q', contentSignature: staleSignature },
+      };
+      const result = computeExplorationStaleness(exploration, modelState);
+      expect(result.stale).toBe(true);
+      expect(result.driftedFrom).toEqual({ type: 'model', name: 'orders_q' });
+    });
+
+    it('does not flag drift when the seeded object was deleted entirely (that is the dangling-ref case, not drift)', () => {
+      const exploration = {
+        draft: { queries: [], insights: [] },
+        seededFrom: { type: 'insight', name: 'gone_insight', contentSignature: 'some-old-signature' },
+      };
+      const result = computeExplorationStaleness(exploration, driftState);
+      expect(result.driftedFrom).toBeNull();
+    });
+
+    it('does not flag drift when no contentSignature was ever recorded (older/legacy explorations)', () => {
+      const exploration = {
+        draft: { queries: [], insights: [] },
+        seededFrom: { type: 'insight', name: 'aggregated_bar' },
+      };
+      const result = computeExplorationStaleness(exploration, driftState);
+      expect(result.driftedFrom).toBeNull();
+      expect(result.stale).toBe(false);
+    });
+
+    it('dangling-ref staleness and drift staleness are additive, not mutually exclusive', () => {
+      const staleSignature = computeSeedContentSignature(
+        { type: 'insight', name: 'aggregated_bar' },
+        { ...driftState, insights: [{ name: 'aggregated_bar', config: { description: 'v1' } }] }
+      );
+      const exploration = {
+        draft: {
+          queries: [],
+          insights: [{ name: 'ins', props: { x: '?{${ref(deleted_model).col}}' } }],
+        },
+        seededFrom: { type: 'insight', name: 'aggregated_bar', contentSignature: staleSignature },
+      };
+      const result = computeExplorationStaleness(exploration, driftState);
+      expect(result.stale).toBe(true);
+      expect(result.danglingRefs).toEqual(['deleted_model']);
+      expect(result.driftedFrom).toEqual({ type: 'insight', name: 'aggregated_bar' });
+    });
+  });
+});
+
+describe('computeSeedContentSignature', () => {
+  it('returns null for a seed type with no meaningful content hash (source/table/metric/dimension)', () => {
+    const state = { models: [], insights: [], charts: [] };
+    expect(computeSeedContentSignature({ type: 'source', name: 'warehouse' }, state)).toBeNull();
+    expect(computeSeedContentSignature({ type: 'table', name: 'orders' }, state)).toBeNull();
+    expect(computeSeedContentSignature({ type: 'metric', name: 'revenue' }, state)).toBeNull();
+  });
+
+  it('returns null when the object cannot be found', () => {
+    const state = { models: [], insights: [], charts: [] };
+    expect(computeSeedContentSignature({ type: 'model', name: 'missing' }, state)).toBeNull();
+  });
+
+  it('returns the same signature regardless of object key order (stable hashing)', () => {
+    const stateA = { models: [{ name: 'm', config: { sql: 'SELECT 1', source: 's' } }] };
+    const stateB = { models: [{ name: 'm', config: { source: 's', sql: 'SELECT 1' } }] };
+    expect(computeSeedContentSignature({ type: 'model', name: 'm' }, stateA)).toBe(
+      computeSeedContentSignature({ type: 'model', name: 'm' }, stateB)
+    );
+  });
+
+  it('returns different signatures for genuinely different content', () => {
+    const stateA = { models: [{ name: 'm', config: { sql: 'SELECT 1' } }] };
+    const stateB = { models: [{ name: 'm', config: { sql: 'SELECT 2' } }] };
+    expect(computeSeedContentSignature({ type: 'model', name: 'm' }, stateA)).not.toBe(
+      computeSeedContentSignature({ type: 'model', name: 'm' }, stateB)
+    );
   });
 });

--- a/viewer/src/components/views/workspace/usePreviewInputDependencies.js
+++ b/viewer/src/components/views/workspace/usePreviewInputDependencies.js
@@ -36,16 +36,37 @@ import { extractInputDependenciesFromProps } from '../../../models/Insight';
  * @param {Object} params
  * @param {string[]} params.insightNames - Parent insight names (multi-insight → union)
  * @param {Object} [params.configForFallback] - Object config (props/layout/interactions) for the config-only window
+ * @param {string[]} [params.extraModelNames] - Additional known model names to
+ *   exclude from `unresolvedNames` beyond the published `state.models` list —
+ *   e.g. an exploration's own draft/not-yet-promoted model tabs, which the
+ *   caller knows about but this hook (deliberately store-generic) doesn't.
  * @returns {{ inputConfigs: Object[], unresolvedNames: string[] }} resolved
  *   `<Input>` configs (empty when none), plus `unresolvedNames` — referenced
- *   names that matched NEITHER a real Input config NOR (Explore 2.0 Phase 4)
- *   a draft input still local to the exploration. A draft referencing a
- *   not-yet-promoted input must surface this explicitly, never silently drop
- *   it (specs/plan/explorer-workspace-unification/02-architecture.md §6).
+ *   names that matched NEITHER a real Input config NOR a known model NOR
+ *   (Explore 2.0 Phase 4) a draft input still local to the exploration. A
+ *   draft referencing a genuinely undefined input must surface this
+ *   explicitly, never silently drop it
+ *   (specs/plan/explorer-workspace-unification/02-architecture.md §6).
+ *
+ *   ux-audit.md's "unresolved-input misclassification" finding (cold-start
+ *   #3, promote-roundtrip #3, pills #3): `extractInputDependenciesFromProps`
+ *   (models/Insight.js) matches ANY `${ref(name).col}` / `${name.col}`
+ *   context string it finds — including a MODEL column ref the Build rail's
+ *   own pill drops write (`?{${ref(model).column}}`), not just genuine Input
+ *   references. Model names (published + the caller-supplied draft set) are
+ *   therefore excluded here before a name is called "unresolved" — a model
+ *   ref was never an input dependency in the first place.
  */
-export const usePreviewInputDependencies = (projectId, { insightNames = [], configForFallback }) => {
+export const usePreviewInputDependencies = (
+  projectId,
+  { insightNames = [], configForFallback, extraModelNames = [] }
+) => {
   const storeInputs = useStore(s => s.inputs);
   const fetchInputs = useStore(s => s.fetchInputs);
+  // A stable, sorted array (mirrors `runtimeNames`' own convention below) —
+  // `useShallow` compares this element-by-element rather than by Set
+  // identity, so an unrelated store write doesn't churn it every render.
+  const storeModelNames = useStore(useShallow(s => (s.models || []).map(m => m.name).sort()));
 
   // Lazy-load the inputs list ONCE if we don't have it. A project with no
   // inputs makes `fetchInputs` write a fresh empty array on every call, which
@@ -97,18 +118,28 @@ export const usePreviewInputDependencies = (projectId, { insightNames = [], conf
   // Resolve name → <Input> config from the store inputs collection. Names with
   // no matching input config (e.g. a model ref mistaken as an input) are dropped
   // from `inputConfigs` but surfaced via `unresolvedNames` (Explore 2.0 Phase 4)
-  // so a draft referencing a not-yet-promoted input isn't a silent drop.
+  // so a draft referencing a genuinely undefined input isn't a silent drop.
   const configByName = useMemo(
     () => new Map((storeInputs || []).map(ic => [ic.name, ic.config || ic])),
     [storeInputs]
+  );
+  // Model names — published (`state.models`) union the caller's own known
+  // draft set — are never input dependencies, no matter how they were
+  // harvested (see the docstring's "unresolved-input misclassification"
+  // note above).
+  const knownModelNames = useMemo(
+    () => new Set([...storeModelNames, ...(extraModelNames || [])]),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [storeModelNames, JSON.stringify(extraModelNames || [])]
   );
   const inputConfigs = useMemo(() => {
     if (allReferencedNames.length === 0) return [];
     return allReferencedNames.filter(name => configByName.has(name)).map(name => configByName.get(name));
   }, [allReferencedNames, configByName]);
   const unresolvedNames = useMemo(
-    () => allReferencedNames.filter(name => !configByName.has(name)),
-    [allReferencedNames, configByName]
+    () =>
+      allReferencedNames.filter(name => !configByName.has(name) && !knownModelNames.has(name)),
+    [allReferencedNames, configByName, knownModelNames]
   );
 
   // Load options + seed defaults for the resolved inputs. Keyed only on the

--- a/viewer/src/components/views/workspace/usePreviewInputDependencies.test.js
+++ b/viewer/src/components/views/workspace/usePreviewInputDependencies.test.js
@@ -27,8 +27,8 @@ jest.mock('zustand/react/shallow', () => ({
   useShallow: fn => fn,
 }));
 
-const seedStore = ({ inputs = [], insightJobs = {} } = {}) => {
-  const state = { inputs, insightJobs, fetchInputs: jest.fn() };
+const seedStore = ({ inputs = [], insightJobs = {}, models = [] } = {}) => {
+  const state = { inputs, insightJobs, models, fetchInputs: jest.fn() };
   useStore.mockImplementation(selector =>
     typeof selector === 'function' ? selector(state) : state
   );
@@ -156,6 +156,60 @@ describe('usePreviewInputDependencies', () => {
 
     expect(result.current.inputConfigs.map(c => c.name)).toEqual(['region']);
     expect(result.current.unresolvedNames).toEqual(['not_yet_promoted_input']);
+  });
+
+  // ux-audit.md "unresolved-input misclassification" finding (cold-start #3,
+  // promote-roundtrip #3, pills #3): a MODEL ref (`?{${ref(model).column}}`)
+  // is harvested by the same extractor real input refs are, but a model name
+  // is never an input dependency — it must never end up in unresolvedNames.
+  it('excludes PUBLISHED model names from unresolvedNames — a model ref is never mistaken for an input', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      models: [{ name: 'orders_q' }],
+      insightJobs: { sales: { inputDependencies: ['region', 'orders_q'] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', { insightNames: ['sales'] })
+    );
+
+    expect(result.current.inputConfigs.map(c => c.name)).toEqual(['region']);
+    expect(result.current.unresolvedNames).toEqual([]);
+  });
+
+  // A draft/not-yet-promoted model tab is never in `state.models` yet — the
+  // caller (ExplorerChartPreview) passes its own known draft names via
+  // `extraModelNames` so those are excluded too.
+  it('excludes caller-supplied extraModelNames (draft model tabs) from unresolvedNames', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      models: [], // 'model' is a draft tab, not yet published
+      insightJobs: { sales: { inputDependencies: ['region', 'model'] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', {
+        insightNames: ['sales'],
+        extraModelNames: ['model'],
+      })
+    );
+
+    expect(result.current.inputConfigs.map(c => c.name)).toEqual(['region']);
+    expect(result.current.unresolvedNames).toEqual([]);
+  });
+
+  it('still surfaces a genuinely undefined name even alongside known model names', () => {
+    seedStore({
+      inputs: [{ name: 'region', config: { name: 'region' } }],
+      models: [{ name: 'orders_q' }],
+      insightJobs: { sales: { inputDependencies: ['region', 'orders_q', 'not_a_real_thing'] } },
+    });
+
+    const { result } = renderHook(() =>
+      usePreviewInputDependencies('p1', { insightNames: ['sales'], extraModelNames: [] })
+    );
+
+    expect(result.current.unresolvedNames).toEqual(['not_a_real_thing']);
   });
 
   it('unresolvedNames is empty when every referenced name resolves', () => {

--- a/viewer/src/hooks/useDraftInsightPreview.js
+++ b/viewer/src/hooks/useDraftInsightPreview.js
@@ -19,6 +19,15 @@ export const draftInsightKey = name => `__draft__:${name}`;
 
 const COMPILE_DEBOUNCE_MS = 1000;
 
+// Matches DuckDB's raw "Catalog Error: Table with name <hash> does not
+// exist!" — the internal draft-lane materialization table name this hook
+// itself mints (`draft_model_<name_hash>_<ts>` registered as `"<name_hash>"`
+// below). See the pre-execution guard's docstring for the primary fix; this
+// pattern is the belt-and-braces fallback ux-audit.md's fix direction calls
+// for so a leaked hash can never reach the user even from an unanticipated
+// path.
+const HASHED_TABLE_ERROR_PATTERN = /Table with name [0-9a-zA-Z_]{8,} does not exist/i;
+
 /** Extract `${name.accessor}` input dependencies from post_query + static_props
  * — byte-for-byte the same regex `useInsightsData.js`'s `processInsight` uses
  * for real insights, so a draft's `pendingInputs`/`inputDependencies` behave
@@ -183,7 +192,23 @@ const useDraftInsightPreview = () => {
         }
         const hasDataProps = Object.keys(state.props || {}).some(k => state.props[k] !== undefined && state.props[k] !== '');
         if (!hasDataProps) {
-          setInsightStatus(name, EMPTY_INSIGHT_STATUS);
+          // ux-audit.md "infinite spinner" finding (cold-start #2): an
+          // insight with nothing mapped yet has NOTHING to compile — no
+          // network call is ever made for it. Previously this reset to
+          // EMPTY_INSIGHT_STATUS (not loading, not blocked, not errored),
+          // which `ExplorerChartPreview` had no way to distinguish from "not
+          // yet checked" — it fell through to `<ChartPreview>` -> `<Chart>`,
+          // whose OWN `hasAllInsightData` gate then spun forever waiting for
+          // `insightJobs[draftKey].data` that nothing was ever going to
+          // populate (this hook correctly never even tries). Every terminal
+          // outcome now gets an explicit blockedReason so the caller can
+          // render a guided empty state instead of a dead spinner.
+          setInsightStatus(name, {
+            isLoading: false,
+            error: null,
+            blockedReason: 'no_data_props',
+            blockedModel: null,
+          });
           continue;
         }
 
@@ -224,11 +249,47 @@ const useDraftInsightPreview = () => {
           });
           if (isStale()) continue;
 
+          // ux-audit.md "draft-preview execution gap" (BLOCKER — cold-start
+          // #1, promote-roundtrip #1): a draft's props can compile to a
+          // valid `post_query` (200) even when FieldResolver never needed a
+          // schema lookup for the specific expression — see
+          // insight_compile_views.py's docstring. That `post_query` still
+          // qualifies columns against `compiled.models[].name_hash`
+          // table(s), which only get CREATEd below when this hook already
+          // has fetched rows for them. Executing anyway used to hand DuckDB
+          // a query against a table that was NEVER created, surfacing a raw
+          // "Catalog Error: Table with name <hash> does not exist!" — an
+          // internal identifier leaked straight to the user (see
+          // ChartPreview.jsx's error panel). Every dependent model must have
+          // actually-fetched rows (the SQL/results lane's own queryResult)
+          // BEFORE post_query is ever sent to DuckDB; otherwise this is
+          // exactly the same "run the query first" gap the server's 422
+          // already models — reuse that same guided state instead of
+          // executing a doomed query.
+          const unloadedModel = (compiled.models || []).find(model => {
+            const rows = modelStates[model.name]?.queryResult?.rows;
+            return !rows || !rows.length;
+          });
+          if (unloadedModel) {
+            if (!isStale()) {
+              removeInsightJob(draftKey);
+              seenDraftKeysRef.current.delete(draftKey);
+              setInsightStatus(name, {
+                isLoading: false,
+                error: null,
+                blockedReason: 'model_not_run',
+                blockedModel: unloadedModel.name,
+              });
+            }
+            continue;
+          }
+
           // Register each dependent model's ALREADY-FETCHED rows (the
           // SQL/results lane, `modelStates[name].queryResult`) as a DuckDB
           // table named by the model's hash — the exact table name
           // `compiled.post_query` qualifies columns against (S2 Q2's forced
-          // dynamic/duckdb build path).
+          // dynamic/duckdb build path). Every model reaching this point is
+          // already known (via the guard above) to have fetched rows.
           const conn = await getConnection(db);
           for (const model of compiled.models || []) {
             const rows = modelStates[model.name]?.queryResult?.rows || [];
@@ -297,6 +358,20 @@ const useDraftInsightPreview = () => {
               error: null,
               blockedReason: 'model_not_run',
               blockedModel: err.modelName || null,
+            });
+          } else if (HASHED_TABLE_ERROR_PATTERN.test(err?.message || '')) {
+            // Belt-and-braces (ux-audit.md's own fix direction): the guard
+            // above should make this unreachable in practice, but if ANY
+            // other path ever reaches DuckDB against an unregistered draft
+            // table, treat it the same as "run the query first" rather than
+            // leaking the raw hashed table name in `error`.
+            removeInsightJob(draftKey);
+            seenDraftKeysRef.current.delete(draftKey);
+            setInsightStatus(name, {
+              isLoading: false,
+              error: null,
+              blockedReason: 'model_not_run',
+              blockedModel: null,
             });
           } else {
             removeInsightJob(draftKey);

--- a/viewer/src/hooks/useDraftInsightPreview.test.js
+++ b/viewer/src/hooks/useDraftInsightPreview.test.js
@@ -148,6 +148,95 @@ describe('useDraftInsightPreview', () => {
     expect(entry.pendingInputs).toEqual(['region']);
   });
 
+  // ux-audit.md "draft-preview execution gap" (BLOCKER — cold-start #1,
+  // promote-roundtrip #1): compile can succeed (200) even when the model's
+  // rows were never actually loaded client-side. Executing post_query
+  // anyway used to hand DuckDB a query against a table this hook never
+  // created, surfacing a raw "Catalog Error: Table with name <hash> does
+  // not exist" — this must instead behave exactly like the server's own
+  // model_not_run 422 (the guided "run the query" empty state), and DuckDB
+  // must never even be asked.
+  test('a compiled model with no loaded rows never reaches DuckDB — blocked like model_not_run instead', async () => {
+    seedState({
+      explorerModelStates: {
+        orders_q: {
+          sql: 'select * from orders',
+          sourceName: 'warehouse',
+          queryResult: null, // never run — no rows
+        },
+      },
+    });
+    compileDraftInsight.mockResolvedValueOnce({
+      post_query: 'SELECT * FROM "mhash1"',
+      pre_query: null,
+      props_mapping: { 'props.x': 'a' },
+      static_props: {},
+      props_slices: {},
+      split_key: null,
+      type: 'scatter',
+      models: [{ name: 'orders_q', name_hash: 'mhash1' }],
+    });
+
+    const { result } = renderHook(() => useDraftInsightPreview());
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.blockedReason).toBe('model_not_run');
+    expect(result.current.blockedModel).toBe('orders_q');
+    expect(FAKE_DB.registerFileText).not.toHaveBeenCalled();
+    expect(runDuckDBQuery).not.toHaveBeenCalled();
+    expect(useStore.getState().insightJobs[draftInsightKey('my_insight')]).toBeUndefined();
+  });
+
+  // ux-audit.md "infinite spinner" finding (cold-start #2, pills #3): an
+  // insight with nothing mapped (no data-bearing props at all) has nothing
+  // to compile — the caller must be able to tell "nothing to preview" apart
+  // from "still loading" instead of spinning forever.
+  test('an insight with no data props at all is blocked as no_data_props, never compiled', async () => {
+    seedState({
+      explorerInsightStates: {
+        my_insight: { type: 'scatter', props: {}, interactions: [] },
+      },
+    });
+
+    const { result } = renderHook(() => useDraftInsightPreview());
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(compileDraftInsight).not.toHaveBeenCalled();
+    expect(result.current.blockedReason).toBe('no_data_props');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // Belt-and-braces (ux-audit.md's own fix direction): even if some other
+  // path still reaches DuckDB against an unregistered draft table, the raw
+  // hashed-table error must never surface as `error` — it maps to the same
+  // guided blocked state.
+  test('a hashed-table DuckDB catalog error is treated as model_not_run, never leaked as a raw error', async () => {
+    compileDraftInsight.mockResolvedValueOnce({
+      post_query: 'SELECT * FROM "mhash1"',
+      static_props: {},
+      props_mapping: {},
+      props_slices: {},
+      split_key: null,
+      type: 'scatter',
+      models: [], // empty models list bypasses the pre-execution guard on purpose
+    });
+    runDuckDBQuery.mockRejectedValueOnce(
+      new Error('Catalog Error: Table with name mfiawdybhqqkwzuxbjzfxqbvbaibc does not exist! Did you mean "pg_index"?')
+    );
+
+    const { result } = renderHook(() => useDraftInsightPreview());
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.blockedReason).toBe('model_not_run');
+    expect(result.current.error).toBeNull();
+  });
+
   test('a model_not_run 422 sets blockedReason and removes any stale draft entry', async () => {
     const err = new Error('Missing schema for model: orders_q.');
     err.errorType = 'model_not_run';

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -89,6 +89,7 @@ import { SAVE_ACTION } from '../components/views/workspace/collectionKeys';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
 import { emitWorkspaceEvent, markExplorationCreated } from '../components/views/workspace/telemetry';
 import { buildInsightFreshnessSignature } from '../utils/insightFreshnessSignature';
+import { computeSeedContentSignature } from '../components/views/workspace/explorationStaleness';
 
 const SYNC_DEBOUNCE_MS = 1000;
 
@@ -168,12 +169,23 @@ const mapDraftToApi = draft => ({
   legacy_state: draft?.legacyState ?? null,
 });
 
+/** `seeded_from.content_signature` (backend, snake_case) <-> `seededFrom.
+ * contentSignature` (frontend, camelCase — Phase 6c-T1's drift-detection
+ * field, `explorationStaleness.js`). The rest of `seeded_from`/`seededFrom`
+ * is passed through verbatim elsewhere in this file (already just `{type,
+ * name}`, no casing to reconcile) — these two helpers exist ONLY because
+ * this one field needs it. */
+const mapSeedFromApi = seed =>
+  seed ? { type: seed.type, name: seed.name, contentSignature: seed.content_signature ?? null } : null;
+const mapSeedToApi = seed =>
+  seed ? { type: seed.type, name: seed.name, content_signature: seed.contentSignature ?? null } : undefined;
+
 const mapExplorationFromApi = record => ({
   id: record.id,
   name: record.name,
   createdAt: record.created_at,
   updatedAt: record.updated_at,
-  seededFrom: record.seeded_from ?? null,
+  seededFrom: mapSeedFromApi(record.seeded_from),
   returnTo: record.return_to ?? null,
   draft: mapDraftFromApi(record.draft),
   promoted: record.promoted || [],
@@ -310,10 +322,23 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      * `explorerStore.js`'s `buildExplorationSeedState`) instead of relying on
      * `legacyStateForSeed`'s `type === 'source'`-only bridge — the "Explore
      * this" context-menu action's pre-wired query for models/tables and its
-     * name-preserving copy for insights/charts both go through this. */
+     * name-preserving copy for insights/charts both go through this.
+     *
+     * Phase 6c-T1 (ux-audit.md existing-objects #8, drift detection): a
+     * `seed` of a hashable type (insight/chart/model — see
+     * `explorationStaleness.js`'s `computeSeedContentSignature`) has its
+     * CURRENT content hashed here, at the exact moment of creation, and
+     * persisted as `seeded_from.content_signature`. This is deliberately
+     * centralized here (every "Explore this" call site — Library, Lineage,
+     * the Source/Semantic-Layer ERDs, Explorer Home — funnels through this
+     * one action) rather than in each caller, so none of them need to know
+     * drift detection exists. */
     createExploration: async (seed = null, returnTo = null, legacyStateOverride = null) => {
       try {
-        const payload = seed ? { seeded_from: seed } : {};
+        const seedWithSignature = seed
+          ? { ...seed, contentSignature: computeSeedContentSignature(seed, get()) }
+          : null;
+        const payload = seedWithSignature ? { seeded_from: mapSeedToApi(seedWithSignature) } : {};
         if (returnTo) payload.return_to = returnTo;
         const seedLegacyState = legacyStateOverride || (seed ? legacyStateForSeed(seed) : null);
         if (seedLegacyState) payload.draft = mapDraftToApi(legacyStateToDraft(seedLegacyState));
@@ -369,7 +394,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       try {
         const created = await explorationsApi.createExploration({
           name: `${existing.name} copy`,
-          seeded_from: existing.seededFrom || undefined,
+          seeded_from: mapSeedToApi(existing.seededFrom) || undefined,
           draft: mapDraftToApi(existing.draft),
         });
         const mapped = mapExplorationFromApi(created);
@@ -433,7 +458,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       try {
         const created = await explorationsApi.createExploration({
           name: existing.name,
-          seeded_from: existing.seededFrom || undefined,
+          seeded_from: mapSeedToApi(existing.seededFrom) || undefined,
           draft: mapDraftToApi(existing.draft),
         });
         const mapped = mapExplorationFromApi(created);

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -81,6 +81,12 @@ const reset = () => {
       explorerInsightStates: {},
       explorerModelStates: {},
       explorerPromotedSignatures: {},
+      // Phase 6c-T1's content-signature computation reads these collections
+      // at seed time (`computeSeedContentSignature`) — reset so one test's
+      // seeded `models`/`insights`/`charts` never leaks into the next.
+      models: [],
+      insights: [],
+      charts: [],
     });
   });
 };
@@ -180,11 +186,57 @@ describe('createExploration', () => {
     });
 
     expect(explorationsApi.createExploration).toHaveBeenCalledWith({
-      seeded_from: { type: 'model', name: 'orders' },
+      // Phase 6c-T1: content_signature is null here because no `orders`
+      // model is loaded in the store at seed time (this test's `beforeEach`
+      // doesn't seed one) — see the drift-detection tests below for the
+      // populated-collection case.
+      seeded_from: { type: 'model', name: 'orders', content_signature: null },
     });
     expect(useStore.getState().workspaceExplorations.byId.exp_1.seededFrom).toEqual({
       type: 'model',
       name: 'orders',
+      contentSignature: null,
+    });
+  });
+
+  // Phase 6c-T1 (ux-audit.md existing-objects #8, drift detection): a
+  // hashable seed type (model/insight/chart) whose object IS loaded in the
+  // store at seed time gets its content hashed into `content_signature` —
+  // the value `computeExplorationStaleness` later compares against on
+  // resume to detect the source having been edited elsewhere.
+  test('a hashable seed with a loaded model computes and sends a content_signature', async () => {
+    useStore.setState({ models: [{ name: 'orders', config: { sql: 'SELECT 1' } }] });
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({
+        seeded_from: { type: 'model', name: 'orders', content_signature: 'irrelevant-for-this-assert' },
+      })
+    );
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'model', name: 'orders' });
+    });
+
+    const payload = explorationsApi.createExploration.mock.calls[0][0];
+    expect(payload.seeded_from.type).toBe('model');
+    expect(payload.seeded_from.name).toBe('orders');
+    expect(typeof payload.seeded_from.content_signature).toBe('string');
+    expect(payload.seeded_from.content_signature.length).toBeGreaterThan(0);
+  });
+
+  test('a source seed (not a hashable type) sends a null content_signature', async () => {
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ seeded_from: { type: 'source', name: 'warehouse' } })
+    );
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'source', name: 'warehouse' });
+    });
+
+    const payload = explorationsApi.createExploration.mock.calls[0][0];
+    expect(payload.seeded_from).toEqual({
+      type: 'source',
+      name: 'warehouse',
+      content_signature: null,
     });
   });
 
@@ -212,7 +264,7 @@ describe('createExploration', () => {
     });
 
     const payload = explorationsApi.createExploration.mock.calls[0][0];
-    expect(payload.seeded_from).toEqual({ type: 'model', name: 'orders' });
+    expect(payload.seeded_from).toEqual({ type: 'model', name: 'orders', content_signature: null });
     expect(payload.draft.queries).toEqual([
       { name: 'query_1', sql: 'SELECT * FROM ${ref(orders)}', source: 'pg' },
     ]);
@@ -655,7 +707,7 @@ describe('duplicateExploration', () => {
 
     expect(explorationsApi.createExploration).toHaveBeenCalledWith({
       name: 'Churn dig copy',
-      seeded_from: { type: 'model', name: 'orders' },
+      seeded_from: { type: 'model', name: 'orders', content_signature: null },
       draft: {
         queries: [{ name: 'q', sql: 'x' }],
         insights: [],

--- a/viewer/src/utils/translatePreviewError.js
+++ b/viewer/src/utils/translatePreviewError.js
@@ -1,0 +1,61 @@
+/**
+ * translatePreviewError — Explore 2.0 Phase 6c-T1 (ux-audit.md's "error
+ * translation" finding: cold-start #1, promote-roundtrip #1/#2, pills #3).
+ *
+ * Maps a raw engine/compile error message (DuckDB-WASM, the Python
+ * compile-draft endpoint, or `Insight.get_query_info`) to plain-language
+ * copy a first-time analyst can act on. The raw message is NEVER discarded —
+ * callers should always keep it available behind a collapsed "technical
+ * details" disclosure, never as the prominent headline/hint (never a hashed
+ * internal table name, never a raw DuckDB catalog "Did you mean pg_*"
+ * suggestion, never DAG-internals jargon like "has no dependent models").
+ *
+ * Known classes (see ux-audit.md's "Code grounding" section for the exact
+ * shapes these come from):
+ *   - A DuckDB "Catalog Error: Table with name <hash> does not exist" — an
+ *     internal draft-lane materialization table that was never registered.
+ *     `useDraftInsightPreview.js`'s own pre-execution guard makes this
+ *     unreachable from the draft-preview path in practice; this stays as a
+ *     defensive translation for any OTHER path (e.g. a promoted-lane engine
+ *     error) that might still surface one.
+ *   - "Insight '<name>' has no dependent models" (visivo/models/insight.py)
+ *     — DAG-internals jargon for "nothing is bound to a column yet".
+ *   - Anything else — a generic, honest headline; the raw message moves to
+ *     the technical-details disclosure rather than ever being the prominent
+ *     copy itself (this is what keeps DuckDB's internal-catalog "Did you
+ *     mean pg_*" suggestions out of the headline even for error shapes this
+ *     module doesn't specifically recognize).
+ *
+ * @param {string} rawMessage
+ * @returns {{headline: string, hint: string, technical: string}}
+ */
+const HASHED_TABLE_PATTERN = /Table with name [0-9a-zA-Z_]{8,} does not exist/i;
+const NO_DEPENDENT_MODELS_PATTERN = /has no dependent models/i;
+
+export function translatePreviewError(rawMessage) {
+  const message = rawMessage == null ? '' : String(rawMessage);
+
+  if (HASHED_TABLE_PATTERN.test(message)) {
+    return {
+      headline: "This chart hasn't loaded any data yet.",
+      hint: 'Run your query, then come back to this tab to see a preview.',
+      technical: message,
+    };
+  }
+
+  if (NO_DEPENDENT_MODELS_PATTERN.test(message)) {
+    return {
+      headline: "This chart isn't connected to any data yet.",
+      hint: 'Drag a column from the Library onto the chart to map it to your query.',
+      technical: message,
+    };
+  }
+
+  return {
+    headline: 'This preview failed to run.',
+    hint: 'Check your query and chart settings below, or see the technical details.',
+    technical: message,
+  };
+}
+
+export default translatePreviewError;

--- a/viewer/src/utils/translatePreviewError.test.js
+++ b/viewer/src/utils/translatePreviewError.test.js
@@ -1,0 +1,39 @@
+import { translatePreviewError } from './translatePreviewError';
+
+describe('translatePreviewError', () => {
+  it('translates a hashed-table DuckDB catalog error and never repeats the hash in the headline/hint', () => {
+    const raw =
+      'Catalog Error: Table with name mfiawdybhqqkwzuxbjzfxqbvbaibc does not exist! Did you mean "pg_index"? LINE 3: FROM ...';
+    const result = translatePreviewError(raw);
+
+    expect(result.headline).not.toMatch(/mfiawdybhqqkwzuxbjzfxqbvbaibc/);
+    expect(result.hint).not.toMatch(/mfiawdybhqqkwzuxbjzfxqbvbaibc/);
+    expect(result.headline).not.toMatch(/pg_index/i);
+    expect(result.hint).not.toMatch(/pg_index/i);
+    expect(result.technical).toBe(raw);
+  });
+
+  it('translates "has no dependent models" DAG jargon into a drag-a-column hint', () => {
+    const raw = "Insight 'insight' has no dependent models";
+    const result = translatePreviewError(raw);
+
+    expect(result.headline).not.toMatch(/dependent models/i);
+    expect(result.hint).toMatch(/drag a column/i);
+    expect(result.technical).toBe(raw);
+  });
+
+  it('falls back to a generic honest headline for an unrecognized message, keeping the raw text as technical', () => {
+    const raw = 'some totally novel engine failure';
+    const result = translatePreviewError(raw);
+
+    expect(result.headline).toBeTruthy();
+    expect(result.hint).toBeTruthy();
+    expect(result.technical).toBe(raw);
+  });
+
+  it('handles null/undefined without throwing', () => {
+    expect(() => translatePreviewError(null)).not.toThrow();
+    expect(() => translatePreviewError(undefined)).not.toThrow();
+    expect(translatePreviewError(null).technical).toBe('');
+  });
+});

--- a/visivo/models/exploration.py
+++ b/visivo/models/exploration.py
@@ -78,10 +78,22 @@ class ReturnToRef(BaseModel):
 
 class SeedRef(BaseModel):
     """Durable provenance — what this exploration was seeded from, shown on
-    Home cards. Unlike ``return_to`` this never clears."""
+    Home cards. Unlike ``return_to`` this never clears.
+
+    ``content_signature`` (Explore 2.0 Phase 6c-T1, ux-audit.md's "no
+    staleness indication after the underlying insight is edited elsewhere"
+    finding — existing-objects #8): a stable client-computed hash of the
+    seeded object's config AT SEED TIME (see
+    ``explorationStaleness.js``'s ``computeSeedContentSignature``). Opaque to
+    the backend — never read or validated here, just persisted verbatim so
+    a later resume can recompute the CURRENT object's signature and detect
+    drift (the source was edited elsewhere since this copy was made), which
+    a bare dangling-ref check can never catch on its own.
+    """
 
     type: str
     name: str
+    content_signature: Optional[str] = None
 
 
 class Exploration(BaseModel):


### PR DESCRIPTION
## Summary

Closes the 6c-T1 slice of `ux-audit.md` (cold-start #1/#2/#3, promote-roundtrip #1/#2/#3, pills #3, plus the two ⚠ conflicts-with-e2e findings assigned to this track: promote-roundtrip #9, existing-objects #8). Territory: `useDraftInsightPreview`, `usePreviewInputDependencies`, `ExplorerChartPreview.jsx`, preview state components, `insight_compile_views.py` (reviewed, no bug found — see disposition below), plus the exploration-staleness/promote-offer machinery for finding 5.

## Per-finding disposition

### 1. Draft-preview execution gap (BLOCKER) — FIXED
`useDraftInsightPreview.js` now checks every `compiled.models[]` entry has actually-fetched rows (`modelStates[name].queryResult.rows`) **before** ever sending `post_query` to DuckDB. A draft whose props compile without a schema lookup (see `insight_compile_views.py`'s own docstring — this is a real, documented server-side behavior, not a bug there) used to hand DuckDB a query against a table this hook never created, surfacing a raw `Catalog Error: Table with name <hash> does not exist!`. The guard now falls back to the existing `model_not_run` guided-empty state instead. A belt-and-braces regex catch also maps any hashed-table DuckDB error that somehow still slips through.
Evidence: `03-chart-tab-before-run-BEFORE.png`, `08-chart-tab-after-mapping-AFTER.png` (no Catalog Error anywhere in the whole walkthrough), `09-no-misclassified-input-banner.png`.

### 2. Infinite spinner — FIXED
Root cause found by tracing the actual code path: an insight with zero data-bearing props never even attempts a compile (correctly — nothing to preview), but the hook used to report a bare "not loading, not blocked" status, which `Chart.jsx`'s own `hasAllInsightData` gate then waited on **forever** (data that was never going to arrive). The hook now reports an explicit `no_data_props` blocked reason; `ExplorerChartPreview` renders a guided "Nothing to preview yet — drag a column..." state instead of ever mounting `<Chart>`.
Evidence: `03-chart-tab-before-run-BEFORE.png` / `04-...-after-6s-still-no-spinner.png` (`chart-preview-loading` count = 0 after a 6s wait, confirmed via the walkthrough script's own assertions).

### 3. Unresolved-"input" misclassification — FIXED
`usePreviewInputDependencies` now excludes published (`state.models`) **and** caller-supplied draft/not-yet-promoted model names (`ExplorerChartPreview` passes its own `explorerModelStates` keys) before computing `unresolvedNames` — a model ref written by a Build-rail pill drop (`?{${ref(model).column}}`) is textually indistinguishable from a real input ref without this exclusion. Banner copy for genuine unresolved inputs also drops "not yet promoted" (D11) for "isn't defined in this project yet." Verified the banner is absent both **before and after** promote (previously it persisted post-promote, per the audit).
Evidence: `09-no-misclassified-input-banner.png` (before promote), `12-chart-tab-after-promote-banner-cleared.png` (after promote, incl. after a fresh navigation back to the tab).

### 4. Error translation — FIXED
New `translatePreviewError.js` maps known error shapes (hashed-table catalog errors, `"has no dependent models"` DAG jargon) to plain-language headline + hint; anything unrecognized gets an honest generic headline. The raw message is **never discarded** — it moves to a collapsed "Technical details" `<details>` in `ChartPreview.jsx`, never the prominent copy. Unit-tested directly (`translatePreviewError.test.js`) since triggering these specific engine errors live wasn't reliably reproducible in a walkthrough without deep DuckDB manipulation.

### 5. ⚠ conflicts-with-e2e — post-promote offers & staleness — FIXED, root causes below
**Post-promote offers (promote-roundtrip #9).** Root cause: **condition too narrow**, not a fixture-reachable-state gap or discoverability problem. Both existing offers are genuinely correct for their own precondition — `dashboard-newchart-roundtrip.spec.mjs` proves "Place in `<dashboard>`" works when `return_to` is armed via the Library's dashboard-scoped "+ New Chart" button; `save-as-metric.spec.mjs` proves "View in Semantic Layer" works after an explicit Save-as-metric. Neither precondition is **ever** true for the single most common promote outcome (Explorer home → source tile → query → chart → Save to Project, which promotes a MODEL + insight + chart, never a metric/dimension, and never arms `return_to`). Fix: broadened `promotedField` to include a promoted `model` row (equally semantic-layer-visible), and added a fallback "Add `<chart>` to a dashboard" offer that fires whenever a chart was promoted with no `return_to` armed, reusing the existing `placeChartInDashboardSlot` plumbing.
Evidence: `11-promote-success-with-fallback-offer.png`, `11b-...-scrolled-into-view.png`, `11d-fallback-offer-accepted-dashboard.png` (chart actually lands in a real dashboard, backend-verifiable).

**Staleness (existing-objects #8).** Root cause: **the existing e2e-verified feature is real but narrower than the audit's expectation, by design** — `explorationStaleness.js`'s own prior "Scope" docstring said so explicitly: dangling-ref detection was implemented, "changed-vs-deleted distinction would need a `ref_fingerprint` persisted on the Exploration record — noted as follow-up work, not implemented here." That follow-up is this fix: `SeedRef.content_signature` (backend) captures a stable hash of the seeded object's config at `createExploration` time (centralized once, so every "Explore this" call site gets it for free); `computeExplorationStaleness` recomputes and compares on resume, additive with (never replacing) the dangling-ref check.
Evidence: `13-explore-this-context-menu.png`, `14-explorer-home-no-drift-yet.png` (before edit), `15-staleness-drift-banner-AFTER.png` (after editing the original insight via the real `/api/insights/<name>/` endpoint and reopening — banner reads "insight changed in the project since this copy was made", no "promoted" jargon).

New specs added under the DOUBLE-REGISTRATION RULE (grep-verified 2 occurrences each in `playwright.config.mjs`): `exploration-promote-fallback-dashboard-offer.spec.mjs`, `exploration-staleness-drift.spec.mjs`.

### 6. D11 vocabulary — FIXED in this track's surfaces
"Save to project" title unchanged/confirmed (`10-save-to-project-modal.png`); no "promote"/"input"/"MODEL" in the guided empty states, translated errors, or the new drift banner copy. Did not touch the promote modal's pre-existing "Promote N selected" CTA or checklist vocabulary (T3 wave 2's territory) beyond the banner-clearing/offer-broadening explicitly in scope here.

## Disputed / out of scope (found, not fixed — belongs to other tracks)

- Reproduced live, during the walkthrough: **drag-drop hit-testing offset** (dropping a column on the x well lands it in y) and **wells defaulting to a static/number-spinner mode** — both exactly the pills-buildrail/promote-roundtrip findings already assigned to 6c-T4 ("DnD integrity & build-rail cleanup"). Worked around in my own walkthrough script (documented inline) purely so the preview pipeline itself could be verified end-to-end; did not touch DnD code.
- `insight_compile_views.py`: reviewed per the grounding anchor — no additional bug found. The fix for finding 1 is entirely client-side per the audit's own fix direction ("Close the gap client-side").

## Test plan
- [x] `bash scripts/viewer-check.sh` — 339 suites / 5726 tests passing, lint clean
- [x] `PYTHONPATH=$(pwd) ./venv14/bin/python -m pytest tests/ -x -q` — 2134 passed
- [x] `./venv14/bin/black --check --target-version py312 .` — clean
- [x] Schema regenerated (`python -m visivo.generate_project_schema_json`) — no diff, `Exploration` is deliberately excluded from the project DAG schema (asserted by `tests/models/test_exploration.py`)
- [x] Standalone Playwright walkthrough against an isolated sandbox (own project copy, ports 8071/3071), screenshots in the session scratchpad, reviewed with vision — see per-finding evidence above
- [ ] New/changed e2e specs run in this PR (per instructions: they can't run against custom ports; verified by careful read + the walkthrough script instead — orchestrator runs the full suite at merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX