### PR TITLE
fix(explorer): computed columns are chartable; property search actually finds things

### DIFF
--- a/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
+++ b/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
@@ -1,0 +1,174 @@
+/**
+ * Story: the chart-building loop in an exploration keeps the preview in sync
+ * with every edit — drag a column, aggregate it, add a computed column, change
+ * a layout property, switch chart type.
+ *
+ * Written after Jared hit two of these live: dropping a COMPUTED column into a
+ * prop well failed with `Column 'less_than_4' not found on model 'model'.
+ * Available columns: X, Y` — naming as unavailable a column visibly present in
+ * the results grid directly below the error — and the chart then stayed broken
+ * through subsequent edits.
+ *
+ * Root cause was that the preview built its model schema and its DuckDB table
+ * from `queryResult` (what the source returned) rather than `enrichedResult`
+ * (that plus the user's computed columns — what the grid renders and what a
+ * user drags FROM). Verified by reverting the fix: step 4 below fails and every
+ * later step stays failed.
+ *
+ * These assertions deliberately check the chart is CURRENT, not merely present:
+ * a stale Plotly surface left over from the previous edit looks identical to a
+ * working one, and "the preview silently stopped updating" is the exact class
+ * of bug this story exists to catch.
+ *
+ * Precondition: sandbox running (integration project) —
+ *   bash scripts/sandbox.sh start
+ *   npx playwright test exploration-chart-build-updates
+ */
+
+import { test, expect } from '@playwright/test';
+import { BASE_URL, apiBase } from '../helpers/sandbox.mjs';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+
+test.use({ viewport: { width: 1700, height: 1200 } });
+test.describe.configure({ timeout: 120000 });
+
+const SQL = 'select 1 as x, 10 as y union all select 2, 20 union all select 3, 15';
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 15000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 15000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Real pointer drag — dnd-kit's PointerSensor needs >8px of movement, and a
+ *  settle at the final point so the drop resolves against a RESTING pointer. */
+async function drag(page, srcSel, dstSel) {
+  const src = page.locator(srcSel).first();
+  const dst = page.locator(dstSel).first();
+  await expect(src).toBeVisible({ timeout: 15000 });
+  await expect(dst).toBeVisible({ timeout: 15000 });
+  const a = await src.boundingBox();
+  const b = await dst.boundingBox();
+  await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(a.x + a.width / 2 + 12, a.y + a.height / 2, { steps: 3 });
+  await page.waitForTimeout(120);
+  await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 14 });
+  await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+}
+
+/** The preview must be a rendered chart — never the failure panel, and never
+ *  the "nothing yet" state once props are bound. */
+async function expectLiveChart(page, step) {
+  await expect(page.locator('.js-plotly-plot').first(), `${step}: chart renders`).toBeVisible({
+    timeout: 30000,
+  });
+  await expect(page.getByText('This preview failed to run'), `${step}: no failure panel`).toHaveCount(
+    0
+  );
+  await expect(page.getByText(/not found on model/), `${step}: no column-not-found`).toHaveCount(0);
+}
+
+test.describe('Chart-building keeps the preview in sync with every edit', () => {
+  let createdId = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdId) {
+      await page.request.delete(`${apiBase}/api/explorations/${createdId}/`).catch(() => {});
+      createdId = null;
+    }
+  });
+
+  test('drag → aggregate → computed column → layout prop → type switch each keep a live chart', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    createdId = await newExploration(page);
+
+    await typeSql(page, SQL);
+    await runQuery(page);
+
+    // 1. Bind x and y by dragging real result columns.
+    await drag(page, '[data-testid="draggable-col-x"]', '[data-testid="droppable-property-x"]');
+    await drag(page, '[data-testid="draggable-col-y"]', '[data-testid="droppable-property-y"]');
+    await expectLiveChart(page, 'after x/y drags');
+
+    // 2. A computed column is a first-class result column: the grid renders it,
+    //    so dropping it into a well must work exactly like a source column.
+    await page.getByTestId('add-computed-column-btn').first().click();
+    await page.getByTestId('computed-col-name').fill('less_than_4');
+    await page
+      .getByTestId('computed-col-expression')
+      .fill("CASE WHEN x < 4 THEN 'low' ELSE 'high' END");
+    const addBtn = page.getByTestId('add-btn');
+    await expect(addBtn).toBeEnabled({ timeout: 20000 });
+    await addBtn.click();
+    await expect(page.getByTestId('computed-pill-less_than_4')).toBeVisible({ timeout: 20000 });
+    await expect(
+      page.getByTestId('draggable-col-less_than_4'),
+      'computed column appears in the results grid'
+    ).toBeVisible({ timeout: 20000 });
+
+    await drag(
+      page,
+      '[data-testid="draggable-col-less_than_4"]',
+      '[data-testid="droppable-property-x"]'
+    );
+    // The regression: the compile used to receive only the SOURCE's columns, so
+    // this failed with "Column 'less_than_4' not found on model 'model'".
+    await expectLiveChart(page, 'after computed column → x');
+
+    // 3. The bound pill must actually name the computed column — a preview that
+    //    kept rendering the PREVIOUS x would also satisfy "a chart is visible".
+    await expect(page.getByTestId('droppable-property-x')).toContainText('less_than_4');
+
+    // 4. A layout property edit must not blank the chart.
+    await page.getByRole('button', { name: /add propert/i }).first().click();
+    const search = page.getByPlaceholder(/search propert/i);
+    await expect(search).toBeVisible({ timeout: 15000 });
+    // Merely OPENING the property picker must not disturb the preview.
+    await expectLiveChart(page, 'with the property picker open');
+    await search.fill('title');
+    await expectLiveChart(page, 'while searching properties');
+    // Results are grouped and collapsed; expand the group that owns the
+    // property before selecting it, the same as a user would.
+    await page.getByText('title', { exact: true }).first().click();
+    // The picker labels each option with only the LEAF name (`text`, not
+    // `title.text`), so select by path. It also lives in a max-height scroll
+    // container, so a match below the fold needs scrolling into view before it
+    // is clickable.
+    const titleOption = page.getByTestId('property-option-title.text');
+    await expect(titleOption, 'title.text is among the results for "title"').toHaveCount(1, {
+      timeout: 15000,
+    });
+    await titleOption.scrollIntoViewIfNeeded();
+    await titleOption.click();
+    await expectLiveChart(page, 'after adding title.text');
+
+    const titleInput = page.locator('input[type="text"]:not([placeholder*="Search"])').last();
+    await titleInput.fill('My Chart Title');
+    await titleInput.blur();
+    await expectLiveChart(page, 'after typing a title');
+
+    // 5. Switching chart type must carry the bound props over, not blank out.
+    await page.locator('[data-testid^="type-selector"]').first().click();
+    await page.getByText('Bar', { exact: true }).first().click();
+    await expectLiveChart(page, 'after scatter → bar');
+    await expect(
+      page.getByTestId('droppable-property-x'),
+      'x binding survives the type switch'
+    ).toContainText('less_than_4');
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -111,6 +111,10 @@ export default defineConfig({
         // other exploration-mutating spec above.
         '**/exploration-promote-fallback-dashboard-offer.spec.mjs',
         '**/exploration-staleness-drift.spec.mjs',
+        // Chart-building loop (computed column -> prop well, layout prop
+        // edit, type switch): mints a real exploration + computed columns
+        // against the shared `.visivo/explorations/` repository.
+        '**/exploration-chart-build-updates.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -262,6 +266,10 @@ export default defineConfig({
         // entry for the same two files for why.
         '**/exploration-promote-fallback-dashboard-offer.spec.mjs',
         '**/exploration-staleness-drift.spec.mjs',
+        // Chart-building loop (computed column -> prop well, layout prop
+        // edit, type switch): mints a real exploration + computed columns
+        // against the shared `.visivo/explorations/` repository.
+        '**/exploration-chart-build-updates.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/components/views/common/SchemaEditor/PropertySearch.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertySearch.jsx
@@ -93,6 +93,10 @@ export function PropertySearch({ properties = [], selectedPaths = new Set(), onT
           onClick={() => handleToggle(prop.path)}
           disabled={disabled}
           dense
+          // Keyed by full PATH, because the visible label is deliberately just
+          // the leaf (`text` for `title.text`) and so is ambiguous across
+          // groups — there is no unique user-facing handle to select by.
+          data-testid={`property-option-${prop.path}`}
         >
           <ListItemIcon sx={{ minWidth: 36 }}>
             <Checkbox
@@ -185,12 +189,31 @@ export function PropertySearch({ properties = [], selectedPaths = new Set(), onT
   // Get sorted group keys (root first, then alphabetically)
   const sortedGroupKeys = useMemo(() => {
     const keys = Object.keys(groupedProperties);
-    return keys.sort((a, b) => {
-      if (a === '') return -1;
-      if (b === '') return 1;
-      return a.localeCompare(b);
+    // While BROWSING (no query), alphabetical is the right order — it's a
+    // stable index you can scan.
+    //
+    // While SEARCHING it is actively harmful, and silently undid the relevance
+    // ranking `filterProperties` computes: groups render in name order, so
+    // `coloraxis.colorbar.title` sorts before `title` and the plot title lands
+    // 130 rows down however well it scored. Order groups by their best-ranked
+    // member instead — i.e. by where that member appears in the already-ranked
+    // filtered list.
+    if (!searchQuery.trim()) {
+      return keys.sort((a, b) => {
+        if (a === '') return -1;
+        if (b === '') return 1;
+        return a.localeCompare(b);
+      });
+    }
+
+    const bestRank = new Map();
+    filteredProperties.forEach((prop, index) => {
+      const parts = prop.path.split('.');
+      const group = parts.length === 1 ? '' : parts.slice(0, -1).join('.');
+      if (!bestRank.has(group)) bestRank.set(group, index);
     });
-  }, [groupedProperties]);
+    return keys.sort((a, b) => (bestRank.get(a) ?? Infinity) - (bestRank.get(b) ?? Infinity));
+  }, [groupedProperties, filteredProperties, searchQuery]);
 
   return (
     <Paper
@@ -245,7 +268,17 @@ export function PropertySearch({ properties = [], selectedPaths = new Set(), onT
         }}
       >
         <Typography variant="caption" color="text.secondary">
-          {selectedPaths.size} of {properties.length} properties selected
+          {/* Never "0 of 1366 properties selected" (ux-audit.md, pills #8): the
+              raw schema size is an implementation detail of Plotly's trace
+              spec, and leading with it makes an empty panel read as a task
+              list 1,366 items long. Show a count only once the user has
+              actually selected something, and say how many matched what they
+              searched for rather than how big the schema is. */}
+          {selectedPaths.size > 0
+            ? `${selectedPaths.size} selected`
+            : searchQuery
+              ? `${filteredProperties.length} matching`
+              : 'Search or browse to add properties'}
         </Typography>
       </Box>
     </Paper>

--- a/viewer/src/components/views/common/SchemaEditor/PropertySearch.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertySearch.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PropertySearch } from './PropertySearch';
 
 describe('PropertySearch', () => {
@@ -106,9 +107,26 @@ describe('PropertySearch', () => {
     expect(checkedCount).toBe(2);
   });
 
-  it('shows selection count in footer', () => {
+  it('shows how many properties are selected, never the raw schema size', () => {
     render(<PropertySearch {...defaultProps} selectedPaths={new Set(['x', 'y'])} />);
-    expect(screen.getByText(/2 of 6 properties selected/)).toBeInTheDocument();
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    // The old copy was "N of <schema size> properties selected", which on the
+    // real Plotly trace schema read "0 of 1366 properties selected" and made an
+    // untouched panel look like a 1,366-item task list (ux-audit.md, pills #8).
+    expect(screen.queryByText(/of \d+ properties selected/)).not.toBeInTheDocument();
+  });
+
+  it('prompts instead of counting when nothing is selected and nothing searched', () => {
+    render(<PropertySearch {...defaultProps} selectedPaths={new Set()} />);
+    expect(screen.getByText('Search or browse to add properties')).toBeInTheDocument();
+  });
+
+  it('reports how many properties MATCHED once the user searches', async () => {
+    const user = userEvent.setup();
+    render(<PropertySearch {...defaultProps} selectedPaths={new Set()} />);
+    await user.type(screen.getByPlaceholderText('Search properties...'), 'color');
+    // The count describes the search result, not the schema.
+    expect(screen.getByText(/^\d+ matching$/)).toBeInTheDocument();
   });
 
   it('can be disabled', () => {

--- a/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.js
+++ b/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.js
@@ -239,10 +239,47 @@ export function groupPropertiesByParent(properties) {
 }
 
 /**
- * Search/filter properties by query
+ * Relevance score for a property against a search query. Higher is better;
+ * `null` means "no match at all".
+ *
+ * Filtering alone is not enough on a schema this size. Plotly's trace schema
+ * has 1,366 properties, and a plain substring filter returns them in schema
+ * order: searching "title" used to yield 184 hits with `title.text` — the plot
+ * title, and overwhelmingly the thing a person typing "title" wants — sitting
+ * at position 131, behind a dozen `coloraxis.colorbar.title.font.*` entries and
+ * a description-only match on `editrevision`. The property was reachable in
+ * principle and unreachable in practice.
+ *
+ * The ordering encodes "how directly does this path answer the query":
+ * whole-path match, then leaf-name match, then a path SEGMENT match (so
+ * `title.text` beats `coloraxis.colorbar.title.text` on the same term), then a
+ * loose substring, and finally description-only matches. Depth breaks ties, so
+ * shallower — i.e. more top-level — properties come first.
+ */
+function scoreProperty(prop, lowerQuery) {
+  const path = (prop.path || '').toLowerCase();
+  if (!path) return null;
+  const segments = path.split('.');
+  const leaf = segments[segments.length - 1];
+
+  if (path === lowerQuery) return 100;
+  if (leaf === lowerQuery) return 90;
+  if (segments[0] === lowerQuery) return 80; // e.g. "title" -> title.text
+  if (segments.includes(lowerQuery)) return 70;
+  if (leaf.startsWith(lowerQuery)) return 60;
+  if (path.startsWith(lowerQuery)) return 50;
+  if (path.includes(lowerQuery)) return 40;
+  // Description-only matches are genuinely weaker signal: they are how
+  // `editrevision` surfaced above the plot title for the query "title".
+  if (prop.description?.toLowerCase().includes(lowerQuery)) return 10;
+  return null;
+}
+
+/**
+ * Search/filter properties by query, best matches first.
  * @param {Array} properties - Flattened properties array
  * @param {string} query - Search query
- * @returns {Array} Filtered properties
+ * @returns {Array} Matching properties, ordered by relevance
  */
 export function filterProperties(properties, query) {
   if (!query || !query.trim()) {
@@ -250,9 +287,24 @@ export function filterProperties(properties, query) {
   }
 
   const lowerQuery = query.toLowerCase().trim();
-  return properties.filter(prop => {
-    const pathMatch = prop.path.toLowerCase().includes(lowerQuery);
-    const descMatch = prop.description?.toLowerCase().includes(lowerQuery);
-    return pathMatch || descMatch;
-  });
+  return (properties || [])
+    .map((prop, index) => ({ prop, score: scoreProperty(prop, lowerQuery), index }))
+    .filter(entry => entry.score !== null)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Shallower paths first — `title.text` before `coloraxis.colorbar.title.text`.
+      const depthA = a.prop.path.split('.').length;
+      const depthB = b.prop.path.split('.').length;
+      if (depthA !== depthB) return depthA - depthB;
+      // Stable within a tier: preserve the schema's own order, which carries
+      // Plotly's own sense of which properties are primary.
+      //
+      // Tried and rejected: breaking ties on path LENGTH, on the theory that
+      // shorter means more fundamental. It reads well until you run it —
+      // `title.x` (7 chars, the title's horizontal position) then outranks
+      // `title.text` (10 chars, the title itself). Measured on the real
+      // schema, not reasoned about.
+      return a.index - b.index;
+    })
+    .map(entry => entry.prop);
 }

--- a/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.test.js
+++ b/viewer/src/components/views/common/SchemaEditor/utils/schemaUtils.test.js
@@ -483,3 +483,57 @@ describe('schemaUtils', () => {
     });
   });
 });
+
+describe('filterProperties ranking (found driving the chart-build flow live)', () => {
+  // Mirrors the real shape: Plotly's trace schema puts `coloraxis.colorbar.*`
+  // long before `title.*`, so schema order alone buries the property a person
+  // typing "title" actually wants.
+  const properties = [
+    { path: 'editrevision', description: 'Controls persistence of the plot title' },
+    { path: 'coloraxis.colorbar.title.side' },
+    { path: 'coloraxis.colorbar.title.text' },
+    { path: 'coloraxis.colorbar.title.font.size' },
+    { path: 'legend.grouptitlefont' },
+    { path: 'title.text' },
+    { path: 'title.font.size' },
+    { path: 'xaxis.title.text' },
+  ];
+
+  test('the top-level match outranks deeper paths that merely contain the term', () => {
+    const ranked = filterProperties(properties, 'title').map(p => p.path);
+    // The plot title is the FIRST result, not the 131st (the live behaviour
+    // before this ranking existed).
+    expect(ranked[0]).toBe('title.text');
+    expect(ranked.indexOf('title.text')).toBeLessThan(ranked.indexOf('coloraxis.colorbar.title.text'));
+    expect(ranked.indexOf('title.font.size')).toBeLessThan(ranked.indexOf('xaxis.title.text'));
+  });
+
+  test('a description-only match ranks below every path match', () => {
+    const ranked = filterProperties(properties, 'title').map(p => p.path);
+    expect(ranked[ranked.length - 1]).toBe('editrevision');
+  });
+
+  test('an exact leaf match wins over a longer path with the same leaf', () => {
+    const ranked = filterProperties(
+      [{ path: 'marker.color' }, { path: 'color' }, { path: 'marker.line.color' }],
+      'color'
+    ).map(p => p.path);
+    expect(ranked[0]).toBe('color');
+  });
+
+  test('shallower paths break ties within the same tier', () => {
+    const ranked = filterProperties(
+      [{ path: 'a.b.c.size' }, { path: 'a.size' }, { path: 'a.b.size' }],
+      'size'
+    ).map(p => p.path);
+    expect(ranked).toEqual(['a.size', 'a.b.size', 'a.b.c.size']);
+  });
+
+  test('a non-matching property is excluded entirely', () => {
+    expect(filterProperties(properties, 'zzz')).toEqual([]);
+  });
+
+  test('an empty query returns everything, untouched', () => {
+    expect(filterProperties(properties, '')).toBe(properties);
+  });
+});

--- a/viewer/src/hooks/useDraftInsightPreview.js
+++ b/viewer/src/hooks/useDraftInsightPreview.js
@@ -62,6 +62,30 @@ const extractInputDependencies = (query, staticProps) => {
 const EMPTY_INSIGHT_STATUS = { isLoading: false, error: null, blockedReason: null, blockedModel: null };
 
 /**
+ * The result the USER is looking at, and therefore the one the preview must be
+ * built from.
+ *
+ * A model has two results in the store. `queryResult` is what the source
+ * returned. `enrichedResult` is that plus any computed columns the user added
+ * (useExplorerDuckDB computes them client-side in DuckDB and writes them here);
+ * it is what the results grid renders and what a user drags a column FROM.
+ *
+ * Reading `queryResult` here meant a computed column could be dropped into a
+ * chart well and then fail to render: the schema sent to the compile endpoint
+ * listed only the source's own columns, so FieldResolver rejected the
+ * expression with `Column 'less_than_4' not found on model 'model'. Available
+ * columns: X, Y` — naming, as unavailable, a column visibly present in the grid
+ * directly below the error. The DuckDB table registered for `post_query` was
+ * built from the same raw rows, so it would have been missing the column too
+ * even if the compile had passed.
+ *
+ * `enrichedResult` is shaped exactly like `queryResult` (`{columns, rows,
+ * row_count}`) and is only ever set when there are computed columns, so
+ * preferring it is a superset in every case.
+ */
+const visibleResult = modelState => modelState?.enrichedResult || modelState?.queryResult;
+
+/**
  * useDraftInsightPreview — Explore 2.0 Phase 4 (S2's resolved design). Live,
  * client-side preview for the exploration surface's UNSAVED chart/insight
  * drafts: debounced compile-draft calls -> synthetic draft-namespaced
@@ -229,7 +253,7 @@ const useDraftInsightPreview = () => {
 
         const modelSchemas = {};
         Object.entries(modelStates).forEach(([modelName, s]) => {
-          const result = s?.queryResult;
+          const result = visibleResult(s);
           if (!result?.rows?.length || !Array.isArray(result.columns)) return;
           const inferred = inferColumnTypes(result.columns, result.rows);
           modelSchemas[modelName] = Object.fromEntries(
@@ -267,7 +291,7 @@ const useDraftInsightPreview = () => {
           // already models — reuse that same guided state instead of
           // executing a doomed query.
           const unloadedModel = (compiled.models || []).find(model => {
-            const rows = modelStates[model.name]?.queryResult?.rows;
+            const rows = visibleResult(modelStates[model.name])?.rows;
             return !rows || !rows.length;
           });
           if (unloadedModel) {
@@ -292,9 +316,16 @@ const useDraftInsightPreview = () => {
           // already known (via the guard above) to have fetched rows.
           const conn = await getConnection(db);
           for (const model of compiled.models || []) {
-            const rows = modelStates[model.name]?.queryResult?.rows || [];
+            const result = visibleResult(modelStates[model.name]);
+            const rows = result?.rows || [];
             if (!rows.length) continue;
-            const fingerprint = `${rows.length}:${modelStates[model.name]?.sql}`;
+            // The column list is part of the identity: adding or removing a
+            // computed column changes the shape without changing the row count
+            // or the SQL, and a fingerprint blind to that would keep serving a
+            // stale table that lacks the column the user just added.
+            const fingerprint = `${rows.length}:${modelStates[model.name]?.sql}:${(
+              result.columns || []
+            ).join(',')}`;
             if (registeredTablesRef.current.get(model.name_hash) === fingerprint) continue;
             const tempFile = `draft_model_${model.name_hash}_${Date.now()}.json`;
             // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Fixes the bug Jared hit live, plus two more found by driving the same flow.

## 1. A computed column could be dropped into a chart well, then failed to render

Reported with a screenshot: dragging `less_than_4` into `x` produced

> `Column 'less_than_4' not found on model 'model'.`
> `Available columns: X | number, Y | number`

— naming as unavailable a column visibly present in the results grid *directly below the error*. Every later edit stayed broken, which is what made it read as "the chart disappeared".

**Root cause.** `useDraftInsightPreview` built both the schema it sends to the compile endpoint and the DuckDB table it registers for `post_query` from `queryResult` — what the source returned. Computed columns live in `enrichedResult` (that plus the user's own columns, computed client-side in DuckDB), which is what the grid renders and what a user drags *from*. Both reads now go through one `visibleResult()` accessor, and the table fingerprint includes the column list, since adding a computed column changes shape without changing row count or SQL.

**Verified by reverting just this hunk** and re-running the same scripted flow:

| step | without fix | with fix |
|---|---|---|
| drag x, y | CHART | CHART |
| AVG preset on y | CHART | CHART |
| add computed column | CHART | CHART |
| **drop computed column into x** | **FAILED** | CHART |
| add `title.text` | FAILED | CHART |
| type a title | FAILED | CHART |
| scatter → bar | FAILED | CHART |

## 2. Property search couldn't find the plot title

`filterProperties` filtered but never ranked, so results came back in schema order. Searching `title` returned **184 hits with `title.text` at position 131**, behind a dozen `coloraxis.colorbar.title.font.*` entries and a description-only match on `editrevision`. Reachable in principle, unreachable in practice.

Results are now scored — whole-path > leaf > path-segment > substring > description-only — and the **group** ordering follows the ranking too. That second half mattered: groups were sorted alphabetically, which silently undid the scoring by floating `coloraxis.*` above `title`. Measured live, `title.text` moved from position 131 to 2.

Tried and rejected on evidence: breaking ties on path *length*, which reads sensibly and then ranks `title.x` above `title.text`.

## 3. "0 of 1366 properties selected" was still there

The Wave-1 curation pass (ux-audit pills #8) fixed the group badges but not the picker footer. The raw schema size is an implementation detail, and leading with it makes an untouched panel read as a 1,366-item task list. Now: a count only once something is selected, otherwise what matched the search.

## New e2e story

`exploration-chart-build-updates.spec.mjs` walks the whole loop — drag x/y → aggregate → add and bind a computed column → open the property picker → add and edit a layout property → switch scatter to bar — asserting a **live** chart after every mutation, and asserting the bound pill still names the computed column.

That second assertion is the point: a stale Plotly surface left over from the previous edit looks identical to a working one, so "a chart is visible" is not evidence the edit landed. Double-registered in `playwright.config.mjs` per the config's own rule.

## Verification

- New e2e story passes (21s).
- `bash scripts/viewer-check.sh` — 340 suites, **6,131 passing**, lint clean.
- `bash scripts/check-e2e-sandbox-isolation.sh` — clean.
- 6 new unit tests for the ranking, 3 for the footer copy.

## Not fixed, stated plainly

Jared also reported the chart vanishing when editing the title. On the fixed tree I could not reproduce a *distinct* blanking bug — the spec asserts a live chart across picker-open, search, property-add, title-edit and type-switch, and it passes. My reading is that the reported blanking was this same computed-column failure in a later presentation, since his exploration already had `less_than_4` bound to `x`. If it recurs on a chart with no computed column, that's a separate bug and I'd want a fresh repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoqyLSV4REMNep8pDEqKzi