### PR TITLE
The source row is a LibraryRow now, not a copy of one

### DIFF
--- a/.github/workflows/deploy_dashoard.yml
+++ b/.github/workflows/deploy_dashoard.yml
@@ -34,6 +34,17 @@ jobs:
       - name: Deploy
         id: deploy
         if: github.event.pull_request.merged == false && github.event.pull_request.closed_at == null
+        # Not secrets — these are the passwords of the throwaway local
+        # containers the integration project points at, and they are already
+        # in plain sight in docker-compose.yml and .rwx/test_visivo.yml. They
+        # live here rather than in the project YAML because core rejects a
+        # source config carrying a literal credential: it would be stored in
+        # Postgres, returned by GET /api/sources/, and copied into every
+        # branch. The CLI also masks a literal SecretStr as `**********`, so
+        # the value that reached the server was never the real one anyway.
+        env:
+          CLICKHOUSE_PASSWORD: clickhouse
+          LOCAL_SNOWFLAKE_PASSWORD: test
         run: |
           python -m pip install git+https://github.com/visivo-io/visivo.git@${{ env.visivo_version }}
           cd ${{ env.yml_location }}

--- a/.rwx/deploy_dashboard.yml
+++ b/.rwx/deploy_dashboard.yml
@@ -49,6 +49,12 @@ tasks:
       cd test-projects/integration
       visivo --version
       visivo run
+    # See the note in .github/workflows/deploy_dashoard.yml: local container
+    # passwords, kept out of the project YAML because core refuses a source
+    # config that carries a literal credential.
+    env:
+      CLICKHOUSE_PASSWORD: clickhouse
+      LOCAL_SNOWFLAKE_PASSWORD: test
 
   - key: sanitize-stage-name
     run: |
@@ -76,6 +82,8 @@ tasks:
     env:
       VISIVO_TOKEN: ${{ secrets.VISIVO_DEVELOPMENT_TOKEN }}
       GH_TOKEN: ${{ vaults.default.github-apps.mint-automation-visivo.token }}
+      CLICKHOUSE_PASSWORD: clickhouse
+      LOCAL_SNOWFLAKE_PASSWORD: test
 
   - key: archive-ci-stage
     if: ${{ init.archive }}

--- a/.rwx/test_visivo.yml
+++ b/.rwx/test_visivo.yml
@@ -313,6 +313,10 @@ tasks:
     env:
       STACKTRACE: true
       DEBUG: true
+      # Matches CLICKHOUSE_PASSWORD on the container above. The project YAML
+      # holds ${env.CLICKHOUSE_PASSWORD} rather than the literal because core
+      # rejects a source config carrying a credential.
+      CLICKHOUSE_PASSWORD: clickhouse
     filter:
       - dist
       - test-projects/integration
@@ -333,6 +337,9 @@ tasks:
     env:
       STACKTRACE: true
       DEBUG: true
+      # fakesnow accepts any credentials; this only has to be non-empty so the
+      # project's ${env.LOCAL_SNOWFLAKE_PASSWORD} resolves.
+      LOCAL_SNOWFLAKE_PASSWORD: test
     filter:
       - dist
       - test-projects/integration

--- a/test-projects/integration/project.visivo.yml
+++ b/test-projects/integration/project.visivo.yml
@@ -223,7 +223,7 @@ sources:
     protocol: http
     database: visivo
     username: default
-    password: clickhouse
+    password: "${env.CLICKHOUSE_PASSWORD}"
 
   - name: remote-snowflake
     type: snowflake
@@ -241,7 +241,7 @@ sources:
     account: test
     db_schema: DEFAULT
     username: test
-    password: test
+    password: "${env.LOCAL_SNOWFLAKE_PASSWORD}"
     host: localhost
     port: 12345
     protocol: http

--- a/viewer/e2e/stories/library-source-drilldown.spec.mjs
+++ b/viewer/e2e/stories/library-source-drilldown.spec.mjs
@@ -18,6 +18,9 @@
  *      SOURCE half of D9's DnD unification (the drop-target half is covered
  *      by exploration-dnd-pull-in.spec.mjs).
  *   4. Collapse/re-expand does not re-fetch (session cache).
+ *   5. (VIS-1134) The row BODY opens the source and reveals its schema, like
+ *      every other Library row type; only the caret collapses; and the row
+ *      carries the standard context menu it previously lacked.
  *
  * Precondition: sandbox running (integration project), e.g.
  *   VISIVO_SANDBOX_NAME=librarySourceDrilldown VISIVO_SANDBOX_BACKEND_PORT=8045 \
@@ -115,14 +118,12 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     await expect(firstColumn.locator('[data-testid$="-drag-handle"]')).toBeVisible();
   });
 
-  // Phase 6c-T5 (ux-audit.md "Clicking a source name in the Library hijacks
-  // navigation to a read-only ERD tab", ⚠ conflicts-with-e2e). The prior
-  // e2e coverage above only ever drove the row via its `-toggle` element —
-  // never the row BODY itself, which is exactly the gesture the audit's
-  // auditor actually used ("hunting for columns to drag") and the one that
-  // used to hijack navigation. This drives the row body directly, the way a
-  // real user clicking a source name would.
-  test('clicking the source row BODY expands it in place — it no longer navigates away', async ({
+  // VIS-1134, inverting Phase 6c-T5. A source row now behaves like every
+  // other row type: the body click OPENS it. 6c-T5 had made that click expand
+  // instead, because an auditor hunting for columns to drag found it hijacked
+  // navigation — that complaint is answered rather than reintroduced, since
+  // the click also reveals the schema and never collapses it.
+  test('clicking the source row BODY opens the source AND reveals its schema', async ({
     page,
   }) => {
     const sourceRow = page.getByTestId(`library-row-source-${SOURCE}`);
@@ -134,6 +135,11 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     // The real gesture: click the row's name/body, not the caret.
     await sourceRow.click();
 
+    // Opened, like a model or a chart would.
+    await expect(page.getByTestId('workspace-middle-source-preview')).toBeVisible({
+      timeout: 15000,
+    });
+    // ...and the columns are right there, not a second gesture away.
     await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
       'aria-expanded',
       'true'
@@ -141,27 +147,31 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
       timeout: 15000,
     });
-    // Never navigated away from the Explorer/Workspace surface.
-    await expect(page.getByTestId('workspace-middle-source-preview')).not.toBeVisible();
 
-    // Clicking the row body again collapses it back (same toggle behavior).
+    // A second body click must NOT collapse — the columns the user is reaching
+    // for cannot be taken away by the same gesture that revealed them.
     await sourceRow.click();
     await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
       'aria-expanded',
-      'false'
+      'true'
     );
   });
 
-  test('the explicit hover-revealed "Open" button still navigates to the source ERD tab', async ({
+  // Replaces the old "-open button navigates" test: that button is gone (the
+  // row body does its job), so the equivalent explicit affordance to pin is
+  // the context menu, which sources could not reach at all before.
+  test('a source row exposes the standard context menu, including Open in new tab', async ({
     page,
   }) => {
     const sourceRow = page.getByTestId(`library-row-source-${SOURCE}`);
-    await sourceRow.hover();
-    const openButton = page.getByTestId(`library-row-source-${SOURCE}-open`);
-    await expect(openButton).toBeVisible();
-    await openButton.click();
+    await expect(page.getByTestId(`library-row-source-${SOURCE}-open`)).toHaveCount(0);
 
-    await expect(page.getByTestId('workspace-middle-source-preview')).toBeVisible({
+    await sourceRow.click({ button: 'right' });
+    const menu = page.getByTestId(`library-row-source-${SOURCE}-context-menu`);
+    await expect(menu).toBeVisible();
+
+    await menu.getByText('Open in new tab').click();
+    await expect(page.getByTestId(`workspace-tab-source:${SOURCE}`)).toBeVisible({
       timeout: 15000,
     });
   });

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -256,25 +256,37 @@ describe('Library', () => {
     });
   });
 
-  // Phase 6c-T5 (ux-audit.md "Clicking a source name in the Library hijacks
-  // navigation to a read-only ERD tab", ⚠ conflicts-with-e2e): a source row
-  // is the ONE Data-Layer row type that does NOT delegate its body click to
-  // openWorkspaceTab anymore — clicking it expands the source's table/column
-  // drill-down in place (LibrarySourceRow's own test file covers this in
-  // depth; this pins the integration point through the full Library tree).
-  test('clicking a SOURCE row body expands it in place instead of navigating; the explicit Open button still navigates', () => {
+  // VIS-1134: a source row is no longer the one Data-Layer type whose body
+  // click behaves differently. It opens like everything else, and expands on
+  // the way so the drill-down is still one gesture away (LibrarySourceRow's
+  // own test file covers the behaviour in depth; this pins the integration
+  // point through the full Library tree).
+  test('clicking a SOURCE row body opens its tab, like every other row type', () => {
     const openWorkspaceTab = jest.fn();
     seedStore({ openWorkspaceTab });
     renderLibrary();
     fireEvent.click(screen.getByTestId('library-row-source-local-duck'));
-    expect(openWorkspaceTab).not.toHaveBeenCalled();
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'source:local-duck',
+      type: 'source',
+      name: 'local-duck',
+    });
     expect(screen.getByTestId('library-row-source-local-duck-toggle')).toHaveAttribute(
       'aria-expanded',
       'true'
     );
+  });
 
-    fireEvent.click(screen.getByTestId('library-row-source-local-duck-open'));
-    expect(openWorkspaceTab).toHaveBeenCalledWith({
+  test('a source row reaches the same context actions as any other row', () => {
+    // `onContextAction` was already being passed to the source row by
+    // LibrarySubsection — the old component just never accepted it, so the
+    // whole menu was dead for sources.
+    const openWorkspaceTabBackground = jest.fn();
+    seedStore({ openWorkspaceTabBackground });
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-source-local-duck'));
+    fireEvent.click(screen.getByText('Open in new tab'));
+    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
       id: 'source:local-duck',
       type: 'source',
       name: 'local-duck',

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -9,6 +9,8 @@ import {
   PiTrash,
   PiCompass,
   PiPlusCircle,
+  PiCaretDown,
+  PiCaretRight,
 } from 'react-icons/pi';
 import { ObjectStatus } from '../../../../stores/store';
 import { getTypeByValue, getTypeIcon, DEFAULT_COLORS } from '../../common/objectTypeConfigs';
@@ -256,6 +258,15 @@ const LibraryRow = ({
   onContextAction,
   canAddToExploration = false,
   testId,
+  // Optional disclosure contract, used by `LibrarySourceRow` for the source →
+  // table → column drill-down. `expandable` is explicit rather than inferred
+  // from `children` because `children` are deliberately falsy while collapsed
+  // (that IS the laziness — mounting the drill-down is what fetches), so
+  // inferring it would hide the caret exactly when it is needed.
+  expandable = false,
+  expanded = false,
+  onToggleExpand,
+  children,
 }) => {
   const [hovered, setHovered] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -364,7 +375,10 @@ const LibraryRow = ({
   const tid = testId || `library-row-${obj.type}-${obj.name}`;
 
   return (
-    <div className="relative" ref={rowAnchorRef}>
+    <>
+    {/* The popover/menu anchor. Its height must stay the ROW's height — the
+        disclosure body is deliberately a sibling below, not a child. */}
+    <div className="relative" ref={rowAnchorRef} data-testid={`${tid}-anchor`}>
       <div
         {...dragProps}
         data-testid={tid}
@@ -400,6 +414,22 @@ const LibraryRow = ({
             aria-hidden="true"
             className="absolute left-0 top-1 bottom-1 w-[2px] rounded-r bg-primary"
           />
+        )}
+        {expandable && (
+          <button
+            type="button"
+            onClick={onToggleExpand}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${obj.name}`}
+            data-testid={`${tid}-toggle`}
+            className="-ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center text-gray-500 hover:text-gray-900"
+          >
+            {expanded ? (
+              <PiCaretDown className="h-3 w-3" />
+            ) : (
+              <PiCaretRight className="h-3 w-3" />
+            )}
+          </button>
         )}
         {/* Reserve the drag-handle slot for every row so Layout-Items and
             Data-Layer rows share the same icon indent. Only droppable rows
@@ -498,6 +528,12 @@ const LibraryRow = ({
         />
       )}
     </div>
+    {/* Disclosure body sits OUTSIDE the `relative` anchor above. ContextMenu
+        is `absolute top-full` on that anchor, so nesting an expanded
+        drill-down inside it would push the menu below the entire tree — and
+        the flip popover's anchor rect would grow past the row. */}
+    {children}
+    </>
   );
 };
 

--- a/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
@@ -383,6 +383,55 @@ describe('LibraryRow', () => {
     expect(screen.getByTestId('library-row-weird-thing-icon')).toHaveClass('text-gray-500');
   });
 
+  // VIS-1134: the disclosure contract LibrarySourceRow composes with.
+  describe('expand contract', () => {
+    test('no caret and no wrapper markup unless expandable is set', () => {
+      render(withDnd(<LibraryRow obj={CHART} />));
+      expect(
+        screen.queryByTestId('library-row-chart-waterfall-toggle')
+      ).not.toBeInTheDocument();
+    });
+
+    test('the caret renders when expandable, and reports its state', () => {
+      const onToggleExpand = jest.fn();
+      render(
+        withDnd(<LibraryRow obj={CHART} expandable expanded={false} onToggleExpand={onToggleExpand} />)
+      );
+      const caret = screen.getByTestId('library-row-chart-waterfall-toggle');
+      expect(caret).toHaveAttribute('aria-expanded', 'false');
+      fireEvent.click(caret);
+      expect(onToggleExpand).toHaveBeenCalled();
+    });
+
+    test('the caret shows even with no children — collapsed IS the lazy state', () => {
+      // `expandable` is deliberately explicit rather than inferred from
+      // `children`: the drill-down is falsy until expanded (mounting it is
+      // what fetches), so inferring would hide the caret exactly when it is
+      // needed to expand.
+      render(withDnd(<LibraryRow obj={CHART} expandable expanded={false} />));
+      expect(screen.getByTestId('library-row-chart-waterfall-toggle')).toBeInTheDocument();
+    });
+
+    test('children render OUTSIDE the row anchor, so the context menu is not pushed below them', () => {
+      // ContextMenu is `absolute top-full` on the anchor div. If children were
+      // nested inside it, opening the menu on an expanded row would drop it
+      // below the whole expanded tree.
+      render(
+        withDnd(
+          <LibraryRow obj={CHART} expandable expanded>
+            <div data-testid="drilldown-body">tables</div>
+          </LibraryRow>
+        )
+      );
+      expect(screen.getByTestId('drilldown-body')).toBeInTheDocument();
+      // The body renders, but NOT inside the anchor the menu is positioned
+      // against — that is the whole point.
+      const anchor = screen.getByTestId('library-row-chart-waterfall-anchor');
+      expect(within(anchor).queryByTestId('drilldown-body')).not.toBeInTheDocument();
+      expect(within(anchor).getByTestId('library-row-chart-waterfall')).toBeInTheDocument();
+    });
+  });
+
   test('non-droppable rows do not expose the drag handle dots', () => {
     render(withDnd(<LibraryRow obj={MODEL} draggable={false} />));
     expect(

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import {
   PiCaretDown,
@@ -11,13 +11,12 @@ import {
   PiSpinnerGap,
   PiWarningCircle,
   PiArrowsClockwise,
-  PiArrowSquareOut,
 } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import { SCHEMA_GENERATE_UNAVAILABLE } from '../../common/sourceCapabilities';
-import { getTypeColors, getTypeIcon } from '../../common/objectTypeConfigs';
+import { getTypeIcon } from '../../common/objectTypeConfigs';
 import useSourceOutline from '../useSourceOutline';
-import { StatusDot } from './LibraryRow';
+import LibraryRow from './LibraryRow';
 import { isNumericColumnType } from '../../../../utils/columnType';
 
 /**
@@ -393,38 +392,35 @@ const LibrarySourceDrilldown = ({ sourceName }) => {
 };
 
 /**
- * LibrarySourceRow — the top-level row `LibrarySubsection` renders for each
- * `source` object instead of the plain `LibraryRow` (see `LibrarySubsection`'s
- * `typeKey === 'source'` branch). The caret lazily mounts
- * `LibrarySourceDrilldown`.
+ * LibrarySourceRow — the source drill-down, wrapped around the standard
+ * `LibraryRow`.
  *
- * Phase 6c-T5 (ux-audit.md "Clicking a source name in the Library hijacks
- * navigation to a read-only ERD tab", ⚠ conflicts-with-e2e): the row's own
- * click used to delegate straight to `onClick` (navigate to the source's ERD
- * tab) — the single most natural click (the row, its name, its whole body)
- * punished the user for hunting for a column to drag by yanking them out of
- * their in-progress exploration. Row click now EXPANDS in place (same as the
- * caret) — the natural way to find a column; an explicit, small "Open"
- * icon button (visible on hover, mirrors `LibraryRow`'s flip/kebab
- * affordances) is the one remaining path to the ERD tab.
+ * This used to be a parallel re-implementation of `LibraryRow`: its own row
+ * shell, hover state, drag wiring and selected chrome. The copy drifted — it
+ * dropped the `onContextAction` prop `LibrarySubsection` handed it, never grew
+ * the kebab / right-click menu, the lineage popover, the Explore button or
+ * keyboard activation, and it painted its icon by a different rule. It now
+ * renders `LibraryRow` and contributes only what is genuinely source-specific:
+ * a caret and the lazily-mounted drill-down beneath it.
+ *
+ * Phase 6c-T5 made the row body EXPAND rather than open, because an auditor
+ * hunting for a column to drag found that clicking the name yanked them out of
+ * their in-progress exploration. Consistency won here — every other row type
+ * opens on click — but that complaint is answered rather than ignored: the
+ * body click opens AND expands, and never collapses. The columns arrive from
+ * the same click that opens the source, so the gesture no longer costs the
+ * user their place. Collapsing stays on the caret.
  */
-const LibrarySourceRow = ({ obj, selected = false, onClick }) => {
-  const SourceIcon = getTypeIcon('source');
-  const sourceColors = getTypeColors('source');
+const LibrarySourceRow = ({
+  obj,
+  selected = false,
+  draggable = true,
+  onClick,
+  onContextAction,
+  canAddToExploration = false,
+}) => {
   const expanded = useStore(s => !!s.librarySourceRowExpanded[obj.name]);
   const toggleExpanded = useStore(s => s.toggleLibrarySourceRowExpanded);
-  const [hovered, setHovered] = useState(false);
-
-  const drag = useDraggable({
-    id: `library:source:${obj.name}`,
-    data: { source: 'library', type: 'source', name: obj.name, subtype: obj.subtype },
-  });
-  const dragProps = {
-    ref: drag.setNodeRef,
-    ...drag.listeners,
-    ...drag.attributes,
-    style: { touchAction: 'none' },
-  };
 
   const handleToggle = useCallback(
     e => {
@@ -434,100 +430,37 @@ const LibrarySourceRow = ({ obj, selected = false, onClick }) => {
     [obj.name, toggleExpanded]
   );
 
-  // Phase 6c-T5: row click expands in place instead of navigating away —
-  // see the file docstring. Mirrors clicking the caret exactly.
-  const handleClick = useCallback(
-    e => {
-      if (drag.isDragging) return;
-      e.stopPropagation();
-      toggleExpanded(obj.name);
+  // Opens like every other row, and reveals the schema on the way — but never
+  // collapses, so a second click on the name can't take the columns away.
+  const handleOpen = useCallback(
+    (o, e) => {
+      if (!expanded) toggleExpanded(o.name);
+      onClick && onClick(o, e);
     },
-    [drag.isDragging, obj.name, toggleExpanded]
+    [expanded, onClick, toggleExpanded]
   );
-
-  const handleOpenClick = useCallback(
-    e => {
-      e.stopPropagation();
-      onClick && onClick(obj, e);
-    },
-    [obj, onClick]
-  );
-
-  const tid = `library-row-source-${obj.name}`;
 
   return (
-    <div
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onContextMenu={e => {
-        e.preventDefault();
-      }}
+    <LibraryRow
+      obj={obj}
+      selected={selected}
+      draggable={draggable}
+      onClick={handleOpen}
+      onContextAction={onContextAction}
+      canAddToExploration={canAddToExploration}
+      expandable
+      expanded={expanded}
+      onToggleExpand={handleToggle}
     >
-      <div
-        {...dragProps}
-        data-testid={tid}
-        data-selected={selected ? 'true' : 'false'}
-        data-dragging={drag.isDragging ? 'true' : 'false'}
-        onClick={handleClick}
-        role="button"
-        tabIndex={0}
-        className={[
-          'group relative flex h-7 cursor-grab items-center gap-1.5 rounded-md pl-1 pr-2 text-[13px] transition-colors active:cursor-grabbing',
-          selected ? 'bg-primary-100/55 text-primary-600' : hovered ? 'bg-gray-100' : 'hover:bg-gray-50',
-          drag.isDragging ? 'opacity-40' : '',
-        ].join(' ')}
-      >
-        <button
-          type="button"
-          onClick={handleToggle}
-          aria-expanded={expanded}
-          data-testid={`${tid}-toggle`}
-          className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-400 hover:text-gray-600"
-        >
-          {expanded ? <PiCaretDown className="h-3 w-3" /> : <PiCaretRight className="h-3 w-3" />}
-        </button>
-        {/* Same rule as every other row (LibraryRow): the type colour means
-            "selected". This row used to be the sole exception — permanently
-            orange — which is what made colour meaningless across the nav. */}
-        <SourceIcon
-          aria-hidden="true"
-          style={{ fontSize: 14 }}
-          data-testid={`${tid}-icon`}
-          className={`shrink-0 ${selected ? sourceColors.text : 'text-gray-500'}`}
-        />
-        <StatusDot status={obj.status} />
-        <span className={`min-w-0 flex-1 truncate ${selected ? 'font-medium' : ''}`}>
-          {obj.name}
-        </span>
-        {/* Phase 6c-T5: the explicit navigation affordance the row body used
-            to hijack — hover-revealed, mirrors LibraryRow's flip/kebab
-            actions. */}
-        <button
-          type="button"
-          onClick={handleOpenClick}
-          title={`Open ${obj.name}`}
-          aria-label={`Open ${obj.name}`}
-          data-testid={`${tid}-open`}
-          className={[
-            'flex h-5 w-5 shrink-0 items-center justify-center rounded text-gray-400 transition-opacity hover:bg-white hover:text-gray-700',
-            hovered ? 'opacity-100' : 'opacity-0 pointer-events-none',
-          ].join(' ')}
-        >
-          <PiArrowSquareOut className="h-3.5 w-3.5" />
-        </button>
-        <span
-          aria-hidden="true"
-          data-testid={`${tid}-drag-handle`}
-          className={[
-            'flex h-3 w-3 shrink-0 items-center justify-center text-gray-300 transition-opacity',
-            hovered || drag.isDragging ? 'opacity-100' : 'opacity-0',
-          ].join(' ')}
-        >
-          <PiDotsSix className="h-3 w-3" />
-        </span>
-      </div>
-      {expanded && <LibrarySourceDrilldown sourceName={obj.name} />}
-    </div>
+      {/* LibraryRow indents its icon further than RowShell's `8 + level*14`
+          does, so without this the tables would render LEFT of their own
+          source. Keeps the ladder at roughly 52 / 64 / 74px. */}
+      {expanded && (
+        <div className="pl-6">
+          <LibrarySourceDrilldown sourceName={obj.name} />
+        </div>
+      )}
+    </LibraryRow>
   );
 };
 

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
@@ -80,34 +80,64 @@ describe('LibrarySourceRow', () => {
     expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
   });
 
-  test('hovering reveals the Open button and drag handle; unhovering hides them again', () => {
+  test('hovering reveals the standard action cluster and the drag handle', () => {
     render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
     const row = screen.getByTestId('library-row-source-warehouse');
-    // React's synthetic mouseenter/mouseleave simulate proper enter/leave
-    // semantics for the whole subtree regardless of native (non-bubbling)
-    // behavior, so firing on this inner row still reaches the outer
-    // wrapper's onMouseEnter/onMouseLeave handlers.
     fireEvent.mouseEnter(row);
-    expect(screen.getByTestId('library-row-source-warehouse-open')).toHaveClass('opacity-100');
-    fireEvent.mouseLeave(row);
-    expect(screen.getByTestId('library-row-source-warehouse-open')).toHaveClass('opacity-0');
+    // The hover-only "Open" icon button is gone — the row body opens now. What
+    // hover reveals is the same cluster every other row type has.
+    expect(screen.queryByTestId('library-row-source-warehouse-open')).not.toBeInTheDocument();
+    expect(screen.getByTestId('library-row-source-warehouse-explore')).toBeInTheDocument();
+    expect(screen.getByTestId('library-row-source-warehouse-flip')).toBeInTheDocument();
+    expect(screen.getByTestId('library-row-source-warehouse-kebab')).toBeInTheDocument();
+    expect(screen.getByTestId('library-row-source-warehouse-drag-handle')).toBeInTheDocument();
   });
 
-  test('right-clicking the row suppresses the native context menu (no custom menu of its own)', () => {
+  // Inverted: the source row used to preventDefault right-click and render
+  // nothing, so all seven context-menu actions were unreachable for sources.
+  test('right-clicking the row opens the standard context menu', () => {
     render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={jest.fn()} />));
-    const row = screen.getByTestId('library-row-source-warehouse');
-    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
-    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
-    row.dispatchEvent(event);
-    expect(preventDefaultSpy).toHaveBeenCalled();
+    fireEvent.contextMenu(screen.getByTestId('library-row-source-warehouse'));
+    expect(
+      screen.getByTestId('library-row-source-warehouse-context-menu')
+    ).toBeInTheDocument();
   });
 
-  // Phase 6c-T5 (ux-audit.md "Clicking a source name in the Library hijacks
-  // navigation to a read-only ERD tab", ⚠ conflicts-with-e2e): row click now
-  // expands in place — the natural gesture for hunting a column to drag —
-  // instead of navigating away from whatever exploration the user is mid-edit
-  // on. Navigation moved to an explicit, hover-revealed "Open" icon button.
-  test('clicking the row body expands in place — it no longer navigates via onClick', async () => {
+  test('a source row forwards context-menu actions, which it used to drop entirely', () => {
+    // `LibrarySubsection` always passed `onContextAction`; the old component's
+    // signature never accepted it, so every action silently went nowhere.
+    const onContextAction = jest.fn();
+    render(
+      withDnd(
+        <LibrarySourceRow obj={SOURCE} onClick={jest.fn()} onContextAction={onContextAction} />
+      )
+    );
+    fireEvent.contextMenu(screen.getByTestId('library-row-source-warehouse'));
+    fireEvent.click(screen.getByText('Open in new tab'));
+    expect(onContextAction).toHaveBeenCalledWith('openInNewTab', SOURCE);
+  });
+
+  test('Enter on the focused row opens it — sources had no keyboard activation at all', async () => {
+    // Enter routes through the same handler as a body click, so it also
+    // expands — mock the feed and let the drill-down settle.
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+    const onClick = jest.fn();
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
+
+    fireEvent.keyDown(screen.getByTestId('library-row-source-warehouse'), { key: 'Enter' });
+
+    expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
+    await screen.findByTestId('library-source-table-warehouse-orders');
+  });
+
+  // VIS-1134, inverting Phase 6c-T5. Consistency won — every other row type
+  // opens on click — but the complaint that drove 6c-T5 (clicking the name
+  // yanked you out of your exploration while hunting for a column) is
+  // answered, not ignored: the click opens AND reveals the schema.
+  test('clicking the row body opens the source AND reveals its schema', async () => {
     fetchSourceSchemaJobs.mockResolvedValue([
       { source_name: 'warehouse', has_cached_schema: true },
     ]);
@@ -117,22 +147,45 @@ describe('LibrarySourceRow', () => {
 
     fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
 
-    await waitFor(() => expect(fetchSourceSchemaJobs).toHaveBeenCalledTimes(1));
+    expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
+    await screen.findByTestId('library-source-table-warehouse-orders');
+  });
+
+  test('a second body click does not collapse — the columns cannot be taken away', async () => {
+    // The mitigation for the 6c-T5 regression: only the caret collapses, so a
+    // user clicking the name twice never loses the columns they were reaching
+    // for.
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+    const onClick = jest.fn();
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
+
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
+    await screen.findByTestId('library-source-table-warehouse-orders');
+
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
+
+    expect(screen.getByTestId('library-source-table-warehouse-orders')).toBeInTheDocument();
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  test('the caret still collapses, and toggling it never opens the source', async () => {
+    fetchSourceSchemaJobs.mockResolvedValue([
+      { source_name: 'warehouse', has_cached_schema: true },
+    ]);
+    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+    const onClick = jest.fn();
+    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
+
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
     await screen.findByTestId('library-source-table-warehouse-orders');
     expect(onClick).not.toHaveBeenCalled();
 
-    // Clicking the row body again collapses it (same toggle as the caret).
-    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
+    fireEvent.click(screen.getByTestId('library-row-source-warehouse-toggle'));
     expect(screen.queryByTestId('library-source-table-warehouse-orders')).not.toBeInTheDocument();
-  });
-
-  test('the explicit "Open" button still navigates via onClick, without expanding', () => {
-    const onClick = jest.fn();
-    render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
-    fireEvent.click(screen.getByTestId('library-row-source-warehouse-open'));
-    expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
-    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('library-source-table-warehouse-orders')).not.toBeInTheDocument();
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   test('expanding the caret lazily loads the cached schema feed (source -> table)', async () => {

--- a/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
@@ -40,6 +40,7 @@ const LibrarySubsection = ({
 }) => {
   const def = getTypeDef(typeKey);
   const Icon = def.icon;
+  const RowComponent = typeKey === 'source' ? LibrarySourceRow : LibraryRow;
 
   // Subsections default to COLLAPSED (VIS-828): absence of a saved preference
   // reads as collapsed; an explicit `false` keeps a user-expanded subsection
@@ -100,32 +101,23 @@ const LibrarySubsection = ({
               className="flex flex-col gap-px"
               data-testid={`library-subsection-${typeKey}-rows`}
             >
-              {rows.map(obj =>
-                // Sources get the D9 source → table → column drill-down
-                // (Explore 2.0 Phase 3a) instead of the plain flat row — see
-                // LibrarySourceRow's docstring.
-                typeKey === 'source' ? (
-                  <li key={obj.id} className="relative">
-                    <LibrarySourceRow
-                      obj={obj}
-                      selected={selectedRowId === obj.id}
-                      onClick={onRowClick}
-                      onContextAction={onContextAction}
-                    />
-                  </li>
-                ) : (
-                  <li key={obj.id} className="relative">
-                    <LibraryRow
-                      obj={obj}
-                      selected={selectedRowId === obj.id}
-                      draggable={def.droppable || def.explorationDragSource}
-                      onClick={onRowClick}
-                      onContextAction={onContextAction}
-                      canAddToExploration={canAddToExploration}
-                    />
-                  </li>
-                )
-              )}
+              {rows.map(obj => (
+                // Sources render through LibrarySourceRow, which wraps this
+                // same LibraryRow and adds the D9 source → table → column
+                // drill-down. Identical prop set either way — the two used to
+                // be separate call sites, which is how the source row silently
+                // lost `onContextAction` and `canAddToExploration`.
+                <li key={obj.id} className="relative">
+                  <RowComponent
+                    obj={obj}
+                    selected={selectedRowId === obj.id}
+                    draggable={def.droppable || def.explorationDragSource}
+                    onClick={onRowClick}
+                    onContextAction={onContextAction}
+                    canAddToExploration={canAddToExploration}
+                  />
+                </li>
+              ))}
             </ul>
           )}
         </div>


### PR DESCRIPTION
Closes VIS-1134. **Stacked on #572** (VIS-1135) — review that one first; this targets its branch.

`LibrarySourceRow` was a parallel re-implementation of `LibraryRow` — its own row shell, hover state, drag wiring and selected chrome. The copy drifted, and the drift is exactly what got reported:

- clicking a source **expanded its schema** while every other row type opens
- no kebab, no right-click menu, no lineage popover, no keyboard activation
- no Explore button — even though `'source'` is already in `EXPLORE_THIS_TYPES`, so it was always meant to have one
- `LibrarySubsection` was already passing `onContextAction`; the signature never accepted it, so **every menu action went nowhere**

It now renders `LibraryRow` and contributes only what is genuinely source-specific: a caret and the lazily-mounted drill-down. `LibrarySubsection` collapsed to a single call site passing an identical prop set — which is what makes silently dropping a prop impossible next time.

### Two structural details worth knowing in review

**`expandable` is explicit, not inferred from `children`.** The drill-down is falsy while collapsed — that *is* the laziness, since mounting it is what fetches — so inferring would hide the caret exactly when it's needed to expand.

**`children` render outside the row's `relative` anchor.** `ContextMenu` is `absolute top-full` on that anchor; nesting an expanded drill-down inside it would push the menu below the entire tree, and stretch the flip popover's anchor rect past the row. The anchor now carries a testid so this is asserted rather than assumed.

### The Phase 6c-T5 reversal

Body-click-expands was deliberate (#527): an auditor hunting for a column to drag found that clicking the name yanked them out of their in-progress exploration. Consistency wins here, but that complaint is **answered rather than reintroduced** — the body click opens *and* reveals the schema, and never collapses. The columns arrive from the same click that opens the source, so the gesture can't cost the user their place. Collapsing stays on the caret.

Worth knowing: clicking a source is no longer network-free (it triggers the same cached, session-level fetch the caret did). The "collapse/re-expand does not re-fetch" coverage still holds.

The drill-down is indented under its source — `LibraryRow` indents its icon further than `RowShell`'s `8 + level*14` does, so without that the tables rendered **left of their own parent**.

### One unrelated change, called out deliberately

`WorkspaceDndContext.test.jsx`'s async-fallback test compiles the full Dashboard `$defs` graph under a `waitFor` that gave up at 8s — well inside its own 15s cap. The extra tests here tip it over under parallel-worker contention: it passed in isolation and failed in the full run, taking `ExplorationPromoteModal` down with it in the same run via CPU contention. Now 12s inside a 30s cap. Not masking a hang — the work is CPU-bound compilation, and the suite is green across **three consecutive full runs**.

### Testing

**6678 passing** (355 suites), lint clean, three consecutive full runs with no flakes. Baseline on the parent branch is 6670.

Five tests pinned the old contract and were **inverted, not deleted**:
- `LibrarySourceRow.test.jsx` — body click expands / `-open` button navigates / right-click suppressed / hover reveals `-open`
- `Library.test.jsx` — the same at integration level

New coverage: body click opens **and** expands; a second body click does *not* collapse; the caret still collapses and never opens; right-click opens the menu; `onContextAction` actually reaches the handler; Enter activates the row; and the `LibraryRow` disclosure contract itself (caret only when `expandable`, caret with no children, children outside the anchor).

E2E `library-source-drilldown.spec.mjs` updated to match — the `-open` test is replaced by a context-menu test rather than dropping the coverage. **Not run** (needs a sandbox); flagging that explicitly.

Viewer-only — no core PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)