### PR TITLE
Grab bag: inline fields, deletes, and a double border

### DIFF
--- a/tests/server/managers/test_mark_for_deletion_semantics.py
+++ b/tests/server/managers/test_mark_for_deletion_semantics.py
@@ -1,0 +1,70 @@
+"""Deleting an object that was never published removes it outright.
+
+Normally a delete is a tombstone: `None` in the cache, which `get_status` reads
+as DELETED so the commit knows to remove it from YAML. That is right for a
+published object.
+
+It is wrong for one created in this session and never published. There is
+nothing in YAML to remove, so there is no change to stage — and the `None`
+placeholder lingered in the cache, keeping the object in listings and making a
+just-created object look undeletable.
+"""
+
+import pytest
+
+from visivo.server.managers.object_manager import ObjectManager, ObjectStatus
+
+
+class _Manager(ObjectManager[dict]):
+    """Concrete stand-in — the behaviour under test is on the base class."""
+
+    def validate_object(self, obj_data: dict) -> dict:
+        return obj_data
+
+    def extract_from_dag(self, dag) -> None:
+        pass
+
+
+@pytest.fixture
+def manager():
+    return _Manager()
+
+
+def _put(manager, name, published=False):
+    obj = {"name": name}
+    if published:
+        manager._published_objects[name] = obj
+    manager._cached_objects[name] = obj
+    return obj
+
+
+def test_a_never_published_object_is_dropped_entirely(manager):
+    _put(manager, "new_dimension")
+
+    assert manager.mark_for_deletion("new_dimension") is True
+
+    # Not tombstoned — gone. A lingering None kept it in listings.
+    assert "new_dimension" not in manager._cached_objects
+    assert manager.get_status("new_dimension") is None
+
+
+def test_a_published_object_is_tombstoned_for_the_commit(manager):
+    _put(manager, "region", published=True)
+
+    assert manager.mark_for_deletion("region") is True
+
+    assert manager._cached_objects["region"] is None
+    assert manager.get_status("region") == ObjectStatus.DELETED
+
+
+def test_deleting_a_published_object_with_no_cached_edit_still_tombstones(manager):
+    manager._published_objects["amount"] = {"name": "amount"}
+
+    assert manager.mark_for_deletion("amount") is True
+
+    assert manager._cached_objects["amount"] is None
+    assert manager.get_status("amount") == ObjectStatus.DELETED
+
+
+def test_an_unknown_name_reports_false(manager):
+    assert manager.mark_for_deletion("nope") is False

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -276,8 +276,11 @@ const SQLEditor = ({
     setProfileColumn(null);
   }, [result]);
 
+  // No border/rounding of its own: the only consumer (CenterPanel) already sits
+  // inside a bordered pane, so carrying one here drew a second, inset rounded
+  // box against the outer square one.
   return (
-    <div className="flex flex-col h-full border border-secondary-200 rounded-lg overflow-hidden bg-white">
+    <div className="flex flex-col h-full overflow-hidden bg-white">
       {/* Toolbar */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-secondary-100 bg-secondary-50">
         <div className="flex items-center gap-3">

--- a/viewer/src/components/views/common/InlineFieldEditor.jsx
+++ b/viewer/src/components/views/common/InlineFieldEditor.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { FormInput } from '../../styled/FormComponents';
+
+/**
+ * Edit a model's inline dimension or metric in place.
+ *
+ * These rows used to be a link: clicking one called `onNavigateToEmbedded` to
+ * open the object in its own editor. Nothing ever passed that callback — a
+ * repo-wide search finds the prop declared and read in three forms and supplied
+ * by none — so the handler was always undefined. "Add" appended a row named
+ * "Dimension 1" with an empty name and expression, and there was no way to fill
+ * either in. The row could then be saved as `{name: '', expression: ''}`.
+ *
+ * Both types need exactly two required fields (`name`, plus `expression` — see
+ * visivo/models/dimension.py and metric.py) and take an optional description, so
+ * an in-place editor is the honest shape here. It also suits the right rail,
+ * which has no navigation stack to push onto.
+ *
+ * @param {object} value - the field config ({name, expression, description})
+ * @param {(next: object) => void} onChange - receives the whole updated config
+ * @param {string} kind - 'dimension' | 'metric', for labels and placeholders
+ */
+const PLACEHOLDERS = {
+  dimension: {
+    name: 'order_month',
+    expression: "DATE_TRUNC('month', order_date)",
+  },
+  metric: {
+    name: 'total_revenue',
+    expression: 'SUM(amount)',
+  },
+};
+
+const InlineFieldEditor = ({ value, onChange, kind = 'dimension', disabled = false }) => {
+  const placeholder = PLACEHOLDERS[kind] || PLACEHOLDERS.dimension;
+  const set = (key, next) => onChange({ ...value, [key]: next });
+
+  return (
+    <div
+      className="space-y-2 rounded-md border border-gray-200 bg-gray-50 p-3"
+      data-testid={`inline-${kind}-editor`}
+    >
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700">Name</label>
+        <FormInput
+          type="text"
+          value={value?.name || ''}
+          onChange={e => set('name', e.target.value)}
+          placeholder={placeholder.name}
+          disabled={disabled}
+          data-testid={`inline-${kind}-name`}
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700">Expression</label>
+        <FormInput
+          type="text"
+          value={value?.expression || ''}
+          onChange={e => set('expression', e.target.value)}
+          placeholder={placeholder.expression}
+          disabled={disabled}
+          data-testid={`inline-${kind}-expression`}
+        />
+        <p className="mt-1 text-[11px] text-gray-500">
+          {kind === 'metric'
+            ? 'An aggregate over the model’s rows.'
+            : 'Computed per row — usable for grouping and filtering.'}
+        </p>
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700">
+          Description <span className="font-normal text-gray-400">(optional)</span>
+        </label>
+        <FormInput
+          type="text"
+          value={value?.description || ''}
+          onChange={e => set('description', e.target.value)}
+          disabled={disabled}
+          data-testid={`inline-${kind}-description`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InlineFieldEditor;

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -10,7 +10,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { getTypeByValue } from './objectTypeConfigs';
-import { setAtPath } from './embeddedObjectUtils';
+import InlineFieldEditor from './InlineFieldEditor';
 
 /**
  * ModelEditForm - Form for creating/editing SqlModel
@@ -23,6 +23,11 @@ import { setAtPath } from './embeddedObjectUtils';
  *   options.applyToParent: (parentConfig, embeddedConfig) => newParentConfig
  */
 const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
+  // Which inline row is open for editing (null = none). These used to be links
+  // into a separate editor that nothing ever wired up, so the fields had no way
+  // to be filled in.
+  const [expandedDimension, setExpandedDimension] = useState(null);
+  const [expandedMetric, setExpandedMetric] = useState(null);
   const deleteModel = useStore(state => state.deleteModel);
   const checkCommitStatus = useStore(state => state.checkCommitStatus);
   const fetchSources = useStore(state => state.fetchSources);
@@ -90,12 +95,18 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
       config.source = source;
     }
 
-    // Include inline dimensions and metrics from state
-    if (dimensions.length > 0) {
-      config.dimensions = dimensions;
+    // Include inline dimensions and metrics from state. An entirely blank row
+    // is an "Add" the user never filled in — persisting it would write
+    // `{name: '', expression: ''}`, which fails validation on the way back.
+    // A partially-filled row IS kept, so the error names the real problem.
+    const isBlank = field => !field?.name?.trim() && !field?.expression?.trim();
+    const filledDimensions = dimensions.filter(d => !isBlank(d));
+    const filledMetrics = metrics.filter(m => !isBlank(m));
+    if (filledDimensions.length > 0) {
+      config.dimensions = filledDimensions;
     }
-    if (metrics.length > 0) {
-      config.metrics = metrics;
+    if (filledMetrics.length > 0) {
+      config.metrics = filledMetrics;
     }
 
     // Call unified save - parent handles routing and panel close
@@ -246,24 +257,11 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
             <button
               type="button"
               onClick={() => {
-                const newDimension = { name: '', expression: '' };
                 const newIndex = dimensions.length;
-                setDimensions([...dimensions, newDimension]);
-                // Navigate to edit the new dimension
-                if (onNavigateToEmbedded) {
-                  const syntheticDimension = {
-                    name: `(new dimension)`,
-                    config: newDimension,
-                    _embedded: { parentType: 'model', parentName: model.name, path: `dimensions[${newIndex}]` },
-                  };
-                  onNavigateToEmbedded('dimension', syntheticDimension, {
-                    applyToParent: (parentConfig, newDimConfig) => {
-                      const newDimensions = [...(parentConfig.dimensions || [])];
-                      newDimensions[newIndex] = newDimConfig;
-                      return { ...parentConfig, dimensions: newDimensions };
-                    },
-                  });
-                }
+                setDimensions([...dimensions, { name: '', expression: '' }]);
+                // Open it straight away — an unopened row has an empty name and
+                // expression, which is neither valid nor editable.
+                setExpandedDimension(newIndex);
               }}
               className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
             >
@@ -279,22 +277,13 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
                 const dimTypeConfig = getTypeByValue('dimension');
                 const DimIcon = dimTypeConfig?.icon;
                 return (
-                  <div key={index} className="flex items-center gap-2">
+                  <div key={index} className="space-y-1">
+                  <div className="flex items-center gap-2">
                     <button
                       type="button"
-                      onClick={() => {
-                        if (onNavigateToEmbedded) {
-                          const syntheticDimension = {
-                            name: dim.name || `(dimension ${index + 1})`,
-                            config: dim,
-                            _embedded: { parentType: 'model', parentName: model.name, path: `dimensions[${index}]` },
-                          };
-                          onNavigateToEmbedded('dimension', syntheticDimension, {
-                            applyToParent: (parentConfig, newDimConfig) =>
-                              setAtPath(parentConfig, `dimensions[${index}]`, newDimConfig),
-                          });
-                        }
-                      }}
+                      onClick={() =>
+                        setExpandedDimension(expandedDimension === index ? null : index)
+                      }
                       className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${dimTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${dimTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
                     >
                       {DimIcon && <DimIcon fontSize="small" className={dimTypeConfig?.colors?.text || 'text-gray-600'} />}
@@ -311,6 +300,16 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
                     >
                       <RemoveIcon fontSize="small" />
                     </button>
+                  </div>
+                  {expandedDimension === index && (
+                    <InlineFieldEditor
+                      kind="dimension"
+                      value={dim}
+                      onChange={next =>
+                        setDimensions(dimensions.map((d, i) => (i === index ? next : d)))
+                      }
+                    />
+                  )}
                   </div>
                 );
               })}
@@ -329,24 +328,9 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
             <button
               type="button"
               onClick={() => {
-                const newMetric = { name: '', expression: '' };
                 const newIndex = metrics.length;
-                setMetrics([...metrics, newMetric]);
-                // Navigate to edit the new metric
-                if (onNavigateToEmbedded) {
-                  const syntheticMetric = {
-                    name: `(new metric)`,
-                    config: newMetric,
-                    _embedded: { parentType: 'model', parentName: model.name, path: `metrics[${newIndex}]` },
-                  };
-                  onNavigateToEmbedded('metric', syntheticMetric, {
-                    applyToParent: (parentConfig, newMetricConfig) => {
-                      const newMetrics = [...(parentConfig.metrics || [])];
-                      newMetrics[newIndex] = newMetricConfig;
-                      return { ...parentConfig, metrics: newMetrics };
-                    },
-                  });
-                }
+                setMetrics([...metrics, { name: '', expression: '' }]);
+                setExpandedMetric(newIndex);
               }}
               className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
             >
@@ -362,22 +346,11 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
                 const metricTypeConfig = getTypeByValue('metric');
                 const MetricIcon = metricTypeConfig?.icon;
                 return (
-                  <div key={index} className="flex items-center gap-2">
+                  <div key={index} className="space-y-1">
+                  <div className="flex items-center gap-2">
                     <button
                       type="button"
-                      onClick={() => {
-                        if (onNavigateToEmbedded) {
-                          const syntheticMetric = {
-                            name: metric.name || `(metric ${index + 1})`,
-                            config: metric,
-                            _embedded: { parentType: 'model', parentName: model.name, path: `metrics[${index}]` },
-                          };
-                          onNavigateToEmbedded('metric', syntheticMetric, {
-                            applyToParent: (parentConfig, newMetricConfig) =>
-                              setAtPath(parentConfig, `metrics[${index}]`, newMetricConfig),
-                          });
-                        }
-                      }}
+                      onClick={() => setExpandedMetric(expandedMetric === index ? null : index)}
                       className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${metricTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${metricTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
                     >
                       {MetricIcon && <MetricIcon fontSize="small" className={metricTypeConfig?.colors?.text || 'text-gray-600'} />}
@@ -394,6 +367,16 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
                     >
                       <RemoveIcon fontSize="small" />
                     </button>
+                  </div>
+                  {expandedMetric === index && (
+                    <InlineFieldEditor
+                      kind="metric"
+                      value={metric}
+                      onChange={next =>
+                        setMetrics(metrics.map((m, i) => (i === index ? next : m)))
+                      }
+                    />
+                  )}
                   </div>
                 );
               })}

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -244,77 +244,65 @@ describe('ModelEditForm — embedded source', () => {
 });
 
 describe('ModelEditForm — inline dimensions', () => {
-  it('Add appends a row and navigates with an applyToParent writing the new index', () => {
-    const onNavigateToEmbedded = jest.fn();
-    render(
-      <ModelEditForm
-        model={editModel()}
-        onSave={jest.fn()}
-        onCancel={jest.fn()}
-        onNavigateToEmbedded={onNavigateToEmbedded}
-      />
-    );
-    // Dimensions section renders its Add button before the metrics one.
+  it('Add appends a row and opens it for editing', () => {
+    // The bug: Add appended a row and called `onNavigateToEmbedded` to open it.
+    // NOTHING passes that prop — a repo-wide search finds it declared and read
+    // in three forms and supplied by none — so the row appeared with an empty
+    // name and expression and no way to fill either in. These tests used to
+    // pass a mock, which is exactly why the dead path looked healthy.
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
     fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
 
-    // The new (unnamed) dimension renders with the fallback label at index 1.
-    expect(screen.getByRole('button', { name: /Dimension 2/ })).toBeInTheDocument();
-    expect(onNavigateToEmbedded).toHaveBeenCalledWith(
-      'dimension',
-      expect.objectContaining({
-        name: '(new dimension)',
-        config: { name: '', expression: '' },
-        _embedded: { parentType: 'model', parentName: 'orders', path: 'dimensions[1]' },
-      }),
-      { applyToParent: expect.any(Function) }
-    );
-
-    const { applyToParent } = onNavigateToEmbedded.mock.calls[0][2];
-    expect(
-      applyToParent(
-        { dimensions: [{ name: 'region', expression: 'region' }] },
-        { name: 'city', expression: 'city' }
-      )
-    ).toEqual({
-      dimensions: [
-        { name: 'region', expression: 'region' },
-        { name: 'city', expression: 'city' },
-      ],
-    });
+    expect(screen.getByTestId('inline-dimension-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('inline-dimension-name')).toHaveValue('');
   });
 
-  it('clicking a row navigates with a setAtPath-based applyToParent', () => {
-    const onNavigateToEmbedded = jest.fn();
-    render(
-      <ModelEditForm
-        model={editModel()}
-        onSave={jest.fn()}
-        onCancel={jest.fn()}
-        onNavigateToEmbedded={onNavigateToEmbedded}
-      />
-    );
-    fireEvent.click(screen.getByRole('button', { name: /region/ }));
+  it('editing the fields updates that row and it survives save', async () => {
+    const onSave = jest.fn().mockResolvedValue({ success: true });
+    render(<ModelEditForm model={editModel()} onSave={onSave} onCancel={jest.fn()} />);
 
-    expect(onNavigateToEmbedded).toHaveBeenCalledWith(
-      'dimension',
-      expect.objectContaining({
-        name: 'region',
-        config: { name: 'region', expression: 'region' },
-        _embedded: { parentType: 'model', parentName: 'orders', path: 'dimensions[0]' },
-      }),
-      { applyToParent: expect.any(Function) }
-    );
-
-    const { applyToParent } = onNavigateToEmbedded.mock.calls[0][2];
-    expect(
-      applyToParent(
-        { sql: 'select 1', dimensions: [{ name: 'region', expression: 'region' }] },
-        { name: 'region', expression: 'upper(region)' }
-      )
-    ).toEqual({
-      sql: 'select 1',
-      dimensions: [{ name: 'region', expression: 'upper(region)' }],
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
+    fireEvent.change(screen.getByTestId('inline-dimension-name'), {
+      target: { value: 'order_month' },
     });
+    fireEvent.change(screen.getByTestId('inline-dimension-expression'), {
+      target: { value: "DATE_TRUNC('month', order_date)" },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][2].dimensions).toContainEqual(
+      expect.objectContaining({
+        name: 'order_month',
+        expression: "DATE_TRUNC('month', order_date)",
+      })
+    );
+  });
+
+  it('a row added but never filled in is not saved', async () => {
+    // Otherwise Add-then-Save persists `{name: '', expression: ''}`, which is
+    // not a valid dimension and fails on the way back.
+    const onSave = jest.fn().mockResolvedValue({ success: true });
+    render(<ModelEditForm model={editModel()} onSave={onSave} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const saved = onSave.mock.calls[0][2].dimensions || [];
+    expect(saved.every(d => d.name || d.expression)).toBe(true);
+  });
+
+  it('clicking a row toggles its editor open and closed', () => {
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    const row = screen.getByRole('button', { name: /region/ });
+    fireEvent.click(row);
+    expect(screen.getByTestId('inline-dimension-editor')).toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(screen.queryByTestId('inline-dimension-editor')).not.toBeInTheDocument();
   });
 
   it('Remove filters the dimension out and the next save drops the key', async () => {
@@ -334,70 +322,31 @@ describe('ModelEditForm — inline dimensions', () => {
 });
 
 describe('ModelEditForm — inline metrics', () => {
-  it('Add appends a row and navigates with an applyToParent writing the new index', () => {
-    const onNavigateToEmbedded = jest.fn();
-    render(
-      <ModelEditForm
-        model={editModel()}
-        onSave={jest.fn()}
-        onCancel={jest.fn()}
-        onNavigateToEmbedded={onNavigateToEmbedded}
-      />
-    );
+  it('Add appends a row and opens it for editing', () => {
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
     fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[1]);
 
-    expect(screen.getByRole('button', { name: /Metric 2/ })).toBeInTheDocument();
-    expect(onNavigateToEmbedded).toHaveBeenCalledWith(
-      'metric',
-      expect.objectContaining({
-        name: '(new metric)',
-        _embedded: { parentType: 'model', parentName: 'orders', path: 'metrics[1]' },
-      }),
-      { applyToParent: expect.any(Function) }
-    );
-
-    const { applyToParent } = onNavigateToEmbedded.mock.calls[0][2];
-    expect(
-      applyToParent(
-        { metrics: [{ name: 'revenue', expression: 'sum(amount)' }] },
-        { name: 'orders_count', expression: 'count(*)' }
-      )
-    ).toEqual({
-      metrics: [
-        { name: 'revenue', expression: 'sum(amount)' },
-        { name: 'orders_count', expression: 'count(*)' },
-      ],
-    });
+    expect(screen.getByTestId('inline-metric-editor')).toBeInTheDocument();
   });
 
-  it('clicking a row navigates with a setAtPath-based applyToParent', () => {
-    const onNavigateToEmbedded = jest.fn();
-    render(
-      <ModelEditForm
-        model={editModel()}
-        onSave={jest.fn()}
-        onCancel={jest.fn()}
-        onNavigateToEmbedded={onNavigateToEmbedded}
-      />
-    );
-    fireEvent.click(screen.getByRole('button', { name: /revenue/ }));
+  it('editing the fields updates that row and it survives save', async () => {
+    const onSave = jest.fn().mockResolvedValue({ success: true });
+    render(<ModelEditForm model={editModel()} onSave={onSave} onCancel={jest.fn()} />);
 
-    expect(onNavigateToEmbedded).toHaveBeenCalledWith(
-      'metric',
-      expect.objectContaining({
-        name: 'revenue',
-        _embedded: { parentType: 'model', parentName: 'orders', path: 'metrics[0]' },
-      }),
-      { applyToParent: expect.any(Function) }
-    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[1]);
+    fireEvent.change(screen.getByTestId('inline-metric-name'), {
+      target: { value: 'total_revenue' },
+    });
+    fireEvent.change(screen.getByTestId('inline-metric-expression'), {
+      target: { value: 'SUM(amount)' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
 
-    const { applyToParent } = onNavigateToEmbedded.mock.calls[0][2];
-    expect(
-      applyToParent(
-        { metrics: [{ name: 'revenue', expression: 'sum(amount)' }] },
-        { name: 'revenue', expression: 'sum(net_amount)' }
-      )
-    ).toEqual({ metrics: [{ name: 'revenue', expression: 'sum(net_amount)' }] });
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][2].metrics).toContainEqual(
+      expect.objectContaining({ name: 'total_revenue', expression: 'SUM(amount)' })
+    );
   });
 
   it('Remove filters the metric out and the next save drops the key', async () => {

--- a/viewer/src/components/views/workspace/library/useLibraryData.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.js
@@ -53,13 +53,25 @@ import useStore from '../../../../stores/store';
 const safeArray = v => (Array.isArray(v) ? v : []);
 
 // Map a plain store collection into Library rows of a single type.
+//
+// Objects marked for deletion are dropped. A delete is a SOFT delete — the
+// server sets status to "deleted" and the row stays until commit removes it
+// from YAML — and the list endpoints return it unfiltered. Rendering it left a
+// deleted object sitting in the tree as though the delete had failed, which is
+// how it read: confirm the dialog, watch nothing happen.
+//
+// The pending deletion is not lost by hiding it here: the commit modal lists
+// every staged change with a DELETED badge, which is where "what will this
+// commit do" belongs.
 const mapRows = (list, type) =>
-  safeArray(list).map(o => ({
-    id: `${type}:${o.name}`,
-    type,
-    name: o.name,
-    status: o.status || null,
-  }));
+  safeArray(list)
+    .filter(o => o.status !== 'deleted')
+    .map(o => ({
+      id: `${type}:${o.name}`,
+      type,
+      name: o.name,
+      status: o.status || null,
+    }));
 
 export function useLibraryData() {
   // Layout-item collections.
@@ -113,18 +125,23 @@ export function useLibraryData() {
     // side decide which. Mirrors `useFieldParentModel.js`'s own resolution
     // (`fieldRecord.parentModel || fieldRecord.config?.model`).
     const withParentModel = (list, type) =>
-      safeArray(list).map(f => ({
-        id: `${type}:${f.name}`,
-        type,
-        name: f.name,
-        status: f.status || null,
-        parentModel: f.parentModel || f.config?.model || null,
-        // The field's own expression — carried so a metric/dimension dropped
-        // onto the results grid's computed-column zone can be replicated as
-        // a computed column bound to a DIFFERENT model (mirrors the legacy
-        // `ExplorerLeftPanel.DraggableItem`'s `item.config?.expression`).
-        expression: f.config?.expression || null,
-      }));
+      safeArray(list)
+        // Same soft-delete filter as mapRows — this is the mapper dimensions
+        // and metrics actually go through, and it is where the reported bug
+        // showed: a deleted dimension stayed in the tree.
+        .filter(f => f.status !== 'deleted')
+        .map(f => ({
+          id: `${type}:${f.name}`,
+          type,
+          name: f.name,
+          status: f.status || null,
+          parentModel: f.parentModel || f.config?.model || null,
+          // The field's own expression — carried so a metric/dimension dropped
+          // onto the results grid's computed-column zone can be replicated as
+          // a computed column bound to a DIFFERENT model (mirrors the legacy
+          // `ExplorerLeftPanel.DraggableItem`'s `item.config?.expression`).
+          expression: f.config?.expression || null,
+        }));
 
     return {
       layoutItems: {

--- a/viewer/src/components/views/workspace/library/useLibraryData.test.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.test.js
@@ -230,3 +230,61 @@ describe('useLibraryData', () => {
     expect(result.current.dataLayer.insight).toEqual([]);
   });
 });
+
+describe('useLibraryData — objects marked for deletion', () => {
+  // A delete is a SOFT delete: the server sets status "deleted" and the row
+  // stays until commit removes it from YAML. The list endpoints return it
+  // unfiltered, so without this the object sat in the tree after you confirmed
+  // the dialog — reading exactly like a delete that had failed.
+  const withStore = state => {
+    useStore.setState(state);
+    return renderHook(() => useLibraryData()).result;
+  };
+
+  it('drops a deleted dimension from the tree', () => {
+    const result = withStore({
+      dimensions: [
+        { name: 'keep_me', status: 'new' },
+        { name: 'new_dimension', status: 'deleted' },
+      ],
+    });
+
+    const names = result.current.dataLayer.dimension.map(d => d.name);
+    expect(names).toEqual(['keep_me']);
+  });
+
+  it('drops a deleted metric too — same mapper', () => {
+    const result = withStore({
+      metrics: [
+        { name: 'revenue', status: 'published' },
+        { name: 'gone', status: 'deleted' },
+      ],
+    });
+
+    expect(result.current.dataLayer.metric.map(m => m.name)).toEqual(['revenue']);
+  });
+
+  it('drops a deleted layout item, which goes through the other mapper', () => {
+    const result = withStore({
+      charts: [
+        { name: 'bar', status: 'modified' },
+        { name: 'removed', status: 'deleted' },
+      ],
+    });
+
+    expect(result.current.layoutItems.chart.map(c => c.name)).toEqual(['bar']);
+  });
+
+  it('keeps every other status, so the unpublished dot still renders', () => {
+    const result = withStore({
+      charts: [
+        { name: 'a', status: 'new' },
+        { name: 'b', status: 'modified' },
+        { name: 'c', status: 'published' },
+        { name: 'd', status: null },
+      ],
+    });
+
+    expect(result.current.layoutItems.chart).toHaveLength(4);
+  });
+});

--- a/visivo/server/managers/object_manager.py
+++ b/visivo/server/managers/object_manager.py
@@ -220,10 +220,21 @@ class ObjectManager(ABC, Generic[T]):
             True if object exists (in cache or published), False otherwise
         """
         with self._lock:
-            if name in self._cached_objects or name in self._published_objects:
+            if name not in self._cached_objects and name not in self._published_objects:
+                return False
+
+            if name in self._cached_objects and name not in self._published_objects:
+                # Never published: there is nothing in YAML to remove, so this
+                # is not a staged change at all. Drop the entry outright rather
+                # than tombstoning it — a `None` placeholder lingered in the
+                # cache, kept the object in listings, and made deleting a
+                # just-created object look like it had failed.
+                del self._cached_objects[name]
+            else:
+                # Published: tombstone it so the commit knows to remove it from
+                # YAML. `get_status` reads the None as DELETED.
                 self._cached_objects[name] = None
-                return True
-            return False
+            return True
 
     def get_objects_for_publish(self) -> Dict[str, T]:
         """


### PR DESCRIPTION
Three from testing. Pairs with [core#325](https://github.com/visivo-io/core/pull/325) for the delete half.

---

## 1. Inline dimensions and metrics were unreachable

Clicking **Add** appended a row called "Dimension 1" with an empty name and
expression, and there was no way to fill either in.

The handler appended the row then called `onNavigateToEmbedded` to open it.
**Nothing passes that prop.** A repo-wide search finds it declared and read in
three forms — `ModelEditForm`, `TableEditForm`, `ChartEditForm` — and supplied
by *none*; the workspace rail explicitly passes `noop` for the ones it wires at
all. So the handler was always `undefined` and the row just sat there.

Its own tests passed a mock callback. That is exactly why a dead path looked
healthy for so long, and those tests are rewritten to drive the real UI.

Both types need the same two required fields (`name`, `expression` — see
`models/dimension.py` and `metric.py`) plus an optional description, so they are
now **edited in place**: Add appends a row *and opens it*, clicking a row toggles
it. That also suits the right rail, which has no navigation stack to push onto.

An entirely blank row is dropped on save — otherwise Add-then-Save persisted
`{name: '', expression: ''}`, which is not a valid dimension and fails on the way
back. A *partially* filled row is kept, so the error names the real problem.

## 2. Deleting an object left it in the tree

Two causes needing different fixes.

**The Library never filtered `status === 'deleted'`.** A delete is a soft delete
— the server tombstones the row so a commit can remove it from YAML — and the
list endpoints return it unfiltered, so the object sat there looking like the
delete had failed. Now filtered in *both* mappers; the second (`withParentModel`)
is the one dimensions and metrics actually go through, and is where you hit it.

The pending deletion isn't lost by hiding it: the commit modal lists it with a
DELETED badge, which is where "what will this commit do" belongs.

**But a soft delete is wrong for something never published.** Per your point:
there is nothing in YAML to remove, so it isn't a change to stage at all — the
tombstone listed a pending deletion of something that had never existed.
`mark_for_deletion` now drops such an entry outright and only tombstones a
published one. core#325 applies the same rule server-side.

## 3. The SQL editor drew a double border

It carried `border … rounded-lg` while its only consumer already sits inside a
bordered pane, so an inset rounded box sat against the outer square one. Removed
rather than made conditional — one consumer means no prop is warranted.

---

## Tests

2304 pytest, 6659 viewer, lint clean. No flakes this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)