### PR TITLE
Extract DashboardExplorerRedirect out of LocalRouter

### DIFF
--- a/viewer/src/LocalRouter.jsx
+++ b/viewer/src/LocalRouter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { Navigate, Route, createBrowserRouter, createRoutesFromElements, useParams } from 'react-router-dom';
 import { futureFlags } from './router-config';
 import { loadProject } from './loaders/project';
@@ -9,9 +9,9 @@ import BreadcrumbLink from './components/common/BreadcrumbLink';
 import ErrorPage from './components/common/ErrorPage';
 import Onboarding from './components/onboarding/Onboarding';
 import Workspace from './components/views/workspace/Workspace';
+import { DashboardExplorerRedirect } from './components/views/workspace/DashboardExplorerRedirect';
 import RunsView from './components/RunsView';
 import { createURLConfig, setGlobalURLConfig } from './contexts/URLContext';
-import useStore from './stores/store';
 
 // VIS-772: /editor/<type>/<name> redirects into Workspace with the edit selector encoded
 // as a query param. Wrapping <Navigate /> so we can pull params out of the URL.
@@ -22,42 +22,11 @@ export const EditorTypeNameRedirect = () => {
   return <Navigate to={`/workspace?edit=${encodeURIComponent(`${type}:${name}`)}`} replace />;
 };
 
-/**
- * DashboardExplorerRedirect — Explore 2.0 Phase 3b cutover
- * (02-architecture.md §5, 01-ux-spec.md §5). The old `/workspace/dashboard/
- * :dashboardName/explorer` route composed `<Workspace/>` + `ExplorerOverlay`
- * (now deleted, along with the standalone `/explorer` route it round-tripped
- * to). Its replacement: mint a FRESH exploration carrying a `return_to`
- * placement intent (`{ dashboard: dashboardName }`) and redirect straight to
- * its own `/workspace/exploration/:id` path — the already-proven deep-link
- * mechanism (`exploration-lifecycle.spec.mjs`) sets `workspaceActiveView` and
- * opens its tab with no further plumbing needed here. Consuming the intent
- * ("Place in <dashboard>" after promote) is Phase 4/5 — this route's job is
- * only to persist it via the existing `return_to` field/`consumeReturnTo`
- * endpoint, both already live (07-exploration-api-contract.md).
- */
-export const DashboardExplorerRedirect = () => {
-  const { dashboardName } = useParams();
-  const createExploration = useStore(s => s.createExploration);
-  const [targetId, setTargetId] = useState(null);
-  const [failed, setFailed] = useState(false);
-  const startedRef = useRef(false);
-
-  useEffect(() => {
-    if (startedRef.current) return;
-    startedRef.current = true;
-    createExploration(null, { dashboard: dashboardName }).then(result => {
-      if (result?.success) setTargetId(result.id);
-      else setFailed(true);
-    });
-  }, [dashboardName, createExploration]);
-
-  if (targetId) return <Navigate to={`/workspace/exploration/${targetId}`} replace />;
-  // Fail open to Explorer Home rather than stranding the user on a blank
-  // route if minting the exploration itself failed (network/API error).
-  if (failed) return <Navigate to="/workspace/exploration" replace />;
-  return null;
-};
+// Re-exported from its own module so the cloud app can mount this route
+// without importing THIS one: the lines just below run at module scope, and
+// importing them from core would repoint its API config and build a second
+// router.
+export { DashboardExplorerRedirect };
 
 // Set global URL config early for router loaders
 export const localURLConfig = createURLConfig({ environment: 'server' });

--- a/viewer/src/components/views/workspace/DashboardExplorerRedirect.jsx
+++ b/viewer/src/components/views/workspace/DashboardExplorerRedirect.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import useStore from '../../../stores/store';
+
+/**
+ * DashboardExplorerRedirect — Explore 2.0 Phase 3b cutover
+ * (02-architecture.md §5, 01-ux-spec.md §5). The old `/workspace/dashboard/
+ * :dashboardName/explorer` route composed `<Workspace/>` + `ExplorerOverlay`
+ * (now deleted, along with the standalone `/explorer` route it round-tripped
+ * to). Its replacement: mint a FRESH exploration carrying a `return_to`
+ * placement intent (`{ dashboard: dashboardName }`) and redirect straight to
+ * its own `/workspace/exploration/:id` path — the already-proven deep-link
+ * mechanism (`exploration-lifecycle.spec.mjs`) sets `workspaceActiveView` and
+ * opens its tab with no further plumbing needed here. Consuming the intent
+ * ("Place in <dashboard>" after promote) is Phase 4/5 — this route's job is
+ * only to persist it via the existing `return_to` field/`consumeReturnTo`
+ * endpoint, both already live (07-exploration-api-contract.md).
+ *
+ * Lives in its own module, not in `LocalRouter.jsx`, because the cloud app
+ * (core) mounts this same route and must be able to import the component
+ * WITHOUT importing that router. `LocalRouter.jsx` calls `setGlobalURLConfig`
+ * and `createBrowserRouter` at module scope; importing it from core would
+ * silently repoint every API call at the local-serve config and build a second
+ * router. It is re-exported from `LocalRouter.jsx` for existing callers.
+ */
+export const DashboardExplorerRedirect = () => {
+  const { dashboardName } = useParams();
+  const createExploration = useStore(s => s.createExploration);
+  const [targetId, setTargetId] = useState(null);
+  const [failed, setFailed] = useState(false);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    createExploration(null, { dashboard: dashboardName }).then(result => {
+      if (result?.success) setTargetId(result.id);
+      else setFailed(true);
+    });
+  }, [dashboardName, createExploration]);
+
+  if (targetId) return <Navigate to={`/workspace/exploration/${targetId}`} replace />;
+  // Fail open to Explorer Home rather than stranding the user on a blank
+  // route if minting the exploration itself failed (network/API error).
+  if (failed) return <Navigate to="/workspace/exploration" replace />;
+  return null;
+};
+
+export default DashboardExplorerRedirect;


### PR DESCRIPTION
Small refactor, but it unblocks core's CI — see *Why now*.

## The problem

The cloud app (core) mounts `/workspace/dashboard/:name/explorer` too, and after Explore 2.0 that route is `DashboardExplorerRedirect`. It could only be imported from `LocalRouter.jsx` — which core cannot import:

```js
export const localURLConfig = createURLConfig({ environment: 'server' });
setGlobalURLConfig(localURLConfig);          // module scope
const LocalRouter = createBrowserRouter(...) // module scope
```

Importing it from core would silently repoint **every API call in the cloud app** at the local-serve URL config, and stand up a second browser router. The build succeeds either way — this only surfaces at runtime — which is exactly why it's worth extracting rather than leaving a comment telling the next person not to do it.

## The change

`DashboardExplorerRedirect` moves to its own module and is re-exported from `LocalRouter`, so existing callers are untouched. The hooks it was the sole user of (`useEffect`/`useRef`/`useState`/`useStore`) come out of `LocalRouter` with it.

`LocalRouter.test.jsx` passes **unmodified** — that's the check that the re-export preserved the contract, not an assurance.

## Why now

core#311 is red on `build-app`:

```
Could not resolve "./viewer/components/explorer/ExplorerOverlay" from "src/App.jsx"
```

Core vendors the viewer from visivo `main` at build time, so #527 deleting `ExplorerPage`/`ExplorerOverlay` broke it. Core's router now follows the same cutover — Explorer as a Workspace destination, `/explorer` as a redirect — and mounts this component for the dashboard round trip. It needs to exist on `main` for that build to pass.

Separated from visivo#546 deliberately: that PR is about async source ops, this is a standalone refactor, and core is blocked on only this half.

Lint clean; 14 `LocalRouter` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)