### PR TITLE
VIS-1132: load model data via model-jobs signed URLs

### DIFF
--- a/viewer/src/hooks/processModel.test.js
+++ b/viewer/src/hooks/processModel.test.js
@@ -1,0 +1,62 @@
+import { processModel } from './useModelsData';
+import { loadInsightParquetFiles, runDuckDBQuery } from '../duckdb/queries';
+import { processArrowResult } from '../duckdb/resultProcessing';
+
+// processModel loads a model-job's parquet through the DuckDB layer; mock it so
+// we can assert it loads the job's server-signed URL — the same file contract
+// insights use — rather than a client-built path (VIS-1132).
+jest.mock('../duckdb/queries', () => ({
+  loadInsightParquetFiles: jest.fn().mockResolvedValue(undefined),
+  runDuckDBQuery: jest.fn().mockResolvedValue({ fake: 'arrow' }),
+}));
+jest.mock('../duckdb/resultProcessing', () => ({ processArrowResult: jest.fn() }));
+
+const DB_ANY = { fake: 'duckdb' };
+const JOB = {
+  name: 'orders',
+  name_hash: 'mabcdefghijklmnopqrstuvwxyzab',
+  signed_data_file_url: 'https://storage.example/signed/orders.parquet?sig=x',
+};
+
+describe('processModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    processArrowResult.mockReturnValue([{ id: 1 }]);
+  });
+
+  it("loads the job's signed file — not a client-built URL — and returns its rows", async () => {
+    const out = await processModel(DB_ANY, JOB);
+
+    // The file it loads is exactly what the server signed; no /api/files/<name>/ guess.
+    expect(loadInsightParquetFiles).toHaveBeenCalledWith(
+      DB_ANY,
+      [{ name_hash: JOB.name_hash, signed_data_file_url: JOB.signed_data_file_url }],
+      false
+    );
+    // The DuckDB table is the job's name_hash.
+    expect(runDuckDBQuery).toHaveBeenCalledWith(
+      DB_ANY,
+      `SELECT * FROM "${JOB.name_hash}"`,
+      3,
+      1000
+    );
+    expect(out).toEqual({
+      orders: {
+        name: 'orders',
+        data: [{ id: 1 }],
+        files: [{ name_hash: JOB.name_hash, signed_data_file_url: JOB.signed_data_file_url }],
+        props_mapping: {},
+        error: null,
+      },
+    });
+  });
+
+  it('reports a failure as an error entry rather than throwing', async () => {
+    loadInsightParquetFiles.mockRejectedValueOnce(new Error('boom'));
+
+    const out = await processModel(DB_ANY, JOB);
+
+    expect(out.orders.error).toBe('boom');
+    expect(out.orders.data).toEqual([]);
+  });
+});

--- a/viewer/src/hooks/useModelTabPrefill.js
+++ b/viewer/src/hooks/useModelTabPrefill.js
@@ -3,6 +3,7 @@ import { useDuckDB } from '../contexts/DuckDBContext';
 import useStore from '../stores/store';
 import { DEFAULT_RUN_ID } from '../constants';
 import { processModel } from './useModelsData';
+import { fetchModelJobs } from '../api/modelJobs';
 
 /**
  * Fill a freshly-opened model tab with the LAST RUN's rows.
@@ -27,9 +28,10 @@ import { processModel } from './useModelsData';
  * - A failure is silent. This is a convenience; the Run button is the
  *   authoritative path and reports its own errors.
  *
- * LOCAL-ONLY in practice: it reads `/api/files/<name>/<run_id>/`, which core
- * deliberately does not serve (see core's urls.py). In cloud the fetch fails and
- * the tab stays empty, exactly as it does today.
+ * Loads the last build through the model-jobs endpoint (fetchModelJobs →
+ * signed_data_file_url), the same path the dashboard uses, so it works in the
+ * cloud as well as locally. A model that has no built data just leaves the grid
+ * empty.
  *
  * @param {string|null} modelName - the active model tab, or null
  * @param {boolean} hasResult - whether that tab already has rows
@@ -37,6 +39,7 @@ import { processModel } from './useModelsData';
 export const useModelTabPrefill = (modelName, hasResult) => {
   const db = useDuckDB();
   const setModelQueryResult = useStore(state => state.setModelQueryResult);
+  const projectId = useStore(state => state.project?.id);
   // Names already attempted this mount — keyed so switching tabs back and forth
   // doesn't re-fetch, and a model with no parquet is asked for exactly once.
   const attemptedRef = useRef(new Set());
@@ -50,7 +53,12 @@ export const useModelTabPrefill = (modelName, hasResult) => {
 
     (async () => {
       try {
-        const loaded = await processModel(db, modelName, DEFAULT_RUN_ID);
+        const jobs = await fetchModelJobs([modelName], { projectId, runId: DEFAULT_RUN_ID });
+        const job = jobs.find(j => j.name === modelName);
+        // No built data for this model — leave the grid empty.
+        if (cancelled || !job?.signed_data_file_url) return;
+
+        const loaded = await processModel(db, job);
         const entry = loaded?.[modelName];
         const rows = entry?.data;
         // `processModel` reports a per-model failure as an `error` key rather
@@ -73,7 +81,7 @@ export const useModelTabPrefill = (modelName, hasResult) => {
     return () => {
       cancelled = true;
     };
-  }, [db, modelName, hasResult, setModelQueryResult]);
+  }, [db, modelName, hasResult, setModelQueryResult, projectId]);
 };
 
 export default useModelTabPrefill;

--- a/viewer/src/hooks/useModelTabPrefill.test.js
+++ b/viewer/src/hooks/useModelTabPrefill.test.js
@@ -13,9 +13,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import useStore from '../stores/store';
 import { useModelTabPrefill } from './useModelTabPrefill';
 import { processModel } from './useModelsData';
+import { fetchModelJobs } from '../api/modelJobs';
 import { useDuckDB } from '../contexts/DuckDBContext';
 
 jest.mock('./useModelsData', () => ({ processModel: jest.fn() }));
+jest.mock('../api/modelJobs', () => ({ fetchModelJobs: jest.fn() }));
 jest.mock('../contexts/DuckDBContext', () => ({ useDuckDB: jest.fn() }));
 
 const DB = { fake: 'duckdb' };
@@ -24,11 +26,16 @@ const ROWS = [
   { id: 2, region: 'west' },
 ];
 
+// A built model-job for whatever name the hook asks about.
+const jobFor = name => ({ name, name_hash: `h_${name}`, signed_data_file_url: `signed/${name}` });
+
 let setModelQueryResult;
 
 beforeEach(() => {
   jest.clearAllMocks();
   useDuckDB.mockReturnValue(DB);
+  // Default: the model has built data. Tests that need "not built" override.
+  fetchModelJobs.mockImplementation(names => Promise.resolve([jobFor(names[0])]));
   setModelQueryResult = jest.fn();
   useStore.setState({ setModelQueryResult });
 });
@@ -59,20 +66,31 @@ it('never overwrites a tab that already has a result', async () => {
 });
 
 it('asks for a given model at most once, even across tab switches', async () => {
-  processModel.mockResolvedValue({ orders: { name: 'orders', data: [] } });
+  processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
 
   const { rerender } = renderHook(({ name }) => useModelTabPrefill(name, false), {
     initialProps: { name: 'orders' },
   });
-  await waitFor(() => expect(processModel).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(fetchModelJobs).toHaveBeenCalledTimes(1));
 
   rerender({ name: 'users' });
+  await waitFor(() => expect(fetchModelJobs).toHaveBeenCalledTimes(2));
   rerender({ name: 'orders' });
+  await Promise.resolve();
 
-  await waitFor(() => expect(processModel).toHaveBeenCalledTimes(2));
-  // 'orders' was not re-fetched on the way back — a model with no parquet
-  // would otherwise 404 on every tab switch.
-  expect(processModel.mock.calls.map(c => c[1])).toEqual(['orders', 'users']);
+  // 'orders' is not asked for again on the way back — a model with no parquet
+  // would otherwise 404 on every tab switch. Each name is fetched at most once.
+  expect(fetchModelJobs.mock.calls.map(c => c[0][0])).toEqual(['orders', 'users']);
+});
+
+it('leaves the grid empty when the model has no built data', async () => {
+  fetchModelJobs.mockResolvedValueOnce([]); // nothing built for this model
+
+  renderHook(() => useModelTabPrefill('orders', false));
+
+  await waitFor(() => expect(fetchModelJobs).toHaveBeenCalled());
+  expect(processModel).not.toHaveBeenCalled();
+  expect(setModelQueryResult).not.toHaveBeenCalled();
 });
 
 it('does not prefill when the model has no rows', async () => {

--- a/viewer/src/hooks/useModelsData.js
+++ b/viewer/src/hooks/useModelsData.js
@@ -3,44 +3,35 @@ import { useQuery } from '@tanstack/react-query';
 import { loadInsightParquetFiles, runDuckDBQuery } from '../duckdb/queries';
 import { processArrowResult } from '../duckdb/resultProcessing';
 import { useDuckDB } from '../contexts/DuckDBContext';
-import { alphaHash } from '../utils/alphaHash';
+import { fetchModelJobs } from '../api/modelJobs';
 import useStore from '../stores/store';
 import { DEFAULT_RUN_ID } from '../constants';
 
 /**
- * Process a single model: load parquet, execute SELECT *, return results.
+ * Load one model's built parquet into DuckDB from its model-job and return the
+ * rows. The job (from ``fetchModelJobs``) carries ``name_hash`` — the DuckDB
+ * table identifier — and ``signed_data_file_url``, the same file contract
+ * insights use, so this loads through the identical path and works in the cloud
+ * (a server-signed URL) as well as locally.
+ *
+ * Exported so the model-tab prefill can reuse the exact load path.
  *
  * @param {import("@duckdb/duckdb-wasm").AsyncDuckDB} db - DuckDB instance
- * @param {string} modelName - Model name
- * @param {string} runId - Run ID for file path
+ * @param {{name: string, name_hash: string, signed_data_file_url: string}} job
  * @returns {Promise<Object>} Processed model data keyed by model name
  */
-// Exported so the model-tab prefill can reuse the exact load path the
-// dashboard uses — same URL contract, same hashing, same DuckDB table.
-export const processModel = async (db, modelName, runId, force = false) => {
+export const processModel = async (db, job, force = false) => {
   try {
-    // ``name_hash`` is the DuckDB table identifier (clean, valid SQL
-    // identifier — model names may contain whitespace/punctuation).
-    // The URL itself uses the *name*, matching visivo Flask's
-    // /api/files/<name>/<run_id>/ contract and core's FileByHash.
-    const nameHash = alphaHash(modelName);
-    const files = [
-      {
-        name_hash: nameHash,
-        signed_data_file_url: `/api/files/${encodeURIComponent(modelName)}/${runId}/`,
-      },
-    ];
+    const files = [{ name_hash: job.name_hash, signed_data_file_url: job.signed_data_file_url }];
 
     await loadInsightParquetFiles(db, files, force);
 
-    const sql = `SELECT * FROM "${nameHash}"`;
-    const result = await runDuckDBQuery(db, sql, 3, 1000);
-    const processedRows = processArrowResult(result);
+    const result = await runDuckDBQuery(db, `SELECT * FROM "${job.name_hash}"`, 3, 1000);
 
     return {
-      [modelName]: {
-        name: modelName,
-        data: processedRows,
+      [job.name]: {
+        name: job.name,
+        data: processArrowResult(result),
         files,
         props_mapping: {},
         error: null,
@@ -48,8 +39,8 @@ export const processModel = async (db, modelName, runId, force = false) => {
     };
   } catch (error) {
     return {
-      [modelName]: {
-        name: modelName,
+      [job.name]: {
+        name: job.name,
         data: [],
         files: [],
         props_mapping: {},
@@ -60,10 +51,12 @@ export const processModel = async (db, modelName, runId, force = false) => {
 };
 
 /**
- * Hook for loading model data directly into DuckDB.
+ * Hook for loading model data into DuckDB.
  *
- * Unlike useInsightsData which fetches insight metadata from the server,
- * this hook computes the model hash client-side and loads the parquet directly.
+ * Mirrors useInsightsData: it asks the server (via fetchModelJobs → the
+ * /api/model-jobs/ endpoint) which of the named models have built data and for
+ * their signed_data_file_url, then loads those parquets. A model with no built
+ * data is simply absent from the response.
  *
  * @param {string} projectId - Project ID
  * @param {string[]} modelNames - Array of model names to load
@@ -86,8 +79,23 @@ export const useModelsData = (
   const queryFn = useCallback(async () => {
     if (!db || !stableModelNames.length) return {};
 
+    // One request for all of them — the endpoint returns a job (with its
+    // signed_data_file_url) for each model that has built data. project_id
+    // scopes it in the cloud, where many projects share a model name.
+    const jobs = await fetchModelJobs(stableModelNames, { runId, projectId });
+    const jobByName = new Map(jobs.map(job => [job.name, job]));
+
     const results = await Promise.allSettled(
-      stableModelNames.map(name => processModel(db, name, runId, Boolean(cacheKey)))
+      stableModelNames.map(name => {
+        const job = jobByName.get(name);
+        if (!job || !job.signed_data_file_url) {
+          // Not built yet — an empty, non-error entry, as before.
+          return Promise.resolve({
+            [name]: { name, data: [], files: [], props_mapping: {}, error: null },
+          });
+        }
+        return processModel(db, job, Boolean(cacheKey));
+      })
     );
 
     const mergedData = {};
@@ -105,7 +113,7 @@ export const useModelsData = (
     });
 
     return mergedData;
-  }, [db, stableModelNames, runId, cacheKey]);
+  }, [db, stableModelNames, runId, cacheKey, projectId]);
 
   const queryEnabled = !!projectId && stableModelNames.length > 0 && !!db && !!runId;
 


### PR DESCRIPTION
## Problem

Model-backed tables and pivots render empty once a project is deployed to the cloud. Opening one on dev showed:

```
{"detail": "No API endpoint at /api/files/redteam-results/main/"}
```

The viewer was building its own `/api/files/<name>/<run_id>/` path for a model's parquet. That path only resolves locally — the server never signs a GCS URL for a client-built path, so every deployed model-backed table 404'd. Insights never had this problem because they fetch their jobs first and load the server-signed `signed_data_file_url`.

## Fix

Make model data follow the exact insight pattern instead of a bespoke route. `processModel` now takes a **model-job** (from `fetchModelJobs` → the existing `/api/model-jobs/` endpoint, the account- and project-scoped sibling of `/api/insight-jobs/`) and loads its `signed_data_file_url` through the same DuckDB path insights use. No client-side path construction, so it works in the cloud and locally alike.

- **`useModelsData`** — `queryFn` fetches jobs for all requested model names in one request, then loads each job's signed parquet. A model with no built data is an empty, non-error entry (unchanged behavior).
- **`useModelTabPrefill`** — fetches the model-job, then prefills the grid from its signed URL. A model with no built data leaves the grid empty rather than 404ing per keystroke.
- No core change: `/api/model-jobs/` already returns `signed_data_file_url` via `ModelJobSerializer`.

## Tests

- `processModel.test.js` rewritten to assert it loads the job's server-signed file (not a `/api/files/<name>/` guess) and that the DuckDB table is the job's `name_hash`.
- `useModelTabPrefill.test.js` updated: fetches a model-job before prefilling, leaves the grid empty when nothing is built, and asks for each model at most once across tab switches.
- Full viewer suite green (6661 pass; the one unrelated `WorkspaceDndContext` flake passes in isolation), `yarn lint` clean.

Closes VIS-1132.