### PR TITLE
The whole-project read answers with an envelope, not the tree

### DIFF
--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -82,7 +82,13 @@ def test_dist_creates_dist_folder(setup_project, output_dir, dist_dir):
         data = json.load(project_json)
         assert "id" in data
         assert "created_at" in data
-        assert "project_json" in data
+        # The bundle ships the same envelope the server serves, not the
+        # whole dereferenced project tree.
+        assert "project_json" not in data
+        assert data["name"] == project.name
+        assert "defaults" in data["config"]
+        assert "dashboard_count" in data
+        assert "source_count" in data
 
 
 def test_dist_errors_without_data(setup_project, output_dir, dist_dir):

--- a/tests/commands/test_serve.py
+++ b/tests/commands/test_serve.py
@@ -59,7 +59,12 @@ def test_serve(output_dir):
     client = server.app.test_client()
     response = client.get("/api/project/")
     response_json = json.loads(response.data)
-    assert "project_json" in response_json
+    # The canonical envelope, not the whole project tree.
+    assert "project_json" not in response_json
+    assert response_json["name"] == project.name
+    assert "defaults" in response_json["config"]
+    assert "dashboard_count" in response_json
+    assert "source_count" in response_json
 
     response = client.get("/api/error/")
     response_json = json.loads(response.data)

--- a/viewer/src/api/project.js
+++ b/viewer/src/api/project.js
@@ -2,14 +2,15 @@ import { getUrl } from '../contexts/URLContext';
 import { apiFetch } from './utils';
 
 // ============================================================
-// Legacy bulk-blob endpoint
+// Whole-project read
 // ============================================================
 //
-// `/api/project/` returns the dereferenced project_json blob — the entire
-// project tree as one giant JSON object. Used by the project loader
-// (loaders/project.js) and the onboarding/commonStore flow. New code should
-// NOT call this; use `fetchProject(id)` to get the canonical per-resource
-// envelope. Candidate for removal once the loader moves to fetchProject(id).
+// `/api/project/` returns the project envelope — `{id, name, status,
+// project_dir, config: {defaults}, dashboard_count, source_count}`. Used by
+// the project loader (loaders/project.js) and the onboarding/commonStore
+// flow. It used to return the entire dereferenced project tree as one
+// `project_json` blob; the fields above are what consumers actually read out
+// of it. Resource lists come from their own endpoints, not from here.
 export const fetchProjectBlob = async (projectId = null) => {
   let url = getUrl('project');
   if (projectId) url += `?project_id=${encodeURIComponent(projectId)}`;

--- a/viewer/src/components/onboarding/OnboardingFlow.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.jsx
@@ -31,8 +31,8 @@ export default function OnboardingFlow() {
   const project = useStore(s => s.project);
   const fetchProject = useStore(s => s.fetchProject);
 
-  const projectDir = project?.project_json?.project_dir ?? '';
-  const projectName = project?.project_json?.name || 'Quickstart Visivo';
+  const projectDir = project?.project_dir ?? '';
+  const projectName = project?.name || 'Quickstart Visivo';
 
   const persisted = useRef(readOnboardingState() || {});
   const startTs = useRef(Date.now());

--- a/viewer/src/components/onboarding/OnboardingFlow.test.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.test.jsx
@@ -56,7 +56,7 @@ beforeEach(() => {
 
   useStore.mockImplementation(selector =>
     selector({
-      project: { project_json: { project_dir: '/tmp/demo', name: 'Quickstart Visivo' } },
+      project: { project_dir: '/tmp/demo', name: 'Quickstart Visivo' },
       fetchProject: jest.fn().mockResolvedValue(undefined),
     })
   );

--- a/viewer/src/components/onboarding/onboardingManifest.js
+++ b/viewer/src/components/onboarding/onboardingManifest.js
@@ -13,14 +13,15 @@
  *                 entries from `includes:` not just top-level YAML).
  *   models      — modelStore.models (same caveat).
  *   insights    — insightStore.insights.
- *   dashboards  — dashboardStore items if present, else fall back to
- *                 project.project_json.dashboards.
+ *   dashboards  — dashboardStore items if present, else the envelope's
+ *                 project.dashboard_count.
  *   persisted   — the parsed onboarding state from localStorage
  *                 (role / path / source_connected / cloud_connected /
  *                 deployed_at / visited_project_route / ...).
  *
- * Why not just project.project_json.{models,insights}? Because top-level
- * `models:` is empty when the user organizes their YAML through includes,
+ * Why the dedicated stores rather than counts off the project envelope?
+ * Because top-level `models:` is empty when the user organizes YAML through
+ * includes,
  * which is the recommended pattern. The dedicated stores fetch the
  * fully-resolved lists from the server.
  *
@@ -49,7 +50,7 @@ export const CHECKLIST_ITEMS = [
     weight: 10,
     predicate: ({ project, sources, persisted }) =>
       (sources?.length ?? 0) > 0 ||
-      (project?.project_json?.sources?.length ?? 0) > 0 ||
+      (project?.source_count ?? 0) > 0 ||
       !!persisted.source_connected,
   },
   {

--- a/viewer/src/components/onboarding/onboardingManifest.test.js
+++ b/viewer/src/components/onboarding/onboardingManifest.test.js
@@ -53,27 +53,27 @@ describe('onboardingManifest', () => {
     });
   });
 
-  test('connect_source predicate is satisfied by sources slice OR project.json OR onboarding flag', () => {
+  test('connect_source predicate is satisfied by sources slice OR source_count OR onboarding flag', () => {
     const it = CHECKLIST_ITEMS.find(i => i.id === 'connect_source');
     expect(
-      it.predicate({ project: { project_json: { sources: [] } }, sources: [], persisted: {} })
+      it.predicate({ project: { source_count: 0 }, sources: [], persisted: {} })
     ).toBe(false);
     expect(
       it.predicate({
-        project: { project_json: { sources: [] } },
+        project: { source_count: 0 },
         sources: [{ name: 'a' }],
         persisted: {},
       })
     ).toBe(true);
     expect(
       it.predicate({
-        project: { project_json: { sources: [{ name: 'a' }] } },
+        project: { source_count: 1 },
         sources: [],
         persisted: {},
       })
     ).toBe(true);
     expect(
-      it.predicate({ project: { project_json: {} }, sources: [], persisted: { source_connected: true } })
+      it.predicate({ project: {}, sources: [], persisted: { source_connected: true } })
     ).toBe(true);
   });
 

--- a/viewer/src/components/project/Project.jsx
+++ b/viewer/src/components/project/Project.jsx
@@ -13,7 +13,7 @@ import useProjectChangeListener from '../views/workspace/useProjectChangeListene
 /**
  * Project - Container component for the new project view
  * Fetches data from stores and passes to Dashboard
- * Reads dashboards from the store instead of a project_json blob
+ * Reads dashboards from the store
  *
  * e2e-gap-review.md D7 ("VIS-1087's remaining half"): `/project` (this
  * component) and `/runs` (RunsView.jsx) render OUTSIDE the Workspace shell —
@@ -81,12 +81,9 @@ function Project() {
     return entry.config || entry;
   }, [dashboards, dashboardName]);
 
-  // Project defaults can live in either of two envelope shapes:
-  //   - visivo Studio: ``project.project_json.defaults`` (full project_json blob)
-  //   - core's canonical envelope: ``project.config.defaults``
-  // Read both so the dashboard filter init works against either backend
-  // without forcing the wrapper to adapt.
-  const projectDefaults = project?.config?.defaults ?? project?.project_json?.defaults;
+  // Both servers answer the whole-project read with the same envelope, so
+  // there is one shape to read defaults out of.
+  const projectDefaults = project?.config?.defaults;
 
   // Initialize dashboard filtering system when dashboards load
   useEffect(() => {

--- a/viewer/src/components/views/project/editor/ProjectEditor.jsx
+++ b/viewer/src/components/views/project/editor/ProjectEditor.jsx
@@ -175,9 +175,9 @@ const ProjectEditor = () => {
   }, []);
 
   const projectName =
-    project?.project_json?.name || project?.name || 'project';
+    project?.name || 'project';
   const projectDefaults =
-    defaults || project?.config?.defaults || project?.project_json?.defaults || null;
+    defaults || project?.config?.defaults || null;
 
   const summary = useMemo(
     () =>

--- a/viewer/src/components/views/workspace/TabStrip.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.jsx
@@ -261,7 +261,7 @@ const TabStrip = () => {
   // early return would otherwise hide the `+` affordance on every fresh visit.
   const safeTabs = tabs || [];
 
-  const projectName = project?.project_json?.name || project?.name || 'project';
+  const projectName = project?.name || 'project';
 
   // The + affordance (and Cmd/Ctrl+T) opens the Workspace's "empty tab" — the
   // Project destination's Home. `openWorkspaceTab` routes a `project`-typed

--- a/viewer/src/components/views/workspace/TabStrip.test.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.test.jsx
@@ -31,7 +31,7 @@ const seedStore = (extra = {}) => {
       closeWorkspaceTab: jest.fn(),
       requestCloseWorkspaceTab: jest.fn(),
       openWorkspaceTab: jest.fn(),
-      project: { id: 'p1', project_json: { name: 'analytics-platform' } },
+      project: { id: 'p1', name: 'analytics-platform' },
       ...extra,
     });
   });

--- a/viewer/src/components/views/workspace/Workspace.jsx
+++ b/viewer/src/components/views/workspace/Workspace.jsx
@@ -65,7 +65,7 @@ const Workspace = () => {
   // (ExplorationPane) — fetched here so it's populated before either mounts.
   const fetchExplorations = useStore(s => s.fetchExplorations);
 
-  const projectName = project?.project_json?.name || project?.name || 'project';
+  const projectName = project?.name || 'project';
 
   // Fire every collection load when the workspace mounts. Per-slice fetches
   // record their own errors; the `.catch` just guards against an unhandled

--- a/viewer/src/components/views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/views/workspace/Workspace.test.jsx
@@ -102,7 +102,7 @@ const resetWorkspaceStore = () => {
       // Stub project that the loader normally hydrates.
       project: {
         id: 'p1',
-        project_json: { name: 'analytics-platform' },
+        name: 'analytics-platform',
       },
       // Stub a no-op checkCommitStatus / openCommitModal so the
       // Workspace mount effect doesn't throw.
@@ -409,7 +409,7 @@ describe('VIS-775 Workspace shell', () => {
     // (the pathname/search haven't changed, so the synced-target guard holds).
     act(() => {
       useStore.setState({
-        project: { id: 'p1', project_json: { name: 'analytics-platform' } },
+        project: { id: 'p1', name: 'analytics-platform' },
       });
     });
     expect(useStore.getState().workspaceActiveTabId).toBeNull();
@@ -424,7 +424,7 @@ describe('VIS-775 Workspace shell', () => {
     ).not.toBeInTheDocument();
     act(() => {
       useStore.setState({
-        project: { id: 'p1', project_json: { name: 'analytics-platform' } },
+        project: { id: 'p1', name: 'analytics-platform' },
       });
     });
     expect(

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -894,7 +894,7 @@ const WorkspaceDndContext = ({ children }) => {
   );
 
   const projectDefaults = useMemo(
-    () => defaults || project?.config?.defaults || project?.project_json?.defaults || null,
+    () => defaults || project?.config?.defaults || null,
     [defaults, project]
   );
 

--- a/viewer/src/components/views/workspace/homes/ProjectHomePane.jsx
+++ b/viewer/src/components/views/workspace/homes/ProjectHomePane.jsx
@@ -12,7 +12,7 @@ import useStore from '../../../../stores/store';
  */
 const ProjectHomePane = () => {
   const project = useStore(s => s.project);
-  const projectName = project?.project_json?.name || project?.name || 'project';
+  const projectName = project?.name || 'project';
   return (
     <section
       data-testid="workspace-middle-project"

--- a/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.js
+++ b/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.js
@@ -95,7 +95,7 @@ export const handleTabShortcut = (e, store, { mac = isMacPlatform() } = {}) => {
   if (key === 't') {
     e.preventDefault();
     const project = store.project;
-    const projectName = project?.project_json?.name || project?.name || 'project';
+    const projectName = project?.name || 'project';
     if (store.openWorkspaceTab) {
       store.openWorkspaceTab({
         id: `project:${projectName}`,

--- a/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.test.jsx
+++ b/viewer/src/components/views/workspace/useWorkspaceTabShortcuts.test.jsx
@@ -28,7 +28,7 @@ const makeEvent = (overrides = {}) => ({
 });
 
 const makeStore = (overrides = {}) => ({
-  project: { project_json: { name: 'analytics' } },
+  project: { name: 'analytics' },
   // Views (project/semantic-layer/explorer) left the tab model in Phase 0 —
   // `workspaceTabs` holds only DOCUMENT tabs now.
   workspaceTabs: [

--- a/viewer/src/stores/branchingStore.test.js
+++ b/viewer/src/stores/branchingStore.test.js
@@ -53,11 +53,11 @@ describe('branchingStore', () => {
       branchingApi.createDraft.mockResolvedValueOnce(draft);
       branchingApi.fetchCapabilities.mockResolvedValueOnce({ can_edit: true });
       const setProject = jest.fn();
-      const store = build({ project: { id: 'proj-1', project_json: { x: 1 } }, setProject });
+      const store = build({ project: { id: 'proj-1', dashboard_count: 1 }, setProject });
       const result = await store.get().startEdit();
       expect(branchingApi.createDraft).toHaveBeenCalledWith('proj-1');
       // Merged: keeps existing project data, retargets the id.
-      expect(setProject).toHaveBeenCalledWith({ id: 'draft-9', name: 'p', project_json: { x: 1 } });
+      expect(setProject).toHaveBeenCalledWith({ id: 'draft-9', name: 'p', dashboard_count: 1 });
       expect(result).toEqual({ success: true, project: draft });
     });
 

--- a/viewer/src/stores/commonStore.js
+++ b/viewer/src/stores/commonStore.js
@@ -26,8 +26,8 @@ const computeIsOnboardingRequested = () => {
 const createCommonSlice = (set, get) => {
   const evaluateIsNewProject = () => {
     const { project } = get();
-    const dashboards = project?.project_json?.dashboards ?? [];
-    const isNew = project?.project_json?.name === 'Quickstart Visivo' && dashboards.length === 0;
+    const isNew =
+      project?.name === 'Quickstart Visivo' && (project?.dashboard_count ?? 0) === 0;
     set({ isNewProject: isNew });
   };
 
@@ -69,11 +69,6 @@ const createCommonSlice = (set, get) => {
     },
 
     fetchProject: async () => {
-      // Onboarding/legacy callers expect the bulk project_json blob (used
-      // by `evaluateIsNewProject` and the project loader). The canonical
-      // per-resource endpoint returns a slim envelope and won't satisfy
-      // those consumers. Switch to `fetchProject` from api/project.js
-      // when the loader + Onboarding are migrated.
       const project = await fetchProjectBlob();
       invalidateSchemaCachesOnProjectSwitch(project);
       set({ project });

--- a/viewer/src/stores/commonStore.test.js
+++ b/viewer/src/stores/commonStore.test.js
@@ -125,10 +125,11 @@ describe('commonStore slice actions', () => {
       const store = createHarness();
 
       store.getState().setProject({
-        project_json: { name: 'Quickstart Visivo', dashboards: [] },
+        name: 'Quickstart Visivo',
+        dashboard_count: 0,
       });
 
-      expect(store.getState().project.project_json.name).toBe('Quickstart Visivo');
+      expect(store.getState().project.name).toBe('Quickstart Visivo');
       expect(store.getState().isNewProject).toBe(true);
     });
 
@@ -136,7 +137,8 @@ describe('commonStore slice actions', () => {
       const store = createHarness();
 
       store.getState().setProject({
-        project_json: { name: 'Quickstart Visivo', dashboards: [{ name: 'd1' }] },
+        name: 'Quickstart Visivo',
+        dashboard_count: 1,
       });
 
       expect(store.getState().isNewProject).toBe(false);
@@ -145,12 +147,12 @@ describe('commonStore slice actions', () => {
     test('a differently-named project is not new even with no dashboards', () => {
       const store = createHarness();
 
-      store.getState().setProject({ project_json: { name: 'my-project', dashboards: [] } });
+      store.getState().setProject({ name: 'my-project', dashboard_count: 0 });
 
       expect(store.getState().isNewProject).toBe(false);
     });
 
-    test('handles a project without project_json without throwing', () => {
+    test('handles a project envelope with neither field without throwing', () => {
       const store = createHarness();
 
       store.getState().setProject({ id: 'p1' });
@@ -170,22 +172,24 @@ describe('commonStore slice actions', () => {
   });
 
   describe('fetchProject', () => {
-    test('loads the bulk project blob and evaluates isNewProject', async () => {
+    test('loads the project envelope and evaluates isNewProject', async () => {
       fetchProjectBlob.mockResolvedValue({
-        project_json: { name: 'Quickstart Visivo', dashboards: [] },
+        name: 'Quickstart Visivo',
+        dashboard_count: 0,
       });
       const store = createHarness();
 
       await store.getState().fetchProject();
 
       expect(fetchProjectBlob).toHaveBeenCalledTimes(1);
-      expect(store.getState().project.project_json.name).toBe('Quickstart Visivo');
+      expect(store.getState().project.name).toBe('Quickstart Visivo');
       expect(store.getState().isNewProject).toBe(true);
     });
 
     test('an existing project loads as not-new', async () => {
       fetchProjectBlob.mockResolvedValue({
-        project_json: { name: 'prod-analytics', dashboards: [{ name: 'kpis' }] },
+        name: 'prod-analytics',
+        dashboard_count: 1,
       });
       const store = createHarness();
 
@@ -280,7 +284,7 @@ describe('commonStore slice actions', () => {
       store.getState().setProject({ id: 'proj-1' });
       await warm();
 
-      store.getState().setProject({ project_json: { name: 'local', dashboards: [] } });
+      store.getState().setProject({ name: 'local', dashboard_count: 0 });
 
       expect(isObjectSchemaLoaded()).toBe(true);
     });
@@ -291,7 +295,7 @@ describe('commonStore slice actions', () => {
       await warm();
 
       // Same-id refetch (the project_changed soft-refresh shape) — intact.
-      fetchProjectBlob.mockResolvedValue({ id: 'proj-1', project_json: { name: 'p' } });
+      fetchProjectBlob.mockResolvedValue({ id: 'proj-1', name: 'p' });
       await store.getState().fetchProject();
       expect(isObjectSchemaLoaded()).toBe(true);
       expect(validateRecordConfigSync('dimension', { expression: 'x' })).toEqual(
@@ -299,7 +303,7 @@ describe('commonStore slice actions', () => {
       );
 
       // Id flip (e.g. the active project became a different one) — cleared.
-      fetchProjectBlob.mockResolvedValue({ id: 'proj-2', project_json: { name: 'p2' } });
+      fetchProjectBlob.mockResolvedValue({ id: 'proj-2', name: 'p2' });
       await store.getState().fetchProject();
       expect(validateRecordConfigSync('dimension', { expression: 'x' })).toBeNull();
       expect(isObjectSchemaLoaded()).toBe(false);

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -58,12 +58,20 @@ def dist_phase(
             dist_dashboards_dir = os.path.join(dist_dir, "data", "dashboards")
             shutil.copytree(dashboards_dir, dist_dashboards_dir, dirs_exist_ok=True)
         created_at = (datetime.datetime.now().isoformat(),)
+        # Same canonical envelope the server serves at /api/project/, so the
+        # viewer reads one shape in both modes. ``project_json`` below stays a
+        # local variable — it drives the per-dashboard files written further
+        # down — but the whole blob is no longer shipped in the bundle.
         with open(f"{dist_dir}/data/project.json", "w") as f:
             f.write(
                 json.dumps(
                     {
                         "id": "id",
-                        "project_json": project_json,
+                        "name": project_json["name"],
+                        "project_dir": project_json.get("project_dir") or "",
+                        "config": {"defaults": project_json.get("defaults", {})},
+                        "dashboard_count": len(project_json.get("dashboards") or []),
+                        "source_count": len(project_json.get("sources") or []),
                         "created_at": created_at,
                     }
                 )

--- a/visivo/server/views/data_views.py
+++ b/visivo/server/views/data_views.py
@@ -28,12 +28,21 @@ def register_data_views(app, flask_app, output_dir):
 
     @app.route("/api/project/")
     def projects_api():
+        # The canonical whole-project envelope: {id, name, status, config}.
+        # It used to carry the entire dereferenced project as ``project_json``
+        # and every consumer dug through that blob. The fields below are what
+        # they actually wanted — ``config.defaults`` nested the way the viewer
+        # reads it (it was flat here, so the nested read silently missed and
+        # fell through to the blob), plus the two counts and the directory the
+        # onboarding flow needs. Resource lists come from their own endpoints.
         project_data = json.loads(flask_app._project_json)
         return {
             "id": "id",
             "name": flask_app._project.name,
-            "project_json": project_data,
-            "config": project_data.get("defaults", {}),
+            "project_dir": flask_app._project.project_dir or "",
+            "config": {"defaults": project_data.get("defaults", {})},
+            "dashboard_count": len(project_data.get("dashboards") or []),
+            "source_count": len(project_data.get("sources") or []),
             "created_at": datetime.datetime.now().isoformat(),
             # Local serve is always an editable draft. This is the one signal
             # the viewer's run-poller (useRunPolling) gates on, so reporting it


### PR DESCRIPTION
Companion to core#334 (VIS-1113), which drops the `project_json` column from core. This removes the blob from the other two places it lived — the `visivo serve` payload and the `visivo dist` bundle.

## What changed

`/api/project/` and `data/project.json` both shipped the entire dereferenced project as one `project_json` blob, and every consumer dug through it for one or two fields. Both now return the same envelope:

```json
{"id", "name", "project_dir", "config": {"defaults": …},
 "dashboard_count", "source_count", "created_at", "status"}
```

Resource lists already have their own endpoints; nothing needed the tree.

## A latent bug this fixes

The viewer reads project defaults at `project?.config?.defaults`. The server put the defaults dict **at** `config`, not under it:

```python
"config": project_data.get("defaults", {}),     # before
```

So that read has been silently missing under `visivo serve` and falling through to `project_json.defaults` — which is why the fallback looked redundant but wasn't. Removing the blob without fixing the shape would have quietly broken dashboard filter defaults locally. The envelope is now nested the way `api/project.js` documented all along, and both servers agree.

## Consumers

Most already had the correct read first and the blob as a dead clause, so they only lose the clause:

- `project?.project_json?.name || project?.name` → `project?.name` — TabStrip, Workspace, useWorkspaceTabShortcuts, ProjectHomePane, ProjectEditor
- `?? project?.project_json?.defaults` dropped — Project.jsx, WorkspaceDndContext, ProjectEditor

**Onboarding was the real dependency** — `project_dir`, plus source and dashboard counts, with no other source. That is why the envelope gains those three fields rather than the blob simply being deleted:

- `OnboardingFlow` → `project?.project_dir`, `project?.name`
- `onboardingManifest` `connect_source` → `project?.source_count` (the `sourceStore` clause ahead of it is unchanged and still primary)
- `commonStore.evaluateIsNewProject` → `project?.name` + `project?.dashboard_count`

## Kept deliberately

`flask_app._project_json` stays. `matches_served_project()` compares it to tell a genuine external YAML edit (drops drafts) from a no-op save that recompiles identically (drafts must survive). That is a fingerprint, not a payload.

## Tests

- python `2318 passed`, 0 failures
- viewer `6659 passed`, 355 suites, `yarn lint` clean, `black --check` clean
- `test_serve` / `test_dist` now assert the envelope's shape and that `project_json` is **absent**, rather than that it is present

Note `ExplorationPromoteModal`'s "accepting the fallback offer…" and one `WorkspaceDndContext` case are flaky — they fail intermittently on a clean tree at this base too. Both pass on re-run; the green figures above are a full clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
