### PR TITLE
Icon colour means "selected", in the sidebar and the tabs

### DIFF
--- a/viewer/src/components/views/workspace/TabStrip.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.jsx
@@ -10,7 +10,7 @@ import {
 } from '@dnd-kit/core';
 import { PiX, PiPlus, PiWarningCircle, PiCaretLeft, PiCaretRight } from 'react-icons/pi';
 import useStore from '../../../stores/store';
-import { getTypeIcon } from '../common/objectTypeConfigs';
+import { getTypeIcon, getTypeColors } from '../common/objectTypeConfigs';
 import TabCloseConfirmDialog from './TabCloseConfirmDialog';
 
 // Tab icons resolve entirely through `objectTypeConfigs.js` — the TabStrip
@@ -84,7 +84,15 @@ const WorkspaceTab = ({ tab, active, onSelect, onClose, isDragging }) => {
         title={displayName}
         data-testid={`workspace-tab-select-${tab.id}`}
       >
-        <TypeIcon aria-hidden="true" style={{ fontSize: 14 }} className="shrink-0 text-gray-500" />
+        {/* Matches the Library rows: the type's colour marks the active tab,
+            gray the rest. Every live tab type has an objectTypeConfigs entry
+            and getTypeColors falls back to gray anyway, so no guard needed. */}
+        <TypeIcon
+          aria-hidden="true"
+          style={{ fontSize: 14 }}
+          data-testid={`workspace-tab-icon-${tab.id}`}
+          className={`shrink-0 ${active ? getTypeColors(tab.type).text : 'text-gray-500'}`}
+        />
         <span className="truncate">{displayName}</span>
         {explorationDeletedRemotely ? (
           <PiWarningCircle

--- a/viewer/src/components/views/workspace/TabStrip.test.jsx
+++ b/viewer/src/components/views/workspace/TabStrip.test.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import TabStrip, { tabDragEndToReorder } from './TabStrip';
 import useStore from '../../../stores/store';
+import { getTypeByValue } from '../common/objectTypeConfigs';
 
 const sampleTabs = [
   { id: 'project:analytics-platform', type: 'project', name: 'analytics-platform' },
@@ -69,6 +70,28 @@ describe('TabStrip', () => {
     expect(
       screen.getByTestId('workspace-tab-chart:revenue_chart')
     ).toHaveAttribute('data-active', 'false');
+  });
+
+  // VIS-1135: the tab icon was `text-gray-500` unconditionally, so the strip
+  // carried no type colour at all. It now matches the Library rows — the
+  // type's colour marks the active tab, gray the rest.
+  test('the active tab paints its icon in the type colour; inactive stay gray', () => {
+    seedStore({ workspaceActiveTabId: 'chart:revenue_chart' });
+    render(<TabStrip />);
+    expect(screen.getByTestId('workspace-tab-icon-chart:revenue_chart')).toHaveClass(
+      getTypeByValue('chart').colors.text
+    );
+    const inactive = screen.getByTestId('workspace-tab-icon-dashboard:simple-dashboard');
+    expect(inactive).toHaveClass('text-gray-500');
+    expect(inactive).not.toHaveClass(getTypeByValue('dashboard').colors.text);
+  });
+
+  test('the active tab colour follows its own type, not one fixed accent', () => {
+    seedStore({ workspaceActiveTabId: 'dashboard:simple-dashboard' });
+    render(<TabStrip />);
+    expect(screen.getByTestId('workspace-tab-icon-dashboard:simple-dashboard')).toHaveClass(
+      getTypeByValue('dashboard').colors.text
+    );
   });
 
   // Explore 2.0 Phase 2: an exploration tab's STABLE identity (`tab.name`)

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -7,6 +7,7 @@ import useLibraryData from './useLibraryData';
 import useLibraryFilter from './useLibraryFilter';
 import { LAYOUT_TYPES, DATA_TYPES, getTypeDef } from './LibraryRow';
 import useStore from '../../../../stores/store';
+import { isLibrarySubsectionCollapsed } from '../../../../stores/libraryPrefsStore';
 import { useWorkspaceScope } from '../useWorkspaceScope';
 import { emitWorkspaceEvent } from '../telemetry';
 import ViewSwitcher from '../ViewSwitcher';
@@ -95,21 +96,34 @@ const Library = () => {
   const toggleLeftCollapsed = useStore(s => s.toggleWorkspaceLeftCollapsed);
   const setLibrarySubsectionCollapsed = useStore(s => s.setLibrarySubsectionCollapsed);
 
-  // #8: when the rail expands (this Library mounts), reveal the active object's
-  // row — expand its type subsection so a selection made while the nav was
-  // minimized isn't hidden in a collapsed group, and scroll it into view. (The
-  // flat list has no section-collapse to reverse anymore.)
+  // #8: reveal the active object's row — expand its type subsection so a
+  // selection isn't hidden in a collapsed group, and scroll it into view.
+  //
+  // This used to read `workspaceActiveObject` off `getState()` with only
+  // `setLibrarySubsectionCollapsed` in the dep array, so it fired ONCE on
+  // mount and never again: selecting a row while the rail was already open
+  // never scrolled to it. Subscribing to the active object's primitives (not
+  // the object, whose identity churns on every store write) makes it track the
+  // selection. Mount is just the `null → type` transition, so the
+  // rail-expansion case it was written for still works.
+  const activeType = useStore(s => s.workspaceActiveObject?.type || null);
+  const activeName = useStore(s => s.workspaceActiveObject?.name || null);
   useEffect(() => {
-    const active = useStore.getState().workspaceActiveObject;
-    if (!active?.type) return;
-    const subType = active.type;
-    if (!LAYOUT_TYPES.includes(subType) && !DATA_TYPES.includes(subType)) return;
-    setLibrarySubsectionCollapsed(subType, false);
+    if (!activeType || !activeName) return undefined;
+    if (!LAYOUT_TYPES.includes(activeType) && !DATA_TYPES.includes(activeType)) return undefined;
+    // Only write when the subsection is actually collapsed. Now that this
+    // effect runs on every selection change (not once per mount), an
+    // unconditional call would mint a new `libraryCollapsedSubsections` object
+    // every time — re-rendering every subscriber and, because the slice is
+    // persisted, writing localStorage on each click.
+    if (isLibrarySubsectionCollapsed(useStore.getState().libraryCollapsedSubsections, activeType)) {
+      setLibrarySubsectionCollapsed(activeType, false);
+    }
     // Best-effort scroll the selected row into view once it renders.
-    requestAnimationFrame(() => {
+    const raf = requestAnimationFrame(() => {
       try {
         const el = document.querySelector(
-          `[data-testid="library-row-${subType}-${active.name}"]`
+          `[data-testid="library-row-${activeType}-${activeName}"]`
         );
         if (el && typeof el.scrollIntoView === 'function') {
           el.scrollIntoView({ block: 'nearest' });
@@ -118,7 +132,8 @@ const Library = () => {
         /* selector can't match an exotic name — the expand alone still reveals it */
       }
     });
-  }, [setLibrarySubsectionCollapsed]);
+    return () => cancelAnimationFrame(raf);
+  }, [activeType, activeName, setLibrarySubsectionCollapsed]);
 
   // The active workspace tab's id is the selected row's id — both are
   // `${type}:${name}`. Surfacing it here drives LibraryRow's mulberry-bar +

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -775,6 +775,61 @@ describe('Library', () => {
     }
   });
 
+  // VIS-1135. The reveal effect read `workspaceActiveObject` off `getState()`
+  // with only `setLibrarySubsectionCollapsed` in its dep array, so it fired
+  // ONCE on mount. Selecting a row while the rail was already open — the
+  // common case — never scrolled to it, and never opened a collapsed
+  // subsection. These pin the post-mount behaviour.
+  test('changing the selection AFTER mount scrolls the newly active row into view', async () => {
+    const scrollIntoView = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    try {
+      seedStore({
+        workspaceActiveObject: { type: 'model', name: 'monthly_revenue' },
+        workspaceActiveTabId: 'model:monthly_revenue',
+        libraryCollapsedSubsections: { ...ALL_EXPANDED },
+      });
+      renderLibrary();
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+      scrollIntoView.mockClear();
+
+      // The gesture the old effect ignored: pick a different object while the
+      // Library stays mounted.
+      act(() => {
+        useStore.setState({
+          workspaceActiveObject: { type: 'chart', name: 'waterfall' },
+          workspaceActiveTabId: 'chart:waterfall',
+        });
+      });
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' }));
+    } finally {
+      delete window.HTMLElement.prototype.scrollIntoView;
+    }
+  });
+
+  test('a post-mount selection also expands its collapsed subsection', async () => {
+    seedStore({
+      workspaceActiveObject: { type: 'model', name: 'monthly_revenue' },
+      workspaceActiveTabId: 'model:monthly_revenue',
+      libraryCollapsedSubsections: { ...ALL_EXPANDED, chart: true },
+    });
+    renderLibrary();
+    expect(useStore.getState().libraryCollapsedSubsections.chart).toBe(true);
+
+    act(() => {
+      useStore.setState({
+        workspaceActiveObject: { type: 'chart', name: 'waterfall' },
+        workspaceActiveTabId: 'chart:waterfall',
+      });
+    });
+
+    await waitFor(() =>
+      expect(useStore.getState().libraryCollapsedSubsections.chart).toBe(false)
+    );
+    expect(screen.getByTestId('library-row-chart-waterfall')).toBeInTheDocument();
+  });
+
   // The old per-surface Project/Explorer/Semantic buttons (and their tests)
   // are retired — the destination switcher now lives in `<ViewSwitcher>`,
   // pinned atop the Library (Explore 2.0 Phase 0, `ViewSwitcher.test.jsx`).

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -11,7 +11,7 @@ import {
   PiPlusCircle,
 } from 'react-icons/pi';
 import { ObjectStatus } from '../../../../stores/store';
-import { getTypeByValue, getTypeIcon } from '../../common/objectTypeConfigs';
+import { getTypeByValue, getTypeIcon, DEFAULT_COLORS } from '../../common/objectTypeConfigs';
 import LibraryRowFlipPopover from './LibraryRowFlipPopover';
 
 /**
@@ -94,6 +94,10 @@ export const getTypeDef = type => {
     icon: cfg?.icon || getTypeIcon(type),
     label: cfg?.singularLabel || type,
     plural: cfg?.label || `${type}s`,
+    // The shared rainbow palette, surfaced here so rows never reach for
+    // `getTypeColors` themselves — this file is the Library's one source of
+    // per-type metadata (see the note above DROPPABLE_TYPES).
+    colors: cfg?.colors || DEFAULT_COLORS,
     droppable,
     creatable: CREATABLE_TYPES.includes(type),
     accent: droppable ? 'mulberry' : 'teal',
@@ -412,10 +416,15 @@ const LibraryRow = ({
           {draggable && <PiDotsSix className="h-3 w-3" />}
         </span>
         <StatusDot status={obj.status} />
+        {/* Icon colour is the selection signal: the type's own colour when
+            selected, gray otherwise. Previously every row was gray and only
+            the source row was permanently type-coloured, so colour said
+            nothing about what was selected. */}
         <Icon
           aria-hidden="true"
           style={{ fontSize: 14 }}
-          className={`shrink-0 ${selected ? 'text-primary-600' : 'text-gray-500'}`}
+          data-testid={`${tid}-icon`}
+          className={`shrink-0 ${selected ? def.colors.text : 'text-gray-500'}`}
         />
         <span className={`min-w-0 flex-1 truncate ${selected ? 'font-medium' : ''}`}>
           {obj.name}

--- a/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
@@ -346,6 +346,43 @@ describe('LibraryRow', () => {
     expect(row).toHaveAttribute('data-selected', 'true');
   });
 
+  // VIS-1135. Icon colour is the selection signal. Before this, every
+  // LibraryRow icon was `text-gray-500` regardless of state and only the
+  // source row was permanently type-coloured — so colour told you nothing
+  // about what was selected. These assert the rule at the row level; the
+  // colours themselves come from objectTypeConfigs (chart=pink, model=amber)
+  // and are pinned by objectTypeConfigs.test.js.
+  test('a selected row paints its icon in the type colour', () => {
+    render(withDnd(<LibraryRow obj={CHART} selected />));
+    expect(screen.getByTestId('library-row-chart-waterfall-icon')).toHaveClass(
+      getTypeByValue('chart').colors.text
+    );
+  });
+
+  test('an unselected row paints its icon gray, whatever its type', () => {
+    render(withDnd(<LibraryRow obj={CHART} />));
+    const icon = screen.getByTestId('library-row-chart-waterfall-icon');
+    expect(icon).toHaveClass('text-gray-500');
+    expect(icon).not.toHaveClass(getTypeByValue('chart').colors.text);
+  });
+
+  test('the type colour follows the type, not a single accent', () => {
+    // Guards against "selected" being wired to one hard-coded colour: a
+    // selected model must be amber, not the chart's pink.
+    render(withDnd(<LibraryRow obj={MODEL} selected />));
+    expect(screen.getByTestId('library-row-model-monthly_revenue-icon')).toHaveClass(
+      getTypeByValue('model').colors.text
+    );
+  });
+
+  test('an unknown type still gets a gray icon rather than crashing', () => {
+    // getTypeDef falls back to DEFAULT_COLORS, so `def.colors.text` is always
+    // defined — this is the guard on that fallback being reachable.
+    const odd = { id: 'weird:thing', type: 'weird', name: 'thing' };
+    render(withDnd(<LibraryRow obj={odd} />));
+    expect(screen.getByTestId('library-row-weird-thing-icon')).toHaveClass('text-gray-500');
+  });
+
   test('non-droppable rows do not expose the drag handle dots', () => {
     render(withDnd(<LibraryRow obj={MODEL} draggable={false} />));
     expect(

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
@@ -184,8 +184,12 @@ const ColumnRow = ({ sourceName, tableName, col }) => {
 };
 
 const TableRow = ({ sourceName, table, expandedSet, onToggle, flatColumns, loadFlatColumns }) => {
+  // The glyph SHAPE is the table icon, but not the `table` type's fuchsia: these
+  // are database tables, not Visivo Table objects, and dragging one yields
+  // `type:'sourceTable'`. Wearing the widget's colour asserted a kinship that
+  // doesn't exist — and left this glyph as the only coloured thing in a tree
+  // whose column rows are already gray.
   const TableIcon = getTypeIcon('table');
-  const tableColors = getTypeColors('table');
   const expanded = expandedSet.has(table.key);
   const cols = flatColumns?.[table.key];
   const colsLoaded = Array.isArray(cols);
@@ -219,7 +223,13 @@ const TableRow = ({ sourceName, table, expandedSet, onToggle, flatColumns, loadF
         hasCaret
         expanded={expanded}
         onToggle={handleToggle}
-        icon={<TableIcon className={`h-3 w-3 shrink-0 ${tableColors.text}`} aria-hidden="true" />}
+        icon={
+          <TableIcon
+            className="h-3 w-3 shrink-0 text-gray-400"
+            aria-hidden="true"
+            data-testid={`library-source-table-${sourceName}-${table.name}-icon`}
+          />
+        }
         name={table.name}
         meta={typeof colCount === 'number' ? `${colCount}` : null}
         draggable
@@ -476,10 +486,14 @@ const LibrarySourceRow = ({ obj, selected = false, onClick }) => {
         >
           {expanded ? <PiCaretDown className="h-3 w-3" /> : <PiCaretRight className="h-3 w-3" />}
         </button>
+        {/* Same rule as every other row (LibraryRow): the type colour means
+            "selected". This row used to be the sole exception — permanently
+            orange — which is what made colour meaningless across the nav. */}
         <SourceIcon
           aria-hidden="true"
           style={{ fontSize: 14 }}
-          className={`shrink-0 ${selected ? 'text-primary-600' : sourceColors.text}`}
+          data-testid={`${tid}-icon`}
+          className={`shrink-0 ${selected ? sourceColors.text : 'text-gray-500'}`}
         />
         <StatusDot status={obj.status} />
         <span className={`min-w-0 flex-1 truncate ${selected ? 'font-medium' : ''}`}>

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
@@ -325,6 +325,39 @@ describe('LibrarySourceRow', () => {
     expect(row).toHaveAttribute('data-selected', 'true');
   });
 
+  // VIS-1135. This row was the reported bug: its icon was painted
+  // `sourceColors.text` when UNSELECTED and mulberry when selected — the exact
+  // inverse of the rule, and the only always-coloured icon in the nav.
+  test('an unselected source icon is gray, not orange', () => {
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    const icon = screen.getByTestId('library-row-source-warehouse-icon');
+    expect(icon).toHaveClass('text-gray-500');
+    expect(icon).not.toHaveClass('text-orange-800');
+  });
+
+  test('a selected source icon carries the source type colour', () => {
+    render(withDnd(<LibrarySourceRow obj={SOURCE} selected onClick={jest.fn()} />));
+    expect(screen.getByTestId('library-row-source-warehouse-icon')).toHaveClass('text-orange-800');
+  });
+
+  test('a drill-down table glyph is gray — these are database tables, not Table objects', async () => {
+    // It used to wear the `table` widget type's fuchsia, which claimed a
+    // kinship that does not exist: dragging one yields `type:'sourceTable'`.
+    // It was also the only coloured glyph in a tree whose column rows
+    // (ColumnRow) are already gray.
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
+
+    const glyph = await screen.findByTestId('library-source-table-warehouse-orders-icon');
+    expect(glyph).toHaveClass('text-gray-400');
+    expect(glyph).not.toHaveClass('text-fuchsia-800');
+  });
+
   test('a click never fires onClick while a drag is in progress (isDragging)', () => {
     useDraggable.mockReturnValueOnce({
       transform: null,


### PR DESCRIPTION
Closes VIS-1135.

Colour was applied three different ways in the nav, and none of them said anything about what was selected:

| Site | Before |
|---|---|
| `LibraryRow` | `text-gray-500` always — the type colour was never consulted for the glyph |
| `LibrarySourceRow` | **orange when unselected**, mulberry when selected — the exact inverse |
| `TabStrip` | `text-gray-500` unconditionally, active or not |

The source row being the one permanently-coloured icon in the nav is what made this visible.

One rule now, at all three sites: **the type's colour when selected, gray otherwise.** Colours come from `getTypeColors` via `getTypeDef`, which now carries `colors` so rows never reach for the palette themselves — that's the Library's existing "never fork per-type metadata" rule, and it's why this didn't need a new key in `objectTypeConfigs`.

### The drill-down table glyphs go gray too

They wore the `table` widget type's fuchsia, which asserts a kinship that doesn't exist — these are *database* tables, and dragging one yields `type:'sourceTable'`, not a Table object. They were also the only coloured glyph in a tree whose column rows are already gray.

### The scroll-into-view half that was missing

`TabStrip` already kept the active tab visible. The Library's equivalent read the active object off `getState()` with only `setLibrarySubsectionCollapsed` in its dep array, so it **fired once on mount and never again** — selecting a row while the rail was already open never scrolled to it, and never opened a collapsed subsection. It now tracks the selection via the active object's primitives, not the object itself, whose identity churns on every store write.

### One thing worth a look in review

Making that effect run on every selection change surfaced a real cost: an unconditional `setLibrarySubsectionCollapsed` mints a new `libraryCollapsedSubsections` object every time, re-rendering every subscriber and — since the slice is **persisted** — writing localStorage on each click. The churn was enough to tip two unrelated async suites (`ExplorationPromoteModal`, `WorkspaceDndContext`) over their timeouts in the full run. Guarding the write so it only fires when the subsection is actually collapsed put them back to green, confirmed over two clean full runs.

### Testing

**6670 passing** (355 suites), lint clean, two consecutive full runs with no flakes. Baseline on main is 6659, so **+11 new tests** — and each was verified to fail without its fix by stashing the source changes and re-running: exactly 11 failures, no more, no fewer.

New coverage asserts what the existing tests didn't — `LibraryRow.test.jsx:343` and `LibrarySourceRow.test.jsx:322` checked `data-selected` and never colour:
- selected icon carries the type colour; unselected is gray, at all three sites
- the colour follows the *type*, not one fixed accent (a selected model is amber, not the chart's pink)
- an unknown type still gets a gray icon via the `DEFAULT_COLORS` fallback
- the drill-down table glyph is gray, not fuchsia
- the Library re-scrolls **and** expands a collapsed subsection when the selection changes *after* mount

Viewer-only — `core/app/src/viewer` is vendored via `yarn copy`, so core picks this up on its next sync. No core PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)