### PR TITLE
Pin the cross-repo model-schema inference contract

### DIFF
--- a/test-projects/integration/validate_run_results.py
+++ b/test-projects/integration/validate_run_results.py
@@ -109,7 +109,7 @@ class VisivoRunValidator:
 
         success = True
         for source_name in expected_sources:
-            source_schema_file = schemas_dir / source_name / "schema.json"
+            source_schema_file = schemas_dir / f"{source_name}.json"
 
             if not source_schema_file.exists():
                 self.log_error(

--- a/tests/contracts/model_schema_inference_cases.json
+++ b/tests/contracts/model_schema_inference_cases.json
@@ -1,0 +1,83 @@
+{
+  "_comment": [
+    "Golden cases for model output-column inference — the CROSS-REPO contract.",
+    "",
+    "visivo and core each implement this independently: visivo in",
+    "visivo/query/model_schema_inference.py, core in",
+    "api/apps/deploys/services/sqlglot_utils.py. Core cannot import visivo (only",
+    "the runner image ships it; pulling it into the Django web image would drag",
+    "every warehouse driver along), so the logic exists twice on purpose.",
+    "",
+    "This file is the single source of truth that keeps them honest. visivo's",
+    "tests/contracts/test_model_schema_inference_contract.py and core's",
+    "apps/deploys/tests/test_model_schema_contract.py both read THIS file and",
+    "assert the same answers. Core locates it via a sibling ../visivo checkout,",
+    "which is how its CI already vendors the viewer.",
+    "",
+    "Add a case here when you change inference in either repo."
+  ],
+  "cases": [
+    {
+      "name": "named columns resolve their types from the source schema",
+      "dialect": "postgres",
+      "sql": "SELECT id, amount FROM orders",
+      "sqlglot_schema": {
+        "orders": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+      },
+      "expected": { "id": "INT", "amount": "DECIMAL" }
+    },
+    {
+      "name": "star expands from the source schema",
+      "dialect": "postgres",
+      "sql": "SELECT * FROM orders",
+      "sqlglot_schema": {
+        "orders": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+      },
+      "expected": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+    },
+    {
+      "name": "aliases are the output names",
+      "dialect": "postgres",
+      "sql": "SELECT id AS order_id, amount AS total FROM orders",
+      "sqlglot_schema": { "orders": { "id": "INT", "amount": "DECIMAL" } },
+      "expected": { "order_id": "INT", "total": "DECIMAL" }
+    },
+    {
+      "name": "an unknown table resolves nothing, and is not an error",
+      "dialect": "postgres",
+      "sql": "SELECT * FROM never_introspected",
+      "sqlglot_schema": { "orders": { "id": "INT" } },
+      "expected": {}
+    },
+    {
+      "name": "unparseable SQL resolves nothing, and is not an error",
+      "dialect": "postgres",
+      "sql": "SELECT FROM WHERE ((",
+      "sqlglot_schema": { "orders": { "id": "INT" } },
+      "expected": {}
+    },
+    {
+      "name": "no cached source schema still resolves literal projections",
+      "dialect": "postgres",
+      "sql": "SELECT 1 AS one",
+      "sqlglot_schema": {},
+      "expected": { "one": "INT" }
+    },
+    {
+      "name": "a nested schema block (source with named schemas) resolves",
+      "dialect": "snowflake",
+      "sql": "SELECT col1 FROM EDW.fact_order",
+      "sqlglot_schema": {
+        "EDW": { "fact_order": { "col1": "INT", "col2": "VARCHAR" } }
+      },
+      "expected": { "col1": "INT" }
+    },
+    {
+      "name": "SQL comments do not break column resolution",
+      "dialect": "postgres",
+      "sql": "SELECT id /* the key */, amount FROM orders",
+      "sqlglot_schema": { "orders": { "id": "INT", "amount": "DECIMAL" } },
+      "expected": { "id": "INT", "amount": "DECIMAL" }
+    }
+  ]
+}

--- a/tests/contracts/test_model_schema_inference_contract.py
+++ b/tests/contracts/test_model_schema_inference_contract.py
@@ -1,0 +1,52 @@
+"""The visivo half of the cross-repo model-schema inference contract.
+
+core reimplements this inference (it cannot import visivo — only the runner
+image ships it), so the two can drift silently: both stay green while answering
+differently, and the symptom in production is a column list that is right
+locally and wrong in cloud, with nothing logged.
+
+``model_schema_inference_cases.json`` is the shared source of truth. This file
+asserts visivo's implementation against it;
+``core/api/apps/deploys/tests/test_model_schema_contract.py`` asserts core's
+against the same file, read from a sibling ``../visivo`` checkout.
+
+Add a case there when you change inference in either repo.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from visivo.query.model_schema_inference import infer_model_columns
+
+CASES_FILE = Path(__file__).parent / "model_schema_inference_cases.json"
+CASES = json.loads(CASES_FILE.read_text())["cases"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_inference_matches_the_shared_contract(case):
+    columns = infer_model_columns(
+        sql=case["sql"],
+        sqlglot_dialect=case["dialect"],
+        model_hash="contract_hash",
+        stored_source_schema={
+            "sqlglot_schema": case["sqlglot_schema"],
+            "metadata": {"default_schema": case.get("default_schema")},
+        },
+        # The contract describes what the ENDPOINTS answer. The run calls the
+        # same function with strict=True so a model whose SQL does not parse
+        # fails the run instead of persisting an empty schema.
+        strict=False,
+    )
+
+    assert columns == case["expected"], (
+        f"visivo inference diverged from the shared contract on "
+        f"{case['name']!r}. If this change is intentional, update "
+        f"{CASES_FILE.name} and core's half of the contract together."
+    )
+
+
+def test_the_contract_file_is_not_empty():
+    """A truncated or unparsed fixture would make every case above vacuous."""
+    assert len(CASES) >= 8

--- a/tests/integration/test_input_uniform_format.py
+++ b/tests/integration/test_input_uniform_format.py
@@ -45,12 +45,12 @@ class TestInputUniformFormat:
         )
 
         # Create schema file for the model
-        schema_dir = Path(output_dir) / "schemas" / model.name
+        schema_dir = Path(output_dir) / "schemas"
         schema_dir.mkdir(parents=True, exist_ok=True)
 
         import json
 
-        schema_file = schema_dir / "schema.json"
+        schema_file = schema_dir / f"{model.name}.json"
         schema_data = {
             model.name_hash(): {
                 "id": "INTEGER",

--- a/tests/jobs/test_run_insight_job_join_errors.py
+++ b/tests/jobs/test_run_insight_job_join_errors.py
@@ -21,8 +21,7 @@ from visivo.models.project import Project
 def _write_schema(schema_base, model, columns):
     """Mirror the on-disk schema layout the FieldResolver reads from."""
     model_hash = model.name_hash()
-    schema_dir = schema_base.mkdir(model.name)
-    schema_file = schema_dir.join("schema.json")
+    schema_file = schema_base.join(f"{model.name}.json")
     schema_file.write(json.dumps({model_hash: columns}))
 
 
@@ -58,7 +57,7 @@ def test_two_unjoined_model_insight_run_yields_missing_relation(tmpdir):
 
     run_id = "main"
     output_dir = str(tmpdir)
-    # FieldResolver reads schemas from {output_dir}/{run_id}/schemas/<model>/schema.json
+    # FieldResolver reads schemas from {output_dir}/{run_id}/schemas/<model>.json
     run_dir = tmpdir.mkdir(run_id)
     schema_base = run_dir.mkdir("schemas")
     _write_schema(schema_base, orders, {"amount": "INTEGER"})

--- a/tests/jobs/test_run_sql_model_job.py
+++ b/tests/jobs/test_run_sql_model_job.py
@@ -130,7 +130,7 @@ class TestSqlModelSchemaArtifact:
         assert model_hash in result
         assert set(result[model_hash].keys()) == {"id", "name"}
 
-        schema_file = os.path.join(output_dir, "main", "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, "main", "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
         with open(schema_file) as fp:
             data = json.load(fp)

--- a/tests/jobs/test_run_sql_model_job_coverage.py
+++ b/tests/jobs/test_run_sql_model_job_coverage.py
@@ -48,9 +48,9 @@ class TestGetErrorMessage:
 
 
 def _write_source_schema(output_dir, source_name, sqlglot_schema, default_schema=None):
-    source_schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", source_name)
+    source_schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
     os.makedirs(source_schema_dir, exist_ok=True)
-    with open(os.path.join(source_schema_dir, "schema.json"), "w") as fp:
+    with open(os.path.join(source_schema_dir, f"{source_name}.json"), "w") as fp:
         json.dump(
             {"sqlglot_schema": sqlglot_schema, "metadata": {"default_schema": default_schema}},
             fp,
@@ -108,7 +108,7 @@ class TestModelQueryAndSchemaAction:
         result = model_query_and_schema_action(model, dag, output_dir)
 
         assert result.success is True
-        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
 
     def test_failure_when_query_references_missing_table(self):
@@ -135,7 +135,7 @@ class TestSchemaOnlyAction:
         result = schema_only_action(model, dag, output_dir)
 
         assert result.success is True
-        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
 
     def test_failure_when_schema_build_raises(self, mocker):

--- a/tests/query/insight/test_draft_overlay.py
+++ b/tests/query/insight/test_draft_overlay.py
@@ -57,9 +57,9 @@ class TestBuildDraftOverlayHappyPath:
     def test_the_overlay_resolves_against_an_already_published_model(self, flask_app, tmp_path):
         _, dag, insight = build_draft_overlay(flask_app, insight_config())
         model_node = dag.get_descendant_by_name("orders_q")
-        schema_dir = tmp_path / "schemas" / "orders_q"
+        schema_dir = tmp_path / "schemas"
         schema_dir.mkdir(parents=True)
-        (schema_dir / "schema.json").write_text(
+        (schema_dir / "orders_q.json").write_text(
             json.dumps({model_node.name_hash(): {"region": "VARCHAR", "amount": "DOUBLE"}})
         )
         query_info = insight.get_query_info(dag, str(tmp_path), force_dynamic=True)

--- a/tests/query/insight/test_insight_default_line_sort.py
+++ b/tests/query/insight/test_insight_default_line_sort.py
@@ -24,9 +24,9 @@ from tests.factories.model_factories import SourceFactory
 @pytest.fixture
 def create_schema_file(tmpdir):
     def _create_schema(model, output_dir):
-        schema_dir = os.path.join(output_dir, "schemas", model.name)
+        schema_dir = os.path.join(output_dir, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): {"x": "INTEGER", "y": "INTEGER"}}, f)
 
     return _create_schema

--- a/tests/query/insight/test_insight_filter_interactions.py
+++ b/tests/query/insight/test_insight_filter_interactions.py
@@ -33,9 +33,7 @@ class TestInsightFilterInteractions:
             """Create a schema.json file for the given model."""
             schema_base = os.path.join(output_dir, "schemas")
             os.makedirs(schema_base, exist_ok=True)
-            schema_dir = os.path.join(schema_base, model.name)
-            os.makedirs(schema_dir, exist_ok=True)
-            schema_file = os.path.join(schema_dir, "schema.json")
+            schema_file = os.path.join(schema_base, f"{model.name}.json")
 
             # Create a basic schema with x and y columns for filter tests
             model_hash = model.name_hash()
@@ -307,9 +305,9 @@ class TestInsightFilterInteractions:
         dag = project.dag()
 
         # Write a schema.json for the referenced model with the given columns.
-        schema_base = os.path.join(str(tmpdir), "schemas", model.name)
+        schema_base = os.path.join(str(tmpdir), "schemas")
         os.makedirs(schema_base, exist_ok=True)
-        with open(os.path.join(schema_base, "schema.json"), "w") as f:
+        with open(os.path.join(schema_base, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): schema_columns}, f)
 
         # Write the input job's JSON output so parsing can obtain a sample value

--- a/tests/query/insight/test_insight_group_by.py
+++ b/tests/query/insight/test_insight_group_by.py
@@ -28,9 +28,9 @@ def build_sql(tmpdir):
             name="p", sources=[source], models=[model], insights=[insight], dashboards=[]
         )
         dag = project.dag()
-        schema_dir = os.path.join(str(tmpdir), "schemas", model.name)
+        schema_dir = os.path.join(str(tmpdir), "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): schema}, f)
         from visivo.query.insight.insight_query_builder import InsightQueryBuilder
 

--- a/tests/query/insight/test_insight_query_builder_with_inputs.py
+++ b/tests/query/insight/test_insight_query_builder_with_inputs.py
@@ -415,9 +415,7 @@ class TestInsightQueryBuilderWithInputs:
             """Create a schema.json file for the given model."""
             schema_base = os.path.join(output_dir, "schemas")
             os.makedirs(schema_base, exist_ok=True)
-            schema_dir = os.path.join(schema_base, model.name)
-            os.makedirs(schema_dir, exist_ok=True)
-            schema_file = os.path.join(schema_dir, "schema.json")
+            schema_file = os.path.join(schema_base, f"{model.name}.json")
 
             # Create a basic schema with common columns
             model_hash = model.name_hash()

--- a/tests/query/insight/test_insight_requires_full_source.py
+++ b/tests/query/insight/test_insight_requires_full_source.py
@@ -22,9 +22,9 @@ from tests.factories.model_factories import SourceFactory
 
 def _write_schema(model, output_dir):
     """FieldResolver needs each model's column schema to resolve ${ref(m).col}."""
-    schema_dir = os.path.join(output_dir, "schemas", model.name)
+    schema_dir = os.path.join(output_dir, "schemas")
     os.makedirs(schema_dir, exist_ok=True)
-    with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+    with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
         json.dump(
             {model.name_hash(): {"x": "INTEGER", "y": "INTEGER", "amount": "DECIMAL"}},
             f,

--- a/tests/query/resolvers/test_field_resolver.py
+++ b/tests/query/resolvers/test_field_resolver.py
@@ -26,8 +26,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_success(self, tmpdir):
         """Test successfully loading a schema file."""
         # Create a mock schema file
-        schema_dir = tmpdir.mkdir("schemas").mkdir("test_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("test_model.json")
         schema_data = {"model_hash_123": {"id": "INTEGER", "name": "VARCHAR", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -45,8 +45,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_caching(self, tmpdir):
         """Test that schemas are cached after first load."""
         # Create a mock schema file
-        schema_dir = tmpdir.mkdir("schemas").mkdir("test_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("test_model.json")
         schema_data = {"model_hash_123": {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -74,8 +74,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_invalid_json(self, tmpdir):
         """Test handling of malformed JSON in schema files."""
         # Create a schema file with invalid JSON
-        schema_dir = tmpdir.mkdir("schemas").mkdir("bad_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("bad_model.json")
         schema_file.write("{invalid json content")
 
         dag = ProjectDag()
@@ -100,8 +100,8 @@ class TestFieldResolverImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -121,8 +121,8 @@ class TestFieldResolverImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -161,8 +161,8 @@ class TestFieldResolverResolveImplicitDimensions:
 
         # Create schema in correct format: {model_hash: {column: type}}
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"x": "INTEGER", "y": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -185,8 +185,8 @@ class TestFieldResolverResolveImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -224,8 +224,8 @@ class TestFieldResolverResolveMetrics:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -269,8 +269,7 @@ class TestFieldResolverResolveMetrics:
             (model_a, {"id": "INTEGER", "amount": "DECIMAL"}),
             (model_b, {"id": "INTEGER", "weight": "DECIMAL"}),
         ]:
-            d = schema_base.mkdir(m.name)
-            d.join("schema.json").write(json.dumps({m.name_hash(): cols}))
+            schema_base.join(f"{m.name}.json").write(json.dumps({m.name_hash(): cols}))
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
 
@@ -341,8 +340,7 @@ class TestFieldResolverComplexExpressions:
         ]:
             model_obj = model1 if model_name == "orders" else model2
             model_hash = model_obj.name_hash()
-            schema_dir = schema_base_dir.mkdir(model_name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base_dir.join(f"{model_name}.json")
             schema_data = {model_hash: fields}
             schema_file.write(json.dumps(schema_data))
 
@@ -370,8 +368,8 @@ class TestFieldResolverComplexExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -444,8 +442,8 @@ class TestFieldResolverQualification:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -466,8 +464,8 @@ class TestFieldResolverQualification:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -506,8 +504,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema for the base model
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -544,8 +542,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema for the base model
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "status": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -582,8 +580,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "price": "DECIMAL", "quantity": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -623,8 +621,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("sales")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("sales.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -657,8 +655,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("another_local_test_table")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("another_local_test_table.json")
         schema_data = {model_hash: {"new_x": "INTEGER", "name": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -699,8 +697,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {
             model_hash: {"status": "VARCHAR", "amount": "DECIMAL", "priority": "INTEGER"}
         }
@@ -745,8 +743,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("products")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("products.json")
         schema_data = {model_hash: {"category": "VARCHAR", "price": "DECIMAL", "stock": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -792,8 +790,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("metrics")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("metrics.json")
         schema_data = {model_hash: {"value": "DECIMAL", "threshold": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -843,8 +841,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -872,8 +870,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL", "date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -901,8 +899,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -930,8 +928,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"status": "VARCHAR", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -966,8 +964,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL", "date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -997,8 +995,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1027,8 +1025,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1058,8 +1056,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("sales")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("sales.json")
         schema_data = {model_hash: {"revenue": "DECIMAL", "month": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1093,8 +1091,8 @@ class TestFieldResolverCaseSensitivity:
 
         # Create schema with UPPERCASE columns (as Snowflake/BigQuery returns)
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("local_test_table")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("local_test_table.json")
         schema_data = {model_hash: {"X": "INTEGER", "Y": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1119,8 +1117,8 @@ class TestFieldResolverCaseSensitivity:
         dag = project.dag()
 
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"AMOUNT": "DECIMAL", "USER_ID": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1168,8 +1166,8 @@ class TestFieldResolverCaseSensitivity:
         dag = project.dag()
 
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL", "status": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1300,8 +1298,8 @@ class TestFieldResolverB10SqlModelFallback:
         dag = project.dag()
 
         # Schema for 'orders' contains a 'revenue' column.
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {orders.name_hash(): {"id": "INTEGER", "revenue": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 

--- a/tests/query/resolvers/test_field_resolver_errors.py
+++ b/tests/query/resolvers/test_field_resolver_errors.py
@@ -92,8 +92,7 @@ class TestSchemaFileCorrupted:
         # Create schema directory but with invalid JSON
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_file.write("{ invalid json content ")
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
@@ -125,8 +124,7 @@ class TestSchemaFileCorrupted:
 
         # Create empty schema file
         schema_base = tmpdir.mkdir("schemas")
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_file.write("{}")
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
@@ -155,8 +153,7 @@ class TestSchemaFieldMissing:
         # Create schema with specific columns
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -247,8 +244,7 @@ class TestResolutionStackTracking:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -283,8 +279,7 @@ class TestCacheInvalidation:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -321,8 +316,7 @@ class TestCacheInvalidation:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -356,8 +350,7 @@ class TestDialectHandling:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 

--- a/tests/query/resolvers/test_field_resolver_with_inputs.py
+++ b/tests/query/resolvers/test_field_resolver_with_inputs.py
@@ -102,8 +102,7 @@ class TestFieldResolverWithInputs:
         # Create schema file
         schema_base = tmpdir.mkdir("schemas")
         model_hash = orders_model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {
             model_hash: {
                 "id": "INTEGER",

--- a/tests/query/test_model_schema_aggregator.py
+++ b/tests/query/test_model_schema_aggregator.py
@@ -87,9 +87,9 @@ class TestLoadModelSchema:
             columns={"id": "INT"},
             source_dialect="duckdb",
         )
-        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
         loaded = ModelSchemaAggregator.load_model_schema("orders", output_dir)
@@ -104,9 +104,9 @@ class TestLoadModelSchema:
             name_hash="mh", model_name="orders", model_type="sql", columns={"id": "INT"}
         )
         run_id = "preview-orders"
-        schema_dir = os.path.join(output_dir, run_id, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, run_id, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
         # Default run_id (main) misses; explicit preview run_id hits.
@@ -120,22 +120,23 @@ class TestListStoredModelSchemas:
         output_dir = str(tmp_path)
         schemas_root = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
 
+        os.makedirs(schemas_root, exist_ok=True)
+
         # A model schema (has model_name).
-        model_dir = os.path.join(schemas_root, "orders")
-        os.makedirs(model_dir, exist_ok=True)
         model_payload = ModelSchemaAggregator.build_envelope(
             name_hash="mh",
             model_name="orders",
             model_type="sql",
             columns={"id": "INT", "total": "DOUBLE"},
         )
-        with open(os.path.join(model_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schemas_root, "orders.json"), "w") as fp:
             json.dump(model_payload, fp)
 
-        # A source schema (has source_name, NOT model_name) in the same dir.
-        source_dir = os.path.join(schemas_root, "my_source")
-        os.makedirs(source_dir, exist_ok=True)
-        with open(os.path.join(source_dir, "schema.json"), "w") as fp:
+        # A source schema (has source_name, NOT model_name) beside it. Models
+        # and sources share this directory, so `model_name` is what tells them
+        # apart — the flat layout removes the per-name directory that used to
+        # be incidental structure, not a filter.
+        with open(os.path.join(schemas_root, "my_source.json"), "w") as fp:
             json.dump(
                 {
                     "source_name": "my_source",

--- a/tests/query/test_model_schema_aggregator_coverage.py
+++ b/tests/query/test_model_schema_aggregator_coverage.py
@@ -15,40 +15,35 @@ from visivo.query.model_schema_aggregator import ModelSchemaAggregator
 class TestLoadModelSchemaErrors:
     def test_corrupt_json_returns_none(self, tmp_path):
         output_dir = str(tmp_path)
-        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             fp.write("{ this is not valid json ")
 
         assert ModelSchemaAggregator.load_model_schema("orders", output_dir) is None
 
 
 class TestListStoredModelSchemasSkips:
-    def test_skips_non_directory_missing_and_corrupt_entries(self, tmp_path):
+    def test_skips_non_json_and_corrupt_entries(self, tmp_path):
         output_dir = str(tmp_path)
         schemas_root = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schemas_root, exist_ok=True)
 
-        # A valid model schema dir.
-        good_dir = os.path.join(schemas_root, "orders")
-        os.makedirs(good_dir, exist_ok=True)
+        # A valid model schema.
         payload = ModelSchemaAggregator.build_envelope(
             name_hash="mh", model_name="orders", model_type="sql", columns={"id": "INT"}
         )
-        with open(os.path.join(good_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schemas_root, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
-        # A plain file (not a directory) in the schemas dir → skipped.
+        # A non-JSON file → skipped. Under the old per-name-directory layout
+        # `os.path.isdir` was the de-facto "is this a schema" filter; flat files
+        # make the extension carry that, so this is the case that pins it.
         with open(os.path.join(schemas_root, "loose_file.txt"), "w") as fp:
             fp.write("ignore me")
 
-        # A directory with no schema.json → skipped.
-        os.makedirs(os.path.join(schemas_root, "empty_dir"), exist_ok=True)
-
-        # A directory with a corrupt schema.json → skipped.
-        corrupt_dir = os.path.join(schemas_root, "corrupt")
-        os.makedirs(corrupt_dir, exist_ok=True)
-        with open(os.path.join(corrupt_dir, "schema.json"), "w") as fp:
+        # A corrupt JSON file → skipped, not fatal to the whole listing.
+        with open(os.path.join(schemas_root, "corrupt.json"), "w") as fp:
             fp.write("{ broken ")
 
         listed = ModelSchemaAggregator.list_stored_model_schemas(output_dir)

--- a/tests/query/test_relation_graph.py
+++ b/tests/query/test_relation_graph.py
@@ -45,8 +45,7 @@ class TestRelationGraphBasics:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "name": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -82,8 +81,7 @@ class TestRelationGraphBasics:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -148,8 +146,7 @@ class TestTwoModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -196,8 +193,7 @@ class TestTwoModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -295,8 +291,7 @@ class TestAmbiguousPaths:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -354,8 +349,7 @@ class TestAmbiguousPaths:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -414,8 +408,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -468,8 +461,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -510,8 +502,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "a_id": "INTEGER", "c_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -603,8 +594,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -651,8 +641,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_users, model_orders, model_addr]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -690,8 +679,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -734,8 +722,7 @@ class TestValidation:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -772,8 +759,7 @@ class TestValidation:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -828,8 +814,7 @@ class TestDefaultRelationResolution:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -889,8 +874,7 @@ class TestDefaultRelationResolution:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "email": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -959,8 +943,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "product_id": "INTEGER"}
             }
@@ -1007,8 +990,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "product_id": "INTEGER"}
             }
@@ -1050,8 +1032,7 @@ class TestRelationGraphScoping:
         # Create schema only for orders
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model_a.name_hash()
-        schema_dir = schema_base.mkdir(model_a.name)
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join(f"{model_a.name}.json")
         schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1092,8 +1073,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -1135,8 +1115,7 @@ class TestDefaultRelationTieBreak:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "email": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -1253,8 +1232,7 @@ class TestStructuredJoinErrorAttributes:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",

--- a/tests/query/test_relation_graph_coverage.py
+++ b/tests/query/test_relation_graph_coverage.py
@@ -41,8 +41,7 @@ def _build_graph(tmpdir, models, relations, columns=None):
 
     schema_base = tmpdir.mkdir("schemas")
     for model in sql_models:
-        schema_dir = schema_base.mkdir(model.name)
-        schema_dir.join("schema.json").write(json.dumps({model.name_hash(): columns}))
+        schema_base.join(f"{model.name}.json").write(json.dumps({model.name_hash(): columns}))
 
     resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
     return RelationGraph(dag=dag, field_resolver=resolver)

--- a/tests/query/test_schema_aggregator.py
+++ b/tests/query/test_schema_aggregator.py
@@ -336,9 +336,7 @@ class TestSchemaAggregatorRunId:
             run_id="test-run-id",
         )
 
-        expected_path = os.path.join(
-            temp_dir, "test-run-id", "schemas", "test_source", "schema.json"
-        )
+        expected_path = os.path.join(temp_dir, "test-run-id", "schemas", "test_source.json")
         assert os.path.exists(expected_path)
 
     def test_aggregate_default_run_id(self, temp_dir):
@@ -356,9 +354,7 @@ class TestSchemaAggregatorRunId:
             output_dir=temp_dir,
         )
 
-        expected_path = os.path.join(
-            temp_dir, DEFAULT_RUN_ID, "schemas", "test_source", "schema.json"
-        )
+        expected_path = os.path.join(temp_dir, DEFAULT_RUN_ID, "schemas", "test_source.json")
         assert os.path.exists(expected_path)
 
     def test_load_from_specific_run_id(self, temp_dir):

--- a/tests/server/views/test_insight_compile_views.py
+++ b/tests/server/views/test_insight_compile_views.py
@@ -57,9 +57,9 @@ def insight_payload(name="draft_insight", model_name="orders_q"):
 
 
 def write_schema(tmp_path, model_name, model_hash, columns):
-    schema_dir = tmp_path / "main" / "schemas" / model_name
+    schema_dir = tmp_path / "main" / "schemas"
     schema_dir.mkdir(parents=True)
-    (schema_dir / "schema.json").write_text(json.dumps({model_hash: columns}))
+    (schema_dir / f"{model_name}.json").write_text(json.dumps({model_hash: columns}))
 
 
 class TestCompileDraftHappyPath:

--- a/tests/server/views/test_model_schema_views.py
+++ b/tests/server/views/test_model_schema_views.py
@@ -33,9 +33,9 @@ def _write_source_schema(output_dir, source_name, tables, run_id=DEFAULT_RUN_ID)
         "sqlglot_schema": tables,
         "metadata": {"default_schema": None},
     }
-    schema_dir = os.path.join(output_dir, run_id, "schemas", source_name)
+    schema_dir = os.path.join(output_dir, run_id, "schemas")
     os.makedirs(schema_dir, exist_ok=True)
-    with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+    with open(os.path.join(schema_dir, f"{source_name}.json"), "w") as fp:
         json.dump(payload, fp)
     return payload
 

--- a/tests/server/views/test_source_schema_jobs_views.py
+++ b/tests/server/views/test_source_schema_jobs_views.py
@@ -22,7 +22,7 @@ class TestSourceSchemaJobsViews:
     @pytest.fixture
     def sample_schema(self, temp_output_dir):
         """Create a sample cached schema file in the main run_id location."""
-        schema_dir = os.path.join(temp_output_dir, DEFAULT_RUN_ID, "schemas", "test_source")
+        schema_dir = os.path.join(temp_output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
 
         schema_data = {
@@ -54,7 +54,7 @@ class TestSourceSchemaJobsViews:
             "metadata": {"total_tables": 2, "total_columns": 6, "databases": []},
         }
 
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, "test_source.json"), "w") as f:
             json.dump(schema_data, f)
 
         return schema_data
@@ -63,7 +63,7 @@ class TestSourceSchemaJobsViews:
     def sample_preview_schema(self, temp_output_dir):
         """Create a sample cached schema file in the preview run_id location."""
         preview_run_id = "preview-test_source"
-        schema_dir = os.path.join(temp_output_dir, preview_run_id, "schemas", "test_source")
+        schema_dir = os.path.join(temp_output_dir, preview_run_id, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
 
         schema_data = {
@@ -85,7 +85,7 @@ class TestSourceSchemaJobsViews:
             "metadata": {"total_tables": 1, "total_columns": 2, "databases": []},
         }
 
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, "test_source.json"), "w") as f:
             json.dump(schema_data, f)
 
         return schema_data

--- a/visivo/jobs/run_sql_model_job.py
+++ b/visivo/jobs/run_sql_model_job.py
@@ -130,9 +130,9 @@ def _build_and_write_schema(
 
     # Organize by run_id
     run_output_dir = f"{output_dir}/{run_id}"
-    schema_directory = f"{run_output_dir}/schemas/{sql_model.name}/"
+    schema_directory = f"{run_output_dir}/schemas"
     os.makedirs(schema_directory, exist_ok=True)
-    schema_file = f"{schema_directory}schema.json"
+    schema_file = f"{schema_directory}/{sql_model.name}.json"
 
     # Persist the richer envelope (legacy {name_hash: {col: type}} block preserved
     # first, for the field resolver) while serializing the resolved output schema.
@@ -237,7 +237,7 @@ def schema_only_action(
 
         # Organize by run_id
         run_output_dir = f"{output_dir}/{run_id}"
-        schema_file = f"{run_output_dir}/schemas/{sql_model.name}/schema.json"
+        schema_file = f"{run_output_dir}/schemas/{sql_model.name}.json"
         success_message = format_message_success(
             details=f"Wrote schema for model \033[4m{sql_model.name}\033[0m",
             start_time=start_time,

--- a/visivo/models/insight.py
+++ b/visivo/models/insight.py
@@ -270,7 +270,7 @@ class Insight(NamedModel, ParentModel):
                 lets a caller resolving a never-run scratch model's raw-column
                 refs supply columns learned some other way (client-side
                 introspection) instead of hitting the normal
-                ``schemas/<model>/schema.json`` disk read. ``None`` (every
+                ``schemas/<model>.json`` disk read. ``None`` (every
                 real run-pipeline caller) is unaffected.
             force_dynamic: Build the DuckDB/model-hash-qualified `post_query`
                 form regardless of whether this insight actually depends on

--- a/visivo/query/model_schema_aggregator.py
+++ b/visivo/query/model_schema_aggregator.py
@@ -4,7 +4,7 @@ column schema as a run-phase job artifact.
 
 This is the model-side parallel of ``SchemaAggregator`` (which is source-shaped:
 ``source_name`` / ``source_type`` / ``tables`` / ``sqlglot_schema``). Models and
-sources share the ``{output_dir}/{run_id}/schemas/{name}/schema.json`` namespace,
+sources share the ``{output_dir}/{run_id}/schemas/{name}.json`` namespace,
 so the two aggregators are intentionally kept separate (and independently
 testable) rather than overloaded.
 
@@ -15,6 +15,7 @@ source artifact's metadata: ``model_name`` / ``model_type`` / ``generated_at`` /
 """
 
 import os
+from pathlib import Path
 import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
@@ -99,7 +100,7 @@ class ModelSchemaAggregator:
             Schema data dictionary or None if not found.
         """
         try:
-            schema_file = f"{output_dir}/{run_id}/schemas/{model_name}/schema.json"
+            schema_file = f"{output_dir}/{run_id}/schemas/{model_name}.json"
             if not os.path.exists(schema_file):
                 return None
 
@@ -137,11 +138,13 @@ class ModelSchemaAggregator:
 
         try:
             for entry_name in os.listdir(schemas_dir):
-                entry_dir = os.path.join(schemas_dir, entry_name)
-                if not os.path.isdir(entry_dir):
+                # `os.path.isdir` used to be the de-facto "is this a schema"
+                # filter under the per-name-directory layout; flat files need
+                # the extension to do that job.
+                if not entry_name.endswith(".json"):
                     continue
-                schema_file = os.path.join(entry_dir, "schema.json")
-                if not os.path.exists(schema_file):
+                schema_file = os.path.join(schemas_dir, entry_name)
+                if not os.path.isfile(schema_file):
                     continue
                 try:
                     with open(schema_file, "r") as fp:
@@ -155,7 +158,7 @@ class ModelSchemaAggregator:
 
                 schemas.append(
                     {
-                        "model_name": schema_data.get("model_name", entry_name),
+                        "model_name": schema_data.get("model_name", Path(entry_name).stem),
                         "model_type": schema_data.get("model_type", "unknown"),
                         "generated_at": schema_data.get("generated_at"),
                         "total_columns": schema_data.get("metadata", {}).get("total_columns", 0),

--- a/visivo/query/model_schema_inference.py
+++ b/visivo/query/model_schema_inference.py
@@ -74,8 +74,9 @@ def infer_model_columns(
     sqlglot_dialect: str,
     model_hash: str,
     stored_source_schema: Optional[Dict[str, Any]] = None,
+    strict: bool = True,
 ) -> Dict[str, Any]:
-    """Infer the output columns of ``sql`` as ``{column_name: DataType}``.
+    """Infer the output columns of ``sql`` as ``{column_name: type_name}``.
 
     Args:
         sql: The model's SQL.
@@ -86,6 +87,16 @@ def infer_model_columns(
             ``sqlglot_schema`` and ``metadata``). ``None`` or a missing block is
             valid and simply means fewer columns can be resolved, not a failure
             — a query that names its columns literally still annotates fine.
+        strict: Whether SQL that will not parse is an error.
+
+            ``True`` (the run): raise. A model whose SQL does not parse is a
+            broken model, and the run has to say so rather than persist an
+            empty schema that later reads as "this model has no columns".
+
+            ``False`` (the endpoints): return ``{}``. The editor asks on every
+            keystroke, so half-written SQL is the normal state — "nothing
+            resolved yet", not a server error. This is also what core's
+            reimplementation does unconditionally, since it has no run path.
 
     Returns:
         ``{column_name: type_name}``, where the type is SQLGlot's type *name*
@@ -101,13 +112,19 @@ def infer_model_columns(
         f"Inferring columns against {len(schema)} schema entries, default: {default_schema}"
     )
 
-    query_result_schema = schema_from_sql(
-        sqlglot_dialect=sqlglot_dialect,
-        sql=sql,
-        schema=schema,
-        model_hash=model_hash,
-        default_schema=default_schema,
-    )
+    try:
+        query_result_schema = schema_from_sql(
+            sqlglot_dialect=sqlglot_dialect,
+            sql=sql,
+            schema=schema,
+            model_hash=model_hash,
+            default_schema=default_schema,
+        )
+    except Exception:
+        if strict:
+            raise
+        Logger.instance().debug("Inference could not resolve the SQL; returning no columns")
+        return {}
     columns = query_result_schema.get(model_hash, {})
 
     # A surviving `*` means qualify could not expand it — the cached schema has

--- a/visivo/query/resolvers/field_resolver.py
+++ b/visivo/query/resolvers/field_resolver.py
@@ -52,7 +52,7 @@ class FieldResolver:
                 ``{model_hash: {column: type_string}, ...}``). Used by the
                 Explore 2.0 compile-draft endpoint to supply a scratch model's
                 columns (learned client-side, never written to
-                ``schemas/<model>/schema.json`` on disk) so
+                ``schemas/<model>.json`` on disk) so
                 ``_qualify_expression``/``_is_implicit_dimension`` resolve
                 without ever touching disk. ``None`` (the default, every real
                 run pipeline caller) preserves today's disk-read-only behavior
@@ -72,7 +72,7 @@ class FieldResolver:
             return self._schema_cache[model_name]
 
         # Build path to schema file
-        schema_file = os.path.join(self.output_dir, "schemas", model_name, "schema.json")
+        schema_file = os.path.join(self.output_dir, "schemas", f"{model_name}.json")
 
         # Try to read schema file
         try:

--- a/visivo/query/schema_aggregator.py
+++ b/visivo/query/schema_aggregator.py
@@ -3,6 +3,7 @@ Schema aggregation utilities for storing SQLGlot schemas from sources.
 """
 
 import os
+from pathlib import Path
 import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
@@ -36,7 +37,7 @@ class SchemaAggregator:
             run_id: Run identifier for schema storage location
         """
         try:
-            schema_dir = f"{output_dir}/{run_id}/schemas/{source_name}"
+            schema_dir = f"{output_dir}/{run_id}/schemas"
             os.makedirs(schema_dir, exist_ok=True)
 
             # Prepare schema data for storage
@@ -72,7 +73,7 @@ class SchemaAggregator:
             storage_data["metadata"]["total_columns"] = total_columns
 
             # Write to file
-            schema_file = f"{schema_dir}/schema.json"
+            schema_file = f"{schema_dir}/{source_name}.json"
             with open(schema_file, "w") as fp:
                 json.dump(storage_data, fp, indent=2, default=str)
 
@@ -212,7 +213,7 @@ class SchemaAggregator:
             Schema data dictionary or None if not found
         """
         try:
-            schema_file = f"{output_dir}/{run_id}/schemas/{source_name}/schema.json"
+            schema_file = f"{output_dir}/{run_id}/schemas/{source_name}.json"
             if not os.path.exists(schema_file):
                 return None
 
@@ -328,29 +329,37 @@ class SchemaAggregator:
             return schemas
 
         try:
-            for source_name in os.listdir(schemas_dir):
-                source_dir = os.path.join(schemas_dir, source_name)
-                if os.path.isdir(source_dir):
-                    schema_file = os.path.join(source_dir, "schema.json")
-                    if os.path.exists(schema_file):
-                        try:
-                            with open(schema_file, "r") as fp:
-                                schema_data = json.load(fp)
-                                schemas.append(
-                                    {
-                                        "source_name": schema_data.get("source_name", source_name),
-                                        "source_type": schema_data.get("source_type", "unknown"),
-                                        "generated_at": schema_data.get("generated_at"),
-                                        "total_tables": schema_data.get("metadata", {}).get(
-                                            "total_tables", 0
-                                        ),
-                                        "total_columns": schema_data.get("metadata", {}).get(
-                                            "total_columns", 0
-                                        ),
-                                    }
-                                )
-                        except Exception as e:
-                            Logger.instance().debug(f"Error reading schema file {schema_file}: {e}")
+            for entry in os.listdir(schemas_dir):
+                # The old layout used a directory per name, so `os.path.isdir`
+                # was the de-facto "is this a schema" filter. With flat files
+                # the extension has to do that job instead.
+                if not entry.endswith(".json"):
+                    continue
+                schema_file = os.path.join(schemas_dir, entry)
+                if not os.path.isfile(schema_file):
+                    continue
+
+                # The name fallback moves from the directory name to the stem.
+                # `Path.stem` strips only the final `.json`, so a source name
+                # containing a dot round-trips.
+                source_name = Path(entry).stem
+                try:
+                    with open(schema_file, "r") as fp:
+                        schema_data = json.load(fp)
+                except Exception as e:
+                    Logger.instance().debug(f"Error reading schema file {schema_file}: {e}")
+                    continue
+
+                metadata = schema_data.get("metadata", {})
+                schemas.append(
+                    {
+                        "source_name": schema_data.get("source_name", source_name),
+                        "source_type": schema_data.get("source_type", "unknown"),
+                        "generated_at": schema_data.get("generated_at"),
+                        "total_tables": metadata.get("total_tables", 0),
+                        "total_columns": metadata.get("total_columns", 0),
+                    }
+                )
 
         except Exception as e:
             Logger.instance().debug(f"Error listing schemas: {e}")

--- a/visivo/server/views/model_schema_views.py
+++ b/visivo/server/views/model_schema_views.py
@@ -85,6 +85,9 @@ def register_model_schema_views(app, flask_app, output_dir):
             sqlglot_dialect=source.get_sqlglot_dialect(),
             model_hash=model_hash,
             stored_source_schema=stored_source_schema,
+            # The editor asks on every keystroke; half-written SQL is normal.
+            # A parse failure is "nothing resolved yet", not a 500.
+            strict=False,
         )
         return jsonify(
             {

--- a/visivo/server/views/schema_path_safety.py
+++ b/visivo/server/views/schema_path_safety.py
@@ -2,7 +2,7 @@
 
 Both the model and source schema endpoints interpolate a user-supplied name and
 optional ``run_id`` query param directly into the on-disk artifact path
-(``{output_dir}/{run_id}/schemas/{name}/schema.json``). Without a strict
+(``{output_dir}/{run_id}/schemas/{name}.json``). Without a strict
 allowlist a caller could smuggle ``..`` / ``/`` segments and traverse outside
 the output directory, so every such value is validated here before it reaches
 the filesystem.


### PR DESCRIPTION
**Stacked on [#553](https://github.com/visivo-io/visivo/pull/553)** → #552 →
`feature/cloud-parity`. GitHub retargets as each merges.

This closes the risk I flagged on #552: core reimplements this inference (it
cannot import visivo — only the runner image ships it, and pulling it into the
Django web image would drag every warehouse driver along), so the two can drift
**silently**. Both repos stay green while answering differently, and the symptom
is a column list that is right locally and wrong in cloud, with nothing logged.

`tests/contracts/model_schema_inference_cases.json` is now the shared source of
truth. This half asserts visivo against it; [core#319](https://github.com/visivo-io/core/pull/319)
reads the same file from a sibling checkout.

## It found a real divergence on its first run

Unparseable SQL: **core returned `{}`, visivo raised** — so the same request
would 500 against Flask and answer 200 against Django. I shipped that in #552
and did not notice; the contract test caught it immediately.

The fix is not simply "make visivo tolerant", because the two callers want
different things:

| caller | unparseable SQL | why |
|---|---|---|
| the endpoints | `{}`, HTTP 200 | the editor asks on every keystroke; half-written SQL is the normal state |
| the run | raise | a model whose SQL does not parse is broken — persisting an empty schema would later read as "this model has no columns" |

So `infer_model_columns` takes `strict`: the run keeps the raising default, the
endpoints pass `strict=False`. The contract file describes the **endpoint**
answer, which is the one both repos serve.

## The 8 cases

Chosen for where the two implementations are most likely to diverge, not for
coverage: star expansion, aliases, nested schema blocks (a source with named
schemas nests one level deeper), unknown table, unparseable SQL, no cached
schema at all, and SQL comments — which break qualify's column lookups if not
stripped, since it compares `'"col" /* c */'` against `'"col"'`.

## Note on CI timing

core's half reads this file from a sibling `../visivo` checkout. Until this
merges to the ref core's CI vendors, core's test **skips with a message** naming
the paths it looked in — it does not silently pass.

## Tests

2319 pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)