### PR TITLE
Phase 6c-T4: DnD integrity + build-rail curation (D12)

### DIFF
--- a/viewer/e2e/stories/exploration-build-rail.spec.mjs
+++ b/viewer/e2e/stories/exploration-build-rail.spec.mjs
@@ -217,7 +217,7 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     const insightName = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames[0]
     );
-    const typeSelectTestId = `insight-type-select-${insightName}`;
+    const typeSelectTestId = `type-selector-${insightName}`;
     await pickSelectOption(page, typeSelectTestId, 'Bar');
     await expect(page.getByTestId(typeSelectTestId)).toContainText('Bar', { timeout: 5000 });
 
@@ -281,7 +281,7 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     // Switch to an indicator so `value` is a scalar-only slot (B13's
     // established fixture for this affordance, per
     // explorer-indicator-slice-authoring.spec.mjs).
-    await pickSelectOption(page, `insight-type-select-${insightName}`, 'Indicator');
+    await pickSelectOption(page, `type-selector-${insightName}`, 'Indicator');
 
     const tableRow = await expandSourceTable(page);
     const { locator: column } = await firstNumericColumn(page, tableRow);
@@ -325,7 +325,7 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     const insightName = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames[0]
     );
-    await pickSelectOption(page, `insight-type-select-${insightName}`, 'Indicator');
+    await pickSelectOption(page, `type-selector-${insightName}`, 'Indicator');
 
     const tableRow = await expandSourceTable(page);
     const { locator: column, name: columnName } = await firstNumericColumn(page, tableRow);

--- a/viewer/e2e/stories/trace-props-editor.spec.mjs
+++ b/viewer/e2e/stories/trace-props-editor.spec.mjs
@@ -110,7 +110,7 @@ test.describe('Trace-Props Editor (VIS-1020)', () => {
     const editor = page.locator(EDITOR);
 
     // TypeSelector reflects the seeded type (react-select shows the label).
-    await expect(editor.getByTestId('type-selector')).toContainText(/Scatter/i, {
+    await expect(editor.getByTestId(`type-selector-${insightName}`)).toContainText(/Scatter/i, {
       timeout: 10000,
     });
 
@@ -138,7 +138,7 @@ test.describe('Trace-Props Editor (VIS-1020)', () => {
     // Drive the TypeSelector react-select: open its menu, type to filter to
     // "Bar", then click the option. The menu portals to document.body and its
     // options carry the brand classNamePrefix `vis-select__option`.
-    const typeSelector = editor.getByTestId('type-selector');
+    const typeSelector = editor.getByTestId(`type-selector-${insightName}`);
     await typeSelector.click();
     const combobox = typeSelector.getByRole('combobox');
     await combobox.fill('Bar');
@@ -148,7 +148,7 @@ test.describe('Trace-Props Editor (VIS-1020)', () => {
 
     // Type updated: the grouped title flips to the bar type, TypeSelector shows Bar.
     await expect(editor.getByText('Key fields (bar)')).toBeVisible({ timeout: 10000 });
-    await expect(editor.getByTestId('type-selector')).toContainText('Bar');
+    await expect(editor.getByTestId(`type-selector-${insightName}`)).toContainText('Bar');
 
     // Compatible prop preserved: `x` is valid in the bar schema, so its
     // PropertyRow is still rendered after the switch (preserveTraceProps).

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { PiCaretDown, PiWarningCircle, PiTextAa, PiTrash } from 'react-icons/pi';
 import useStore from '../../../stores/store';
@@ -177,17 +177,25 @@ function Divider() {
  *   only for `kind: 'aggregate'` pills; undefined keeps it disabled.
  * @param {() => void} props.onRemove - clear this slot's value.
  * @param {boolean} [props.disabled]
+ *
+ * T4 (pills-buildrail #10): exposes an imperative `open()` (via `ref` +
+ * `useImperativeHandle`) so the pill BODY (not just this chevron) can also
+ * open the menu — `PropertyRow` holds a ref and calls it from the pill's own
+ * onClick. The chevron stays a real, independently-clickable trigger too
+ * (toggle open/closed); its own click handler stops propagation so a click
+ * on the 16px chevron doesn't ALSO fire the pill body's onClick underneath it
+ * (open, then immediately re-forced-open is harmless, but a toggle-closed
+ * immediately reopened would read as a broken click).
  */
-const PillMenu = ({
-  state,
-  onSelectPreset,
-  onCustomAggregation,
-  onSaveAsMetric,
-  onRemove,
-  disabled = false,
-}) => {
+const PillMenu = React.forwardRef(
+  (
+    { state, onSelectPreset, onCustomAggregation, onSaveAsMetric, onRemove, disabled = false },
+    ref
+  ) => {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
+
+  useImperativeHandle(ref, () => ({ open: () => setOpen(true) }), []);
 
   const isColumnBacked = state?.kind === 'dimension' || state?.kind === 'aggregate';
   const isNumeric = useColumnIsNumeric(isColumnBacked ? state.ref : null, state?.column);
@@ -211,13 +219,18 @@ const PillMenu = ({
     setOpen(false);
   };
 
+  // T4 (pills-buildrail #5): the INITIAL guess (open downward, anchored to
+  // the trigger's bottom edge) — `PillMenuPopover` measures its own actual
+  // rendered height after mount and flips to open UPWARD when it would
+  // overflow the viewport bottom (the common case: the pill row sits near
+  // the bottom of the Build rail by design).
   const menuStyle = useMemo(() => {
     if (!open || !triggerRef.current) return null;
     const rect = triggerRef.current.getBoundingClientRect();
     const MENU_WIDTH = 260;
     const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
     const left = Math.max(8, Math.min(rect.left, viewportWidth - MENU_WIDTH - 8));
-    return { top: rect.bottom + 4, left };
+    return { top: rect.bottom + 4, left, triggerTop: rect.top, triggerBottom: rect.bottom };
   }, [open]);
 
   return (
@@ -225,7 +238,10 @@ const PillMenu = ({
       <button
         type="button"
         ref={triggerRef}
-        onClick={() => setOpen(o => !o)}
+        onClick={e => {
+          e.stopPropagation();
+          setOpen(o => !o);
+        }}
         disabled={disabled}
         aria-haspopup="menu"
         aria-expanded={open}
@@ -267,7 +283,9 @@ const PillMenu = ({
         )}
     </span>
   );
-};
+  }
+);
+PillMenu.displayName = 'PillMenu';
 
 const PillMenuPopover = ({
   state,
@@ -286,6 +304,32 @@ const PillMenuPopover = ({
   triggerRef,
 }) => {
   const containerRef = useRef(null);
+  // T4 (pills-buildrail #5): measured-then-flip. `style` is the DOWNWARD
+  // guess computed before the popover's actual content (a variable-length
+  // preset list + header + collision warning) has rendered anywhere, so its
+  // real height isn't knowable in advance. Render once at the guessed
+  // position, measure, and if the bottom edge would fall below the
+  // viewport, flip to open UPWARD from the trigger's top edge instead — this
+  // is the common case since the pill row is anchored near the Build rail's
+  // bottom by design (06 §4/§5's own mock).
+  const [resolvedTop, setResolvedTop] = useState(style.top);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 768;
+    const rect = el.getBoundingClientRect();
+    const overflowsBottom = rect.bottom > viewportHeight - 8;
+    if (overflowsBottom) {
+      const flippedTop = style.triggerTop - rect.height - 4;
+      setResolvedTop(Math.max(8, flippedTop));
+    } else {
+      setResolvedTop(style.top);
+    }
+    // Re-run only when the anchor itself moves (open/close, trigger reposition) —
+    // not on every render, which would fight the flip decision.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [style.top, style.triggerTop, style.left]);
 
   React.useEffect(() => {
     const handler = e => {
@@ -317,7 +361,7 @@ const PillMenuPopover = ({
     <div
       ref={containerRef}
       className="fixed bg-white border border-gray-200 rounded-lg shadow-xl w-64 py-1 text-xs text-gray-700 z-[9999]"
-      style={{ top: style.top, left: style.left }}
+      style={{ top: resolvedTop, left: style.left }}
       data-testid="pill-menu"
       role="menu"
     >

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -364,6 +364,14 @@ const PillMenuPopover = ({
       style={{ top: resolvedTop, left: style.left }}
       data-testid="pill-menu"
       role="menu"
+      // React portals bubble events through the REACT tree, not the DOM tree:
+      // without this, every click in here also reaches the pill body's
+      // open-the-menu handler (PropertyRow's handlePillBodyClick), which
+      // re-opened the menu in the same tick that selecting a preset closed
+      // it — leaving it stuck open, so the user's next chevron click only
+      // appeared to do nothing (it toggled the already-open menu shut).
+      onClick={e => e.stopPropagation()}
+      onKeyDown={e => e.stopPropagation()}
     >
       {/* Header — source/field + type (06 §4's anatomy) */}
       <div className="px-3 py-2 border-b border-gray-100">

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -31,6 +31,35 @@ describe('PillMenu', () => {
     expect(screen.getByText('orders_q ▸ region')).toBeInTheDocument();
   });
 
+  test('selecting a preset closes the popover, and a click inside it never re-opens it through a portal-bubbling ancestor handler', () => {
+    // Composed-gate regression (Wave 1): the popover renders through a React
+    // portal, and portal events bubble up the REACT tree — so every click
+    // inside it also reached the pill BODY's open-the-menu handler one level
+    // up, re-opening the menu in the same tick that selecting a preset closed
+    // it. The menu then stayed open forever and the next chevron click only
+    // appeared to do nothing (it toggled the already-open menu shut).
+    const onSelectPreset = jest.fn();
+    const reopen = jest.fn();
+    render(
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div onClick={reopen} data-testid="pill-body-ancestor">
+        <PillMenu
+          state={{ kind: 'dimension', ref: 'orders_q', column: 'amount' }}
+          onSelectPreset={onSelectPreset}
+        />
+      </div>
+    );
+    openMenu();
+    expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('pill-menu-preset-sum'));
+
+    expect(onSelectPreset).toHaveBeenCalledWith('sum');
+    expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
+    // The ancestor never saw the in-menu click, so nothing re-opened it.
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
   test('a dimension pill offers the Dimension + every non-restricted preset (unknown numeric-ness fails open)', () => {
     render(<PillMenu state={{ kind: 'dimension', ref: 'orders_q', column: 'amount' }} />);
     openMenu();

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
-import { useDroppable } from '@dnd-kit/core';
+import { useDroppable, useDraggable } from '@dnd-kit/core';
 import { PiTrash, PiCode, PiSliders } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import RefTextArea from '../RefTextArea';
 import FieldPill from '../FieldPill';
 import PillMenu from '../PillMenu';
 import * as pillGrammar from '../pillGrammar';
+import { useWorkspaceDrag } from '../../workspace/WorkspaceDndContext';
 import {
   isQueryStringValue,
   parseQueryString,
@@ -87,8 +88,28 @@ export function PropertyRow({
     disabled: !dropEnabled,
   });
 
+  // T4 (cold-start #3 / pills-buildrail #4): highlight EVERY eligible slot
+  // the instant a compatible drag starts, not just the one under the
+  // cursor — `isOver`-only feedback means a user gets no signal about WHERE
+  // they can drop until they're already hovering the exact right pixel.
+  const activeDrag = useWorkspaceDrag();
+  const isDragEligibleForThisRow =
+    dropEnabled && !!activeDrag && ['library', 'column', 'pill'].includes(activeDrag.kind);
+
   const isQueryMode = useMemo(() => isQueryStringValue(value), [value]);
-  const [forceQueryMode, setForceQueryMode] = useState(() => isQueryStringValue(value));
+  // T4 (promote-roundtrip #4 / pills #9): a droppable, query-capable slot
+  // (the Build rail's x/y "Essentials" fields) defaults to "Static value" —
+  // a bare `<input type="number">` — even though dropping/typing a column
+  // ref is the overwhelming use case. Typing a ref into that number input
+  // silently mangles it character-by-character (observed: '?{query_1.X}'
+  // reduced to 'e1'). Default droppable + query-capable EMPTY slots to query
+  // mode instead; the toggle above still lets someone who genuinely wants a
+  // literal static value switch to it explicitly. Non-droppable consumers
+  // (right-rail InsightEditForm/ChartEditForm/SchemaLeafForm) are unaffected
+  // — `droppable` is false there, matching every other gate in this file.
+  const [forceQueryMode, setForceQueryMode] = useState(
+    () => isQueryStringValue(value) || (droppable && queryStringSupported)
+  );
 
   // Auto-enter query mode when value externally changes to ?{...} (e.g., chart load, DnD drop)
   useEffect(() => {
@@ -226,6 +247,20 @@ export function PropertyRow({
 
   const isDropTarget = isOver && dropEnabled;
 
+  // T4 (pills-buildrail #10): clicking the PILL BODY opens the same menu the
+  // chevron does — the chevron's 16px hit target was the ONLY interactive
+  // affordance on the pill, failing Fitts and discoverability.
+  const pillMenuRef = useRef(null);
+  const handlePillBodyClick = useCallback(() => {
+    pillMenuRef.current?.open();
+  }, []);
+  const handlePillBodyKeyDown = useCallback(e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      pillMenuRef.current?.open();
+    }
+  }, []);
+
   const pillState = useMemo(
     () => pillGrammar.parse(body, pillFieldOpts),
     [body, pillFieldOpts]
@@ -268,6 +303,24 @@ export function PropertyRow({
         ? `${pillState.ref} ▸ ${pillState.column}`
         : pillState.ref;
 
+  // T4 (pills-buildrail #4): the whole pill is a drag SOURCE too, so it can
+  // move between slots (drag the x pill onto the y slot), not just receive
+  // drops. `sourcePath` + `raw` (the parsed body, pre-`?{}`-wrap) are all
+  // the target slot needs — see `handleDropField`'s `source === 'pill'`
+  // branch and `WorkspaceDndContext`'s matching router extension. Only
+  // wired up when a pill is actually showing (`showPill`) — an opaque/
+  // raw-edit row has no pill to drag.
+  const {
+    attributes: pillDragAttributes,
+    listeners: pillDragListeners,
+    setNodeRef: setPillDragRef,
+    isDragging: isPillDragging,
+  } = useDraggable({
+    id: `pill-${path}`,
+    data: { source: 'pill', sourcePath: path, raw: body, label: pillLabel },
+    disabled: !showPill,
+  });
+
   const handleSelectPreset = useCallback(
     preset => {
       const nextState =
@@ -304,9 +357,12 @@ export function PropertyRow({
       className={`flex flex-col gap-1.5 p-2.5 rounded-md transition-all duration-150 ${
         isDropTarget
           ? 'bg-primary-50 ring-2 ring-primary-300'
-          : 'bg-gray-50 hover:bg-gray-100'
+          : isDragEligibleForThisRow
+            ? 'bg-primary-50/40 ring-2 ring-dashed ring-primary-200'
+            : 'bg-gray-50 hover:bg-gray-100'
       }`}
       data-testid={droppable ? `droppable-property-${path}` : undefined}
+      data-drag-eligible={isDragEligibleForThisRow ? 'true' : undefined}
     >
       {/* Header row with path, toggle, and remove button */}
       <div className="flex items-center gap-1.5">
@@ -376,9 +432,25 @@ export function PropertyRow({
             <div className="flex-1 min-w-[180px]">
               {showPill ? (
                 <FieldPill
+                  ref={setPillDragRef}
                   type={pillType}
                   label={pillLabel}
                   data-testid={`property-pill-${path}`}
+                  // T4 (pills-buildrail #4/#10): the pill is both a drag
+                  // SOURCE (move it to another slot) and a click target
+                  // (open the same menu the chevron does) — the chevron's
+                  // 16px hit target was previously the ONLY interactive
+                  // affordance. `role="button"`/`tabIndex` keep it keyboard-
+                  // reachable without turning the pill into a real `<button>`
+                  // (PillMenu's own chevron trigger is a REAL button nested
+                  // inside; two real buttons would be invalid HTML nesting).
+                  role="button"
+                  tabIndex={disabled ? -1 : 0}
+                  onClick={disabled ? undefined : handlePillBodyClick}
+                  onKeyDown={disabled ? undefined : handlePillBodyKeyDown}
+                  {...pillDragAttributes}
+                  {...pillDragListeners}
+                  className={`${isPillDragging ? 'opacity-50' : ''} cursor-grab active:cursor-grabbing`}
                   // Delta-review fix (HIGH): a dangling ref (e.g. its query
                   // chip was deleted, or the model it names no longer
                   // resolves) must render as an explicit warning pill, never
@@ -390,6 +462,7 @@ export function PropertyRow({
                   warningMessage={error}
                   extra={
                     <PillMenu
+                      ref={pillMenuRef}
                       state={pillState}
                       onSelectPreset={handleSelectPreset}
                       onCustomAggregation={() => setForceRawEdit(true)}

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -28,11 +28,19 @@ jest.mock('../RefTextArea', () => {
 // the drop-hover ring). Declared at module scope (not nested in a describe)
 // so babel's jest.mock hoisting resolves the closure over `droppableData`
 // unambiguously.
+//
+// T4 (pills-buildrail #4): `useDraggable` (the pill-as-drag-source wiring)
+// is mocked the same way — capture the payload, no real pointer drag.
 const droppableData = {};
+const draggableData = {};
 jest.mock('@dnd-kit/core', () => ({
   useDroppable: ({ id, data, disabled }) => {
     droppableData[id] = { data, disabled };
     return { setNodeRef: () => {}, isOver: false };
+  },
+  useDraggable: ({ id, data, disabled }) => {
+    draggableData[id] = { data, disabled };
+    return { attributes: {}, listeners: {}, setNodeRef: () => {}, isDragging: false };
   },
 }));
 
@@ -464,6 +472,42 @@ describe('PropertyRow', () => {
       expect(droppableData['property-x'].disabled).toBe(true);
     });
 
+    // T4 (promote-roundtrip #4 / pills-buildrail #9): a droppable,
+    // query-capable EMPTY slot (the Build rail's x/y "Essentials" fields)
+    // must NOT default to the "Static value" number spinner — typing a
+    // dropped/typed ref into that input silently mangles it character by
+    // character (observed live: '?{query_1.X}' reduced to 'e1').
+    test('a droppable, query-capable EMPTY slot defaults to query mode, not the static number spinner', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value={undefined}
+          droppable
+        />
+      );
+      expect(screen.getByRole('button', { name: /query/i })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: /static/i })).toHaveAttribute('aria-pressed', 'false');
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+    });
+
+    // Non-droppable consumers (right-rail InsightEditForm/ChartEditForm/
+    // SchemaLeafForm) are UNCHANGED — this gate is additive, not universal.
+    test('a NON-droppable EMPTY slot still defaults to static (unaffected — gated on `droppable`)', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value={undefined}
+        />
+      );
+      expect(screen.getByRole('button', { name: /static/i })).toHaveAttribute('aria-pressed', 'true');
+    });
+
     test('a recognized dimension ref renders a FieldPill + PillMenu instead of RefTextArea when droppable', () => {
       render(
         <PropertyRow
@@ -750,6 +794,86 @@ describe('PropertyRow', () => {
       );
       expect(screen.getByText('churn_rate')).toBeInTheDocument();
       expect(screen.queryByTestId('ref-text-area')).not.toBeInTheDocument();
+    });
+
+    // T4 (pills-buildrail #4): the pill is ALSO a drag SOURCE, so it can be
+    // moved to another slot (drag the x pill onto the y slot) — mirrors the
+    // droppable-data assertion style above, but against the mocked
+    // `useDraggable`.
+    describe('pill as a drag source + click-to-open (T4)', () => {
+      beforeEach(() => {
+        for (const k of Object.keys(draggableData)) delete draggableData[k];
+      });
+
+      test('a shown pill registers as a drag source carrying sourcePath + the raw (unwrapped) body', () => {
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{${ref(orders_q).amount}}"
+            droppable
+          />
+        );
+        const entry = draggableData['pill-x'];
+        expect(entry).toBeDefined();
+        expect(entry.disabled).toBe(false);
+        expect(entry.data.source).toBe('pill');
+        expect(entry.data.sourcePath).toBe('x');
+        expect(entry.data.raw).toBe('${ref(orders_q).amount}');
+      });
+
+      test('the drag source is DISABLED when no pill is showing (opaque/raw-edit rows have nothing to drag)', () => {
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="not a recognized shape"
+            droppable
+          />
+        );
+        expect(draggableData['pill-x'].disabled).toBe(true);
+      });
+
+      // T4 (pills-buildrail #10): clicking the pill BODY opens the same menu
+      // the 16px chevron does — previously the chevron was the ONLY
+      // interactive affordance on the whole pill.
+      test('clicking the pill body opens the PillMenu popover (same as the chevron)', () => {
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{${ref(orders_q).amount}}"
+            droppable
+          />
+        );
+        expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('property-pill-x'));
+        expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+      });
+
+      test('the pill body is keyboard-reachable (role="button", Enter opens the menu)', () => {
+        render(
+          <PropertyRow
+            {...defaultProps}
+            path="x"
+            schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+            defs={queryStringDef}
+            value="?{${ref(orders_q).amount}}"
+            droppable
+          />
+        );
+        const pill = screen.getByTestId('property-pill-x');
+        expect(pill).toHaveAttribute('role', 'button');
+        expect(pill).toHaveAttribute('tabIndex', '0');
+        fireEvent.keyDown(pill, { key: 'Enter' });
+        expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
@@ -19,6 +19,12 @@ import {
  * @param {Array<string>} props.initiallyExpanded - Properties to show by default
  * @param {boolean} props.disabled - Whether the editor is disabled
  * @param {boolean} props.droppable - Whether property rows support DnD drops
+ * @param {boolean} [props.hidePropertyCount] - D12 (pills-buildrail #8/#9,
+ *   promote-roundtrip minor): a bare "0 of 1366 properties" reads as a raw
+ *   Plotly-schema-size inventory, not guidance — hides that line. Default
+ *   false (unchanged for every existing caller); the exploration Build
+ *   rail's `ChartBuildSection` (Layout Properties, whose schema genuinely
+ *   has 1300+ leaves) opts in.
  */
 export function SchemaEditor({
   schema,
@@ -28,6 +34,7 @@ export function SchemaEditor({
   initiallyExpanded = [],
   disabled = false,
   droppable = false,
+  hidePropertyCount = false,
 }) {
   const [addedProperties, setAddedProperties] = useState(() => new Set(initiallyExpanded));
   const [showPropertyPicker, setShowPropertyPicker] = useState(false);
@@ -145,9 +152,11 @@ export function SchemaEditor({
           {showPropertyPicker ? 'Hide Properties' : 'Add Properties'}
         </button>
 
-        <span className="ml-auto text-xs text-gray-500">
-          {displayedProperties.length} of {allProperties.length} properties
-        </span>
+        {!hidePropertyCount && (
+          <span className="ml-auto text-xs text-gray-500">
+            {displayedProperties.length} of {allProperties.length} properties
+          </span>
+        )}
       </div>
 
       {/* Property search/picker */}

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
@@ -83,6 +83,14 @@ describe('SchemaEditor', () => {
     expect(propertyCountTexts.length).toBeGreaterThan(0);
   });
 
+  // D12 (pills-buildrail #8/#9): "0 of 1366 properties" was the single
+  // most-quoted "raw schema dump" line in the audit — `ChartBuildSection`'s
+  // Layout Properties panel (a genuinely 1300+-leaf schema) opts out.
+  it('hides the property count when `hidePropertyCount` is set', () => {
+    render(<SchemaEditor {...defaultProps} hidePropertyCount />);
+    expect(screen.queryByText(/of.*properties/)).not.toBeInTheDocument();
+  });
+
   it('shows empty state when no properties added', () => {
     render(<SchemaEditor {...defaultProps} />);
     expect(screen.getByText(/No properties added yet/)).toBeInTheDocument();

--- a/viewer/src/components/views/common/TracePropsEditor.jsx
+++ b/viewer/src/components/views/common/TracePropsEditor.jsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
-import { PiMagnifyingGlass, PiWarningCircle } from 'react-icons/pi';
+import { PiMagnifyingGlass, PiWarningCircle, PiX } from 'react-icons/pi';
 import TypeSelector from './TypeSelector';
 import FieldGroupList from '../workspace/FieldGroupList';
 import { getSchema } from '../../../schemas/schemas';
 import { loadCatalog, loadTraceGroups } from '../../../schemas/traceCatalogLoader';
-import { buildTraceGroupSpec } from './buildTraceGroupSpec';
+import { buildTraceGroupSpec, humanizePath } from './buildTraceGroupSpec';
 import { getRequiredFields } from './insightRequiredFields';
 import { preserveTraceProps } from './preserveTraceProps';
 import { validateProps } from '../../../schemas/plotlyValidator';
@@ -107,6 +107,14 @@ const TracePropsEditor = ({
   // revealed (jumped-to) in the grouped form after a compound-result select.
   const [fieldFinderOpen, setFieldFinderOpen] = useState(false);
   const [revealPath, setRevealPath] = useState(null);
+
+  // T4 (pills-buildrail #2): a chart-type switch silently wiped every
+  // configured field with no warning ("Build, blind, wipe" — the audit's own
+  // words). `preserveTraceProps` already carries forward whatever's
+  // COMPATIBLE with the new type (x/y survive scatter->bar); this surfaces
+  // what ISN'T — a dismissible, human-readable list of what just got
+  // dropped, right where the switch happened.
+  const [typeChangeWarning, setTypeChangeWarning] = useState(null); // { fromType, toType, dropped: string[] }
 
   // Load schema + catalog + groups whenever the type changes.
   useEffect(() => {
@@ -250,7 +258,7 @@ const TracePropsEditor = ({
       if (!newType || newType === type || !onChange) return;
 
       const newSchema = await getSchema(newType);
-      const { props: nextProps, typePropsCache } = preserveTraceProps({
+      const { props: nextProps, typePropsCache, dropped } = preserveTraceProps({
         oldProps: traceProps || {},
         oldType: type,
         newType,
@@ -258,6 +266,7 @@ const TracePropsEditor = ({
         typePropsCache: typePropsCacheRef.current,
       });
       typePropsCacheRef.current = typePropsCache;
+      setTypeChangeWarning(dropped && dropped.length > 0 ? { fromType: type, toType: newType, dropped } : null);
       onChange(nextProps);
     },
     [type, traceProps, onChange]
@@ -325,10 +334,20 @@ const TracePropsEditor = ({
 
   return (
     <div className="flex flex-col gap-3" data-testid="trace-props-editor">
-      {/* Type selector + overall validity indicator */}
+      {/* Type selector + overall validity indicator. D12 (grounding
+          diagnosis #4): this is now the ONLY chart-type control on the Build
+          rail — the legacy top-level `Type` <Select> InsightBuildSection
+          used to render alongside it was a byte-for-byte duplicate and is
+          deleted. `ownerName`-scoped testid so a Build rail stacking several
+          insight sections still has one unambiguous selector per insight. */}
       <div className="flex items-center gap-2">
         <div className="flex-1 min-w-0">
-          <TypeSelector value={type} onChange={handleTypeChange} disabled={disabled} />
+          <TypeSelector
+            value={type}
+            onChange={handleTypeChange}
+            disabled={disabled}
+            data-testid={ownerName ? `type-selector-${ownerName}` : undefined}
+          />
         </div>
         {!isValid && (
           <span
@@ -341,6 +360,34 @@ const TracePropsEditor = ({
           </span>
         )}
       </div>
+
+      {/* T4 (pills-buildrail #2): dismissible warning naming exactly what the
+          type switch just dropped — compatible fields (x/y etc.) already
+          survive via `preserveTraceProps`; this only fires when something
+          genuinely didn't carry over. */}
+      {typeChangeWarning && (
+        <div
+          data-testid="trace-props-type-change-warning"
+          className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+        >
+          <PiWarningCircle size={14} className="mt-0.5 flex-shrink-0" />
+          <span className="flex-1">
+            Switching to <strong>{typeChangeWarning.toType}</strong> dropped{' '}
+            {typeChangeWarning.dropped.length === 1 ? 'this field' : 'these fields'} not supported
+            on that chart type:{' '}
+            <strong>{typeChangeWarning.dropped.map(humanizePath).join(', ')}</strong>.
+          </span>
+          <button
+            type="button"
+            onClick={() => setTypeChangeWarning(null)}
+            aria-label="Dismiss"
+            data-testid="trace-props-type-change-warning-dismiss"
+            className="flex-shrink-0 text-amber-500 hover:text-amber-700"
+          >
+            <PiX size={12} />
+          </button>
+        </div>
+      )}
 
       {/* Field finder affordance (palette is VIS-1021; this is just the entry point) */}
       <button

--- a/viewer/src/components/views/common/TracePropsEditor.test.jsx
+++ b/viewer/src/components/views/common/TracePropsEditor.test.jsx
@@ -152,8 +152,10 @@ describe('TracePropsEditor', () => {
     );
 
     // TypeSelector bound to scatter (react-select renders the selected label
-    // inside the type-selector container).
-    const typeSelector = await screen.findByTestId('type-selector');
+    // inside the type-selector container). T4: scoped to `ownerName` so a
+    // Build rail stacking several insight sections has one selector per
+    // insight rather than a single ambiguous `type-selector`.
+    const typeSelector = await screen.findByTestId('type-selector-my_insight');
     expect(typeSelector).toHaveTextContent('Scatter / Line');
 
     // Grouped fields appear once async loaders resolve.

--- a/viewer/src/components/views/common/preserveTraceProps.js
+++ b/viewer/src/components/views/common/preserveTraceProps.js
@@ -17,9 +17,15 @@
  * @param {string} args.newType         The trace type being switched to (e.g. 'bar').
  * @param {Object} args.newSchema       Per-type Plotly schema for `newType` ({ properties }).
  * @param {Object} [args.typePropsCache] Cache of `{ [type]: propsWithoutType }` from prior switches.
- * @returns {{ props: Object, typePropsCache: Object }}
+ * @returns {{ props: Object, typePropsCache: Object, dropped: string[] }}
  *   `props` always has `props.type === newType`.
  *   `typePropsCache` is a new object with `oldType`'s full props (minus `type`) stashed.
+ *   `dropped` (T4 / pills-buildrail #2) — top-level prop names that had a
+ *   value under `oldType` but aren't valid on `newType` (and aren't being
+ *   silently restored from a prior visit to `newType`), so the caller can
+ *   warn rather than lose them with no signal. Always `[]` when switching to
+ *   a previously-visited type (an exact snapshot is restored instead) or
+ *   when nothing was actually configured.
  */
 export function preserveTraceProps({ oldProps, oldType, newType, newSchema, typePropsCache }) {
   const safeOldProps = oldProps && typeof oldProps === 'object' ? oldProps : {};
@@ -53,15 +59,22 @@ export function preserveTraceProps({ oldProps, oldType, newType, newSchema, type
   // present in `newSchema.properties`; drop it otherwise. Carry-forward values win over
   // the restored snapshot so the most recent user edits survive a round-trip.
   const carried = {};
+  const dropped = [];
+  // A prior visit to `newType` restores its exact snapshot (`restored`), so
+  // anything not carried forward is already accounted for there — only warn
+  // about a genuine loss when this is the FIRST visit to `newType`.
+  const isFreshType = !updatedCache[newType];
   for (const [name, value] of Object.entries(oldPropsWithoutType)) {
     if (isAllowed(name)) {
       carried[name] = value;
+    } else if (isFreshType) {
+      dropped.push(name);
     }
   }
 
   const props = { ...restored, ...carried, type: newType };
 
-  return { props, typePropsCache: updatedCache };
+  return { props, typePropsCache: updatedCache, dropped };
 }
 
 export default preserveTraceProps;

--- a/viewer/src/components/views/workspace/ChartBuildSection.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.jsx
@@ -187,9 +187,15 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
               }
             }}
             onClick={e => e.stopPropagation()}
-            className={`text-sm font-medium text-pink-800 bg-transparent border-0 border-b border-transparent px-0 py-0 outline-none focus:border-pink-400 disabled:cursor-default ${
-              renameError ? 'border-highlight-400 focus:border-highlight-400' : ''
-            }`}
+            // D12: an unnamed chart's fallback text ('Untitled') is styled as
+            // a lighter, italic placeholder rather than a solid committed
+            // name — "Chart: Untitled" previously read like a real, boring
+            // title rather than "you haven't named this yet". Purely visual;
+            // the underlying rename/sentinel logic (commitRename treating a
+            // re-typed 'Untitled' as a no-op) is unchanged.
+            className={`text-sm bg-transparent border-0 border-b border-transparent px-0 py-0 outline-none focus:border-pink-400 disabled:cursor-default ${
+              !chartName && !isEditing ? 'italic text-gray-400 font-normal' : 'font-medium text-pink-800'
+            } ${renameError ? 'border-highlight-400 focus:border-highlight-400' : ''}`}
           />
           {renameError && (
             <span data-testid="chart-rename-error" className="text-xs text-highlight-600 mt-0.5">
@@ -247,6 +253,12 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
 
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">Layout Properties</label>
+            {/* D12 (pills-buildrail #8/#9): the Plotly layout schema has
+                1300+ leaves — "0 of 1366 properties" is the single most-
+                quoted "raw schema dump" moment in the audit. Curated
+                cleanup, not a picker redesign: hide the count, keep the
+                existing search-driven "Add Properties" picker as the one
+                path into the long tail. */}
             <SchemaEditor
               schema={layoutSchema}
               value={chartLayout}
@@ -254,6 +266,7 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
               excludeProperties={[]}
               initiallyExpanded={Object.keys(chartLayout || {})}
               droppable={false}
+              hidePropertyCount
             />
           </div>
         </div>

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
@@ -77,7 +77,11 @@ const ExplorationBuildRail = ({ explorationId }) => {
       data-testid="exploration-build-rail"
       className="w-96 flex-shrink-0 border-l border-secondary-200 bg-white flex flex-col h-full overflow-hidden"
     >
-      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+      {/* T4 (cold-start #3 / promote-roundtrip #3): opts this scroll body OUT
+          of dnd-kit's built-in auto-scroll (see WorkspaceDndContext's
+          `autoScroll.canScroll`) — auto-scrolling THIS container mid-drag is
+          what moved x/y drop targets out from under the cursor. */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-3" data-dnd-freeze-scroll>
         <ChartBuildSection isExpanded={chartExpanded} onToggleExpand={handleToggleChart} />
 
         <div className="border-t-2 border-gray-200" />

--- a/viewer/src/components/views/workspace/FieldGroup.jsx
+++ b/viewer/src/components/views/workspace/FieldGroup.jsx
@@ -174,12 +174,20 @@ export function FieldGroup({
         </span>
         <GroupIcon size={16} className="text-gray-500" />
         <span className="flex-1 text-sm font-medium text-gray-700">{label}</span>
-        <span
-          className="text-xs font-medium text-gray-500 bg-gray-200 rounded-full px-2 py-0.5"
-          data-testid={`field-group-badge-${id}`}
-        >
-          {presentCount}/{fields.length}
-        </span>
+        {/* D12 (pills-buildrail #8/#9, promote-roundtrip minor): a "0/180"
+            or "0 of 1366" badge reads as a raw schema-size inventory,
+            intimidating on first contact and adding nothing when there is
+            nothing configured to count. Once at least one field IS set, the
+            fraction is genuinely useful signal ("1/2 essentials filled in"),
+            so it still renders — only the empty, all-zero case is hidden. */}
+        {presentCount > 0 && (
+          <span
+            className="text-xs font-medium text-gray-500 bg-gray-200 rounded-full px-2 py-0.5"
+            data-testid={`field-group-badge-${id}`}
+          >
+            {presentCount}/{fields.length}
+          </span>
+        )}
       </button>
 
       {!collapsed && (

--- a/viewer/src/components/views/workspace/FieldGroup.test.jsx
+++ b/viewer/src/components/views/workspace/FieldGroup.test.jsx
@@ -74,11 +74,33 @@ const advancedGroup = {
 describe('FieldGroup', () => {
   beforeEach(resetCollapse);
 
-  test('renders header label, group icon, and present/total count badge', () => {
+  test('renders header label, group icon, and present/total count badge once something is configured', () => {
     render(<FieldGroup group={essentialsGroup} value={{ expression: 'x' }} onChange={() => {}} />);
     expect(screen.getByTestId('field-group-header-essentials')).toBeInTheDocument();
     // 1 of 2 fields present (expression).
     expect(screen.getByTestId('field-group-badge-essentials')).toHaveTextContent('1/2');
+  });
+
+  // D12 (pills-buildrail #8/#9): "0/180"-style raw schema counts read as an
+  // intimidating inventory when nothing is configured yet — the badge is
+  // hidden entirely in that state (it comes back the moment ANY field in
+  // the group has a value, per the test above). Fields spec their own
+  // `present`/`required` flags (pre-computed by buildGroupSpec, not derived
+  // live here), so this uses a fixture where BOTH are false throughout.
+  test('hides the count badge entirely when nothing in the group is configured (D12 curation)', () => {
+    const emptyStyleGroup = {
+      id: 'style',
+      label: 'Style',
+      icon: 'style',
+      objectType: 'scatter',
+      alwaysOpen: false,
+      fields: [
+        { name: 'marker.color', schema: { type: 'string' }, required: false, present: false, expanded: false },
+        { name: 'line.width', schema: { type: 'number' }, required: false, present: false, expanded: false },
+      ],
+    };
+    render(<FieldGroup group={emptyStyleGroup} value={{}} onChange={() => {}} />);
+    expect(screen.queryByTestId('field-group-badge-style')).not.toBeInTheDocument();
   });
 
   test('Essentials is always open and its header is disabled (cannot collapse)', () => {

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -3,7 +3,6 @@ import { PiCaretDown, PiCaretRight, PiX, PiPlus } from 'react-icons/pi';
 import { useDroppable } from '@dnd-kit/core';
 import useStore from '../../../stores/store';
 import { getSourceDialect, selectInsightStatus } from '../../../stores/explorerStore';
-import { CHART_TYPES } from '../../../schemas/schemas';
 import TracePropsEditor from '../common/TracePropsEditor';
 import RefTextArea from '../common/RefTextArea';
 import Select from '../../common/Select';
@@ -119,6 +118,7 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
   const sources = useStore(s => s.sources);
   const explorerSources = useStore(s => s.explorerSources);
   const models = useStore(s => s.models);
+  const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
@@ -139,13 +139,6 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
   const tracePropsValue = useMemo(
     () => ({ ...(insightState?.props || {}), type }),
     [insightState?.props, type]
-  );
-
-  const handleTypeChange = useCallback(
-    value => {
-      setInsightType(insightName, value);
-    },
-    [insightName, setInsightType]
   );
 
   // TracePropsEditor's onChange always hands back the FULL props object with
@@ -180,9 +173,28 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
   // D10 §3 v1 drop-default heuristic + D9 payload resolution (mirrors
   // routeExplorationDragEnd's buildRefExpr, generalized here since this
   // callback OWNS the drop — no global "active insight" indirection).
+  //
+  // T4 (cold-start #3 / pills-buildrail #1): every drop this handler doesn't
+  // act on now says why, via the shared workspace toast — a drop that just
+  // does nothing (no pill, no error, no animation) is the single most
+  // trust-destroying moment the audit found. `source === 'pill'` (T4,
+  // pills-buildrail #4) is the ONE other successful path: a pill dragged
+  // out of a sibling slot in the SAME insight section moves (clears the
+  // source), rather than rebuilding a ref from a Library/column payload.
   const handleDropField = useCallback(
     (path, dragData) => {
-      if (!dragData || dragData.type === 'sourceTable') return;
+      if (!dragData) return;
+      if (dragData.source === 'pill') {
+        if (!dragData.sourcePath || !dragData.raw) return;
+        if (dragData.sourcePath === path) return; // dropped back on itself — no-op, nothing to warn about
+        setInsightProp(insightName, path, `?{${dragData.raw}}`);
+        removeInsightProp(insightName, dragData.sourcePath);
+        return;
+      }
+      if (dragData.type === 'sourceTable') {
+        showWorkspaceToast?.("Can't drop a whole table here — drag a column instead.");
+        return;
+      }
       let body;
       if (dragData.type === 'metric' || dragData.type === 'dimension') {
         body = dragData.parentModel
@@ -191,16 +203,20 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
       } else if (dragData.type === 'input') {
         const accessor = dragData.inputType === 'multi-select' ? 'values' : 'value';
         body = formatRefExpression(dragData.name, accessor);
-      } else {
+      } else if (dragData.name) {
         const columnRef = formatRefExpression(activeModelName, dragData.name);
         body =
           dragData.type === 'sourceColumn' && isNumericColumnType(dragData.columnType)
             ? `sum(${columnRef})`
             : columnRef;
+      } else {
+        // Unrecognized drag payload — never fail silently.
+        showWorkspaceToast?.("Can't drop that here.");
+        return;
       }
       setInsightProp(insightName, path, `?{${body}}`);
     },
-    [activeModelName, insightName, setInsightProp]
+    [activeModelName, insightName, setInsightProp, removeInsightProp, showWorkspaceToast]
   );
 
   // Explore 2.0 Phase 4 (06 §4): opens the name-prompt for a slot's
@@ -424,23 +440,15 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
 
       {isExpanded && (
         <div className="px-3 py-3 space-y-4 border-l-4 border-purple-400">
-          {/* Legacy explicit Type selector kept for parity with the onboarding
-              anchor + a quick top-level switch; TracePropsEditor ALSO renders
-              its own TypeSelector — both write through the same handler, so
-              they never disagree. */}
+          {/* D12 (grounding diagnosis #4): the legacy top-level Type <Select>
+              that used to live here was a byte-for-byte duplicate of
+              TracePropsEditor's OWN <TypeSelector> just below — both wrote
+              through the same handler and always agreed, so the second
+              control was pure confusion ("Type: Scatter/Line" stacked on
+              "Properties: Scatter/Line"). Deleted; TracePropsEditor's
+              TypeSelector (data-testid `type-selector-${ownerName}`) is now
+              the ONLY place type switching happens. */}
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Type</label>
-            <Select
-              data-testid={`insight-type-select-${insightName}`}
-              size="sm"
-              value={type}
-              options={CHART_TYPES}
-              onChange={handleTypeChange}
-            />
-          </div>
-
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Properties</label>
             <TracePropsEditor
               ownerName={insightName}
               props={tracePropsValue}

--- a/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings */
 import React from 'react';
-import { render, screen, fireEvent, within, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InsightBuildSection from './InsightBuildSection';
 import useStore from '../../../stores/store';
@@ -11,10 +11,6 @@ async function renderSettled(ui) {
   await act(async () => {
     render(ui);
   });
-}
-
-function openSelectMenu(testId) {
-  fireEvent.mouseDown(within(screen.getByTestId(testId)).getByRole('combobox'));
 }
 
 let mockCaptured = {};
@@ -123,26 +119,18 @@ describe('InsightBuildSection', () => {
     expect(header.className).toContain('border-purple');
   });
 
-  it('renders type selector dropdown with CHART_TYPES', async () => {
+  // D12 (grounding diagnosis #4): the legacy top-level Type <Select> — a
+  // byte-for-byte duplicate of TracePropsEditor's own TypeSelector — is
+  // deleted. Type switching is now exercised for real in
+  // TracePropsEditor.test.jsx (TracePropsEditor is mocked in THIS file, so
+  // the real TypeSelector never mounts here); this is a regression guard
+  // that the duplicate control never comes back.
+  it('renders no legacy top-level Type select — TracePropsEditor owns type switching alone', async () => {
     await renderSettled(
       <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
     );
-    const select = screen.getByTestId('insight-type-select-test_insight');
-    expect(select).toHaveTextContent('Scatter / Line');
-    openSelectMenu('insight-type-select-test_insight');
-    const options = screen.getAllByRole('option');
-    expect(options.map(o => o.textContent)).toEqual(['Scatter / Line', 'Bar', 'Pie']);
-  });
-
-  it('changing type via the top Select calls setInsightType', async () => {
-    const setInsightType = jest.fn();
-    useStore.setState({ setInsightType });
-    await renderSettled(
-      <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
-    );
-    openSelectMenu('insight-type-select-test_insight');
-    fireEvent.click(screen.getAllByRole('option').find(o => o.textContent === 'Bar'));
-    expect(setInsightType).toHaveBeenCalledWith('test_insight', 'bar');
+    await screen.findByTestId('trace-props-editor-mock');
+    expect(screen.queryByTestId('insight-type-select-test_insight')).not.toBeInTheDocument();
   });
 
   it('renders TracePropsEditor with droppable=true and props.type re-attached, when expanded', async () => {
@@ -307,9 +295,13 @@ describe('InsightBuildSection', () => {
       );
     });
 
-    it('a sourceTable drop is a no-op (not a scalar ref)', async () => {
+    // T4 (cold-start #3 / pills-buildrail #1): every drop this handler
+    // doesn't act on now SAYS WHY via the shared workspace toast, instead
+    // of failing with no pill, no error, and no animation.
+    it('a sourceTable drop is a no-op AND shows visible feedback (never fails silently)', async () => {
       const setInsightProp = jest.fn();
-      useStore.setState({ setInsightProp });
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ setInsightProp, showWorkspaceToast });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
@@ -317,6 +309,64 @@ describe('InsightBuildSection', () => {
 
       mockCaptured.onDropField('x', { type: 'sourceTable', name: 'orders' });
       expect(setInsightProp).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringContaining("Can't drop"));
+    });
+
+    it('an unrecognized drag payload with no name is a no-op AND shows visible feedback', async () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ setInsightProp, showWorkspaceToast });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      await screen.findByTestId('trace-props-editor-mock');
+
+      mockCaptured.onDropField('x', { type: 'mystery-payload' });
+      expect(setInsightProp).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalled();
+    });
+  });
+
+  // T4 (pills-buildrail #4): pills can be dragged BETWEEN slots — the whole
+  // pill is a drag source (PropertyRow) whose payload reaches this same
+  // onDropField as `{ source: 'pill', sourcePath, raw }`.
+  describe('pill-to-pill move (T4 — drag a pill between slots)', () => {
+    it('moves the resolved expression from the source slot to the target slot, clearing the source', async () => {
+      const setInsightProp = jest.fn();
+      const removeInsightProp = jest.fn();
+      useStore.setState({ setInsightProp, removeInsightProp });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      await screen.findByTestId('trace-props-editor-mock');
+
+      mockCaptured.onDropField('y', {
+        source: 'pill',
+        sourcePath: 'x',
+        raw: '${ref(orders_q).amount}',
+      });
+
+      expect(setInsightProp).toHaveBeenCalledWith('test_insight', 'y', '?{${ref(orders_q).amount}}');
+      expect(removeInsightProp).toHaveBeenCalledWith('test_insight', 'x');
+    });
+
+    it('dropping a pill back onto its own slot is a no-op', async () => {
+      const setInsightProp = jest.fn();
+      const removeInsightProp = jest.fn();
+      useStore.setState({ setInsightProp, removeInsightProp });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      await screen.findByTestId('trace-props-editor-mock');
+
+      mockCaptured.onDropField('x', {
+        source: 'pill',
+        sourcePath: 'x',
+        raw: '${ref(orders_q).amount}',
+      });
+
+      expect(setInsightProp).not.toHaveBeenCalled();
+      expect(removeInsightProp).not.toHaveBeenCalled();
     });
   });
 

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -335,8 +335,14 @@ export const routeWorkspaceDragEnd = (
   // already has a generic non-metric/dimension/input fallback that resolves a
   // bare `column` against the active model correctly, so admitting it here is
   // the fix rather than adding a second parallel handler.
+  //
+  // `dragData.source === 'pill'` (T4): a pill dragged OUT of its own slot
+  // (see `PropertyRow.jsx`'s `useDraggable`) targeting another property-zone
+  // slot — moves the resolved expression rather than rebuilding a ref from a
+  // Library payload. `handleDropField` recognizes this shape and also clears
+  // the source slot (a move, not a copy).
   if (
-    (dragData.source === 'library' || dragData.type === 'column') &&
+    (dragData.source === 'library' || dragData.type === 'column' || dragData.source === 'pill') &&
     dropData.kind === 'property-zone'
   ) {
     emit &&
@@ -727,6 +733,23 @@ export const mapDragStartData = data => {
   if (data.source === 'library') {
     return { kind: 'library', name: data.name, type: data.type, data };
   }
+  // Results-grid column header (`DraggableColumnHeader`, `sourceType:
+  // 'data-table'`) never carries `source: 'library'` (it isn't a Library
+  // row), so it fell through every branch here and got NO DragOverlay
+  // content at all — the "no ghost" defect (pills-buildrail #4/T4 scope):
+  // dragging a column from the results grid showed nothing following the
+  // cursor. Column drags from the SQL editor's Library-column path already
+  // carry `source: 'library'` and are unaffected; this covers the
+  // data-table-only path.
+  if (data.sourceType === 'data-table' || data.type === 'column') {
+    return { kind: 'column', name: data.name };
+  }
+  // A pill dragged out of an Essentials/Key-fields slot to move it to
+  // another slot (T4 — "pill draggable between slots"). See
+  // `PropertyRow.jsx`'s `useDraggable` for the matching drag source.
+  if (data.source === 'pill') {
+    return { kind: 'pill', name: data.label || data.sourcePath };
+  }
   if (data.source === 'level') {
     return { kind: 'level', name: data.title || 'Level' };
   }
@@ -752,6 +775,40 @@ export const mapDragStartData = data => {
 
 const DashboardIcon = getTypeIcon('dashboard');
 const DASH_COLORS = getTypeColors('dashboard');
+const DIMENSION_COLORS = getTypeColors('dimension');
+
+/**
+ * ColumnDragPreview — the DragOverlay pill for a results-grid column-header
+ * drag (T4: pills-buildrail #4 "no ghost"). Mirrors the Library pill's visual
+ * language (architecture §2.6's "the drag preview IS the source pill") using
+ * the shared dimension palette, since a raw data-table column is a dimension
+ * until the drop target's default heuristic decides otherwise.
+ */
+const ColumnDragPreview = ({ name }) => (
+  <div
+    data-testid="column-drag-preview"
+    className={`pointer-events-none inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-[12px] font-medium shadow-lg ${DIMENSION_COLORS.bg} ${DIMENSION_COLORS.text} ${DIMENSION_COLORS.border}`}
+  >
+    <span aria-hidden="true">#</span>
+    {name}
+  </div>
+);
+
+/**
+ * PillDragPreview — the DragOverlay pill for an Essentials/Key-fields pill
+ * being dragged to another slot (T4: pills-buildrail #4 "pills draggable
+ * between slots"). Plain, since the pill's own `<FieldPill>` already renders
+ * inline at its source — this overlay just needs to read as "the same thing,
+ * moving".
+ */
+const PillDragPreview = ({ name }) => (
+  <div
+    data-testid="pill-drag-preview"
+    className="pointer-events-none inline-flex items-center gap-1.5 rounded-full border border-primary-300 bg-primary-50 px-2 py-1 text-[12px] font-medium text-primary-700 shadow-lg"
+  >
+    {name}
+  </div>
+);
 
 /**
  * CanvasRowDragPreview — the DragOverlay pill for a canvas ROW drag (VIS-901 #5).
@@ -966,6 +1023,22 @@ const WorkspaceDndContext = ({ children }) => {
         // once at drag-start goes stale and collisions miss. `Always` keeps the
         // measured rects in sync with the live overlay positions.
         measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+        // T4 (cold-start #3 / promote-roundtrip #3): dnd-kit's built-in
+        // auto-scroll fires on ANY scrollable ancestor near the pointer,
+        // including the exploration Build rail's `overflow-y-auto` body.
+        // Confirmed empirically: dragging a results-grid column toward the y
+        // well near a normal (720px) viewport's bottom edge auto-scrolled the
+        // rail ~166px mid-gesture, so the drop landed under a DIFFERENT row
+        // than the one highlighted when the drag started (or missed every
+        // droppable once the rect had moved) — the exact "column dropped on
+        // x lands in y" / "drop silently swallowed" reports. Rather than
+        // disabling auto-scroll globally (canvas dashboards legitimately need
+        // it for long layouts), exclude any container opting out via
+        // `data-dnd-freeze-scroll` — the Build rail's scroll body sets this.
+        autoScroll={{
+          canScroll: element =>
+            !(element && typeof element.closest === 'function' && element.closest('[data-dnd-freeze-scroll]')),
+        }}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragCancel={handleDragCancel}
@@ -974,6 +1047,10 @@ const WorkspaceDndContext = ({ children }) => {
         <DragOverlay dropAnimation={null}>
           {activeDrag?.kind === 'dashboard' ? (
             <DashboardTilePreview name={activeDrag.name} />
+          ) : activeDrag?.kind === 'column' ? (
+            <ColumnDragPreview name={activeDrag.name} />
+          ) : activeDrag?.kind === 'pill' ? (
+            <PillDragPreview name={activeDrag.name} />
           ) : activeDrag?.kind === 'pivot-field' ? (
             <PivotFieldDragPreview name={activeDrag.name} />
           ) : activeDrag?.kind === 'level' ? (

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -452,6 +452,52 @@ describe('routeWorkspaceDragEnd — property-zone branch (Explore 2.0 Phase 3b, 
     expect(result).toBe('property_zone_accepted');
     expect(onDropField).toHaveBeenCalledWith(dragData);
   });
+
+  // T4 (pills-buildrail #4): a pill dragged out of a sibling slot
+  // (`PropertyRow`'s `useDraggable`, `data: { source: 'pill', ... }`)
+  // dropped on ANOTHER property-zone slot must also route through — pills
+  // move between slots the same way a Library/column drop lands one.
+  test('a pill dragged from one slot onto another property-zone still invokes onDropField', () => {
+    const onDropField = jest.fn();
+    const dragData = { source: 'pill', sourcePath: 'x', raw: '${ref(orders_q).amount}' };
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: dragData } },
+        over: { data: { current: { kind: 'property-zone', path: 'y', onDropField } } },
+      },
+      {}
+    );
+    expect(result).toBe('property_zone_accepted');
+    expect(onDropField).toHaveBeenCalledWith(dragData);
+  });
+});
+
+describe('mapDragStartData — column + pill drag previews (T4, pills-buildrail #4)', () => {
+  test('a results-grid column drag (no `source` key) maps to a "column" preview', () => {
+    expect(mapDragStartData({ name: 'X', type: 'column', sourceType: 'data-table' })).toEqual({
+      kind: 'column',
+      name: 'X',
+    });
+  });
+
+  test('a Library-sourced column-shaped drag is NOT reclassified — `source: "library"` still wins', () => {
+    const out = mapDragStartData({ source: 'library', type: 'sourceColumn', name: 'amount' });
+    expect(out.kind).toBe('library');
+  });
+
+  test('a pill drag maps to a "pill" preview', () => {
+    expect(mapDragStartData({ source: 'pill', sourcePath: 'x', raw: '${ref(q).amount}', label: 'q ▸ amount' })).toEqual({
+      kind: 'pill',
+      name: 'q ▸ amount',
+    });
+  });
+
+  test('a pill drag with no label falls back to the sourcePath', () => {
+    expect(mapDragStartData({ source: 'pill', sourcePath: 'x', raw: '${ref(q).amount}' })).toEqual({
+      kind: 'pill',
+      name: 'x',
+    });
+  });
 });
 
 describe('routeWorkspaceDragEnd — relation ERD model-drop branch (VIS-1006b)', () => {
@@ -953,6 +999,28 @@ describe('WorkspaceDndContext drag overlay previews (VIS-901 #5 / VIS-1008)', ()
     await startDrag('probe');
     expect(screen.getByTestId('level-drag-preview')).toHaveTextContent('Org');
     await dropDrag();
+  });
+
+  // T4 (pills-buildrail #4 "no ghost"): a results-grid column drag
+  // previously mapped to NOTHING (`mapDragStartData` fell through every
+  // branch), so nothing followed the cursor. Confirms the fix end-to-end
+  // through a REAL pointer drag, not just the pure mapper.
+  test('a results-grid column drag (no `source` key) shows the column pill overlay', async () => {
+    renderWith({ name: 'X', type: 'column', sourceType: 'data-table' });
+    await startDrag('probe');
+    expect(screen.getByTestId('column-drag-preview')).toHaveTextContent('X');
+    await dropDrag();
+    expect(screen.queryByTestId('column-drag-preview')).not.toBeInTheDocument();
+  });
+
+  // T4 (pills-buildrail #4 "pills draggable between slots"): a pill dragged
+  // out of its slot shows an overlay too.
+  test('a pill drag shows the pill overlay', async () => {
+    renderWith({ source: 'pill', sourcePath: 'x', raw: '${ref(q).amount}', label: 'q ▸ amount' });
+    await startDrag('probe');
+    expect(screen.getByTestId('pill-drag-preview')).toHaveTextContent('q ▸ amount');
+    await dropDrag();
+    expect(screen.queryByTestId('pill-drag-preview')).not.toBeInTheDocument();
   });
 
   test('a dashboard tile drag shows the tile preview and cancels on Escape', async () => {

--- a/viewer/src/schemas/plotlyValidator.js
+++ b/viewer/src/schemas/plotlyValidator.js
@@ -36,6 +36,25 @@ function instancePathToDotPath(instancePath) {
     .join('.');
 }
 
+// T4 (promote-roundtrip #5): AJV's default `pattern`-keyword message is the
+// LITERAL regex source ('must match pattern "^\?\{.*\}..."') — exactly the
+// string the audit quoted verbatim as a trust-destroying validation message.
+// The `?{...}` / `${ref(...)}` query-string grammar (`$defs/query-string` in
+// every committed per-type schema — see queryString.js's own docstring for
+// the canonical pattern) is by far the most common `pattern`-constrained
+// shape a user hits (clearing or mistyping an x/y well); recognize it and
+// translate to the instruction a person can actually act on. Anything else
+// pattern-constrained (rare in the Plotly schemas) still gets a message with
+// zero raw regex syntax rather than AJV's default.
+const QUERY_STRING_PATTERN_MARKER = '\\?\\{';
+function humanizePatternError(error) {
+  const pattern = error.params?.pattern || '';
+  if (pattern.includes(QUERY_STRING_PATTERN_MARKER)) {
+    return 'Enter a query expression like ?{ref(model).column}, or drag a column here.';
+  }
+  return "This value doesn't match the format this field expects.";
+}
+
 /**
  * Build a human-readable message from an AJV error, augmenting enum errors with
  * their allowed values and additionalProperties errors with the offending key.
@@ -43,6 +62,10 @@ function instancePathToDotPath(instancePath) {
  * @returns {string}
  */
 function formatErrorMessage(error) {
+  if (error.keyword === 'pattern') {
+    return humanizePatternError(error);
+  }
+
   const base = error.message || 'is invalid';
 
   if (error.keyword === 'enum' && error.params?.allowedValues) {

--- a/viewer/src/schemas/plotlyValidator.test.js
+++ b/viewer/src/schemas/plotlyValidator.test.js
@@ -111,6 +111,28 @@ describe('validateProps - unknown chart type', () => {
   });
 });
 
+// T4 (promote-roundtrip #5): "the wells display the literal pattern:
+// must match pattern '^\?\{.*\}...' — an unreadable regex, shown twice (x
+// and y)" was the audit's exact quote. `x`/`y` are `query-string`-shaped
+// (oneOf: [pattern-constrained ?{...} string, static array]); a plain
+// non-matching string fails BOTH branches, and AJV's nested `pattern`
+// sub-error (raw regex source) is what used to leak through.
+describe('validateProps - pattern violations never leak the raw regex (T4)', () => {
+  test('a non-matching x value never surfaces `\\?\\{` / `^` / `$` regex syntax in its message', async () => {
+    const result = await validateProps('scatter', { type: 'scatter', x: 'not-a-ref-or-array' });
+    expect(result.valid).toBe(false);
+    const xErrors = result.errors.filter(e => e.path === 'x' || e.path.startsWith('x.'));
+    expect(xErrors.length).toBeGreaterThan(0);
+    xErrors.forEach(err => {
+      expect(err.message).not.toMatch(/\\\?\\\{/);
+      expect(err.message).not.toMatch(/\^.*\$/);
+      expect(err.message.toLowerCase()).not.toContain('pattern "');
+    });
+    // The actionable, human copy IS present.
+    expect(xErrors.some(e => e.message.includes('?{ref(model).column}'))).toBe(true);
+  });
+});
+
 describe('error shape', () => {
   test('every error is { path: string, message: string }', async () => {
     const result = await validateProps('scatter', { type: 'scatter', mode: 'bogus' });


### PR DESCRIPTION
## Summary

Phase 6c-T4 — DnD integrity & build-rail cleanup, closing the audit's most
trust-destroying findings: drops landing in the wrong slot, silent
rejections, and a build rail that read like a raw Plotly-schema dump.

Root-cause note: three separate-looking blockers (cold-start #3's "70px
auto-scroll drift", promote-roundtrip #3's "drop on x lands in y", and
pills #1's "static-mode silently rejects the drop") turned out to share ONE
root cause — dnd-kit's built-in auto-scroll firing on the Build rail's
`overflow-y-auto` body mid-drag. Fixing that at the source (a
`data-dnd-freeze-scroll` opt-out on the shared `<DndContext>`'s
`autoScroll.canScroll`) resolved all three simultaneously; this was
confirmed empirically (166px drift → 0px, wrong-slot drop → correct-slot
drop) before I touched anything else.

## Findings closed

### DnD integrity

| # | Finding | Fix | Evidence |
|---|---|---|---|
| 1 | **[cold-start #3 / promote-roundtrip #3, BLOCKER]** Rail auto-scroll during drag moves drop targets; column dropped on x lands in y | `WorkspaceDndContext`'s shared `DndContext` gets `autoScroll.canScroll` excluding any `[data-dnd-freeze-scroll]` ancestor; `ExplorationBuildRail`'s scroll body opts in | `before-02-mid-drag-DRIFTED.png` (149px drift, wrong content under cursor) vs `after-02-mid-drag-STABLE.png` (0px drift); `before-03-after-drop-SWALLOWED.png` (both x/y empty) vs `after-03-after-drop-LANDED.png` (y correctly filled) |
| 2 | **[pills #1, BLOCKER]** Drop on a "Static value" slot silently rejected | Root-caused to the SAME auto-scroll drift above — once frozen, the drop lands and (see #4 below) auto-switches to field mode | same before/after pair as #1; isolated confirmation in `PropertyRow.test.jsx` ("a droppable, query-capable EMPTY slot defaults to query mode…") |
| 3 | **[cold-start #3 / pills #1]** No visible feedback on a rejected/no-op drop | `InsightBuildSection.handleDropField` fires the shared workspace toast for every drag payload it can't act on (whole-table drop, unrecognized payload) | `13-rejected-drop-toast.png` — green "Can't drop a whole table here — drag a column instead." toast |
| 4 | **[pills #4]** No drag ghost; results-grid column drags mapped to nothing in `mapDragStartData` | Added `column`/`pill` branches + `ColumnDragPreview`/`PillDragPreview` overlays | `06-drag-ghost-results-grid.png` — a `# X` pill now follows the cursor (previously nothing rendered) |
| 5 | **[cold-start #3]** Eligible wells don't highlight on drag-start, only on hover | `PropertyRow` reads `useWorkspaceDrag()`; eligible droppable rows get a dashed ring the instant a compatible drag starts | visible in `06`/`07`-series screenshots (dashed ring around x/y while dragging) |
| 6 | **[pills #4]** Pills can't be dragged between slots | Pill is now also a drag SOURCE (`useDraggable`, `{source:'pill', sourcePath, raw}`); router + `handleDropField` move the resolved expression and clear the source slot | `09-pill-drag-mid.png` → `10-pill-drag-after.png`: x pill dragged onto y — x clears to the empty-well placeholder, y shows `SUM · model ▸ X` |
| 7 | **[pills #10]** Pill body click does nothing; only the 16px chevron works | Pill body is `role="button"`, click/Enter open the same `PillMenu` via an imperative `ref.open()` (chevron still works, `stopPropagation`s so the two don't double-fire) | `08-pill-menu-from-body-click.png` — menu opens from a click well outside the chevron |
| 8 | **[pills #5]** Preset menu opens off the bottom of the viewport | `PillMenuPopover` measures its own rendered height (`useLayoutEffect`) and flips to open upward when it would overflow | `14-pill-menu-collision-aware.png` at a 900px-tall viewport — full menu (8 presets + Custom aggregation + Save as metric + Remove) rendered entirely above the fold |

### Build-rail cleanup (D12)

| # | Finding | Fix | Evidence |
|---|---|---|---|
| 9 | **[grounding diagnosis #4]** Duplicate `Type` selector stacked over TracePropsEditor's own `TypeSelector` | Deleted the legacy `<Select>` in `InsightBuildSection`; `TypeSelector` is scoped `type-selector-${ownerName}` so it stays unambiguous with multiple insight sections stacked | `11-single-type-selector.png` — `type-selector` count 1, legacy `insight-type-select` count 0 |
| 10 | **[pills #2, BLOCKER]** Chart-type change silently wipes all pills | `preserveTraceProps` already carried forward compatible top-level props (x/y survive scatter→bar) — the wipe was specifically the deleted duplicate selector bypassing that path. Now also returns `dropped: string[]` so `TracePropsEditor` shows a dismissible warning naming what a genuinely incompatible switch (e.g. →Pie) removed | `12-type-change-warning.png` — "Switching to **pie** dropped this field not supported on that chart type: **X**." |
| 11 | **[pills #8/#9]** Raw schema counts ("0 of 1366 properties", "0/180", "+84 more") | `FieldGroup`'s badge hides at `presentCount === 0`; `SchemaEditor` gets an opt-in `hidePropertyCount` used by `ChartBuildSection`'s Layout Properties | `16-curated-sections-fresh.png` — no badges on any empty group header, no "0 of 1366 properties" line; confirmed via `bodyText.includes(...)` all `false` |
| 12 | **[D12]** "Chart: Untitled" header reads as a real, boring committed name | Unnamed-chart fallback renders italic/gray instead of solid text | visible in `16-curated-sections-fresh.png` header |
| 13 | **[promote-roundtrip #4 / pills #9]** Wells default to a number spinner that mangles a dropped/typed ref into "e1" | Droppable, query-capable EMPTY slots now default to query mode (the existing `RefTextArea` "Type @ to insert a reference" placeholder), not the static number `<input>` | `13-rejected-drop-toast.png` / `15-empty-wells-query-mode-default.png` — fresh x/y show the RefTextArea placeholder, not spin-button inputs |
| 14 | **[promote-roundtrip #5]** Raw JSON-schema regex shown as a validation message | `plotlyValidator.formatErrorMessage` recognizes the AJV `pattern` keyword and returns "Enter a query expression like `?{ref(model).column}`…" instead of the literal regex source | new unit test `plotlyValidator.test.js` validates against the REAL committed `scatter.schema.json` and asserts no `\?\{`, `^...$`, or `pattern "` substring ever appears |

Copy touched follows **D11** — "Save to project" (unchanged), no new user-visible "promote"/"input" language (toast/warning copy reviewed).

## Out of scope / left alone

Per the T4 charter I did not touch the rail's mount/outer container,
`ExplorationWorkbench`, `WorkspaceShell`, `RightRail`, or the preview hooks
— those are T2's and T1's territory respectively.

## Test evidence

- `bash scripts/viewer-check.sh` (from `visivo/`): **338 suites, 5708 passed / 2 skipped, 0 failed. Lint clean.**
- New/updated unit coverage: `WorkspaceDndContext.test.jsx` (column/pill drag mapping + overlay previews + property-zone pill-drop routing), `PropertyRow.test.jsx` (query-mode default for empty droppable slots, pill-as-drag-source, click/keyboard-to-open), `InsightBuildSection.test.jsx` (pill-to-pill move + source-clear, reject-toast on sourceTable/unrecognized payload, legacy-selector-removed regression guard), `TracePropsEditor.test.jsx` (scoped testid), `FieldGroup.test.jsx` (badge hidden at zero), `SchemaEditor.test.jsx` (`hidePropertyCount`), `plotlyValidator.test.js` (no raw regex leak against the real schema).
- UX walkthrough: standalone Playwright scripts driven with real `page.mouse` gestures (steps:15+, down/move/up — no `evaluate` shortcuts) against an isolated sandbox (`VISIVO_SANDBOX_NAME=uxt4`, ports 8074/3074, own `test-projects/integration` copy). Screenshots referenced above are in
  `/private/tmp/claude-501/-Users-jaredjesionek-visivo-Product/9b3f866e-0f25-4361-a48f-483a18803463/scratchpad/ux-fix-t4/`.
- `e2e/stories/exploration-build-rail.spec.mjs` and `trace-props-editor.spec.mjs` updated for the `type-selector-*` testid move (no assertions weakened — same control, scoped selector). Two of `pill-aggregation.spec.mjs`'s tests that don't depend on the hardcoded `:8001` backend-poll helper (`a confidently non-numeric column...`, `no raw ?{ or ${ syntax ever appears...`) were run directly against the sandbox and pass; the `waitForBackendDraft`-dependent tests in that file assume the standard 3001/8001 port pairing (pre-existing, unrelated to this change) and couldn't be exercised from my custom-port sandbox without violating the "never 8001/3001" sandboxing rule — the orchestrator's standard-port merge run covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQYjb2XjBnqBdotFKCp9tX
