### PR TITLE
Parquet lives in the directory that produced it

### DIFF
--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import json
 import re
@@ -8,7 +9,11 @@ from tests.factories.model_factories import (
     InsightFactory,
 )
 from tests.support.utils import temp_file, temp_folder, temp_yml_file
-from visivo.commands.deploy_phase import deploy_phase
+from visivo.commands.deploy_phase import (
+    PURPOSE_BY_DESCRIPTION,
+    deploy_phase,
+    start_files,
+)
 from visivo.parsers.file_names import PROFILE_FILE_NAME, PROJECT_FILE_NAME
 
 from visivo.utils import sanitize_filename
@@ -181,3 +186,68 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
     # Resources were decomposed into per-type endpoint POSTs.
     posted_paths = {r.path for r in requests_mock.request_history if r.method == "POST"}
     assert "/api/charts/" in posted_paths
+
+
+def test_start_files_declares_purpose_and_identity(httpx_mock):
+    """Core builds an artifact's object path when it signs the upload URL —
+    before it has seen a byte — so anything the deploy fails to declare here is
+    unrecoverable. The file is already written under an `unknown` prefix by the
+    time the record is created, where no query engine will find it.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        url="http://host/api/files/direct/start/",
+        json=[{"id": "f1", "name": "orders.parquet", "upload_url": "http://host/put"}],
+    )
+
+    asyncio.run(
+        start_files(
+            [{"filename": "orders.parquet", "name": "orders"}],
+            "model",
+            {},
+            "http://host",
+            {"completed": 0, "total": 1},
+            project_id="proj-1",
+        )
+    )
+
+    [request] = httpx_mock.get_requests()
+    assert json.loads(request.content) == [
+        {
+            "filename": "orders.parquet",
+            "purpose": "model_job_data",
+            "name": "orders",
+            "project_id": "proj-1",
+        }
+    ]
+
+
+def test_start_files_omits_identity_for_thumbnails(httpx_mock):
+    """A thumbnail is metadata — nothing queries it, so it carries no project
+    identity and core files it by account and date alone."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://host/api/files/direct/start/",
+        json=[{"id": "f1", "name": "dash.png", "upload_url": "http://host/put"}],
+    )
+
+    asyncio.run(
+        start_files(
+            [{"filename": "dash.png"}],
+            "thumbnail",
+            {},
+            "http://host",
+            {"completed": 0, "total": 1},
+        )
+    )
+
+    [request] = httpx_mock.get_requests()
+    assert json.loads(request.content) == [{"filename": "dash.png", "purpose": "thumbnail"}]
+
+
+def test_every_upload_description_maps_to_a_purpose():
+    """A description with no purpose silently sends `null`, which core stores as
+    UNKNOWN — the object still uploads, it just becomes unqueryable. Pin the map
+    so adding an upload kind without a purpose fails here instead."""
+    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "insight", "input", "thumbnail"}
+    assert all(PURPOSE_BY_DESCRIPTION.values())

--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -270,10 +270,12 @@ def test_static_insight_parquet_is_not_collected_as_a_model(tmp_path):
     (VIS-1126).
     """
     output_dir = str(tmp_path)
-    os.makedirs(os.path.join(output_dir, "files"))
-    for name in ("static_insight", "orders"):
-        with open(os.path.join(output_dir, "files", f"{name}.parquet"), "wb") as f:
-            f.write(b"PAR1")
+    os.makedirs(os.path.join(output_dir, "insights"))
+    os.makedirs(os.path.join(output_dir, "models"))
+    with open(os.path.join(output_dir, "insights", "static_insight.parquet"), "wb") as f:
+        f.write(b"PAR1")
+    with open(os.path.join(output_dir, "models", "orders.parquet"), "wb") as f:
+        f.write(b"PAR1")
 
     # A plain stub rather than InsightFactory: the collectors only touch name,
     # name_hash and is_dynamic, and Insight is a pydantic model that rejects
@@ -287,15 +289,15 @@ def test_static_insight_parquet_is_not_collected_as_a_model(tmp_path):
 
     assert models == []
     assert [f["name"] for f in parquet] == ["static_insight"]
-    assert parquet[0]["file_path"] == "files/static_insight.parquet"
+    assert parquet[0]["file_path"] == "insights/static_insight.parquet"
 
 
 def test_dynamic_insight_still_collects_its_dependent_models(tmp_path):
     """A dynamic insight owns no parquet — its data is the models it queries
     client-side, and those are still uploaded as models."""
     output_dir = str(tmp_path)
-    os.makedirs(os.path.join(output_dir, "files"))
-    with open(os.path.join(output_dir, "files", "orders.parquet"), "wb") as f:
+    os.makedirs(os.path.join(output_dir, "models"))
+    with open(os.path.join(output_dir, "models", "orders.parquet"), "wb") as f:
         f.write(b"PAR1")
 
     model = mock.Mock()

--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -11,6 +11,7 @@ from tests.factories.model_factories import (
 from tests.support.utils import temp_file, temp_folder, temp_yml_file
 from visivo.commands.deploy_phase import (
     PURPOSE_BY_DESCRIPTION,
+    create_insight_records,
     deploy_phase,
     start_files,
 )
@@ -44,20 +45,6 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
             "upload_url": "http://google/upload/id3",
         },
     ]
-    insight_file_starts = [
-        {
-            "name": f"{insight.name}.json",
-            "id": "id4",
-            "upload_url": "http://google/upload/id4",
-        },
-    ]
-    input_file_starts = [
-        {
-            "name": f"{input_obj.name}.json",
-            "id": "id5",
-            "upload_url": "http://google/upload/id5",
-        },
-    ]
 
     run_id = "main"
 
@@ -89,31 +76,11 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
         url="http://host/api/files/direct/start/",
         json=thumbnail_file_starts,
     )
-    # Mock responses for insight files
-    httpx_mock.add_response(
-        method="POST",
-        url="http://host/api/files/direct/start/",
-        json=insight_file_starts,
-    )
-    # Mock responses for input files
-    httpx_mock.add_response(
-        method="POST",
-        url="http://host/api/files/direct/start/",
-        json=input_file_starts,
-    )
 
-    # Mock file uploads
+    # Only the thumbnail is uploaded. Insight and input envelopes are sent as
+    # `content` on the record — core never read the uploaded JSON back, so it
+    # is not uploaded at all (VIS-1125).
     httpx_mock.add_response(method="PUT", url="http://google/upload/id3", status_code=200)
-    httpx_mock.add_response(method="PUT", url="http://google/upload/id4", status_code=200)
-    httpx_mock.add_response(method="PUT", url="http://google/upload/id5", status_code=200)
-
-    # Mock file finish calls
-    httpx_mock.add_response(
-        method="POST", url="http://host/api/files/direct/finish/", status_code=204
-    )
-    httpx_mock.add_response(
-        method="POST", url="http://host/api/files/direct/finish/", status_code=204
-    )
     httpx_mock.add_response(
         method="POST", url="http://host/api/files/direct/finish/", status_code=204
     )
@@ -249,5 +216,34 @@ def test_every_upload_description_maps_to_a_purpose():
     """A description with no purpose silently sends `null`, which core stores as
     UNKNOWN — the object still uploads, it just becomes unqueryable. Pin the map
     so adding an upload kind without a purpose fails here instead."""
-    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "insight", "input", "thumbnail"}
+    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "thumbnail"}
     assert all(PURPOSE_BY_DESCRIPTION.values())
+
+
+def test_insight_records_carry_content_and_no_file(httpx_mock):
+    """The envelope IS the record. core builds its /api/insight-jobs/ response
+    from `content` and never read the uploaded JSON back, so nothing is
+    uploaded and no data_file_id is sent (VIS-1125)."""
+    httpx_mock.add_response(
+        method="POST", url="http://host/api/insight-jobs/", json=[{"id": "i1"}], status_code=201
+    )
+
+    asyncio.run(
+        create_insight_records(
+            [{"name": "orders_trend", "name_hash": "mabc", "content": {"type": "bar"}}],
+            "proj-1",
+            {},
+            "http://host",
+            {"completed": 0, "total": 1},
+        )
+    )
+
+    [request] = httpx_mock.get_requests()
+    [body] = json.loads(request.content)
+    assert body == {
+        "name": "orders_trend",
+        "name_hash": "mabc",
+        "project_id": "proj-1",
+        "content": {"type": "bar"},
+    }
+    assert "data_file_id" not in body

--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import json
 import re
+from unittest import mock
 
 from tests.factories.model_factories import (
     ProjectFactory,
@@ -11,6 +12,8 @@ from tests.factories.model_factories import (
 from tests.support.utils import temp_file, temp_folder, temp_yml_file
 from visivo.commands.deploy_phase import (
     PURPOSE_BY_DESCRIPTION,
+    collect_models_for_insights,
+    collect_static_insight_parquet,
     create_insight_records,
     deploy_phase,
     start_files,
@@ -216,8 +219,17 @@ def test_every_upload_description_maps_to_a_purpose():
     """A description with no purpose silently sends `null`, which core stores as
     UNKNOWN — the object still uploads, it just becomes unqueryable. Pin the map
     so adding an upload kind without a purpose fails here instead."""
-    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "thumbnail"}
+    assert set(PURPOSE_BY_DESCRIPTION) == {"model", "insight", "input", "thumbnail"}
     assert all(PURPOSE_BY_DESCRIPTION.values())
+
+
+def test_each_job_type_owns_its_own_parquet_purpose():
+    """A model, a static insight and an input's options are three different
+    things. They all used to go up as model job data, which made a model and
+    the insight built on it indistinguishable in the store (VIS-1126)."""
+    assert PURPOSE_BY_DESCRIPTION["model"] == "model_job_data"
+    assert PURPOSE_BY_DESCRIPTION["insight"] == "insight_job_data"
+    assert PURPOSE_BY_DESCRIPTION["input"] == "input_job_data"
 
 
 def test_insight_records_carry_content_and_no_file(httpx_mock):
@@ -247,3 +259,57 @@ def test_insight_records_carry_content_and_no_file(httpx_mock):
         "content": {"type": "bar"},
     }
     assert "data_file_id" not in body
+
+
+def test_static_insight_parquet_is_not_collected_as_a_model(tmp_path):
+    """A static insight's precomputed result is the INSIGHT's file.
+
+    It used to be collected here and uploaded as a model named after the
+    insight, which put a model and the insight built on it in the same place in
+    the artifact store — and, under the typed layout, the same BigQuery table
+    (VIS-1126).
+    """
+    output_dir = str(tmp_path)
+    os.makedirs(os.path.join(output_dir, "files"))
+    for name in ("static_insight", "orders"):
+        with open(os.path.join(output_dir, "files", f"{name}.parquet"), "wb") as f:
+            f.write(b"PAR1")
+
+    # A plain stub rather than InsightFactory: the collectors only touch name,
+    # name_hash and is_dynamic, and Insight is a pydantic model that rejects
+    # attribute assignment.
+    static = mock.Mock(name_hash=lambda: "mstatic", is_dynamic=lambda _dag: False)
+    static.name = "static_insight"
+    dag = mock.Mock()
+
+    models = collect_models_for_insights([static], dag, output_dir)
+    parquet = collect_static_insight_parquet([static], dag, output_dir)
+
+    assert models == []
+    assert [f["name"] for f in parquet] == ["static_insight"]
+    assert parquet[0]["file_path"] == "files/static_insight.parquet"
+
+
+def test_dynamic_insight_still_collects_its_dependent_models(tmp_path):
+    """A dynamic insight owns no parquet — its data is the models it queries
+    client-side, and those are still uploaded as models."""
+    output_dir = str(tmp_path)
+    os.makedirs(os.path.join(output_dir, "files"))
+    with open(os.path.join(output_dir, "files", "orders.parquet"), "wb") as f:
+        f.write(b"PAR1")
+
+    model = mock.Mock()
+    model.name = "orders"
+    model.name_hash = lambda: "morders"
+    dynamic = mock.Mock(
+        name_hash=lambda: "mdynamic",
+        is_dynamic=lambda _dag: True,
+        get_all_dependent_models=lambda _dag: [model],
+    )
+    dynamic.name = "dynamic_insight"
+
+    models = collect_models_for_insights([dynamic], mock.Mock(), output_dir)
+    parquet = collect_static_insight_parquet([dynamic], mock.Mock(), output_dir)
+
+    assert [m["name"] for m in models] == ["orders"]
+    assert parquet == []

--- a/tests/server/test_model_jobs_views.py
+++ b/tests/server/test_model_jobs_views.py
@@ -21,14 +21,14 @@ from tests.factories.model_factories import ProjectFactory
 def client(tmp_path):
     project = ProjectFactory.build()
     output_dir = str(tmp_path / "target")
-    os.makedirs(os.path.join(output_dir, "main", "files"), exist_ok=True)
+    os.makedirs(os.path.join(output_dir, "main", "models"), exist_ok=True)
     app = FlaskApp(output_dir=output_dir, project=project).app
     app.config["TESTING"] = True
     return app.test_client(), output_dir
 
 
 def _write_parquet(output_dir, name, run_id="main"):
-    path = os.path.join(output_dir, run_id, "files", f"{name}.parquet")
+    path = os.path.join(output_dir, run_id, "models", f"{name}.parquet")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     open(path, "wb").write(b"PAR1")  # contents never read — only existence
     return path

--- a/tests/server/views/test_file_views.py
+++ b/tests/server/views/test_file_views.py
@@ -42,8 +42,11 @@ def client(output_dir):
     return app.test_client()
 
 
-def _put_parquet(output_dir, run_id, stem, payload=b"PAR1content"):
-    path = os.path.join(output_dir, run_id, "files", f"{stem}.parquet")
+def _put_parquet(output_dir, run_id, stem, payload=b"PAR1content", kind="models"):
+    # Parquet is written into the directory named for what produced it
+    # (VIS-1128). The route resolves a hash across all of them, because the
+    # caller asks by alpha_hash(name) and does not know which kind built it.
+    path = os.path.join(output_dir, run_id, kind, f"{stem}.parquet")
     _write_stub_parquet(path, payload)
     return path
 
@@ -172,3 +175,24 @@ def test_cache_keyed_per_run_id(client, output_dir):
     assert a.data == b"PAR1from-a"
     assert b.status_code == 200
     assert b.data == b"PAR1from-b"
+
+
+def test_parquet_resolves_from_any_producing_directory(client, output_dir):
+    """A model, a static insight and an input's options all write parquet, each
+    into its own directory. The caller asks by hash and cannot know which — so
+    the route has to look in all three."""
+    for kind, stem in (
+        ("models", "orders"),
+        ("insights", "orders_trend"),
+        ("inputs", "region_opts"),
+    ):
+        _put_parquet(output_dir, "main", stem, payload=f"PAR1{kind}".encode(), kind=kind)
+
+    for kind, stem in (
+        ("models", "orders"),
+        ("insights", "orders_trend"),
+        ("inputs", "region_opts"),
+    ):
+        response = client.get(f"/api/files/{alpha_hash(stem)}/main/")
+        assert response.status_code == 200, kind
+        assert response.data == f"PAR1{kind}".encode()

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -115,12 +115,13 @@ def _raise_if_any_failed(results, summary: str):
 #
 # Note every parquet file goes up as "model": a model's own data, a static
 # insight's precomputed result, and a query-based input's options all funnel
-# through process_models_async. The "insight" and "input" descriptions are
-# their JSON envelopes, which core keeps but never queries.
+# through process_models_async. So an insight's rows ARE queryable — they just
+# arrive as model job data. The "insight" and "input" descriptions carry only
+# the JSON envelope, which is why they are named envelope rather than data.
 PURPOSE_BY_DESCRIPTION = {
     "model": "model_job_data",
-    "insight": "insight_job_data",
-    "input": "input_job_data",
+    "insight": "insight_job_envelope",
+    "input": "input_job_envelope",
     "thumbnail": "thumbnail",
 }
 

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -872,12 +872,12 @@ def collect_models_for_insights(insights, dag, output_dir):
         if not insight.is_dynamic(dag):
             continue
         for model in insight.get_all_dependent_models(dag):
-            parquet_path = f"{output_dir}/files/{model.name}.parquet"
+            parquet_path = f"{output_dir}/models/{model.name}.parquet"
             if os.path.exists(parquet_path):
                 models_dict[model.name] = {
                     "name": model.name,
                     "name_hash": model.name_hash(),
-                    "file_path": f"files/{model.name}.parquet",
+                    "file_path": f"models/{model.name}.parquet",
                 }
 
     return list(models_dict.values())
@@ -894,12 +894,12 @@ def collect_static_insight_parquet(insights, dag, output_dir):
     for insight in insights:
         if insight.is_dynamic(dag):
             continue
-        if os.path.exists(f"{output_dir}/files/{insight.name}.parquet"):
+        if os.path.exists(f"{output_dir}/insights/{insight.name}.parquet"):
             files.append(
                 {
                     "name": insight.name,
                     "name_hash": insight.name_hash(),
-                    "file_path": f"files/{insight.name}.parquet",
+                    "file_path": f"insights/{insight.name}.parquet",
                 }
             )
     return files
@@ -930,7 +930,7 @@ def collect_parquet_files_for_inputs(inputs, output_dir):
                     if "name_hash" in file_ref and "signed_data_file_url" in file_ref:
                         file_hash = file_ref["name_hash"]
                         # The signed_data_file_url contains the local path like
-                        # {output_dir}/files/{hash}_options.parquet
+                        # {output_dir}/inputs/{hash}_options.parquet
                         file_path = file_ref["signed_data_file_url"]
                         # Extract the relative path from output_dir
                         if file_path.startswith(output_dir):

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -113,14 +113,24 @@ def _raise_if_any_failed(results, summary: str):
 # seen a byte — so anything we do not declare here lands under an `unknown`
 # prefix where no query engine will find it.
 #
-# Only two kinds of object are uploaded at all. Every parquet goes up as
-# "model" — a model's own data, a static insight's precomputed result, and a
-# query-based input's options all funnel through process_models_async — so an
-# insight's rows are queryable, they just arrive as model job data. Insight and
-# input envelopes are not uploaded (VIS-1125): they are sent as `content` on
-# the record, which is the only copy core ever read.
+# What core stores each upload as. Purpose decides the object path, and core
+# picks that path when it signs the URL — before it has seen a byte — so an
+# undeclared upload lands somewhere no query engine looks.
+#
+# Every one of these is parquet except the thumbnail. Each kind of job owns its
+# own: a model's data, a STATIC insight's precomputed result, and a query-based
+# input's options. They all used to go up as "model", which made a model and
+# the insight built on it indistinguishable in the store (VIS-1126).
+#
+# A DYNAMIC insight owns nothing — its files[] name the models it queries
+# client-side, and those are uploaded as models.
+#
+# The insight and input JSON envelopes are not uploaded at all (VIS-1125):
+# they ride as `content` on the record, which is the only copy core ever read.
 PURPOSE_BY_DESCRIPTION = {
     "model": "model_job_data",
+    "insight": "insight_job_data",
+    "input": "input_job_data",
     "thumbnail": "thumbnail",
 }
 
@@ -345,7 +355,7 @@ async def create_insight_records(batch, project_id, json_headers, host, progress
                 "name": record["name"],
                 "name_hash": record["name_hash"],
                 "project_id": project_id,
-                # No data_file_id: an envelope has no file (VIS-1125).
+                **({"data_file_id": record["data_file_id"]} if record.get("data_file_id") else {}),
                 "content": record.get("content"),
             },
             batch,
@@ -385,7 +395,7 @@ async def create_input_records(batch, project_id, json_headers, host, progress):
                 "name": record["name"],
                 "name_hash": record["name_hash"],
                 "project_id": project_id,
-                # No data_file_id: an envelope has no file (VIS-1125).
+                **({"data_file_id": record["data_file_id"]} if record.get("data_file_id") else {}),
                 "content": record.get("content"),
             },
             batch,
@@ -535,11 +545,63 @@ async def process_dashboards_async(
     _raise_if_any_failed(response_items, "Failed to create dashboard records")
 
 
+async def _upload_job_parquet(
+    files, description, output_dir, form_headers, host, progress, project_id, batch_size=20
+):
+    """Create file records, PUT each parquet, finish them. Returns ``{name: file_id}``.
+
+    Shared by the insight and input paths, which upload the same way and differ
+    only in which job type owns the result — the thing that used to be a single
+    ``process_models_async`` for all three (VIS-1126).
+    """
+    tasks = []
+    for i in range(0, len(files), batch_size):
+        batch = files[i : i + batch_size]
+        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
+        tasks.append(
+            start_files(items, description, form_headers, host, progress, project_id=project_id)
+        )
+    started = await asyncio.gather(*tasks, return_exceptions=True)
+    _raise_if_any_failed(started, f"Failed to create {description} parquet files")
+    uploads = [item for sublist in started for item in sublist]
+
+    tasks = [
+        upload_file(
+            files[i]["name"],
+            upload["upload_url"],
+            files[i]["file_path"],
+            output_dir,
+            form_headers,
+            progress,
+        )
+        for i, upload in enumerate(uploads)
+    ]
+    _raise_if_any_failed(
+        await asyncio.gather(*tasks, return_exceptions=True),
+        f"Failed to upload {description} parquet",
+    )
+
+    ids = [u["id"] for u in uploads]
+    tasks = [
+        finish_files(ids[i : i + batch_size], description, form_headers, host, progress)
+        for i in range(0, len(ids), batch_size)
+    ]
+    _raise_if_any_failed(
+        await asyncio.gather(*tasks, return_exceptions=True),
+        f"Failed to finish {description} parquet files",
+    )
+    return {files[i]["name"]: u["id"] for i, u in enumerate(uploads)}
+
+
 async def process_insights_async(
-    insights, output_dir, project_id, form_headers, json_headers, host
+    insights, dag, output_dir, project_id, form_headers, json_headers, host
 ):
     """
-    Coordinates the asynchronous upload of insight JSON files and creation of insight records.
+    Upload each static insight's parquet and create the insight records.
+
+    ``dag`` is needed to tell a static insight from a dynamic one: only a
+    static insight has a precomputed result of its own to upload. A dynamic
+    insight's data is its dependent models', uploaded as models.
     """
     batch_size = 20
 
@@ -561,12 +623,23 @@ async def process_insights_async(
     if not insight_files:
         return
 
-    # One operation per batch: there are no files to create, upload or finish.
-    # The envelope IS ``content``. It used to be uploaded to the bucket as well
-    # and core never read it back — every response is built from ``content``
-    # plus the MODEL job's parquet URL — so the upload was pure object count
-    # (VIS-1125).
-    progress = {"completed": 0, "total": math.ceil(len(insight_files) / batch_size)}
+    # A static insight's precomputed parquet is its OWN file, keyed by the
+    # insight's hash — so it attaches to the record built below rather than
+    # creating a row of its own. It used to go up as a model named after the
+    # insight (VIS-1126). The envelope is not uploaded at all; it rides as
+    # ``content`` (VIS-1125).
+    parquet_files = collect_static_insight_parquet(insights, dag, output_dir)
+    progress = {
+        "completed": 0,
+        "total": math.ceil(len(insight_files) / batch_size)
+        + (3 * math.ceil(len(parquet_files) / batch_size) if parquet_files else 0),
+    }
+
+    data_file_ids = {}
+    if parquet_files:
+        data_file_ids = await _upload_job_parquet(
+            parquet_files, "insight", output_dir, form_headers, host, progress, project_id
+        )
 
     # Read the local JSON so core can store it on the InsightJob row and serve a
     # fully-inlined response from /api/insight-jobs/ (matching visivo Flask's
@@ -580,6 +653,8 @@ async def process_insights_async(
     content_failures = []
     for insight_file in insight_files:
         record = {"name": insight_file["name"], "name_hash": insight_file["name_hash"]}
+        if insight_file["name"] in data_file_ids:
+            record["data_file_id"] = data_file_ids[insight_file["name"]]
         local_path = os.path.join(output_dir, insight_file["file_path"])
         try:
             with open(local_path, "r") as f:
@@ -674,6 +749,45 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
     _raise_if_any_failed(response_items, "Failed to create input records")
 
 
+async def process_input_parquet_async(
+    parquet_files, output_dir, project_id, form_headers, json_headers, host
+):
+    """Upload a query-based input's options parquet as INPUT job data.
+
+    Unlike an insight's, an options file is keyed by its OWN hash (of
+    ``{input}_options``), not the input's — so the record that holds it is a
+    separate row rather than the input's own. That is the shape that already
+    existed; only the job type changed, from model to input (VIS-1126), so a
+    model and an input's options are no longer indistinguishable in the store.
+    """
+    if not parquet_files:
+        return
+    batch_size = 20
+    progress = {"completed": 0, "total": 4 * math.ceil(len(parquet_files) / batch_size)}
+
+    data_file_ids = await _upload_job_parquet(
+        parquet_files, "input", output_dir, form_headers, host, progress, project_id
+    )
+
+    records = [
+        {
+            "name": f["name"],
+            "name_hash": f["name_hash"],
+            "data_file_id": data_file_ids[f["name"]],
+        }
+        for f in parquet_files
+        if f["name"] in data_file_ids
+    ]
+    tasks = [
+        create_input_records(records[i : i + batch_size], project_id, json_headers, host, progress)
+        for i in range(0, len(records), batch_size)
+    ]
+    _raise_if_any_failed(
+        await asyncio.gather(*tasks, return_exceptions=True),
+        "Failed to create input parquet records",
+    )
+
+
 async def process_models_async(models, output_dir, project_id, form_headers, json_headers, host):
     """
     Coordinates the asynchronous upload of model parquet files and creation of records.
@@ -741,40 +855,54 @@ async def process_models_async(models, output_dir, project_id, form_headers, jso
 
 def collect_models_for_insights(insights, dag, output_dir):
     """
-    Collect parquet files needed by insights for client-side DuckDB queries.
+    Collect the MODEL parquet a dynamic insight queries client-side.
 
-    There are two types of parquet files:
-    1. Static insight result files: Pre-computed query results stored at
-       files/{insight.name}.parquet - these need to be uploaded so the
-       client can load them via DuckDB.
-    2. Model files for dynamic insights: Model parquet files at
-       files/{model.name}.parquet - only needed for insights with
-       Input dependencies that require client-side queries on model data.
+    A dynamic insight has Input dependencies, so its data can't be precomputed
+    — the client runs the query against each dependent model's parquet in
+    DuckDB. Those files belong to the models, so they go up as models.
+
+    A static insight's precomputed result used to be collected here too, and
+    went up as a model named after the insight — which made a model and the
+    insight built on it indistinguishable in the artifact store (VIS-1126). It
+    is now uploaded by ``process_insights_async`` as the insight's own file.
     """
     models_dict = {}
 
     for insight in insights:
-        if insight.is_dynamic(dag):
-            # Dynamic insights need model parquet files for client-side queries
-            for model in insight.get_all_dependent_models(dag):
-                parquet_path = f"{output_dir}/files/{model.name}.parquet"
-                if os.path.exists(parquet_path):
-                    models_dict[model.name] = {
-                        "name": model.name,
-                        "name_hash": model.name_hash(),
-                        "file_path": f"files/{model.name}.parquet",
-                    }
-        else:
-            # Static insights have pre-computed result files that need to be uploaded
-            parquet_path = f"{output_dir}/files/{insight.name}.parquet"
+        if not insight.is_dynamic(dag):
+            continue
+        for model in insight.get_all_dependent_models(dag):
+            parquet_path = f"{output_dir}/files/{model.name}.parquet"
             if os.path.exists(parquet_path):
-                models_dict[insight.name] = {
+                models_dict[model.name] = {
+                    "name": model.name,
+                    "name_hash": model.name_hash(),
+                    "file_path": f"files/{model.name}.parquet",
+                }
+
+    return list(models_dict.values())
+
+
+def collect_static_insight_parquet(insights, dag, output_dir):
+    """A static insight's precomputed result, keyed by the INSIGHT's own hash.
+
+    Which is why it attaches to the existing InsightJob rather than creating a
+    row of its own: the insight's files[] ref names the insight, so one record
+    carries both the envelope and the file.
+    """
+    files = []
+    for insight in insights:
+        if insight.is_dynamic(dag):
+            continue
+        if os.path.exists(f"{output_dir}/files/{insight.name}.parquet"):
+            files.append(
+                {
                     "name": insight.name,
                     "name_hash": insight.name_hash(),
                     "file_path": f"files/{insight.name}.parquet",
                 }
-
-    return list(models_dict.values())
+            )
+    return files
 
 
 def collect_parquet_files_for_inputs(inputs, output_dir):
@@ -996,6 +1124,7 @@ def deploy_phase(
             asyncio.run(
                 process_insights_async(
                     insights=insights,
+                    dag=dag,
                     output_dir=run_output_dir,
                     project_id=project_id,
                     form_headers=form_headers,
@@ -1036,8 +1165,8 @@ def deploy_phase(
         input_parquet_files = collect_parquet_files_for_inputs(inputs, run_output_dir)
         if input_parquet_files:
             asyncio.run(
-                process_models_async(
-                    models=input_parquet_files,
+                process_input_parquet_async(
+                    parquet_files=input_parquet_files,
                     output_dir=run_output_dir,
                     project_id=project_id,
                     form_headers=form_headers,

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -108,12 +108,40 @@ def _raise_if_any_failed(results, summary: str):
     raise click.ClickException(f"{summary} — {len(failures)} batch failure(s). See log above.")
 
 
+# What core stores each class of upload as. Purpose is what the object path is
+# built from, and core picks that path when it signs the URL — before it has
+# seen a byte — so anything we do not declare here lands under an `unknown`
+# prefix where no query engine will find it.
+#
+# Note every parquet file goes up as "model": a model's own data, a static
+# insight's precomputed result, and a query-based input's options all funnel
+# through process_models_async. The "insight" and "input" descriptions are
+# their JSON envelopes, which core keeps but never queries.
+PURPOSE_BY_DESCRIPTION = {
+    "model": "model_job_data",
+    "insight": "insight_job_data",
+    "input": "input_job_data",
+    "thumbnail": "thumbnail",
+}
+
+
 @retry(stop=stop_after_attempt(MAX_ATTEMPTS), wait=wait_fixed(2))
-async def start_files(file_names, description, form_headers, host, progress):
+async def start_files(items, description, form_headers, host, progress, project_id=None):
     """
-    Asynchronously uploads trace data files.
+    Asynchronously creates file records and returns their signed upload URLs.
+
+    ``items`` are ``[{filename, name?}]``. ``name`` and ``project_id`` are the
+    artifact's identity, which core turns into its object path; omitting them
+    is what makes an object unqueryable, not merely unlabelled.
     """
-    files = list(map(lambda file_name: {"filename": file_name}, file_names))
+    files = []
+    for item in items:
+        file = {"filename": item["filename"], "purpose": PURPOSE_BY_DESCRIPTION.get(description)}
+        if item.get("name"):
+            file["name"] = item["name"]
+        if project_id:
+            file["project_id"] = str(project_id)
+        files.append(file)
     url = f"{host}/api/files/direct/start/"
     attempt.set(attempt.get(0) + 1)
     async with semaphore_3():
@@ -123,7 +151,7 @@ async def start_files(file_names, description, form_headers, host, progress):
                 response.raise_for_status()
                 progress["completed"] += 1
                 Logger.instance().success(
-                    f"\t{len(file_names)} {description} files created. [{progress['completed']}/{progress['total']}]"
+                    f"\t{len(files)} {description} files created. [{progress['completed']}/{progress['total']}]"
                 )
                 return response.json()
         except httpx.HTTPStatusError as e:
@@ -447,7 +475,9 @@ async def process_dashboards_async(
         if os.path.exists(f"{dashboards_dir}/{sanitized_name}.png"):
             file_names.append(f"{sanitized_name}.png")
 
-    create_thumbnail_files_task = start_files(file_names, "thumbnail", form_headers, host, progress)
+    create_thumbnail_files_task = start_files(
+        [{"filename": name} for name in file_names], "thumbnail", form_headers, host, progress
+    )
 
     thumbnail_file_uploads_nested = await asyncio.gather(
         create_thumbnail_files_task, return_exceptions=True
@@ -539,8 +569,8 @@ async def process_insights_async(
     tasks = []
     for i in range(0, len(insight_files), batch_size):
         batch = insight_files[i : i + batch_size]
-        file_names = [f["file_path"].split("/")[-1] for f in batch]
-        task = start_files(file_names, "insight", form_headers, host, progress)
+        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
+        task = start_files(items, "insight", form_headers, host, progress, project_id=project_id)
         tasks.append(task)
     data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
     _raise_if_any_failed(data_file_ids, "Failed to create insight files")
@@ -642,8 +672,8 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
     tasks = []
     for i in range(0, len(input_files), batch_size):
         batch = input_files[i : i + batch_size]
-        file_names = [f["file_path"].split("/")[-1] for f in batch]
-        task = start_files(file_names, "input", form_headers, host, progress)
+        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
+        task = start_files(items, "input", form_headers, host, progress, project_id=project_id)
         tasks.append(task)
     data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
     _raise_if_any_failed(data_file_ids, "Failed to create input files")
@@ -729,8 +759,8 @@ async def process_models_async(models, output_dir, project_id, form_headers, jso
     tasks = []
     for i in range(0, len(models), batch_size):
         batch = models[i : i + batch_size]
-        file_names = [f["file_path"].split("/")[-1] for f in batch]
-        task = start_files(file_names, "model", form_headers, host, progress)
+        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
+        task = start_files(items, "model", form_headers, host, progress, project_id=project_id)
         tasks.append(task)
     data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
     _raise_if_any_failed(data_file_ids, "Failed to create models")

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -113,15 +113,14 @@ def _raise_if_any_failed(results, summary: str):
 # seen a byte — so anything we do not declare here lands under an `unknown`
 # prefix where no query engine will find it.
 #
-# Note every parquet file goes up as "model": a model's own data, a static
-# insight's precomputed result, and a query-based input's options all funnel
-# through process_models_async. So an insight's rows ARE queryable — they just
-# arrive as model job data. The "insight" and "input" descriptions carry only
-# the JSON envelope, which is why they are named envelope rather than data.
+# Only two kinds of object are uploaded at all. Every parquet goes up as
+# "model" — a model's own data, a static insight's precomputed result, and a
+# query-based input's options all funnel through process_models_async — so an
+# insight's rows are queryable, they just arrive as model job data. Insight and
+# input envelopes are not uploaded (VIS-1125): they are sent as `content` on
+# the record, which is the only copy core ever read.
 PURPOSE_BY_DESCRIPTION = {
     "model": "model_job_data",
-    "insight": "insight_job_envelope",
-    "input": "input_job_envelope",
     "thumbnail": "thumbnail",
 }
 
@@ -342,12 +341,12 @@ async def create_insight_records(batch, project_id, json_headers, host, progress
     """
     body = list(
         map(
-            lambda data_file_upload: {
-                "name": data_file_upload["name"],
-                "name_hash": data_file_upload["name_hash"],
+            lambda record: {
+                "name": record["name"],
+                "name_hash": record["name_hash"],
                 "project_id": project_id,
-                "data_file_id": data_file_upload["id"],
-                "content": data_file_upload.get("content"),
+                # No data_file_id: an envelope has no file (VIS-1125).
+                "content": record.get("content"),
             },
             batch,
         )
@@ -382,12 +381,12 @@ async def create_input_records(batch, project_id, json_headers, host, progress):
     """
     body = list(
         map(
-            lambda data_file_upload: {
-                "name": data_file_upload["name"],
-                "name_hash": data_file_upload["name_hash"],
+            lambda record: {
+                "name": record["name"],
+                "name_hash": record["name_hash"],
                 "project_id": project_id,
-                "data_file_id": data_file_upload["id"],
-                "content": data_file_upload.get("content"),
+                # No data_file_id: an envelope has no file (VIS-1125).
+                "content": record.get("content"),
             },
             batch,
         )
@@ -562,71 +561,36 @@ async def process_insights_async(
     if not insight_files:
         return
 
-    total_operations = len(insight_files)
-    total_operations += 3 * math.ceil(len(insight_files) / batch_size)
-    progress = {"completed": 0, "total": total_operations}
+    # One operation per batch: there are no files to create, upload or finish.
+    # The envelope IS ``content``. It used to be uploaded to the bucket as well
+    # and core never read it back — every response is built from ``content``
+    # plus the MODEL job's parquet URL — so the upload was pure object count
+    # (VIS-1125).
+    progress = {"completed": 0, "total": math.ceil(len(insight_files) / batch_size)}
 
-    # Create file records
-    tasks = []
-    for i in range(0, len(insight_files), batch_size):
-        batch = insight_files[i : i + batch_size]
-        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
-        task = start_files(items, "insight", form_headers, host, progress, project_id=project_id)
-        tasks.append(task)
-    data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(data_file_ids, "Failed to create insight files")
-
-    data_file_uploads = [item for sublist in data_file_ids for item in sublist]
-
-    # Upload files
-    tasks = []
-    for i, data_file_upload in enumerate(data_file_uploads):
-        insight_file = insight_files[i]
-        task = upload_file(
-            insight_file["name"],
-            data_file_upload["upload_url"],
-            insight_file["file_path"],
-            output_dir,
-            form_headers,
-            progress,
-        )
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to upload insight data")
-
-    # Finish files
-    data_file_ids_list = [item["id"] for item in data_file_uploads]
-    tasks = []
-    for i in range(0, len(data_file_ids_list), batch_size):
-        batch = data_file_ids_list[i : i + batch_size]
-        task = finish_files(batch, "insight", form_headers, host, progress)
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to finish insight files")
-
-    # Create insight records - merge insight metadata with file upload info.
-    # Also read the local JSON file content so core can store it on the
-    # InsightJob row and serve a fully-inlined response from
-    # /api/insight-jobs/ (matching visivo Flask's contract).
+    # Read the local JSON so core can store it on the InsightJob row and serve a
+    # fully-inlined response from /api/insight-jobs/ (matching visivo Flask's
+    # contract).
     #
-    # Track failures and abort the deploy if any occurred — a silent
-    # warning would leave the cloud-side InsightJob row with NULL
-    # content, which renders an empty insight to the viewer with no
-    # signal to the operator.
+    # Abort on any failure rather than letting NULL ``content`` rows reach the
+    # cloud: a silent warning would render an empty insight to the viewer with no
+    # signal to the operator. That matters more now that ``content`` is the only
+    # copy.
+    records = []
     content_failures = []
-    for i, upload in enumerate(data_file_uploads):
-        upload["name"] = insight_files[i]["name"]
-        upload["name_hash"] = insight_files[i]["name_hash"]
-        local_path = os.path.join(output_dir, insight_files[i]["file_path"])
+    for insight_file in insight_files:
+        record = {"name": insight_file["name"], "name_hash": insight_file["name_hash"]}
+        local_path = os.path.join(output_dir, insight_file["file_path"])
         try:
             with open(local_path, "r") as f:
-                upload["content"] = json.load(f)
+                record["content"] = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             Logger.instance().warning(
-                f"Could not load insight JSON content for {insight_files[i]['name']}: {e}"
+                f"Could not load insight JSON content for {insight_file['name']}: {e}"
             )
-            upload["content"] = None
-            content_failures.append(insight_files[i]["name"])
+            record["content"] = None
+            content_failures.append(insight_file["name"])
+        records.append(record)
     if content_failures:
         raise click.ClickException(
             f"Failed to read insight JSON content for {len(content_failures)} insight(s): "
@@ -634,8 +598,8 @@ async def process_insights_async(
         )
 
     tasks = []
-    for i in range(0, len(data_file_uploads), batch_size):
-        batch = data_file_uploads[i : i + batch_size]
+    for i in range(0, len(records), batch_size):
+        batch = records[i : i + batch_size]
         task = create_insight_records(batch, project_id, json_headers, host, progress)
         tasks.append(task)
     response_items = await asyncio.gather(*tasks, return_exceptions=True)
@@ -665,69 +629,36 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
     if not input_files:
         return
 
-    total_operations = len(input_files)
-    total_operations += 3 * math.ceil(len(input_files) / batch_size)
-    progress = {"completed": 0, "total": total_operations}
+    # One operation per batch: there are no files to create, upload or finish.
+    # The envelope IS ``content``. It used to be uploaded to the bucket as well
+    # and core never read it back — every response is built from ``content``
+    # plus the MODEL job's parquet URL — so the upload was pure object count
+    # (VIS-1125).
+    progress = {"completed": 0, "total": math.ceil(len(input_files) / batch_size)}
 
-    # Create file records
-    tasks = []
-    for i in range(0, len(input_files), batch_size):
-        batch = input_files[i : i + batch_size]
-        items = [{"filename": f["file_path"].split("/")[-1], "name": f["name"]} for f in batch]
-        task = start_files(items, "input", form_headers, host, progress, project_id=project_id)
-        tasks.append(task)
-    data_file_ids = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(data_file_ids, "Failed to create input files")
-
-    data_file_uploads = [item for sublist in data_file_ids for item in sublist]
-
-    # Upload files
-    tasks = []
-    for i, data_file_upload in enumerate(data_file_uploads):
-        input_file = input_files[i]
-        task = upload_file(
-            input_file["name"],
-            data_file_upload["upload_url"],
-            input_file["file_path"],
-            output_dir,
-            form_headers,
-            progress,
-        )
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to upload input data")
-
-    # Finish files
-    data_file_ids_list = [item["id"] for item in data_file_uploads]
-    tasks = []
-    for i in range(0, len(data_file_ids_list), batch_size):
-        batch = data_file_ids_list[i : i + batch_size]
-        task = finish_files(batch, "input", form_headers, host, progress)
-        tasks.append(task)
-    response_items = await asyncio.gather(*tasks, return_exceptions=True)
-    _raise_if_any_failed(response_items, "Failed to finish input files")
-
-    # Create input records - merge input metadata with file upload info.
-    # Read the local JSON content so core can store it on the InputJob
-    # row and serve a fully-inlined response from /api/input-jobs/
-    # (matching visivo Flask's contract).
+    # Read the local JSON so core can store it on the InputJob row and serve a
+    # fully-inlined response from /api/input-jobs/ (matching visivo Flask's
+    # contract).
     #
-    # See process_insights_async for why we abort on any failure rather
-    # than letting NULL ``content`` rows reach the cloud.
+    # Abort on any failure rather than letting NULL ``content`` rows reach the
+    # cloud: a silent warning would render an empty input to the viewer with no
+    # signal to the operator. That matters more now that ``content`` is the only
+    # copy.
+    records = []
     content_failures = []
-    for i, upload in enumerate(data_file_uploads):
-        upload["name"] = input_files[i]["name"]
-        upload["name_hash"] = input_files[i]["name_hash"]
-        local_path = os.path.join(output_dir, input_files[i]["file_path"])
+    for input_file in input_files:
+        record = {"name": input_file["name"], "name_hash": input_file["name_hash"]}
+        local_path = os.path.join(output_dir, input_file["file_path"])
         try:
             with open(local_path, "r") as f:
-                upload["content"] = json.load(f)
+                record["content"] = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             Logger.instance().warning(
-                f"Could not load input JSON content for {input_files[i]['name']}: {e}"
+                f"Could not load input JSON content for {input_file['name']}: {e}"
             )
-            upload["content"] = None
-            content_failures.append(input_files[i]["name"])
+            record["content"] = None
+            content_failures.append(input_file["name"])
+        records.append(record)
     if content_failures:
         raise click.ClickException(
             f"Failed to read input JSON content for {len(content_failures)} input(s): "
@@ -735,8 +666,8 @@ async def process_inputs_async(inputs, output_dir, project_id, form_headers, jso
         )
 
     tasks = []
-    for i in range(0, len(data_file_uploads), batch_size):
-        batch = data_file_uploads[i : i + batch_size]
+    for i in range(0, len(records), batch_size):
+        batch = records[i : i + batch_size]
         task = create_input_records(batch, project_id, json_headers, host, progress)
         tasks.append(task)
     response_items = await asyncio.gather(*tasks, return_exceptions=True)

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -104,10 +104,16 @@ def dist_phase(
         with open(f"{dist_dir}/data/traces.json", "w") as f:
             json.dump(traces_list, f)
 
-        # Copy parquet data files used by insights and inputs
-        files_src = os.path.join(run_dir, "files")
-        if os.path.isdir(files_src):
-            os.makedirs(f"{dist_dir}/data/files", exist_ok=True)
+        # Copy parquet data files used by insights and inputs. The run writes
+        # them into the directory named for what produced them (VIS-1128), but
+        # dist stays FLAT: refs are rewritten to data/files/<basename> and the
+        # viewer's dist mode reads them there. Names are globally unique within
+        # a project, so flattening cannot collide.
+        os.makedirs(f"{dist_dir}/data/files", exist_ok=True)
+        for src_dir in ("models", "insights", "inputs"):
+            files_src = os.path.join(run_dir, src_dir)
+            if not os.path.isdir(files_src):
+                continue
             for parquet_file in glob(f"{files_src}/*.parquet"):
                 filename = os.path.basename(parquet_file)
                 shutil.copyfile(parquet_file, f"{dist_dir}/data/files/{filename}")

--- a/visivo/jobs/run_input_job.py
+++ b/visivo/jobs/run_input_job.py
@@ -6,7 +6,7 @@ This module handles both single-select and multi-select input types:
 - MultiSelectInput: Execute options OR range queries, store as parquet/JSON
 
 Output follows the insights pattern:
-- Parquet files in {output_dir}/files/{name}_{key}.parquet for list data
+- Parquet files in {output_dir}/inputs/{name}_{key}.parquet for list data
 - Metadata JSON in {output_dir}/inputs/{name}.json with file references
 - Scalars (range values, single-select defaults) resolved at runtime and stored in metadata
 """
@@ -58,9 +58,10 @@ def _write_parquet_file(
     """
     # Organize files by run_id
     run_output_dir = f"{output_dir}/{run_id}"
-    files_directory = f"{run_output_dir}/files"
-    os.makedirs(files_directory, exist_ok=True)
-    parquet_path = f"{files_directory}/{input_name}_{key}.parquet"
+    # Beside the input's own metadata, in inputs/ — see run_model_data_job.
+    inputs_directory = f"{run_output_dir}/inputs"
+    os.makedirs(inputs_directory, exist_ok=True)
+    parquet_path = f"{inputs_directory}/{input_name}_{key}.parquet"
     df.write_parquet(parquet_path)
     return parquet_path
 
@@ -490,7 +491,7 @@ def action(
     Execute input job - compute options/range and store results as parquet + JSON metadata.
 
     Output structure follows the insights pattern:
-    - Parquet files in {output_dir}/{run_id}/files/{name}_{key}.parquet
+    - Parquet files in {output_dir}/{run_id}/inputs/{name}_{key}.parquet
     - Metadata JSON in {output_dir}/{run_id}/inputs/{name}.json
 
     Args:

--- a/visivo/jobs/run_insight_job.py
+++ b/visivo/jobs/run_insight_job.py
@@ -26,7 +26,8 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
         run_id: Run ID for this execution (default: "main" for standard runs)
     """
     # Organize files by run_id
-    # Structure: {output_dir}/{run_id}/files/ and {output_dir}/{run_id}/insights/
+    # Structure: {output_dir}/{run_id}/{models,insights}/ — parquet lives in
+    # the directory named for what produced it (VIS-1128).
     run_output_dir = f"{output_dir}/{run_id}"
     start_time = time()
     insight_query_info = None
@@ -63,17 +64,20 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
                         f"Input validation failed for insight '{insight.name}': {str(e)}"
                     ) from e
 
-        files_directory = f"{run_output_dir}/files"
+        # A static insight's precomputed result is the insight's own file, so
+        # it lives beside its metadata in insights/. A dynamic insight has none
+        # — it references the models it queries, which live in models/.
+        models_directory = f"{run_output_dir}/models"
         insights_directory = f"{run_output_dir}/insights"
 
         if insight_query_info.pre_query:
             from visivo.jobs.parquet_io import write_dicts_to_parquet
 
             data = source.read_sql(insight_query_info.pre_query)
-            os.makedirs(files_directory, exist_ok=True)
+            os.makedirs(insights_directory, exist_ok=True)
             # name_hash stays in the metadata as the DuckDB table identifier;
             # the file on disk uses the clean name for storage consistency.
-            parquet_path = f"{files_directory}/{insight.name}.parquet"
+            parquet_path = f"{insights_directory}/{insight.name}.parquet"
             write_dicts_to_parquet(data, parquet_path)
             files = [{"name_hash": insight.name_hash(), "signed_data_file_url": parquet_path}]
         else:
@@ -81,10 +85,10 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
             files = [
                 {
                     "name_hash": model.name_hash(),
-                    "signed_data_file_url": f"{files_directory}/{model.name}.parquet",
+                    "signed_data_file_url": f"{models_directory}/{model.name}.parquet",
                 }
                 for model in models
-                if os.path.exists(f"{files_directory}/{model.name}.parquet")
+                if os.path.exists(f"{models_directory}/{model.name}.parquet")
             ]
 
         # Store insight metadata with file references and post_query

--- a/visivo/jobs/run_model_data_job.py
+++ b/visivo/jobs/run_model_data_job.py
@@ -32,9 +32,13 @@ def write_parquet_from_data(
     Returns:
         Path to the written parquet file
     """
-    files_directory = f"{output_dir}/{run_id}/files"
-    os.makedirs(files_directory, exist_ok=True)
-    parquet_path = f"{files_directory}/{name}.parquet"
+    # Parquet lives in the directory named for what produced it — models/,
+    # insights/, inputs/ — so the layout on disk says what each file IS. They
+    # all used to share files/, which meant nothing downstream could tell a
+    # model's data from a static insight's result without the dag (VIS-1128).
+    models_directory = f"{output_dir}/{run_id}/models"
+    os.makedirs(models_directory, exist_ok=True)
+    parquet_path = f"{models_directory}/{name}.parquet"
     write_dicts_to_parquet(data, parquet_path)
     return parquet_path
 

--- a/visivo/server/views/file_views.py
+++ b/visivo/server/views/file_views.py
@@ -12,17 +12,24 @@ def register_file_views(app, output_dir):
     _cache = {}
     _lock = threading.Lock()
 
-    def _files_dir(run_id):
-        return os.path.join(output_dir, run_id, "files")
+    # Parquet is written into the directory named for what produced it, so the
+    # layout says what each file is (VIS-1128). A hash still resolves against
+    # all of them: the caller asks by alpha_hash(name) and does not know, or
+    # need to know, which kind of job built the thing it is asking for.
+    PARQUET_DIRS = ("models", "insights", "inputs")
+
+    def _parquet_dirs(run_id):
+        return [os.path.join(output_dir, run_id, d) for d in PARQUET_DIRS]
 
     def _build_cache(run_id):
         mapping = {}
-        files_dir = _files_dir(run_id)
-        if os.path.isdir(files_dir):
+        for files_dir in _parquet_dirs(run_id):
+            if not os.path.isdir(files_dir):
+                continue
             for entry in os.listdir(files_dir):
                 if entry.endswith(".parquet"):
                     stem = entry[: -len(".parquet")]
-                    mapping[alpha_hash(stem)] = entry
+                    mapping[alpha_hash(stem)] = os.path.join(files_dir, entry)
         return mapping
 
     def _resolve_filename(hash_value, run_id):
@@ -38,23 +45,22 @@ def register_file_views(app, output_dir):
         """Serve a parquet by hash, with a fallback that hashes on-disk stems.
 
         Resolution order:
-          1. Direct match: ``<run_id>/files/<hash>.parquet`` (legacy path used
+          1. Direct match: ``<run_id>/<dir>/<hash>.parquet`` (legacy path used
              pre-1.0.82 when parquets were written with hash filenames).
-          2. Hash-of-stem fallback: scan the run's files dir, return the
-             parquet whose stem hashes to ``<hash>``. This is the post-1.0.82
-             path — parquets are written under their clean model name while
-             the frontend still requests ``alpha_hash(model_name)``.
+          2. Hash-of-stem fallback: scan the run's parquet dirs, return the
+             one whose stem hashes to ``<hash>``. This is the post-1.0.82 path
+             — parquets are written under their clean name while the frontend
+             still requests ``alpha_hash(name)``.
         """
         try:
-            data_file = os.path.join(output_dir, run_id, "files", f"{hash}.parquet")
-            if os.path.exists(data_file):
-                return send_file(data_file)
+            for files_dir in _parquet_dirs(run_id):
+                data_file = os.path.join(files_dir, f"{hash}.parquet")
+                if os.path.exists(data_file):
+                    return send_file(data_file)
 
-            filename = _resolve_filename(hash, run_id)
-            if filename:
-                resolved = os.path.join(output_dir, run_id, "files", filename)
-                if os.path.exists(resolved):
-                    return send_file(resolved)
+            resolved = _resolve_filename(hash, run_id)
+            if resolved and os.path.exists(resolved):
+                return send_file(resolved)
 
             return (
                 jsonify({"message": f"Data file not found for hash: {hash} in run: {run_id}"}),

--- a/visivo/server/views/model_jobs_views.py
+++ b/visivo/server/views/model_jobs_views.py
@@ -38,7 +38,9 @@ def register_model_jobs_views(app, flask_app, output_dir):
             missing = []
 
             for name in model_names:
-                data_file = os.path.join(output_dir, run_id, "files", f"{name}.parquet")
+                # models/, not files/: parquet is written into the directory
+                # named for what produced it (VIS-1128).
+                data_file = os.path.join(output_dir, run_id, "models", f"{name}.parquet")
                 if not os.path.exists(data_file):
                     Logger.instance().info(f"Model data file not found: {data_file}")
                     missing.append(name)


### PR DESCRIPTION
Closes the visivo half of VIS-1128. Pairs with [visivo-io/core#331](https://github.com/visivo-io/core/pull/331), which is what this unblocks. **Stacked on [#563](https://github.com/visivo-io/visivo/pull/563)**.

## One directory, three meanings

Everything a run built landed in `files/`: a model's data, a static insight's precomputed result, and a query-based input's options. Nothing downstream could tell them apart from the layout. The deploy managed it only because it holds the `dag` — and the runner, which has none, labelled every parquet a model, so a static insight's result became a `ModelJob` named after the insight.

```
target/<run>/models/{model}.parquet
target/<run>/insights/{insight}.parquet     ← beside insights/{insight}.json
target/<run>/inputs/{input}_{key}.parquet   ← beside inputs/{input}.json
```

Three writers, one line each — `run_model_data_job`, `run_insight_job`, `run_input_job`. The JSON envelopes were already organised this way; the parquet now matches. An insight's result sits beside its metadata, which is where it belongs: it *is* the insight's file.

## Readers

- **Flask** resolves a hash across all three dirs. The caller asks by `alpha_hash(name)` and neither knows nor should know which kind of job built what it wants.
- **`model_jobs_views`** reads `models/` — it serves model data by definition.
- **dist stays flat, deliberately.** Refs are rewritten to `data/files/<basename>` and the viewer's dist mode reads them there, so nothing in the viewer changes. Names are globally unique within a project, so flattening cannot collide.
- **deploy collectors** follow the new paths.

The viewer is untouched throughout — it goes through `/api/files/<name>/<run_id>/`, an API route rather than a filesystem path.

## No fallback for `files/`

`target/` is rebuilt by every run, and a fallback would preserve exactly the ambiguity this removes.

## Testing

New: a parquet in each of the three directories resolves through the hash route, which is the property the multi-dir scan exists for.

Updated: `_put_parquet` and the model-jobs fixtures write into the typed dirs; the collector tests place a static insight's result in `insights/` and a model's in `models/`.

**2309 passed.** The 3 failures in `tests/templates/test_samples.py` are pre-existing and environmental (`pyenv: visivo command not found`) — identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
