### PR TITLE
Let the host set where the viewer is mounted

### DIFF
--- a/viewer/src/components/explorer/ExplorerOverlay.jsx
+++ b/viewer/src/components/explorer/ExplorerOverlay.jsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { PiX, PiArrowsClockwise } from 'react-icons/pi';
 import useStore from '../../stores/store';
 import { getTypeColors } from '../views/common/objectTypeConfigs';
 import { emitWorkspaceEvent } from '../views/workspace/telemetry';
 import { ExplorerRoundTripProvider } from './ExplorerRoundTripContext';
 import ExplorerPage from './ExplorerPage';
+import { useViewerNavigate } from '../../hooks/useViewerNavigate';
 
 /**
  * ExplorerOverlay — VIS-778 / J-2.
@@ -33,7 +34,7 @@ const slotLabel = slot => {
 };
 
 const ExplorerOverlay = () => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const { dashboardName } = useParams();
   const [searchParams] = useSearchParams();
   const slot = searchParams.get('slot') || 'new';

--- a/viewer/src/components/explorer/ExplorerReturnChip.jsx
+++ b/viewer/src/components/explorer/ExplorerReturnChip.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PiArrowLeft } from 'react-icons/pi';
 import { getTypeColors } from '../views/common/objectTypeConfigs';
+import { useViewerNavigate } from '../../hooks/useViewerNavigate';
 
 /**
  * ExplorerReturnChip — VIS-782 / J-3.
@@ -17,7 +18,7 @@ import { getTypeColors } from '../views/common/objectTypeConfigs';
  * is untouched in the default case.
  */
 const ExplorerReturnChip = () => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const [searchParams] = useSearchParams();
 
   const returnTo = searchParams.get('return_to');

--- a/viewer/src/components/explorer/ExplorerSaveModal.jsx
+++ b/viewer/src/components/explorer/ExplorerSaveModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useStore from '../../stores/store';
 import EmbeddedPill from '../views/lineage/EmbeddedPill';
 import Select from '../common/Select';
+import { useViewerNavigate } from '../../hooks/useViewerNavigate';
 
 /**
  * Session-scoped key for remembering the last-used "After save" choice (J-1 /
@@ -66,7 +66,7 @@ const buildSlotOptions = dashboardConfig => {
  * - onClose: (function) called when the modal should close (cancel or successful save)
  */
 const ExplorerSaveModal = ({ onClose }) => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const diffResult = useStore((s) => s.explorerDiffResult);
   const modelStates = useStore((s) => s.explorerModelStates);
   const insightStates = useStore((s) => s.explorerInsightStates);

--- a/viewer/src/components/onboarding/OnboardingFlow.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import './onboarding.css';
 import { CONCEPTS } from './concepts';
@@ -14,6 +13,7 @@ import { readOnboardingState, writeOnboardingState } from './onboardingState';
 import SourceEditForm from '../views/common/SourceEditForm';
 import useStore from '../../stores/store';
 import logo from '../../images/logo.png';
+import { useViewerNavigate } from '../../hooks/useViewerNavigate';
 
 function buildSteps() {
   return [
@@ -27,7 +27,7 @@ function buildSteps() {
 }
 
 export default function OnboardingFlow() {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const project = useStore(s => s.project);
   const fetchProject = useStore(s => s.fetchProject);
 

--- a/viewer/src/components/project/ProjectViewFlipLayer.jsx
+++ b/viewer/src/components/project/ProjectViewFlipLayer.jsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PiArrowsClockwise, PiLink } from 'react-icons/pi';
-import { useNavigate } from 'react-router-dom';
 import { parseRefValue } from '../../utils/refString';
 import { parseCanvasPath } from '../views/project/canvas/canvasReorder';
 import ItemFlipCard from './ItemFlipCard';
 import ItemActionMenu from './ItemActionMenu';
 import copyItemLink from './copyItemLink';
 import { emitWorkspaceEvent } from '../views/workspace/telemetry';
+import { useViewerNavigate } from '../../hooks/useViewerNavigate';
 
 /**
  * ProjectViewFlipLayer — VIS-788 / I-1 (View-mode flip gesture).
@@ -92,7 +92,7 @@ const itemAtKey = (config, key) => {
 };
 
 const ProjectViewFlipLayer = ({ rootRef, dashboardConfig }) => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const reducedMotion = prefersReducedMotion();
   const [hoverKey, setHoverKey] = useState(null);
   // The kebab lives in a sibling overlay, so reaching for it clears the slot

--- a/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useStore from '../../../../stores/store';
 import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
 import { buildTemplateRow, insertRowAtIndex } from './canvasReorder';
 import RowTemplateMenu from './RowTemplateMenu';
+import { useViewerNavigate } from '../../../../hooks/useViewerNavigate';
 
 /**
  * CanvasAddRow — VIS-794 / Track D D-7 + D-8.
@@ -64,7 +64,7 @@ const INLINE_CREATE_TYPES = [
 const CanvasAddRow = ({ rootRef, dashboardName }) => {
   const dashboards = useStore(s => s.dashboards);
   const commitCanvasConfig = useWorkspaceCommit();
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
 
   // openMenu: which trigger's menu is open. null | { kind: 'end' } |
   // { kind: 'between', index } | { kind: 'empty' }.

--- a/viewer/src/components/views/project/canvas/CanvasContextMenu.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasContextMenu.jsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useStore from '../../../../stores/store';
 import { parseRefValue } from '../../../../utils/refString';
 import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { useViewerNavigate } from '../../../../hooks/useViewerNavigate';
 import {
   wrapItemInContainer,
   unwrapTrivialContainer,
@@ -145,7 +145,7 @@ const MenuItem = ({ testid, label, hint, onClick, danger }) => (
 );
 
 const CanvasContextMenu = ({ rootRef, dashboardName }) => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const dashboards = useStore(s => s.dashboards);
   const setWorkspaceSelection = useStore(s => s.setWorkspaceSelection);
   // Selection routed through the unified action (VIS-994). No revealEdit:

--- a/viewer/src/components/views/project/canvas/CanvasItemFlipLayer.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasItemFlipLayer.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PiArrowsClockwise, PiLink } from 'react-icons/pi';
-import { useNavigate } from 'react-router-dom';
 import useStore from '../../../../stores/store';
 import { useWorkspaceDrag } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
@@ -9,6 +8,7 @@ import { parseCanvasPath } from './canvasReorder';
 import ItemFlipCard from '../../../project/ItemFlipCard';
 import ItemActionMenu from '../../../project/ItemActionMenu';
 import copyItemLink from '../../../project/copyItemLink';
+import { useViewerNavigate } from '../../../../hooks/useViewerNavigate';
 
 /**
  * CanvasItemFlipLayer — VIS-785 / Track D D-6 (flip-to-lineage).
@@ -103,7 +103,7 @@ const prefersReducedMotion = () =>
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const CanvasItemFlipLayer = ({ rootRef, dashboardName }) => {
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const dashboards = useStore(s => s.dashboards);
   const hoverKey = useStore(s => s.workspaceCanvasHoverKey);
   const selectedKey = useStore(s => s.workspaceOutlineSelectedKey);

--- a/viewer/src/components/views/workspace/RecordRunStatus.jsx
+++ b/viewer/src/components/views/workspace/RecordRunStatus.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { PiWarningCircle } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import { findLatestRunFailureFor } from '../../../stores/runFailures';
+import { viewerPath } from '../../../contexts/viewerBase';
 
 /**
  * RecordRunStatus — VIS-993 §2 (folds VIS-981's wiring).
@@ -49,7 +50,7 @@ const RecordRunStatus = ({ name, showRunsLink = false }) => {
       </div>
       {showRunsLink && (
         <Link
-          to="/runs"
+          to={viewerPath('/runs')}
           data-testid="record-run-status-view-runs"
           className="shrink-0 text-[11px] font-medium text-highlight underline transition-colors hover:text-highlight-600"
         >

--- a/viewer/src/components/views/workspace/Workspace.jsx
+++ b/viewer/src/components/views/workspace/Workspace.jsx
@@ -6,6 +6,7 @@ import { emitWorkspaceEvent, markBuildModeEntered } from './telemetry';
 import { useWorkspaceScope } from './useWorkspaceScope';
 import useProjectChangeListener from './useProjectChangeListener';
 import { workspaceTabFromUrl, WORKSPACE_BASE } from './workspaceUrl';
+import { getViewerBase } from '../../../contexts/viewerBase';
 
 /**
  * Workspace — route container for `/workspace` and
@@ -91,13 +92,15 @@ const Workspace = () => {
     fetchDashboards,
   ]);
 
-  // The mount prefix for this Workspace. Studio serves it at the root
-  // (`/workspace`); a host that mounts the viewer under a path prefix (the
-  // cloud app, at `/:account/:stage/:project/workspace`) needs its tab URLs to
-  // carry that prefix, or `navigate` escapes to the root and the route 404s.
-  // Derive it from the path up to and including the `workspace` segment so the
-  // same component works at either mount.
+  // The mount prefix for this Workspace's tab URLs. Prefer what the host told
+  // us (contexts/viewerBase) — it is correct before the first navigation and
+  // regardless of where we are. Fall back to deriving it from the path for a
+  // host that mounts the viewer under a prefix without setting the base; that
+  // was the only mechanism before, and it can only work once you are already on
+  // a `/workspace` URL.
   const workspaceUrlBase = useMemo(() => {
+    const base = getViewerBase();
+    if (base) return `${base}${WORKSPACE_BASE}`;
     const segments = location.pathname.split('/');
     const workspaceIndex = segments.indexOf('workspace');
     return workspaceIndex === -1

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { PiPlus, PiSidebar, PiHouse, PiMagnifyingGlass, PiTreeStructure } from 'react-icons/pi';
 import LibrarySearch from './LibrarySearch';
 import LibraryFilter from './LibraryFilter';
@@ -10,6 +9,7 @@ import { LAYOUT_TYPES, DATA_TYPES, getTypeDef } from './LibraryRow';
 import useStore from '../../../../stores/store';
 import { useWorkspaceScope } from '../useWorkspaceScope';
 import { emitWorkspaceEvent } from '../telemetry';
+import { useViewerNavigate } from '../../../../hooks/useViewerNavigate';
 
 /**
  * Library — VIS-769 / Track C C1 (+ C2 / C3).
@@ -56,7 +56,7 @@ const routeType = obj => obj.canonicalType || obj.type;
 
 const Library = () => {
   const data = useLibraryData();
-  const navigate = useNavigate();
+  const navigate = useViewerNavigate();
   const scope = useWorkspaceScope();
 
   // Workspace actions — read from the store directly so the Library has no

--- a/viewer/src/contexts/viewerBase.js
+++ b/viewer/src/contexts/viewerBase.js
@@ -1,0 +1,54 @@
+/**
+ * Where the viewer is mounted in the host's URL space.
+ *
+ * Visivo Studio serves the viewer at the router root — `/workspace`,
+ * `/explorer`, `/runs` — so its internal navigations are written root-absolute
+ * and the base is `''`. A host that mounts the viewer deeper (the cloud app, at
+ * `/:account/:stage/:project/…`) sets the base once and every navigation lands
+ * inside it.
+ *
+ * Before this existed, the cloud app let those root-absolute navigations escape
+ * and caught them at its router root with a redirect back into the project
+ * prefix. That worked, but it cost two navigations per click and unmounted the
+ * whole project subtree in between — which is what made a "Loading" placeholder
+ * flash on every sidebar click. Being *told* the base removes the round trip
+ * rather than repairing it after the fact.
+ *
+ * Module state, not a React context, deliberately: navigation happens from
+ * stores and callbacks that aren't inside the tree (the workspace tab loop
+ * already registers its navigate this way), and a context would only be
+ * reachable from components. Same shape as `setAuthHeaderProvider` in
+ * `api/utils.js` — the host installs it at boot.
+ */
+
+let viewerBase = '';
+
+/**
+ * Set the mount base, e.g. `/acme/production/analytics`. Pass `''` (or nothing)
+ * for a root mount. A trailing slash is trimmed so callers can pass either form.
+ */
+export const setViewerBase = base => {
+  if (typeof base !== 'string' || base === '/') {
+    viewerBase = '';
+    return;
+  }
+  viewerBase = base.replace(/\/+$/, '');
+};
+
+export const getViewerBase = () => viewerBase;
+
+/**
+ * Resolve a viewer path against the mount base.
+ *
+ * Only root-absolute paths are rebased — a relative path is already resolved
+ * against the current location by the router, and an absolute URL belongs to
+ * someone else. Passing an already-based path through is a no-op, so this is
+ * safe to apply twice (a call site that gets converted while its caller already
+ * rebased won't double up).
+ */
+export const viewerPath = path => {
+  if (typeof path !== 'string' || !path.startsWith('/')) return path;
+  if (!viewerBase) return path;
+  if (path === viewerBase || path.startsWith(`${viewerBase}/`)) return path;
+  return `${viewerBase}${path}`;
+};

--- a/viewer/src/contexts/viewerBase.test.js
+++ b/viewer/src/contexts/viewerBase.test.js
@@ -1,0 +1,63 @@
+import { setViewerBase, getViewerBase, viewerPath } from './viewerBase';
+
+afterEach(() => setViewerBase(''));
+
+describe('viewerBase', () => {
+  test('defaults to a root mount, so Studio is unaffected', () => {
+    expect(getViewerBase()).toBe('');
+    expect(viewerPath('/workspace')).toBe('/workspace');
+  });
+
+  test('rebases root-absolute viewer paths under the mount', () => {
+    setViewerBase('/acme/production/analytics');
+    expect(viewerPath('/workspace')).toBe('/acme/production/analytics/workspace');
+    expect(viewerPath('/explorer?create=model')).toBe(
+      '/acme/production/analytics/explorer?create=model'
+    );
+  });
+
+  test('is idempotent — an already-based path passes through', () => {
+    // Matters because call sites get converted piecemeal: one that rebases a
+    // value its caller already rebased must not double the prefix.
+    setViewerBase('/acme/production/analytics');
+    const once = viewerPath('/workspace');
+    expect(viewerPath(once)).toBe(once);
+  });
+
+  test('a path that merely starts with the same characters is still rebased', () => {
+    setViewerBase('/acme');
+    expect(viewerPath('/acmex/workspace')).toBe('/acme/acmex/workspace');
+  });
+
+  test('leaves relative paths alone — the router resolves those', () => {
+    setViewerBase('/acme/production/analytics');
+    expect(viewerPath('workspace')).toBe('workspace');
+    expect(viewerPath('../explorer')).toBe('../explorer');
+  });
+
+  test('leaves absolute URLs alone — they belong to someone else', () => {
+    setViewerBase('/acme/production/analytics');
+    expect(viewerPath('https://docs.visivo.io/')).toBe('https://docs.visivo.io/');
+  });
+
+  test('trims a trailing slash so either form of base works', () => {
+    setViewerBase('/acme/');
+    expect(viewerPath('/runs')).toBe('/acme/runs');
+  });
+
+  test('treats "/" as a root mount rather than doubling the slash', () => {
+    setViewerBase('/');
+    expect(viewerPath('/runs')).toBe('/runs');
+  });
+
+  test('a non-string base resets to root instead of corrupting every path', () => {
+    setViewerBase(undefined);
+    expect(viewerPath('/runs')).toBe('/runs');
+  });
+
+  test('passes non-string destinations through untouched', () => {
+    setViewerBase('/acme');
+    expect(viewerPath(-1)).toBe(-1);
+    expect(viewerPath(null)).toBe(null);
+  });
+});

--- a/viewer/src/hooks/useViewerNavigate.js
+++ b/viewer/src/hooks/useViewerNavigate.js
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { viewerPath } from '../contexts/viewerBase';
+
+/**
+ * `useNavigate`, with root-absolute paths resolved against the viewer's mount
+ * base (see contexts/viewerBase).
+ *
+ * Use this instead of `useNavigate` anywhere the destination is a viewer
+ * surface written root-absolute (`/workspace`, `/explorer`, …). At the root
+ * mount it is exactly `useNavigate`; under a prefix it keeps the navigation
+ * inside it, so the host doesn't have to catch and repair the escape.
+ *
+ * Everything `useNavigate` accepts still works: a delta (`navigate(-1)`), a
+ * relative path, or a location object — only a root-absolute string is rebased.
+ */
+export const useViewerNavigate = () => {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (...args) => {
+      const [to, ...rest] = args;
+      if (typeof to === 'number') return navigate(to);
+      const rebased =
+        to && typeof to === 'object' && typeof to.pathname === 'string'
+          ? { ...to, pathname: viewerPath(to.pathname) }
+          : viewerPath(to);
+      // Forward the arguments we were actually given. Always passing a second
+      // one would turn `navigate('/x')` into `navigate('/x', undefined)` — same
+      // behaviour at runtime, but it breaks every caller's test assertion and
+      // makes this a leaky drop-in rather than a transparent one.
+      return navigate(rebased, ...rest);
+    },
+    [navigate]
+  );
+};
+
+export default useViewerNavigate;

--- a/viewer/src/hooks/useViewerNavigate.test.js
+++ b/viewer/src/hooks/useViewerNavigate.test.js
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { useViewerNavigate } from './useViewerNavigate';
+import { setViewerBase } from '../contexts/viewerBase';
+
+// `mock`-prefixed: jest hoists the factory above this declaration.
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }));
+
+beforeEach(() => mockNavigate.mockClear());
+afterEach(() => setViewerBase(''));
+
+const run = () => renderHook(() => useViewerNavigate()).result.current;
+
+describe('useViewerNavigate', () => {
+  test('is plain useNavigate at a root mount', () => {
+    run()('/explorer');
+    expect(mockNavigate).toHaveBeenCalledWith('/explorer');
+  });
+
+  test('keeps a root-absolute viewer path inside the mount', () => {
+    // The whole point: without this the cloud app had to let the navigation
+    // escape to its router root and redirect it back, costing two navigations
+    // and a remount of the project subtree.
+    setViewerBase('/acme/production/analytics');
+    run()('/explorer');
+    expect(mockNavigate).toHaveBeenCalledWith('/acme/production/analytics/explorer');
+  });
+
+  test('forwards navigate options, and passes only the args it was given', () => {
+    setViewerBase('/acme');
+    run()('/workspace', { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith('/acme/workspace', { replace: true });
+  });
+
+  test('passes a history delta straight through', () => {
+    setViewerBase('/acme');
+    run()(-1);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  test('rebases the pathname of a location object, preserving the rest', () => {
+    setViewerBase('/acme');
+    run()({ pathname: '/workspace', search: '?view=lineage' });
+    expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/acme/workspace', search: '?view=lineage' });
+  });
+
+  test('leaves a relative path to the router', () => {
+    setViewerBase('/acme');
+    run()('dashboard/Sales');
+    expect(mockNavigate).toHaveBeenCalledWith('dashboard/Sales');
+  });
+});


### PR DESCRIPTION
Gives a host a way to say **where the viewer is mounted**, so the viewer's own navigations land there first time.

## The problem

Studio serves the viewer at the router root, so its internal navigations are written root-absolute — `navigate('/explorer')`, `navigate('/workspace/dashboard/…')`, `to="/runs"`, ten in total.

A host that mounts the viewer deeper had no way to say so. The cloud app mounts it at `/:account/:stage/:project/…`, so it caught those escaped paths at its own router root and redirected them back into the project prefix (`ViewerEscapeRedirect` + `projectPrefix.js`, remembering the prefix in `sessionStorage`).

That works, but every such click costs **two navigations**, and in between the URL is outside the project route — so the host unmounts the entire project subtree and remounts it. In core that is what makes a `<Loading>` placeholder flash on each sidebar click.

Repairing the escape after the fact is the wrong shape. Being told the base removes the round trip.

## What this adds

**`contexts/viewerBase`** — `setViewerBase` / `getViewerBase` / `viewerPath`.

**`hooks/useViewerNavigate`** — `useNavigate` with root-absolute paths resolved against the base.

Module state rather than a React context, matching `setAuthHeaderProvider` in `api/utils.js`: navigation also happens from stores and callbacks that aren't inside the tree — the workspace tab loop already registers its `navigate` this way — and a context would only be reachable from components.

**Studio is unchanged.** The default base is `''`, so `viewerPath` returns its argument and `useViewerNavigate` is `useNavigate`.

## Changed call sites

Nine components move from `useNavigate` to `useViewerNavigate`; `RecordRunStatus`'s `to="/runs"` becomes `to={viewerPath('/runs')}`.

`Workspace` already derived a mount base by slicing the path for a `workspace` segment. It now prefers the injected base and keeps that derivation as a fallback — the derivation can only work once you are *already* on a `/workspace` URL, which is precisely when it is least needed.

## Two details worth reviewing

**`viewerPath` is idempotent.** Call sites get converted piecemeal, so one that rebases a value its caller already rebased must not double the prefix. Covered by a test, along with the near-miss case (`/acmex` under base `/acme` is still rebased).

**`useViewerNavigate` forwards only the arguments it was given.** My first version always passed a second argument, turning `navigate('/x')` into `navigate('/x', undefined)`. Identical at runtime, but it broke eight callers' test assertions — a leaky drop-in rather than a transparent one. Worth knowing because it is the kind of thing that looks harmless in review.

## Testing

16 new tests across the two modules — rebasing, idempotency, relative and absolute paths left alone, history deltas, location objects, and the trailing-slash / non-string base cases.

Full suite: **316 suites, 5170 tests, green**, with no existing test modified.

## Follow-up in core

Core sets the base in `ProjectLayout` and deletes `ViewerEscapeRedirect` + `projectPrefix.js` and the five escape routes. That change needs this vendored first, so **merge this before the core PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
