### PR TITLE
test(e2e): metric creation in the chart-build loop + de-flake the chart assertion

### DIFF
--- a/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
+++ b/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
@@ -72,9 +72,27 @@ async function drag(page, srcSel, dstSel) {
 /** The preview must be a rendered chart — never the failure panel, and never
  *  the "nothing yet" state once props are bound. */
 async function expectLiveChart(page, step) {
-  await expect(page.locator('.js-plotly-plot').first(), `${step}: chart renders`).toBeVisible({
-    timeout: 30000,
-  });
+  // Assert that a plotly surface IS VISIBLE, not that the first matching node
+  // is. During a re-render the DOM can briefly hold more than one
+  // `.js-plotly-plot` (an outgoing one still detaching), and `.first()` can
+  // land on the hidden one — which fails while the user is looking at a
+  // perfectly good chart. Observed as a 1-in-3 flake before this changed.
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () =>
+            [...document.querySelectorAll('.js-plotly-plot')].filter(el => {
+              const r = el.getBoundingClientRect();
+              return r.width > 0 && r.height > 0 && getComputedStyle(el).visibility !== 'hidden';
+            }).length
+        ),
+      {
+        message: `${step}: at least one plotly surface is visible`,
+        timeout: 30000,
+      }
+    )
+    .toBeGreaterThan(0);
   await expect(page.getByText('This preview failed to run'), `${step}: no failure panel`).toHaveCount(
     0
   );
@@ -83,11 +101,18 @@ async function expectLiveChart(page, step) {
 
 test.describe('Chart-building keeps the preview in sync with every edit', () => {
   let createdId = null;
+  let createdMetric = null;
 
   test.afterEach(async ({ page }) => {
     if (createdId) {
       await page.request.delete(`${apiBase}/api/explorations/${createdId}/`).catch(() => {});
       createdId = null;
+    }
+    if (createdMetric) {
+      await page.request
+        .delete(`${apiBase}/api/metrics/${encodeURIComponent(createdMetric)}/`)
+        .catch(() => {});
+      createdMetric = null;
     }
   });
 
@@ -162,7 +187,40 @@ test.describe('Chart-building keeps the preview in sync with every edit', () => 
     await titleInput.blur();
     await expectLiveChart(page, 'after typing a title');
 
-    // 5. Switching chart type must carry the bound props over, not blank out.
+    // 5. Promoting a bound pill to a metric must not disturb the chart. The
+    //    metric flow has its own spec (save-as-metric.spec.mjs) covering the
+    //    naming, collision and born-bound-to-parent-model contracts; what is
+    //    NOT covered anywhere is whether the CHART survives it — the pill is
+    //    rewritten from an inline aggregate to a metric reference underneath,
+    //    which is exactly the kind of swap that can silently blank a preview.
+    const ySlot = page.getByTestId('droppable-property-y');
+    await ySlot.getByTestId('pill-menu-trigger').click();
+    await expect(page.getByTestId('pill-menu')).toBeVisible({ timeout: 10000 });
+    // Only an AGGREGATE pill can become a metric (PillMenu gates the action and
+    // says so in its tooltip), so apply a preset first — which is itself an
+    // edit the chart has to survive.
+    await page.getByTestId('pill-menu-preset-sum').click();
+    await expectLiveChart(page, 'after applying the SUM preset to y');
+    await expect(ySlot).toContainText('SUM');
+
+    await ySlot.getByTestId('pill-menu-trigger').click();
+    await expect(page.getByTestId('pill-menu')).toBeVisible({ timeout: 10000 });
+    const saveAsMetric = page.getByTestId('pill-menu-save-as-metric');
+    await expect(saveAsMetric).toBeEnabled({ timeout: 10000 });
+    await saveAsMetric.click();
+    await expect(page.getByTestId('save-as-metric-prompt')).toBeVisible({ timeout: 10000 });
+    const metricName = await page.getByTestId('save-as-metric-name-input').inputValue();
+    createdMetric = metricName;
+    await page.getByTestId('save-as-metric-submit').click();
+    await expect(page.getByTestId('save-as-metric-prompt')).not.toBeVisible({ timeout: 20000 });
+
+    // The pill now names the metric rather than the raw aggregate...
+    await expect(ySlot).toContainText(metricName);
+    await expect(ySlot, 'never raw ref syntax (D8)').not.toContainText('?{');
+    // ...and the chart is still live, bound to it.
+    await expectLiveChart(page, 'after saving the y pill as a metric');
+
+    // 6. Switching chart type must carry the bound props over, not blank out.
     await page.locator('[data-testid^="type-selector"]').first().click();
     await page.getByText('Bar', { exact: true }).first().click();
     await expectLiveChart(page, 'after scatter → bar');
@@ -170,5 +228,9 @@ test.describe('Chart-building keeps the preview in sync with every edit', () => 
       page.getByTestId('droppable-property-x'),
       'x binding survives the type switch'
     ).toContainText('less_than_4');
+    await expect(
+      page.getByTestId('droppable-property-y'),
+      'the metric binding survives the type switch too'
+    ).toContainText(createdMetric);
   });
 });


### PR DESCRIPTION
Follow-up to #534, closing the gap Jared named: *"the creating of metrics and dimensions"* in the chart-building flow.

## What was missing

Metric creation already has its own spec (`save-as-metric.spec.mjs`) covering the naming, collision and born-bound-to-parent-model contracts. What nothing covered was whether **the chart survives it** — saving a pill as a metric rewrites it from an inline aggregate to a metric reference underneath, which is precisely the kind of swap that can silently blank a preview.

Added to the loop: apply a SUM preset to `y` (only an aggregate pill can become a metric — `PillMenu` gates it and says so in a tooltip), save it as a metric, then assert the pill names the metric, carries no raw `?{` syntax (D8), the chart is still live, and the metric binding **survives the subsequent scatter→bar switch**.

## A flake I introduced, and the correction

`expectLiveChart` asserted `.js-plotly-plot` **`.first()`** was visible. During a re-render the DOM can briefly hold more than one such node — an outgoing one still detaching — and `.first()` can land on the hidden one, failing while the user is looking at a perfectly good chart.

It failed 1-in-3 on the "with the property picker open" step, and **I initially reported that as Jared's "chart disappears" bug reproducing.** That was wrong. A direct probe measuring the chart's bounding box across four picker-opens found it unchanged at 502×450 and visible every time, which is what pointed at the spec rather than the app.

The assertion now checks that *at least one* plotly surface is visible, which is the actual product claim rather than an accident of DOM ordering. 5/5 clean after the change; it was 2/3 before.

This does not change the standing explanation for the original report: that was the computed-column compile failure fixed in #534, proven by reverting the hunk and watching the failure return.

## Verification

- Extended spec: 5 consecutive clean runs (~24s each).
- `bash scripts/viewer-check.sh` — 340 suites, 6,131 passing, lint clean.
- `bash scripts/check-e2e-sandbox-isolation.sh` — clean.

## Still not covered

**Dimension** creation. The pill menu has a `dimension` preset (`pill-menu-preset-dimension`) that this loop never exercises. Worth adding, and I'd rather name it than let a passing spec imply the matrix is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoqyLSV4REMNep8pDEqKzi