### PR TITLE
VIS-1136: fail deploy when there is no run output to upload

### DIFF
--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -410,6 +410,34 @@ def test_verify_run_output_ignores_an_insight_that_built_nothing(tmp_path):
         verify_run_output(project, str(tmp_path))  # does not raise
 
 
+def test_verify_run_output_rejects_a_missing_run_directory(tmp_path):
+    """The trap the user hit: `deploy` before `run`. deploy uploads what the run
+    wrote and never runs itself, so a run directory that isn't there means zero
+    data uploaded — but the per-envelope checks skip missing envelopes and the
+    deploy 'succeeds' empty. A project with insights but no run directory is that
+    trap, so it must fail loudly instead."""
+    missing_dir = os.path.join(str(tmp_path), "main")  # never created — no run happened
+    project, insight = _project_with_insight()
+
+    with mock.patch("visivo.commands.deploy_phase.all_descendants_of_type", return_value=[insight]):
+        with pytest.raises(click.ClickException) as exc:
+            verify_run_output(project, missing_dir)
+
+    assert "visivo run" in str(exc.value)
+
+
+def test_verify_run_output_allows_a_missing_directory_with_nothing_to_build(tmp_path):
+    """A project with no insights or inputs has no run data to upload, so an
+    absent run directory is not the trap — deploy of a markdown-only project that
+    was never run should not be forced through a pointless build."""
+    missing_dir = os.path.join(str(tmp_path), "main")
+    project = mock.Mock(inputs=[])
+    project.dag = lambda: mock.Mock()
+
+    with mock.patch("visivo.commands.deploy_phase.all_descendants_of_type", return_value=[]):
+        verify_run_output(project, missing_dir)  # does not raise
+
+
 def test_verify_run_output_stays_short_by_default(tmp_path, monkeypatch):
     """The list is diagnostic, not a to-do — the reader acts on the remedy, not
     on individual paths. Long output here reads as a wall of noise."""

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -888,7 +888,25 @@ def verify_run_output(project, output_dir):
     A referenced file must exist AND sit in one of the directories a collector
     searches. Existence alone would pass a stale ``target/``, where the file is
     real but sits in the ``files/`` directory nothing reads any more.
+
+    The per-envelope checks below cannot see the case that bites hardest: a run
+    directory that isn't there at all. ``deploy`` uploads what ``visivo run``
+    wrote under this directory and never runs itself, so if the directory is
+    absent every collector finds nothing, uploads nothing, and the deploy
+    reports success with zero data — exactly the silent failure this function
+    exists to prevent. A missing envelope is the run's business (an insight may
+    fail to build and ``run`` still exits 0), but a project that HAS data to
+    build with NO run directory means the run never happened. Name it.
     """
+    insights = list(all_descendants_of_type(type=Insight, dag=project.dag()))
+    inputs = list(project.inputs) if getattr(project, "inputs", None) else []
+
+    if (insights or inputs) and not os.path.isdir(output_dir):
+        raise click.ClickException(
+            f"No run output at '{output_dir}'. `visivo run` builds the data that "
+            f"`visivo deploy` uploads — run it, then deploy."
+        )
+
     searched = ("models", "insights", "inputs")
     missing = []
 
@@ -917,10 +935,10 @@ def verify_run_output(project, output_dir):
             if not any(os.path.exists(os.path.join(output_dir, d, filename)) for d in searched):
                 missing.append(f"{filename}  (referenced by {owner})")
 
-    for insight in all_descendants_of_type(type=Insight, dag=project.dag()):
+    for insight in insights:
         _check_envelope(f"insights/{insight.name}.json", f"insight '{insight.name}'")
 
-    for input_obj in project.inputs if getattr(project, "inputs", None) else []:
+    for input_obj in inputs:
         _check_envelope(f"inputs/{input_obj.name}.json", f"input '{input_obj.name}'")
 
     if not missing:


### PR DESCRIPTION
## Problem

`visivo deploy` on `docs-examples` **succeeded** but uploaded no data — every data stage read `completed in 0.00 seconds` and the deployed project had no insight data:

```
Insight uploads completed in 0.00 seconds
Model uploads completed in 0.00 seconds
0 source schemas uploaded
```

`deploy` compiles the project and uploads what a **prior `visivo run`** wrote under `target/<run_id>/` — it never runs itself. Here the deploy ran before the run output existed (the `target/main/insights/*.parquet` files were timestamped ~2.5 min *after* the deploy), so there was genuinely nothing to upload.

The defect is that deploy reported **success**. `verify_run_output()` exists to prevent "deploy succeeds but uploads no data", but it only fires when an envelope *exists and references a missing file*. When the **entire run directory is absent** (deploy-before-run, or a cleared `target/`), it has nothing to check and passes silently.

## Fix

`verify_run_output` now also fails when the project has data-producing objects (insights/inputs) but the run output directory doesn't exist:

> No run output at '&lt;dir&gt;'. `visivo run` builds the data that `visivo deploy` uploads — run it, then deploy.

Scope is deliberately narrow and preserves existing behavior:
- A missing **envelope** is still tolerated — an insight can fail to build and `visivo run` exits 0 either way (`test_verify_run_output_ignores_an_insight_that_built_nothing` still passes).
- A stale layout is still rejected by the existing per-file check.
- A project with **nothing to build** (markdown-only) is unaffected — an absent run dir there is not the trap.

## Tests

- `test_verify_run_output_rejects_a_missing_run_directory` — insight + no run dir → raises with the "run it, then deploy" remedy.
- `test_verify_run_output_allows_a_missing_directory_with_nothing_to_build` — no insights/inputs → no raise.
- Full `test_deploy_phase.py` green: 16 passed. `black --check` clean.

Closes VIS-1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)