### PR TITLE
viewer: allow workspace to work under nested URLs

### DIFF
--- a/viewer/src/components/views/workspace/Workspace.jsx
+++ b/viewer/src/components/views/workspace/Workspace.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import useStore from '../../../stores/store';
 import WorkspaceShell from './WorkspaceShell';
 import { emitWorkspaceEvent, markBuildModeEntered } from './telemetry';
 import { useWorkspaceScope } from './useWorkspaceScope';
 import useProjectChangeListener from './useProjectChangeListener';
-import { workspaceTabFromUrl } from './workspaceUrl';
+import { workspaceTabFromUrl, WORKSPACE_BASE } from './workspaceUrl';
 
 /**
  * Workspace — route container for `/workspace` and
@@ -31,6 +31,7 @@ const Workspace = () => {
   // goes through `openWorkspaceTab`, which routes the selection through the URL.
   const activateWorkspaceTab = useStore(s => s.activateWorkspaceTab);
   const registerWorkspaceUrlNavigate = useStore(s => s.registerWorkspaceUrlNavigate);
+  const registerWorkspaceUrlBase = useStore(s => s.registerWorkspaceUrlBase);
   const workspaceActiveTabId = useStore(s => s.workspaceActiveTabId);
   const workspaceTabs = useStore(s => s.workspaceTabs);
   const restoreWorkspaceTabs = useStore(s => s.restoreWorkspaceTabs);
@@ -96,13 +97,29 @@ const Workspace = () => {
     fetchDashboards,
   ]);
 
-  // Register the router's `navigate` so the store's tab actions can route the
-  // active selection through the URL (the single clean loop). Unregister on
-  // unmount so a stale navigate can't fire once the Workspace is gone.
+  // The mount prefix for this Workspace. Studio serves it at the root
+  // (`/workspace`); a host that mounts the viewer under a path prefix (the
+  // cloud app, at `/:account/:stage/:project/workspace`) needs its tab URLs to
+  // carry that prefix, or `navigate` escapes to the root and the route 404s.
+  // Derive it from the path up to and including the `workspace` segment so the
+  // same component works at either mount.
+  const workspaceUrlBase = useMemo(() => {
+    const segments = location.pathname.split('/');
+    const workspaceIndex = segments.indexOf('workspace');
+    return workspaceIndex === -1
+      ? WORKSPACE_BASE
+      : segments.slice(0, workspaceIndex + 1).join('/');
+  }, [location.pathname]);
+
+  // Register the router's `navigate` (and the derived mount base) so the store's
+  // tab actions can route the active selection through the URL (the single clean
+  // loop). Unregister on unmount so a stale navigate can't fire once the
+  // Workspace is gone.
   useEffect(() => {
     registerWorkspaceUrlNavigate(navigate);
+    registerWorkspaceUrlBase(workspaceUrlBase);
     return () => registerWorkspaceUrlNavigate(null);
-  }, [navigate, registerWorkspaceUrlNavigate]);
+  }, [navigate, workspaceUrlBase, registerWorkspaceUrlNavigate, registerWorkspaceUrlBase]);
 
   // #6: persist the OPEN-TAB SET across refresh (the active tab is restored from
   // the URL). Keyed per project so projects don't share strips.
@@ -140,7 +157,7 @@ const Workspace = () => {
       syncedTargetRef.current = `project:${projectName}`;
     }
 
-    const target = workspaceTabFromUrl(location.pathname, searchParams) || {
+    const target = workspaceTabFromUrl(location.pathname, searchParams, workspaceUrlBase) || {
       type: 'project',
       name: projectName,
     };
@@ -176,6 +193,7 @@ const Workspace = () => {
     projectName,
     location.pathname,
     searchParams,
+    workspaceUrlBase,
     activateWorkspaceTab,
     setWorkspaceLens,
   ]);

--- a/viewer/src/components/views/workspace/workspaceUrl.js
+++ b/viewer/src/components/views/workspace/workspaceUrl.js
@@ -5,22 +5,33 @@
  * the URL (see `workspaceStore.openWorkspaceTab`), `useWorkspaceUrlSync` reads
  * the URL back into the store, and every surface reads the store.
  *
- * The project + object tabs live at `/workspace`, distinguished by
+ * The project + object tabs live at `<base>`, distinguished by
  * `?edit=<type>:<name>`; dashboard and semantic-layer keep their dedicated
  * routes (the dashboard path also drives scope detection). Adding a NEW
  * URL-addressable value is a param here + a case in `useWorkspaceUrlSync`.
+ *
+ * `base` is the mount prefix. Studio serves the viewer at the root, so it
+ * defaults to `/workspace`; a host that mounts the viewer under a path prefix
+ * (the cloud app, at `/:account/:stage/:project/workspace`) passes its own
+ * base so tab navigation stays inside the mount instead of escaping to the
+ * root. The Workspace derives that base from the URL and registers it on the
+ * store (see `registerWorkspaceUrlBase`).
  */
 
 export const WORKSPACE_BASE = '/workspace';
 
+// Escape a base path for embedding in a RegExp — a host mount prefix can carry
+// regex-special characters (e.g. a `.` or `+` in an account slug).
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /** The URL that represents `tab` as the active tab. `null`/project → the base. */
-export const workspaceTabUrl = tab => {
-  if (!tab || tab.type === 'project') return WORKSPACE_BASE;
+export const workspaceTabUrl = (tab, base = WORKSPACE_BASE) => {
+  if (!tab || tab.type === 'project') return base;
   if (tab.type === 'dashboard') {
-    return `${WORKSPACE_BASE}/dashboard/${encodeURIComponent(tab.name)}`;
+    return `${base}/dashboard/${encodeURIComponent(tab.name)}`;
   }
-  if (tab.type === 'semantic-layer') return `${WORKSPACE_BASE}/semantic-layer`;
-  return `${WORKSPACE_BASE}?edit=${encodeURIComponent(`${tab.type}:${tab.name}`)}`;
+  if (tab.type === 'semantic-layer') return `${base}/semantic-layer`;
+  return `${base}?edit=${encodeURIComponent(`${tab.type}:${tab.name}`)}`;
 };
 
 /**
@@ -28,12 +39,12 @@ export const workspaceTabUrl = tab => {
  * `workspaceTabUrl`: dashboard/semantic-layer come from the path; every other
  * object comes from `?edit=<type>:<name>`.
  */
-export const workspaceTabFromUrl = (pathname, searchParams) => {
-  const dashMatch = pathname.match(/^\/workspace\/dashboard\/([^/]+)\/?$/);
+export const workspaceTabFromUrl = (pathname, searchParams, base = WORKSPACE_BASE) => {
+  const dashMatch = pathname.match(new RegExp(`^${escapeRegExp(base)}/dashboard/([^/]+)/?$`));
   if (dashMatch) {
     return { type: 'dashboard', name: decodeURIComponent(dashMatch[1]) };
   }
-  if (pathname === `${WORKSPACE_BASE}/semantic-layer`) {
+  if (pathname === `${base}/semantic-layer`) {
     return { type: 'semantic-layer', name: 'semantic-layer' };
   }
   const edit = searchParams.get('edit');

--- a/viewer/src/components/views/workspace/workspaceUrl.test.js
+++ b/viewer/src/components/views/workspace/workspaceUrl.test.js
@@ -1,0 +1,93 @@
+/**
+ * workspaceUrl — the workspace tab ⇄ URL mapping.
+ *
+ * Pins both the default root mount (`/workspace`, Studio) and a host prefix
+ * mount (`/:account/:stage/:project/workspace`, the cloud app) so tab
+ * navigation stays inside whatever prefix the viewer is mounted under.
+ */
+import { WORKSPACE_BASE, workspaceTabUrl, workspaceTabFromUrl } from './workspaceUrl';
+
+const params = search => new URLSearchParams(search);
+
+describe('workspaceTabUrl (default root base)', () => {
+  test('project / null tab → the base', () => {
+    expect(workspaceTabUrl(null)).toBe(WORKSPACE_BASE);
+    expect(workspaceTabUrl({ type: 'project', name: 'p' })).toBe(WORKSPACE_BASE);
+  });
+
+  test('object tab → ?edit=<type>:<name> (encoded)', () => {
+    expect(workspaceTabUrl({ type: 'chart', name: 'revenue' })).toBe(
+      '/workspace?edit=chart%3Arevenue'
+    );
+  });
+
+  test('dashboard and semantic-layer keep their dedicated paths', () => {
+    expect(workspaceTabUrl({ type: 'dashboard', name: 'sales' })).toBe(
+      '/workspace/dashboard/sales'
+    );
+    expect(workspaceTabUrl({ type: 'semantic-layer', name: 'semantic-layer' })).toBe(
+      '/workspace/semantic-layer'
+    );
+  });
+});
+
+describe('workspaceTabUrl (host prefix base)', () => {
+  const base = '/acme/main/proj/workspace';
+
+  test('every tab kind is prefixed with the mount base', () => {
+    expect(workspaceTabUrl({ type: 'project', name: 'p' }, base)).toBe(base);
+    expect(workspaceTabUrl({ type: 'chart', name: 'revenue' }, base)).toBe(
+      `${base}?edit=chart%3Arevenue`
+    );
+    expect(workspaceTabUrl({ type: 'dashboard', name: 'sales' }, base)).toBe(
+      `${base}/dashboard/sales`
+    );
+    expect(workspaceTabUrl({ type: 'semantic-layer', name: 'semantic-layer' }, base)).toBe(
+      `${base}/semantic-layer`
+    );
+  });
+});
+
+describe('workspaceTabFromUrl', () => {
+  test('parses ?edit, dashboard, and semantic-layer at the root base', () => {
+    expect(workspaceTabFromUrl('/workspace', params('?edit=chart:revenue'))).toEqual({
+      type: 'chart',
+      name: 'revenue',
+    });
+    expect(workspaceTabFromUrl('/workspace/dashboard/sales', params(''))).toEqual({
+      type: 'dashboard',
+      name: 'sales',
+    });
+    expect(workspaceTabFromUrl('/workspace/semantic-layer', params(''))).toEqual({
+      type: 'semantic-layer',
+      name: 'semantic-layer',
+    });
+    expect(workspaceTabFromUrl('/workspace', params(''))).toBeNull();
+  });
+
+  test('parses the same shapes under a host prefix base', () => {
+    const base = '/acme/main/proj/workspace';
+    expect(workspaceTabFromUrl(base, params('?edit=chart:revenue'), base)).toEqual({
+      type: 'chart',
+      name: 'revenue',
+    });
+    expect(workspaceTabFromUrl(`${base}/dashboard/sales`, params(''), base)).toEqual({
+      type: 'dashboard',
+      name: 'sales',
+    });
+    expect(workspaceTabFromUrl(`${base}/semantic-layer`, params(''), base)).toEqual({
+      type: 'semantic-layer',
+      name: 'semantic-layer',
+    });
+    // A bare dashboard path WITHOUT the prefix must not match under a prefixed base.
+    expect(workspaceTabFromUrl('/workspace/dashboard/sales', params(''), base)).toBeNull();
+  });
+
+  test('round-trips object tabs through a prefixed base', () => {
+    const base = '/acme/main/proj/workspace';
+    const tab = { type: 'insight', name: 'weekly:active' };
+    const url = workspaceTabUrl(tab, base);
+    const [pathname, search] = url.split('?');
+    expect(workspaceTabFromUrl(pathname, params(search ? `?${search}` : ''), base)).toEqual(tab);
+  });
+});

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -43,7 +43,7 @@ import { emitWorkspaceEvent } from '../components/views/workspace/telemetry';
 import { generateUniqueName } from '../utils/uniqueName';
 import { COLLECTION_KEY } from '../components/views/workspace/collectionKeys';
 import { unwrapConfig, withConfig } from '../components/views/workspace/unwrapRecordConfig';
-import { workspaceTabUrl } from '../components/views/workspace/workspaceUrl';
+import { workspaceTabUrl, WORKSPACE_BASE } from '../components/views/workspace/workspaceUrl';
 
 /**
  * Two `{ type, name }` selection descriptors identify the same object.
@@ -75,6 +75,14 @@ const createWorkspaceSlice = (set, get) => ({
   // fall back to activating in-store synchronously, so callers keep working.
   workspaceUrlNavigate: null,
   registerWorkspaceUrlNavigate: fn => set({ workspaceUrlNavigate: fn || null }),
+
+  // The mount prefix for the tab URLs above. Studio serves the viewer at the
+  // root (`/workspace`); a host that mounts it under a path prefix (the cloud
+  // app, at `/:account/:stage/:project/workspace`) registers its own base so
+  // tab navigation stays inside the mount instead of escaping to the root. The
+  // Workspace derives this from the URL on mount.
+  workspaceUrlBase: WORKSPACE_BASE,
+  registerWorkspaceUrlBase: base => set({ workspaceUrlBase: base || WORKSPACE_BASE }),
 
   // Dirty-close confirmation (VIS-812 / O-3): the tab id awaiting the user's
   // confirm/cancel in the close dialog, or null when no close is pending.
@@ -166,7 +174,7 @@ const createWorkspaceSlice = (set, get) => ({
       // Route the active selection THROUGH the URL: navigate to the tab's URL
       // and let `useWorkspaceUrlSync` set it active (single clean loop). The id
       // is returned synchronously so callers keep their contract.
-      nav(workspaceTabUrl({ type: tab.type, name: tab.name }));
+      nav(workspaceTabUrl({ type: tab.type, name: tab.name }, get().workspaceUrlBase));
       return id;
     }
     // No router mounted — activate in-store directly (synchronous fallback).
@@ -255,7 +263,7 @@ const createWorkspaceSlice = (set, get) => ({
     // Route the selection through the URL (Back button + single loop); the
     // no-router fallback focuses in-store directly.
     if (state.workspaceUrlNavigate) {
-      state.workspaceUrlNavigate(workspaceTabUrl(tab));
+      state.workspaceUrlNavigate(workspaceTabUrl(tab, state.workspaceUrlBase));
       return;
     }
     state.activateWorkspaceTab(tab);
@@ -303,7 +311,7 @@ const createWorkspaceSlice = (set, get) => ({
     // workspace (active null) — navigating to `/workspace` there would resurrect
     // the project tab, so we skip it.
     if (wasActive && newActive && state.workspaceUrlNavigate) {
-      state.workspaceUrlNavigate(workspaceTabUrl(newActive));
+      state.workspaceUrlNavigate(workspaceTabUrl(newActive, state.workspaceUrlBase));
     }
   },
 

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -17,6 +17,7 @@ const reset = () => {
       workspaceActiveTabId: null,
       workspacePendingCloseTabId: null,
       workspaceUrlNavigate: null,
+      workspaceUrlBase: '/workspace',
       workspaceLeftCollapsed: false,
       workspaceRightCollapsed: false,
       workspaceRightTab: 'edit',
@@ -57,6 +58,27 @@ describe('workspace store slice', () => {
       id = useStore.getState().openWorkspaceTab({ type: 'chart', name: 'revenue' });
     });
     expect(id).toBe('chart:revenue');
+  });
+
+  test('tab navigation carries the registered mount base (host prefix)', () => {
+    const nav = jest.fn();
+    act(() => {
+      // A host that mounts the viewer under a prefix registers its own base.
+      useStore.getState().registerWorkspaceUrlBase('/acme/main/proj/workspace');
+      useStore.getState().registerWorkspaceUrlNavigate(nav);
+      useStore.getState().openWorkspaceTab({ type: 'chart', name: 'revenue' });
+    });
+    expect(nav).toHaveBeenCalledWith('/acme/main/proj/workspace?edit=chart%3Arevenue');
+  });
+
+  test('registerWorkspaceUrlBase falls back to the root base when cleared', () => {
+    const nav = jest.fn();
+    act(() => {
+      useStore.getState().registerWorkspaceUrlBase(null);
+      useStore.getState().registerWorkspaceUrlNavigate(nav);
+      useStore.getState().openWorkspaceTab({ type: 'dashboard', name: 'd1' });
+    });
+    expect(nav).toHaveBeenCalledWith('/workspace/dashboard/d1');
   });
 
   test('activateWorkspaceTab is the URL→store write — it sets active without navigating', () => {


### PR DESCRIPTION
The Workspace drives navigation with a hardcoded root base (`/workspace`) in both directions: `workspaceTabUrl` builds `/workspace?edit=…` and `workspaceTabFromUrl` matches the `/workspace/...` path. That assumes the viewer owns the URL root, which is true for Studio (`visivo serve`) but not for a host that mounts the viewer under a path prefix — the cloud app serves it at `/:account/:stage/:project/workspace`. There, opening/editing an object navigated to the ROOT `/workspace?edit=…`, dropping the prefix, so the route 404'd (clicking a source → "unexpected error").

Make the base a parameter:
- workspaceUrl: `workspaceTabUrl(tab, base)` / `workspaceTabFromUrl(pathname, searchParams, base)`, both defaulting to `/workspace` (Studio unchanged).
- workspaceStore: hold `workspaceUrlBase` (default `/workspace`) + `registerWorkspaceUrlBase`; the tab-nav actions build URLs with it.
- Workspace: derive the mount base from the path (up to and including the `workspace` segment), register it alongside the router navigate, and parse the URL with it. Auto-adapts to either mount with no host wiring.

Tests: new workspaceUrl.test.js (default + prefixed base, round-trip) and store coverage for prefixed navigation. viewer suites green.