### PR TITLE
Four follow-ups: schema UX, create status, model tab prefill

### DIFF
--- a/tests/query/test_sqlglot_available_message.py
+++ b/tests/query/test_sqlglot_available_message.py
@@ -1,0 +1,56 @@
+"""The "what could I resolve against" line in a schema-validation failure.
+
+It used to read ``Available schemas: <keys>`` while only ever collecting keys
+whose value was itself a dict — the NESTED ``{schema: {table: {col}}}`` shape.
+DuckDB and SQLite produce a FLAT ``{table: {col}}``, so the line always said
+``Available schemas: None`` regardless of whether anything had loaded.
+
+That is worse than unhelpful. It claims nothing was loaded at exactly the moment
+you are trying to establish whether anything was loaded, and sends you looking
+for a missing schema when the real cause is usually a mistyped column.
+"""
+
+from sqlglot import exp
+
+from visivo.query.sqlglot_utils import _describe_available
+
+
+def _cols(*names):
+    return {name: exp.DataType.build("INT") for name in names}
+
+
+def test_a_flat_schema_names_its_tables_rather_than_claiming_none():
+    """The regression. A duckdb source with tables used to print 'None'."""
+    message = _describe_available({"orders": _cols("id"), "users": _cols("id")})
+
+    assert "orders" in message and "users" in message
+    assert "None" not in message
+
+
+def test_a_nested_schema_still_names_its_schemas():
+    message = _describe_available({"EDW": {"fact_order": _cols("col1")}})
+
+    assert message == "Available schemas: EDW"
+
+
+def test_an_empty_schema_says_so_unambiguously():
+    """The case the old message was accidentally right about — now it is the
+    only case that reports nothing, so the report means something."""
+    message = _describe_available({})
+
+    assert "EMPTY" in message
+    assert "no schema was loaded" in message
+
+
+def test_a_long_table_list_is_capped():
+    """A warehouse source can carry hundreds of tables; an error that scrolls
+    off the screen is its own problem."""
+    message = _describe_available({f"t{i}": _cols("id") for i in range(50)})
+
+    assert "+30 more" in message
+    assert len(message) < 400
+
+
+def test_a_non_dict_schema_does_not_raise_inside_the_error_path():
+    """This runs while already raising — it must not raise again."""
+    assert "EMPTY" in _describe_available(None)

--- a/tests/server/test_run_views.py
+++ b/tests/server/test_run_views.py
@@ -296,7 +296,7 @@ class TestDataAffectingGate:
             r = self._save_insight(
                 integration_client, "w", {"type": "scatter", "x": "?{ ${ref(M).a} }"}
             )
-            assert r.status_code == 200
+            assert r.status_code == 201
             req.assert_called_once()
             assert req.call_args[0][1] == ["w"]
 
@@ -313,7 +313,7 @@ class TestDataAffectingGate:
                 "w",
                 {"type": "scatter", "x": "?{ ${ref(M).a} }", "marker": {"color": "blue"}},
             )
-            assert r.status_code == 200
+            assert r.status_code == 201
             req.assert_not_called()
 
     def test_query_edit_runs(self, integration_client):
@@ -373,7 +373,7 @@ class TestDataAffectingGate:
             self._save_chart(integration_client, "c", {"title": {"text": "Hello"}})
             req.reset_mock()
             r = self._save_chart(integration_client, "c", {"title": {"text": "Goodbye"}})
-            assert r.status_code == 200
+            assert r.status_code == 201
             req.assert_not_called()
 
     def test_deleting_a_plain_chart_skips_run(self, integration_client):
@@ -404,7 +404,7 @@ class TestTriggerMode:
             r = self._save_insight(
                 integration_client, "w", {"type": "scatter", "x": "?{ ${ref(M).a} }"}
             )
-        assert r.status_code == 200
+        assert r.status_code == 201
         req.assert_not_called()
         assert StagedManager.instance().list() == [
             {"name": "w", "type": "insight", "status": "modified"}

--- a/tests/server/views/test_insight_save_rejects_invalid_props.py
+++ b/tests/server/views/test_insight_save_rejects_invalid_props.py
@@ -120,7 +120,7 @@ class TestInsightSaveRejectsInvalidProps:
             content_type="application/json",
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         data = response.get_json()
         assert data["insight"] == "good_insight"
         # The valid insight is persisted to cache.

--- a/tests/server/views/test_model_views.py
+++ b/tests/server/views/test_model_views.py
@@ -96,7 +96,7 @@ class TestModelViews:
             content_type="application/json",
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         data = response.get_json()
         assert data["model"] == "new_model"
         assert data["status"] == "new"

--- a/tests/server/views/test_resource_views.py
+++ b/tests/server/views/test_resource_views.py
@@ -118,10 +118,26 @@ class TestUniformResourceViews:
         mgr.save_from_config.return_value = Mock()
         mgr.get_status.return_value = ObjectStatus.NEW
         resp = client.post(f"/api/{key}/a/", json={"foo": "bar"})
-        assert resp.status_code == 200
+        # 201 for a NEW object, matching core. The viewer used to treat anything
+        # but 200 as a failure, so cloud's 201 made every "+ New" look like it
+        # had done nothing; both servers now say the same thing.
+        assert resp.status_code == 201
         assert resp.get_json()["status"] == "new"
         # name is forced to match the URL parameter
         assert mgr.save_from_config.call_args[0][0]["name"] == "a"
+
+    def test_save_existing_is_200_not_201(self, key, register, mgr_attr, get_all, get_one):
+        """Updating an object is not creating one — core answers 200 +
+        "modified" here, and the distinction is the whole point of the code."""
+        client, fa = _client(register)
+        mgr = getattr(fa, mgr_attr)
+        mgr.save_from_config.return_value = Mock()
+        mgr.get_status.return_value = ObjectStatus.MODIFIED
+
+        resp = client.post(f"/api/{key}/a/", json={"foo": "bar"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "modified"
 
     def test_save_no_config(self, key, register, mgr_attr, get_all, get_one):
         client, fa = _client(register)
@@ -200,8 +216,19 @@ class TestModelScopedResourceViews:
         mgr.save_from_config.return_value = Mock()
         mgr.get_status.return_value = ObjectStatus.NEW
         resp = client.post(f"/api/{key}/d/", json={"expression": "sum(x)"})
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         assert resp.get_json()["status"] == "new"
+
+    def test_save_existing_is_200_not_201(self, key, register, mgr_attr, get_all, get_one):
+        client, fa = _client(register)
+        mgr = getattr(fa, mgr_attr)
+        mgr.save_from_config.return_value = Mock()
+        mgr.get_status.return_value = ObjectStatus.MODIFIED
+
+        resp = client.post(f"/api/{key}/d/", json={"expression": "sum(x)"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "modified"
 
     def test_delete(self, key, register, mgr_attr, get_all, get_one):
         client, fa = _client(register)

--- a/tests/server/views/test_sources_views.py
+++ b/tests/server/views/test_sources_views.py
@@ -96,7 +96,7 @@ class TestSourcesViews:
             content_type="application/json",
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         data = response.get_json()
         assert data["source"] == "new_source"
         assert data["status"] == "new"

--- a/viewer/src/components/explorer/CenterPanel.jsx
+++ b/viewer/src/components/explorer/CenterPanel.jsx
@@ -12,6 +12,7 @@ import VerticalDivider from '../common/VerticalDivider';
 import Divider from '../common/Divider';
 import Select from '../common/Select';
 import useStore from '../../stores/store';
+import { useModelTabPrefill } from '../../hooks/useModelTabPrefill';
 import {
   selectActiveModelSql,
   selectActiveModelSourceName,
@@ -57,6 +58,11 @@ const CenterPanel = ({
   const sql = useStore(selectActiveModelSql);
   const setSql = useStore((s) => s.setActiveModelSql);
   const queryResult = useStore(selectActiveModelQueryResult);
+
+  // Show the last run's rows when a model tab opens with none, instead of an
+  // empty grid beside a parquet that already exists. Never overwrites a query
+  // the user just ran (see the hook).
+  useModelTabPrefill(activeModelName, Boolean(queryResult));
   const queryError = useStore(selectActiveModelQueryError);
   const setModelQueryResult = useStore((s) => s.setModelQueryResult);
   const setModelQueryError = useStore((s) => s.setModelQueryError);

--- a/viewer/src/components/views/common/sourceCapabilities.js
+++ b/viewer/src/components/views/common/sourceCapabilities.js
@@ -38,20 +38,37 @@ export const isLocalFileSource = (config = {}) => {
 };
 
 /**
- * Whether a connection test can meaningfully run for this source here.
+ * Whether the serving process can open this source at all.
+ *
+ * One fact, two consumers: testing a connection and introspecting a schema both
+ * require opening the database, and both fail the same way in cloud for a
+ * file-backed source — the runner reports "database does not exist" because the
+ * file is on the author's machine.
  *
  * @param {object} config - the source config
- * @param {object|null} capabilities - the project capabilities payload; while it
- *   is still loading we allow the test rather than flickering the button
- *   disabled, since the common case (local serve) supports it.
+ * @param {object|null} capabilities - the project capabilities payload. While it
+ *   is still loading we assume reachable rather than flickering controls
+ *   disabled on first paint, and an older server that omits the flag keeps
+ *   today's behaviour. Only an explicit `false` gates anything.
  */
-export const canTestConnection = (config, capabilities) => {
+export const canReachSource = (config, capabilities) => {
   if (!isLocalFileSource(config)) return true;
   if (!capabilities) return true;
   return capabilities.local_filesystem !== false;
 };
 
+/** Whether a connection test can meaningfully run for this source here. */
+export const canTestConnection = canReachSource;
+
+/** Whether a schema can be introspected for this source here. */
+export const canGenerateSchema = canReachSource;
+
 /** Why the test is unavailable, for the disabled control's tooltip. */
 export const CONNECTION_TEST_UNAVAILABLE =
   'This source reads a file on your machine, which the cloud server cannot open. ' +
   'Test it with `visivo serve` locally.';
+
+/** Why the schema cannot be generated here. */
+export const SCHEMA_GENERATE_UNAVAILABLE =
+  'This source reads a file on your machine, which the cloud server cannot open. ' +
+  'Its schema is uploaded by `visivo deploy` — run and deploy locally to refresh it.';

--- a/viewer/src/components/views/common/sourceCapabilities.test.js
+++ b/viewer/src/components/views/common/sourceCapabilities.test.js
@@ -1,6 +1,8 @@
 import {
   isLocalFileSource,
   canTestConnection,
+  canGenerateSchema,
+  canReachSource,
 } from './sourceCapabilities';
 
 describe('isLocalFileSource', () => {
@@ -60,5 +62,31 @@ describe('canTestConnection', () => {
   it('allows it when an older server omits the flag entirely', () => {
     // Only an explicit `false` disables — an unknown server is assumed capable.
     expect(canTestConnection(LOCAL_FILE, { can_edit: true })).toBe(true);
+  });
+});
+
+describe('canGenerateSchema', () => {
+  const LOCAL_FILE = { type: 'duckdb', database: 'target/seeds/pie.duckdb' };
+
+  it('is the same fact as canTestConnection — one reachability question', () => {
+    // Both require opening the database, and both fail identically in cloud
+    // with "database does not exist". Keeping them one predicate means they
+    // cannot drift into disagreeing about the same source.
+    expect(canGenerateSchema).toBe(canReachSource);
+    expect(canTestConnection).toBe(canReachSource);
+  });
+
+  it('refuses a local-file source in cloud, where its schema comes from deploy', () => {
+    expect(canGenerateSchema(LOCAL_FILE, { local_filesystem: false })).toBe(false);
+  });
+
+  it('allows it under visivo serve', () => {
+    expect(canGenerateSchema(LOCAL_FILE, { local_filesystem: true })).toBe(true);
+  });
+
+  it('allows it for a warehouse source anywhere', () => {
+    expect(
+      canGenerateSchema({ type: 'snowflake', database: 'PROD' }, { local_filesystem: false })
+    ).toBe(true);
   });
 });

--- a/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
+++ b/viewer/src/components/views/workspace/SourceOutlineTreePanel.jsx
@@ -11,6 +11,7 @@ import {
   PiWarningCircle,
 } from 'react-icons/pi';
 import useStore from '../../../stores/store';
+import { SCHEMA_GENERATE_UNAVAILABLE } from '../common/sourceCapabilities';
 import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import useSourceOutline, { sourceRootKey } from './useSourceOutline';
 
@@ -199,6 +200,7 @@ const SourceOutlineTreePanel = ({ sourceName }) => {
     status,
     error,
     isCold,
+    canGenerate,
     generating,
     generateSchema,
     loadFlatColumns,
@@ -410,6 +412,16 @@ const SourceOutlineTreePanel = ({ sourceName }) => {
             Retry
           </button>
         </EmptyState>
+      ) : isCold && !canGenerate ? (
+        // A file-backed source in cloud. Its schema comes from `visivo deploy`,
+        // since the database file never leaves the author's machine — a
+        // generate here could only report "database does not exist".
+        <EmptyState
+          icon={SourceIcon}
+          testId="source-outline-local-only"
+          title="Schema comes from deploy"
+          body={SCHEMA_GENERATE_UNAVAILABLE}
+        />
       ) : isCold ? (
         <EmptyState
           icon={SourceIcon}

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
@@ -14,6 +14,7 @@ import {
   PiArrowSquareOut,
 } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
+import { SCHEMA_GENERATE_UNAVAILABLE } from '../../common/sourceCapabilities';
 import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
 import useSourceOutline from '../useSourceOutline';
 import { StatusDot } from './LibraryRow';
@@ -262,6 +263,7 @@ const LibrarySourceDrilldown = ({ sourceName }) => {
     status,
     error,
     isCold,
+    canGenerate,
     generating,
     generateSchema,
     loadFlatColumns,
@@ -313,6 +315,20 @@ const LibrarySourceDrilldown = ({ sourceName }) => {
         >
           Retry
         </button>
+      </div>
+    );
+  }
+
+  if (isCold && !canGenerate) {
+    // A file-backed source in cloud: its schema arrives via `visivo deploy`,
+    // because the database file is on the author's machine. Offering the button
+    // here would only ever produce "database does not exist".
+    return (
+      <div
+        className="py-1 pl-10 text-[11px] text-gray-400"
+        data-testid={`library-source-${sourceName}-local-only`}
+      >
+        {SCHEMA_GENERATE_UNAVAILABLE}
       </div>
     );
   }

--- a/viewer/src/components/views/workspace/useSourceOutline.js
+++ b/viewer/src/components/views/workspace/useSourceOutline.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useStore from '../../../stores/store';
 import { isAvailable } from '../../../contexts/URLContext';
 import { pollJob } from '../../../api/jobs';
+import { canGenerateSchema } from '../common/sourceCapabilities';
 import {
   fetchSourceSchemaJobs,
   generateSourceSchema,
@@ -99,6 +100,15 @@ export default function useSourceOutline(sourceName) {
   // Subscribed at render rather than read via getState() inside an async
   // callback: that samples the id at request time, not render time.
   const projectId = useStore(s => s.project?.id);
+  // A file-backed source can only be introspected where its file lives. In
+  // cloud there is no such file, so "Generate schema" would fail every time
+  // with "database does not exist" — its schema arrives via `visivo deploy`
+  // instead. Same fact that gates the connection test.
+  const capabilities = useStore(s => s.capabilities);
+  const sourceConfig = useStore(s =>
+    (s.sources || []).find(source => source.name === sourceName)?.config
+  );
+  const canGenerate = canGenerateSchema(sourceConfig, capabilities);
 
   // The cached tree is the source of truth; `null` until first load completes.
   const [nodes, setNodes] = useState(null);
@@ -240,6 +250,10 @@ export default function useSourceOutline(sourceName) {
    */
   const generateSchema = useCallback(async () => {
     if (!sourceName || !isAvailable('sourceSchemaJobsList')) return;
+    // Guarded here as well as in the UI: the surfaces render an explanation
+    // rather than the button, but a stale handler must not fire a request that
+    // can only fail.
+    if (!canGenerate) return;
     const epoch = epochRef.current;
     const stale = () => epochRef.current !== epoch;
     setGenerating({ status: 'starting', progress: 0, message: '' });
@@ -295,7 +309,7 @@ export default function useSourceOutline(sourceName) {
       setGenerating(null);
       setError(e.message);
     }
-  }, [sourceName, projectId]);
+  }, [sourceName, projectId, canGenerate]);
 
   /**
    * Populate a table's columns on expand by slicing the already-fetched
@@ -352,6 +366,7 @@ export default function useSourceOutline(sourceName) {
     status,
     error,
     isCold,
+    canGenerate,
     generating,
     generateSchema,
     loadFlatColumns,

--- a/viewer/src/hooks/useModelTabPrefill.js
+++ b/viewer/src/hooks/useModelTabPrefill.js
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+import { useDuckDB } from '../contexts/DuckDBContext';
+import useStore from '../stores/store';
+import { DEFAULT_RUN_ID } from '../constants';
+import { processModel } from './useModelsData';
+
+/**
+ * Fill a freshly-opened model tab with the LAST RUN's rows.
+ *
+ * Opening a model used to show an empty grid until you pressed Run, even though
+ * the previous run's parquet was sitting right there. `explorerStore` used to do
+ * this itself, and lost the ability when `api/modelData.js` was removed: the
+ * rows now come from the parquet via DuckDB, and DuckDB is reachable from a
+ * hook, not from a Zustand store.
+ *
+ * So it lives here rather than in the store. The alternative — exposing a DuckDB
+ * singleton for the store to reach into — is smaller but puts a browser resource
+ * behind a synchronous state container, where nothing owns its lifecycle.
+ *
+ * Deliberately conservative:
+ *
+ * - It only fills a tab that has NO result. A query you just ran is never
+ *   overwritten by a stale build.
+ * - It attempts each model at most once per mount, whether it succeeded or not.
+ *   A model that has never been built has no parquet, and a 404 per keystroke
+ *   is worse than an empty grid.
+ * - A failure is silent. This is a convenience; the Run button is the
+ *   authoritative path and reports its own errors.
+ *
+ * LOCAL-ONLY in practice: it reads `/api/files/<name>/<run_id>/`, which core
+ * deliberately does not serve (see core's urls.py). In cloud the fetch fails and
+ * the tab stays empty, exactly as it does today.
+ *
+ * @param {string|null} modelName - the active model tab, or null
+ * @param {boolean} hasResult - whether that tab already has rows
+ */
+export const useModelTabPrefill = (modelName, hasResult) => {
+  const db = useDuckDB();
+  const setModelQueryResult = useStore(state => state.setModelQueryResult);
+  // Names already attempted this mount — keyed so switching tabs back and forth
+  // doesn't re-fetch, and a model with no parquet is asked for exactly once.
+  const attemptedRef = useRef(new Set());
+
+  useEffect(() => {
+    if (!db || !modelName || hasResult) return;
+    if (attemptedRef.current.has(modelName)) return;
+    attemptedRef.current.add(modelName);
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const loaded = await processModel(db, modelName, DEFAULT_RUN_ID);
+        const entry = loaded?.[modelName];
+        const rows = entry?.data;
+        // `processModel` reports a per-model failure as an `error` key rather
+        // than throwing, so an empty or errored result is not a prefill.
+        if (cancelled || entry?.error || !Array.isArray(rows) || rows.length === 0) return;
+
+        setModelQueryResult(modelName, {
+          columns: Object.keys(rows[0]),
+          rows,
+          row_count: rows.length,
+          // Marks the grid as showing the last build rather than a query the
+          // user just ran, so the UI can say so if it wants to.
+          from_last_run: true,
+        });
+      } catch {
+        // Convenience only — the Run button owns error reporting.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [db, modelName, hasResult, setModelQueryResult]);
+};
+
+export default useModelTabPrefill;

--- a/viewer/src/hooks/useModelTabPrefill.test.js
+++ b/viewer/src/hooks/useModelTabPrefill.test.js
@@ -1,0 +1,123 @@
+/**
+ * Opening a model tab shows the last run's rows instead of an empty grid.
+ *
+ * `explorerStore.autoLoadModelData` used to do this and lost the ability when
+ * `api/modelData.js` was removed — the rows come from the parquet via DuckDB
+ * now, and DuckDB is reachable from a hook, not from a Zustand store.
+ *
+ * The behaviour worth protecting is what it REFUSES to do: it must never
+ * overwrite a query the user just ran, and it must not re-ask for a model that
+ * has no parquet.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import useStore from '../stores/store';
+import { useModelTabPrefill } from './useModelTabPrefill';
+import { processModel } from './useModelsData';
+import { useDuckDB } from '../contexts/DuckDBContext';
+
+jest.mock('./useModelsData', () => ({ processModel: jest.fn() }));
+jest.mock('../contexts/DuckDBContext', () => ({ useDuckDB: jest.fn() }));
+
+const DB = { fake: 'duckdb' };
+const ROWS = [
+  { id: 1, region: 'east' },
+  { id: 2, region: 'west' },
+];
+
+let setModelQueryResult;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useDuckDB.mockReturnValue(DB);
+  setModelQueryResult = jest.fn();
+  useStore.setState({ setModelQueryResult });
+});
+
+it('fills an empty tab with the last run rows', async () => {
+  processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+  const [name, result] = setModelQueryResult.mock.calls[0];
+  expect(name).toBe('orders');
+  expect(result.rows).toEqual(ROWS);
+  expect(result.columns).toEqual(['id', 'region']);
+  expect(result.row_count).toBe(2);
+  // Flagged so the UI can distinguish "last build" from "you just ran this".
+  expect(result.from_last_run).toBe(true);
+});
+
+it('never overwrites a tab that already has a result', async () => {
+  // The important refusal: a query you just ran must not be replaced by a
+  // stale build.
+  renderHook(() => useModelTabPrefill('orders', true));
+
+  await Promise.resolve();
+  expect(processModel).not.toHaveBeenCalled();
+  expect(setModelQueryResult).not.toHaveBeenCalled();
+});
+
+it('asks for a given model at most once, even across tab switches', async () => {
+  processModel.mockResolvedValue({ orders: { name: 'orders', data: [] } });
+
+  const { rerender } = renderHook(({ name }) => useModelTabPrefill(name, false), {
+    initialProps: { name: 'orders' },
+  });
+  await waitFor(() => expect(processModel).toHaveBeenCalledTimes(1));
+
+  rerender({ name: 'users' });
+  rerender({ name: 'orders' });
+
+  await waitFor(() => expect(processModel).toHaveBeenCalledTimes(2));
+  // 'orders' was not re-fetched on the way back — a model with no parquet
+  // would otherwise 404 on every tab switch.
+  expect(processModel.mock.calls.map(c => c[1])).toEqual(['orders', 'users']);
+});
+
+it('does not prefill when the model has no rows', async () => {
+  processModel.mockResolvedValue({ orders: { name: 'orders', data: [] } });
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await waitFor(() => expect(processModel).toHaveBeenCalled());
+  expect(setModelQueryResult).not.toHaveBeenCalled();
+});
+
+it('treats a per-model error as no data rather than a result', async () => {
+  // processModel reports a failure as an `error` key instead of throwing.
+  processModel.mockResolvedValue({
+    orders: { name: 'orders', data: [], error: 'file not found' },
+  });
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await waitFor(() => expect(processModel).toHaveBeenCalled());
+  expect(setModelQueryResult).not.toHaveBeenCalled();
+});
+
+it('stays silent when the load throws', async () => {
+  // A convenience path: the Run button owns error reporting.
+  processModel.mockRejectedValue(new Error('network down'));
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await waitFor(() => expect(processModel).toHaveBeenCalled());
+  expect(setModelQueryResult).not.toHaveBeenCalled();
+});
+
+it('does nothing before DuckDB is ready', async () => {
+  useDuckDB.mockReturnValue(null);
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await Promise.resolve();
+  expect(processModel).not.toHaveBeenCalled();
+});
+
+it('does nothing without an active model', async () => {
+  renderHook(() => useModelTabPrefill(null, false));
+
+  await Promise.resolve();
+  expect(processModel).not.toHaveBeenCalled();
+});

--- a/viewer/src/hooks/useModelsData.js
+++ b/viewer/src/hooks/useModelsData.js
@@ -15,7 +15,9 @@ import { DEFAULT_RUN_ID } from '../constants';
  * @param {string} runId - Run ID for file path
  * @returns {Promise<Object>} Processed model data keyed by model name
  */
-const processModel = async (db, modelName, runId, force = false) => {
+// Exported so the model-tab prefill can reuse the exact load path the
+// dashboard uses — same URL contract, same hashing, same DuckDB table.
+export const processModel = async (db, modelName, runId, force = false) => {
   try {
     // ``name_hash`` is the DuckDB table identifier (clean, valid SQL
     // identifier — model names may contain whitespace/punctuation).

--- a/visivo/query/sqlglot_utils.py
+++ b/visivo/query/sqlglot_utils.py
@@ -414,6 +414,38 @@ def identify_column_references(
     return qualified_sql
 
 
+def _describe_available(schema: dict) -> str:
+    """What the qualifier actually had to resolve against.
+
+    This line used to read ``Available schemas: <nested keys>``, which listed
+    only keys whose value was itself a dict — i.e. only the NESTED
+    ``{schema: {table: {col}}}`` shape. A flat ``{table: {col}}`` schema, which
+    is what DuckDB and SQLite produce, therefore always printed
+    ``Available schemas: None`` — whether the schema was empty or fully loaded.
+
+    That is worse than unhelpful: it says "nothing was loaded" at the exact
+    moment you are trying to work out whether anything was loaded, and sends you
+    hunting for a missing schema when the real problem is usually a column name.
+    """
+    if not isinstance(schema, dict) or not schema:
+        return "Available schema: EMPTY (no schema was loaded for this source)"
+
+    nested = [
+        key
+        for key, value in schema.items()
+        if isinstance(value, dict) and isinstance(next(iter(value.values()), None), dict)
+    ]
+    if nested:
+        return f"Available schemas: {', '.join(sorted(nested))}"
+
+    # Flat: the keys ARE the tables. Cap the list — a warehouse source can carry
+    # hundreds, and an error message that scrolls is its own problem.
+    tables = sorted(str(key) for key in schema)
+    shown = ", ".join(tables[:20])
+    suffix = f" (+{len(tables) - 20} more)" if len(tables) > 20 else ""
+    return f"Available tables: {shown}{suffix}"
+
+
 def schema_from_sql(
     sqlglot_dialect: str,
     sql: str,
@@ -473,18 +505,9 @@ def schema_from_sql(
             db=default_schema,
         )
     except OptimizeError as e:
-        # Provide actionable error message with available schemas
-        available_schemas = []
-        if isinstance(schema, dict):
-            for key, value in schema.items():
-                if isinstance(value, dict):
-                    first_val = next(iter(value.values()), None) if value else None
-                    if isinstance(first_val, dict):
-                        # Nested structure - key is a schema name
-                        available_schemas.append(key)
         raise click.ClickException(
             f"Schema validation failed: {e}\n"
-            f"Available schemas: {', '.join(available_schemas) if available_schemas else 'None'}\n"
+            f"{_describe_available(schema)}\n"
             f"Default schema: {default_schema}\n"
             f"Hint: Ensure all referenced tables exist in the source database."
         )

--- a/visivo/server/views/charts_views.py
+++ b/visivo/server/views/charts_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_charts_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_charts_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Chart validation failed: {e}")

--- a/visivo/server/views/dashboard_views.py
+++ b/visivo/server/views/dashboard_views.py
@@ -4,6 +4,7 @@ from flask import Response, jsonify, request, send_from_directory
 from pydantic import ValidationError
 
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_dashboard_views(app, flask_app, output_dir):
@@ -121,7 +122,7 @@ def register_dashboard_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Dashboard validation failed: {e}")

--- a/visivo/server/views/dimension_views.py
+++ b/visivo/server/views/dimension_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_dimension_views(app, flask_app, output_dir):
@@ -72,7 +73,7 @@ def register_dimension_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Dimension validation failed: {e}")

--- a/visivo/server/views/inputs_views.py
+++ b/visivo/server/views/inputs_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_inputs_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_inputs_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Input validation failed: {e}")

--- a/visivo/server/views/insights_views.py
+++ b/visivo/server/views/insights_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_insights_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_insights_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Insight validation failed: {e}")

--- a/visivo/server/views/markdowns_views.py
+++ b/visivo/server/views/markdowns_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_markdowns_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_markdowns_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Markdown validation failed: {e}")

--- a/visivo/server/views/metrics_views.py
+++ b/visivo/server/views/metrics_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_metrics_views(app, flask_app, output_dir):
@@ -72,7 +73,7 @@ def register_metrics_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Metric validation failed: {e}")

--- a/visivo/server/views/models_views.py
+++ b/visivo/server/views/models_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_models_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_models_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Model validation failed: {e}")

--- a/visivo/server/views/relations_views.py
+++ b/visivo/server/views/relations_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_relations_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_relations_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Relation validation failed: {e}")

--- a/visivo/server/views/sources_views.py
+++ b/visivo/server/views/sources_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 from visivo.server.managers.source_op_job_manager import SourceOpJobManager
 from visivo.server.source_metadata import (
     validate_source_from_config,
@@ -85,7 +86,7 @@ def register_source_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Source validation failed: {e}")

--- a/visivo/server/views/tables_views.py
+++ b/visivo/server/views/tables_views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
+from visivo.server.managers.object_manager import ObjectStatus
 
 
 def register_tables_views(app, flask_app, output_dir):
@@ -49,7 +50,7 @@ def register_tables_views(app, flask_app, output_dir):
                         "status": status.value if status else None,
                     }
                 ),
-                200,
+                201 if status == ObjectStatus.NEW else 200,
             )
         except ValidationError as e:
             Logger.instance().debug(f"Table validation failed: {e}")


### PR DESCRIPTION
The four remaining items. All independent of each other.

---

## 1. The error message that misled me for two turns

A schema-validation failure printed `Available schemas: <keys>` — while only
ever collecting keys whose value was *itself* a dict, i.e. the **nested**
`{schema: {table: {col}}}` shape. DuckDB and SQLite produce a **flat**
`{table: {col}}`, so the line read `Available schemas: None` **whether the
schema was empty or fully loaded**.

That is worse than unhelpful. It claims nothing loaded at exactly the moment
you're working out whether anything loaded, and sends you hunting for a missing
schema when the cause is usually a mistyped column. It is how I misread your
`funnel-data-cohorts` failure and told you the model "couldn't see a source
schema that just succeeded" — which was wrong.

Now:

| schema | message |
|---|---|
| empty | `Available schema: EMPTY (no schema was loaded for this source)` |
| flat | `Available tables: orders, users` |
| nested | `Available schemas: EDW` |

Capped at 20 tables so a warehouse source doesn't produce an error that scrolls.

## 2. "Generate schema" hidden where it cannot work

A file-backed duckdb/sqlite source can only be introspected where its file
lives. In cloud the button could only ever produce `database does not exist` —
which is the state in your screenshot. Its schema arrives via `visivo deploy`
instead, and both surfaces now say that rather than offering the button.

This is the **same fact** that already gates the connection test, so it is one
predicate — `canReachSource` — with two named aliases, rather than two rules
that can drift into disagreeing about the same source.

## 3. Local answers 201 on create, matching core

Core has always been precise: **201 + `"new"`** on create, **200 + `"modified"`**
on update. Local returned 200 for both.

The viewer accepts either since the last PR, so this is the two servers agreeing
rather than a user-facing fix — but a client written against one should behave
the same against the other. There is now a test pinning the create/update
distinction on the local side too.

**DELETE already agreed** at 200 on both. Nothing to change there.

## 4. A model tab shows the last run's rows again

`explorerStore.autoLoadModelData` lost this when `api/modelData.js` was removed:
the rows come from the parquet via DuckDB now, and DuckDB is reachable from a
hook, not from a Zustand store.

So it is a hook that `CenterPanel` (which owns the tab) mounts. The alternative —
exposing a DuckDB singleton for the store to reach into — is smaller, but puts a
browser resource behind a synchronous state container where nothing owns its
lifecycle.

Conservative by design, and the refusals are what the tests protect:

- **Never overwrites a result you just ran.** A stale build must not replace a
  fresh query.
- **Asks for a given model at most once per mount.** A model with no parquet
  would otherwise 404 on every tab switch.
- **Fails silently.** The Run button is the authoritative path and reports its
  own errors.

Still local-only: it reads `/api/files/<name>/<run_id>/`, which core deliberately
does not serve.

---

## Tests

2300 pytest, 6653 viewer, lint clean. The 2 viewer failures are the pre-existing
VIS-993 async-schema flakes (both pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)