### PR TITLE
Deploy stops uploading insight and input envelopes

### DIFF
--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -11,6 +11,7 @@ from tests.factories.model_factories import (
 from tests.support.utils import temp_file, temp_folder, temp_yml_file
 from visivo.commands.deploy_phase import (
     PURPOSE_BY_DESCRIPTION,
+    create_insight_records,
     deploy_phase,
     start_files,
 )
@@ -44,20 +45,6 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
             "upload_url": "http://google/upload/id3",
         },
     ]
-    insight_file_starts = [
-        {
-            "name": f"{insight.name}.json",
-            "id": "id4",
-            "upload_url": "http://google/upload/id4",
-        },
-    ]
-    input_file_starts = [
-        {
-            "name": f"{input_obj.name}.json",
-            "id": "id5",
-            "upload_url": "http://google/upload/id5",
-        },
-    ]
 
     run_id = "main"
 
@@ -89,31 +76,11 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
         url="http://host/api/files/direct/start/",
         json=thumbnail_file_starts,
     )
-    # Mock responses for insight files
-    httpx_mock.add_response(
-        method="POST",
-        url="http://host/api/files/direct/start/",
-        json=insight_file_starts,
-    )
-    # Mock responses for input files
-    httpx_mock.add_response(
-        method="POST",
-        url="http://host/api/files/direct/start/",
-        json=input_file_starts,
-    )
 
-    # Mock file uploads
+    # Only the thumbnail is uploaded. Insight and input envelopes are sent as
+    # `content` on the record — core never read the uploaded JSON back, so it
+    # is not uploaded at all (VIS-1125).
     httpx_mock.add_response(method="PUT", url="http://google/upload/id3", status_code=200)
-    httpx_mock.add_response(method="PUT", url="http://google/upload/id4", status_code=200)
-    httpx_mock.add_response(method="PUT", url="http://google/upload/id5", status_code=200)
-
-    # Mock file finish calls
-    httpx_mock.add_response(
-        method="POST", url="http://host/api/files/direct/finish/", status_code=204
-    )
-    httpx_mock.add_response(
-        method="POST", url="http://host/api/files/direct/finish/", status_code=204
-    )
     httpx_mock.add_response(
         method="POST", url="http://host/api/files/direct/finish/", status_code=204
     )
@@ -249,5 +216,34 @@ def test_every_upload_description_maps_to_a_purpose():
     """A description with no purpose silently sends `null`, which core stores as
     UNKNOWN — the object still uploads, it just becomes unqueryable. Pin the map
     so adding an upload kind without a purpose fails here instead."""
-    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "insight", "input", "thumbnail"}
+    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "thumbnail"}
     assert all(PURPOSE_BY_DESCRIPTION.values())
+
+
+def test_insight_records_carry_content_and_no_file(httpx_mock):
+    """The envelope IS the record. core builds its /api/insight-jobs/ response
+    from `content` and never read the uploaded JSON back, so nothing is
+    uploaded and no data_file_id is sent (VIS-1125)."""
+    httpx_mock.add_response(
+        method="POST", url="http://host/api/insight-jobs/", json=[{"id": "i1"}], status_code=201
+    )
+
+    asyncio.run(
+        create_insight_records(
+            [{"name": "orders_trend", "name_hash": "mabc", "content": {"type": "bar"}}],
+            "proj-1",
+            {},
+            "http://host",
+            {"completed": 0, "total": 1},
+        )
+    )
+
+    [request] = httpx_mock.get_requests()
+    [body] = json.loads(request.content)
+    assert body == {
+        "name": "orders_trend",
+        "name_hash": "mabc",
+        "project_id": "proj-1",
+        "content": {"type": "bar"},
+    }
+    assert "data_file_id" not in body

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -113,15 +113,14 @@ def _raise_if_any_failed(results, summary: str):
 # seen a byte — so anything we do not declare here lands under an `unknown`
 # prefix where no query engine will find it.
 #
-# Note every parquet file goes up as "model": a model's own data, a static
-# insight's precomputed result, and a query-based input's options all funnel
-# through process_models_async. So an insight's rows ARE queryable — they just
-# arrive as model job data. The "insight" and "input" descriptions carry only
-# the JSON envelope, which is why they are named envelope rather than data.
+# Only two kinds of object are uploaded at all. Every parquet goes up as
+# "model" — a model's own data, a static insight's precomputed result, and a
+# query-based input's options all funnel through process_models_async — so an
+# insight's rows are queryable, they just arrive as model job data. Insight and
+# input envelopes are not uploaded (VIS-1125): they are sent as `content` on
+# the record, which is the only copy core ever read.
 PURPOSE_BY_DESCRIPTION = {
     "model": "model_job_data",
-    "insight": "insight_job_envelope",
-    "input": "input_job_envelope",
     "thumbnail": "thumbnail",
 }
 
@@ -342,12 +341,12 @@ async def create_insight_records(batch, project_id, json_headers, host, progress
     """
     body = list(
         map(
-            lambda data_file_upload: {
-                "name": data_file_upload["name"],
-                "name_hash": data_file_upload["name_hash"],
+            lambda record: {
+                "name": record["name"],
+                "name_hash": record["name_hash"],
                 "project_id": project_id,
-                "data_file_id": data_file_upload["id"],
-                "content": data_file_upload.get("content"),
+                # No data_file_id: an envelope has no file (VIS-1125).
+                "content": record.get("content"),
             },
             batch,
         )
@@ -382,12 +381,12 @@ async def create_input_records(batch, project_id, json_headers, host, progress):
     """
     body = list(
         map(
-            lambda data_file_upload: {
-                "name": data_file_upload["name"],
-                "name_hash": data_file_upload["name_hash"],
+            lambda record: {
+                "name": record["name"],
+                "name_hash": record["name_hash"],
                 "project_id": project_id,
-                "data_file_id": data_file_upload["id"],
-                "content": data_file_upload.get("content"),
+                # No data_file_id: an envelope has no file (VIS-1125).
+                "content": record.get("content"),
             },
             batch,
         )
@@ -562,71 +561,36 @@ async def process_insights_async(
     if not insight_files:
         return
 
-    total_operations = len(insight_files)
-    total_operations += 3 * math.ceil(len(insight_files) / batch_size)
-    progress = {"completed": 0, "total": total_operations}
+    # One operation per batch: there are no files to create, upload or finish.
+    # The envelope IS ``content``. It used to be uploaded to the bucket as well
+    # and core never read it back — every response is built from ``content``
+    # plus the MODEL job's parquet URL — so the upload was pure object count
+    # (VIS-1125).
+    progress = {"completed": 0, "total": math.ceil(len(insight_files) / batch_size)}
 
-    # Create file records
-    tasks = []
-    for i in range(0, len(insight_files), batch_size):
-        batch = insight_files[i : i + batch_size]
-        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
-        task = start_files(items, "insight", form_headers, host, progress, project_id=project_id)
-        tasks.append(task)
-    data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(data_file_ids, "Failed to create insight files")
-
-    data_file_uploads = [item for sublist in data_file_ids for item in sublist]
-
-    # Upload files
-    tasks = []
-    for i, data_file_upload in enumerate(data_file_uploads):
-        insight_file = insight_files[i]
-        task = upload_file(
-            insight_file["name"],
-            data_file_upload["upload_url"],
-            insight_file["file_path"],
-            output_dir,
-            form_headers,
-            progress,
-        )
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to upload insight data")
-
-    # Finish files
-    data_file_ids_list = [item["id"] for item in data_file_uploads]
-    tasks = []
-    for i in range(0, len(data_file_ids_list), batch_size):
-        batch = data_file_ids_list[i : i + batch_size]
-        task = finish_files(batch, "insight", form_headers, host, progress)
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to finish insight files")
-
-    # Create insight records - merge insight metadata with file upload info.
-    # Also read the local JSON file content so core can store it on the
-    # InsightJob row and serve a fully-inlined response from
-    # /api/insight-jobs/ (matching visivo Flask's contract).
+    # Read the local JSON so core can store it on the InsightJob row and serve a
+    # fully-inlined response from /api/insight-jobs/ (matching visivo Flask's
+    # contract).
     #
-    # Track failures and abort the deploy if any occurred — a silent
-    # warning would leave the cloud-side InsightJob row with NULL
-    # content, which renders an empty insight to the viewer with no
-    # signal to the operator.
+    # Abort on any failure rather than letting NULL ``content`` rows reach the
+    # cloud: a silent warning would render an empty insight to the viewer with no
+    # signal to the operator. That matters more now that ``content`` is the only
+    # copy.
+    records = []
     content_failures = []
-    for i, upload in enumerate(data_file_uploads):
-        upload["name"] = insight_files[i]["name"]
-        upload["name_hash"] = insight_files[i]["name_hash"]
-        local_path = os.path.join(output_dir, insight_files[i]["file_path"])
+    for insight_file in insight_files:
+        record = {"name": insight_file["name"], "name_hash": insight_file["name_hash"]}
+        local_path = os.path.join(output_dir, insight_file["file_path"])
         try:
             with open(local_path, "r") as f:
-                upload["content"] = json.load(f)
+                record["content"] = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             Logger.instance().warning(
-                f"Could not load insight JSON content for {insight_files[i]['name']}: {e}"
+                f"Could not load insight JSON content for {insight_file['name']}: {e}"
             )
-            upload["content"] = None
-            content_failures.append(insight_files[i]["name"])
+            record["content"] = None
+            content_failures.append(insight_file["name"])
+        records.append(record)
     if content_failures:
         raise click.ClickException(
             f"Failed to read insight JSON content for {len(content_failures)} insight(s): "
@@ -634,8 +598,8 @@ async def process_insights_async(
         )
 
     tasks = []
-    for i in range(0, len(data_file_uploads), batch_size):
-        batch = data_file_uploads[i : i + batch_size]
+    for i in range(0, len(records), batch_size):
+        batch = records[i : i + batch_size]
         task = create_insight_records(batch, project_id, json_headers, host, progress)
         tasks.append(task)
     response_items = await asyncio.gather(*tasks, return_exceptions=True)
@@ -665,69 +629,36 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
     if not input_files:
         return
 
-    total_operations = len(input_files)
-    total_operations += 3 * math.ceil(len(input_files) / batch_size)
-    progress = {"completed": 0, "total": total_operations}
+    # One operation per batch: there are no files to create, upload or finish.
+    # The envelope IS ``content``. It used to be uploaded to the bucket as well
+    # and core never read it back — every response is built from ``content``
+    # plus the MODEL job's parquet URL — so the upload was pure object count
+    # (VIS-1125).
+    progress = {"completed": 0, "total": math.ceil(len(input_files) / batch_size)}
 
-    # Create file records
-    tasks = []
-    for i in range(0, len(input_files), batch_size):
-        batch = input_files[i : i + batch_size]
-        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
-        task = start_files(items, "input", form_headers, host, progress, project_id=project_id)
-        tasks.append(task)
-    data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(data_file_ids, "Failed to create input files")
-
-    data_file_uploads = [item for sublist in data_file_ids for item in sublist]
-
-    # Upload files
-    tasks = []
-    for i, data_file_upload in enumerate(data_file_uploads):
-        input_file = input_files[i]
-        task = upload_file(
-            input_file["name"],
-            data_file_upload["upload_url"],
-            input_file["file_path"],
-            output_dir,
-            form_headers,
-            progress,
-        )
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to upload input data")
-
-    # Finish files
-    data_file_ids_list = [item["id"] for item in data_file_uploads]
-    tasks = []
-    for i in range(0, len(data_file_ids_list), batch_size):
-        batch = data_file_ids_list[i : i + batch_size]
-        task = finish_files(batch, "input", form_headers, host, progress)
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to finish input files")
-
-    # Create input records - merge input metadata with file upload info.
-    # Read the local JSON content so core can store it on the InputJob
-    # row and serve a fully-inlined response from /api/input-jobs/
-    # (matching visivo Flask's contract).
+    # Read the local JSON so core can store it on the InputJob row and serve a
+    # fully-inlined response from /api/input-jobs/ (matching visivo Flask's
+    # contract).
     #
-    # See process_insights_async for why we abort on any failure rather
-    # than letting NULL ``content`` rows reach the cloud.
+    # Abort on any failure rather than letting NULL ``content`` rows reach the
+    # cloud: a silent warning would render an empty input to the viewer with no
+    # signal to the operator. That matters more now that ``content`` is the only
+    # copy.
+    records = []
     content_failures = []
-    for i, upload in enumerate(data_file_uploads):
-        upload["name"] = input_files[i]["name"]
-        upload["name_hash"] = input_files[i]["name_hash"]
-        local_path = os.path.join(output_dir, input_files[i]["file_path"])
+    for input_file in input_files:
+        record = {"name": input_file["name"], "name_hash": input_file["name_hash"]}
+        local_path = os.path.join(output_dir, input_file["file_path"])
         try:
             with open(local_path, "r") as f:
-                upload["content"] = json.load(f)
+                record["content"] = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             Logger.instance().warning(
-                f"Could not load input JSON content for {input_files[i]['name']}: {e}"
+                f"Could not load input JSON content for {input_file['name']}: {e}"
             )
-            upload["content"] = None
-            content_failures.append(input_files[i]["name"])
+            record["content"] = None
+            content_failures.append(input_file["name"])
+        records.append(record)
     if content_failures:
         raise click.ClickException(
             f"Failed to read input JSON content for {len(content_failures)} input(s): "
@@ -735,8 +666,8 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
         )
 
     tasks = []
-    for i in range(0, len(data_file_uploads), batch_size):
-        batch = data_file_uploads[i : i + batch_size]
+    for i in range(0, len(records), batch_size):
+        batch = records[i : i + batch_size]
         task = create_input_records(batch, project_id, json_headers, host, progress)
         tasks.append(task)
     response_items = await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
The visivo half of VIS-1125. **Stacked on [#561](https://github.com/visivo-io/visivo/pull/561)**. Pairs with [visivo-io/core#328](https://github.com/visivo-io/core/pull/328), which makes the file optional.

## The upload was never read

Each deploy created a file record for every insight and input, PUT the JSON, and marked the upload finished — for an object core never opens. The same JSON is posted inline as `content`, and every `/api/insight-jobs/` response is built from that plus the **ModelJob's** parquet URL.

Sampled production: **73% of all objects are under 2 KB** — envelope-sized — against 15% over 20 KB. Object count is 88% of the storage bill.

## Changes

`process_insights_async` and `process_inputs_async` read the local JSON and post the record directly. No `start_files`, no `upload_file`, no `finish_files`, no `data_file_id`. Three round trips per batch become one.

The abort-on-unreadable-content guard stays and matters *more* than before — `content` is now the only copy, so a silent `None` would render an empty insight with no signal to the operator. It already raised; that behaviour is unchanged and now load-bearing.

`PURPOSE_BY_DESCRIPTION` drops its `insight` and `input` entries: nothing in those paths uploads, so they need no purpose. Only `model` and `thumbnail` remain.

## Testing

New: `test_insight_records_carry_content_and_no_file` asserts the posted body is exactly `{name, name_hash, project_id, content}` with no `data_file_id`.

Updated: `test_deploy_with_insights_and_inputs_success` drops the file-start, PUT and finish mocks for envelopes — they're no longer requested, which `pytest_httpx` correctly flagged.

**2305 passed.** The 3 failures in `tests/templates/test_samples.py` are pre-existing and environmental (`pyenv: visivo command not found`) — identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
