### PR TITLE
Render an insight's chart type from the live config

### DIFF
--- a/viewer/src/components/items/Chart.jsx
+++ b/viewer/src/components/items/Chart.jsx
@@ -55,6 +55,24 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
     })
   );
 
+  // Chart type from the LIVE authored config, so a config-only edit (bar→scatter)
+  // that skipped the runner renders immediately instead of showing the artifact's
+  // stale type (VIS-1023). Keyed by name, shallow-compared so it only re-renders
+  // when a type actually changes; empty in views that don't load insight configs,
+  // where chartDataFromInsightData falls back to the artifact type.
+  const insightTypeOverrides = useStore(
+    useShallow(state => {
+      if (!chartInsightNames.length) return {};
+      const overrides = {};
+      for (const name of chartInsightNames) {
+        const config = state.insights?.find(i => i.name === name)?.config;
+        const type = config?.props?.type ?? config?.type;
+        if (type) overrides[name] = type;
+      }
+      return overrides;
+    })
+  );
+
   const hasAllInsightData = useMemo(() => {
     if (!chartInsightNames.length) return true;
     return chartInsightNames.every(
@@ -73,14 +91,14 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
 
     if (hasInsights && insightsData) {
       const insightNames = chart.insights.map(i => i.name);
-      const insightData = chartDataFromInsightData(insightsData, inputs);
+      const insightData = chartDataFromInsightData(insightsData, inputs, insightTypeOverrides);
       data.push(
         ...insightData.filter(insight => insightNames.includes(insight.sourceInsight || insight.name))
       );
     }
 
     return data;
-  }, [insightsData, chart.insights, hasInsights, inputs]);
+  }, [insightsData, chart.insights, hasInsights, inputs, insightTypeOverrides]);
 
   const layoutRef = useMemo(() => {
     const l = structuredClone(chart.layout ? chart.layout : {});

--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -251,6 +251,12 @@ const Dashboard = ({
   // Input store
   const fetchInputs = useStore(state => state.fetchInputs);
   const getInputByName = useStore(state => state.getInputByName);
+
+  // Insight configs — the /project route doesn't otherwise load them, but Chart
+  // reads the live authored `type` from here so a config-only edit renders
+  // without a run (VIS-1023). Optional so older/other shells that don't provide
+  // the slice don't break.
+  const fetchInsights = useStore(state => state.fetchInsights);
   // Bumped by the run poller when a draft run succeeds; threaded into the data
   // hooks as a cacheKey so they refetch + force-reload the rebuilt output.
   const runDataVersion = useStore(state => state.runDataVersion);
@@ -300,7 +306,8 @@ const Dashboard = ({
     fetchMarkdowns();
     fetchInputs();
     fetchModels();
-  }, [fetchCharts, fetchTables, fetchMarkdowns, fetchInputs, fetchModels]);
+    fetchInsights?.();
+  }, [fetchCharts, fetchTables, fetchMarkdowns, fetchInputs, fetchModels, fetchInsights]);
 
   // Stable membership test against the fetched model registry. A name not present
   // in the registry is treated as a non-model (insight), preserving the prior

--- a/viewer/src/models/Insight.js
+++ b/viewer/src/models/Insight.js
@@ -395,7 +395,7 @@ export function applySliceExpression(value, sliceExpr) {
  * @param {Object} inputs - Optional map of input names to input objects with accessor values
  * @returns {Array<Object>} Array of Plotly trace objects
  */
-export function chartDataFromInsightData(insightsData, inputs = {}) {
+export function chartDataFromInsightData(insightsData, inputs = {}, typeOverrides = {}) {
   if (!insightsData) {
     return [];
   }
@@ -408,6 +408,14 @@ export function chartDataFromInsightData(insightsData, inputs = {}) {
     }
 
     const { data, props_mapping, split_key, type, static_props, props_slices } = insightObj;
+
+    // Presentation (the chart type) comes from the LIVE authored config when the
+    // caller supplies it, falling back to the type baked into the built artifact.
+    // A config-only edit (bar→scatter) skips the runner, so the artifact keeps
+    // the old type; overlaying the live value makes that edit render instantly
+    // instead of waiting for the next data run (VIS-1023). Data — props_mapping,
+    // query results, files — still comes from the artifact.
+    const effectiveType = typeOverrides[insightName] ?? type;
 
     if (!data || data.length === 0) {
       continue;
@@ -443,9 +451,9 @@ export function chartDataFromInsightData(insightsData, inputs = {}) {
           deepMergeStaticProps(traceProps, processedStaticProps);
         }
 
-        // Set trace type from insight definition
-        if (type) {
-          traceProps.type = type;
+        // Set trace type from the live config (or artifact fallback)
+        if (effectiveType) {
+          traceProps.type = effectiveType;
         }
 
         // Set trace name to split value only (for cleaner legend display)
@@ -467,9 +475,9 @@ export function chartDataFromInsightData(insightsData, inputs = {}) {
         deepMergeStaticProps(traceProps, processedStaticProps);
       }
 
-      // Set trace type from insight definition
-      if (type) {
-        traceProps.type = type;
+      // Set trace type from the live config (or artifact fallback)
+      if (effectiveType) {
+        traceProps.type = effectiveType;
       }
 
       traceProps.name = insightName;

--- a/viewer/src/models/Insight.test.js
+++ b/viewer/src/models/Insight.test.js
@@ -105,6 +105,48 @@ describe('chartDataFromInsightData', () => {
     expect(result[0].y).toEqual([10, 20]);
   });
 
+  it('overrides the artifact type with the live config type (VIS-1023)', () => {
+    // A config-only edit (bar→scatter) skips the runner, so the artifact keeps
+    // `bar`; the live type must win so the edit renders without a run.
+    const insight = {
+      'My Insight': {
+        data: [{ x_val: 1, y_val: 10 }],
+        props_mapping: { 'props.x': 'x_val', 'props.y': 'y_val' },
+        type: 'bar',
+      },
+    };
+    const result = chartDataFromInsightData(insight, {}, { 'My Insight': 'scatter' });
+    expect(result[0].type).toBe('scatter');
+  });
+
+  it('falls back to the artifact type when no override is supplied for the insight', () => {
+    const insight = {
+      'My Insight': {
+        data: [{ x_val: 1, y_val: 10 }],
+        props_mapping: { 'props.x': 'x_val', 'props.y': 'y_val' },
+        type: 'bar',
+      },
+    };
+    expect(chartDataFromInsightData(insight, {}, { Other: 'scatter' })[0].type).toBe('bar');
+  });
+
+  it('applies the type override on the split branch too', () => {
+    const insight = {
+      'Split Insight': {
+        data: [
+          { x_val: 1, y_val: 10, cohort: 'A' },
+          { x_val: 2, y_val: 20, cohort: 'B' },
+        ],
+        props_mapping: { 'props.x': 'x_val', 'props.y': 'y_val' },
+        split_key: 'cohort',
+        type: 'bar',
+      },
+    };
+    const result = chartDataFromInsightData(insight, {}, { 'Split Insight': 'scatter' });
+    expect(result.length).toBe(2);
+    expect(result.every(t => t.type === 'scatter')).toBe(true);
+  });
+
   it('skips insights without data or props_mapping', () => {
     const data = {
       invalid: {


### PR DESCRIPTION
VIS-1023. The config-only fast-path (core `459325d`) correctly skips the runner for a presentation-only edit like flipping an insight bar→scatter — but the chart kept rendering the old type until an unrelated data change forced a run, so the edit looked like it didn't take. The viewer read `type` off the built artifact, which the skipped run never updated.

## Fix

Type is presentation, not data — source it from the **live authored config**, keep data (`props_mapping`, query results, files) on the artifact.

- **`models/Insight.js`** — `chartDataFromInsightData(insightsData, inputs, typeOverrides = {})` prefers `typeOverrides[name]` over the artifact `type`, on both the split and non-split branches. The param defaults to `{}`, so every existing caller (and every surface that doesn't load insight configs) falls back to the artifact type exactly as before.
- **`components/items/Chart.jsx`** — builds the `{name: config.props.type ?? config.type}` map from the insight store, `useShallow`-compared so it only re-renders when a type actually changes, and passes it in.
- **`components/project/Dashboard.jsx`** — `fetchInsights()` on the `/project` route (it fetched charts/tables/markdowns/inputs but not insights), so the live type is present in the plain dashboard view and after a reload. Guarded with `?.` so a shell without the slice is unaffected.

## Scope / verification

- **Single choke point.** `chartDataFromInsightData` has exactly one non-test caller — `Chart.jsx`. The workspace `ChartPreview` and the explorer preview both render *through* Chart (the draft preview compiles the draft into a synthetic `insightJobs` entry), so they inherit the overlay with no separate change and already showed live type during editing anyway.
- **`static_props`** (colors/titles) is the documented follow-up in the issue; this is the type-only v1.

## Tests

3 new in `Insight.test.js` — override wins over the artifact type, falls back when no override is supplied, and applies on the split branch. Affected suites (Insight / Chart / Dashboard / ChartPreview) green: 216 passing. Full viewer suite: 6675 total with only the two known-flaky suites (`ExplorationPromoteModal`, `WorkspaceDndContext`) intermittently red — they fail on a clean tree at this base and pass in isolation (226/226). `yarn lint` clean.

Not run: I did not `yarn deploy` the vendored copy into core (per repo guidance) — the canonical edit is here; core picks it up via `yarn copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
