### PR TITLE
Cancel becomes Discard, and actually does something

### DIFF
--- a/viewer/src/components/styled/FormFooter.jsx
+++ b/viewer/src/components/styled/FormFooter.jsx
@@ -22,6 +22,8 @@ import { Button, ButtonOutline } from './Button';
  * - deleteConfirm: Delete confirmation state object { show, message, onConfirm, onCancel, deleting }
  * - saveLabel: Custom save button label (default: "Save")
  * - cancelLabel: Custom cancel button label (default: "Cancel")
+ * - saveDisabled / cancelDisabled: gate the buttons on form state (VIS-1133 —
+ *   in the rail these carry "nothing to save / nothing to discard")
  * - leftActions: Optional additional buttons/elements to render on the left side
  */
 const FormFooter = ({
@@ -33,6 +35,8 @@ const FormFooter = ({
   deleteConfirm,
   saveLabel = 'Save',
   cancelLabel = 'Cancel',
+  saveDisabled = false,
+  cancelDisabled = false,
   leftActions,
   // VIS-993 auto-save mode: persistence is debounced through useRecordSave,
   // so the footer renders NO Cancel/Save buttons — just Delete plus whatever
@@ -88,10 +92,22 @@ const FormFooter = ({
           </div>
         ) : (
           <div className="flex gap-2">
-            <ButtonOutline type="button" onClick={onCancel} className="text-sm">
+            <ButtonOutline
+              type="button"
+              onClick={onCancel}
+              disabled={cancelDisabled}
+              data-testid="form-footer-cancel"
+              className="text-sm"
+            >
               {cancelLabel}
             </ButtonOutline>
-            <Button type="button" onClick={onSave} disabled={saving} className="text-sm">
+            <Button
+              type="button"
+              onClick={onSave}
+              disabled={saving || saveDisabled}
+              data-testid="form-footer-save"
+              className="text-sm"
+            >
               {saving ? (
                 <>
                   <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -29,7 +30,7 @@ import useRecordSave from '../../../hooks/useRecordSave';
  * - onSave: Callback after successful save
  * - onNavigateToEmbedded: Callback(type, object) to navigate to embedded objects
  */
-const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded }) => {
+const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded, onDirtyChange }) => {
   const { deleteChart, checkCommitStatus, insights: storeInsights, fetchInsights } = useStore();
 
   // Form state
@@ -161,32 +162,44 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded 
     }
   };
 
+  // VIS-1133: the values that constitute "the saved chart", as form state.
+  // Kept as a pure function so the seeding effect and the dirty check agree by
+  // construction rather than by inspection.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setInsights(values.insights);
+    setLayoutValues(values.layoutValues);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+
   // Initialize form when chart changes
   useEffect(() => {
     if (chart) {
       // Edit mode - populate from existing chart
-      setName(chart.name || '');
-
-      // Extract insight refs (strings only, not embedded objects)
       const chartInsights = chart.config?.insights || chart.insights || [];
-      setInsights(
-        chartInsights
-          .filter(i => typeof i === 'string')
-          .map(i => parseRefValue(i))
-      );
-
-      // Layout as object
-      const layout = chart.config?.layout || chart.layout || {};
-      setLayoutValues(layout);
+      seed({
+        name: chart.name || '',
+        // Insight refs only (strings), not embedded objects.
+        insights: chartInsights.filter(i => typeof i === 'string').map(i => parseRefValue(i)),
+        layoutValues: chart.config?.layout || chart.layout || {},
+      });
     } else if (isCreate) {
-      // Create mode - reset form
-      setName('');
-      setInsights([]);
-      setLayoutValues({});
+      seed({ name: '', insights: [], layoutValues: {} });
     }
     setErrors({});
     setSaveError(null);
+    // `seed` is stable per `applyValues`; re-running on it would re-seed the
+    // form mid-edit and silently discard the user's changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chart, isCreate]);
+
+  const dirty = isDirtyAgainst({ name, insights, layoutValues });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Build the options for the insight props picker: every ref insight by name,
   // plus an entry per embedded insight. Keeps a stable identity so the picker
@@ -597,10 +610,24 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded 
           </div>
 
           <div className="flex gap-2">
-            <ButtonOutline type="button" onClick={onClose} className="text-sm">
-              Cancel
+            {/* VIS-1133: in the rail there is no modal to close, so this
+                button reverts to the last saved values instead. In create mode
+                (the onboarding modal) it stays a real Cancel. */}
+            <ButtonOutline
+              type="button"
+              onClick={isEditMode ? discard : onClose}
+              disabled={isEditMode && (!dirty || saving || deleting)}
+              data-testid="chart-form-discard"
+              className="text-sm"
+            >
+              {isEditMode ? 'Discard' : 'Cancel'}
             </ButtonOutline>
-            <Button type="button" onClick={handleSave} disabled={saving} className="text-sm">
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || (isEditMode && !dirty)}
+              className="text-sm"
+            >
               {saving ? (
                 <>
                   <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />

--- a/viewer/src/components/views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.test.jsx
@@ -190,6 +190,13 @@ describe('ChartEditForm — insight fetch guard', () => {
   });
 });
 
+// VIS-1133: Save is disabled on an untouched edit-mode form, so tests that
+// exercise the SAVE PATH must first make a real edit. The name field is
+// orthogonal to `config.insights` / `config.layout` (it travels as its own
+// argument to onSave), so touching it leaves every config assertion intact.
+const makeDirty = () =>
+  fireEvent.change(screen.getByLabelText(/Chart Name/), { target: { value: 'edited_name' } });
+
 describe('ChartEditForm — embedded insights on save', () => {
   const embeddedInsight = { name: 'inline_insight', props: { type: 'scatter' } };
 
@@ -206,6 +213,7 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByText('Embedded Insights');
 
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -231,12 +239,13 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     const [, , config] = onSave.mock.calls[0];
-    // Order drives trace layering/legend order — an untouched save must not
-    // rewrite [embedded, ref] as [ref, embedded].
+    // Order drives trace layering/legend order — a save that never touched the
+    // insight list must not rewrite [embedded, ref] as [ref, embedded].
     expect(config.insights).toEqual([embeddedInsight, 'ref(revenue_insight)']);
   });
 });
@@ -292,6 +301,7 @@ describe('ChartEditForm — validation & save paths', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -302,6 +312,7 @@ describe('ChartEditForm — validation & save paths', () => {
     const onSave = jest.fn(async () => ({ success: false, error: 'chart save exploded' }));
     await renderForm({ onSave });
 
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(await screen.findByText('chart save exploded')).toBeInTheDocument();

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -36,7 +37,7 @@ import {
  * - setIsPreviewOpen: Function to toggle the preview panel
  * - setPreviewConfig: Function to set the preview configuration in parent
  */
-const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPreviewOpen, setIsPreviewOpen, setPreviewConfig }) => {
+const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPreviewOpen, setIsPreviewOpen, setPreviewConfig, onDirtyChange }) => {
   const { deleteInsight, checkCommitStatus } = useStore();
 
   // Form state - Basic fields
@@ -91,38 +92,48 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
   }, [setPreviewConfig, name, insight?.name, debouncedProps, debouncedInteractions]);
 
   // Initialize form when insight changes
+  // VIS-1133: the saved insight, as form state.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setDescription(values.description);
+    setProps(values.props);
+    setInteractions(values.interactions);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+
   useEffect(() => {
     if (insight) {
-      // Edit mode - populate from existing insight
-      setName(insight.name || '');
-
       const configToUse = insight.config;
-      setDescription(configToUse?.description || '');
-
-      // Props - the full Plotly props object (carries `.type`).
-      setProps(configToUse?.props || { type: 'scatter' });
-
-      // Interactions - each interaction has only one type (filter, split, or sort)
       const insightInteractions = configToUse?.interactions || [];
-      setInteractions(
-        insightInteractions.map(i => {
-          // Determine which type this interaction is
+      seed({
+        name: insight.name || '',
+        description: configToUse?.description || '',
+        // The full Plotly props object (carries `.type`).
+        props: configToUse?.props || { type: 'scatter' },
+        // Each interaction carries exactly one of filter / split / sort.
+        interactions: insightInteractions.map(i => {
           if (i.filter) return { type: 'filter', value: i.filter };
           if (i.split) return { type: 'split', value: i.split };
           if (i.sort) return { type: 'sort', value: i.sort };
           return { type: 'filter', value: '' }; // Default
-        })
-      );
+        }),
+      });
     } else if (isCreate) {
-      // Create mode - reset form
-      setName('');
-      setDescription('');
-      setProps({ type: 'scatter' });
-      setInteractions([]);
+      seed({ name: '', description: '', props: { type: 'scatter' }, interactions: [] });
     }
     setErrors({});
     setSaveError(null);
+    // Re-seeding on `seed` would wipe the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [insight, isCreate]);
+
+  const dirty = isDirtyAgainst({ name, description, props, interactions });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   const validateForm = () => {
     const newErrors = {};
@@ -440,10 +451,23 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
           </div>
 
           <div className="flex gap-2">
-            <ButtonOutline type="button" onClick={onClose} className="text-sm">
-              Cancel
+            {/* VIS-1133: no modal to close in the rail, so this reverts to the
+                last saved values. Create mode (modal hosts) keeps Cancel. */}
+            <ButtonOutline
+              type="button"
+              onClick={isEditMode ? discard : onClose}
+              disabled={isEditMode && (!dirty || saving || deleting)}
+              data-testid="insight-form-discard"
+              className="text-sm"
+            >
+              {isEditMode ? 'Discard' : 'Cancel'}
             </ButtonOutline>
-            <Button type="button" onClick={handleSave} disabled={saving} className="text-sm">
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || (isEditMode && !dirty)}
+              className="text-sm"
+            >
               {saving ? (
                 <>
                   <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />

--- a/viewer/src/components/views/common/InsightEditForm.test.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.test.jsx
@@ -334,11 +334,17 @@ describe('InsightEditForm — edit mode', () => {
     expect(screen.getByLabelText('Split')).toHaveValue('b');
     expect(screen.getByLabelText('Sort')).toHaveValue('c DESC');
 
+    // VIS-1133: Save is disabled until something changes. Editing the
+    // description leaves props/interactions — what this test is really about —
+    // untouched, and proves the edit itself round-trips.
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'edited description' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave).toHaveBeenCalledWith('insight', 'rev', {
       name: 'rev',
-      description: 'revenue insight',
+      description: 'edited description',
       props: { type: 'bar', x: 'ref(m).x', y: 'ref(m).y' },
       // The empty fallback interaction is dropped; the rest round-trip.
       interactions: [{ filter: 'a > 1' }, { split: 'b' }, { sort: 'c DESC' }],
@@ -448,12 +454,19 @@ describe('InsightEditForm — embedded insights', () => {
 
     // Saving skips name validation and omits `name` from the config (the
     // synthetic embedded name still rides along as the routing arg).
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'edited' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     const [type, name, config] = onSave.mock.calls[0];
     expect(type).toBe('insight');
     expect(name).toBe('inline');
-    expect(config).toEqual({ props: { type: 'scatter', x: 'ref(m).x' } });
+    expect(config).toEqual({
+      description: 'edited',
+      props: { type: 'scatter', x: 'ref(m).x' },
+    });
+    // The point of the test: still nameless, even after an edit.
     expect(config).not.toHaveProperty('name');
   });
 });

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import Editor from '@monaco-editor/react';
 import useStore from '../../../stores/store';
 import RefSelector from './RefSelector';
@@ -22,7 +23,7 @@ import InlineFieldEditor from './InlineFieldEditor';
  * - onNavigateToEmbedded: Callback(type, object, options) to navigate to an embedded object
  *   options.applyToParent: (parentConfig, embeddedConfig) => newParentConfig
  */
-const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
+const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyChange }) => {
   // Which inline row is open for editing (null = none). These used to be links
   // into a separate editor that nothing ever wired up, so the fields had no way
   // to be filled in.
@@ -49,28 +50,43 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
   const hasEmbeddedSource = model?.config?.source && typeof model.config.source === 'object';
 
   // Initialize form with model data
+  // VIS-1133: the saved model, as form state. `expandedDimension` /
+  // `expandedMetric` are UI-only and deliberately excluded — which row is open
+  // is not an unsaved change.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setSql(values.sql);
+    setSource(values.source);
+    setDimensions(values.dimensions);
+    setMetrics(values.metrics);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+
   useEffect(() => {
     if (model) {
-      setName(model.name || '');
-      setSql(model.config?.sql || '');
-      // Source comes from API - could be ref() string, embedded object, or null
-      // Only set source state if it's a string reference, not embedded
-      if (typeof model.config?.source === 'string') {
-        setSource(model.config.source);
-      } else {
-        setSource(null);
-      }
-      // Initialize inline dimensions and metrics
-      setDimensions(model.config?.dimensions || []);
-      setMetrics(model.config?.metrics || []);
+      seed({
+        name: model.name || '',
+        sql: model.config?.sql || '',
+        // Source may be a ref() string, an embedded object, or null — only a
+        // string reference belongs in form state.
+        source: typeof model.config?.source === 'string' ? model.config.source : null,
+        dimensions: model.config?.dimensions || [],
+        metrics: model.config?.metrics || [],
+      });
     } else {
-      setName('');
-      setSql('');
-      setSource(null);
-      setDimensions([]);
-      setMetrics([]);
+      seed({ name: '', sql: '', source: null, dimensions: [], metrics: [] });
     }
+    // Re-seeding on `seed` would wipe the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model]);
+
+  const dirty = isDirtyAgainst({ name, sql, source, dimensions, metrics });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Fetch sources on mount to populate RefSelector
   useEffect(() => {
@@ -430,15 +446,22 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded }) => {
         </div>
 
         <div className="flex gap-3">
+          {/* VIS-1133: no modal to close in the rail, so this reverts to the
+              last saved values. Create mode keeps a real Cancel. */}
           <ButtonOutline
             type="button"
-            onClick={onCancel}
-            disabled={saving || deleting}
+            onClick={isCreate ? onCancel : discard}
+            disabled={saving || deleting || (!isCreate && !dirty)}
+            data-testid="model-form-discard"
             className="text-sm"
           >
-            Cancel
+            {isCreate ? 'Cancel' : 'Discard'}
           </ButtonOutline>
-          <Button type="submit" disabled={!isValid || saving || deleting} className="text-sm">
+          <Button
+            type="submit"
+            disabled={!isValid || saving || deleting || (!isCreate && !dirty)}
+            className="text-sm"
+          >
             {saving ? (
               <>
                 <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -70,6 +70,12 @@ beforeEach(() => {
   mockState.checkCommitStatus.mockResolvedValue({ success: true });
 });
 
+// VIS-1133: Save is disabled on an untouched edit-mode form. The model NAME is
+// disabled in edit mode, so SQL is the lever — assertions move with it rather
+// than being weakened.
+const makeDirty = (value = 'select * from orders where region is not null') =>
+  fireEvent.change(screen.getByLabelText('code'), { target: { value } });
+
 describe('ModelEditForm — create mode', () => {
   it('fetches sources on mount and disables Save until name and sql are provided', () => {
     render(<ModelEditForm model={null} onSave={jest.fn()} onCancel={jest.fn()} />);
@@ -153,12 +159,13 @@ describe('ModelEditForm — edit mode initialization and save', () => {
     const model = editModel();
     const onSave = jest.fn(async () => ({ success: true }));
     render(<ModelEditForm model={model} onSave={onSave} onCancel={jest.fn()} />);
+    makeDirty();
     clickSave();
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave).toHaveBeenCalledWith('model', 'orders', {
       name: 'orders',
-      sql: 'select * from orders',
+      sql: 'select * from orders where region is not null',
       source: 'ref(warehouse)',
       dimensions: [{ name: 'region', expression: 'region' }],
       metrics: [{ name: 'revenue', expression: 'sum(amount)' }],
@@ -236,6 +243,7 @@ describe('ModelEditForm — embedded source', () => {
     const model = embeddedModel();
     const onSave = jest.fn(async () => ({ success: true }));
     render(<ModelEditForm model={model} onSave={onSave} onCancel={jest.fn()} />);
+    makeDirty();
     clickSave();
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -433,5 +441,96 @@ describe('ModelEditForm — cancel', () => {
     render(<ModelEditForm model={null} onSave={jest.fn()} onCancel={onCancel} />);
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// VIS-1133. In the persistent rail there is no modal to close, so the footer's
+// left button reverts instead — and both buttons stay inert until something
+// actually changed. Create mode (a modal host) keeps a real Cancel.
+describe('ModelEditForm — Discard (edit mode)', () => {
+  it('labels the button Discard in edit mode and Cancel in create mode', () => {
+    const { unmount } = render(
+      <ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />
+    );
+    expect(screen.getByTestId('model-form-discard')).toHaveTextContent('Discard');
+    unmount();
+
+    render(<ModelEditForm model={null} onSave={jest.fn()} onCancel={jest.fn()} />);
+    expect(screen.getByTestId('model-form-discard')).toHaveTextContent('Cancel');
+  });
+
+  it('disables Save and Discard on an untouched form', () => {
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('enables both once a field changes, and Discard puts it back', () => {
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    makeDirty('select 1');
+    expect(screen.getByLabelText('code')).toHaveValue('select 1');
+    expect(screen.getByTestId('model-form-discard')).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('model-form-discard'));
+
+    expect(screen.getByLabelText('code')).toHaveValue('select * from orders');
+    // Back to clean, so both go inert again.
+    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('restores inline dimensions and metrics too, not just scalar fields', () => {
+    // These are arrays rebuilt on every render — reference comparison would
+    // have reported the form permanently dirty and made Discard a no-op.
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
+    expect(screen.getByTestId('model-form-discard')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('model-form-discard'));
+
+    expect(screen.queryByTestId('inline-dimension-editor')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();
+  });
+
+  it('a saved edit clears dirty — the form does not stay stuck', () => {
+    // The baseline advances when the record prop changes identity, which is
+    // exactly what useRecordSave's optimistic write does after a save. Without
+    // it, Save would light up forever and Discard would offer to undo
+    // already-committed work.
+    const { rerender } = render(
+      <ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />
+    );
+    makeDirty('select 1');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    const saved = editModel();
+    saved.config.sql = 'select 1';
+    rerender(<ModelEditForm model={saved} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+  });
+
+  it('reports dirtiness upward so the tab strip can show its unsaved dot', () => {
+    const onDirtyChange = jest.fn();
+    render(
+      <ModelEditForm
+        model={editModel()}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        onDirtyChange={onDirtyChange}
+      />
+    );
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+    makeDirty('select 1');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.click(screen.getByTestId('model-form-discard'));
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import { ButtonOutline } from '../../styled/Button';
 import SourceTypeSelector from '../../sources/SourceTypeSelector';
@@ -29,7 +30,7 @@ import SeedsEditor, { sourceTypeSupportsSeeds } from './SeedsEditor';
  * - onSave: Function(type, name, config) - Unified save callback
  * - onGoBack: Callback to navigate back to parent (for embedded sources)
  */
-const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
+const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyChange }) => {
   const { deleteSource, testConnection, connectionStatus, clearConnectionStatus, checkCommitStatus } =
     useStore();
   // Tells us whether the serving process shares a filesystem with the project,
@@ -51,36 +52,52 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
   const isEmbedded = isEmbeddedObject(source);
   const parentName = source?._embedded?.parentName;
 
+  // VIS-1133: the saved source, as form state.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setSourceType(values.sourceType);
+    setFormValues(values.formValues);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+
   // Initialize form when source changes
   useEffect(() => {
     if (source) {
-      // Edit mode - populate from existing source
-      setName(source.name || '');
-
       const configToUse = source.config;
-
-      // Extract form values from the config object
       if (configToUse) {
-        setSourceType(configToUse.type || '');
         const { name: _, type: __, ...formProps } = configToUse;
-        setFormValues(formProps);
+        seed({
+          name: source.name || '',
+          sourceType: configToUse.type || '',
+          formValues: formProps,
+        });
       } else {
         // Fallback for flat source objects — restore the type from the flat
         // object too, otherwise a config-less source renders the "select a
         // source type" placeholder instead of its connection fields.
-        setSourceType(source.type || '');
         const { name: _, type: __, status: ___, config: ____, _embedded: _____, ...formProps } = source;
-        setFormValues(formProps);
+        seed({
+          name: source.name || '',
+          sourceType: source.type || '',
+          formValues: formProps,
+        });
       }
     } else if (isCreate) {
-      // Create mode - reset form
-      setName('');
-      setSourceType('');
-      setFormValues({});
+      seed({ name: '', sourceType: '', formValues: {} });
     }
     setErrors({});
     setSaveError(null);
+    // Re-seeding on `seed` would wipe the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source, isCreate]);
+
+  const dirty = isDirtyAgainst({ name, sourceType, formValues });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Clear connection status when panel closes
   useEffect(() => {
@@ -295,9 +312,12 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack }) => {
       </FormLayout>
 
       <FormFooter
-        onCancel={onClose}
+        onCancel={isEditMode ? discard : onClose}
         onSave={handleSave}
         saving={saving}
+        cancelLabel={isEditMode ? 'Discard' : 'Cancel'}
+        cancelDisabled={isEditMode && (!dirty || saving || deleting)}
+        saveDisabled={isEditMode && !dirty}
         showDelete={isEditMode && !showDeleteConfirm && !isEmbedded}
         onDeleteClick={() => setShowDeleteConfirm(true)}
         deleteConfirm={

--- a/viewer/src/components/views/common/SourceEditForm.test.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.test.jsx
@@ -270,6 +270,12 @@ describe('SourceEditForm — test connection', () => {
   });
 });
 
+// VIS-1133: Save is disabled on an untouched edit-mode form, so save-path
+// tests must make a real edit first. The source NAME is orthogonal to the
+// seeds/type assertions below, so touching it leaves them intact.
+const makeDirty = () =>
+  fireEvent.change(screen.getByLabelText(/Source Name/), { target: { value: 'edited_name' } });
+
 describe('SourceEditForm — embedded sources', () => {
   const embedded = {
     _embedded: { parentName: 'model_a', path: 'source' },
@@ -281,9 +287,13 @@ describe('SourceEditForm — embedded sources', () => {
     const onSave = jest.fn(async () => ({ success: true }));
     renderForm({ source: embedded, isCreate: false, onSave });
     expect(screen.queryByLabelText(/Source Name/)).not.toBeInTheDocument();
+    // No name field here, so dirty the form through a real config field — and
+    // assert the edit round-trips, which is strictly more than the old
+    // untouched save proved.
+    fireEvent.change(screen.getByLabelText(/Database/), { target: { value: 'edited.db' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() =>
-      expect(onSave).toHaveBeenCalledWith('source', '', { type: 'sqlite', database: 'e.db' })
+      expect(onSave).toHaveBeenCalledWith('source', '', { type: 'sqlite', database: 'edited.db' })
     );
     expect(onSave.mock.calls[0][2]).not.toHaveProperty('name');
   });
@@ -322,6 +332,7 @@ describe('SourceEditForm — seeds', () => {
     renderForm({ source: seededSqlite, isCreate: false, onSave });
 
     expect(screen.getByLabelText('Seed 1 table name')).toHaveValue('raw');
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
@@ -356,6 +367,7 @@ describe('SourceEditForm — seeds', () => {
       onSave,
     });
 
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
@@ -373,6 +385,9 @@ describe('SourceEditForm — seeds', () => {
       onSave,
     });
 
+    // Dirty via the NAME so the seed stays invalid — otherwise Save is
+    // disabled and this would pass vacuously, never reaching validation.
+    makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onSave).not.toHaveBeenCalled();

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import { Button, ButtonOutline } from '../../styled/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -26,7 +27,7 @@ import Select from '../../common/Select';
  * - onSave: Callback after successful save
  * - onNavigateToEmbedded: Callback(type, object) to navigate to embedded objects
  */
-const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded }) => {
+const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded, onDirtyChange }) => {
   const {
     deleteTable,
     checkCommitStatus,
@@ -82,33 +83,46 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded 
   const isEmbeddedData = rawData && typeof rawData === 'object';
 
   // Initialize form when table changes
+  // VIS-1133: the saved table, as form state — one shape for both seeding and
+  // the dirty check, so they cannot disagree.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setDataRef(values.dataRef);
+    setRowsPerPage(values.rowsPerPage);
+    setColumns(values.columns);
+    setRows(values.rows);
+    setValues(values.values);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+
   useEffect(() => {
     if (table) {
       const config = table.config || table;
-      setName(table.name || '');
-
       const tableData = config.data;
-      if (typeof tableData === 'string') {
-        setDataRef(parseRefValue(tableData) || '');
-      } else {
-        setDataRef('');
-      }
-
-      setRowsPerPage(config.rows_per_page || 25);
-      setColumns(config.columns || []);
-      setRows(config.rows || []);
-      setValues(config.values || []);
+      seed({
+        name: table.name || '',
+        dataRef: typeof tableData === 'string' ? parseRefValue(tableData) || '' : '',
+        rowsPerPage: config.rows_per_page || 25,
+        columns: config.columns || [],
+        rows: config.rows || [],
+        values: config.values || [],
+      });
     } else if (isCreate) {
-      setName('');
-      setDataRef('');
-      setRowsPerPage(25);
-      setColumns([]);
-      setRows([]);
-      setValues([]);
+      seed({ name: '', dataRef: '', rowsPerPage: 25, columns: [], rows: [], values: [] });
     }
     setErrors({});
     setSaveError(null);
+    // Re-seeding on `seed` would wipe the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table, isCreate]);
+
+  const dirty = isDirtyAgainst({ name, dataRef, rowsPerPage, columns, rows, values });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Blank pivot entries (the '' scaffold RefListField's Add button creates, or
   // whitespace-only edits) must never save — `columns: ['']` is not a valid
@@ -435,10 +449,23 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded 
           </div>
 
           <div className="flex gap-2">
-            <ButtonOutline type="button" onClick={onClose} className="text-sm">
-              Cancel
+            {/* VIS-1133: no modal to close in the rail, so this reverts to the
+                last saved values. Create mode (modal hosts) keeps Cancel. */}
+            <ButtonOutline
+              type="button"
+              onClick={isEditMode ? discard : onClose}
+              disabled={isEditMode && (!dirty || saving || deleting)}
+              data-testid="table-form-discard"
+              className="text-sm"
+            >
+              {isEditMode ? 'Discard' : 'Cancel'}
             </ButtonOutline>
-            <Button type="button" onClick={handleSave} disabled={saving} className="text-sm">
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || (isEditMode && !dirty)}
+              className="text-sm"
+            >
               {saving ? (
                 <>
                   <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />

--- a/viewer/src/components/views/common/TableEditForm.test.jsx
+++ b/viewer/src/components/views/common/TableEditForm.test.jsx
@@ -54,6 +54,16 @@ const renderForm = (props = {}) =>
     />
   );
 
+// VIS-1133: Save is disabled on an untouched edit-mode form. The Table NAME
+// field is disabled in edit mode, so rows-per-page is the lever here — the
+// assertions below move with it rather than being weakened.
+// Rows Per Page is a react-select, so it is driven with selectEvent (the same
+// way the create-mode tests below already do it), not fireEvent.change.
+const makeDirty = async (value = '50') =>
+  selectEvent.select(screen.getByLabelText('Rows Per Page'), value, {
+    container: document.body,
+  });
+
 describe('TableEditForm — fetch guard', () => {
   test('fetches insights/models only once when the project has zero of them', () => {
     const fetchInsights = jest.fn();
@@ -100,6 +110,9 @@ describe('TableEditForm — data ref + pivot conflict', () => {
     expect(screen.getByText('Data Source')).toBeInTheDocument();
     expect(screen.getByText('Pivot Configuration')).toBeInTheDocument();
 
+    // Dirty the form so Save is reachable — the conflict it must report is
+    // untouched, so this still tests validation and not the gate.
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(
@@ -316,12 +329,13 @@ describe('TableEditForm — save payloads', () => {
     expect(screen.getByText('Data Source')).toBeInTheDocument();
     expect(screen.queryByText('Pivot Configuration')).not.toBeInTheDocument();
 
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave).toHaveBeenCalledWith('table', 't1', {
       name: 't1',
-      rows_per_page: 100,
+      rows_per_page: 50,
       data: 'ref(rev_insight)',
     });
   });
@@ -391,12 +405,13 @@ describe('TableEditForm — embedded data source', () => {
     const onSave = jest.fn(async () => ({ success: true }));
     renderForm({ table: embeddedTable, isCreate: false, onSave });
 
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave).toHaveBeenCalledWith('table', 't2', {
       name: 't2',
-      rows_per_page: 25,
+      rows_per_page: 50,
       data: rawData,
     });
   });

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PiPencil, PiPlus } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import useWorkspaceScope from './useWorkspaceScope';
@@ -657,7 +657,11 @@ const INLINE_LEAF_FORMS = {
   source: (record, common) => <SourceEditForm source={record} {...common} />,
   insight: (record, common) => <InsightEditForm insight={record} {...common} />,
   model: (record, common) => (
-    <ModelEditForm model={record} onSave={common.onSave} onCancel={common.onClose} />
+    <ModelEditForm
+      model={record}
+      onSave={common.onSave}
+      onDirtyChange={common.onDirtyChange}
+    />
   ),
   // VIS-996: dimension/metric/relation render through the generic schema-driven
   // leaf form — field sets come from the published $defs, not bespoke JSX.
@@ -687,9 +691,30 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   // the dashboard-structure forms.
   const [leafSaveStatus, setLeafSaveStatus] = useState(undefined);
 
-  // No modal to close in the rail, so the forms' close/cancel/embedded-nav
-  // callbacks are no-ops.
+  // No modal to close in the rail. This used to be handed to the forms as
+  // `onClose`/`onCancel`, which made their Cancel button a literal no-op —
+  // VIS-1133. The forms now branch on their own `isCreate`/`isEditMode` and
+  // render Discard (revert to last saved) in the rail, so nothing here needs a
+  // close handler; `onGoBack`/`onNavigateToEmbedded` still have no rail
+  // meaning and keep the stub.
   const noop = useCallback(() => {}, []);
+
+  // VIS-1133: lift the active form's dirtiness to the tab strip. The dot
+  // (`TabStrip`) and the guarded close (`requestCloseWorkspaceTab`) were both
+  // already built for this, but nothing produced the signal for these types.
+  //
+  // Cleared on unmount / record change on purpose: this panel is a SINGLE
+  // instance bound to the active object, with no per-tab form cache, so
+  // switching tabs destroys the draft. A dot that outlived the form would
+  // advertise unsaved work that has already been dropped, and the close
+  // confirm would fire over nothing.
+  const setWorkspaceTabDirty = useStore(s => s.setWorkspaceTabDirty);
+  const [leafDirty, setLeafDirty] = useState(false);
+  useEffect(() => {
+    const tabId = `${type}:${name}`;
+    setWorkspaceTabDirty(tabId, leafDirty);
+    return () => setWorkspaceTabDirty(tabId, false);
+  }, [type, name, leafDirty, setWorkspaceTabDirty]);
 
   // Standalone (non-embedded) save through the unified optimistic + debounced
   // backbone — one `useRecordSave` instance per open record (VIS-1018 step 3,
@@ -753,11 +778,14 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   if (renderForm) {
     const common = {
       isCreate: false,
-      onClose: noop,
+      // Deliberately no `onClose`: there is no modal here, and handing the
+      // forms a no-op is what left Cancel dead for so long. In edit mode they
+      // render Discard and revert locally instead.
       onSave: handleObjectSave,
       onNavigateToEmbedded: noop,
       onGoBack: noop,
       onSaveStatusChange: setLeafSaveStatus,
+      onDirtyChange: setLeafDirty,
     };
     return (
       <>

--- a/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.test.jsx
@@ -101,8 +101,25 @@ const stubForm = (testid, prop) => ({
 // save routes through the unified `useRecordSave` backbone (VIS-1018 step 3).
 jest.mock('../common/ChartEditForm', () => ({
   __esModule: true,
-  default: ({ chart, onSave }) => (
+  default: ({ chart, onSave, onDirtyChange, onClose }) => (
     <div data-testid="chart-edit-form-stub">
+      <span data-testid="chart-stub-onclose">{onClose ? 'present' : 'absent'}</span>
+      {/* VIS-1133: the real form reports dirtiness up so the tab strip's dot
+          and its guarded close reflect actual edits. */}
+      <button
+        type="button"
+        data-testid="chart-stub-dirty"
+        onClick={() => onDirtyChange?.(true)}
+      >
+        dirty
+      </button>
+      <button
+        type="button"
+        data-testid="chart-stub-clean"
+        onClick={() => onDirtyChange?.(false)}
+      >
+        clean
+      </button>
       {`chart-edit-form-stub:${chart?.name || 'none'}`}
       {/* The config must be SCHEMA-VALID (Chart forbids unknown properties) or
           the VIS-993 validation gate blocks the save this test asserts. */}
@@ -896,6 +913,66 @@ describe('RightRailEditPanel standalone leaf save (VIS-1018 step 3)', () => {
     // And the store collection was updated OPTIMISTICALLY before the round-trip.
     const entry = useStore.getState().charts.find(c => c.name === 'rev_chart');
     expect((entry.config || entry).layout.title.text).toBe('Edited');
+  });
+});
+
+// ── VIS-1133: the rail no longer hands the forms a no-op close callback, and
+// it lifts their dirtiness to the tab strip ──────────────────────────────────
+describe('RightRailEditPanel leaf dirty wiring (VIS-1133)', () => {
+  const seedChartTab = () =>
+    resetStore({
+      workspaceActiveObject: { type: 'chart', name: 'rev_chart' },
+      charts: [{ name: 'rev_chart', config: { title: 'Old' } }],
+      workspaceTabs: [{ id: 'chart:rev_chart', type: 'chart', name: 'rev_chart' }],
+      workspaceActiveTabId: 'chart:rev_chart',
+    });
+
+  const dirtyOf = id =>
+    useStore.getState().workspaceTabs.find(t => t.id === id)?.dirty;
+
+  test('a dirty leaf form marks its tab dirty', () => {
+    seedChartTab();
+    renderPanel();
+    expect(dirtyOf('chart:rev_chart')).toBeFalsy();
+
+    fireEvent.click(screen.getByTestId('chart-stub-dirty'));
+
+    expect(dirtyOf('chart:rev_chart')).toBe(true);
+  });
+
+  test('going clean again clears the dot', () => {
+    seedChartTab();
+    renderPanel();
+    fireEvent.click(screen.getByTestId('chart-stub-dirty'));
+    expect(dirtyOf('chart:rev_chart')).toBe(true);
+
+    fireEvent.click(screen.getByTestId('chart-stub-clean'));
+
+    expect(dirtyOf('chart:rev_chart')).toBe(false);
+  });
+
+  test('unmounting clears the dot, because the draft dies with the form', () => {
+    // This panel is a SINGLE instance bound to the active object — there is no
+    // per-tab form cache, so switching tabs destroys the local draft. A dot
+    // that outlived the form would advertise unsaved work that is already
+    // gone, and the close confirm would fire over nothing.
+    seedChartTab();
+    const { unmount } = renderPanel();
+    fireEvent.click(screen.getByTestId('chart-stub-dirty'));
+    expect(dirtyOf('chart:rev_chart')).toBe(true);
+
+    unmount();
+
+    expect(dirtyOf('chart:rev_chart')).toBe(false);
+  });
+
+  test('the forms are no longer handed a no-op onClose', () => {
+    // The original bug: `onClose` was `() => {}`, so every form's Cancel did
+    // nothing. Passing NOTHING is what lets a form tell "I am in a modal" from
+    // "I am in the rail" and render Discard instead.
+    seedChartTab();
+    renderPanel();
+    expect(screen.getByTestId('chart-stub-onclose')).toHaveTextContent('absent');
   });
 });
 

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -1437,11 +1437,17 @@ describe('WorkspaceDndContext commit path (D-3 / D-4, gated per VIS-993)', () =>
     fireEvent.click(screen.getByTestId('commit-probe'));
 
     // Generous timeout: the fallback compiles the full Dashboard $defs graph.
-    await waitFor(() => expect(saveDashboard).toHaveBeenCalledTimes(1), { timeout: 8000 });
+    // Kept inside this test's own budget rather than well under it — at 8s the
+    // waitFor gave up first, so a busy full-suite run (where jest workers
+    // contend for CPU) failed here while the suite passed in isolation. The
+    // work is CPU-bound compilation, not a hang.
+    await waitFor(() => expect(saveDashboard).toHaveBeenCalledTimes(1), { timeout: 12000 });
     expect(saveDashboard.mock.calls[0][1]).toBe(VALID_CONFIG);
     // Restore the warm cache for any following test.
     await preloadValidationSchema();
-  }, 15000);
+    // 30s, not 15s: the waitFor above can legitimately use 12s of that budget
+    // and the preload here is a second compile of the same graph.
+  }, 30000);
 
   test('the commit is a safe no-op without a dashboard name', () => {
     const saveDashboard = jest.fn();

--- a/viewer/src/hooks/useFormBaseline.js
+++ b/viewer/src/hooks/useFormBaseline.js
@@ -1,0 +1,54 @@
+import { useCallback, useState } from 'react';
+import isEqual from 'lodash/isEqual';
+
+/**
+ * Track a form's last-saved values so it can report dirtiness and revert.
+ *
+ * The right rail's Cancel button was `() => {}` — modal-dismiss plumbing that
+ * was stubbed out when the forms moved into the persistent rail and never
+ * replaced. Making it Discard needs something to discard *to*, and no leaf
+ * form retained one: each seeds plain `useState` from its record and keeps no
+ * copy of the seed.
+ *
+ * **Snapshot the form's own state values, not its built config.** The forms
+ * normalise on save (`formatRef`, trimming, omitting empty `layout`/`seeds`,
+ * the chart's ref/embedded interleave rebuild), so diffing `buildConfig()`
+ * against the stored record reports a freshly-loaded form as dirty on arrival.
+ *
+ * The baseline advances by itself after a save: the rail persists through
+ * `useRecordSave.saveNow`, whose `updateRecordConfigOptimistic` replaces the
+ * collection entry with a NEW object, so the form's `[record]`-keyed seeding
+ * effect re-runs and calls `seed` again. Same mechanism that re-seeds when the
+ * user switches to a different record.
+ *
+ * @param {(values: object) => void} apply - push a value set into form state.
+ *   Setters are stable, so this can safely be a `useCallback(..., [])`.
+ */
+export default function useFormBaseline(apply) {
+  const [baseline, setBaseline] = useState(null);
+
+  /** Seed form state AND record it as the clean baseline. */
+  const seed = useCallback(
+    values => {
+      setBaseline(values);
+      apply(values);
+    },
+    [apply]
+  );
+
+  /** Put every field back to the baseline. No-op before the first seed. */
+  const discard = useCallback(() => {
+    if (baseline) apply(baseline);
+  }, [baseline, apply]);
+
+  /**
+   * Deep-compare the current values against the baseline. Reports clean until
+   * the first seed, so a form mid-mount never flashes its buttons enabled.
+   */
+  const isDirtyAgainst = useCallback(
+    values => baseline !== null && !isEqual(values, baseline),
+    [baseline]
+  );
+
+  return { seed, discard, isDirtyAgainst, baseline };
+}

--- a/viewer/src/hooks/useFormBaseline.test.js
+++ b/viewer/src/hooks/useFormBaseline.test.js
@@ -1,0 +1,95 @@
+/**
+ * useFormBaseline — the seed/dirty/revert primitive behind the rail's Discard
+ * button (VIS-1133).
+ *
+ * The behaviour that matters is the baseline ADVANCING: a form whose baseline
+ * never moved would report itself permanently dirty after its first save, and
+ * Discard would keep offering to undo work the user already committed.
+ */
+import { renderHook, act } from '@testing-library/react';
+import useFormBaseline from './useFormBaseline';
+
+/** Drive the hook with a spy `apply` so we can see what it pushes back. */
+const setup = () => {
+  const applied = [];
+  const apply = values => applied.push(values);
+  const view = renderHook(() => useFormBaseline(apply));
+  return { view, applied };
+};
+
+describe('useFormBaseline', () => {
+  it('reports clean before the first seed, so a mounting form never flashes enabled', () => {
+    const { view } = setup();
+    expect(view.result.current.isDirtyAgainst({ name: 'anything' })).toBe(false);
+  });
+
+  it('seeds form state and records it as the clean baseline', () => {
+    const { view, applied } = setup();
+    act(() => view.result.current.seed({ name: 'orders', sql: 'select 1' }));
+
+    expect(applied).toEqual([{ name: 'orders', sql: 'select 1' }]);
+    expect(view.result.current.isDirtyAgainst({ name: 'orders', sql: 'select 1' })).toBe(false);
+  });
+
+  it('is dirty once any field differs', () => {
+    const { view } = setup();
+    act(() => view.result.current.seed({ name: 'orders', sql: 'select 1' }));
+    expect(view.result.current.isDirtyAgainst({ name: 'orders', sql: 'select 2' })).toBe(true);
+  });
+
+  it('compares deeply — a structurally equal array or object is NOT a change', () => {
+    // The forms hold arrays/objects (dimensions, layout, props) that are
+    // rebuilt on every render, so reference equality would report every form
+    // as permanently dirty.
+    const { view } = setup();
+    act(() =>
+      view.result.current.seed({ dimensions: [{ name: 'region' }], layout: { title: 'x' } })
+    );
+    expect(
+      view.result.current.isDirtyAgainst({
+        dimensions: [{ name: 'region' }],
+        layout: { title: 'x' },
+      })
+    ).toBe(false);
+    expect(
+      view.result.current.isDirtyAgainst({
+        dimensions: [{ name: 'country' }],
+        layout: { title: 'x' },
+      })
+    ).toBe(true);
+  });
+
+  it('discard pushes the baseline back through apply', () => {
+    const { view, applied } = setup();
+    act(() => view.result.current.seed({ name: 'orders' }));
+    applied.length = 0;
+
+    act(() => view.result.current.discard());
+
+    expect(applied).toEqual([{ name: 'orders' }]);
+  });
+
+  it('discard before any seed is a no-op rather than a crash', () => {
+    const { view, applied } = setup();
+    act(() => view.result.current.discard());
+    expect(applied).toEqual([]);
+  });
+
+  it('re-seeding advances the baseline — this is what clears dirty after a save', () => {
+    // The rail persists through useRecordSave, whose optimistic write replaces
+    // the store record with a NEW object; the form's [record]-keyed effect then
+    // re-seeds. Without this, a saved form stays dirty forever.
+    const { view, applied } = setup();
+    act(() => view.result.current.seed({ name: 'orders' }));
+    expect(view.result.current.isDirtyAgainst({ name: 'edited' })).toBe(true);
+
+    act(() => view.result.current.seed({ name: 'edited' }));
+
+    expect(view.result.current.isDirtyAgainst({ name: 'edited' })).toBe(false);
+
+    // ...and Discard now returns to the NEW baseline, not the pre-save one.
+    applied.length = 0;
+    act(() => view.result.current.discard());
+    expect(applied).toEqual([{ name: 'edited' }]);
+  });
+});


### PR DESCRIPTION
Closes VIS-1133. Independent of #572/#573 (different files) — mergeable in any order.

The edit panel's Cancel was `() => {}` (`RightRailEditPanel.jsx:692`). Modal-dismiss plumbing, stubbed when the forms moved into the persistent rail and never replaced. Save was equally indiscriminate — always enabled, whether or not anything had changed.

### Why this stayed small

The five rail forms that show these buttons — chart, table, insight, model, source — are all *delegating*: they hold edits in local state and only call `onSave`, so **the store record stays clean until Save is pressed** and is already a valid last-saved baseline. No new API, no snapshot plumbing. (The other forms auto-save and have no buttons to fix.)

### Three decisions worth reviewing

**Snapshot form state, not the built config.** The forms normalise on save — `formatRef`, trimming, omitting empty `layout`/`seeds`, the chart's ref/embedded interleave rebuild — so diffing `buildConfig()` against the record reports a freshly-loaded form as **dirty on arrival**. `useFormBaseline` also compares *deeply*, because dimensions/layout/props are rebuilt every render and reference equality would call every form permanently dirty.

**Stop passing the noop rather than passing a better one.** That absence is what lets a form distinguish "I'm in a modal" from "I'm in the rail": create mode (`OnboardingFlow`'s modal) keeps a working Cancel, edit mode renders Discard and reverts locally.

**The baseline advances by itself after a save.** `useRecordSave`'s optimistic write replaces the collection entry with a *new* object, so each form's `[record]`-keyed effect re-seeds. Without that a saved form stays dirty forever — there's a test on exactly that, since it's the failure mode this design could plausibly have.

### The bonus

Dirtiness is lifted to the tab strip, which makes the unsaved dot **and the guarded tab close** real for these types for the first time. Until now `setWorkspaceTabDirty`'s only producer was `ExplorationPane`, passing `syncStatus === 'saving'` — "currently saving", not "has unsaved changes".

It's cleared on unmount deliberately: this panel is a *single* instance bound to the active object with no per-tab form cache, so switching tabs destroys the draft. A dot that outlived the form would advertise work that was already dropped, and the close confirm would fire over nothing. **Residual gap, stated rather than hidden:** switching tabs still drops the draft silently. Closing that needs form drafts hoisted into the store — a separate change.

### Test churn, and why it isn't weakening

Eleven existing tests clicked Save in edit mode without editing, so they now drive a disabled button. Each got a **real edit** rather than a relaxed assertion, and where that edit changes the saved config the expectation moved with it — so several now prove an edit *round-trips*, which the untouched saves never did.

The one that needed care: `refuses to save a seed with no table name` would have passed **vacuously** (Save disabled → `onSave` not called → assertion trivially true, validation never reached). It's dirtied via a field the seed doesn't own, so it still exercises validation.

One real consequence to be aware of: a config that differs from its stored form *only after normalisation* (e.g. blank arg rows in a seed) can no longer be cleaned up by pressing Save, because Save is disabled until something changes.

### Testing

**6676 passing** (356 suites), lint clean. Baseline on main is 6659, so +17.

New: `useFormBaseline.test.js` (seed / deep-compare / discard / **baseline advances**), and a Discard suite on `ModelEditForm` (label per mode, both buttons inert when pristine, revert restores scalars *and* inline dimension arrays, a saved edit clears dirty, dirtiness reported upward). Rail-level: dirty reaches `setWorkspaceTabDirty`, clears on unmount, and the forms are no longer handed an `onClose` at all — the assertion that would have caught the original bug.

### Two things I did not fix, flagged rather than buried

1. `WorkspaceDndContext`'s async-fallback test had an 8s `waitFor` inside its own 15s cap; it compiles the full Dashboard `$defs` graph and was first to give up under worker contention. Raised to 12s inside 30s. **Same one-line change as #573** — whichever lands first makes it a no-op in the other.
2. `ExplorationPromoteModal` flakes roughly **1 full run in 3** — I reproduced that on clean `main` at the same rate, so it is not from this change. That file also contains whole **duplicated describe blocks** (`(coverage-push)`) re-testing identical test titles, and it is the duplicate that fails. Left alone; it wants its own ticket.

Viewer-only — no core PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)