### PR TITLE
Six fixes from cloud-editing testing

### DIFF
--- a/tests/commands/test_deploy_source_schemas.py
+++ b/tests/commands/test_deploy_source_schemas.py
@@ -1,0 +1,108 @@
+"""`visivo deploy` ships the source schema envelopes a run computed.
+
+This is what makes a deployed project browsable. Nothing runs in cloud to
+produce these — and for a file-backed duckdb/sqlite source nothing could, since
+the database file never leaves the author's machine. Before this, a deploy
+uploaded insights, models, inputs, dashboards and thumbnails, and left the
+schemas on disk; every source in the editor then read
+``has_cached_schema: false``.
+"""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from visivo.commands.deploy_phase import upload_source_schemas
+
+
+def _write(schemas_dir, filename, payload):
+    os.makedirs(schemas_dir, exist_ok=True)
+    with open(os.path.join(schemas_dir, filename), "w") as fp:
+        json.dump(payload, fp)
+
+
+def _source_envelope(name, total_tables=1):
+    return {
+        "source_name": name,
+        "source_type": "duckdb",
+        "generated_at": "2026-08-02T12:00:00",
+        "tables": {"orders": {"columns": {"id": {"type": "INT"}}}},
+        "metadata": {"total_tables": total_tables, "total_columns": 1},
+    }
+
+
+@pytest.fixture
+def post():
+    with patch("visivo.commands.deploy_phase.requests.post") as mock_post:
+        mock_post.return_value = Mock(
+            status_code=201, json=lambda: {"stored": 2}, raise_for_status=lambda: None
+        )
+        yield mock_post
+
+
+class TestUploadSourceSchemas:
+    def test_posts_every_source_envelope(self, tmp_path, post):
+        schemas = os.path.join(str(tmp_path), "schemas")
+        _write(schemas, "wh.json", _source_envelope("wh"))
+        _write(schemas, "pie-data-source.json", _source_envelope("pie-data-source"))
+
+        stored = upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app")
+
+        assert stored == 2
+        body = json.loads(post.call_args.kwargs["data"])
+        assert sorted(item["name"] for item in body) == ["pie-data-source", "wh"]
+        assert body[0]["content"]["source_type"] == "duckdb"
+
+    def test_scopes_the_request_to_the_project(self, tmp_path, post):
+        _write(os.path.join(str(tmp_path), "schemas"), "wh.json", _source_envelope("wh"))
+
+        upload_source_schemas(str(tmp_path), "proj-9", {}, "https://app")
+
+        assert "project_id=proj-9" in post.call_args.args[0]
+
+    def test_skips_model_schemas_sharing_the_directory(self, tmp_path, post):
+        """Models and sources both write here; `source_name` tells them apart —
+        the same key core classifies on."""
+        schemas = os.path.join(str(tmp_path), "schemas")
+        _write(schemas, "wh.json", _source_envelope("wh"))
+        _write(schemas, "orders.json", {"model_name": "orders", "columns": {}})
+
+        upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app")
+
+        body = json.loads(post.call_args.kwargs["data"])
+        assert [item["name"] for item in body] == ["wh"]
+
+    def test_a_corrupt_envelope_costs_only_itself(self, tmp_path, post):
+        schemas = os.path.join(str(tmp_path), "schemas")
+        _write(schemas, "wh.json", _source_envelope("wh"))
+        with open(os.path.join(schemas, "broken.json"), "w") as fp:
+            fp.write("{ not json")
+
+        upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app")
+
+        body = json.loads(post.call_args.kwargs["data"])
+        assert [item["name"] for item in body] == ["wh"]
+
+    def test_no_schemas_directory_is_not_an_error(self, tmp_path, post):
+        """A project that has never been run still deploys."""
+        assert upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app") == 0
+        post.assert_not_called()
+
+    def test_an_empty_schemas_directory_posts_nothing(self, tmp_path, post):
+        os.makedirs(os.path.join(str(tmp_path), "schemas"), exist_ok=True)
+
+        assert upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app") == 0
+        post.assert_not_called()
+
+    def test_non_json_files_are_ignored(self, tmp_path, post):
+        schemas = os.path.join(str(tmp_path), "schemas")
+        _write(schemas, "wh.json", _source_envelope("wh"))
+        with open(os.path.join(schemas, "notes.txt"), "w") as fp:
+            fp.write("ignore me")
+
+        upload_source_schemas(str(tmp_path), "proj-1", {}, "https://app")
+
+        body = json.loads(post.call_args.kwargs["data"])
+        assert [item["name"] for item in body] == ["wh"]

--- a/viewer/src/LocalRouter.test.jsx
+++ b/viewer/src/LocalRouter.test.jsx
@@ -199,9 +199,10 @@ describe('Explore 2.0 Phase 3b cutover routes', () => {
       expect(await screen.findByTestId('probe-pathname')).toHaveTextContent(
         '/workspace/exploration/exp_new1'
       );
-      expect(explorationsApi.createExploration).toHaveBeenCalledWith({
-        return_to: { dashboard: 'sales' },
-      });
+      expect(explorationsApi.createExploration).toHaveBeenCalledWith(
+        { return_to: { dashboard: 'sales' } },
+        undefined
+      );
     });
 
     test('fails open to Explorer Home if minting the exploration fails', async () => {

--- a/viewer/src/api/branching.js
+++ b/viewer/src/api/branching.js
@@ -67,8 +67,30 @@ export const createBranch = async ({ projectId, newStageName }) => {
 };
 
 /**
- * Discard (delete) a draft entirely — drop the working copy and return to the
- * published project. DELETE /api/projects/<draftId>/discard/.
+ * Discard a draft's uncommitted CHANGES, keeping the draft itself.
+ * POST /api/projects/<draftId>/discard/ -> {discarded, dirty}.
+ *
+ * This is what the Discard button means: revert to last-published, stay in the
+ * draft. Distinct from `discardDraft` below, which deletes the working copy
+ * outright — the two share a path and differ only by verb, which is exactly how
+ * the wrong one got wired up.
+ */
+export const discardDraftChanges = async draftId => {
+  const response = await apiFetch(getUrl('projectDiscard', { projectId: draftId }), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.detail || errorData.errors || 'Failed to discard changes');
+  }
+  return response.json().catch(() => ({ discarded: true }));
+};
+
+/**
+ * Delete a draft entirely — drop the working copy and return to the published
+ * project. DELETE /api/projects/<draftId>/discard/.
  */
 export const discardDraft = async draftId => {
   const response = await apiFetch(getUrl('projectDiscard', { projectId: draftId }), {

--- a/viewer/src/api/charts.js
+++ b/viewer/src/api/charts.js
@@ -41,7 +41,11 @@ export const saveChart = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/dashboards.js
+++ b/viewer/src/api/dashboards.js
@@ -27,7 +27,11 @@ export const saveDashboard = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/dimensions.js
+++ b/viewer/src/api/dimensions.js
@@ -41,7 +41,11 @@ export const saveDimension = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/explorations.js
+++ b/viewer/src/api/explorations.js
@@ -1,4 +1,5 @@
 import { getUrl } from '../contexts/URLContext';
+import { withProjectId } from './projectScope';
 import { apiFetch } from './utils';
 
 /**
@@ -17,8 +18,8 @@ const parseErrorOr = async (response, fallback) => {
 /**
  * List explorations, ordered by `updated_at` desc.
  */
-export const fetchExplorations = async () => {
-  const response = await apiFetch(getUrl('explorationsList'));
+export const fetchExplorations = async (projectId = null) => {
+  const response = await apiFetch(withProjectId(getUrl('explorationsList'), projectId));
   if (response.status === 200) {
     return await response.json();
   }
@@ -30,8 +31,8 @@ export const fetchExplorations = async () => {
  * `{ name?, seeded_from?, return_to?, draft? }` — the server mints `id` and
  * defaults `name` ("Scratch", "Exploration N") when omitted.
  */
-export const createExploration = async (payload = {}) => {
-  const response = await apiFetch(getUrl('explorationsList'), {
+export const createExploration = async (payload = {}, projectId = null) => {
+  const response = await apiFetch(withProjectId(getUrl('explorationsList'), projectId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -46,8 +47,10 @@ export const createExploration = async (payload = {}) => {
  * Fetch a single exploration by id. Returns `null` on 404 (mirrors
  * `fetchModel`'s convention) rather than throwing.
  */
-export const fetchExploration = async id => {
-  const response = await apiFetch(getUrl('explorationDetail', { id }));
+export const fetchExploration = async (id, projectId = null) => {
+  const response = await apiFetch(
+    withProjectId(getUrl('explorationDetail', { id }), projectId)
+  );
   if (response.status === 200) {
     return await response.json();
   }
@@ -63,8 +66,8 @@ export const fetchExploration = async id => {
  * (`name`/`draft`/`return_to`); `id`/`created_at`/`seeded_from`/`promoted`
  * are immutable via this route regardless of what's included.
  */
-export const updateExploration = async (id, payload) => {
-  const response = await apiFetch(getUrl('explorationDetail', { id }), {
+export const updateExploration = async (id, payload, projectId = null) => {
+  const response = await apiFetch(withProjectId(getUrl('explorationDetail', { id }), projectId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -85,8 +88,8 @@ export const updateExploration = async (id, payload) => {
 /**
  * Delete an exploration. Resolves `true` on success (204, no body).
  */
-export const deleteExploration = async id => {
-  const response = await apiFetch(getUrl('explorationDetail', { id }), {
+export const deleteExploration = async (id, projectId = null) => {
+  const response = await apiFetch(withProjectId(getUrl('explorationDetail', { id }), projectId), {
     method: 'DELETE',
   });
   if (response.status === 204) {
@@ -99,8 +102,10 @@ export const deleteExploration = async id => {
  * Atomically null `return_to` — the placement intent has been consumed.
  * Idempotent: consuming an already-null `return_to` still resolves 200.
  */
-export const consumeReturnTo = async id => {
-  const response = await apiFetch(getUrl('explorationConsumeReturnTo', { id }), {
+export const consumeReturnTo = async (id, projectId = null) => {
+  const response = await apiFetch(
+    withProjectId(getUrl('explorationConsumeReturnTo', { id }), projectId),
+    {
     method: 'POST',
   });
   if (response.status === 200) {
@@ -115,8 +120,10 @@ export const consumeReturnTo = async id => {
  * stamps `promoted_at`. `type`/`name` are the promoted object's kind
  * ('model'|'metric'|'dimension'|'insight'|'chart') and name.
  */
-export const recordPromotion = async (id, type, name) => {
-  const response = await apiFetch(getUrl('explorationRecordPromotion', { id }), {
+export const recordPromotion = async (id, type, name, projectId = null) => {
+  const response = await apiFetch(
+    withProjectId(getUrl('explorationRecordPromotion', { id }), projectId),
+    {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ type, name }),

--- a/viewer/src/api/inputs.js
+++ b/viewer/src/api/inputs.js
@@ -41,7 +41,11 @@ export const saveInput = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/insights.js
+++ b/viewer/src/api/insights.js
@@ -41,7 +41,11 @@ export const saveInsight = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/markdowns.js
+++ b/viewer/src/api/markdowns.js
@@ -41,7 +41,11 @@ export const saveMarkdown = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/metrics.js
+++ b/viewer/src/api/metrics.js
@@ -41,7 +41,11 @@ export const saveMetric = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/models.js
+++ b/viewer/src/api/models.js
@@ -41,7 +41,11 @@ export const saveModel = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/relations.js
+++ b/viewer/src/api/relations.js
@@ -41,7 +41,11 @@ export const saveRelation = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/resourceApis.test.js
+++ b/viewer/src/api/resourceApis.test.js
@@ -19,9 +19,13 @@ jest.mock('../contexts/URLContext', () => ({
   getUrl: (key, params) => `/api/${key}${params && params.name ? `/${params.name}` : ''}`,
 }));
 
-const ok = data => ({ status: 200, json: async () => data });
-const notFound = () => ({ status: 404, json: async () => ({}) });
-const fail = (status, data = {}) => ({ status, json: async () => data });
+// Real Responses carry `ok`; the save paths read it, because creating a NEW
+// resource answers 201 in cloud and 200 locally.
+const res = (status, data = {}) => ({ status, ok: status >= 200 && status < 300, json: async () => data });
+const ok = data => res(200, data);
+const created = data => res(201, data);
+const notFound = () => res(404);
+const fail = (status, data = {}) => res(status, data);
 
 const CASES = [
   {
@@ -144,6 +148,22 @@ describe('per-type resource API modules', () => {
         expect.any(String),
         expect.objectContaining({ method: 'POST', body: JSON.stringify({ a: 1 }) })
       );
+    });
+
+    it('save accepts 201, which is what cloud answers for a NEW resource', async () => {
+      // The reported bug: "+ New" created the object server-side (201) but the
+      // client treated anything but 200 as a failure — so the list never
+      // refetched and no tab opened. It looked like nothing had happened.
+      apiFetch.mockResolvedValueOnce(created({ message: 'created', status: 'new' }));
+      await expect(save('x', { a: 1 })).resolves.toEqual({
+        message: 'created',
+        status: 'new',
+      });
+    });
+
+    it('save still rejects a real failure', async () => {
+      apiFetch.mockResolvedValueOnce(fail(400, { error: 'bad config' }));
+      await expect(save('x', { a: 1 })).rejects.toThrow('bad config');
     });
 
     it('save scopes by project_id when one is given, and omits it otherwise', async () => {

--- a/viewer/src/api/sources.js
+++ b/viewer/src/api/sources.js
@@ -42,7 +42,11 @@ export const saveSource = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/api/tables.js
+++ b/viewer/src/api/tables.js
@@ -41,7 +41,11 @@ export const saveTable = async (name, config, projectId = null) => {
     },
     body: JSON.stringify(config),
   });
-  if (response.status === 200) {
+  // 2xx, not 200: creating a NEW resource answers 201 in cloud, and
+  // treating that as a failure meant every "+ New" threw — the object
+  // was created server-side but the list never refetched and no tab
+  // opened, so it looked like nothing happened.
+  if (response.ok) {
     return await response.json();
   }
   const errorData = await response.json().catch(() => ({}));

--- a/viewer/src/components/sources/SourceEditorModal.jsx
+++ b/viewer/src/components/sources/SourceEditorModal.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import useStore from '../../stores/store';
+import {
+  canTestConnection,
+  CONNECTION_TEST_UNAVAILABLE,
+} from '../views/common/sourceCapabilities';
 import { ModalOverlay, ModalWrapper } from '../styled/Modal';
 import { Button, ButtonOutline } from '../styled/Button';
 import SourceTypeSelector from './SourceTypeSelector';
@@ -19,6 +23,9 @@ const SourceEditorModal = () => {
     connectionStatus,
     clearConnectionStatus,
   } = useStore();
+  // See sourceCapabilities: a file-backed source can only be reached where its
+  // file lives, so cloud cannot test one however valid the config is.
+  const capabilities = useStore(state => state.capabilities);
 
   const isEditMode = !!editingSource;
   const sourceName = editingSource?.name || '';
@@ -27,6 +34,11 @@ const SourceEditorModal = () => {
   const [name, setName] = useState('');
   const [sourceType, setSourceType] = useState('');
   const [formValues, setFormValues] = useState({});
+  const connectionTestable = canTestConnection(
+    { type: sourceType, ...formValues },
+    capabilities
+  );
+
   const [errors, setErrors] = useState({});
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(null);
@@ -252,7 +264,12 @@ const SourceEditorModal = () => {
           <ButtonOutline
             type="button"
             onClick={handleTestConnection}
-            disabled={!sourceType || currentConnectionStatus?.status === 'testing'}
+            disabled={
+              !sourceType ||
+              currentConnectionStatus?.status === 'testing' ||
+              !connectionTestable
+            }
+            title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
           >
             Test Connection
           </ButtonOutline>

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -3,6 +3,7 @@ import useStore, { ObjectStatus } from '../../../stores/store';
 import { ButtonOutline } from '../../styled/Button';
 import SourceTypeSelector from '../../sources/SourceTypeSelector';
 import SourceFormGenerator, { getSourceSchema } from '../../sources/SourceFormGenerator';
+import { canTestConnection, CONNECTION_TEST_UNAVAILABLE } from './sourceCapabilities';
 import CircularProgress from '@mui/material/CircularProgress';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -31,6 +32,9 @@ import SeedsEditor, { sourceTypeSupportsSeeds } from './SeedsEditor';
 const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
   const { deleteSource, testConnection, connectionStatus, clearConnectionStatus, checkCommitStatus } =
     useStore();
+  // Tells us whether the serving process shares a filesystem with the project,
+  // which is what decides if a file-backed source can be reached at all.
+  const capabilities = useStore(state => state.capabilities);
 
   // Form state
   const [name, setName] = useState('');
@@ -140,6 +144,14 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
 
     await testConnection(config);
   };
+
+  // A file-backed source only resolves where its file lives. In cloud there is
+  // no such file, so the test can only fail in a way that says nothing about
+  // the config — don't offer it.
+  const connectionTestable = canTestConnection(
+    { type: sourceType, ...formValues },
+    capabilities
+  );
 
   const handleSave = async () => {
     if (!validateForm()) return;
@@ -305,7 +317,12 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
           <ButtonOutline
             type="button"
             onClick={handleTestConnection}
-            disabled={!sourceType || currentConnectionStatus?.status === 'testing'}
+            disabled={
+              !sourceType ||
+              currentConnectionStatus?.status === 'testing' ||
+              !connectionTestable
+            }
+            title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
             className="text-sm"
           >
             Test Connection

--- a/viewer/src/components/views/common/sourceCapabilities.js
+++ b/viewer/src/components/views/common/sourceCapabilities.js
@@ -1,0 +1,57 @@
+/**
+ * What a given source can actually do on the server that is serving us.
+ *
+ * A duckdb or sqlite source addressed by a filesystem path only resolves where
+ * that path exists — the author's machine. Under `visivo serve` that is the same
+ * machine, so everything works. In cloud the file was never uploaded, so the
+ * runner reports
+ *
+ *   Cannot open database "/runner/target/seeds/pie_data.duckdb" ... does not exist
+ *
+ * and a connection test can only ever fail. Offering the button there invites a
+ * failure that says nothing about the user's configuration.
+ *
+ * The server tells us which world we are in via the `local_filesystem`
+ * capability rather than the client inferring it from some other flag.
+ */
+
+/** Source types addressed by a filesystem path rather than a network endpoint. */
+const FILE_BACKED_TYPES = new Set(['duckdb', 'sqlite']);
+
+/**
+ * True when this source is backed by a file on the author's machine.
+ *
+ * `:memory:` is excluded (nothing on disk to be missing), as is anything with a
+ * URI scheme — `md:` (MotherDuck), `s3://`, `https://` are all remote and
+ * resolve the same from anywhere.
+ */
+export const isLocalFileSource = (config = {}) => {
+  const type = String(config.type || '').toLowerCase();
+  if (!FILE_BACKED_TYPES.has(type)) return false;
+
+  const database = config.database;
+  if (typeof database !== 'string' || !database) return false;
+  if (database === ':memory:') return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(database)) return false;
+
+  return true;
+};
+
+/**
+ * Whether a connection test can meaningfully run for this source here.
+ *
+ * @param {object} config - the source config
+ * @param {object|null} capabilities - the project capabilities payload; while it
+ *   is still loading we allow the test rather than flickering the button
+ *   disabled, since the common case (local serve) supports it.
+ */
+export const canTestConnection = (config, capabilities) => {
+  if (!isLocalFileSource(config)) return true;
+  if (!capabilities) return true;
+  return capabilities.local_filesystem !== false;
+};
+
+/** Why the test is unavailable, for the disabled control's tooltip. */
+export const CONNECTION_TEST_UNAVAILABLE =
+  'This source reads a file on your machine, which the cloud server cannot open. ' +
+  'Test it with `visivo serve` locally.';

--- a/viewer/src/components/views/common/sourceCapabilities.test.js
+++ b/viewer/src/components/views/common/sourceCapabilities.test.js
@@ -1,0 +1,64 @@
+import {
+  isLocalFileSource,
+  canTestConnection,
+} from './sourceCapabilities';
+
+describe('isLocalFileSource', () => {
+  it('is true for a duckdb or sqlite file path', () => {
+    expect(isLocalFileSource({ type: 'duckdb', database: 'target/seeds/pie.duckdb' })).toBe(true);
+    expect(isLocalFileSource({ type: 'sqlite', database: './local.db' })).toBe(true);
+  });
+
+  it('is false for a network source, whatever its database field says', () => {
+    expect(isLocalFileSource({ type: 'postgresql', database: 'analytics' })).toBe(false);
+    expect(isLocalFileSource({ type: 'snowflake', database: 'PROD' })).toBe(false);
+  });
+
+  it('is false for :memory: — there is no file to be missing', () => {
+    expect(isLocalFileSource({ type: 'duckdb', database: ':memory:' })).toBe(false);
+  });
+
+  it('is false for a URI, which resolves the same from anywhere', () => {
+    // MotherDuck, object storage and http all reach the same place from cloud
+    // as from a laptop, so they are not "local" in the sense that matters.
+    expect(isLocalFileSource({ type: 'duckdb', database: 'md:my_db' })).toBe(false);
+    expect(isLocalFileSource({ type: 'duckdb', database: 's3://bucket/x.duckdb' })).toBe(false);
+    expect(isLocalFileSource({ type: 'duckdb', database: 'https://h/x.duckdb' })).toBe(false);
+  });
+
+  it('is false when there is no database at all', () => {
+    expect(isLocalFileSource({ type: 'duckdb' })).toBe(false);
+    expect(isLocalFileSource({})).toBe(false);
+    expect(isLocalFileSource()).toBe(false);
+  });
+});
+
+describe('canTestConnection', () => {
+  const LOCAL_FILE = { type: 'duckdb', database: 'target/seeds/pie.duckdb' };
+  const REMOTE = { type: 'postgresql', database: 'analytics' };
+
+  it('refuses a local-file source when the server has no local filesystem', () => {
+    // The case that motivated this: in cloud the file was never uploaded, so
+    // the test can only report a failure that says nothing about the config.
+    expect(canTestConnection(LOCAL_FILE, { local_filesystem: false })).toBe(false);
+  });
+
+  it('allows it under visivo serve, where the file really is there', () => {
+    expect(canTestConnection(LOCAL_FILE, { local_filesystem: true })).toBe(true);
+  });
+
+  it('always allows a network source', () => {
+    expect(canTestConnection(REMOTE, { local_filesystem: false })).toBe(true);
+  });
+
+  it('allows the test while capabilities are still loading', () => {
+    // Rather than flickering the control disabled on first paint. The request
+    // may fail, which is no worse than today.
+    expect(canTestConnection(LOCAL_FILE, null)).toBe(true);
+  });
+
+  it('allows it when an older server omits the flag entirely', () => {
+    // Only an explicit `false` disables — an unknown server is assumed capable.
+    expect(canTestConnection(LOCAL_FILE, { can_edit: true })).toBe(true);
+  });
+});

--- a/viewer/src/stores/commitStore.js
+++ b/viewer/src/stores/commitStore.js
@@ -1,6 +1,5 @@
 import * as branchingApi from '../api/branching';
 import * as preferencesApi from '../api/preferences';
-import * as commitApi from '../api/commit';
 import { emitFirstPublishTelemetry } from '../components/views/workspace/telemetry';
 
 /**
@@ -199,22 +198,38 @@ const createCommitSlice = (set, get) => ({
     return { success: false, action: body.action, error };
   },
 
-  // Discard all cached changes without writing YAML (Q14 rollback) — local
-  // Flask only (/api/commit/discard/). The named-child refetch is what makes
-  // the canvas revert to last-committed. Cloud drafts are discarded through
-  // branchingApi.discardDraft (drop the draft project) instead.
+  // Discard the draft's uncommitted changes, reverting to last-published.
+  //
+  // Goes through `POST /api/projects/<id>/discard/`, the same mirrored surface
+  // commitChanges uses — NOT the local-only `/api/commit/discard/`, which core
+  // does not implement, so in cloud the button 404'd and the header kept
+  // showing Commit/Discard as though nothing had happened.
+  //
+  // Note the sibling `discardDraft` DELETEs the same path to drop the working
+  // copy entirely. Same URL, different verb, very different meaning.
   discardChanges: async () => {
+    const projectId = get().project?.id;
+    if (!projectId) return { success: false, error: 'No active project' };
     set({ discardLoading: true });
     try {
-      const result = await commitApi.discardChanges();
+      const result = await branchingApi.discardDraftChanges(projectId);
       set({
         discardLoading: false,
         hasUncommittedChanges: false,
         pendingChanges: [],
         pendingCount: 0,
+        // Clearing the STAGED set too is what actually refreshes the header:
+        // it drives the run-pending affordance independently of pendingChanges,
+        // so leaving it set kept the toolbar dirty after a successful discard.
+        stagedChanges: [],
+        stagedCount: 0,
+        stagedDagFilter: '',
         commitError: null,
       });
       await get()._refreshNamedChildren();
+      // Re-read the server's own view rather than trusting the optimistic
+      // clear above — a per-resource discard can leave the draft still dirty.
+      await get().checkCommitStatus();
       return { success: true, result };
     } catch (error) {
       // Surface through commitError so CommitModal shows feedback instead of

--- a/viewer/src/stores/commitStore.test.js
+++ b/viewer/src/stores/commitStore.test.js
@@ -16,6 +16,7 @@ import { emitFirstPublishTelemetry } from '../components/views/workspace/telemet
 jest.mock('../api/branching', () => ({
   fetchChanges: jest.fn(),
   commitDraft: jest.fn(),
+  discardDraftChanges: jest.fn(),
 }));
 
 jest.mock('../api/preferences', () => ({
@@ -295,7 +296,7 @@ describe('commitStore (VIS-806)', () => {
   describe('discardChanges', () => {
     test('drops pending state and refreshes every collection (canvas revert)', async () => {
       useStore.setState({ pendingCount: 4, hasUncommittedChanges: true });
-      commitApi.discardChanges.mockResolvedValue({ discarded_count: 4 });
+      branchingApi.discardDraftChanges.mockResolvedValue({ discarded: true, dirty: false });
 
       const result = await useStore.getState().discardChanges();
 
@@ -307,9 +308,42 @@ describe('commitStore (VIS-806)', () => {
       FETCHER_KEYS.forEach(key => expect(fetcherStubs[key]).toHaveBeenCalled());
     });
 
+    test('clears the STAGED set too, which is what refreshes the header', async () => {
+      // The reported bug: discard succeeded but the toolbar kept showing
+      // Commit/Discard. pendingChanges was cleared and stagedChanges was not,
+      // and the header reads the staged set independently.
+      branchingApi.discardDraftChanges.mockResolvedValue({ discarded: true, dirty: false });
+      branchingApi.fetchChanges.mockResolvedValue({ has_changes: false, staged: [] });
+      useStore.setState({
+        stagedChanges: [{ name: 'orders' }],
+        stagedCount: 1,
+        stagedDagFilter: '+orders+',
+      });
+
+      await useStore.getState().discardChanges();
+
+      const state = useStore.getState();
+      expect(state.stagedCount).toBe(0);
+      expect(state.stagedChanges).toEqual([]);
+      expect(state.stagedDagFilter).toBe('');
+    });
+
+    test('discards through the project-scoped route both servers implement', async () => {
+      // Not `/api/commit/discard/`, which core does not implement — that is why
+      // the cloud button 404'd and the header never changed.
+      branchingApi.discardDraftChanges.mockResolvedValue({ discarded: true });
+      branchingApi.fetchChanges.mockResolvedValue({ has_changes: false, staged: [] });
+      useStore.setState({ project: { id: 'proj-9' } });
+
+      await useStore.getState().discardChanges();
+
+      expect(branchingApi.discardDraftChanges).toHaveBeenCalledWith('proj-9');
+      expect(commitApi.discardChanges).not.toHaveBeenCalled();
+    });
+
     test('reports failure without clearing pending state and surfaces commitError', async () => {
       useStore.setState({ pendingCount: 4, hasUncommittedChanges: true });
-      commitApi.discardChanges.mockRejectedValue(new Error('boom'));
+      branchingApi.discardDraftChanges.mockRejectedValue(new Error('boom'));
 
       const result = await useStore.getState().discardChanges();
 

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -234,7 +234,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
       // VIS-1085: enqueued (not fired directly) so this can never interleave
       // with a concurrent rename/discard-revert write for the SAME id.
       const updated = await enqueueWrite(id, () =>
-        explorationsApi.updateExploration(id, { draft: mapDraftToApi(record.draft) })
+        explorationsApi.updateExploration(id, { draft: mapDraftToApi(record.draft) }, get().project?.id)
       );
       set(state =>
         patchExploration(state, id, {
@@ -289,7 +289,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      * from the backend — localStorage is not a source of truth). */
     fetchExplorations: async () => {
       try {
-        const list = await explorationsApi.fetchExplorations();
+        const list = await explorationsApi.fetchExplorations(get().project?.id);
         const byId = {};
         const order = [];
         list.forEach(record => {
@@ -352,7 +352,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         if (defaultName) payload.name = defaultName;
         const seedLegacyState = legacyStateOverride || (seed ? legacyStateForSeed(seed) : null);
         if (seedLegacyState) payload.draft = mapDraftToApi(legacyStateToDraft(seedLegacyState));
-        const created = await explorationsApi.createExploration(payload);
+        const created = await explorationsApi.createExploration(payload, get().project?.id);
         const mapped = mapExplorationFromApi(created);
         set(state => insertExploration(state, mapped));
         // VIS-1072 — flywheel telemetry: the create moment + the
@@ -406,7 +406,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
           name: `${existing.name} copy`,
           seeded_from: mapSeedToApi(existing.seededFrom) || undefined,
           draft: mapDraftToApi(existing.draft),
-        });
+        }, get().project?.id);
         const mapped = mapExplorationFromApi(created);
         set(state => insertExploration(state, mapped));
         // VIS-1072 — "branch" gets its own time_to_first_chart clock too,
@@ -428,7 +428,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
     deleteExploration: async id => {
       const existing = get().workspaceExplorations.byId[id];
       try {
-        await explorationsApi.deleteExploration(id);
+        await explorationsApi.deleteExploration(id, get().project?.id);
       } catch (error) {
         return { success: false, error: error.message };
       }
@@ -470,7 +470,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
           name: existing.name,
           seeded_from: mapSeedToApi(existing.seededFrom) || undefined,
           draft: mapDraftToApi(existing.draft),
-        });
+        }, get().project?.id);
         const mapped = mapExplorationFromApi(created);
         set(state => insertExploration(state, mapped));
         clearPendingSyncTimer(id);
@@ -537,7 +537,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         // debounced draft-sync can never interleave with it — see the file
         // docstring's "WRITE SERIALIZATION" note.
         const updated = await enqueueWrite(id, () =>
-          explorationsApi.updateExploration(id, { name: trimmed })
+          explorationsApi.updateExploration(id, { name: trimmed }, get().project?.id)
         );
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, mapped));
@@ -648,7 +648,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         // VIS-1085: enqueued alongside every other write for this id — see
         // the file docstring's "WRITE SERIALIZATION" note.
         const updated = await enqueueWrite(id, () =>
-          explorationsApi.updateExploration(id, { draft: mapDraftToApi(snapshot) })
+          explorationsApi.updateExploration(id, { draft: mapDraftToApi(snapshot) }, get().project?.id)
         );
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, { promoted: mapped.promoted, updatedAt: mapped.updatedAt }));
@@ -677,7 +677,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      */
     consumeExplorationReturnTo: async id => {
       try {
-        const updated = await enqueueWrite(id, () => explorationsApi.consumeReturnTo(id));
+        const updated = await enqueueWrite(id, () => explorationsApi.consumeReturnTo(id, get().project?.id));
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, { returnTo: mapped.returnTo }));
         return { success: true };
@@ -704,7 +704,7 @@ const createWorkspaceExplorationsSlice = (set, get) => {
      * just-appended `promoted[]` entry this call exists to record. */
     recordExplorationPromotion: async (id, type, name) => {
       try {
-        const updated = await enqueueWrite(id, () => explorationsApi.recordPromotion(id, type, name));
+        const updated = await enqueueWrite(id, () => explorationsApi.recordPromotion(id, type, name, get().project?.id));
         const mapped = mapExplorationFromApi(updated);
         set(state => patchExploration(state, id, mapped));
         return { success: true };

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -192,6 +192,27 @@ describe('fetchExplorations', () => {
 });
 
 describe('createExploration', () => {
+  test('scopes every write to the active project (cloud requires project_id)', async () => {
+    // Core answers `{error: "project_id is required param"}` without it, so
+    // creating an exploration in cloud failed outright. Every other resource
+    // module scoped its calls; this one never did.
+    const previousProject = useStore.getState().project;
+    useStore.setState({ project: { id: 'proj-42' } });
+    explorationsApi.createExploration.mockResolvedValue({ id: 'exp_9', name: 'x' });
+
+    try {
+      await act(async () => {
+        await useStore.getState().createExploration();
+      });
+
+      expect(explorationsApi.createExploration).toHaveBeenCalledWith({}, 'proj-42');
+    } finally {
+      // The store is shared across tests here, so leaving a project set would
+      // change what every later assertion sees.
+      useStore.setState({ project: previousProject });
+    }
+  });
+
   test('creates with no seed, POSTs {}, and inserts at the front of order', async () => {
     explorationsApi.createExploration.mockResolvedValueOnce(wireExploration({ name: 'Scratch' }));
 
@@ -200,7 +221,7 @@ describe('createExploration', () => {
       result = await useStore.getState().createExploration();
     });
 
-    expect(explorationsApi.createExploration).toHaveBeenCalledWith({});
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith({}, undefined);
     expect(result).toMatchObject({ success: true, id: 'exp_1' });
     const state = useStore.getState().workspaceExplorations;
     expect(state.order[0]).toBe('exp_1');
@@ -226,7 +247,7 @@ describe('createExploration', () => {
       // default name derived from what was explored, rather than the
       // backend's generic 'Exploration N' counter.
       name: 'orders exploration',
-    });
+    }, undefined);
     expect(useStore.getState().workspaceExplorations.byId.exp_1.seededFrom).toEqual({
       type: 'model',
       name: 'orders',
@@ -320,7 +341,7 @@ describe('createExploration', () => {
 
     expect(explorationsApi.createExploration).toHaveBeenCalledWith({
       return_to: { dashboard: 'sales' },
-    });
+    }, undefined);
     expect(useStore.getState().workspaceExplorations.byId.exp_1.returnTo).toEqual({
       dashboard: 'sales',
     });
@@ -331,7 +352,7 @@ describe('createExploration', () => {
     await act(async () => {
       await useStore.getState().createExploration();
     });
-    expect(explorationsApi.createExploration).toHaveBeenCalledWith({});
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith({}, undefined);
   });
 
   test('newer creations land ahead of older ones in order', async () => {
@@ -397,7 +418,7 @@ describe('updateExplorationDraft', () => {
         computed_columns: [{ expression: 'a' }],
         legacy_state: null,
       },
-    });
+    }, undefined);
     expect(useStore.getState().workspaceExplorations.byId.exp_1.syncStatus).toBe('synced');
   });
 
@@ -438,7 +459,7 @@ describe('updateExplorationDraft', () => {
         computed_columns: [],
         legacy_state: null,
       },
-    });
+    }, undefined);
   });
 
   test('sets syncStatus to error when the persist fails', async () => {
@@ -662,7 +683,7 @@ describe('recreateExplorationFromDeleted (VIS-1083)', () => {
 
     expect(explorationsApi.createExploration).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Churn dig' })
-    );
+      , undefined    );
     expect(result).toMatchObject({ success: true, id: 'exp_2' });
     const state = useStore.getState().workspaceExplorations;
     expect(state.byId.exp_1).toBeUndefined();
@@ -823,7 +844,7 @@ describe('duplicateExploration', () => {
         computed_columns: [],
         legacy_state: null,
       },
-    });
+    }, undefined);
     expect(result).toMatchObject({ success: true, id: 'exp_2' });
     expect(useStore.getState().workspaceExplorations.order).toEqual(['exp_2', 'exp_1']);
   });
@@ -872,7 +893,7 @@ describe('duplicateExploration', () => {
           legacy_state: null,
         },
       })
-    );
+      , undefined    );
   });
 });
 
@@ -886,7 +907,7 @@ describe('deleteExploration', () => {
       result = await useStore.getState().deleteExploration('exp_1');
     });
 
-    expect(explorationsApi.deleteExploration).toHaveBeenCalledWith('exp_1');
+    expect(explorationsApi.deleteExploration).toHaveBeenCalledWith('exp_1', undefined);
     expect(useStore.getState().closeWorkspaceTab).toHaveBeenCalledWith('exploration:exp_1');
     expect(result).toEqual({ success: true });
     const state = useStore.getState().workspaceExplorations;
@@ -1007,7 +1028,11 @@ describe('renameExploration', () => {
 
     const result = await act(async () => renamePromise);
 
-    expect(explorationsApi.updateExploration).toHaveBeenCalledWith('exp_1', { name: 'Churn dig' });
+    expect(explorationsApi.updateExploration).toHaveBeenCalledWith(
+      'exp_1',
+      { name: 'Churn dig' },
+      undefined
+    );
     expect(result).toMatchObject({ success: true });
     expect(useStore.getState().workspaceExplorations.byId.exp_1.name).toBe('Churn dig');
   });
@@ -1120,7 +1145,7 @@ describe('VIS-1085 — per-id write serialization (rename vs debounced draft-syn
     expect(explorationsApi.updateExploration).toHaveBeenCalledTimes(2);
     expect(explorationsApi.updateExploration).toHaveBeenNthCalledWith(2, 'exp_1', {
       name: 'Renamed',
-    });
+    }, undefined);
   });
 
   test('a debounced draft-sync fired while a rename is in flight for the SAME id waits for it (reverse ordering)', async () => {
@@ -1175,7 +1200,7 @@ describe('VIS-1085 — per-id write serialization (rename vs debounced draft-syn
         computed_columns: [],
         legacy_state: null,
       },
-    });
+    }, undefined);
   });
 
   test('writes for DIFFERENT ids are never serialized against each other', async () => {
@@ -1294,7 +1319,7 @@ describe('VIS-1081 discard mechanics', () => {
         computed_columns: [],
         legacy_state: null,
       },
-    });
+    }, undefined);
   });
 
   test('discardExploration cancels a pending debounce even when the fire-time POST would have raced it', async () => {
@@ -1365,7 +1390,12 @@ describe('recordExplorationPromotion', () => {
       result = await useStore.getState().recordExplorationPromotion('exp_1', 'model', 'orders_q');
     });
     expect(result).toEqual({ success: true });
-    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith('exp_1', 'model', 'orders_q');
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith(
+      'exp_1',
+      'model',
+      'orders_q',
+      undefined
+    );
     expect(useStore.getState().workspaceExplorations.byId.exp_1.promoted).toEqual([
       { type: 'model', name: 'orders_q', promoted_at: '2026-07-18T00:00:00Z' },
     ]);
@@ -1393,7 +1423,7 @@ describe('consumeExplorationReturnTo', () => {
       result = await useStore.getState().consumeExplorationReturnTo('exp_1');
     });
     expect(result).toEqual({ success: true });
-    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1');
+    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1', undefined);
     expect(useStore.getState().workspaceExplorations.byId.exp_1.returnTo).toBeNull();
   });
 
@@ -1441,7 +1471,7 @@ describe('consumeExplorationReturnTo', () => {
       resolveDraftSync(wireExploration());
       await consumePromise;
     });
-    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1');
+    expect(explorationsApi.consumeReturnTo).toHaveBeenCalledWith('exp_1', undefined);
   });
 });
 
@@ -1492,7 +1522,12 @@ describe('recordExplorationPromotion — P4-D1 write serialization', () => {
     });
 
     expect(explorationsApi.recordPromotion).toHaveBeenCalledTimes(1);
-    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith('exp_1', 'model', 'orders_q');
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith(
+      'exp_1',
+      'model',
+      'orders_q',
+      undefined
+    );
   });
 
   test('a draft-sync fired while a promotion is in flight for the same id waits for it (reverse ordering)', async () => {
@@ -1831,7 +1866,12 @@ describe('promoteExploration', () => {
     });
 
     expect(explorationsApi.recordPromotion).toHaveBeenCalledTimes(1);
-    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith('exp_1', 'model', 'good_model');
+    expect(explorationsApi.recordPromotion).toHaveBeenCalledWith(
+      'exp_1',
+      'model',
+      'good_model',
+      undefined
+    );
   });
 
   test('surfaces reclassification offers when a promoted metric/dimension collides with a sibling bare-column ref (delta-review fix)', async () => {

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -259,6 +259,54 @@ async def create_dashboard_records(
 
 
 @retry(stop=stop_after_attempt(MAX_ATTEMPTS), wait=wait_fixed(2))
+def upload_source_schemas(run_output_dir, project_id, json_headers, host):
+    """Ship the source schema envelopes `visivo run` wrote, like any other artifact.
+
+    A schema is a build output — the run computed it, so the deploy uploads it,
+    exactly as it does insight and model files. Nothing runs in cloud to produce
+    these, and for a file-backed duckdb/sqlite source nothing COULD: the database
+    file lives on this machine and is never uploaded, so introspecting it
+    remotely fails with "database does not exist".
+
+    Best-effort by design. A project with no schemas on disk (never run) deploys
+    fine, and a schema upload failure must not fail a deploy whose data landed —
+    the editor degrades to "Generate schema to browse", which is exactly the
+    state it was already in.
+
+    Returns the number stored.
+    """
+    schemas_dir = os.path.join(run_output_dir, "schemas")
+    if not os.path.isdir(schemas_dir):
+        return 0
+
+    payload = []
+    for entry in sorted(os.listdir(schemas_dir)):
+        if not entry.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(schemas_dir, entry)) as fp:
+                content = json.load(fp)
+        except (OSError, ValueError):
+            continue
+        # Models and sources share this directory; `source_name` is what tells
+        # them apart, the same key core classifies on.
+        if not isinstance(content, dict) or not content.get("source_name"):
+            continue
+        payload.append({"name": content["source_name"], "content": content})
+
+    if not payload:
+        return 0
+
+    response = requests.post(
+        f"{host}/api/source-schema-jobs/?project_id={project_id}",
+        data=json.dumps(payload),
+        headers=json_headers,
+    )
+    response.raise_for_status()
+    return response.json().get("stored", len(payload))
+
+
+@retry(stop=stop_after_attempt(MAX_ATTEMPTS), wait=wait_fixed(2))
 async def create_insight_records(batch, project_id, json_headers, host, progress):
     """
     Asynchronously creates insight records on the server.
@@ -1058,6 +1106,22 @@ def deploy_phase(
             )
         send_progress(
             f"Model uploads completed in {time() - process_models_start_time:.2f} seconds",
+            "info",
+        )
+
+        # Source schemas — small inline JSON, no files to upload.
+        Logger.instance().info(f"")
+        send_progress("Processing source schemas...", "info")
+        schemas_start_time = time()
+        try:
+            stored = upload_source_schemas(run_output_dir, project_id, json_headers, host)
+            send_progress(f"\t{stored} source schemas uploaded", "success" if stored else "info")
+        except Exception as e:
+            # Never fail a deploy over this: the data landed, and the editor
+            # falls back to "Generate schema to browse".
+            Logger.instance().error(f"\tSource schema upload failed: {repr(e)}")
+        send_progress(
+            f"Source schemas completed in {time() - schemas_start_time:.2f} seconds",
             "info",
         )
 

--- a/visivo/server/views/commit_views.py
+++ b/visivo/server/views/commit_views.py
@@ -197,6 +197,11 @@ def register_commit_views(app, flask_app, output_dir):
                 "is_draft": True,
                 # No separate published project locally → no "Go to Draft".
                 "draft_id": None,
+                # `visivo serve` runs on the author's machine, so file-backed
+                # sources (duckdb/sqlite on a local path) resolve normally.
+                # Cloud reports False and the client hides what cannot work
+                # there.
+                "local_filesystem": True,
             }
         )
 

--- a/visivo/server/views/commit_views.py
+++ b/visivo/server/views/commit_views.py
@@ -519,8 +519,15 @@ def register_commit_views(app, flask_app, output_dir):
             return jsonify({"error": str(e)}), 500
 
     @app.route("/api/commit/discard/", methods=["POST"])
-    def discard_changes():
-        """Drop every cached draft without writing YAML (the Discard rollback, Q14)."""
+    @app.route("/api/projects/<project_id>/discard/", methods=["POST"])
+    def discard_changes(project_id=None):
+        """Drop every cached draft without writing YAML (the Discard rollback, Q14).
+
+        Dual-mounted like ``commit`` above, so the project-scoped path core
+        serves works here too and the viewer has ONE discard code path. Without
+        the mirror the viewer had to special-case cloud, and the special case
+        was never written — the button 404'd against core.
+        """
         try:
             managers = [
                 flask_app.source_manager,
@@ -550,6 +557,10 @@ def register_commit_views(app, flask_app, output_dir):
                 {
                     "message": "Changes discarded",
                     "discarded_count": discarded_count,
+                    # Core's shape, so the client reads one contract. Local
+                    # discards everything, so it is never still dirty after.
+                    "discarded": True,
+                    "dirty": False,
                 }
             )
         except Exception as e:


### PR DESCRIPTION
Six fixes from your testing session. Pairs with [core#323](https://github.com/visivo-io/core/pull/323).

---

## 1. "+ New" created the object but nothing appeared

Every resource save checked `response.status === 200`. Core answers **201 Created** for a new resource (`_resource.py:286`) — so the client *threw on success*: the object was written server-side, then the list never refetched and no tab opened.

All **11** resource modules had it. All 11 now accept `response.ok`.

Worth noting how it survived: the shared `resourceApis.test.js` mocked `{status: 200}` with **no `ok` property** — a Response shape that cannot exist. The mocks are realistic now, plus an explicit 201 case.

## 2. Discard 404'd in cloud, and the header never cleared

`discardChanges` posted to `/api/commit/discard/`, which **core does not implement**. The store's own comment said cloud goes via `branchingApi.discardDraft` — but nothing ever called it, and it sends `DELETE` (drop the draft) where the button means `POST` (discard changes, keep it). Same URL, different verb, very different meaning.

Now both servers serve `POST /api/projects/<id>/discard/`; local gains the mirror, dual-mounted like `commit` beside it.

The header bug was separate: it cleared `pendingChanges` but not `stagedChanges`, which the header reads independently.

## 3. Explorations never sent `project_id`

Core requires it and answers `{error: "project_id is required param"}`, so creating an exploration in cloud failed outright. Every other resource module scoped its calls; this one never did. All 7 functions, all 10 call sites.

## 4. Deploy now uploads source schemas

**This is the fix for the 126 sources reading `has_cached_schema: false`.**

A schema is a build output — `visivo run` computes it, so the deploy ships it, exactly as it already ships insight files, model files and dashboards. It didn't, so they stayed on your laptop.

Nothing in cloud could have filled the gap:

- `request_auto_run` **no-ops unless the project is a draft**, so a deploy schedules no run. Cloud Logging showed exactly **one** `run.submit` in three days — the auto-run from your edit, which failed.
- For a file-backed duckdb/sqlite source nothing in cloud ever *could* build it. The runner said `Cannot open database "/runner/target/seeds/pie_data.duckdb" ... does not exist`.

Best-effort by design: a never-run project deploys fine, a corrupt envelope costs only itself, and an upload failure logs rather than failing a deploy whose data landed.

## 5. No connection test where it cannot succeed

Capabilities gains `local_filesystem` — `True` from `visivo serve`, `False` from core. Both source editors disable the test for a file-backed source when the server has no local filesystem.

`isLocalFileSource` is deliberately narrow: `:memory:` is excluded (no file to be missing), and so is anything with a URI scheme — `md:`, `s3://`, `https://` reach the same place from cloud as from a laptop. An unknown or still-loading capability **allows** the test; only an explicit `false` disables it, so an older server behaves as it does today.

## 6. (core side) Thumbnails no longer store 503s

See core#323 — `page.goto`'s Response was discarded, so an nginx error page became a valid PNG and was stored *permanently*.

---

## Tests

2287 pytest, 6641 viewer, lint clean. The one viewer failure is the pre-existing VIS-993 async-schema flake.

## Follow-up, design settled

"Generate schema" should become an ordinary draft Run scoped to `+source+`, retiring `RunnerJobKind.SOURCE_SCHEMA` and the runner's `_op_source_schema` — draft-only, failing if the project isn't a draft, exactly like the on-demand model run. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
