### PR TITLE
One request for a source's schema, and cover useSourceSchema

### DIFF
--- a/viewer/src/api/sourceSchemaJobs.js
+++ b/viewer/src/api/sourceSchemaJobs.js
@@ -290,3 +290,52 @@ export const fetchTableColumns = async (sourceName, tableName, { search = '', ru
 
   return response.json();
 };
+
+// ---------------------------------------------------------------------------
+// Deriving the sliced shapes from a whole envelope
+//
+// `fetchSourceSchema` returns the entire stored envelope, which already
+// contains everything the `/tables/` and `/tables/<t>/columns/` endpoints
+// return — those endpoints load the same record and throw most of it away.
+//
+// A caller that needs EVERY column (the ERD, SQL autocomplete) is therefore
+// strictly better off fetching once and slicing here: one request instead of
+// 1 + N. The tree browser still uses the endpoints, because it shows a few of
+// many tables and a wide warehouse envelope is ~840KB at 300 tables.
+//
+// These reproduce the server's shapes exactly, so a caller can be repointed
+// without changing how it reads the result.
+// ---------------------------------------------------------------------------
+
+/** `[{name, column_count, metadata}]`, matching `GET .../<name>/tables/`. */
+export const tablesFromEnvelope = (envelope, { search = '' } = {}) => {
+  const tables = (envelope || {}).tables || {};
+  const needle = (search || '').trim().toLowerCase();
+  return Object.entries(tables)
+    .filter(([name]) => !needle || name.toLowerCase().includes(needle))
+    .map(([name, table]) => ({
+      name,
+      column_count: Object.keys((table || {}).columns || {}).length,
+      metadata: (table || {}).metadata || {},
+    }))
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+};
+
+/**
+ * `[{name, type, nullable}]` for one table, matching
+ * `GET .../<name>/tables/<table>/columns/`. Unknown table -> `[]`, the same
+ * answer the endpoint gives.
+ */
+export const columnsFromEnvelope = (envelope, tableName, { search = '' } = {}) => {
+  const table = ((envelope || {}).tables || {})[tableName] || {};
+  const columns = table.columns || {};
+  const needle = (search || '').trim().toLowerCase();
+  return Object.entries(columns)
+    .filter(([name]) => !needle || name.toLowerCase().includes(needle))
+    .map(([name, meta]) => ({
+      name,
+      type: (meta || {}).type,
+      nullable: (meta || {}).nullable ?? true,
+    }))
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+};

--- a/viewer/src/api/sourceSchemaJobs.test.js
+++ b/viewer/src/api/sourceSchemaJobs.test.js
@@ -10,6 +10,8 @@ import {
   fetchOrGenerateSchema,
   fetchSourceTables,
   fetchTableColumns,
+  tablesFromEnvelope,
+  columnsFromEnvelope,
 } from './sourceSchemaJobs';
 import { apiFetch } from './utils';
 import { isAvailable } from '../contexts/URLContext';
@@ -185,5 +187,61 @@ describe('fetchTableColumns', () => {
     await expect(fetchTableColumns('src', 't1')).rejects.toThrow(
       /Loading columns for 'src\.t1' failed \(500\): bad table/
     );
+  });
+});
+
+// The envelope slicers. These have to reproduce the server's shapes exactly —
+// they exist so a caller that needs every column can fetch once and slice
+// locally instead of paying 1 + N requests, and that only works if the sliced
+// result is indistinguishable from what the endpoints return.
+describe('tablesFromEnvelope / columnsFromEnvelope', () => {
+  const envelope = {
+    tables: {
+      users: { columns: { id: { type: 'INTEGER', nullable: false } }, metadata: { rows: 9 } },
+      orders: {
+        columns: {
+          id: { type: 'INTEGER', nullable: false },
+          amount: { type: 'DOUBLE' },
+        },
+      },
+    },
+  };
+
+  it('matches the /tables/ shape: name, column_count, metadata', () => {
+    expect(tablesFromEnvelope(envelope)).toEqual([
+      { name: 'orders', column_count: 2, metadata: {} },
+      { name: 'users', column_count: 1, metadata: { rows: 9 } },
+    ]);
+  });
+
+  it('matches the /columns/ shape, defaulting nullable to true like the server', () => {
+    expect(columnsFromEnvelope(envelope, 'orders')).toEqual([
+      { name: 'amount', type: 'DOUBLE', nullable: true },
+      { name: 'id', type: 'INTEGER', nullable: false },
+    ]);
+  });
+
+  it('sorts by name, as the endpoints do', () => {
+    expect(tablesFromEnvelope(envelope).map(t => t.name)).toEqual(['orders', 'users']);
+    expect(columnsFromEnvelope(envelope, 'orders').map(c => c.name)).toEqual(['amount', 'id']);
+  });
+
+  it('filters on search, case-insensitively', () => {
+    expect(tablesFromEnvelope(envelope, { search: 'ORD' }).map(t => t.name)).toEqual(['orders']);
+    expect(
+      columnsFromEnvelope(envelope, 'orders', { search: 'amo' }).map(c => c.name)
+    ).toEqual(['amount']);
+  });
+
+  it('returns [] for an unknown table, the same answer the endpoint gives', () => {
+    expect(columnsFromEnvelope(envelope, 'nope')).toEqual([]);
+  });
+
+  it('survives a missing or malformed envelope rather than throwing', () => {
+    for (const bad of [null, undefined, {}, { tables: null }]) {
+      expect(tablesFromEnvelope(bad)).toEqual([]);
+      expect(columnsFromEnvelope(bad, 'orders')).toEqual([]);
+    }
+    expect(columnsFromEnvelope({ tables: { t: {} } }, 't')).toEqual([]);
   });
 });

--- a/viewer/src/components/views/workspace/source/SourceErd.jsx
+++ b/viewer/src/components/views/workspace/source/SourceErd.jsx
@@ -6,8 +6,9 @@ import { PiGraph } from 'react-icons/pi';
 import { isAvailable } from '../../../../contexts/URLContext';
 import {
   fetchSourceSchemaJobs,
-  fetchSourceTables,
-  fetchTableColumns,
+  fetchSourceSchema,
+  tablesFromEnvelope,
+  columnsFromEnvelope,
 } from '../../../../api/sourceSchemaJobs';
 import { getTypeColors } from '../../common/objectTypeConfigs';
 import { computeLayout } from '../../lineage/useLineageDag';
@@ -98,26 +99,20 @@ const SourceErdCanvas = ({ activeObject }) => {
           return;
         }
 
-        // Load the flat cached tables, then each table's columns. Shape them into
-        // the `{ databases: [{ name, tables }] }` entry useSourceErdDag flattens.
-        const tables = await fetchSourceTables(sourceName, { projectId: projectId });
+        // One request for the whole envelope, then slice locally into the
+        // `{ databases: [{ name, tables }] }` entry useSourceErdDag flattens.
+        // The ERD needs every column to draw its nodes, so it was already
+        // fetching all of them — just as 1 + N requests via Promise.all rather
+        // than one. Nothing is fetched now that wasn't fetched before.
+        const envelope = await fetchSourceSchema(sourceName, null, projectId);
         if (cancelledRef.current) return;
-        const tableEntries = await Promise.all(
-          (tables || []).map(async t => {
-            const name = typeof t === 'string' ? t : t.name;
-            let columns = [];
-            try {
-              const cols = await fetchTableColumns(sourceName, name, { projectId: projectId });
-              columns = (cols || []).map(c =>
-                typeof c === 'string' ? { name: c } : { name: c.name, type: c.type }
-              );
-            } catch {
-              columns = [];
-            }
-            return { name, columns };
-          })
-        );
-        if (cancelledRef.current) return;
+        const tableEntries = tablesFromEnvelope(envelope).map(t => ({
+          name: t.name,
+          columns: columnsFromEnvelope(envelope, t.name).map(c => ({
+            name: c.name,
+            type: c.type,
+          })),
+        }));
         // Single pseudo-database named after the source — the cached feed is flat
         // (no db/schema layer), matching how useSourceOutline renders it.
         setEntry({

--- a/viewer/src/components/views/workspace/source/SourceErd.test.jsx
+++ b/viewer/src/components/views/workspace/source/SourceErd.test.jsx
@@ -15,16 +15,23 @@ import {
 } from '../../../../contexts/URLContext';
 
 // Mock the cached-schema feed.
-jest.mock('../../../../api/sourceSchemaJobs', () => ({
-  fetchSourceSchemaJobs: jest.fn(),
-  fetchSourceTables: jest.fn(),
-  fetchTableColumns: jest.fn(),
-}));
+jest.mock('../../../../api/sourceSchemaJobs', () => {
+  // The envelope slicers are pure functions over the fetched record — keep the
+  // real ones so these tests exercise the same derivation the component does.
+  const actual = jest.requireActual('../../../../api/sourceSchemaJobs');
+  return {
+    ...actual,
+    fetchSourceSchemaJobs: jest.fn(),
+    fetchSourceSchema: jest.fn(),
+  };
+});
 const {
   fetchSourceSchemaJobs,
-  fetchSourceTables,
-  fetchTableColumns,
+  fetchSourceSchema,
 } = require('../../../../api/sourceSchemaJobs');
+
+/** The stored envelope shape: tables -> columns -> {type, nullable}. */
+const envelope = tables => ({ source_name: SRC, tables });
 
 // Mock computeLayout (dagre) — return the nodes with dummy positions.
 jest.mock('../../lineage/useLineageDag', () => ({
@@ -80,14 +87,10 @@ beforeEach(() => {
   setGlobalURLConfig(createURLConfig({ environment: 'server' }));
   // Warm (cached) source with two tables by default.
   fetchSourceSchemaJobs.mockResolvedValue([{ source_name: SRC, has_cached_schema: true }]);
-  fetchSourceTables.mockResolvedValue([
-    { name: 'orders', column_count: 2 },
-    { name: 'users', column_count: 2 },
-  ]);
-  fetchTableColumns.mockResolvedValue([
-    { name: 'id', type: 'INTEGER' },
-    { name: 'amount', type: 'DOUBLE' },
-  ]);
+  const cols = { id: { type: 'INTEGER' }, amount: { type: 'DOUBLE' } };
+  fetchSourceSchema.mockResolvedValue(
+    envelope({ orders: { columns: cols }, users: { columns: cols } })
+  );
 });
 
 afterEach(() => {
@@ -102,7 +105,7 @@ describe('SourceErd (VIS-1005)', () => {
     expect(await screen.findByTestId('source-erd-node-orders')).toBeInTheDocument();
     expect(screen.getByTestId('source-erd-node-users')).toBeInTheDocument();
     // It reads the cached feed, never the live introspect.
-    expect(fetchSourceTables).toHaveBeenCalledWith(SRC, { projectId: undefined });
+    expect(fetchSourceSchema).toHaveBeenCalledWith(SRC, null, undefined);
   });
 
   test('passes column-aware layoutSize heights to computeLayout so tall tables do not overlap', async () => {
@@ -134,7 +137,7 @@ describe('SourceErd (VIS-1005)', () => {
   });
 
   test('shows the empty state for a cached source with no tables', async () => {
-    fetchSourceTables.mockResolvedValue([]);
+    fetchSourceSchema.mockResolvedValue(envelope({}));
     render(<SourceErd activeObject={{ type: 'source', name: SRC }} />);
 
     expect(await screen.findByTestId('source-erd-empty')).toBeInTheDocument();
@@ -147,7 +150,7 @@ describe('SourceErd (VIS-1005)', () => {
 
     expect(await screen.findByTestId('source-erd-connection-failed')).toBeInTheDocument();
     // It never fetches tables for a source with no cached schema.
-    expect(fetchSourceTables).not.toHaveBeenCalled();
+    expect(fetchSourceSchema).not.toHaveBeenCalled();
   });
 
   test('shows the connection-failed state when the cached load throws', async () => {
@@ -178,11 +181,13 @@ describe('SourceErd (VIS-1005)', () => {
     expect(fetchSourceSchemaJobs).toHaveBeenCalled();
   });
 
-  test('a per-table column fetch failure degrades that table to zero columns', async () => {
-    fetchTableColumns.mockImplementation((_src, table) =>
-      table === 'orders'
-        ? Promise.reject(new Error('cols boom'))
-        : Promise.resolve([{ name: 'id', type: 'INTEGER' }])
+  test('a table carrying no columns still diagrams, with no column rows', async () => {
+    // Was "a per-table column fetch failure degrades that table": there is no
+    // longer a per-table fetch to fail. The surviving risk is the same shape —
+    // a table present in the envelope with nothing under `columns` must still
+    // draw a node rather than break the diagram.
+    fetchSourceSchema.mockResolvedValue(
+      envelope({ orders: {}, users: { columns: { id: { type: 'INTEGER' } } } })
     );
     render(<SourceErd activeObject={{ type: 'source', name: SRC }} />);
 

--- a/viewer/src/hooks/useSourceSchema.js
+++ b/viewer/src/hooks/useSourceSchema.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import useStore from '../stores/store';
 import {
   fetchSourceSchema,
@@ -29,7 +29,19 @@ export const useSourceSchema = (sourceName, options = {}) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  // Per-invocation cancellation, the same guard useSourceOutline carries.
+  // SQLEditor keeps ONE hook instance and swaps `sourceName`, so without this a
+  // slow response for the source you just left lands after the new one and
+  // leaves autocomplete offering columns that do not exist on the current
+  // source. A single shared boolean would not do: the next effect resets it,
+  // which is the bug rather than the fix. Each run captures its own epoch.
+  const epochRef = useRef(0);
+
   const fetchSchema = useCallback(async () => {
+    epochRef.current += 1;
+    const epoch = epochRef.current;
+    const superseded = () => epochRef.current !== epoch;
+
     if (!sourceName) {
       setTables([]);
       setTableColumns({});
@@ -46,6 +58,7 @@ export const useSourceSchema = (sourceName, options = {}) => {
       // autocomplete worked at all. Every column was fetched either way, so
       // there was nothing to be gained by asking for them separately.
       const envelope = await fetchSourceSchema(sourceName, runId, projectId);
+      if (superseded()) return;
       const fetchedTables = tablesFromEnvelope(envelope);
       setTables(fetchedTables);
 
@@ -55,11 +68,12 @@ export const useSourceSchema = (sourceName, options = {}) => {
       }
       setTableColumns(columnsMap);
     } catch (err) {
+      if (superseded()) return;
       setError(err.message);
       setTables([]);
       setTableColumns({});
     } finally {
-      setIsLoading(false);
+      if (!superseded()) setIsLoading(false);
     }
   }, [sourceName, runId, projectId]);
 

--- a/viewer/src/hooks/useSourceSchema.js
+++ b/viewer/src/hooks/useSourceSchema.js
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import useStore from '../stores/store';
-import { fetchSourceTables, fetchTableColumns } from '../api/sourceSchemaJobs';
+import {
+  fetchSourceSchema,
+  tablesFromEnvelope,
+  columnsFromEnvelope,
+} from '../api/sourceSchemaJobs';
 
 /**
  * Hook for fetching and managing source schema data for SQL autocomplete.
@@ -36,23 +40,18 @@ export const useSourceSchema = (sourceName, options = {}) => {
     setError(null);
 
     try {
-      const fetchedTables = await fetchSourceTables(sourceName, { runId, projectId: projectId });
-      setTables(fetchedTables || []);
+      // One request for the whole envelope, then slice locally. This used to
+      // fetch the table list and then every table's columns in a SEQUENTIAL
+      // loop — a source with 40 tables was 41 serialized round trips before
+      // autocomplete worked at all. Every column was fetched either way, so
+      // there was nothing to be gained by asking for them separately.
+      const envelope = await fetchSourceSchema(sourceName, runId, projectId);
+      const fetchedTables = tablesFromEnvelope(envelope);
+      setTables(fetchedTables);
 
       const columnsMap = {};
-      for (const table of fetchedTables || []) {
-        const tableName = table.table_name || table.name;
-        if (tableName) {
-          try {
-            const columns = await fetchTableColumns(sourceName, tableName, {
-              runId,
-              projectId: projectId,
-            });
-            columnsMap[tableName] = columns || [];
-          } catch {
-            columnsMap[tableName] = [];
-          }
-        }
+      for (const table of fetchedTables) {
+        columnsMap[table.name] = columnsFromEnvelope(envelope, table.name);
       }
       setTableColumns(columnsMap);
     } catch (err) {

--- a/viewer/src/hooks/useSourceSchema.test.js
+++ b/viewer/src/hooks/useSourceSchema.test.js
@@ -1,0 +1,176 @@
+/**
+ * useSourceSchema — the schema feed behind the SQL editor's autocomplete
+ * (`SQLEditor.jsx:61`).
+ *
+ * Had no test file at all, which is how it kept a sequential
+ * fetch-columns-per-table loop: a 40-table source cost 41 serialized round
+ * trips before autocomplete worked. It now fetches the envelope once and
+ * slices locally, and the request count is pinned here so it cannot regress
+ * quietly — nothing about the returned shape would change if it did.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import useStore from '../stores/store';
+import useSourceSchema from './useSourceSchema';
+import { fetchSourceSchema } from '../api/sourceSchemaJobs';
+
+jest.mock('../api/sourceSchemaJobs', () => {
+  // The slicers are pure functions over the fetched record — keep the real
+  // ones so these tests exercise the same derivation the hook does.
+  const actual = jest.requireActual('../api/sourceSchemaJobs');
+  return { ...actual, fetchSourceSchema: jest.fn() };
+});
+
+/** The stored envelope: tables -> columns -> {type, nullable}. */
+const envelope = tables => ({ source_name: 'db', tables });
+
+const TWO_TABLES = envelope({
+  orders: {
+    columns: { id: { type: 'INTEGER', nullable: false }, amount: { type: 'DOUBLE' } },
+  },
+  users: { columns: { email: { type: 'VARCHAR' } } },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  act(() => {
+    useStore.setState({ project: { id: 'proj-1' } });
+  });
+});
+
+describe('useSourceSchema', () => {
+  it('fetches the envelope ONCE and derives both tables and columns from it', async () => {
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+
+    const { result } = renderHook(() => useSourceSchema('db'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The point of the change: one request, not one per table.
+    expect(fetchSourceSchema).toHaveBeenCalledTimes(1);
+    expect(fetchSourceSchema).toHaveBeenCalledWith('db', null, 'proj-1');
+
+    expect(result.current.tables.map(t => t.name)).toEqual(['orders', 'users']);
+    expect(result.current.tableColumns.orders.map(c => c.name)).toEqual(['amount', 'id']);
+    expect(result.current.tableColumns.users).toEqual([
+      { name: 'email', type: 'VARCHAR', nullable: true },
+    ]);
+  });
+
+  it('stays at one request as the table count grows', async () => {
+    const many = {};
+    for (let i = 0; i < 40; i += 1) many[`t${i}`] = { columns: { id: { type: 'INTEGER' } } };
+    fetchSourceSchema.mockResolvedValue(envelope(many));
+
+    const { result } = renderHook(() => useSourceSchema('db'));
+    await waitFor(() => expect(result.current.tables).toHaveLength(40));
+
+    // Was 1 + N, and serialized. This is the assertion that keeps it at 1.
+    expect(fetchSourceSchema).toHaveBeenCalledTimes(1);
+    expect(Object.keys(result.current.tableColumns)).toHaveLength(40);
+  });
+
+  it('passes the runId through when one is given', async () => {
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+    renderHook(() => useSourceSchema('db', { runId: 'preview-x' }));
+    await waitFor(() =>
+      expect(fetchSourceSchema).toHaveBeenCalledWith('db', 'preview-x', 'proj-1')
+    );
+  });
+
+  it('does not fetch without a source name, and clears any prior state', async () => {
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+    const { result, rerender } = renderHook(({ name }) => useSourceSchema(name), {
+      initialProps: { name: 'db' },
+    });
+    await waitFor(() => expect(result.current.tables).toHaveLength(2));
+
+    fetchSourceSchema.mockClear();
+    rerender({ name: null });
+
+    await waitFor(() => expect(result.current.tables).toEqual([]));
+    expect(result.current.tableColumns).toEqual({});
+    expect(fetchSourceSchema).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure and clears the schema rather than serving a stale one', async () => {
+    fetchSourceSchema.mockRejectedValue(new Error('source unreachable'));
+
+    const { result } = renderHook(() => useSourceSchema('db'));
+    await waitFor(() => expect(result.current.error).toBe('source unreachable'));
+
+    // Autocomplete offering tables that are no longer valid is worse than none.
+    expect(result.current.tables).toEqual([]);
+    expect(result.current.tableColumns).toEqual({});
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears a previous error on a later successful load', async () => {
+    fetchSourceSchema.mockRejectedValueOnce(new Error('boom'));
+    const { result, rerender } = renderHook(({ name }) => useSourceSchema(name), {
+      initialProps: { name: 'db' },
+    });
+    await waitFor(() => expect(result.current.error).toBe('boom'));
+
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+    rerender({ name: 'other' });
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.tables).toHaveLength(2);
+  });
+
+  it('refresh() refetches on demand', async () => {
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+    const { result } = renderHook(() => useSourceSchema('db'));
+    await waitFor(() => expect(fetchSourceSchema).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fetchSourceSchema).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches when the project changes, not just the source', async () => {
+    // projectId is subscribed from the store, so a project switch has to
+    // re-scope the request — otherwise autocomplete keeps the old project's
+    // tables.
+    fetchSourceSchema.mockResolvedValue(TWO_TABLES);
+    renderHook(() => useSourceSchema('db'));
+    await waitFor(() => expect(fetchSourceSchema).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useStore.setState({ project: { id: 'proj-2' } });
+    });
+
+    await waitFor(() =>
+      expect(fetchSourceSchema).toHaveBeenLastCalledWith('db', null, 'proj-2')
+    );
+  });
+
+  it('a slow response for the PREVIOUS source cannot overwrite the current one', async () => {
+    // The race `useSourceOutline` carries an epoch guard for. SQLEditor keeps
+    // one hook instance and swaps `sourceName`, so switching sources while a
+    // request is in flight can land the old source's tables in the new
+    // source's autocomplete — offering columns that do not exist.
+    let resolveSlow;
+    fetchSourceSchema
+      .mockImplementationOnce(
+        () => new Promise(resolve => {
+          resolveSlow = () => resolve(envelope({ stale_table: { columns: {} } }));
+        })
+      )
+      .mockResolvedValueOnce(envelope({ fresh_table: { columns: {} } }));
+
+    const { result, rerender } = renderHook(({ name }) => useSourceSchema(name), {
+      initialProps: { name: 'slow_source' },
+    });
+    rerender({ name: 'fast_source' });
+    await waitFor(() => expect(result.current.tables.map(t => t.name)).toEqual(['fresh_table']));
+
+    // The first request only now comes back.
+    await act(async () => {
+      resolveSlow();
+    });
+
+    expect(result.current.tables.map(t => t.name)).toEqual(['fresh_table']);
+  });
+});


### PR DESCRIPTION
First of the two remaining source-schema items. Stacked on `feature/cloud-parity`.

## The endpoint already existed

`fetchSourceSchema` returns the whole stored envelope, and **both servers already answer it unsliced** — core's `SourceSchemaJobDetail` returns `row.content`, Flask's `_get_source_schema` returns the loaded file. It had **zero callers**.

Every browsing surface used the sliced `fetchSourceTables` + `fetchTableColumns` pair instead. Those reload the same record server-side and throw most of it away: the tables endpoint reads `content["tables"]` only to compute `len(columns)`; the columns endpoint discards every other table plus `sqlglot_schema`.

So this is *use what's there*, not build something.

## What changed, and what deliberately didn't

Two consumers were fetching **every column anyway**, just in N+1 requests:

| | before | after |
|---|---|---|
| `useSourceSchema` (SQL autocomplete) | 1 + N, **sequential** | 1 |
| `SourceErd` (canvas ERD) | 1 + N via `Promise.all` | 1 |

The autocomplete one is the worst: a source with 40 tables was **41 serialized round trips** before autocomplete worked at all.

**`useSourceOutline` keeps the lazy per-table fetch.** It's a tree — you expand three of three hundred rows — and the envelope is not free. I measured a real one at **~191 bytes/column**, so:

- 300 tables × 15 columns → **~840 KB**
- 1000 tables × 20 columns → **~3.7 MB**

Pulling that to expand three rows would be a regression. The split follows what each caller actually needs rather than applying one rule to all three.

That measurement is also why I didn't delete `fetchSourceTables` / `fetchTableColumns` or their backend endpoints — the tree still wants them.

## The slicers

`tablesFromEnvelope` / `columnsFromEnvelope` reproduce the endpoints' shapes exactly — same fields, same sort order, same `nullable` default — so a caller can be repointed without changing how it reads the result. Tested directly against malformed and missing envelopes too.

## One test changed meaning, not shape

`SourceErd`'s "a per-table column fetch failure degrades that table to zero columns" had no per-table fetch left to fail. It now covers the surviving risk of the same shape: a table present in the envelope with nothing under `columns` must still draw a node rather than break the diagram.

## Testing

**352 suites / 6602 tests**, lint clean.

One pre-existing flake in `WorkspaceDndContext` under full-suite load — passes in isolation (128 tests), fails the same way on the base branch, and imports nothing this touches.

Worth driving in a browser before merge: open a source in the Data tab and the canvas ERD and confirm in the network panel that the ERD costs 1 request rather than 2+N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)