### PR TITLE
Source connection tests get their own plural collection

### DIFF
--- a/test-projects/integration/validate_run_results.py
+++ b/test-projects/integration/validate_run_results.py
@@ -109,7 +109,7 @@ class VisivoRunValidator:
 
         success = True
         for source_name in expected_sources:
-            source_schema_file = schemas_dir / source_name / "schema.json"
+            source_schema_file = schemas_dir / f"{source_name}.json"
 
             if not source_schema_file.exists():
                 self.log_error(

--- a/tests/contracts/model_schema_inference_cases.json
+++ b/tests/contracts/model_schema_inference_cases.json
@@ -1,0 +1,83 @@
+{
+  "_comment": [
+    "Golden cases for model output-column inference — the CROSS-REPO contract.",
+    "",
+    "visivo and core each implement this independently: visivo in",
+    "visivo/query/model_schema_inference.py, core in",
+    "api/apps/deploys/services/sqlglot_utils.py. Core cannot import visivo (only",
+    "the runner image ships it; pulling it into the Django web image would drag",
+    "every warehouse driver along), so the logic exists twice on purpose.",
+    "",
+    "This file is the single source of truth that keeps them honest. visivo's",
+    "tests/contracts/test_model_schema_inference_contract.py and core's",
+    "apps/deploys/tests/test_model_schema_contract.py both read THIS file and",
+    "assert the same answers. Core locates it via a sibling ../visivo checkout,",
+    "which is how its CI already vendors the viewer.",
+    "",
+    "Add a case here when you change inference in either repo."
+  ],
+  "cases": [
+    {
+      "name": "named columns resolve their types from the source schema",
+      "dialect": "postgres",
+      "sql": "SELECT id, amount FROM orders",
+      "sqlglot_schema": {
+        "orders": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+      },
+      "expected": { "id": "INT", "amount": "DECIMAL" }
+    },
+    {
+      "name": "star expands from the source schema",
+      "dialect": "postgres",
+      "sql": "SELECT * FROM orders",
+      "sqlglot_schema": {
+        "orders": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+      },
+      "expected": { "id": "INT", "amount": "DECIMAL", "region": "VARCHAR" }
+    },
+    {
+      "name": "aliases are the output names",
+      "dialect": "postgres",
+      "sql": "SELECT id AS order_id, amount AS total FROM orders",
+      "sqlglot_schema": { "orders": { "id": "INT", "amount": "DECIMAL" } },
+      "expected": { "order_id": "INT", "total": "DECIMAL" }
+    },
+    {
+      "name": "an unknown table resolves nothing, and is not an error",
+      "dialect": "postgres",
+      "sql": "SELECT * FROM never_introspected",
+      "sqlglot_schema": { "orders": { "id": "INT" } },
+      "expected": {}
+    },
+    {
+      "name": "unparseable SQL resolves nothing, and is not an error",
+      "dialect": "postgres",
+      "sql": "SELECT FROM WHERE ((",
+      "sqlglot_schema": { "orders": { "id": "INT" } },
+      "expected": {}
+    },
+    {
+      "name": "no cached source schema still resolves literal projections",
+      "dialect": "postgres",
+      "sql": "SELECT 1 AS one",
+      "sqlglot_schema": {},
+      "expected": { "one": "INT" }
+    },
+    {
+      "name": "a nested schema block (source with named schemas) resolves",
+      "dialect": "snowflake",
+      "sql": "SELECT col1 FROM EDW.fact_order",
+      "sqlglot_schema": {
+        "EDW": { "fact_order": { "col1": "INT", "col2": "VARCHAR" } }
+      },
+      "expected": { "col1": "INT" }
+    },
+    {
+      "name": "SQL comments do not break column resolution",
+      "dialect": "postgres",
+      "sql": "SELECT id /* the key */, amount FROM orders",
+      "sqlglot_schema": { "orders": { "id": "INT", "amount": "DECIMAL" } },
+      "expected": { "id": "INT", "amount": "DECIMAL" }
+    }
+  ]
+}

--- a/tests/contracts/test_model_schema_inference_contract.py
+++ b/tests/contracts/test_model_schema_inference_contract.py
@@ -1,0 +1,52 @@
+"""The visivo half of the cross-repo model-schema inference contract.
+
+core reimplements this inference (it cannot import visivo — only the runner
+image ships it), so the two can drift silently: both stay green while answering
+differently, and the symptom in production is a column list that is right
+locally and wrong in cloud, with nothing logged.
+
+``model_schema_inference_cases.json`` is the shared source of truth. This file
+asserts visivo's implementation against it;
+``core/api/apps/deploys/tests/test_model_schema_contract.py`` asserts core's
+against the same file, read from a sibling ``../visivo`` checkout.
+
+Add a case there when you change inference in either repo.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from visivo.query.model_schema_inference import infer_model_columns
+
+CASES_FILE = Path(__file__).parent / "model_schema_inference_cases.json"
+CASES = json.loads(CASES_FILE.read_text())["cases"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_inference_matches_the_shared_contract(case):
+    columns = infer_model_columns(
+        sql=case["sql"],
+        sqlglot_dialect=case["dialect"],
+        model_hash="contract_hash",
+        stored_source_schema={
+            "sqlglot_schema": case["sqlglot_schema"],
+            "metadata": {"default_schema": case.get("default_schema")},
+        },
+        # The contract describes what the ENDPOINTS answer. The run calls the
+        # same function with strict=True so a model whose SQL does not parse
+        # fails the run instead of persisting an empty schema.
+        strict=False,
+    )
+
+    assert columns == case["expected"], (
+        f"visivo inference diverged from the shared contract on "
+        f"{case['name']!r}. If this change is intentional, update "
+        f"{CASES_FILE.name} and core's half of the contract together."
+    )
+
+
+def test_the_contract_file_is_not_empty():
+    """A truncated or unparsed fixture would make every case above vacuous."""
+    assert len(CASES) >= 8

--- a/tests/integration/test_input_uniform_format.py
+++ b/tests/integration/test_input_uniform_format.py
@@ -45,12 +45,12 @@ class TestInputUniformFormat:
         )
 
         # Create schema file for the model
-        schema_dir = Path(output_dir) / "schemas" / model.name
+        schema_dir = Path(output_dir) / "schemas"
         schema_dir.mkdir(parents=True, exist_ok=True)
 
         import json
 
-        schema_file = schema_dir / "schema.json"
+        schema_file = schema_dir / f"{model.name}.json"
         schema_data = {
             model.name_hash(): {
                 "id": "INTEGER",

--- a/tests/jobs/test_run_insight_job_join_errors.py
+++ b/tests/jobs/test_run_insight_job_join_errors.py
@@ -21,8 +21,7 @@ from visivo.models.project import Project
 def _write_schema(schema_base, model, columns):
     """Mirror the on-disk schema layout the FieldResolver reads from."""
     model_hash = model.name_hash()
-    schema_dir = schema_base.mkdir(model.name)
-    schema_file = schema_dir.join("schema.json")
+    schema_file = schema_base.join(f"{model.name}.json")
     schema_file.write(json.dumps({model_hash: columns}))
 
 
@@ -58,7 +57,7 @@ def test_two_unjoined_model_insight_run_yields_missing_relation(tmpdir):
 
     run_id = "main"
     output_dir = str(tmpdir)
-    # FieldResolver reads schemas from {output_dir}/{run_id}/schemas/<model>/schema.json
+    # FieldResolver reads schemas from {output_dir}/{run_id}/schemas/<model>.json
     run_dir = tmpdir.mkdir(run_id)
     schema_base = run_dir.mkdir("schemas")
     _write_schema(schema_base, orders, {"amount": "INTEGER"})

--- a/tests/jobs/test_run_sql_model_job.py
+++ b/tests/jobs/test_run_sql_model_job.py
@@ -130,7 +130,7 @@ class TestSqlModelSchemaArtifact:
         assert model_hash in result
         assert set(result[model_hash].keys()) == {"id", "name"}
 
-        schema_file = os.path.join(output_dir, "main", "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, "main", "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
         with open(schema_file) as fp:
             data = json.load(fp)

--- a/tests/jobs/test_run_sql_model_job_coverage.py
+++ b/tests/jobs/test_run_sql_model_job_coverage.py
@@ -48,9 +48,9 @@ class TestGetErrorMessage:
 
 
 def _write_source_schema(output_dir, source_name, sqlglot_schema, default_schema=None):
-    source_schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", source_name)
+    source_schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
     os.makedirs(source_schema_dir, exist_ok=True)
-    with open(os.path.join(source_schema_dir, "schema.json"), "w") as fp:
+    with open(os.path.join(source_schema_dir, f"{source_name}.json"), "w") as fp:
         json.dump(
             {"sqlglot_schema": sqlglot_schema, "metadata": {"default_schema": default_schema}},
             fp,
@@ -108,7 +108,7 @@ class TestModelQueryAndSchemaAction:
         result = model_query_and_schema_action(model, dag, output_dir)
 
         assert result.success is True
-        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
 
     def test_failure_when_query_references_missing_table(self):
@@ -135,7 +135,7 @@ class TestSchemaOnlyAction:
         result = schema_only_action(model, dag, output_dir)
 
         assert result.success is True
-        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", model.name, "schema.json")
+        schema_file = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", f"{model.name}.json")
         assert os.path.exists(schema_file)
 
     def test_failure_when_schema_build_raises(self, mocker):

--- a/tests/query/insight/test_draft_overlay.py
+++ b/tests/query/insight/test_draft_overlay.py
@@ -57,9 +57,9 @@ class TestBuildDraftOverlayHappyPath:
     def test_the_overlay_resolves_against_an_already_published_model(self, flask_app, tmp_path):
         _, dag, insight = build_draft_overlay(flask_app, insight_config())
         model_node = dag.get_descendant_by_name("orders_q")
-        schema_dir = tmp_path / "schemas" / "orders_q"
+        schema_dir = tmp_path / "schemas"
         schema_dir.mkdir(parents=True)
-        (schema_dir / "schema.json").write_text(
+        (schema_dir / "orders_q.json").write_text(
             json.dumps({model_node.name_hash(): {"region": "VARCHAR", "amount": "DOUBLE"}})
         )
         query_info = insight.get_query_info(dag, str(tmp_path), force_dynamic=True)

--- a/tests/query/insight/test_insight_default_line_sort.py
+++ b/tests/query/insight/test_insight_default_line_sort.py
@@ -24,9 +24,9 @@ from tests.factories.model_factories import SourceFactory
 @pytest.fixture
 def create_schema_file(tmpdir):
     def _create_schema(model, output_dir):
-        schema_dir = os.path.join(output_dir, "schemas", model.name)
+        schema_dir = os.path.join(output_dir, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): {"x": "INTEGER", "y": "INTEGER"}}, f)
 
     return _create_schema

--- a/tests/query/insight/test_insight_filter_interactions.py
+++ b/tests/query/insight/test_insight_filter_interactions.py
@@ -33,9 +33,7 @@ class TestInsightFilterInteractions:
             """Create a schema.json file for the given model."""
             schema_base = os.path.join(output_dir, "schemas")
             os.makedirs(schema_base, exist_ok=True)
-            schema_dir = os.path.join(schema_base, model.name)
-            os.makedirs(schema_dir, exist_ok=True)
-            schema_file = os.path.join(schema_dir, "schema.json")
+            schema_file = os.path.join(schema_base, f"{model.name}.json")
 
             # Create a basic schema with x and y columns for filter tests
             model_hash = model.name_hash()
@@ -307,9 +305,9 @@ class TestInsightFilterInteractions:
         dag = project.dag()
 
         # Write a schema.json for the referenced model with the given columns.
-        schema_base = os.path.join(str(tmpdir), "schemas", model.name)
+        schema_base = os.path.join(str(tmpdir), "schemas")
         os.makedirs(schema_base, exist_ok=True)
-        with open(os.path.join(schema_base, "schema.json"), "w") as f:
+        with open(os.path.join(schema_base, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): schema_columns}, f)
 
         # Write the input job's JSON output so parsing can obtain a sample value

--- a/tests/query/insight/test_insight_group_by.py
+++ b/tests/query/insight/test_insight_group_by.py
@@ -28,9 +28,9 @@ def build_sql(tmpdir):
             name="p", sources=[source], models=[model], insights=[insight], dashboards=[]
         )
         dag = project.dag()
-        schema_dir = os.path.join(str(tmpdir), "schemas", model.name)
+        schema_dir = os.path.join(str(tmpdir), "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
             json.dump({model.name_hash(): schema}, f)
         from visivo.query.insight.insight_query_builder import InsightQueryBuilder
 

--- a/tests/query/insight/test_insight_query_builder_with_inputs.py
+++ b/tests/query/insight/test_insight_query_builder_with_inputs.py
@@ -415,9 +415,7 @@ class TestInsightQueryBuilderWithInputs:
             """Create a schema.json file for the given model."""
             schema_base = os.path.join(output_dir, "schemas")
             os.makedirs(schema_base, exist_ok=True)
-            schema_dir = os.path.join(schema_base, model.name)
-            os.makedirs(schema_dir, exist_ok=True)
-            schema_file = os.path.join(schema_dir, "schema.json")
+            schema_file = os.path.join(schema_base, f"{model.name}.json")
 
             # Create a basic schema with common columns
             model_hash = model.name_hash()

--- a/tests/query/insight/test_insight_requires_full_source.py
+++ b/tests/query/insight/test_insight_requires_full_source.py
@@ -22,9 +22,9 @@ from tests.factories.model_factories import SourceFactory
 
 def _write_schema(model, output_dir):
     """FieldResolver needs each model's column schema to resolve ${ref(m).col}."""
-    schema_dir = os.path.join(output_dir, "schemas", model.name)
+    schema_dir = os.path.join(output_dir, "schemas")
     os.makedirs(schema_dir, exist_ok=True)
-    with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+    with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
         json.dump(
             {model.name_hash(): {"x": "INTEGER", "y": "INTEGER", "amount": "DECIMAL"}},
             f,

--- a/tests/query/resolvers/test_field_resolver.py
+++ b/tests/query/resolvers/test_field_resolver.py
@@ -26,8 +26,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_success(self, tmpdir):
         """Test successfully loading a schema file."""
         # Create a mock schema file
-        schema_dir = tmpdir.mkdir("schemas").mkdir("test_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("test_model.json")
         schema_data = {"model_hash_123": {"id": "INTEGER", "name": "VARCHAR", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -45,8 +45,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_caching(self, tmpdir):
         """Test that schemas are cached after first load."""
         # Create a mock schema file
-        schema_dir = tmpdir.mkdir("schemas").mkdir("test_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("test_model.json")
         schema_data = {"model_hash_123": {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -74,8 +74,8 @@ class TestFieldResolverSchemaLoading:
     def test_load_model_schema_invalid_json(self, tmpdir):
         """Test handling of malformed JSON in schema files."""
         # Create a schema file with invalid JSON
-        schema_dir = tmpdir.mkdir("schemas").mkdir("bad_model")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("bad_model.json")
         schema_file.write("{invalid json content")
 
         dag = ProjectDag()
@@ -100,8 +100,8 @@ class TestFieldResolverImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -121,8 +121,8 @@ class TestFieldResolverImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -161,8 +161,8 @@ class TestFieldResolverResolveImplicitDimensions:
 
         # Create schema in correct format: {model_hash: {column: type}}
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"x": "INTEGER", "y": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -185,8 +185,8 @@ class TestFieldResolverResolveImplicitDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -224,8 +224,8 @@ class TestFieldResolverResolveMetrics:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -269,8 +269,7 @@ class TestFieldResolverResolveMetrics:
             (model_a, {"id": "INTEGER", "amount": "DECIMAL"}),
             (model_b, {"id": "INTEGER", "weight": "DECIMAL"}),
         ]:
-            d = schema_base.mkdir(m.name)
-            d.join("schema.json").write(json.dumps({m.name_hash(): cols}))
+            schema_base.join(f"{m.name}.json").write(json.dumps({m.name_hash(): cols}))
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
 
@@ -341,8 +340,7 @@ class TestFieldResolverComplexExpressions:
         ]:
             model_obj = model1 if model_name == "orders" else model2
             model_hash = model_obj.name_hash()
-            schema_dir = schema_base_dir.mkdir(model_name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base_dir.join(f"{model_name}.json")
             schema_data = {model_hash: fields}
             schema_file.write(json.dumps(schema_data))
 
@@ -370,8 +368,8 @@ class TestFieldResolverComplexExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -444,8 +442,8 @@ class TestFieldResolverQualification:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -466,8 +464,8 @@ class TestFieldResolverQualification:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -506,8 +504,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema for the base model
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -544,8 +542,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema for the base model
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "status": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -582,8 +580,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "price": "DECIMAL", "quantity": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -623,8 +621,8 @@ class TestFieldResolverGlobalMetricsAndDimensions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("sales")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("sales.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -657,8 +655,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("another_local_test_table")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("another_local_test_table.json")
         schema_data = {model_hash: {"new_x": "INTEGER", "name": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -699,8 +697,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {
             model_hash: {"status": "VARCHAR", "amount": "DECIMAL", "priority": "INTEGER"}
         }
@@ -745,8 +743,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("products")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("products.json")
         schema_data = {model_hash: {"category": "VARCHAR", "price": "DECIMAL", "stock": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -792,8 +790,8 @@ class TestFieldResolverCaseStatements:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("metrics")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("metrics.json")
         schema_data = {model_hash: {"value": "DECIMAL", "threshold": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -843,8 +841,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -872,8 +870,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL", "date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -901,8 +899,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -930,8 +928,8 @@ class TestFieldResolverDialectQuoting:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"status": "VARCHAR", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -966,8 +964,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL", "date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -997,8 +995,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"date": "DATE"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1027,8 +1025,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1058,8 +1056,8 @@ class TestFieldResolverSortExpressions:
 
         # Create schema
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("sales")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("sales.json")
         schema_data = {model_hash: {"revenue": "DECIMAL", "month": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1093,8 +1091,8 @@ class TestFieldResolverCaseSensitivity:
 
         # Create schema with UPPERCASE columns (as Snowflake/BigQuery returns)
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("local_test_table")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("local_test_table.json")
         schema_data = {model_hash: {"X": "INTEGER", "Y": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1119,8 +1117,8 @@ class TestFieldResolverCaseSensitivity:
         dag = project.dag()
 
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"AMOUNT": "DECIMAL", "USER_ID": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1168,8 +1166,8 @@ class TestFieldResolverCaseSensitivity:
         dag = project.dag()
 
         model_hash = model.name_hash()
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL", "status": "VARCHAR"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1300,8 +1298,8 @@ class TestFieldResolverB10SqlModelFallback:
         dag = project.dag()
 
         # Schema for 'orders' contains a 'revenue' column.
-        schema_dir = tmpdir.mkdir("schemas").mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_dir = tmpdir.mkdir("schemas")
+        schema_file = schema_dir.join("orders.json")
         schema_data = {orders.name_hash(): {"id": "INTEGER", "revenue": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 

--- a/tests/query/resolvers/test_field_resolver_errors.py
+++ b/tests/query/resolvers/test_field_resolver_errors.py
@@ -92,8 +92,7 @@ class TestSchemaFileCorrupted:
         # Create schema directory but with invalid JSON
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_file.write("{ invalid json content ")
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
@@ -125,8 +124,7 @@ class TestSchemaFileCorrupted:
 
         # Create empty schema file
         schema_base = tmpdir.mkdir("schemas")
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_file.write("{}")
 
         resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
@@ -155,8 +153,7 @@ class TestSchemaFieldMissing:
         # Create schema with specific columns
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -247,8 +244,7 @@ class TestResolutionStackTracking:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -283,8 +279,7 @@ class TestCacheInvalidation:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER", "amount": "DECIMAL"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -321,8 +316,7 @@ class TestCacheInvalidation:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -356,8 +350,7 @@ class TestDialectHandling:
         # Create schema
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {model_hash: {"id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 

--- a/tests/query/resolvers/test_field_resolver_with_inputs.py
+++ b/tests/query/resolvers/test_field_resolver_with_inputs.py
@@ -102,8 +102,7 @@ class TestFieldResolverWithInputs:
         # Create schema file
         schema_base = tmpdir.mkdir("schemas")
         model_hash = orders_model.name_hash()
-        schema_dir = schema_base.mkdir("orders")
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join("orders.json")
         schema_data = {
             model_hash: {
                 "id": "INTEGER",

--- a/tests/query/test_model_schema_aggregator.py
+++ b/tests/query/test_model_schema_aggregator.py
@@ -87,9 +87,9 @@ class TestLoadModelSchema:
             columns={"id": "INT"},
             source_dialect="duckdb",
         )
-        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
         loaded = ModelSchemaAggregator.load_model_schema("orders", output_dir)
@@ -104,9 +104,9 @@ class TestLoadModelSchema:
             name_hash="mh", model_name="orders", model_type="sql", columns={"id": "INT"}
         )
         run_id = "preview-orders"
-        schema_dir = os.path.join(output_dir, run_id, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, run_id, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
         # Default run_id (main) misses; explicit preview run_id hits.
@@ -120,22 +120,23 @@ class TestListStoredModelSchemas:
         output_dir = str(tmp_path)
         schemas_root = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
 
+        os.makedirs(schemas_root, exist_ok=True)
+
         # A model schema (has model_name).
-        model_dir = os.path.join(schemas_root, "orders")
-        os.makedirs(model_dir, exist_ok=True)
         model_payload = ModelSchemaAggregator.build_envelope(
             name_hash="mh",
             model_name="orders",
             model_type="sql",
             columns={"id": "INT", "total": "DOUBLE"},
         )
-        with open(os.path.join(model_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schemas_root, "orders.json"), "w") as fp:
             json.dump(model_payload, fp)
 
-        # A source schema (has source_name, NOT model_name) in the same dir.
-        source_dir = os.path.join(schemas_root, "my_source")
-        os.makedirs(source_dir, exist_ok=True)
-        with open(os.path.join(source_dir, "schema.json"), "w") as fp:
+        # A source schema (has source_name, NOT model_name) beside it. Models
+        # and sources share this directory, so `model_name` is what tells them
+        # apart — the flat layout removes the per-name directory that used to
+        # be incidental structure, not a filter.
+        with open(os.path.join(schemas_root, "my_source.json"), "w") as fp:
             json.dump(
                 {
                     "source_name": "my_source",

--- a/tests/query/test_model_schema_aggregator_coverage.py
+++ b/tests/query/test_model_schema_aggregator_coverage.py
@@ -15,40 +15,35 @@ from visivo.query.model_schema_aggregator import ModelSchemaAggregator
 class TestLoadModelSchemaErrors:
     def test_corrupt_json_returns_none(self, tmp_path):
         output_dir = str(tmp_path)
-        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas", "orders")
+        schema_dir = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
-        with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schema_dir, "orders.json"), "w") as fp:
             fp.write("{ this is not valid json ")
 
         assert ModelSchemaAggregator.load_model_schema("orders", output_dir) is None
 
 
 class TestListStoredModelSchemasSkips:
-    def test_skips_non_directory_missing_and_corrupt_entries(self, tmp_path):
+    def test_skips_non_json_and_corrupt_entries(self, tmp_path):
         output_dir = str(tmp_path)
         schemas_root = os.path.join(output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schemas_root, exist_ok=True)
 
-        # A valid model schema dir.
-        good_dir = os.path.join(schemas_root, "orders")
-        os.makedirs(good_dir, exist_ok=True)
+        # A valid model schema.
         payload = ModelSchemaAggregator.build_envelope(
             name_hash="mh", model_name="orders", model_type="sql", columns={"id": "INT"}
         )
-        with open(os.path.join(good_dir, "schema.json"), "w") as fp:
+        with open(os.path.join(schemas_root, "orders.json"), "w") as fp:
             json.dump(payload, fp)
 
-        # A plain file (not a directory) in the schemas dir → skipped.
+        # A non-JSON file → skipped. Under the old per-name-directory layout
+        # `os.path.isdir` was the de-facto "is this a schema" filter; flat files
+        # make the extension carry that, so this is the case that pins it.
         with open(os.path.join(schemas_root, "loose_file.txt"), "w") as fp:
             fp.write("ignore me")
 
-        # A directory with no schema.json → skipped.
-        os.makedirs(os.path.join(schemas_root, "empty_dir"), exist_ok=True)
-
-        # A directory with a corrupt schema.json → skipped.
-        corrupt_dir = os.path.join(schemas_root, "corrupt")
-        os.makedirs(corrupt_dir, exist_ok=True)
-        with open(os.path.join(corrupt_dir, "schema.json"), "w") as fp:
+        # A corrupt JSON file → skipped, not fatal to the whole listing.
+        with open(os.path.join(schemas_root, "corrupt.json"), "w") as fp:
             fp.write("{ broken ")
 
         listed = ModelSchemaAggregator.list_stored_model_schemas(output_dir)

--- a/tests/query/test_relation_graph.py
+++ b/tests/query/test_relation_graph.py
@@ -45,8 +45,7 @@ class TestRelationGraphBasics:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "name": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -82,8 +81,7 @@ class TestRelationGraphBasics:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -148,8 +146,7 @@ class TestTwoModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -196,8 +193,7 @@ class TestTwoModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -295,8 +291,7 @@ class TestAmbiguousPaths:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -354,8 +349,7 @@ class TestAmbiguousPaths:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -414,8 +408,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -468,8 +461,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "address_id": "INTEGER"}
             }
@@ -510,8 +502,7 @@ class TestMultiModelJoins:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "a_id": "INTEGER", "c_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -603,8 +594,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -651,8 +641,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_users, model_orders, model_addr]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -690,8 +679,7 @@ class TestJoinPlan:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -734,8 +722,7 @@ class TestValidation:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -772,8 +759,7 @@ class TestValidation:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -828,8 +814,7 @@ class TestDefaultRelationResolution:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",
@@ -889,8 +874,7 @@ class TestDefaultRelationResolution:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "email": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -959,8 +943,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "product_id": "INTEGER"}
             }
@@ -1007,8 +990,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {"id": "INTEGER", "user_id": "INTEGER", "product_id": "INTEGER"}
             }
@@ -1050,8 +1032,7 @@ class TestRelationGraphScoping:
         # Create schema only for orders
         schema_base = tmpdir.mkdir("schemas")
         model_hash = model_a.name_hash()
-        schema_dir = schema_base.mkdir(model_a.name)
-        schema_file = schema_dir.join("schema.json")
+        schema_file = schema_base.join(f"{model_a.name}.json")
         schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
         schema_file.write(json.dumps(schema_data))
 
@@ -1092,8 +1073,7 @@ class TestRelationGraphScoping:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -1135,8 +1115,7 @@ class TestDefaultRelationTieBreak:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {model_hash: {"id": "INTEGER", "user_id": "INTEGER", "email": "VARCHAR"}}
             schema_file.write(json.dumps(schema_data))
 
@@ -1253,8 +1232,7 @@ class TestStructuredJoinErrorAttributes:
         schema_base = tmpdir.mkdir("schemas")
         for model in [model_a, model_b, model_c, model_d]:
             model_hash = model.name_hash()
-            schema_dir = schema_base.mkdir(model.name)
-            schema_file = schema_dir.join("schema.json")
+            schema_file = schema_base.join(f"{model.name}.json")
             schema_data = {
                 model_hash: {
                     "id": "INTEGER",

--- a/tests/query/test_relation_graph_coverage.py
+++ b/tests/query/test_relation_graph_coverage.py
@@ -41,8 +41,7 @@ def _build_graph(tmpdir, models, relations, columns=None):
 
     schema_base = tmpdir.mkdir("schemas")
     for model in sql_models:
-        schema_dir = schema_base.mkdir(model.name)
-        schema_dir.join("schema.json").write(json.dumps({model.name_hash(): columns}))
+        schema_base.join(f"{model.name}.json").write(json.dumps({model.name_hash(): columns}))
 
     resolver = FieldResolver(dag=dag, output_dir=str(tmpdir), native_dialect="duckdb")
     return RelationGraph(dag=dag, field_resolver=resolver)

--- a/tests/query/test_schema_aggregator.py
+++ b/tests/query/test_schema_aggregator.py
@@ -336,9 +336,7 @@ class TestSchemaAggregatorRunId:
             run_id="test-run-id",
         )
 
-        expected_path = os.path.join(
-            temp_dir, "test-run-id", "schemas", "test_source", "schema.json"
-        )
+        expected_path = os.path.join(temp_dir, "test-run-id", "schemas", "test_source.json")
         assert os.path.exists(expected_path)
 
     def test_aggregate_default_run_id(self, temp_dir):
@@ -356,9 +354,7 @@ class TestSchemaAggregatorRunId:
             output_dir=temp_dir,
         )
 
-        expected_path = os.path.join(
-            temp_dir, DEFAULT_RUN_ID, "schemas", "test_source", "schema.json"
-        )
+        expected_path = os.path.join(temp_dir, DEFAULT_RUN_ID, "schemas", "test_source.json")
         assert os.path.exists(expected_path)
 
     def test_load_from_specific_run_id(self, temp_dir):

--- a/tests/server/test_flask_endpoints.py
+++ b/tests/server/test_flask_endpoints.py
@@ -253,7 +253,7 @@ class TestFlaskSourceEndpoints:
             )
 
     def test_test_source_connection_success(self):
-        """Test POST /api/sources/test-connection/ with valid config."""
+        """Test POST /api/source-connections/ with valid config."""
         with patch("visivo.server.views.sources_views.validate_source_from_config") as mock_test:
             mock_test.return_value = {"status": "connected", "source": "test_source"}
 
@@ -265,18 +265,18 @@ class TestFlaskSourceEndpoints:
             }
 
             response = self.client.post(
-                "/api/sources/test-connection/",
+                "/api/source-connections/",
                 json=source_config,
                 headers={"Content-Type": "application/json"},
             )
 
-            job = self._await_job(response, "/api/sources/test-connection/")
+            job = self._await_job(response, "/api/source-connections/")
             assert job["status"] == "completed"
             assert job["result"]["status"] == "connected"
             mock_test.assert_called_once_with(source_config)
 
     def test_test_source_connection_failure(self):
-        """Test POST /api/sources/test-connection/ with connection failure."""
+        """Test POST /api/source-connections/ with connection failure."""
         with patch("visivo.server.views.sources_views.validate_source_from_config") as mock_test:
             mock_test.return_value = {"status": "connection_failed", "error": "Connection timeout"}
 
@@ -288,7 +288,7 @@ class TestFlaskSourceEndpoints:
             }
 
             response = self.client.post(
-                "/api/sources/test-connection/",
+                "/api/source-connections/",
                 json=source_config,
                 headers={"Content-Type": "application/json"},
             )
@@ -296,16 +296,16 @@ class TestFlaskSourceEndpoints:
             # A refused connection is a job that COMPLETED and reported a
             # failure — distinct from a job that failed, which means the op
             # itself blew up. Collapsing the two would hide real crashes.
-            job = self._await_job(response, "/api/sources/test-connection/")
+            job = self._await_job(response, "/api/source-connections/")
             assert job["status"] == "completed"
             assert job["result"]["status"] == "connection_failed"
             assert "Connection timeout" in job["result"]["error"]
             mock_test.assert_called_once_with(source_config)
 
     def test_test_source_connection_no_config(self):
-        """Test POST /api/sources/test-connection/ with missing config."""
+        """Test POST /api/source-connections/ with missing config."""
         response = self.client.post(
-            "/api/sources/test-connection/", headers={"Content-Type": "application/json"}
+            "/api/source-connections/", headers={"Content-Type": "application/json"}
         )
 
         assert response.status_code == 400
@@ -313,9 +313,9 @@ class TestFlaskSourceEndpoints:
         assert "Source configuration is required" in data["error"]
 
     def test_test_source_connection_invalid_json(self):
-        """Test POST /api/sources/test-connection/ with invalid JSON."""
+        """Test POST /api/source-connections/ with invalid JSON."""
         response = self.client.post(
-            "/api/sources/test-connection/",
+            "/api/source-connections/",
             data="invalid json",
             headers={"Content-Type": "application/json"},
         )
@@ -325,14 +325,14 @@ class TestFlaskSourceEndpoints:
         assert "Invalid JSON in request body" in data["error"]
 
     def test_test_source_connection_exception(self):
-        """Test POST /api/sources/test-connection/ with unexpected exception."""
+        """Test POST /api/source-connections/ with unexpected exception."""
         with patch("visivo.server.views.sources_views.validate_source_from_config") as mock_test:
             mock_test.side_effect = Exception("Unexpected error")
 
             source_config = {"name": "test_source", "type": "postgresql", "host": "localhost"}
 
             response = self.client.post(
-                "/api/sources/test-connection/",
+                "/api/source-connections/",
                 json=source_config,
                 headers={"Content-Type": "application/json"},
             )
@@ -341,7 +341,7 @@ class TestFlaskSourceEndpoints:
             # response. The viewer maps a failed job to
             # {status: 'connection_failed', error}, so what the user sees is
             # unchanged; what changed is that the crash is attributable.
-            job = self._await_job(response, "/api/sources/test-connection/")
+            job = self._await_job(response, "/api/source-connections/")
             assert job["status"] == "failed"
             assert "Unexpected error" in job["error"]
 

--- a/tests/server/test_flask_endpoints.py
+++ b/tests/server/test_flask_endpoints.py
@@ -70,28 +70,28 @@ class TestFlaskSourceEndpoints:
             time.sleep(0.01)
         raise AssertionError(f"job {job_id} never reached a terminal state")
 
-    def test_test_connection_success(self):
-        """Test GET /api/project/sources/<name>/test-connection."""
-        with patch("visivo.server.views.sources_views.check_source_connection") as mock_test:
-            mock_test.return_value = {"source": "test_source", "status": "connected"}
+    def test_endpoint_paths_with_special_characters(self):
+        """Path params survive dashes, underscores and dots.
 
-            response = self.client.get("/api/project/sources/test_source/test-connection/")
+        Was written against the source test-connection route, which is gone
+        (nothing called it). The property belongs to the URL converter, not to
+        that endpoint, so it moved to the sibling that still has a {name}
+        segment rather than being deleted with the route.
+        """
+        special_names = [
+            "source-with-dash",
+            "source_with_underscore",
+            "source.with.dot",
+        ]
 
-            assert response.status_code == 200
-            data = json.loads(response.data)
-            assert data["status"] == "connected"
-            mock_test.assert_called_once_with(self.sources_list, "test_source")
+        for source_name in special_names:
+            with patch("visivo.server.views.sources_views.get_source_databases") as mock_get_dbs:
+                mock_get_dbs.return_value = {"source": source_name, "databases": []}
 
-    def test_test_connection_not_found(self):
-        """Test connection test for non-existent source."""
-        with patch("visivo.server.views.sources_views.check_source_connection") as mock_test:
-            mock_test.return_value = ({"error": "Source 'bad_source' not found"}, 404)
+                response = self.client.get(f"/api/project/sources/{source_name}/databases/")
 
-            response = self.client.get("/api/project/sources/bad_source/test-connection/")
-
-            assert response.status_code == 404
-            data = json.loads(response.data)
-            assert "not found" in data["error"]
+                assert response.status_code == 200
+                mock_get_dbs.assert_called_with(self.sources_list, source_name)
 
     def test_list_source_databases_success(self):
         """Test GET /api/project/sources/<name>/databases."""
@@ -389,7 +389,6 @@ class TestFlaskSourceEndpoints:
         """Test that all endpoints handle tuple error responses correctly."""
         # Test each endpoint that checks for tuple responses
         endpoints_and_mocks = [
-            ("/api/project/sources/test/test-connection/", "check_source_connection"),
             ("/api/project/sources/test/databases/", "get_source_databases"),
             ("/api/project/sources/test/databases/db/schemas/", "get_database_schemas"),
             ("/api/project/sources/test/databases/db/tables/", "get_schema_tables"),
@@ -405,23 +404,6 @@ class TestFlaskSourceEndpoints:
                 assert response.status_code == 400
                 data = json.loads(response.data)
                 assert data["error"] == "Custom error"
-
-    def test_endpoint_paths_with_special_characters(self):
-        """Test endpoints handle special characters in path parameters."""
-        special_names = [
-            "source-with-dash",
-            "source_with_underscore",
-            "source.with.dot",
-        ]
-
-        for source_name in special_names:
-            with patch("visivo.server.views.sources_views.check_source_connection") as mock_test:
-                mock_test.return_value = {"source": source_name, "status": "connected"}
-
-                response = self.client.get(f"/api/project/sources/{source_name}/test-connection/")
-
-                assert response.status_code == 200
-                mock_test.assert_called_with(self.sources_list, source_name)
 
     def test_multiple_path_parameters(self):
         """Test endpoints with multiple path parameters."""

--- a/tests/server/test_source_metadata.py
+++ b/tests/server/test_source_metadata.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch, MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
 from visivo.server.source_metadata import (
-    check_source_connection,
     get_source_databases,
     get_database_schemas,
     get_schema_tables,
@@ -47,81 +46,6 @@ class TestSourceMetadata:
     def teardown_method(self):
         """Clean up patches."""
         self.isinstance_patcher.stop()
-
-    def test_test_source_connection_success(self):
-        """Test successful source connection test."""
-        # Setup - the new simplified logic uses read_sql first
-        self.mock_source.read_sql = Mock(return_value=[{"test": 1}])
-        sources = [self.mock_source]
-
-        # Execute
-        with patch("visivo.server.source_metadata.Logger"):
-            result = check_source_connection(sources, "test_source")
-
-        # Assert
-        assert result == {"source": "test_source", "status": "connected"}
-        self.mock_source.read_sql.assert_called_once_with("SELECT 1 as test_column LIMIT 1")
-
-    def test_test_source_connection_with_read_only_param(self):
-        """Test connection test using read_sql method."""
-        # Setup - simplified logic now uses read_sql directly
-        self.mock_source.read_sql = Mock(return_value=[{"test": 1}])
-        sources = [self.mock_source]
-
-        # Execute
-        with patch("visivo.server.source_metadata.Logger"):
-            result = check_source_connection(sources, "test_source")
-
-        # Assert
-        assert result == {"source": "test_source", "status": "connected"}
-        self.mock_source.read_sql.assert_called_once_with("SELECT 1 as test_column LIMIT 1")
-
-    def test_test_source_connection_failure(self):
-        """Test failed source connection test."""
-
-        # Setup - the new simplified logic uses read_sql first, so make it fail
-        self.mock_source.read_sql = Mock(side_effect=Exception("Connection failed"))
-        sources = [self.mock_source]
-
-        # Execute
-        with patch("visivo.server.source_metadata.Logger"):
-            result = check_source_connection(sources, "test_source")
-
-        # Assert
-        assert result["source"] == "test_source"
-        assert result["status"] == "connection_failed"
-        assert "Connection failed" in result["error"]
-
-    def test_test_source_connection_not_found(self):
-        """Test connection test with non-existent source."""
-        sources = [self.mock_source]
-
-        result = check_source_connection(sources, "non_existent")
-
-        assert result == ({"error": "Source 'non_existent' not found"}, 404)
-
-    def test_test_source_connection_fallback_to_connect(self):
-        """Test connection test fallback to connect() when read_sql is not available."""
-        # Setup - no read_sql method, should fall back to connect()
-        self.mock_source.read_sql = Mock(
-            side_effect=AttributeError("'MockSource' object has no attribute 'read_sql'")
-        )
-
-        # Mock the connect method
-        mock_conn = Mock()
-        self.mock_source.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        self.mock_source.connect.return_value.__exit__ = Mock(return_value=None)
-
-        sources = [self.mock_source]
-
-        # Execute
-        with patch("visivo.server.source_metadata.Logger"):
-            result = check_source_connection(sources, "test_source")
-
-        # Assert
-        assert result == {"source": "test_source", "status": "connected"}
-        self.mock_source.read_sql.assert_called_once_with("SELECT 1 as test_column LIMIT 1")
-        self.mock_source.connect.assert_called_once()
 
     def test_get_source_databases_success(self):
         """Test successful database listing."""
@@ -493,10 +417,6 @@ class TestSourceMetadata:
             mock_isinstance_local.side_effect = isinstance_side_effect_local
 
             # Test each function
-            assert check_source_connection(sources, "not_sqlalchemy") == (
-                {"error": "Source 'not_sqlalchemy' not found"},
-                404,
-            )
             assert get_source_databases(sources, "not_sqlalchemy") == (
                 {"error": "Source 'not_sqlalchemy' not found"},
                 404,

--- a/tests/server/views/test_insight_compile_views.py
+++ b/tests/server/views/test_insight_compile_views.py
@@ -57,9 +57,9 @@ def insight_payload(name="draft_insight", model_name="orders_q"):
 
 
 def write_schema(tmp_path, model_name, model_hash, columns):
-    schema_dir = tmp_path / "main" / "schemas" / model_name
+    schema_dir = tmp_path / "main" / "schemas"
     schema_dir.mkdir(parents=True)
-    (schema_dir / "schema.json").write_text(json.dumps({model_hash: columns}))
+    (schema_dir / f"{model_name}.json").write_text(json.dumps({model_hash: columns}))
 
 
 class TestCompileDraftHappyPath:

--- a/tests/server/views/test_model_schema_views.py
+++ b/tests/server/views/test_model_schema_views.py
@@ -33,9 +33,9 @@ def _write_source_schema(output_dir, source_name, tables, run_id=DEFAULT_RUN_ID)
         "sqlglot_schema": tables,
         "metadata": {"default_schema": None},
     }
-    schema_dir = os.path.join(output_dir, run_id, "schemas", source_name)
+    schema_dir = os.path.join(output_dir, run_id, "schemas")
     os.makedirs(schema_dir, exist_ok=True)
-    with open(os.path.join(schema_dir, "schema.json"), "w") as fp:
+    with open(os.path.join(schema_dir, f"{source_name}.json"), "w") as fp:
         json.dump(payload, fp)
     return payload
 

--- a/tests/server/views/test_source_schema_jobs_views.py
+++ b/tests/server/views/test_source_schema_jobs_views.py
@@ -22,7 +22,7 @@ class TestSourceSchemaJobsViews:
     @pytest.fixture
     def sample_schema(self, temp_output_dir):
         """Create a sample cached schema file in the main run_id location."""
-        schema_dir = os.path.join(temp_output_dir, DEFAULT_RUN_ID, "schemas", "test_source")
+        schema_dir = os.path.join(temp_output_dir, DEFAULT_RUN_ID, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
 
         schema_data = {
@@ -54,7 +54,7 @@ class TestSourceSchemaJobsViews:
             "metadata": {"total_tables": 2, "total_columns": 6, "databases": []},
         }
 
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, "test_source.json"), "w") as f:
             json.dump(schema_data, f)
 
         return schema_data
@@ -63,7 +63,7 @@ class TestSourceSchemaJobsViews:
     def sample_preview_schema(self, temp_output_dir):
         """Create a sample cached schema file in the preview run_id location."""
         preview_run_id = "preview-test_source"
-        schema_dir = os.path.join(temp_output_dir, preview_run_id, "schemas", "test_source")
+        schema_dir = os.path.join(temp_output_dir, preview_run_id, "schemas")
         os.makedirs(schema_dir, exist_ok=True)
 
         schema_data = {
@@ -85,7 +85,7 @@ class TestSourceSchemaJobsViews:
             "metadata": {"total_tables": 1, "total_columns": 2, "databases": []},
         }
 
-        with open(os.path.join(schema_dir, "schema.json"), "w") as f:
+        with open(os.path.join(schema_dir, "test_source.json"), "w") as f:
             json.dump(schema_data, f)
 
         return schema_data

--- a/viewer/src/api/sources.js
+++ b/viewer/src/api/sources.js
@@ -94,7 +94,7 @@ export const validateSource = async (name, config) => {
  * mean "didn't connect", and the error text says which.
  */
 export const testSourceConnection = async config => {
-  const path = getUrl('sourceTestConnection');
+  const path = getUrl('sourceConnections');
   const response = await apiFetch(path, {
     method: 'POST',
     headers: {

--- a/viewer/src/api/sources.test.js
+++ b/viewer/src/api/sources.test.js
@@ -36,11 +36,11 @@ describe('testSourceConnection', () => {
     });
 
     const [startUrl, options] = apiFetch.mock.calls[0];
-    expect(startUrl).toBe('/api/sourceTestConnection/');
+    expect(startUrl).toBe('/api/sourceConnections/');
     expect(options.method).toBe('POST');
     expect(JSON.parse(options.body)).toEqual({ name: 'db' });
     // The job hangs off the same path the start request used.
-    expect(apiFetch).toHaveBeenLastCalledWith('/api/sourceTestConnection/job-1/');
+    expect(apiFetch).toHaveBeenLastCalledWith('/api/sourceConnections/job-1/');
   });
 
   it('reports a refused connection in the shape the form renders', async () => {

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -19,9 +19,11 @@ const URL_PATTERNS = {
     sourcesList: '/api/sources/',
     sourceDetail: '/api/sources/{name}/',
     sourceValidate: '/api/sources/{name}/validate/',
-    // OUTLIER: a verb on the collection. Tests credentials that may not belong
-    // to a saved source yet, so there is no {name} to hang it off.
-    sourceTestConnection: '/api/sources/test-connection/',
+    // Connection tests are their own collection: the credentials being tested
+    // may not belong to a saved source yet, so there is no {name} to nest
+    // under. POST starts a job; its detail hangs off this path with the job id
+    // appended, which is what runOnDemandJob does.
+    sourceConnections: '/api/source-connections/',
 
     modelsList: '/api/models/',
     modelDetail: '/api/models/{name}/',

--- a/visivo/jobs/run_sql_model_job.py
+++ b/visivo/jobs/run_sql_model_job.py
@@ -130,9 +130,9 @@ def _build_and_write_schema(
 
     # Organize by run_id
     run_output_dir = f"{output_dir}/{run_id}"
-    schema_directory = f"{run_output_dir}/schemas/{sql_model.name}/"
+    schema_directory = f"{run_output_dir}/schemas"
     os.makedirs(schema_directory, exist_ok=True)
-    schema_file = f"{schema_directory}schema.json"
+    schema_file = f"{schema_directory}/{sql_model.name}.json"
 
     # Persist the richer envelope (legacy {name_hash: {col: type}} block preserved
     # first, for the field resolver) while serializing the resolved output schema.
@@ -237,7 +237,7 @@ def schema_only_action(
 
         # Organize by run_id
         run_output_dir = f"{output_dir}/{run_id}"
-        schema_file = f"{run_output_dir}/schemas/{sql_model.name}/schema.json"
+        schema_file = f"{run_output_dir}/schemas/{sql_model.name}.json"
         success_message = format_message_success(
             details=f"Wrote schema for model \033[4m{sql_model.name}\033[0m",
             start_time=start_time,

--- a/visivo/models/insight.py
+++ b/visivo/models/insight.py
@@ -270,7 +270,7 @@ class Insight(NamedModel, ParentModel):
                 lets a caller resolving a never-run scratch model's raw-column
                 refs supply columns learned some other way (client-side
                 introspection) instead of hitting the normal
-                ``schemas/<model>/schema.json`` disk read. ``None`` (every
+                ``schemas/<model>.json`` disk read. ``None`` (every
                 real run-pipeline caller) is unaffected.
             force_dynamic: Build the DuckDB/model-hash-qualified `post_query`
                 form regardless of whether this insight actually depends on

--- a/visivo/query/model_schema_aggregator.py
+++ b/visivo/query/model_schema_aggregator.py
@@ -4,7 +4,7 @@ column schema as a run-phase job artifact.
 
 This is the model-side parallel of ``SchemaAggregator`` (which is source-shaped:
 ``source_name`` / ``source_type`` / ``tables`` / ``sqlglot_schema``). Models and
-sources share the ``{output_dir}/{run_id}/schemas/{name}/schema.json`` namespace,
+sources share the ``{output_dir}/{run_id}/schemas/{name}.json`` namespace,
 so the two aggregators are intentionally kept separate (and independently
 testable) rather than overloaded.
 
@@ -15,6 +15,7 @@ source artifact's metadata: ``model_name`` / ``model_type`` / ``generated_at`` /
 """
 
 import os
+from pathlib import Path
 import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
@@ -99,7 +100,7 @@ class ModelSchemaAggregator:
             Schema data dictionary or None if not found.
         """
         try:
-            schema_file = f"{output_dir}/{run_id}/schemas/{model_name}/schema.json"
+            schema_file = f"{output_dir}/{run_id}/schemas/{model_name}.json"
             if not os.path.exists(schema_file):
                 return None
 
@@ -137,11 +138,13 @@ class ModelSchemaAggregator:
 
         try:
             for entry_name in os.listdir(schemas_dir):
-                entry_dir = os.path.join(schemas_dir, entry_name)
-                if not os.path.isdir(entry_dir):
+                # `os.path.isdir` used to be the de-facto "is this a schema"
+                # filter under the per-name-directory layout; flat files need
+                # the extension to do that job.
+                if not entry_name.endswith(".json"):
                     continue
-                schema_file = os.path.join(entry_dir, "schema.json")
-                if not os.path.exists(schema_file):
+                schema_file = os.path.join(schemas_dir, entry_name)
+                if not os.path.isfile(schema_file):
                     continue
                 try:
                     with open(schema_file, "r") as fp:
@@ -155,7 +158,7 @@ class ModelSchemaAggregator:
 
                 schemas.append(
                     {
-                        "model_name": schema_data.get("model_name", entry_name),
+                        "model_name": schema_data.get("model_name", Path(entry_name).stem),
                         "model_type": schema_data.get("model_type", "unknown"),
                         "generated_at": schema_data.get("generated_at"),
                         "total_columns": schema_data.get("metadata", {}).get("total_columns", 0),

--- a/visivo/query/model_schema_inference.py
+++ b/visivo/query/model_schema_inference.py
@@ -74,8 +74,9 @@ def infer_model_columns(
     sqlglot_dialect: str,
     model_hash: str,
     stored_source_schema: Optional[Dict[str, Any]] = None,
+    strict: bool = True,
 ) -> Dict[str, Any]:
-    """Infer the output columns of ``sql`` as ``{column_name: DataType}``.
+    """Infer the output columns of ``sql`` as ``{column_name: type_name}``.
 
     Args:
         sql: The model's SQL.
@@ -86,6 +87,16 @@ def infer_model_columns(
             ``sqlglot_schema`` and ``metadata``). ``None`` or a missing block is
             valid and simply means fewer columns can be resolved, not a failure
             — a query that names its columns literally still annotates fine.
+        strict: Whether SQL that will not parse is an error.
+
+            ``True`` (the run): raise. A model whose SQL does not parse is a
+            broken model, and the run has to say so rather than persist an
+            empty schema that later reads as "this model has no columns".
+
+            ``False`` (the endpoints): return ``{}``. The editor asks on every
+            keystroke, so half-written SQL is the normal state — "nothing
+            resolved yet", not a server error. This is also what core's
+            reimplementation does unconditionally, since it has no run path.
 
     Returns:
         ``{column_name: type_name}``, where the type is SQLGlot's type *name*
@@ -101,13 +112,19 @@ def infer_model_columns(
         f"Inferring columns against {len(schema)} schema entries, default: {default_schema}"
     )
 
-    query_result_schema = schema_from_sql(
-        sqlglot_dialect=sqlglot_dialect,
-        sql=sql,
-        schema=schema,
-        model_hash=model_hash,
-        default_schema=default_schema,
-    )
+    try:
+        query_result_schema = schema_from_sql(
+            sqlglot_dialect=sqlglot_dialect,
+            sql=sql,
+            schema=schema,
+            model_hash=model_hash,
+            default_schema=default_schema,
+        )
+    except Exception:
+        if strict:
+            raise
+        Logger.instance().debug("Inference could not resolve the SQL; returning no columns")
+        return {}
     columns = query_result_schema.get(model_hash, {})
 
     # A surviving `*` means qualify could not expand it — the cached schema has

--- a/visivo/query/resolvers/field_resolver.py
+++ b/visivo/query/resolvers/field_resolver.py
@@ -52,7 +52,7 @@ class FieldResolver:
                 ``{model_hash: {column: type_string}, ...}``). Used by the
                 Explore 2.0 compile-draft endpoint to supply a scratch model's
                 columns (learned client-side, never written to
-                ``schemas/<model>/schema.json`` on disk) so
+                ``schemas/<model>.json`` on disk) so
                 ``_qualify_expression``/``_is_implicit_dimension`` resolve
                 without ever touching disk. ``None`` (the default, every real
                 run pipeline caller) preserves today's disk-read-only behavior
@@ -72,7 +72,7 @@ class FieldResolver:
             return self._schema_cache[model_name]
 
         # Build path to schema file
-        schema_file = os.path.join(self.output_dir, "schemas", model_name, "schema.json")
+        schema_file = os.path.join(self.output_dir, "schemas", f"{model_name}.json")
 
         # Try to read schema file
         try:

--- a/visivo/query/schema_aggregator.py
+++ b/visivo/query/schema_aggregator.py
@@ -3,6 +3,7 @@ Schema aggregation utilities for storing SQLGlot schemas from sources.
 """
 
 import os
+from pathlib import Path
 import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
@@ -36,7 +37,7 @@ class SchemaAggregator:
             run_id: Run identifier for schema storage location
         """
         try:
-            schema_dir = f"{output_dir}/{run_id}/schemas/{source_name}"
+            schema_dir = f"{output_dir}/{run_id}/schemas"
             os.makedirs(schema_dir, exist_ok=True)
 
             # Prepare schema data for storage
@@ -72,7 +73,7 @@ class SchemaAggregator:
             storage_data["metadata"]["total_columns"] = total_columns
 
             # Write to file
-            schema_file = f"{schema_dir}/schema.json"
+            schema_file = f"{schema_dir}/{source_name}.json"
             with open(schema_file, "w") as fp:
                 json.dump(storage_data, fp, indent=2, default=str)
 
@@ -212,7 +213,7 @@ class SchemaAggregator:
             Schema data dictionary or None if not found
         """
         try:
-            schema_file = f"{output_dir}/{run_id}/schemas/{source_name}/schema.json"
+            schema_file = f"{output_dir}/{run_id}/schemas/{source_name}.json"
             if not os.path.exists(schema_file):
                 return None
 
@@ -328,29 +329,37 @@ class SchemaAggregator:
             return schemas
 
         try:
-            for source_name in os.listdir(schemas_dir):
-                source_dir = os.path.join(schemas_dir, source_name)
-                if os.path.isdir(source_dir):
-                    schema_file = os.path.join(source_dir, "schema.json")
-                    if os.path.exists(schema_file):
-                        try:
-                            with open(schema_file, "r") as fp:
-                                schema_data = json.load(fp)
-                                schemas.append(
-                                    {
-                                        "source_name": schema_data.get("source_name", source_name),
-                                        "source_type": schema_data.get("source_type", "unknown"),
-                                        "generated_at": schema_data.get("generated_at"),
-                                        "total_tables": schema_data.get("metadata", {}).get(
-                                            "total_tables", 0
-                                        ),
-                                        "total_columns": schema_data.get("metadata", {}).get(
-                                            "total_columns", 0
-                                        ),
-                                    }
-                                )
-                        except Exception as e:
-                            Logger.instance().debug(f"Error reading schema file {schema_file}: {e}")
+            for entry in os.listdir(schemas_dir):
+                # The old layout used a directory per name, so `os.path.isdir`
+                # was the de-facto "is this a schema" filter. With flat files
+                # the extension has to do that job instead.
+                if not entry.endswith(".json"):
+                    continue
+                schema_file = os.path.join(schemas_dir, entry)
+                if not os.path.isfile(schema_file):
+                    continue
+
+                # The name fallback moves from the directory name to the stem.
+                # `Path.stem` strips only the final `.json`, so a source name
+                # containing a dot round-trips.
+                source_name = Path(entry).stem
+                try:
+                    with open(schema_file, "r") as fp:
+                        schema_data = json.load(fp)
+                except Exception as e:
+                    Logger.instance().debug(f"Error reading schema file {schema_file}: {e}")
+                    continue
+
+                metadata = schema_data.get("metadata", {})
+                schemas.append(
+                    {
+                        "source_name": schema_data.get("source_name", source_name),
+                        "source_type": schema_data.get("source_type", "unknown"),
+                        "generated_at": schema_data.get("generated_at"),
+                        "total_tables": metadata.get("total_tables", 0),
+                        "total_columns": metadata.get("total_columns", 0),
+                    }
+                )
 
         except Exception as e:
             Logger.instance().debug(f"Error listing schemas: {e}")

--- a/visivo/server/source_metadata.py
+++ b/visivo/server/source_metadata.py
@@ -69,15 +69,6 @@ def _test_source_connection(source: Source, source_name: str) -> Dict[str, Any]:
         return {"source": source_name, "status": "connection_failed", "error": str(e)}
 
 
-def check_source_connection(sources, source_name):
-    """Test connection to a specific source."""
-    src = _find_source(sources, source_name)
-    if not src:
-        return _source_not_found_error(source_name)
-
-    return _test_source_connection(src, source_name)
-
-
 def get_source_databases(sources, source_name):
     """Return list of databases for a specific source."""
     src = _find_source(sources, source_name)

--- a/visivo/server/views/model_schema_views.py
+++ b/visivo/server/views/model_schema_views.py
@@ -85,6 +85,9 @@ def register_model_schema_views(app, flask_app, output_dir):
             sqlglot_dialect=source.get_sqlglot_dialect(),
             model_hash=model_hash,
             stored_source_schema=stored_source_schema,
+            # The editor asks on every keystroke; half-written SQL is normal.
+            # A parse failure is "nothing resolved yet", not a 500.
+            strict=False,
         )
         return jsonify(
             {

--- a/visivo/server/views/schema_path_safety.py
+++ b/visivo/server/views/schema_path_safety.py
@@ -2,7 +2,7 @@
 
 Both the model and source schema endpoints interpolate a user-supplied name and
 optional ``run_id`` query param directly into the on-disk artifact path
-(``{output_dir}/{run_id}/schemas/{name}/schema.json``). Without a strict
+(``{output_dir}/{run_id}/schemas/{name}.json``). Without a strict
 allowlist a caller could smuggle ``..`` / ``/`` segments and traverse outside
 the output directory, so every such value is validated here before it reaches
 the filesystem.

--- a/visivo/server/views/sources_views.py
+++ b/visivo/server/views/sources_views.py
@@ -158,7 +158,7 @@ def register_source_views(app, flask_app, output_dir):
             Logger.instance().error(f"Error listing columns: {str(e)}")
             return jsonify({"message": str(e)}), 500
 
-    @app.route("/api/sources/test-connection/", methods=["POST"])
+    @app.route("/api/source-connections/", methods=["POST"])
     def test_source_connection():
         """Start a connection test for an (unsaved) config; poll for the result.
 
@@ -182,7 +182,7 @@ def register_source_views(app, flask_app, output_dir):
             Logger.instance().error(f"Error starting source connection test: {str(e)}")
             return jsonify({"status": "connection_failed", "error": str(e)}), 500
 
-    @app.route("/api/sources/test-connection/<job_id>/", methods=["GET"])
+    @app.route("/api/source-connections/<job_id>/", methods=["GET"])
     def test_source_connection_job(job_id):
         """Poll a test-connection job."""
         job = SourceOpJobManager.instance().get_job(job_id)

--- a/visivo/server/views/sources_views.py
+++ b/visivo/server/views/sources_views.py
@@ -3,7 +3,6 @@ from pydantic import ValidationError
 from visivo.logger.logger import Logger
 from visivo.server.managers.source_op_job_manager import SourceOpJobManager
 from visivo.server.source_metadata import (
-    check_source_connection,
     gather_source_metadata,
     get_database_schemas,
     get_schema_tables,
@@ -30,21 +29,6 @@ def register_source_views(app, flask_app, output_dir):
             return jsonify(metadata)
         except Exception as e:
             Logger.instance().error(f"Error gathering source metadata: {str(e)}")
-            return jsonify({"message": str(e)}), 500
-
-    @app.route("/api/project/sources/<source_name>/test-connection/", methods=["GET"])
-    def test_connection(source_name):
-        """Test connection to a specific source."""
-        try:
-            # Use source_manager to include both cached and published sources
-            result = check_source_connection(
-                flask_app.source_manager.get_sources_list(), source_name
-            )
-            if isinstance(result, tuple):  # Error response
-                return jsonify(result[0]), result[1]
-            return jsonify(result)
-        except Exception as e:
-            Logger.instance().error(f"Error testing connection for {source_name}: {str(e)}")
             return jsonify({"message": str(e)}), 500
 
     @app.route("/api/project/sources/<source_name>/databases/", methods=["GET"])


### PR DESCRIPTION
**Top of the stack**: #554 → #553 → #552 → `feature/cloud-parity`.

Two things: rename the live endpoint to a plural collection, and delete the dead one next to it.

## Rename

`/api/sources/test-connection/` → `/api/source-connections/`, matching the model-schemas rename below it: a plural noun rather than a verb hung off a resource it does not belong to.

**This removes a real ordering constraint.** `api/sources/test-connection/` had to be declared *before* `api/sources/<name>/`, or a source named `test-connection` would have shadowed it. In core that rule was written down in a comment; it held only by convention and by whoever kept the block in order. A separate noun removes it outright — the same fix `/api/model-schemas/` applied to the `/api/models/schema/` collision in #552.

The poll route follows: `/api/source-connections/<job_id>/`, which is what `runOnDemandJob` already builds by appending the id.

## Removal

`GET /api/project/sources/<name>/test-connection/` had **no caller** — not "no viewer caller", none anywhere. Nothing in `viewer/src`, core never implemented it, and its only exercise was its own tests. The single grep hit outside them was a stale file under `viewer/coverage/`, gitignored build output from a component Explore 2.0 deleted.

It was also the second, incompatible way to ask the same question: it took a saved source *name* and answered synchronously, where the live endpoint takes a *config* (so an unsaved source can be tested) and runs as a job. `check_source_connection` went with it — the route was its only production caller.

The parametrized *"path params survive dashes/underscores/dots"* test is **retargeted, not deleted**. It was written against this route, but the property belongs to the URL converter, so it moved to `/api/project/sources/<name>/databases/` — the sibling that still has a `{name}` segment.

## URL audit

You asked me to check the map for plural consistency. After these renames, **every collection is plural**. The remaining singular first segments are not collections:

| path | why singular is right |
|---|---|
| `/api/project/`, `/api/error/`, `/api/me/` | singletons — one project, one error file, one current user |
| `/api/commit/` | the single pending commit |
| `/api/query/{projectId}/`, `/api/insight-compile-draft/`, `/api/insight-execute-draft/`, `/api/telemetry/workspace-event/` | verbs, not resources |

**One inconsistency I did not fix:** paths under `/api/project/` use snake_case — `write_changes`, `project_file_path`, `sources_metadata` — where everything else is kebab-case. Real drift, but it touches endpoints outside this stack.

## Two more dead things, flagged not removed

Found while verifying, and each its own decision:

- **`/api/project/sources_metadata/`** — its docstring already says *"Nothing in the viewer calls this today"*, and `getUrl('sourcesMetadata')` has zero call sites. Core carries a stub for it plus a `RunnerJobKind.SOURCES_METADATA` with no producer.
- **`/api/project/sources/<name>/databases/`** — no viewer caller either, though it now holds the retargeted test above.

## Tests

2312 pytest; 114 across the touched viewer suites, run twice. The 7 full-run viewer failures are the pre-existing VIS-993 async-schema flakes.

Pairs with [core#320](https://github.com/visivo-io/core/pull/320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
