### PR TITLE
Choose when runs happen: automatic or manual, with a staged-changes surface and cancel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ test-resulsts/
 
 # Playwright story QA screenshots (regenerated locally; not snapshot baselines)
 **/__screens__/
-

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ test-resulsts/
 
 # Playwright story QA screenshots (regenerated locally; not snapshot baselines)
 **/__screens__/
+
+# scripts/dev.sh syncs the sibling ../visivo checkout in here so a local runner
+# image runs the visivo you actually have. Only the placeholder is tracked.
+runner/visivo-src/*
+!runner/visivo-src/.keep

--- a/runner/visivo-src/.keep
+++ b/runner/visivo-src/.keep
@@ -1,0 +1,3 @@
+Placeholder so the Dockerfile's COPY has something to copy.
+scripts/dev.sh replaces this directory with the sibling ../visivo checkout
+when building a local runner; every other build leaves it as-is.

--- a/tests/server/test_run_views.py
+++ b/tests/server/test_run_views.py
@@ -6,7 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
-from visivo.server.managers.run_manager import RunManager, RunState
+from visivo.server import user_config
+from visivo.server.managers.run_manager import Run, RunManager, RunState
+from visivo.server.managers.staged_manager import StagedManager
 from visivo.server.jobs import save_run_executor
 from visivo.server.views.run_views import _RESOURCE_ROUTE_RE, RESOURCE_META
 
@@ -18,12 +20,22 @@ def clean_run_state():
     with mgr._lock:
         mgr._runs.clear()
         mgr._order.clear()
+    StagedManager.instance().clear()
     with save_run_executor._pending_lock:
         if save_run_executor._pending_timer is not None:
             save_run_executor._pending_timer.cancel()
         save_run_executor._pending_timer = None
         save_run_executor._pending_names.clear()
     yield
+
+
+@pytest.fixture(autouse=True)
+def automatic_trigger(monkeypatch):
+    """The existing suite was written when every data save ran immediately, so
+    keep that as the baseline. The manual path has its own class below."""
+    monkeypatch.setattr(
+        "visivo.server.views.run_views.get_run_trigger", lambda: user_config.AUTOMATIC
+    )
 
 
 class TestRunManager:
@@ -283,3 +295,201 @@ class TestDataAffectingGate:
             r = integration_client.delete("/api/charts/c/")
             assert r.status_code < 400
             req.assert_not_called()
+
+
+class TestTriggerMode:
+    """Whether a save fires a run is the user's choice; whether it *stages* is
+    not. Both modes record the change — that's what the Run view lists, and what
+    the Run button builds."""
+
+    def _save_insight(self, client, name, props):
+        return client.post(f"/api/insights/{name}/", json={"props": props})
+
+    def _manual(self, monkeypatch):
+        monkeypatch.setattr(
+            "visivo.server.views.run_views.get_run_trigger", lambda: user_config.MANUAL
+        )
+
+    def test_manual_stages_without_running(self, integration_client, monkeypatch):
+        self._manual(monkeypatch)
+        with patch("visivo.server.views.run_views.request_run") as req:
+            r = self._save_insight(
+                integration_client, "w", {"type": "scatter", "x": "?{ ${ref(M).a} }"}
+            )
+        assert r.status_code == 200
+        req.assert_not_called()
+        assert StagedManager.instance().list() == [
+            {"name": "w", "type": "insight", "status": "modified"}
+        ]
+
+    def test_automatic_stages_and_runs(self, integration_client):
+        with patch("visivo.server.views.run_views.request_run") as req:
+            self._save_insight(
+                integration_client, "w", {"type": "scatter", "x": "?{ ${ref(M).a} }"}
+            )
+        req.assert_called_once()
+        assert [i["name"] for i in StagedManager.instance().list()] == ["w"]
+
+    def test_a_presentation_only_edit_stages_nothing_in_either_mode(
+        self, integration_client, monkeypatch
+    ):
+        self._manual(monkeypatch)
+        with patch("visivo.server.views.run_views.request_run"):
+            self._save_insight(
+                integration_client,
+                "w",
+                {"type": "bar", "x": "?{ ${ref(M).a} }", "marker": {"color": "red"}},
+            )
+            StagedManager.instance().mark_built(None)  # pretend a run built it
+            self._save_insight(
+                integration_client,
+                "w",
+                {"type": "scatter", "x": "?{ ${ref(M).a} }", "marker": {"color": "blue"}},
+            )
+        assert StagedManager.instance().list() == []
+
+    def test_a_deleted_resource_stages_as_deleted(self, integration_client, monkeypatch):
+        self._manual(monkeypatch)
+        with patch("visivo.server.views.run_views.request_run"):
+            self._save_insight(
+                integration_client, "w", {"type": "scatter", "x": "?{ ${ref(M).a} }"}
+            )
+            integration_client.delete("/api/insights/w/")
+        assert StagedManager.instance().list() == [
+            {"name": "w", "type": "insight", "status": "deleted"}
+        ]
+
+
+class TestStagedSet:
+    """The staged registry is local serve's stand-in for the cloud's data_hash /
+    last_built_data_hash columns, and has to behave the same way."""
+
+    def test_a_successful_run_unstages_what_it_built(self):
+        staged = StagedManager.instance()
+        staged.record("source", "db", "hash-1")
+        staged.record("model", "orders", "hash-2")
+        staged.mark_built({"db"})
+        assert [i["name"] for i in staged.list()] == ["orders"]
+
+    def test_a_full_rebuild_unstages_everything(self):
+        staged = StagedManager.instance()
+        staged.record("source", "db", "hash-1")
+        staged.record("model", "orders", "hash-2")
+        staged.mark_built(None)
+        assert staged.list() == []
+
+    def test_reverting_an_edit_unstages_it(self):
+        """The behavior the cloud gets free from comparing hashes: change a model
+        and change it back, and there is nothing left to run. Without it the tab
+        dot would stay lit forever."""
+        staged = StagedManager.instance()
+        staged.record("source", "db", "original")
+        staged.mark_built(None)
+        staged.record("source", "db", "edited")
+        assert [i["name"] for i in staged.list()] == ["db"]
+        staged.record("source", "db", "original")
+        assert staged.list() == []
+
+    def test_a_failed_run_leaves_the_change_staged(self):
+        """mark_built is only called on success, so nothing here un-stages."""
+        staged = StagedManager.instance()
+        staged.record("source", "db", "hash-1")
+        assert [i["name"] for i in staged.list()] == ["db"]
+
+    def test_dag_filter_names_exactly_the_staged_items(self):
+        staged = StagedManager.instance()
+        staged.record("source", "db", "h1")
+        staged.record("model", "orders", "h2")
+        assert set(staged.dag_filter().split(",")) == {"+db+", "+orders+"}
+
+    def test_a_deletion_forces_a_full_rebuild(self):
+        staged = StagedManager.instance()
+        staged.record("source", "db", "h1", status="deleted")
+        assert staged.dag_filter() == ""
+
+    def test_nothing_staged_means_run_everything(self):
+        assert StagedManager.instance().dag_filter() == ""
+
+    def test_a_built_deletion_drops_out_entirely(self):
+        staged = StagedManager.instance()
+        staged.record("source", "db", "h1", status="deleted")
+        staged.mark_built(None)
+        assert staged.list() == []
+
+
+class TestTriggerRunEndpoint:
+    def _unregistered_run(self, dag_filter):
+        """A Run the manager doesn't know about — creating one through the
+        manager would register it as queued, and the endpoint would then refuse
+        its own stubbed run as already in flight."""
+        return Run("stub-run", dag_filter)
+
+    def test_builds_the_staged_set_by_default(self, integration_client):
+        StagedManager.instance().record("source", "db", "h1")
+        with patch("visivo.server.views.run_views.run_now") as run_now:
+            run_now.return_value = self._unregistered_run("+db+")
+            r = integration_client.post("/api/projects/p/run/", json={})
+        assert r.status_code == 201
+        assert run_now.call_args[0][1] == "+db+"
+
+    def test_an_explicit_empty_filter_rebuilds_everything(self, integration_client):
+        StagedManager.instance().record("source", "db", "h1")
+        with patch("visivo.server.views.run_views.run_now") as run_now:
+            run_now.return_value = self._unregistered_run("")
+            r = integration_client.post("/api/projects/p/run/", json={"dag_filter": ""})
+        assert r.status_code == 201
+        assert run_now.call_args[0][1] == ""
+
+    def test_refuses_while_a_run_is_in_flight(self, integration_client):
+        RunManager.instance().create("+db+")  # created queued
+        with patch("visivo.server.views.run_views.run_now") as run_now:
+            r = integration_client.post("/api/projects/p/run/", json={})
+        assert r.status_code == 409
+        assert r.get_json()["action"] == "run_in_progress"
+        run_now.assert_not_called()
+
+    def test_returns_the_run_in_the_cloud_shape(self, integration_client):
+        with patch("visivo.server.views.run_views.run_now") as run_now:
+            run_now.return_value = self._unregistered_run("+db+")
+            body = integration_client.post("/api/projects/p/run/", json={}).get_json()
+        assert body["state"] == "queued"
+        assert body["dag_filter"] == "+db+"
+        assert "created_at" in body
+
+
+class TestPreferencesEndpoint:
+    @pytest.fixture(autouse=True)
+    def config_in_tmp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            user_config, "user_config_path", lambda: tmp_path / ".visivo" / "config.yml"
+        )
+
+    def test_get_reports_the_local_default(self, integration_client):
+        r = integration_client.get("/api/me/preferences/")
+        assert r.status_code == 200
+        assert r.get_json() == {"run_trigger": "automatic"}
+
+    def test_put_round_trips(self, integration_client):
+        r = integration_client.put("/api/me/preferences/", json={"run_trigger": "manual"})
+        assert r.status_code == 200
+        assert r.get_json()["run_trigger"] == "manual"
+        assert integration_client.get("/api/me/preferences/").get_json() == {
+            "run_trigger": "manual"
+        }
+
+    def test_an_unknown_value_is_rejected(self, integration_client):
+        r = integration_client.put("/api/me/preferences/", json={"run_trigger": "sometimes"})
+        assert r.status_code == 400
+        assert user_config.get_run_trigger() == "automatic"
+
+
+class TestChangesCarriesStaged:
+    def test_staged_keys_are_additive(self, integration_client):
+        StagedManager.instance().record("source", "db", "h1")
+        body = integration_client.get("/api/projects/p/changes/").get_json()
+        # The keys an older viewer reads are untouched…
+        assert "to_publish" in body and "to_remove" in body and "has_changes" in body
+        # …and the new ones sit alongside them.
+        assert body["staged"] == [{"name": "db", "type": "source", "status": "modified"}]
+        assert body["staged_dag_filter"] == "+db+"
+        assert body["run_trigger"] in ("automatic", "manual")

--- a/tests/server/test_user_config.py
+++ b/tests/server/test_user_config.py
@@ -1,0 +1,87 @@
+"""~/.visivo/config.yml — the per-user preference file.
+
+Nothing wrote this file before; users hand-edited it. So the writer has to be a
+good citizen of a file it doesn't own: keep their comments, keep their key order,
+and never drop a key it doesn't recognise. And every read has to survive a file
+that isn't there, or that someone left half-edited — a preference lookup must
+not be the thing that stops `visivo serve` from starting.
+"""
+
+import pytest
+
+from visivo.server import user_config
+
+
+@pytest.fixture(autouse=True)
+def config_in_tmp(tmp_path, monkeypatch):
+    """Never touch the developer's real ~/.visivo/config.yml."""
+    path = tmp_path / ".visivo" / "config.yml"
+    monkeypatch.setattr(user_config, "user_config_path", lambda: path)
+    return path
+
+
+class TestReading:
+    def test_missing_file_reads_as_empty(self, config_in_tmp):
+        assert not config_in_tmp.exists()
+        assert user_config.read_user_config() == {}
+
+    def test_missing_file_gives_the_default_trigger(self):
+        assert user_config.get_run_trigger() == user_config.AUTOMATIC
+
+    def test_local_defaults_to_automatic(self):
+        """A local run is a sub-second in-process rebuild, so rebuilding as you
+        type is the behavior that fits. Cloud defaults the other way."""
+        assert user_config.DEFAULT_RUN_TRIGGER == user_config.AUTOMATIC
+
+    def test_corrupt_yaml_falls_back_instead_of_raising(self, config_in_tmp):
+        config_in_tmp.parent.mkdir(parents=True)
+        config_in_tmp.write_text("run_trigger: [unclosed\n")
+        assert user_config.read_user_config() == {}
+        assert user_config.get_run_trigger() == user_config.AUTOMATIC
+
+    def test_an_unrecognised_value_falls_back(self, config_in_tmp):
+        config_in_tmp.parent.mkdir(parents=True)
+        config_in_tmp.write_text("run_trigger: sometimes\n")
+        assert user_config.get_run_trigger() == user_config.AUTOMATIC
+
+
+class TestWriting:
+    def test_round_trips(self):
+        assert user_config.set_run_trigger(user_config.MANUAL) is True
+        assert user_config.get_run_trigger() == user_config.MANUAL
+
+    def test_creates_the_directory(self, config_in_tmp):
+        user_config.set_run_trigger(user_config.MANUAL)
+        assert config_in_tmp.exists()
+
+    def test_refuses_an_unknown_value(self):
+        assert user_config.set_run_trigger("sometimes") is False
+        assert user_config.get_run_trigger() == user_config.AUTOMATIC
+
+    def test_preserves_comments_and_unknown_keys(self, config_in_tmp):
+        """This is a file people edit by hand — writing a preference must not
+        quietly delete the rest of it."""
+        config_in_tmp.parent.mkdir(parents=True)
+        config_in_tmp.write_text(
+            "# my visivo settings\n" "telemetry_enabled: false\n" "some_future_key: 42\n"
+        )
+        user_config.set_run_trigger(user_config.MANUAL)
+
+        written = config_in_tmp.read_text()
+        assert "# my visivo settings" in written
+        assert "run_trigger: manual" in written
+        config = user_config.read_user_config()
+        assert config["telemetry_enabled"] is False
+        assert config["some_future_key"] == 42
+
+    def test_telemetry_reads_the_same_file(self, config_in_tmp):
+        """One parser for the file, so the two settings can't disagree about
+        where it lives or how a broken one is handled."""
+        from visivo.telemetry.config import _check_global_config_disabled
+
+        config_in_tmp.parent.mkdir(parents=True)
+        config_in_tmp.write_text("telemetry_enabled: false\n")
+        assert _check_global_config_disabled() is True
+
+        user_config.set_run_trigger(user_config.MANUAL)
+        assert _check_global_config_disabled() is True  # still off after our write

--- a/tests/server/views/test_commit_views_coverage.py
+++ b/tests/server/views/test_commit_views_coverage.py
@@ -26,6 +26,7 @@ from tests.factories.model_factories import (
 )
 from visivo.models.markdown import Markdown
 from visivo.server.managers.object_manager import ObjectStatus
+from visivo.server.managers.staged_manager import StagedManager
 from visivo.server.views.commit_views import register_commit_views
 
 # (manager attribute, pending/changes "type" string, factory for a real object)
@@ -53,6 +54,10 @@ def env():
     flask_app.project.project_file_path = "/tmp/project.yaml"
     flask_app.hot_reload_server = None
     flask_app._cached_defaults = None
+    # A real one, not a Mock: /changes/ serializes its output, and a Mock's
+    # return value isn't JSON-serializable.
+    flask_app.staged_manager = StagedManager()
+    flask_app.staged_manager.clear()
 
     for attr, _, _ in MANAGER_SPECS:
         manager = Mock()
@@ -109,7 +114,19 @@ class TestChangesEndpoint:
 
     def test_no_changes_reports_empty(self, client):
         data = client.get("/api/projects/proj1/changes/").get_json()
-        assert data == {"to_publish": [], "to_remove": [], "has_changes": False}
+        assert data["to_publish"] == []
+        assert data["to_remove"] == []
+        assert data["has_changes"] is False
+
+    def test_the_run_view_keys_ride_along(self, client):
+        """What a RUN would build, beside what a COMMIT would publish. Added as
+        extra keys rather than a new shape, so a viewer older than the server
+        keeps working — cloud vendors the SPA at a lagging release tag, and local
+        installs upgrade whenever the user does."""
+        data = client.get("/api/projects/proj1/changes/").get_json()
+        assert data["staged"] == []
+        assert data["staged_dag_filter"] == ""
+        assert data["run_trigger"] in ("automatic", "manual")
 
 
 class TestProjectScopedContract:

--- a/viewer/src/api/branching.js
+++ b/viewer/src/api/branching.js
@@ -116,6 +116,26 @@ export const fetchRunLog = async runId => {
 };
 
 /**
+ * Stop a run in flight. POST /api/runs/<id>/cancel/.
+ *
+ * Returns the raw {status, body} rather than throwing, because 409 isn't an
+ * error the user needs shouting about — it just means the run reached a terminal
+ * state before their click landed, and a refetch will show that.
+ *   200 {state, execution_stopped}  — canceled
+ *   409 {detail}                    — already finished
+ */
+export const cancelRun = async runId => {
+  const response = await apiFetch(getUrl('runCancel', { runId }), { method: 'POST' });
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+};
+
+/**
  * Commit (publish) a draft. POST /api/projects/<id>/commit/ {message}.
  *
  * Returns the raw {status, body} so the caller can branch on the gates the

--- a/viewer/src/api/branching.js
+++ b/viewer/src/api/branching.js
@@ -103,6 +103,70 @@ export const fetchRuns = async projectId => {
 };
 
 /**
+ * Launch a run. POST /api/projects/<id>/run/.
+ *
+ * Send NO dag_filter to build what's staged — the button's normal action, scoped
+ * to exactly the list the Run view is showing. Send an explicit `dag_filter: ''`
+ * to rebuild everything ("Run all"), which is the only way back when outputs are
+ * missing but the fingerprints claim they're built. Absent and empty are
+ * genuinely different requests; don't collapse them.
+ *
+ * Returns the raw {status, body} like cancelRun/commitDraft, because 409
+ * ("a run is already in flight") is a state to render, not an exception.
+ */
+export const triggerRun = async (projectId, { dagFilter } = {}) => {
+  const response = await apiFetch(getUrl('projectRun', { projectId }), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dagFilter === undefined ? {} : { dag_filter: dagFilter }),
+  });
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+};
+
+/**
+ * The requesting user's own preferences. GET /api/me/preferences/ ->
+ * {run_trigger}. Returns null where there's no such endpoint (dist), so the
+ * caller can simply not render the control.
+ */
+export const fetchPreferences = async () => {
+  try {
+    const response = await apiFetch(getUrl('mePreferences'));
+    if (response.status === 200) {
+      return await response.json();
+    }
+  } catch {
+    // No URL configured for this environment — same as "not available".
+  }
+  return null;
+};
+
+/**
+ * PUT /api/me/preferences/ -> the saved {run_trigger}. Returns null on failure;
+ * the caller reverts its optimistic update.
+ */
+export const savePreferences = async preferences => {
+  try {
+    const response = await apiFetch(getUrl('mePreferences'), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(preferences),
+    });
+    if (response.status === 200) {
+      return await response.json();
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+};
+
+/**
  * A single run's captured log. GET /api/runs/<id>/logs/ -> {state, logs,
  * error_json}. The runner streams the log live while the run executes (the
  * editor tail-polls this), then it settles into the final static log.

--- a/viewer/src/api/branching.js
+++ b/viewer/src/api/branching.js
@@ -2,13 +2,17 @@ import { getUrl } from '../contexts/URLContext';
 import { apiFetch } from './utils';
 
 /**
- * Branching API (core/Django only) — draft / branch / commit / run endpoints.
+ * Branching API — the shape of the project you are editing: capabilities,
+ * draft, branch, discard, the pending-changes set, and commit.
  *
- * These endpoints exist only in the cloud (core) backend, not in local
- * `visivo serve` (Flask). `fetchCapabilities` is the mode probe: a 200 means
- * the Edit/Branch/commit flow applies; a 404 means local serve, where the
- * legacy always-editable Flask commit flow stays in charge (see api/commit.js
- * + commitStore).
+ * Runs live in api/runs.js and user preferences in api/preferences.js. They were
+ * here once only because the cloud endpoints landed together; a run is the
+ * execution of a project, not an operation on its branching state.
+ *
+ * `fetchCapabilities` is the mode probe. Note it is no longer a cloud-only
+ * signal: local `visivo serve` implements it too (returning can_branch: false,
+ * draft_id: null), so a NULL return means "no such endpoint at all" — dist —
+ * rather than "local serve". Branch on the values, not on null.
  */
 
 /**
@@ -88,115 +92,6 @@ export const fetchChanges = async projectId => {
     return await response.json();
   }
   throw new Error('Failed to fetch changes');
-};
-
-/**
- * The draft's recent runs (status of each auto-run). GET /api/projects/<id>/run/
- * -> [{id, state, created_at, dag_filter, error_json, is_superseded, ...}].
- */
-export const fetchRuns = async projectId => {
-  const response = await apiFetch(getUrl('projectRun', { projectId }));
-  if (response.status === 200) {
-    return await response.json();
-  }
-  throw new Error('Failed to fetch runs');
-};
-
-/**
- * Launch a run. POST /api/projects/<id>/run/.
- *
- * Send NO dag_filter to build what's staged — the button's normal action, scoped
- * to exactly the list the Run view is showing. Send an explicit `dag_filter: ''`
- * to rebuild everything ("Run all"), which is the only way back when outputs are
- * missing but the fingerprints claim they're built. Absent and empty are
- * genuinely different requests; don't collapse them.
- *
- * Returns the raw {status, body} like cancelRun/commitDraft, because 409
- * ("a run is already in flight") is a state to render, not an exception.
- */
-export const triggerRun = async (projectId, { dagFilter } = {}) => {
-  const response = await apiFetch(getUrl('projectRun', { projectId }), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(dagFilter === undefined ? {} : { dag_filter: dagFilter }),
-  });
-  let body = null;
-  try {
-    body = await response.json();
-  } catch {
-    body = null;
-  }
-  return { status: response.status, body };
-};
-
-/**
- * The requesting user's own preferences. GET /api/me/preferences/ ->
- * {run_trigger}. Returns null where there's no such endpoint (dist), so the
- * caller can simply not render the control.
- */
-export const fetchPreferences = async () => {
-  try {
-    const response = await apiFetch(getUrl('mePreferences'));
-    if (response.status === 200) {
-      return await response.json();
-    }
-  } catch {
-    // No URL configured for this environment — same as "not available".
-  }
-  return null;
-};
-
-/**
- * PUT /api/me/preferences/ -> the saved {run_trigger}. Returns null on failure;
- * the caller reverts its optimistic update.
- */
-export const savePreferences = async preferences => {
-  try {
-    const response = await apiFetch(getUrl('mePreferences'), {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(preferences),
-    });
-    if (response.status === 200) {
-      return await response.json();
-    }
-  } catch {
-    // fall through
-  }
-  return null;
-};
-
-/**
- * A single run's captured log. GET /api/runs/<id>/logs/ -> {state, logs,
- * error_json}. The runner streams the log live while the run executes (the
- * editor tail-polls this), then it settles into the final static log.
- */
-export const fetchRunLog = async runId => {
-  const response = await apiFetch(getUrl('runLogs', { runId }));
-  if (response.status === 200) {
-    return await response.json();
-  }
-  throw new Error('Failed to fetch run log');
-};
-
-/**
- * Stop a run in flight. POST /api/runs/<id>/cancel/.
- *
- * Returns the raw {status, body} rather than throwing, because 409 isn't an
- * error the user needs shouting about — it just means the run reached a terminal
- * state before their click landed, and a refetch will show that.
- *   200 {state, execution_stopped}  — canceled
- *   409 {detail}                    — already finished
- */
-export const cancelRun = async runId => {
-  const response = await apiFetch(getUrl('runCancel', { runId }), { method: 'POST' });
-  let body = null;
-  try {
-    body = await response.json();
-  } catch {
-    body = null;
-  }
-  return { status: response.status, body };
 };
 
 /**

--- a/viewer/src/api/branching.test.js
+++ b/viewer/src/api/branching.test.js
@@ -1,5 +1,6 @@
 // Coverage for the branching API (api/branching.js): the cloud-editing
-// draft / branch / discard / changes / runs / run-log / commit endpoints.
+// draft / branch / discard / changes / commit endpoints. Run and preference
+// calls live in api/runs.js and api/preferences.js with their own suites.
 // apiFetch + getUrl are mocked; getUrl echoes the key + id so we can assert the
 // endpoint hit and (for writes) the method/body. Each function's success,
 // error, and edge (non-JSON body) paths are exercised.
@@ -9,8 +10,6 @@ import {
   createBranch,
   discardDraft,
   fetchChanges,
-  fetchRuns,
-  fetchRunLog,
   commitDraft,
 } from './branching';
 import { apiFetch } from './utils';
@@ -133,21 +132,6 @@ describe('read endpoints', () => {
     await expect(fetchChanges('p1')).rejects.toThrow('Failed to fetch changes');
   });
 
-  it('fetchRuns returns json on 200, throws otherwise', async () => {
-    apiFetch.mockResolvedValueOnce(res(200, [{ id: 'r1' }]));
-    await expect(fetchRuns('p1')).resolves.toEqual([{ id: 'r1' }]);
-    expect(apiFetch).toHaveBeenCalledWith('/api/projectRun/p1');
-    apiFetch.mockResolvedValueOnce(res(503));
-    await expect(fetchRuns('p1')).rejects.toThrow('Failed to fetch runs');
-  });
-
-  it('fetchRunLog hits the run-scoped endpoint, returns json on 200, throws otherwise', async () => {
-    apiFetch.mockResolvedValueOnce(res(200, { state: 'running', logs: 'x' }));
-    await expect(fetchRunLog('run-9')).resolves.toEqual({ state: 'running', logs: 'x' });
-    expect(apiFetch).toHaveBeenCalledWith('/api/runLogs/run-9');
-    apiFetch.mockResolvedValueOnce(res(404));
-    await expect(fetchRunLog('run-9')).rejects.toThrow('Failed to fetch run log');
-  });
 });
 
 describe('commitDraft', () => {

--- a/viewer/src/api/preferences.js
+++ b/viewer/src/api/preferences.js
@@ -1,0 +1,48 @@
+import { getUrl } from '../contexts/URLContext';
+import { apiFetch } from './utils';
+
+/**
+ * The requesting user's own preferences.
+ *
+ * Also split out of branching.js — a preference belongs to the person, not to
+ * the project being branched. Each server keeps them in its own place (the User
+ * row in cloud, ~/.visivo/config.yml locally) behind the same endpoint, which is
+ * how the viewer avoids caring which one it is talking to.
+ */
+
+/**
+ * The requesting user's own preferences. GET /api/me/preferences/ ->
+ * {run_trigger}. Returns null where there's no such endpoint (dist), so the
+ * caller can simply not render the control.
+ */
+export const fetchPreferences = async () => {
+  try {
+    const response = await apiFetch(getUrl('mePreferences'));
+    if (response.status === 200) {
+      return await response.json();
+    }
+  } catch {
+    // No URL configured for this environment — same as "not available".
+  }
+  return null;
+};
+
+/**
+ * PUT /api/me/preferences/ -> the saved {run_trigger}. Returns null on failure;
+ * the caller reverts its optimistic update.
+ */
+export const savePreferences = async preferences => {
+  try {
+    const response = await apiFetch(getUrl('mePreferences'), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(preferences),
+    });
+    if (response.status === 200) {
+      return await response.json();
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+};

--- a/viewer/src/api/preferences.test.js
+++ b/viewer/src/api/preferences.test.js
@@ -1,0 +1,61 @@
+// Coverage for api/preferences.js. These had none before the split out of
+// branching.js, and their whole contract is "never throw": the caller renders a
+// control that must simply not appear where the endpoint is unavailable (dist),
+// so an exception escaping here would take a page down over a missing toggle.
+import { fetchPreferences, savePreferences } from './preferences';
+import { apiFetch } from './utils';
+
+jest.mock('./utils', () => ({ apiFetch: jest.fn() }));
+jest.mock('../contexts/URLContext', () => ({
+  getUrl: key => {
+    // Mirrors the real getUrl: an unavailable key throws rather than returning
+    // a broken URL. In `dist` mePreferences is null, so this is the live path.
+    if (key === 'unavailable') throw new Error("URL key 'mePreferences' is not available");
+    return `/api/${key}/`;
+  },
+}));
+
+const res = (status, body = {}) => ({ status, json: async () => body });
+
+beforeEach(() => apiFetch.mockReset());
+
+describe('fetchPreferences', () => {
+  it('returns the preferences on 200', async () => {
+    apiFetch.mockResolvedValueOnce(res(200, { run_trigger: 'manual' }));
+    await expect(fetchPreferences()).resolves.toEqual({ run_trigger: 'manual' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/mePreferences/');
+  });
+
+  it('returns null on a non-200 instead of throwing', async () => {
+    apiFetch.mockResolvedValueOnce(res(404));
+    await expect(fetchPreferences()).resolves.toBeNull();
+  });
+
+  it('returns null when the request itself fails', async () => {
+    apiFetch.mockRejectedValueOnce(new Error('offline'));
+    await expect(fetchPreferences()).resolves.toBeNull();
+  });
+});
+
+describe('savePreferences', () => {
+  it('PUTs the preferences and returns what the server stored', async () => {
+    apiFetch.mockResolvedValueOnce(res(200, { run_trigger: 'automatic' }));
+    await expect(savePreferences({ run_trigger: 'automatic' })).resolves.toEqual({
+      run_trigger: 'automatic',
+    });
+    const [url, options] = apiFetch.mock.calls[0];
+    expect(url).toBe('/api/mePreferences/');
+    expect(options.method).toBe('PUT');
+    expect(JSON.parse(options.body)).toEqual({ run_trigger: 'automatic' });
+  });
+
+  it('returns null on rejection so the caller can revert its optimistic update', async () => {
+    apiFetch.mockResolvedValueOnce(res(400, { run_trigger: ['invalid'] }));
+    await expect(savePreferences({ run_trigger: 'sometimes' })).resolves.toBeNull();
+  });
+
+  it('returns null when the request itself fails', async () => {
+    apiFetch.mockRejectedValueOnce(new Error('offline'));
+    await expect(savePreferences({ run_trigger: 'manual' })).resolves.toBeNull();
+  });
+});

--- a/viewer/src/api/runs.js
+++ b/viewer/src/api/runs.js
@@ -1,0 +1,88 @@
+import { getUrl } from '../contexts/URLContext';
+import { apiFetch } from './utils';
+
+/**
+ * Run API — launching a run, watching it, and reading what it produced.
+ *
+ * Split out of branching.js: a run is not a branching operation. Branching is
+ * draft / branch / changes / commit — the shape of the project you are editing.
+ * A run is the execution of that project, with its own lifecycle (queued →
+ * running → succeeded/failed/canceled) and its own consumers (runStore, the
+ * Runs view). They only ever met because the cloud endpoints arrived together.
+ *
+ * Both servers implement these: Django in cloud, Flask under `visivo serve`.
+ * There is no local-vs-cloud branching here — behaviour follows what the
+ * endpoints return.
+ */
+
+/**
+ * The draft's recent runs (status of each auto-run). GET /api/projects/<id>/run/
+ * -> [{id, state, created_at, dag_filter, error_json, is_superseded, ...}].
+ */
+export const fetchRuns = async projectId => {
+  const response = await apiFetch(getUrl('projectRun', { projectId }));
+  if (response.status === 200) {
+    return await response.json();
+  }
+  throw new Error('Failed to fetch runs');
+};
+
+/**
+ * Launch a run. POST /api/projects/<id>/run/.
+ *
+ * Send NO dag_filter to build what's staged — the button's normal action, scoped
+ * to exactly the list the Run view is showing. Send an explicit `dag_filter: ''`
+ * to rebuild everything ("Run all"), which is the only way back when outputs are
+ * missing but the fingerprints claim they're built. Absent and empty are
+ * genuinely different requests; don't collapse them.
+ *
+ * Returns the raw {status, body} like cancelRun/commitDraft, because 409
+ * ("a run is already in flight") is a state to render, not an exception.
+ */
+export const triggerRun = async (projectId, { dagFilter } = {}) => {
+  const response = await apiFetch(getUrl('projectRun', { projectId }), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dagFilter === undefined ? {} : { dag_filter: dagFilter }),
+  });
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+};
+
+/**
+ * A single run's captured log. GET /api/runs/<id>/logs/ -> {state, logs,
+ * error_json}. The runner streams the log live while the run executes (the
+ * editor tail-polls this), then it settles into the final static log.
+ */
+export const fetchRunLog = async runId => {
+  const response = await apiFetch(getUrl('runLogs', { runId }));
+  if (response.status === 200) {
+    return await response.json();
+  }
+  throw new Error('Failed to fetch run log');
+};
+
+/**
+ * Stop a run in flight. POST /api/runs/<id>/cancel/.
+ *
+ * Returns the raw {status, body} rather than throwing, because 409 isn't an
+ * error the user needs shouting about — it just means the run reached a terminal
+ * state before their click landed, and a refetch will show that.
+ *   200 {state, execution_stopped}  — canceled
+ *   409 {detail}                    — already finished
+ */
+export const cancelRun = async runId => {
+  const response = await apiFetch(getUrl('runCancel', { runId }), { method: 'POST' });
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+};

--- a/viewer/src/api/runs.test.js
+++ b/viewer/src/api/runs.test.js
@@ -1,0 +1,110 @@
+// Coverage for the run API (api/runs.js). apiFetch + getUrl are mocked; getUrl
+// echoes the key + id so the endpoint hit — and, for writes, the method and body
+// — can be asserted. fetchRuns/fetchRunLog moved here from branching.test.js
+// with the code; triggerRun and cancelRun are covered here for the first time.
+import { fetchRuns, triggerRun, fetchRunLog, cancelRun } from './runs';
+import { apiFetch } from './utils';
+
+jest.mock('./utils', () => ({ apiFetch: jest.fn() }));
+jest.mock('../contexts/URLContext', () => ({
+  getUrl: (key, params = {}) => `/api/${key}/${params.projectId ?? params.runId ?? ''}`,
+}));
+
+const REJECT = Symbol('reject');
+const res = (status, body = {}) => ({
+  status,
+  json: async () => {
+    if (body === REJECT) throw new SyntaxError('Unexpected end of JSON input');
+    return body;
+  },
+});
+
+beforeEach(() => apiFetch.mockReset());
+
+describe('fetchRuns', () => {
+  it('returns json on 200, throws otherwise', async () => {
+    apiFetch.mockResolvedValueOnce(res(200, [{ id: 'r1' }]));
+    await expect(fetchRuns('p1')).resolves.toEqual([{ id: 'r1' }]);
+    expect(apiFetch).toHaveBeenCalledWith('/api/projectRun/p1');
+
+    apiFetch.mockResolvedValueOnce(res(503));
+    await expect(fetchRuns('p1')).rejects.toThrow('Failed to fetch runs');
+  });
+});
+
+describe('fetchRunLog', () => {
+  it('hits the run-scoped endpoint, returns json on 200, throws otherwise', async () => {
+    apiFetch.mockResolvedValueOnce(res(200, { state: 'running', logs: 'x' }));
+    await expect(fetchRunLog('run-9')).resolves.toEqual({ state: 'running', logs: 'x' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/runLogs/run-9');
+
+    apiFetch.mockResolvedValueOnce(res(404));
+    await expect(fetchRunLog('run-9')).rejects.toThrow('Failed to fetch run log');
+  });
+});
+
+describe('triggerRun', () => {
+  const bodyOf = () => JSON.parse(apiFetch.mock.calls[0][1].body);
+
+  it('POSTs with NO dag_filter key by default — "build what is staged"', async () => {
+    // Absent and empty are different requests to the server: absent scopes the
+    // run to the staged set, empty means rebuild everything. Collapsing them
+    // would silently turn every button press into a full rebuild.
+    apiFetch.mockResolvedValueOnce(res(201, { id: 'r1' }));
+    await triggerRun('p1');
+    expect(apiFetch).toHaveBeenCalledWith('/api/projectRun/p1', expect.objectContaining({ method: 'POST' }));
+    expect(bodyOf()).toEqual({});
+  });
+
+  it('sends an explicit empty dag_filter when asked to run everything', async () => {
+    apiFetch.mockResolvedValueOnce(res(201, { id: 'r1' }));
+    await triggerRun('p1', { dagFilter: '' });
+    expect(bodyOf()).toEqual({ dag_filter: '' });
+  });
+
+  it('passes a scoped filter through', async () => {
+    apiFetch.mockResolvedValueOnce(res(201, { id: 'r1' }));
+    await triggerRun('p1', { dagFilter: '+db+' });
+    expect(bodyOf()).toEqual({ dag_filter: '+db+' });
+  });
+
+  it('returns the raw status and body rather than throwing on 409', async () => {
+    // "a run is already in flight" is a state the Run view renders, not an error.
+    apiFetch.mockResolvedValueOnce(res(409, { action: 'run_in_progress' }));
+    await expect(triggerRun('p1')).resolves.toEqual({
+      status: 409,
+      body: { action: 'run_in_progress' },
+    });
+  });
+
+  it('survives a non-JSON body', async () => {
+    apiFetch.mockResolvedValueOnce(res(500, REJECT));
+    await expect(triggerRun('p1')).resolves.toEqual({ status: 500, body: null });
+  });
+});
+
+describe('cancelRun', () => {
+  it('POSTs to the run-scoped cancel endpoint', async () => {
+    apiFetch.mockResolvedValueOnce(res(200, { state: 'canceled' }));
+    await expect(cancelRun('run-9')).resolves.toEqual({
+      status: 200,
+      body: { state: 'canceled' },
+    });
+    expect(apiFetch).toHaveBeenCalledWith('/api/runCancel/run-9', { method: 'POST' });
+  });
+
+  it('reports a 409 rather than throwing', async () => {
+    // The run reached a terminal state between render and click; a refetch will
+    // show that, so there is nothing to shout about.
+    apiFetch.mockResolvedValueOnce(res(409, { detail: 'already finished' }));
+    await expect(cancelRun('run-9')).resolves.toEqual({
+      status: 409,
+      body: { detail: 'already finished' },
+    });
+  });
+
+  it('survives a non-JSON body', async () => {
+    apiFetch.mockResolvedValueOnce(res(502, REJECT));
+    await expect(cancelRun('run-9')).resolves.toEqual({ status: 502, body: null });
+  });
+});

--- a/viewer/src/components/RunsView.jsx
+++ b/viewer/src/components/RunsView.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import useStore from '../stores/store';
-import { fetchRuns, fetchRunLog } from '../api/branching';
+import { fetchRuns, fetchRunLog, cancelRun } from '../api/branching';
 import AnsiText from './common/AnsiText';
 
 // queued/running are the only non-terminal states — while active a run is still
@@ -18,6 +18,43 @@ const STATE_BADGE = {
 };
 
 const scopeLabel = run => run.dag_filter || (run.state === 'queued' ? '—' : 'all');
+
+/**
+ * Stop a run that's still going.
+ *
+ * Only rendered for queued/running runs — cancelling a finished one is
+ * meaningless, and the endpoint 409s on it anyway. A 409 here isn't worth an
+ * error state either: it just means the run terminated between render and click,
+ * and the refetch below will show that.
+ *
+ * What cancelling guarantees is the state change: the run goes `canceled`, the
+ * spinner stops and the commit gate reopens. Stopping the compute is best-effort
+ * on the server (a Kubernetes Job is deleted; a warm-pool run finishes in the
+ * background with its results discarded), which is why the button says "Cancel
+ * run" rather than promising to kill anything.
+ */
+function CancelRunButton({ run }) {
+  const queryClient = useQueryClient();
+  const { mutate, isPending, isError } = useMutation({
+    mutationFn: () => cancelRun(run.id),
+    // Refetch either way: on 409 the list is simply out of date.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['runs'] }),
+  });
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => mutate()}
+        disabled={isPending}
+        className="px-2 py-1 text-xs font-medium rounded border border-red-200 text-red-700 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isPending ? 'Cancelling…' : 'Cancel run'}
+      </button>
+      {isError && <span className="text-red-600">Couldn't cancel — try again.</span>}
+    </div>
+  );
+}
 
 function RunDetail({ run }) {
   const err = run.error_json;
@@ -46,6 +83,7 @@ function RunDetail({ run }) {
 
   return (
     <div className="space-y-3 text-xs">
+      {active && <CancelRunButton run={run} />}
       <dl className="space-y-1">
         {meta.map(([label, value, mono]) => (
           <div key={label} className="flex gap-2">
@@ -100,8 +138,8 @@ export default function RunsView() {
     <div className="p-6">
       <h2 className="text-xl font-bold text-gray-900 mb-1">Runs</h2>
       <p className="text-gray-500 text-sm mb-4">
-        Each saved change triggers a debounced run that rebuilds the affected assets. Click a
-        run for details.
+        Each saved change triggers a debounced run that rebuilds the affected assets. Click a run
+        for details.
       </p>
       {runs.length === 0 ? (
         <p className="text-gray-500">No runs yet — edit a resource to trigger one.</p>
@@ -137,7 +175,9 @@ export default function RunsView() {
                   </span>
                   <span className="flex-1 text-gray-600">{scopeLabel(run)}</span>
                   <span className="w-16 flex items-center justify-end gap-2 text-gray-400">
-                    {run.error_json && <span className="text-red-600 text-xs font-medium">error</span>}
+                    {run.error_json && (
+                      <span className="text-red-600 text-xs font-medium">error</span>
+                    )}
                     <span aria-hidden="true">{isOpen ? '▾' : '▸'}</span>
                   </span>
                 </button>

--- a/viewer/src/components/RunsView.jsx
+++ b/viewer/src/components/RunsView.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import useStore from '../stores/store';
-import { fetchRuns, fetchRunLog, cancelRun } from '../api/branching';
+import { fetchRuns, fetchRunLog, cancelRun } from '../api/runs';
 import AnsiText from './common/AnsiText';
 import { getTypeColors, getTypeIcon } from './views/common/objectTypeConfigs';
 

--- a/viewer/src/components/RunsView.jsx
+++ b/viewer/src/components/RunsView.jsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import useStore from '../stores/store';
 import { fetchRuns, fetchRunLog, cancelRun } from '../api/branching';
 import AnsiText from './common/AnsiText';
+import { getTypeColors, getTypeIcon } from './views/common/objectTypeConfigs';
 
 // queued/running are the only non-terminal states — while active a run is still
 // building, so the detail panel tail-polls the log.
@@ -18,6 +19,154 @@ const STATE_BADGE = {
 };
 
 const scopeLabel = run => run.dag_filter || (run.state === 'queued' ? '—' : 'all');
+
+/**
+ * The changes that need a run, with the button that runs them.
+ *
+ * This is the whole point of a manual trigger: your edits stop starting runs, so
+ * there has to be one place that says what's outstanding and lets you act on it.
+ * The list is exactly what the run will build — the server derives the scope from
+ * the same unbuilt set it lists here, so the two can't drift apart.
+ *
+ * Note the button stays enabled with nothing staged, as "Run all". An explicit
+ * full rebuild is the only way back when the outputs are missing or corrupt but
+ * the fingerprints say they're built.
+ */
+function StagedPanel() {
+  const staged = useStore(s => s.stagedChanges);
+  const runTrigger = useStore(s => s.runTrigger);
+  const setRunTrigger = useStore(s => s.setRunTrigger);
+  const triggerRun = useStore(s => s.triggerRun);
+  const latestRun = useStore(s => s.latestRun);
+  const [error, setError] = useState(null);
+  const [starting, setStarting] = useState(false);
+
+  const running = latestRun ? isActiveRun(latestRun) : false;
+  const count = staged.length;
+
+  const onRun = async () => {
+    setError(null);
+    setStarting(true);
+    // No dagFilter => build the staged set. With nothing staged the server reads
+    // that as a full rebuild, which is what "Run all" promises.
+    const result = await triggerRun();
+    setStarting(false);
+    if (!result.success) {
+      setError(
+        result.action === 'run_in_progress'
+          ? 'A run is already in progress.'
+          : result.error || 'Could not start the run.'
+      );
+    }
+  };
+
+  return (
+    <div className="border rounded mb-6" data-testid="runs-staged-panel">
+      <div className="flex items-start justify-between gap-4 px-3 py-3 border-b">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-gray-900">
+            {count === 0
+              ? 'No changes waiting to run'
+              : `${count} change${count === 1 ? '' : 's'} waiting to run`}
+          </h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            {count === 0
+              ? 'Everything built. Editing a query, model or source will queue work here.'
+              : 'A run rebuilds these and everything downstream of them.'}
+          </p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <RunTriggerToggle value={runTrigger} onChange={setRunTrigger} />
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={running || starting}
+            className={`px-3 py-1.5 rounded text-sm font-medium text-white ${
+              running || starting
+                ? 'bg-gray-300 cursor-not-allowed'
+                : 'bg-primary hover:opacity-90'
+            }`}
+          >
+            {running ? 'Running…' : count === 0 ? 'Run all' : `Run ${count}`}
+          </button>
+        </div>
+      </div>
+      {error && (
+        <div className="px-3 py-2 text-xs text-red-600 border-b" role="alert">
+          {error}
+        </div>
+      )}
+      {count > 0 && (
+        <ul className="max-h-48 overflow-y-auto divide-y">
+          {staged.map(item => (
+            <li
+              key={`${item.type}:${item.name}`}
+              className="flex items-center gap-2 px-3 py-2 text-sm"
+            >
+              <StagedTypeBadge type={item.type} />
+              <span className="flex-1 truncate text-gray-800">{item.name}</span>
+              {item.status === 'deleted' && (
+                <span className="text-xs text-gray-500">deleted</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function StagedTypeBadge({ type }) {
+  const { bg, text } = getTypeColors(type);
+  const Icon = getTypeIcon(type);
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium ${bg} ${text}`}
+    >
+      {Icon && <Icon className="h-3 w-3" />}
+      {type}
+    </span>
+  );
+}
+
+/**
+ * Automatic vs manual. Lives here rather than in the top bar because this is the
+ * only screen where the consequence is visible — and it's where the tab dot sends
+ * someone wondering why their changes aren't running.
+ *
+ * The scope caption is deliberately visible text, not a tooltip: assuming this is
+ * per-project is the obvious mistake to make.
+ */
+function RunTriggerToggle({ value, onChange }) {
+  if (!onChange) return null;
+  return (
+    <div className="text-right">
+      <div
+        className="inline-flex rounded border overflow-hidden text-xs"
+        role="group"
+        aria-label="When to run"
+      >
+        {[
+          ['automatic', 'Automatic'],
+          ['manual', 'Manual'],
+        ].map(([mode, label]) => (
+          <button
+            key={mode}
+            type="button"
+            aria-pressed={value === mode}
+            onClick={() => value !== mode && onChange(mode)}
+            className={`px-2 py-1 ${
+              value === mode ? 'bg-gray-800 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <p className="text-[10px] text-gray-400 mt-0.5">Applies to all your projects.</p>
+    </div>
+  );
+}
 
 /**
  * Stop a run that's still going.
@@ -138,11 +287,11 @@ export default function RunsView() {
     <div className="p-6">
       <h2 className="text-xl font-bold text-gray-900 mb-1">Runs</h2>
       <p className="text-gray-500 text-sm mb-4">
-        Each saved change triggers a debounced run that rebuilds the affected assets. Click a run
-        for details.
+        A run rebuilds the assets your changes affect. Click a run for details.
       </p>
+      <StagedPanel />
       {runs.length === 0 ? (
-        <p className="text-gray-500">No runs yet — edit a resource to trigger one.</p>
+        <p className="text-gray-500">No runs yet.</p>
       ) : (
         <div className="border rounded text-sm">
           <div className="flex items-center gap-4 px-3 py-2 text-gray-500 border-b text-xs font-medium">

--- a/viewer/src/components/RunsView.test.jsx
+++ b/viewer/src/components/RunsView.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 import RunsView from './RunsView';
 import { cancelRun } from '../api/branching';
@@ -146,5 +146,99 @@ describe('RunsView cancel', () => {
     openDetail();
     fireEvent.click(screen.getByRole('button', { name: /cancel run/i }));
     expect(cancelRun).toHaveBeenCalledWith('r-target');
+  });
+});
+
+describe('RunsView staged panel', () => {
+  const staged = [
+    { name: 'db', type: 'source', status: 'modified' },
+    { name: 'orders', type: 'model', status: 'modified' },
+  ];
+
+  const setup = (state = {}) => {
+    const triggerRun = jest.fn().mockResolvedValue({ success: true });
+    const setRunTrigger = jest.fn();
+    useStore.setState({
+      project: { id: 'p1' },
+      stagedChanges: staged,
+      runTrigger: 'manual',
+      latestRun: null,
+      triggerRun,
+      setRunTrigger,
+      ...state,
+    });
+    return { triggerRun, setRunTrigger };
+  };
+
+  test('lists what a run would build', () => {
+    setup();
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    expect(screen.getByText('db')).toBeInTheDocument();
+    expect(screen.getByText('orders')).toBeInTheDocument();
+    expect(screen.getByText('2 changes waiting to run')).toBeInTheDocument();
+  });
+
+  test('the button names the count so it matches the list', () => {
+    setup();
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    expect(screen.getByRole('button', { name: 'Run 2' })).toBeInTheDocument();
+  });
+
+  test('clicking it builds the staged set — no explicit filter', async () => {
+    const { triggerRun } = setup();
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    fireEvent.click(screen.getByRole('button', { name: 'Run 2' }));
+    // Called with no argument: the server then scopes the run to the same
+    // unbuilt set it listed. An explicit '' would mean "rebuild everything".
+    await waitFor(() => expect(triggerRun).toHaveBeenCalledWith());
+  });
+
+  test('with nothing staged it offers Run all rather than going dead', () => {
+    // The escape hatch: the only way back when outputs are missing but the
+    // fingerprints claim they are built.
+    setup({ stagedChanges: [] });
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    const button = screen.getByRole('button', { name: 'Run all' });
+    expect(button).toBeEnabled();
+    expect(screen.getByText('No changes waiting to run')).toBeInTheDocument();
+  });
+
+  test('is disabled while a run is in flight', () => {
+    setup({ latestRun: { id: 'r1', state: 'running' } });
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    expect(screen.getByRole('button', { name: 'Running…' })).toBeDisabled();
+  });
+
+  test('surfaces a refusal instead of silently doing nothing', async () => {
+    const { triggerRun } = setup();
+    triggerRun.mockResolvedValue({ success: false, action: 'run_in_progress' });
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    fireEvent.click(screen.getByRole('button', { name: 'Run 2' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('already in progress');
+  });
+
+  test('the toggle reflects and changes the trigger mode', () => {
+    const { setRunTrigger } = setup();
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    expect(screen.getByRole('button', { name: 'Manual' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Automatic' }));
+    expect(setRunTrigger).toHaveBeenCalledWith('automatic');
+  });
+
+  test('the scope is stated in the control, not hidden in a tooltip', () => {
+    setup();
+    mockQueries({ runs: [] });
+    render(<RunsView />);
+    expect(screen.getByText('Applies to all your projects.')).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/RunsView.test.jsx
+++ b/viewer/src/components/RunsView.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 import RunsView from './RunsView';
-import { cancelRun } from '../api/branching';
+import { cancelRun } from '../api/runs';
 import useStore from '../stores/store';
 
 // Control the runs the view renders; the real store provides the project id.
@@ -20,7 +20,7 @@ jest.mock('@tanstack/react-query', () => {
     useQueryClient: () => ({ invalidateQueries: jest.fn() }),
   };
 });
-jest.mock('../api/branching', () => ({
+jest.mock('../api/runs', () => ({
   fetchRuns: jest.fn(),
   fetchRunLog: jest.fn(),
   cancelRun: jest.fn(),

--- a/viewer/src/components/RunsView.test.jsx
+++ b/viewer/src/components/RunsView.test.jsx
@@ -1,16 +1,29 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 import RunsView from './RunsView';
+import { cancelRun } from '../api/branching';
 import useStore from '../stores/store';
 
 // Control the runs the view renders; the real store provides the project id.
 jest.mock('@tanstack/react-query', () => {
   const actual = jest.requireActual('@tanstack/react-query');
-  return { ...actual, useQuery: jest.fn() };
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+    // The cancel button's mutation: run mutationFn immediately so a click is
+    // observable without a real QueryClient.
+    useMutation: jest.fn(({ mutationFn }) => ({
+      mutate: (...args) => mutationFn(...args),
+      isPending: false,
+      isError: false,
+    })),
+    useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+  };
 });
 jest.mock('../api/branching', () => ({
   fetchRuns: jest.fn(),
   fetchRunLog: jest.fn(),
+  cancelRun: jest.fn(),
 }));
 
 // RunsView and the expanded RunDetail each call useQuery; dispatch on the key so
@@ -30,8 +43,7 @@ const run = over => ({
   ...over,
 });
 
-const logQueryOpts = () =>
-  useQuery.mock.calls.find(([opts]) => opts.queryKey[0] === 'runLog')?.[0];
+const logQueryOpts = () => useQuery.mock.calls.find(([opts]) => opts.queryKey[0] === 'runLog')?.[0];
 
 beforeEach(() => {
   useQuery.mockReset();
@@ -97,5 +109,42 @@ describe('RunsView detail expansion', () => {
     fireEvent.click(screen.getByRole('button', { name: /failed/i }));
     expect(screen.getByText(/boom: query failed at line 3/)).toBeInTheDocument();
     expect(screen.getByText(/Error — run/)).toBeInTheDocument();
+  });
+});
+
+// Cancelling a run: the button only exists while there's something to cancel,
+// and its whole job is reopening the commit gate — the state change, not
+// killing compute (which the server does best-effort).
+describe('RunsView cancel', () => {
+  const openDetail = () => fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+  test('an active run offers a cancel button', () => {
+    mockQueries({ runs: [run({ state: 'running' })], log: { logs: '' } });
+    render(<RunsView />);
+    openDetail();
+    expect(screen.getByRole('button', { name: /cancel run/i })).toBeInTheDocument();
+  });
+
+  test('a queued run offers it too — that is the one users get stuck on', () => {
+    mockQueries({ runs: [run({ state: 'queued' })], log: { logs: '' } });
+    render(<RunsView />);
+    openDetail();
+    expect(screen.getByRole('button', { name: /cancel run/i })).toBeInTheDocument();
+  });
+
+  test.each(['succeeded', 'failed', 'canceled'])('a %s run offers no cancel button', state => {
+    mockQueries({ runs: [run({ state })], log: { logs: '' } });
+    render(<RunsView />);
+    openDetail();
+    expect(screen.queryByRole('button', { name: /cancel run/i })).not.toBeInTheDocument();
+  });
+
+  test('clicking it cancels that specific run', () => {
+    cancelRun.mockResolvedValue({ status: 200, body: { state: 'canceled' } });
+    mockQueries({ runs: [run({ id: 'r-target', state: 'running' })], log: { logs: '' } });
+    render(<RunsView />);
+    openDetail();
+    fireEvent.click(screen.getByRole('button', { name: /cancel run/i }));
+    expect(cancelRun).toHaveBeenCalledWith('r-target');
   });
 });

--- a/viewer/src/components/commit/CommitModal.jsx
+++ b/viewer/src/components/commit/CommitModal.jsx
@@ -46,6 +46,7 @@ const CommitModal = () => {
   const pendingChanges = useStore(state => state.pendingChanges);
   const commitLoading = useStore(state => state.commitLoading);
   const commitError = useStore(state => state.commitError);
+  const commitAction = useStore(state => state.commitAction);
   const commitChanges = useStore(state => state.commitChanges);
   // Discard (Q14 rollback) — drops the draft cache without writing YAML. It's
   // destructive, so it confirms inline before firing. Local serve only:
@@ -96,7 +97,16 @@ const CommitModal = () => {
         </p>
 
         {commitError && (
-          <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md">{commitError}</div>
+          <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md">
+            {commitError}
+            {/* With a manual run trigger this refusal is the ordinary path, not
+                an edge case — so say where to go and do something about it. */}
+            {(commitAction === 'run_required' || commitAction === 'run_failed') && (
+              <span className="block mt-1 text-xs">
+                Open the Runs tab to see what needs building and start a run.
+              </span>
+            )}
+          </div>
         )}
 
         <div className="max-h-64 overflow-y-auto mb-6" data-testid="commit-modal-pending-list">

--- a/viewer/src/components/common/RunsToolIcon.jsx
+++ b/viewer/src/components/common/RunsToolIcon.jsx
@@ -5,16 +5,21 @@ import useStore from '../../stores/store';
 
 /**
  * Icon for the "Runs" tab. Spins (a loader) while a draft run is in flight,
- * tints red when the latest run failed, and is the plain checklist otherwise —
- * so run status lives on the tab itself (no separate "Running…" pill). Kept in
- * lockstep with core's bootstrap/RunsToolIcon so the local viewer and the
- * cloud editor show run status the same way.
+ * tints red when the latest run failed, carries an amber dot when there are
+ * changes nobody has run yet, and is the plain checklist otherwise — so run
+ * status lives on the tab itself (no separate "Running…" pill).
+ *
+ * The dot is the only signal that a manual-trigger user has work outstanding:
+ * their edits don't start a run, so without it the Run view is somewhere you'd
+ * have to think to visit. Amber rather than the mulberry used for an unsaved
+ * workspace tab — "saved but not built" is a different state from "not saved".
  */
 export default function RunsToolIcon({ size = 16 }) {
   // Backend-owned status: the run is created `queued` on edit and the runner
   // flips it to `running` on actual start, so the icon just reflects the real
   // state — queued/running spin (queued the moment you edit), failed tints red.
   const state = useStore(s => s.latestRun?.state);
+  const stagedCount = useStore(s => s.stagedCount);
 
   if (state === 'queued' || state === 'running') {
     return (
@@ -25,5 +30,17 @@ export default function RunsToolIcon({ size = 16 }) {
       />
     );
   }
-  return <PiListChecks size={size} color={state === 'failed' ? '#e06b5b' : undefined} />;
+
+  const icon = <PiListChecks size={size} color={state === 'failed' ? '#e06b5b' : undefined} />;
+  if (!stagedCount) return icon;
+  return (
+    <span className="relative inline-flex" data-testid="runs-tool-staged-dot">
+      {icon}
+      <span
+        aria-hidden="true"
+        title={`${stagedCount} change${stagedCount === 1 ? '' : 's'} not run yet`}
+        className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-amber-500"
+      />
+    </span>
+  );
 }

--- a/viewer/src/components/common/RunsToolIcon.test.jsx
+++ b/viewer/src/components/common/RunsToolIcon.test.jsx
@@ -42,3 +42,31 @@ describe('RunsToolIcon', () => {
     expect(screen.queryByTitle('Queued…')).not.toBeInTheDocument();
   });
 });
+
+// The dot is the only thing telling a manual-trigger user they have work
+// outstanding — their edits don't start a run, so nothing else moves.
+describe('RunsToolIcon staged dot', () => {
+  const setState = state => {
+    useStore.mockImplementation(selector => selector(state));
+  };
+
+  it('appears when there are changes nobody has run', () => {
+    setState({ latestRun: { state: 'succeeded' }, stagedCount: 2 });
+    render(<RunsToolIcon />);
+    expect(screen.getByTestId('runs-tool-staged-dot')).toBeInTheDocument();
+  });
+
+  it('stays away when everything is built', () => {
+    setState({ latestRun: { state: 'succeeded' }, stagedCount: 0 });
+    render(<RunsToolIcon />);
+    expect(screen.queryByTestId('runs-tool-staged-dot')).not.toBeInTheDocument();
+  });
+
+  it('yields to the spinner while a run is in flight', () => {
+    // The run IS the answer to "there is outstanding work" at that point;
+    // showing both would say the same thing twice.
+    setState({ latestRun: { state: 'running' }, stagedCount: 2 });
+    render(<RunsToolIcon />);
+    expect(screen.queryByTestId('runs-tool-staged-dot')).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -78,8 +78,6 @@ const URL_PATTERNS = {
     dashboardDelete: '/api/dashboards/{name}/delete/',
     dashboardValidate: '/api/dashboards/{name}/validate/',
 
-
-
     // Defaults management endpoints
     defaults: '/api/defaults/',
 
@@ -103,6 +101,7 @@ const URL_PATTERNS = {
     projectDiscard: '/api/projects/{projectId}/discard/',
     projectRun: '/api/projects/{projectId}/run/',
     runLogs: '/api/runs/{runId}/logs/',
+    runCancel: '/api/runs/{runId}/cancel/',
 
     // Source schema jobs endpoints
     sourceSchemaJobsList: '/api/source-schema-jobs/',
@@ -215,8 +214,6 @@ const URL_PATTERNS = {
     dashboardSave: null,
     dashboardDelete: null,
     dashboardValidate: null,
-
-
 
     // Defaults management endpoints (not available in dist)
     defaults: null,

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -92,6 +92,11 @@ const URL_PATTERNS = {
     commit: '/api/commit/',
     commitDiscard: '/api/commit/discard/',
 
+    // The user's own preferences. Both servers implement it — cloud off the User
+    // row, local off ~/.visivo/config.yml — with different defaults, which is how
+    // the viewer stays free of local-vs-cloud branching.
+    mePreferences: '/api/me/preferences/',
+
     // Cloud-editing endpoints (core/Django only; 404 under local `visivo serve`)
     projectCapabilities: '/api/projects/{projectId}/capabilities/',
     projectDraft: '/api/projects/{projectId}/draft/',
@@ -223,6 +228,9 @@ const URL_PATTERNS = {
     commitPending: null,
     commit: null,
     commitDiscard: null,
+
+    // No server to hold a preference against — the toggle simply doesn't render.
+    mePreferences: null,
 
     // Cloud-editing endpoints (not available in dist)
     projectCapabilities: null,

--- a/viewer/src/stores/commitStore.js
+++ b/viewer/src/stores/commitStore.js
@@ -1,4 +1,5 @@
 import * as branchingApi from '../api/branching';
+import * as preferencesApi from '../api/preferences';
 import * as commitApi from '../api/commit';
 import { emitFirstPublishTelemetry } from '../components/views/workspace/telemetry';
 
@@ -129,7 +130,7 @@ const createCommitSlice = (set, get) => ({
   setRunTrigger: async runTrigger => {
     const previous = get().runTrigger;
     set({ runTrigger });
-    const saved = await branchingApi.savePreferences({ run_trigger: runTrigger });
+    const saved = await preferencesApi.savePreferences({ run_trigger: runTrigger });
     if (!saved) {
       set({ runTrigger: previous });
       return false;

--- a/viewer/src/stores/commitStore.js
+++ b/viewer/src/stores/commitStore.js
@@ -37,13 +37,40 @@ const NAMED_CHILD_FETCHERS = [
   'fetchDefaults',
 ];
 
+// What "we don't know of any changes" looks like. Used both before a project is
+// loaded and when /changes/ is unreachable — the badge and the Runs dot fail
+// closed rather than showing a stale count.
+const EMPTY_CHANGES = {
+  hasUncommittedChanges: false,
+  pendingChanges: [],
+  pendingCount: 0,
+  stagedChanges: [],
+  stagedCount: 0,
+  stagedDagFilter: '',
+};
+
 const createCommitSlice = (set, get) => ({
   // State
   hasUncommittedChanges: false,
   pendingChanges: [], // [{name, type, status}]
   pendingCount: 0,
+  // What a RUN would build, as opposed to what a COMMIT would publish. Narrower
+  // than pendingChanges: a chart colour or a dashboard layout tweak is
+  // uncommitted but needs no run, so it's absent here. Carried on the same
+  // /changes/ response, which is why the Runs tab dot updates on save rather
+  // than waiting for the next run poll.
+  stagedChanges: [], // [{name, type, status}]
+  stagedCount: 0,
+  stagedDagFilter: '',
+  // 'automatic' | 'manual' — the user's own setting, echoed here for first
+  // paint. GET/PUT /api/me/preferences/ is the source of truth.
+  runTrigger: 'automatic',
   commitLoading: false,
   commitError: null,
+  // The machine-readable reason a commit was refused ('run_required' /
+  // 'run_in_progress' / 'run_failed' / 'branch_required' / 'invalid'), so the
+  // modal can say something more useful than the raw detail string.
+  commitAction: null,
   commitModalOpen: false,
   discardLoading: false,
   // Timestamp of the last successful commit — the TopBar cluster derives
@@ -73,21 +100,42 @@ const createCommitSlice = (set, get) => ({
   checkCommitStatus: async () => {
     const projectId = get().project?.id;
     if (!projectId) {
-      set({ hasUncommittedChanges: false, pendingChanges: [], pendingCount: 0 });
+      set({ ...EMPTY_CHANGES });
       return;
     }
     try {
       const changes = await branchingApi.fetchChanges(projectId);
       const pending = [...(changes.to_publish || []), ...(changes.to_remove || [])];
+      // A server older than this viewer sends no staged keys; default them
+      // rather than rendering `undefined` as an empty-but-unknown state.
+      const staged = changes.staged || [];
       set({
         hasUncommittedChanges: !!changes.has_changes,
         pendingChanges: pending,
         pendingCount: pending.length,
+        stagedChanges: staged,
+        stagedCount: staged.length,
+        stagedDagFilter: changes.staged_dag_filter || '',
+        runTrigger: changes.run_trigger || get().runTrigger,
       });
     } catch (error) {
       // Endpoint may be unavailable (e.g. dist mode) — fail closed.
-      set({ hasUncommittedChanges: false, pendingChanges: [], pendingCount: 0 });
+      set({ ...EMPTY_CHANGES });
     }
+  },
+
+  // Flip the run trigger. Optimistic so the toggle doesn't lag the click, then
+  // reconciled with whatever the server actually stored.
+  setRunTrigger: async runTrigger => {
+    const previous = get().runTrigger;
+    set({ runTrigger });
+    const saved = await branchingApi.savePreferences({ run_trigger: runTrigger });
+    if (!saved) {
+      set({ runTrigger: previous });
+      return false;
+    }
+    set({ runTrigger: saved.run_trigger });
+    return true;
   },
 
   // Kept for callers that fetch the list directly; same source as the badge.
@@ -104,7 +152,7 @@ const createCommitSlice = (set, get) => ({
   commitChanges: async () => {
     const projectId = get().project?.id;
     if (!projectId) return { success: false, error: 'No active project' };
-    set({ commitLoading: true, commitError: null });
+    set({ commitLoading: true, commitError: null, commitAction: null });
     let status, body;
     try {
       ({ status, body } = await branchingApi.commitDraft(projectId));
@@ -143,7 +191,10 @@ const createCommitSlice = (set, get) => ({
     // 422 invalid. Surface the action + message.
     const error =
       body.detail || (body.errors && JSON.stringify(body.errors)) || 'Failed to commit changes';
-    set({ commitLoading: false, commitError: error });
+    // Store the action too, not just the message: the modal needs to know a
+    // refusal was `run_required` to point at the Runs tab, and the detail string
+    // is not something to pattern-match on.
+    set({ commitLoading: false, commitError: error, commitAction: body.action || null });
     return { success: false, action: body.action, error };
   },
 

--- a/viewer/src/stores/commitStore.test.js
+++ b/viewer/src/stores/commitStore.test.js
@@ -15,6 +15,7 @@ import { emitFirstPublishTelemetry } from '../components/views/workspace/telemet
 jest.mock('../api/branching', () => ({
   fetchChanges: jest.fn(),
   commitDraft: jest.fn(),
+  savePreferences: jest.fn(),
 }));
 
 jest.mock('../api/commit', () => ({
@@ -315,5 +316,76 @@ describe('commitStore (VIS-806)', () => {
       expect(state.commitError).toBe('boom');
       expect(fetcherStubs.fetchDashboards).not.toHaveBeenCalled();
     });
+  });
+});
+
+/**
+ * The staged set is what a RUN would build — narrower than the commit diff, and
+ * carried on the same /changes/ response so the Runs tab dot refreshes on every
+ * save rather than on a poll.
+ */
+describe('commitStore staged changes', () => {
+  const staged = [{ name: 'db', type: 'source', status: 'modified' }];
+
+  beforeEach(() => {
+    useStore.setState({ project: { id: 'p1' } });
+  });
+
+  test('hydrates the staged keys from /changes/', async () => {
+    branchingApi.fetchChanges.mockResolvedValue({
+      to_publish: [{ name: 'db', type: 'source', status: 'modified' }],
+      to_remove: [],
+      has_changes: true,
+      staged,
+      staged_dag_filter: '+db+',
+      run_trigger: 'manual',
+    });
+    await useStore.getState().checkCommitStatus();
+    const state = useStore.getState();
+    expect(state.stagedChanges).toEqual(staged);
+    expect(state.stagedCount).toBe(1);
+    expect(state.stagedDagFilter).toBe('+db+');
+    expect(state.runTrigger).toBe('manual');
+  });
+
+  test('a server older than this viewer sends no staged keys and still works', () => {
+    // Cloud vendors the SPA at a lagging release tag and local installs upgrade
+    // whenever the user does, so viewer-newer-than-server is a real pairing.
+    branchingApi.fetchChanges.mockResolvedValue({
+      to_publish: [],
+      to_remove: [],
+      has_changes: false,
+    });
+    return useStore
+      .getState()
+      .checkCommitStatus()
+      .then(() => {
+        expect(useStore.getState().stagedChanges).toEqual([]);
+        expect(useStore.getState().stagedCount).toBe(0);
+        expect(useStore.getState().stagedDagFilter).toBe('');
+      });
+  });
+
+  test('an unreachable endpoint clears the dot rather than leaving it stale', async () => {
+    useStore.setState({ stagedChanges: staged, stagedCount: 1 });
+    branchingApi.fetchChanges.mockRejectedValue(new Error('offline'));
+    await useStore.getState().checkCommitStatus();
+    expect(useStore.getState().stagedCount).toBe(0);
+  });
+
+  test('setRunTrigger applies immediately and keeps what the server stored', async () => {
+    branchingApi.savePreferences.mockResolvedValue({ run_trigger: 'manual' });
+    const ok = await useStore.getState().setRunTrigger('manual');
+    expect(ok).toBe(true);
+    expect(branchingApi.savePreferences).toHaveBeenCalledWith({ run_trigger: 'manual' });
+    expect(useStore.getState().runTrigger).toBe('manual');
+  });
+
+  test('setRunTrigger reverts when the save fails, so the toggle never lies', async () => {
+    useStore.setState({ runTrigger: 'automatic' });
+    branchingApi.savePreferences.mockResolvedValue(null);
+    const ok = await useStore.getState().setRunTrigger('manual');
+    expect(ok).toBe(false);
+    expect(useStore.getState().runTrigger).toBe('automatic');
   });
 });

--- a/viewer/src/stores/commitStore.test.js
+++ b/viewer/src/stores/commitStore.test.js
@@ -9,12 +9,16 @@
  */
 import useStore from './store';
 import * as branchingApi from '../api/branching';
+import * as preferencesApi from '../api/preferences';
 import * as commitApi from '../api/commit';
 import { emitFirstPublishTelemetry } from '../components/views/workspace/telemetry';
 
 jest.mock('../api/branching', () => ({
   fetchChanges: jest.fn(),
   commitDraft: jest.fn(),
+}));
+
+jest.mock('../api/preferences', () => ({
   savePreferences: jest.fn(),
 }));
 
@@ -374,16 +378,16 @@ describe('commitStore staged changes', () => {
   });
 
   test('setRunTrigger applies immediately and keeps what the server stored', async () => {
-    branchingApi.savePreferences.mockResolvedValue({ run_trigger: 'manual' });
+    preferencesApi.savePreferences.mockResolvedValue({ run_trigger: 'manual' });
     const ok = await useStore.getState().setRunTrigger('manual');
     expect(ok).toBe(true);
-    expect(branchingApi.savePreferences).toHaveBeenCalledWith({ run_trigger: 'manual' });
+    expect(preferencesApi.savePreferences).toHaveBeenCalledWith({ run_trigger: 'manual' });
     expect(useStore.getState().runTrigger).toBe('manual');
   });
 
   test('setRunTrigger reverts when the save fails, so the toggle never lies', async () => {
     useStore.setState({ runTrigger: 'automatic' });
-    branchingApi.savePreferences.mockResolvedValue(null);
+    preferencesApi.savePreferences.mockResolvedValue(null);
     const ok = await useStore.getState().setRunTrigger('manual');
     expect(ok).toBe(false);
     expect(useStore.getState().runTrigger).toBe('automatic');

--- a/viewer/src/stores/runStore.js
+++ b/viewer/src/stores/runStore.js
@@ -1,4 +1,4 @@
-import * as branchingApi from '../api/branching';
+import * as runsApi from '../api/runs';
 
 export const ACTIVE_RUN_STATES = ['queued', 'running'];
 
@@ -34,7 +34,7 @@ const createRunSlice = (set, get) => ({
     if (!projectId) return null;
     let runs;
     try {
-      runs = await branchingApi.fetchRuns(projectId);
+      runs = await runsApi.fetchRuns(projectId);
     } catch (e) {
       return null; // no run endpoint here (local serve / dist) — nothing to poll
     }
@@ -73,7 +73,7 @@ const createRunSlice = (set, get) => ({
   triggerRun: async ({ dagFilter } = {}) => {
     const projectId = get().project?.id;
     if (!projectId) return { success: false, error: 'No active project' };
-    const { status, body } = await branchingApi.triggerRun(projectId, { dagFilter });
+    const { status, body } = await runsApi.triggerRun(projectId, { dagFilter });
     if (status === 201) {
       // Adopt it immediately so the tab spinner starts on click rather than on
       // the next poll tick.

--- a/viewer/src/stores/runStore.js
+++ b/viewer/src/stores/runStore.js
@@ -44,9 +44,37 @@ const createRunSlice = (set, get) => ({
       } else if (succeeded.id !== prev) {
         // A newer run finished — bump so data hooks refetch the rebuilt output.
         set({ lastSucceededRunId: succeeded.id, runDataVersion: get().runDataVersion + 1 });
+        // The run just built (some of) the staged set, so that list and the
+        // Runs-tab dot are now stale. This is the one transition /changes/
+        // doesn't already cover: it refreshes on every save, but a run
+        // completing isn't a save. One request per successful run, not per poll.
+        get().checkCommitStatus?.();
       }
     }
     return latest;
+  },
+
+  /**
+   * Launch a run for the current project.
+   *
+   * With no argument it builds the staged set — the server derives the scope
+   * from the same data the Run view listed, so the two can't disagree. Pass
+   * `{ dagFilter: '' }` for a deliberate full rebuild ("Run all").
+   *
+   * A 409 means one is already in flight; that's a state to show, not an error.
+   */
+  triggerRun: async ({ dagFilter } = {}) => {
+    const projectId = get().project?.id;
+    if (!projectId) return { success: false, error: 'No active project' };
+    const { status, body } = await branchingApi.triggerRun(projectId, { dagFilter });
+    if (status === 201) {
+      // Adopt it immediately so the tab spinner starts on click rather than on
+      // the next poll tick.
+      set({ latestRun: body, runs: [body, ...get().runs] });
+      return { success: true, run: body };
+    }
+    await get().pollRuns();
+    return { success: false, action: body?.action, error: body?.detail };
   },
 });
 

--- a/viewer/src/stores/runStore.js
+++ b/viewer/src/stores/runStore.js
@@ -20,6 +20,13 @@ const createRunSlice = (set, get) => ({
   // to record names via dag_filter. Stays [] where the endpoint 404s.
   runs: [],
   lastSucceededRunId: null,
+  // The project the baseline below was taken for. "Have we polled yet?" and
+  // "have we ever seen a succeeded run?" are different questions, and conflating
+  // them meant a draft whose FIRST run succeeded while you watched was mistaken
+  // for a baseline: neither the data refresh nor the staged-list refresh fired,
+  // so the Runs tab kept showing work that had just been built until you
+  // reloaded the page.
+  polledProjectId: null,
   runDataVersion: 0,
 
   pollRuns: async () => {
@@ -32,24 +39,24 @@ const createRunSlice = (set, get) => ({
       return null; // no run endpoint here (local serve / dist) — nothing to poll
     }
     const latest = (runs && runs[0]) || null;
-    set({ latestRun: latest, runs: runs || [] });
+    const firstPollForProject = get().polledProjectId !== projectId;
+    set({ latestRun: latest, runs: runs || [], polledProjectId: projectId });
 
     const succeeded = (runs || []).find(r => r.state === 'succeeded');
-    if (succeeded) {
-      const prev = get().lastSucceededRunId;
-      if (prev === null) {
-        // First poll: adopt the current succeeded run as the baseline. The data
-        // already on screen reflects it, so don't trigger a spurious refetch.
-        set({ lastSucceededRunId: succeeded.id });
-      } else if (succeeded.id !== prev) {
-        // A newer run finished — bump so data hooks refetch the rebuilt output.
-        set({ lastSucceededRunId: succeeded.id, runDataVersion: get().runDataVersion + 1 });
-        // The run just built (some of) the staged set, so that list and the
-        // Runs-tab dot are now stale. This is the one transition /changes/
-        // doesn't already cover: it refreshes on every save, but a run
-        // completing isn't a save. One request per successful run, not per poll.
-        get().checkCommitStatus?.();
-      }
+    if (firstPollForProject) {
+      // Adopt whatever we find as the baseline — the screen already reflects it —
+      // and reset when switching drafts so another project's run can't look like
+      // ours completing.
+      set({ lastSucceededRunId: succeeded ? succeeded.id : null });
+    } else if (succeeded && succeeded.id !== get().lastSucceededRunId) {
+      // A run finished since we started watching. Bump so data hooks refetch the
+      // rebuilt output...
+      set({ lastSucceededRunId: succeeded.id, runDataVersion: get().runDataVersion + 1 });
+      // ...and re-read what's still outstanding: the run just built (some of) the
+      // staged set, so that list and the Runs-tab dot are now stale. This is the
+      // one transition /changes/ doesn't already cover — it refreshes on every
+      // save, but a run completing isn't a save.
+      get().checkCommitStatus?.();
     }
     return latest;
   },

--- a/viewer/src/stores/runStore.test.js
+++ b/viewer/src/stores/runStore.test.js
@@ -161,3 +161,66 @@ describe('runStore triggerRun', () => {
     expect(result).toMatchObject({ success: false, action: 'run_in_progress' });
   });
 });
+
+describe('runStore: the first run to succeed still counts', () => {
+  // The bug this covers: `lastSucceededRunId === null` was read as "this is the
+  // first poll, the screen already reflects it", but it really means "we have
+  // never seen a succeeded run". On a draft whose runs had only failed, the
+  // first success was therefore swallowed as a baseline — the rebuilt data was
+  // never refetched and the Runs tab kept listing changes that had just been
+  // built, until you reloaded the page.
+  const build = (initial = {}) =>
+    makeStore(createRunSlice, { project: { id: 'draft-1' }, ...initial });
+
+  test('a first success after a failure refreshes data and the staged list', async () => {
+    const checkCommitStatus = jest.fn();
+    const store = build({ checkCommitStatus });
+
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-failed', state: 'failed' }]);
+    await store.get().pollRuns();
+    expect(store.get().runDataVersion).toBe(0);
+
+    branchingApi.fetchRuns.mockResolvedValueOnce([
+      { id: 'r-ok', state: 'succeeded' },
+      { id: 'r-failed', state: 'failed' },
+    ]);
+    await store.get().pollRuns();
+
+    expect(store.get().runDataVersion).toBe(1);
+    expect(checkCommitStatus).toHaveBeenCalledTimes(1);
+  });
+
+  test('a success already on screen at first poll is still a baseline', async () => {
+    // The behaviour the old code was reaching for, which must survive: arriving
+    // on a project whose last run succeeded shouldn't refetch anything.
+    const checkCommitStatus = jest.fn();
+    const store = build({ checkCommitStatus });
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-ok', state: 'succeeded' }]);
+    await store.get().pollRuns();
+    expect(store.get().runDataVersion).toBe(0);
+    expect(checkCommitStatus).not.toHaveBeenCalled();
+  });
+
+  test('switching drafts re-baselines instead of firing', async () => {
+    const checkCommitStatus = jest.fn();
+    const store = build({ checkCommitStatus });
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'a-ok', state: 'succeeded' }]);
+    await store.get().pollRuns();
+
+    // Another draft, whose newest succeeded run is a different id.
+    store.get().project.id = 'draft-2';
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'b-ok', state: 'succeeded' }]);
+    await store.get().pollRuns();
+
+    expect(store.get().runDataVersion).toBe(0);
+    expect(checkCommitStatus).not.toHaveBeenCalled();
+    expect(store.get().lastSucceededRunId).toBe('b-ok');
+  });
+
+  test('a draft with no succeeded run leaves no stale baseline behind', async () => {
+    const store = build();
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'x', state: 'failed' }]);
+    await store.get().pollRuns();
+    expect(store.get().lastSucceededRunId).toBeNull();
+  });
+});

--- a/viewer/src/stores/runStore.test.js
+++ b/viewer/src/stores/runStore.test.js
@@ -1,7 +1,7 @@
 import createRunSlice from './runStore';
-import * as branchingApi from '../api/branching';
+import * as runsApi from '../api/runs';
 
-jest.mock('../api/branching');
+jest.mock('../api/runs');
 
 const makeStore = (slice, initial = {}) => {
   let state = { ...initial };
@@ -20,12 +20,12 @@ describe('runStore', () => {
   const build = () => makeStore(createRunSlice, { project: { id: 'draft-1' } });
 
   it('sets latestRun and adopts the first succeeded run as baseline (no bump)', async () => {
-    branchingApi.fetchRuns.mockResolvedValueOnce([
+    runsApi.fetchRuns.mockResolvedValueOnce([
       { id: 'r1', state: 'succeeded' },
     ]);
     const store = build();
     await store.get().pollRuns();
-    expect(branchingApi.fetchRuns).toHaveBeenCalledWith('draft-1');
+    expect(runsApi.fetchRuns).toHaveBeenCalledWith('draft-1');
     expect(store.get().latestRun).toEqual({ id: 'r1', state: 'succeeded' });
     expect(store.get().lastSucceededRunId).toBe('r1');
     expect(store.get().runDataVersion).toBe(0); // baseline, no refresh
@@ -33,13 +33,13 @@ describe('runStore', () => {
 
   it('bumps runDataVersion when a NEW run succeeds', async () => {
     const store = build();
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r1', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r1', state: 'succeeded' }]);
     await store.get().pollRuns(); // baseline
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r2', state: 'running' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r2', state: 'running' }]);
     await store.get().pollRuns();
     expect(store.get().latestRun.state).toBe('running');
     expect(store.get().runDataVersion).toBe(0); // not succeeded yet
-    branchingApi.fetchRuns.mockResolvedValueOnce([
+    runsApi.fetchRuns.mockResolvedValueOnce([
       { id: 'r2', state: 'succeeded' },
       { id: 'r1', state: 'succeeded' },
     ]);
@@ -49,7 +49,7 @@ describe('runStore', () => {
   });
 
   it('no-ops when the run endpoint is unavailable (local serve / dist)', async () => {
-    branchingApi.fetchRuns.mockRejectedValueOnce(new Error('404'));
+    runsApi.fetchRuns.mockRejectedValueOnce(new Error('404'));
     const store = build();
     const result = await store.get().pollRuns();
     expect(result).toBeNull();
@@ -81,7 +81,7 @@ describe('runStore', () => {
         created_at: '2026-07-01T11:00:00Z',
       },
     ];
-    branchingApi.fetchRuns.mockResolvedValueOnce(runsPayload);
+    runsApi.fetchRuns.mockResolvedValueOnce(runsPayload);
     const store = build();
     expect(store.get().runs).toEqual([]); // initial state
     await store.get().pollRuns();
@@ -89,7 +89,7 @@ describe('runStore', () => {
   });
 
   it('normalizes a null runs payload to an empty list', async () => {
-    branchingApi.fetchRuns.mockResolvedValueOnce(null);
+    runsApi.fetchRuns.mockResolvedValueOnce(null);
     const store = build();
     const result = await store.get().pollRuns();
     expect(result).toBeNull();
@@ -108,11 +108,11 @@ describe('runStore run completion refreshes the staged set', () => {
       project: { id: 'draft-1' },
       checkCommitStatus,
     });
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r1', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r1', state: 'succeeded' }]);
     await store.get().pollRuns(); // first poll adopts the baseline
     expect(checkCommitStatus).not.toHaveBeenCalled();
 
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r2', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r2', state: 'succeeded' }]);
     await store.get().pollRuns();
     expect(checkCommitStatus).toHaveBeenCalledTimes(1);
   });
@@ -122,18 +122,18 @@ describe('runStore triggerRun', () => {
   const build = () => makeStore(createRunSlice, { project: { id: 'draft-1' }, runs: [] });
 
   test('builds the staged set when given no filter', async () => {
-    branchingApi.triggerRun.mockResolvedValue({
+    runsApi.triggerRun.mockResolvedValue({
       status: 201,
       body: { id: 'r1', state: 'queued' },
     });
     const store = build();
     const result = await store.get().triggerRun();
-    expect(branchingApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: undefined });
+    expect(runsApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: undefined });
     expect(result.success).toBe(true);
   });
 
   test('adopts the new run at once so the tab spinner starts on click', async () => {
-    branchingApi.triggerRun.mockResolvedValue({
+    runsApi.triggerRun.mockResolvedValue({
       status: 201,
       body: { id: 'r1', state: 'queued' },
     });
@@ -144,18 +144,18 @@ describe('runStore triggerRun', () => {
   });
 
   test('passes an explicit empty filter through as a deliberate full rebuild', async () => {
-    branchingApi.triggerRun.mockResolvedValue({ status: 201, body: { id: 'r1' } });
+    runsApi.triggerRun.mockResolvedValue({ status: 201, body: { id: 'r1' } });
     const store = build();
     await store.get().triggerRun({ dagFilter: '' });
-    expect(branchingApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: '' });
+    expect(runsApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: '' });
   });
 
   test('a 409 is reported, not thrown', async () => {
-    branchingApi.triggerRun.mockResolvedValue({
+    runsApi.triggerRun.mockResolvedValue({
       status: 409,
       body: { action: 'run_in_progress' },
     });
-    branchingApi.fetchRuns.mockResolvedValue([]);
+    runsApi.fetchRuns.mockResolvedValue([]);
     const store = build();
     const result = await store.get().triggerRun();
     expect(result).toMatchObject({ success: false, action: 'run_in_progress' });
@@ -176,11 +176,11 @@ describe('runStore: the first run to succeed still counts', () => {
     const checkCommitStatus = jest.fn();
     const store = build({ checkCommitStatus });
 
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-failed', state: 'failed' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-failed', state: 'failed' }]);
     await store.get().pollRuns();
     expect(store.get().runDataVersion).toBe(0);
 
-    branchingApi.fetchRuns.mockResolvedValueOnce([
+    runsApi.fetchRuns.mockResolvedValueOnce([
       { id: 'r-ok', state: 'succeeded' },
       { id: 'r-failed', state: 'failed' },
     ]);
@@ -195,7 +195,7 @@ describe('runStore: the first run to succeed still counts', () => {
     // on a project whose last run succeeded shouldn't refetch anything.
     const checkCommitStatus = jest.fn();
     const store = build({ checkCommitStatus });
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-ok', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'r-ok', state: 'succeeded' }]);
     await store.get().pollRuns();
     expect(store.get().runDataVersion).toBe(0);
     expect(checkCommitStatus).not.toHaveBeenCalled();
@@ -204,12 +204,12 @@ describe('runStore: the first run to succeed still counts', () => {
   test('switching drafts re-baselines instead of firing', async () => {
     const checkCommitStatus = jest.fn();
     const store = build({ checkCommitStatus });
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'a-ok', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'a-ok', state: 'succeeded' }]);
     await store.get().pollRuns();
 
     // Another draft, whose newest succeeded run is a different id.
     store.get().project.id = 'draft-2';
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'b-ok', state: 'succeeded' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'b-ok', state: 'succeeded' }]);
     await store.get().pollRuns();
 
     expect(store.get().runDataVersion).toBe(0);
@@ -219,7 +219,7 @@ describe('runStore: the first run to succeed still counts', () => {
 
   test('a draft with no succeeded run leaves no stale baseline behind', async () => {
     const store = build();
-    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'x', state: 'failed' }]);
+    runsApi.fetchRuns.mockResolvedValueOnce([{ id: 'x', state: 'failed' }]);
     await store.get().pollRuns();
     expect(store.get().lastSucceededRunId).toBeNull();
   });

--- a/viewer/src/stores/runStore.test.js
+++ b/viewer/src/stores/runStore.test.js
@@ -97,3 +97,67 @@ describe('runStore', () => {
     expect(store.get().runs).toEqual([]);
   });
 });
+
+describe('runStore run completion refreshes the staged set', () => {
+  test('a newly succeeded run re-checks what is still outstanding', async () => {
+    // The one transition /changes/ doesn't already cover: it refreshes on every
+    // save, but a run finishing isn't a save. Without this the Runs tab would
+    // keep its dot until the user's next keystroke.
+    const checkCommitStatus = jest.fn();
+    const store = makeStore(createRunSlice, {
+      project: { id: 'draft-1' },
+      checkCommitStatus,
+    });
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r1', state: 'succeeded' }]);
+    await store.get().pollRuns(); // first poll adopts the baseline
+    expect(checkCommitStatus).not.toHaveBeenCalled();
+
+    branchingApi.fetchRuns.mockResolvedValueOnce([{ id: 'r2', state: 'succeeded' }]);
+    await store.get().pollRuns();
+    expect(checkCommitStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runStore triggerRun', () => {
+  const build = () => makeStore(createRunSlice, { project: { id: 'draft-1' }, runs: [] });
+
+  test('builds the staged set when given no filter', async () => {
+    branchingApi.triggerRun.mockResolvedValue({
+      status: 201,
+      body: { id: 'r1', state: 'queued' },
+    });
+    const store = build();
+    const result = await store.get().triggerRun();
+    expect(branchingApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: undefined });
+    expect(result.success).toBe(true);
+  });
+
+  test('adopts the new run at once so the tab spinner starts on click', async () => {
+    branchingApi.triggerRun.mockResolvedValue({
+      status: 201,
+      body: { id: 'r1', state: 'queued' },
+    });
+    const store = build();
+    await store.get().triggerRun();
+    expect(store.get().latestRun).toEqual({ id: 'r1', state: 'queued' });
+    expect(store.get().runs[0].id).toBe('r1');
+  });
+
+  test('passes an explicit empty filter through as a deliberate full rebuild', async () => {
+    branchingApi.triggerRun.mockResolvedValue({ status: 201, body: { id: 'r1' } });
+    const store = build();
+    await store.get().triggerRun({ dagFilter: '' });
+    expect(branchingApi.triggerRun).toHaveBeenCalledWith('draft-1', { dagFilter: '' });
+  });
+
+  test('a 409 is reported, not thrown', async () => {
+    branchingApi.triggerRun.mockResolvedValue({
+      status: 409,
+      body: { action: 'run_in_progress' },
+    });
+    branchingApi.fetchRuns.mockResolvedValue([]);
+    const store = build();
+    const result = await store.get().triggerRun();
+    expect(result).toMatchObject({ success: false, action: 'run_in_progress' });
+  });
+});

--- a/visivo/commands/serve_phase.py
+++ b/visivo/commands/serve_phase.py
@@ -94,6 +94,15 @@ def serve_phase(
                 no_deprecation_warnings=no_deprecation_warnings,
             )
             app.project = runner.project
+            # The watcher path always rebuilds, whatever the run-trigger
+            # preference says — it's the core `visivo serve` contract for editing
+            # YAML in a text editor, and it swaps app.project besides. The
+            # preference gates the EDITOR's save path only. Since this run did
+            # build the changed slice, drop those items from the staged set so
+            # the Runs tab doesn't keep asking for work that's already done.
+            from visivo.server.jobs.save_run_executor import mark_staged_built
+
+            mark_staged_built(app, changed_dag_filter)
             emit_project_changed(drafts_dropped)
             if one_shot:
                 Logger.instance().success("Closing server...")

--- a/visivo/server/flask_app.py
+++ b/visivo/server/flask_app.py
@@ -19,6 +19,7 @@ from visivo.server.managers.table_manager import TableManager
 from visivo.server.managers.dashboard_manager import DashboardManager
 from visivo.server.managers.project_manager import ProjectManager
 from visivo.server.managers.run_manager import RunManager
+from visivo.server.managers.staged_manager import StagedManager
 
 
 class FlaskApp:
@@ -38,6 +39,11 @@ class FlaskApp:
         # In-memory run registry for the run-on-save loop (mirrors the cloud Run
         # model so the viewer's run-poller / Runs view work locally).
         self.run_manager = RunManager()
+        # Which resources currently need a run — the local stand-in for the
+        # cloud's data_hash / last_built_data_hash columns. Populated on save
+        # whether or not a run fires, so a manual trigger has something to hold
+        # the change in and the Runs tab has something to list.
+        self.staged_manager = StagedManager()
 
         self.app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
 

--- a/visivo/server/jobs/save_run_executor.py
+++ b/visivo/server/jobs/save_run_executor.py
@@ -48,10 +48,20 @@ def _fire(flask_app):
         _pending_timer = None
     if not names:
         return
-    dag_filter = ",".join(f"+{name}+" for name in names)
+    run_now(flask_app, ",".join(f"+{name}+" for name in names))
+
+
+def run_now(flask_app, dag_filter):
+    """Start a run for ``dag_filter`` on a background thread and return it.
+
+    The single entry point for both triggers — the debounced run-on-save above
+    and the Run button (``POST /api/projects/<id>/run/``) — so a manual run
+    behaves identically to an automatic one.
+    """
     run = flask_app.run_manager.create(dag_filter)
     thread = threading.Thread(target=_execute, args=(flask_app, run.id, dag_filter), daemon=True)
     thread.start()
+    return run
 
 
 def _execute(flask_app, run_id, dag_filter):
@@ -82,6 +92,10 @@ def _execute(flask_app, run_id, dag_filter):
         if runner.failed_job_results:
             run_manager.set_state(run_id, RunState.FAILED, logs=logs, error_json={"phase": "run"})
         else:
+            # Record what this run built, so the staged list drops exactly the
+            # items it covered. A failure deliberately leaves them staged — the
+            # change still needs a run.
+            mark_staged_built(flask_app, dag_filter)
             run_manager.set_state(run_id, RunState.SUCCEEDED, logs=logs)
     except Exception as exc:  # compile/validation/etc. — surface as a failed run
         Logger.instance().error(f"save-run {run_id} failed: {exc}")
@@ -91,6 +105,20 @@ def _execute(flask_app, run_id, dag_filter):
             logs=str(exc),
             error_json={"phase": "run", "error": str(exc)},
         )
+
+
+def mark_staged_built(flask_app, dag_filter):
+    """Un-stage what a successful run just built.
+
+    An empty ``dag_filter`` is a full rebuild, so everything staged is now built.
+    Otherwise take the names back out of the ``+name+`` selector — the same set
+    the filter was built from.
+    """
+    staged_manager = getattr(flask_app, "staged_manager", None)
+    if staged_manager is None:
+        return
+    names = None if not dag_filter else {part.strip("+") for part in dag_filter.split(",")}
+    staged_manager.mark_built(names)
 
 
 def _format_logs(runner):

--- a/visivo/server/managers/staged_manager.py
+++ b/visivo/server/managers/staged_manager.py
@@ -1,0 +1,108 @@
+"""StagedManager — which resources currently need a run, for local serve.
+
+The cloud answers this from two columns on every resource row (``data_hash`` vs
+``last_built_data_hash``). Local serve has no such storage: ``run_on_save``
+fingerprints a resource before and after each write, notices the difference, and
+fires — recording nothing. That was enough while every data edit ran
+immediately, but a manual trigger needs somewhere to *hold* the change until the
+user presses Run, and the Run view needs to list it.
+
+So this keeps two maps, mirroring the cloud's two columns:
+
+* ``current`` — the resource's data fingerprint as of its last save.
+* ``built``   — the fingerprint the last successful run actually built.
+
+A resource is staged when those differ, which gives the same revert behavior the
+cloud gets for free: edit a model and change it back, and the fingerprint returns
+to the built value, so it un-stages instead of leaving the Runs tab lit forever.
+"""
+
+import threading
+
+
+class StagedManager:
+    """Thread-safe registry of un-run changes (one per Flask process)."""
+
+    _instance = None
+    _instance_lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._init()
+        return cls._instance
+
+    def _init(self):
+        self._current = {}  # (type, name) -> fingerprint as last saved
+        self._built = {}  # (type, name) -> fingerprint last successfully built
+        self._status = {}  # (type, name) -> "new" | "modified" | "deleted"
+        self._lock = threading.Lock()
+
+    @classmethod
+    def instance(cls):
+        return cls()
+
+    def record(self, type_name, name, fingerprint, status="modified"):
+        """Note a resource's current data fingerprint after a save or delete."""
+        key = (type_name, name)
+        with self._lock:
+            self._current[key] = fingerprint
+            self._status[key] = status
+
+    def mark_built(self, names=None):
+        """Record that a run built these resources (all of them if ``names`` is
+        None, which is what a full rebuild does).
+
+        A deleted resource drops out entirely once built — there is no row left
+        to be dirty.
+        """
+        with self._lock:
+            keys = [key for key in self._current if names is None or key[1] in names]
+            for key in keys:
+                if self._status.get(key) == "deleted":
+                    self._current.pop(key, None)
+                    self._built.pop(key, None)
+                    self._status.pop(key, None)
+                else:
+                    self._built[key] = self._current[key]
+
+    def list(self):
+        """The staged set as ``[{name, type, status}]``, sorted for a stable UI.
+
+        Matches the cloud's ``unbuilt_changes`` shape exactly so the viewer needs
+        no branch.
+        """
+        with self._lock:
+            staged = [
+                {
+                    "name": name,
+                    "type": type_name,
+                    "status": self._status.get((type_name, name), "modified"),
+                }
+                for (type_name, name), fingerprint in self._current.items()
+                if self._built.get((type_name, name)) != fingerprint
+            ]
+        return sorted(staged, key=lambda item: (item["type"], item["name"]))
+
+    def dag_filter(self):
+        """The visivo selector covering the staged set — the same rules the
+        cloud's ``run_dag_filter`` uses, so the list and the run agree.
+
+        Empty (a full rebuild) when a data resource was deleted (its node is gone
+        and its consumers must recompute) or when nothing is staged (an explicit
+        run with no delta means "rebuild everything").
+        """
+        staged = self.list()
+        if not staged:
+            return ""
+        if any(item["status"] == "deleted" for item in staged):
+            return ""
+        return ",".join(f"+{name}+" for name in sorted({item["name"] for item in staged}))
+
+    def clear(self):
+        with self._lock:
+            self._current.clear()
+            self._built.clear()
+            self._status.clear()

--- a/visivo/server/user_config.py
+++ b/visivo/server/user_config.py
@@ -1,0 +1,87 @@
+"""Read/write the per-user config at ``~/.visivo/config.yml``.
+
+That file already held ``telemetry_enabled`` (read by ``visivo.telemetry.config``)
+but nothing ever wrote it — users hand-edited it. Now that ``run_trigger`` is
+settable from the editor we need a writer, and a writer has to be careful: this
+is a file people edit themselves, so it round-trips through ruamel in ``rt`` mode
+to preserve their comments, key order, and any keys we don't know about.
+
+Reads never raise. A missing directory, a missing file, or YAML someone broke
+mid-edit all fall back to defaults — a preference lookup must never be the thing
+that stops ``visivo serve`` from starting.
+"""
+
+import os
+from pathlib import Path
+
+import ruamel.yaml
+
+from visivo.logger.logger import Logger
+
+# Local serve runs on your own machine, where a run is a sub-second in-process
+# rebuild — so edits rebuilding as you type is the behavior that fits. (Cloud
+# defaults to "manual": there a run claims a sandboxed pod.) The viewer takes
+# whichever value the server reports, which is how it stays free of any
+# local-vs-cloud branching.
+AUTOMATIC = "automatic"
+MANUAL = "manual"
+RUN_TRIGGERS = (AUTOMATIC, MANUAL)
+DEFAULT_RUN_TRIGGER = AUTOMATIC
+
+
+def user_config_path():
+    """``~/.visivo/config.yml`` — one definition, shared with telemetry."""
+    return Path.home() / ".visivo" / "config.yml"
+
+
+def _yaml():
+    yaml = ruamel.yaml.YAML(typ="rt")
+    yaml.preserve_quotes = True
+    return yaml
+
+
+def read_user_config():
+    """The parsed config, or ``{}`` when it's absent or unreadable."""
+    path = user_config_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r") as file:
+            return _yaml().load(file) or {}
+    except Exception as e:
+        Logger.instance().error(f"Could not read {path}: {e}")
+        return {}
+
+
+def write_user_config(**values):
+    """Merge ``values`` into the config, preserving everything already there.
+
+    Returns True on success. A failure is logged and reported rather than raised:
+    the caller is an API request whose job is to record a preference, and an
+    unwritable home directory shouldn't 500 the editor.
+    """
+    path = user_config_path()
+    config = read_user_config()
+    config.update(values)
+    try:
+        os.makedirs(path.parent, exist_ok=True)
+        with open(path, "w") as file:
+            _yaml().dump(config, file)
+        return True
+    except Exception as e:
+        Logger.instance().error(f"Could not write {path}: {e}")
+        return False
+
+
+def get_run_trigger():
+    """``"automatic"`` or ``"manual"`` — whether saving a resource should launch
+    a run, or stage the change and wait for the Run button."""
+    value = read_user_config().get("run_trigger")
+    return value if value in RUN_TRIGGERS else DEFAULT_RUN_TRIGGER
+
+
+def set_run_trigger(value):
+    """Persist the run trigger. Returns True if it was valid and written."""
+    if value not in RUN_TRIGGERS:
+        return False
+    return write_user_config(run_trigger=value)

--- a/visivo/server/views/__init__.py
+++ b/visivo/server/views/__init__.py
@@ -27,6 +27,7 @@ from visivo.server.views.explorer_views import register_explorer_views
 from visivo.server.views.expression_views import register_expression_views
 from visivo.server.views.model_data_views import register_model_data_views
 from visivo.server.views.run_views import register_run_views
+from visivo.server.views.preferences_views import register_preferences_views
 from visivo.server.views.model_schema_jobs_views import register_model_schema_jobs_views
 
 
@@ -61,4 +62,5 @@ def register_views(app, flask_app, output_dir):
     register_expression_views(app, flask_app, output_dir)
     register_model_data_views(app, flask_app, output_dir)
     register_run_views(app, flask_app, output_dir)
+    register_preferences_views(app, flask_app, output_dir)
     register_model_schema_jobs_views(app, flask_app, output_dir)

--- a/visivo/server/views/commit_views.py
+++ b/visivo/server/views/commit_views.py
@@ -2,6 +2,7 @@ from flask import jsonify
 from visivo.logger.logger import Logger
 from visivo.server.managers.object_manager import ObjectStatus
 from visivo.server.project_writer import ProjectWriter
+from visivo.server.user_config import get_run_trigger
 
 
 def register_commit_views(app, flask_app, output_dir):
@@ -228,11 +229,21 @@ def register_commit_views(app, flask_app, output_dir):
                             to_publish.append(entry)
             if flask_app._cached_defaults is not None:
                 to_publish.append({"name": "defaults", "type": "defaults", "status": "modified"})
+            # `staged` is a different question from `to_publish`: what a RUN
+            # would build, not what a COMMIT would publish. A chart colour edit
+            # is in the second and not the first. They share this endpoint
+            # because the editor already calls it after every resource write, so
+            # the Run view's list and the tab dot update on save rather than on
+            # the next poll — and because adding keys to an object response
+            # can't break a viewer older than the server.
             return jsonify(
                 {
                     "to_publish": to_publish,
                     "to_remove": to_remove,
                     "has_changes": bool(to_publish or to_remove),
+                    "staged": flask_app.staged_manager.list(),
+                    "staged_dag_filter": flask_app.staged_manager.dag_filter(),
+                    "run_trigger": get_run_trigger(),
                 }
             )
         except Exception as e:

--- a/visivo/server/views/preferences_views.py
+++ b/visivo/server/views/preferences_views.py
@@ -1,0 +1,37 @@
+"""User preferences — the local half of ``GET``/``PUT /api/me/preferences/``.
+
+Cloud stores these on the User row; local serve stores them in
+``~/.visivo/config.yml``, beside ``telemetry_enabled``. Same endpoint, same
+response shape, different defaults — which is exactly how the shared viewer
+avoids ever asking "am I running against Flask or Django?". It renders whichever
+mode the server reports.
+"""
+
+from flask import jsonify, request
+
+from visivo.logger.logger import Logger
+from visivo.server.user_config import RUN_TRIGGERS, get_run_trigger, set_run_trigger
+
+
+def register_preferences_views(app, flask_app, output_dir):
+    @app.route("/api/me/preferences/", methods=["GET"])
+    def get_preferences():
+        return jsonify({"run_trigger": get_run_trigger()})
+
+    @app.route("/api/me/preferences/", methods=["PUT"])
+    def put_preferences():
+        body = request.get_json(silent=True) or {}
+        value = body.get("run_trigger")
+        if value is not None:
+            if value not in RUN_TRIGGERS:
+                return (
+                    jsonify({"run_trigger": [f"Must be one of {', '.join(RUN_TRIGGERS)}."]}),
+                    400,
+                )
+            if not set_run_trigger(value):
+                # An unwritable home directory shouldn't 500 the editor, but it
+                # must not silently report success either — the setting would
+                # revert on restart with no explanation.
+                Logger.instance().error("Could not persist run_trigger preference")
+                return jsonify({"error": "Could not write ~/.visivo/config.yml"}), 500
+        return jsonify({"run_trigger": get_run_trigger()})

--- a/visivo/server/views/run_views.py
+++ b/visivo/server/views/run_views.py
@@ -29,7 +29,8 @@ from flask import g, jsonify, request
 
 from visivo.logger.logger import Logger
 from visivo.server.hash.data_fingerprint import data_fingerprint
-from visivo.server.jobs.save_run_executor import request_run
+from visivo.server.jobs.save_run_executor import request_run, run_now
+from visivo.server.user_config import AUTOMATIC, get_run_trigger
 
 # URL segment -> (manager attr, fingerprint mode, data_producing). Public so the
 # resource→data-mode mapping is easy to find. Mirrors core's per-type DATA_MODE /
@@ -54,6 +55,11 @@ RESOURCE_META = {
     "markdowns": ("markdown_manager", "query", False),
     "dashboards": ("dashboard_manager", "query", False),
 }
+
+# URL segment -> the type name the viewer renders (and the one core's
+# ``unbuilt_changes`` emits). Every segment is the plural of its type, so this is
+# derived rather than a second list to keep in sync.
+RESOURCE_TYPE_NAMES = {segment: segment[:-1] for segment in RESOURCE_META}
 
 # Detail routes (``/api/<segment>/<name>/``) for the mapped resources — derived
 # from RESOURCE_META so the two can't drift. Longest-first alternation so a
@@ -111,22 +117,65 @@ def register_run_views(app, flask_app, output_dir):
                 resource = _resource_from_path(request.path)
                 if resource:
                     segment, name = resource
-                    after = _resource_fingerprint(
-                        flask_app, segment, name, deleted=(request.method == "DELETE")
-                    )
+                    deleted = request.method == "DELETE"
+                    after = _resource_fingerprint(flask_app, segment, name, deleted=deleted)
                     if after != getattr(g, "_presave_data_fingerprint", None):
-                        request_run(flask_app, [name])
+                        # Stage the change either way: the staged set is what the
+                        # Run view lists and what the Run button builds, so it has
+                        # to be recorded whether or not a run fires now.
+                        flask_app.staged_manager.record(
+                            RESOURCE_TYPE_NAMES[segment],
+                            name,
+                            after,
+                            status="deleted" if deleted else "modified",
+                        )
+                        if get_run_trigger() == AUTOMATIC:
+                            request_run(flask_app, [name])
         except Exception as e:  # never let the hook break a save response
             Logger.instance().error(f"run-on-save hook error: {str(e)}")
         return response
 
     @app.route("/api/projects/<project_id>/run/", methods=["GET"])
     def list_runs(project_id):
-        """Newest-first runs, in the cloud ``RunSerializer`` shape."""
+        """Newest-first runs, in the cloud ``RunSerializer`` shape.
+
+        Deliberately still a bare array, matching cloud: the staged set rides on
+        ``/api/projects/<id>/changes/`` instead. Changing this response shape
+        would break any viewer older than the server, and the viewer ships on its
+        own schedule at both ends (a vendored release tag in cloud, whenever the
+        user upgrades locally).
+        """
         try:
             return jsonify(flask_app.run_manager.list())
         except Exception as e:
             Logger.instance().error(f"Error listing runs: {str(e)}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/projects/<project_id>/run/", methods=["POST"])
+    def trigger_run(project_id):
+        """The Run button. Mirrors the cloud contract, including the distinction
+        between an absent ``dag_filter`` (build what's staged) and an explicit
+        empty one (rebuild everything — the Run-all escape hatch, and the only
+        recovery when outputs are missing but the fingerprints say built)."""
+        try:
+            active = [
+                run for run in flask_app.run_manager.list() if run["state"] in ("queued", "running")
+            ]
+            if active:
+                return (
+                    jsonify({"action": "run_in_progress", "run": active[0]}),
+                    409,
+                )
+
+            body = request.get_json(silent=True) or {}
+            if "dag_filter" in body:
+                dag_filter = body.get("dag_filter") or ""
+            else:
+                dag_filter = flask_app.staged_manager.dag_filter()
+            run = run_now(flask_app, dag_filter)
+            return jsonify(run.to_dict()), 201
+        except Exception as e:
+            Logger.instance().error(f"Error triggering run: {str(e)}")
             return jsonify({"error": str(e)}), 500
 
     @app.route("/api/runs/<run_id>/logs/", methods=["GET"])

--- a/visivo/telemetry/config.py
+++ b/visivo/telemetry/config.py
@@ -28,17 +28,13 @@ def _check_env_disabled() -> bool:
 
 def _check_global_config_disabled() -> bool:
     """Check if telemetry is disabled in global config file."""
-    config_path = Path.home() / ".visivo" / "config.yml"
-    if not config_path.exists():
-        return False
+    # Same file as every other user-level preference — read through the shared
+    # helper so the path and the "unreadable means defaults" handling have one
+    # definition. Imported here rather than at module scope: telemetry loads
+    # very early, and server.user_config pulls in the logger.
+    from visivo.server.user_config import read_user_config
 
-    try:
-        with open(config_path, "r") as f:
-            config = yaml.safe_load(f) or {}
-            return config.get("telemetry_enabled", True) is False
-    except Exception:
-        # If we can't read the config, assume telemetry is enabled
-        return False
+    return read_user_config().get("telemetry_enabled", True) is False
 
 
 def is_telemetry_enabled(project_defaults: Optional[object] = None) -> bool:


### PR DESCRIPTION
Two related changes to how runs are controlled: you can **cancel** one that's in flight, and you can choose whether runs fire **on save or on a button**.

---

# 1. Choosing when a run happens

Today a run is a side effect of typing. Every data-affecting save schedules one — debounced, but never asked for. Locally that's fine, since a run is a sub-second in-process rebuild. In cloud it isn't: a run claims a sandboxed pod. And in neither case can you answer *"what would a run build right now?"* — the information exists, but only ever as a boolean.

So: a per-user setting, **Automatic** or **Manual**. Local defaults to automatic, cloud to manual. In both modes the Run view lists the changes waiting to run, the Runs tab carries a dot when that list is non-empty, and a Run button builds exactly what's listed.

### The staged set is what a run would build — not what a commit would publish

These are different questions and the UI now treats them as such. A chart colour or a dashboard layout tweak is uncommitted but needs no run, so it appears in the commit panel and *not* in the staged list. Listing it beside a Run button would promise work that button doesn't do.

The scope of the run is derived from the same set that's displayed, so **the list and the run cannot disagree** — locally the staged registry produces both the list and the `dag_filter`; in cloud `run_dag_filter` is derived from `unbuilt_changes`.

### Where the mode lives

Each server answers for itself, so the viewer needs no local-vs-cloud branch — the doctrine `stores/branchingStore.js` already states:

> There is NO local-vs-cloud branching here — behavior is driven entirely by what the endpoints return.

| | stores it in | default |
|---|---|---|
| local | `~/.visivo/config.yml` | automatic |
| cloud | `User.run_trigger` | manual |

Both expose `GET`/`PUT /api/me/preferences/`.

`~/.visivo/config.yml` already held `telemetry_enabled` but **nothing had ever written it** — users hand-edited it. So the writer round-trips through ruamel in `rt` mode: comments, key order, and unrecognised keys all survive. Reads never raise; a missing, unreadable, or half-edited file falls back to defaults rather than stopping `visivo serve`. Telemetry now reads through the same helper, so the two settings can't disagree about where the file is or how a broken one behaves.

### Tracking un-run changes locally

Cloud answers "does this need a run?" from two columns per resource (`data_hash` vs `last_built_data_hash`). Local serve had no equivalent — `run_on_save` fingerprinted a resource before and after each write, noticed a difference, and fired, recording nothing. That was enough while every data edit ran immediately; a manual trigger needs somewhere to *hold* the change.

`StagedManager` mirrors those two columns with a `current` and a `built` map. Keeping both is what gives local the same revert behaviour cloud gets for free: **edit a model and change it back, and it un-stages** rather than leaving the Runs tab lit forever.

### Two local boundaries, stated so nobody "fixes" them later

- **Manual gates the editor's save path only.** The file watcher (`serve_phase.on_project_change`) and the commit-triggered rebuild stay automatic. The watcher also swaps `app.project`, the whole serve loop depends on it, and a CLI-first user editing YAML in an editor expects it to rebuild. Those runs clear the staged set so state stays consistent.
- **There is no local commit gate and there must not be one.** "Commit blocked until you run" is cloud-only. Locally, commit means "write YAML".

### Changes

| file | |
|---|---|
| `visivo/server/user_config.py` | new — read/write `~/.visivo/config.yml`, ruamel round-trip |
| `visivo/server/managers/staged_manager.py` | new — the un-run set, `current` + `built` |
| `visivo/server/views/preferences_views.py` | new — `GET`/`PUT /api/me/preferences/` |
| `visivo/server/views/run_views.py` | always stage; fire only when automatic. New `POST /api/projects/<id>/run/` |
| `visivo/server/views/commit_views.py` | `/changes/` also returns `staged`, `staged_dag_filter`, `run_trigger` |
| `visivo/server/jobs/save_run_executor.py` | `run_now()` shared by the debounce and the button; unstage on success |
| `visivo/commands/serve_phase.py` | clear staged after a watcher rebuild |
| `visivo/telemetry/config.py` | read the user config through the shared helper |
| `viewer/.../RunsView.jsx` | staged panel: the list, the Run button, the mode toggle |
| `viewer/.../RunsToolIcon.jsx` | amber dot when changes are waiting |
| `viewer/.../commitStore.js` | staged state, `runTrigger`, `setRunTrigger`, `commitAction` |
| `viewer/.../runStore.js` | `triggerRun`; refresh staged when a run succeeds |
| `viewer/.../CommitModal.jsx` | a `run_required` refusal now names the Runs tab |

### Two details worth reviewing

**The Run button is never disabled for an empty staged set** — it becomes **"Run all"**. Sending an explicit empty `dag_filter` means "rebuild everything", and it's the only way back when outputs are missing or corrupt but the fingerprints claim they're built. Absent and empty are deliberately different requests; don't collapse them.

**`staged` rides on `/changes/`, not on the run endpoint.** That endpoint returns an object, so new keys are invisible to an older client — and the viewer ships on its own schedule at both ends (cloud vendors it at a lagging release tag; local upgrades when the user does). Changing the run endpoint from array to object would silently kill the run indicator on any viewer older than the server. `/changes/` is also already called after every resource write, so the staged list and the tab dot update **on save, with no new request and no polling latency**.

---

# 2. Cancelling a run

A run that wedges leaves the editor spinning and the commit gate shut, with no way out short of editing the database — which is what we had to do by hand for a run stuck mid-build. This gives its owner a button.

- Rendered only for **queued and running** runs. Cancelling a finished one is meaningless and the endpoint 409s on it. Queued matters as much as running — that's the state users actually get stuck in.
- What the button promises is the **state change**: the run goes `canceled`, the spinner stops, the commit gate reopens.
- Stopping the compute is best-effort server-side (a Kubernetes Job is deleted; a warm-pool run finishes in the background with its results discarded). Hence "Cancel run" rather than anything implying a kill.
- A 409 is deliberately **not** an error — it only means the run terminated between render and click, and the refetch shows that.

| file | |
|---|---|
| `viewer/.../RunsView.jsx` | `CancelRunButton`, shown in `RunDetail` while the run is active |
| `viewer/.../api/branching.js` | `cancelRun` — returns `{status, body}` rather than throwing |
| `viewer/.../config/urls.js` | `runCancel` route |

**Not implemented locally.** `FilteredRunner` runs on a daemon thread with no cancellation primitive, and faking it would be worse than its absence — so `POST /api/runs/<id>/cancel/` is cloud-only for now, and the button will fail under `visivo serve`. Worth hiding it when the endpoint isn't available; called out rather than quietly left.

---

## Dependencies

Needs the matching core work — `POST /api/runs/<id>/cancel/`, `User.run_trigger` + `/api/me/preferences/`, and `unbuilt_changes` on `/changes/`. **Merge and deploy core first**, or the button and the toggle call endpoints that don't exist. Core then picks the viewer up via `yarn copy`.

Note the cloud default is manual, so after that deploy an edit stages instead of running until someone presses Run. The staged list and the tab dot are what make that legible — ship the API and the UI together rather than in separate deploys.

## Testing

- `poetry run pytest tests/` — 2064 pass. New: `tests/server/test_user_config.py` (defaults, round-trip, comments and unknown keys preserved, corrupt YAML falls back). Extended `tests/server/test_run_views.py` with trigger-mode, staged-set, run-endpoint and preferences coverage.
- `yarn test` — 5181 pass across 314 suites. New coverage for the staged panel, the tab dot, `triggerRun`, and the store hydration — including the case where the **server is older than the viewer and sends no staged keys**.
- `yarn lint` clean; `black --check visivo/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
