### PR TITLE
Left-tree tweaks: ordering, indent, source selection, model form

### DIFF
--- a/viewer/e2e/stories/library-source-drilldown.spec.mjs
+++ b/viewer/e2e/stories/library-source-drilldown.spec.mjs
@@ -18,9 +18,11 @@
  *      SOURCE half of D9's DnD unification (the drop-target half is covered
  *      by exploration-dnd-pull-in.spec.mjs).
  *   4. Collapse/re-expand does not re-fetch (session cache).
- *   5. (VIS-1134) The row BODY opens the source and reveals its schema, like
- *      every other Library row type; only the caret collapses; and the row
- *      carries the standard context menu it previously lacked.
+ *   5. The row BODY selects the source, like every other Library row type.
+ *      Expanding is a separate control in the row's hover action cluster (it
+ *      used to be a leading caret, which put the row at its CATEGORY header's
+ *      indent rather than its siblings'), and the row carries the standard
+ *      context menu it previously lacked.
  *
  * Precondition: sandbox running (integration project), e.g.
  *   VISIVO_SANDBOX_NAME=librarySourceDrilldown VISIVO_SANDBOX_BACKEND_PORT=8045 \
@@ -56,6 +58,18 @@ async function expandSourcesSubsection(page) {
   await expect(body).toBeVisible({ timeout: 5000 });
 }
 
+/**
+ * Expand/collapse a SOURCE row.
+ *
+ * The toggle is no longer a leading caret — it lives in the row's hover action
+ * cluster (VIS: left-tree tweaks), which is `pointer-events-none` until the row
+ * is hovered, so a bare click would miss it.
+ */
+async function toggleSource(page, source = SOURCE) {
+  await page.getByTestId(`library-row-source-${source}`).hover();
+  await page.getByTestId(`library-row-source-${source}-toggle`).click();
+}
+
 test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
   test.beforeEach(async ({ page }) => {
     await gotoWorkspace(page);
@@ -82,7 +96,7 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     await page.waitForTimeout(500);
     expect(fetchedBeforeExpand).toBe(false);
 
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
       timeout: 15000,
     });
@@ -91,7 +105,7 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
   test('expanding a table shows its columns with type glyphs (# numeric, T text)', async ({
     page,
   }) => {
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
     await expect(tableRow).toBeVisible({ timeout: 15000 });
 
@@ -105,7 +119,7 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
   });
 
   test('table and column rows expose a hover-revealed drag handle', async ({ page }) => {
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
     await expect(tableRow).toBeVisible({ timeout: 15000 });
     await tableRow.hover();
@@ -118,43 +132,50 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     await expect(firstColumn.locator('[data-testid$="-drag-handle"]')).toBeVisible();
   });
 
-  // VIS-1134, inverting Phase 6c-T5. A source row now behaves like every
-  // other row type: the body click OPENS it. 6c-T5 had made that click expand
-  // instead, because an auditor hunting for columns to drag found it hijacked
-  // navigation — that complaint is answered rather than reintroduced, since
-  // the click also reveals the schema and never collapses it.
-  test('clicking the source row BODY opens the source AND reveals its schema', async ({
+  // Selecting and expanding are separate gestures. The body click used to
+  // expand (Phase 6c-T5), then briefly did both — one click doing two things
+  // made "selected" ambiguous and gave no way to select without also fetching
+  // a schema.
+  test('clicking the source row BODY selects the source without expanding it', async ({
     page,
   }) => {
     const sourceRow = page.getByTestId(`library-row-source-${SOURCE}`);
-    await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    );
+    const toggle = page.getByTestId(`library-row-source-${SOURCE}-toggle`);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-    // The real gesture: click the row's name/body, not the caret.
+    // The real gesture: click the row's name/body, not the expand control.
     await sourceRow.click();
 
-    // Opened, like a model or a chart would.
+    // Selected — the source opens, like a model or a chart would.
     await expect(page.getByTestId('workspace-middle-source-preview')).toBeVisible({
       timeout: 15000,
     });
-    // ...and the columns are right there, not a second gesture away.
-    await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
+    // ...and it did NOT expand.
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(
+      page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)
+    ).not.toBeVisible();
+
+    // Expanding is the dedicated control, and it does not change selection.
+    await toggleSource(page);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
     await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
       timeout: 15000,
     });
+  });
 
-    // A second body click must NOT collapse — the columns the user is reaching
-    // for cannot be taken away by the same gesture that revealed them.
-    await sourceRow.click();
-    await expect(page.getByTestId(`library-row-source-${SOURCE}-toggle`)).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
+  test('the expand control stays visible while expanded, so it can be collapsed', async ({
+    page,
+  }) => {
+    // The rest of the action cluster is hover-only. If expand hid too, the
+    // only way to collapse a long drill-down would be to hover the row it is
+    // pushing off screen.
+    await toggleSource(page);
+    const toggle = page.getByTestId(`library-row-source-${SOURCE}-toggle`);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await page.getByTestId('workspace-left-rail').hover();
+    await expect(toggle).toBeVisible();
   });
 
   // Replaces the old "-open button navigates" test: that button is gone (the
@@ -184,7 +205,7 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
       if (req.url().includes('/api/source-schema-jobs/')) fetchCount += 1;
     });
 
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
       timeout: 15000,
     });
@@ -192,11 +213,11 @@ test.describe('Library source drill-down (Explore 2.0 Phase 3a — D9)', () => {
     expect(countAfterFirstExpand).toBeGreaterThan(0);
 
     // Collapse.
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     await expect(page.getByTestId(`library-source-${SOURCE}-tables`)).not.toBeVisible();
 
     // Re-expand — reads the session cache, no additional fetch.
-    await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+    await toggleSource(page);
     await expect(page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`)).toBeVisible({
       timeout: 5000,
     });

--- a/viewer/src/components/styled/FormFooter.jsx
+++ b/viewer/src/components/styled/FormFooter.jsx
@@ -51,7 +51,12 @@ const FormFooter = ({
         <div className="px-4 py-3 bg-highlight-50 border-b border-highlight-200">
           <p className="text-sm text-highlight-700 mb-2">{deleteConfirm.message}</p>
           <div className="flex gap-2">
+            {/* type="button" on both: a <button> inside a <form> defaults to
+                submit, so confirming a delete also fired the form's save. Only
+                ModelEditForm wraps this footer in a <form>, which is why it
+                took until then to show up. */}
             <button
+              type="button"
               onClick={deleteConfirm.onCancel}
               disabled={deleteConfirm.deleting}
               className="px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
@@ -59,6 +64,7 @@ const FormFooter = ({
               Cancel
             </button>
             <button
+              type="button"
               onClick={deleteConfirm.onConfirm}
               disabled={deleteConfirm.deleting}
               className="px-3 py-1 text-sm text-white bg-highlight-600 rounded hover:bg-highlight-700 disabled:opacity-50"

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -3,10 +3,7 @@ import useFormBaseline from '../../../hooks/useFormBaseline';
 import Editor from '@monaco-editor/react';
 import useStore from '../../../stores/store';
 import RefSelector from './RefSelector';
-import { FormInput, FormAlert } from '../../styled/FormComponents';
-import { Button, ButtonOutline } from '../../styled/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { FormInput, FormAlert, FormLayout, FormFooter } from '../../styled/FormComponents';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
@@ -93,8 +90,12 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
     fetchSources();
   }, [fetchSources]);
 
-  const handleSubmit = async e => {
+  const handleFormSubmit = e => {
     e.preventDefault();
+    handleSave();
+  };
+
+  const handleSave = async () => {
     setError(null);
     setSaving(true);
 
@@ -160,319 +161,279 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
   const isNewObject = model?.status === 'new';
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && <FormAlert variant="error">{error}</FormAlert>}
+    // `flex h-full flex-col` so FormLayout's `flex-1 overflow-y-auto` gets a
+    // height to fill — the other leaf forms return a fragment and inherit that
+    // from the rail, but this one owns a <form> element in between.
+    <form onSubmit={handleFormSubmit} className="flex h-full flex-col">
+      <FormLayout>
+        {error && <FormAlert variant="error">{error}</FormAlert>}
 
-      <FormInput
-        id="model-name"
-        label="Name"
-        value={name}
-        onChange={e => setName(e.target.value)}
-        disabled={!isCreate}
-        helperText={!isCreate ? 'Model names cannot be changed after creation.' : undefined}
-      />
-
-      {/* SQL field - Monaco Editor doesn't fit the standard form pattern */}
-      <div className="space-y-1">
-        <label htmlFor="model-sql" className="block text-sm font-medium text-gray-700">
-          SQL Query
-        </label>
-        <div className="border border-gray-300 rounded-md overflow-hidden">
-          <Editor
-            height={Math.max(160, (sql.split('\n').length + 1) * 19)}
-            language="sql"
-            theme="vs-dark"
-            value={sql}
-            onChange={value => setSql(value || '')}
-            options={{
-              minimap: { enabled: false },
-              scrollBeyondLastLine: false,
-              fontSize: 13,
-              automaticLayout: true,
-              wordWrap: 'on',
-              padding: { top: 12, bottom: 12, left: 8, right: 8 },
-              lineNumbers: 'on',
-              glyphMargin: false,
-              folding: false,
-              lineDecorationsWidth: 12,
-              lineNumbersMinChars: 3,
-              scrollbar: {
-                vertical: 'auto',
-                horizontal: 'auto',
-              },
-            }}
-          />
-        </div>
-        <p className="text-xs text-gray-500">
-          Write the SQL query that will generate your model's data.
-        </p>
-      </div>
-
-      {/* Show embedded source as clickable link, or RefSelector for selection */}
-      {hasEmbeddedSource ? (() => {
-        const sourceTypeConfig = getTypeByValue('source');
-        const SourceIcon = sourceTypeConfig?.icon;
-        const embeddedConfig = model.config.source;
-        return (
-          <div className="space-y-1">
-            <label className="block text-sm font-medium text-gray-700">
-              Data Source
-            </label>
-            <button
-              type="button"
-              onClick={() => {
-                if (onNavigateToEmbedded) {
-                  // Create synthetic source with embedded marker
-                  const syntheticSource = {
-                    name: `(embedded in ${model.name})`,
-                    config: embeddedConfig,
-                    _embedded: { parentType: 'model', parentName: model.name, path: 'source' },
-                  };
-                  // Navigate with applyToParent to update model's source on save
-                  onNavigateToEmbedded('source', syntheticSource, {
-                    applyToParent: (parentConfig, newSourceConfig) => ({
-                      ...parentConfig,
-                      source: newSourceConfig,
-                    }),
-                  });
-                }
-              }}
-              className={`w-full flex items-center gap-2 px-3 py-2 rounded-md border transition-colors ${sourceTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${sourceTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
-            >
-              {SourceIcon && <SourceIcon fontSize="small" className={sourceTypeConfig?.colors?.text || 'text-gray-600'} />}
-              <span className={`text-sm font-medium ${sourceTypeConfig?.colors?.text || 'text-gray-700'}`}>
-                Source: {embeddedConfig.type || 'embedded'}
-              </span>
-              <ChevronRightIcon fontSize="small" className={`ml-auto ${sourceTypeConfig?.colors?.text || 'text-gray-600'}`} />
-            </button>
-            {embeddedConfig.database && (
-              <p className="text-xs text-gray-500 ml-1">
-                Database: {embeddedConfig.database}
-              </p>
-            )}
-          </div>
-        );
-      })() : (
-        <RefSelector
-          value={source}
-          onChange={setSource}
-          objectType="source"
-          label="Data Source"
-          placeholder="No source (use default)"
-          helperText="Select a source to run the SQL query against, or leave empty to use the default source."
+        <FormInput
+          id="model-name"
+          label="Model Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          disabled={!isCreate}
+          helperText={!isCreate ? 'Model names cannot be changed after creation.' : undefined}
         />
-      )}
 
-      {/* Inline Dimensions Section */}
-      {!isCreate && (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <label className="block text-sm font-medium text-gray-700">
-              Inline Dimensions
-            </label>
-            <button
-              type="button"
-              onClick={() => {
-                const newIndex = dimensions.length;
-                setDimensions([...dimensions, { name: '', expression: '' }]);
-                // Open it straight away — an unopened row has an empty name and
-                // expression, which is neither valid nor editable.
-                setExpandedDimension(newIndex);
+        {/* SQL field - Monaco Editor doesn't fit the standard form pattern */}
+        <div className="space-y-1">
+          <label htmlFor="model-sql" className="block text-sm font-medium text-gray-700">
+            SQL Query
+          </label>
+          <div className="border border-gray-300 rounded-md overflow-hidden">
+            <Editor
+              height={Math.max(160, (sql.split('\n').length + 1) * 19)}
+              language="sql"
+              theme="vs-dark"
+              value={sql}
+              onChange={value => setSql(value || '')}
+              options={{
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                fontSize: 13,
+                automaticLayout: true,
+                wordWrap: 'on',
+                padding: { top: 12, bottom: 12, left: 8, right: 8 },
+                lineNumbers: 'on',
+                glyphMargin: false,
+                folding: false,
+                lineDecorationsWidth: 12,
+                lineNumbersMinChars: 3,
+                scrollbar: {
+                  vertical: 'auto',
+                  horizontal: 'auto',
+                },
               }}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
-            >
-              <AddIcon fontSize="small" />
-              Add
-            </button>
+            />
           </div>
-          {dimensions.length === 0 ? (
-            <p className="text-xs text-gray-500 italic">No inline dimensions defined.</p>
-          ) : (
-            <div className="space-y-1">
-              {dimensions.map((dim, index) => {
-                const dimTypeConfig = getTypeByValue('dimension');
-                const DimIcon = dimTypeConfig?.icon;
-                return (
-                  <div key={index} className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setExpandedDimension(expandedDimension === index ? null : index)
-                      }
-                      className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${dimTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${dimTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
-                    >
-                      {DimIcon && <DimIcon fontSize="small" className={dimTypeConfig?.colors?.text || 'text-gray-600'} />}
-                      <span className={`text-sm font-medium truncate ${dimTypeConfig?.colors?.text || 'text-gray-700'}`}>
-                        {dim.name || `Dimension ${index + 1}`}
-                      </span>
-                      <ChevronRightIcon fontSize="small" className={`ml-auto flex-shrink-0 ${dimTypeConfig?.colors?.text || 'text-gray-600'}`} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setDimensions(dimensions.filter((_, i) => i !== index))}
-                      className="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
-                      title="Remove dimension"
-                    >
-                      <RemoveIcon fontSize="small" />
-                    </button>
-                  </div>
-                  {expandedDimension === index && (
-                    <InlineFieldEditor
-                      kind="dimension"
-                      value={dim}
-                      onChange={next =>
-                        setDimensions(dimensions.map((d, i) => (i === index ? next : d)))
-                      }
-                    />
-                  )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Inline Metrics Section */}
-      {!isCreate && (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <label className="block text-sm font-medium text-gray-700">
-              Inline Metrics
-            </label>
-            <button
-              type="button"
-              onClick={() => {
-                const newIndex = metrics.length;
-                setMetrics([...metrics, { name: '', expression: '' }]);
-                setExpandedMetric(newIndex);
-              }}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
-            >
-              <AddIcon fontSize="small" />
-              Add
-            </button>
-          </div>
-          {metrics.length === 0 ? (
-            <p className="text-xs text-gray-500 italic">No inline metrics defined.</p>
-          ) : (
-            <div className="space-y-1">
-              {metrics.map((metric, index) => {
-                const metricTypeConfig = getTypeByValue('metric');
-                const MetricIcon = metricTypeConfig?.icon;
-                return (
-                  <div key={index} className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setExpandedMetric(expandedMetric === index ? null : index)}
-                      className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${metricTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${metricTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
-                    >
-                      {MetricIcon && <MetricIcon fontSize="small" className={metricTypeConfig?.colors?.text || 'text-gray-600'} />}
-                      <span className={`text-sm font-medium truncate ${metricTypeConfig?.colors?.text || 'text-gray-700'}`}>
-                        {metric.name || `Metric ${index + 1}`}
-                      </span>
-                      <ChevronRightIcon fontSize="small" className={`ml-auto flex-shrink-0 ${metricTypeConfig?.colors?.text || 'text-gray-600'}`} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setMetrics(metrics.filter((_, i) => i !== index))}
-                      className="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
-                      title="Remove metric"
-                    >
-                      <RemoveIcon fontSize="small" />
-                    </button>
-                  </div>
-                  {expandedMetric === index && (
-                    <InlineFieldEditor
-                      kind="metric"
-                      value={metric}
-                      onChange={next =>
-                        setMetrics(metrics.map((m, i) => (i === index ? next : m)))
-                      }
-                    />
-                  )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Delete Confirmation */}
-      {showDeleteConfirm && !isCreate && (
-        <div className="p-3 bg-red-50 border border-red-200 rounded-md">
-          <p className="text-sm text-red-700 mb-2">
-            {isNewObject
-              ? 'Are you sure you want to delete this model? This will discard your unsaved changes.'
-              : 'Are you sure you want to delete this model? This will mark it for deletion and remove it from YAML when you commit.'}
+          <p className="text-xs text-gray-500">
+            Write the SQL query that will generate your model's data.
           </p>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(false)}
-              disabled={deleting}
-              className="px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleDelete}
-              disabled={deleting}
-              className="px-3 py-1 text-sm text-white bg-red-600 rounded hover:bg-red-700 disabled:opacity-50"
-            >
-              {deleting ? 'Deleting...' : 'Confirm Delete'}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Action buttons */}
-      <div className="flex justify-between gap-3 pt-4 border-t border-gray-200">
-        <div>
-          {!isCreate && !showDeleteConfirm && (
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(true)}
-              className="p-1.5 text-red-600 hover:text-red-700 border border-red-300 hover:bg-red-50 rounded transition-colors"
-              title="Delete model"
-            >
-              <DeleteOutlineIcon fontSize="small" />
-            </button>
-          )}
         </div>
 
-        <div className="flex gap-3">
-          {/* VIS-1133: no modal to close in the rail, so this reverts to the
-              last saved values. Create mode keeps a real Cancel. */}
-          <ButtonOutline
-            type="button"
-            onClick={isCreate ? onCancel : discard}
-            disabled={saving || deleting || (!isCreate && !dirty)}
-            data-testid="model-form-discard"
-            className="text-sm"
-          >
-            {isCreate ? 'Cancel' : 'Discard'}
-          </ButtonOutline>
-          <Button
-            type="submit"
-            disabled={!isValid || saving || deleting || (!isCreate && !dirty)}
-            className="text-sm"
-          >
-            {saving ? (
-              <>
-                <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
-                Saving...
-              </>
+        {/* Show embedded source as clickable link, or RefSelector for selection */}
+        {hasEmbeddedSource ? (() => {
+          const sourceTypeConfig = getTypeByValue('source');
+          const SourceIcon = sourceTypeConfig?.icon;
+          const embeddedConfig = model.config.source;
+          return (
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Data Source
+              </label>
+              <button
+                type="button"
+                onClick={() => {
+                  if (onNavigateToEmbedded) {
+                    // Create synthetic source with embedded marker
+                    const syntheticSource = {
+                      name: `(embedded in ${model.name})`,
+                      config: embeddedConfig,
+                      _embedded: { parentType: 'model', parentName: model.name, path: 'source' },
+                    };
+                    // Navigate with applyToParent to update model's source on save
+                    onNavigateToEmbedded('source', syntheticSource, {
+                      applyToParent: (parentConfig, newSourceConfig) => ({
+                        ...parentConfig,
+                        source: newSourceConfig,
+                      }),
+                    });
+                  }
+                }}
+                className={`w-full flex items-center gap-2 px-3 py-2 rounded-md border transition-colors ${sourceTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${sourceTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
+              >
+                {SourceIcon && <SourceIcon fontSize="small" className={sourceTypeConfig?.colors?.text || 'text-gray-600'} />}
+                <span className={`text-sm font-medium ${sourceTypeConfig?.colors?.text || 'text-gray-700'}`}>
+                  Source: {embeddedConfig.type || 'embedded'}
+                </span>
+                <ChevronRightIcon fontSize="small" className={`ml-auto ${sourceTypeConfig?.colors?.text || 'text-gray-600'}`} />
+              </button>
+              {embeddedConfig.database && (
+                <p className="text-xs text-gray-500 ml-1">
+                  Database: {embeddedConfig.database}
+                </p>
+              )}
+            </div>
+          );
+        })() : (
+          <RefSelector
+            value={source}
+            onChange={setSource}
+            objectType="source"
+            label="Data Source"
+            placeholder="No source (use default)"
+            helperText="Select a source to run the SQL query against, or leave empty to use the default source."
+          />
+        )}
+
+        {/* Inline Dimensions Section */}
+        {!isCreate && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="block text-sm font-medium text-gray-700">
+                Inline Dimensions
+              </label>
+              <button
+                type="button"
+                onClick={() => {
+                  const newIndex = dimensions.length;
+                  setDimensions([...dimensions, { name: '', expression: '' }]);
+                  // Open it straight away — an unopened row has an empty name and
+                  // expression, which is neither valid nor editable.
+                  setExpandedDimension(newIndex);
+                }}
+                className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+              >
+                <AddIcon fontSize="small" />
+                Add
+              </button>
+            </div>
+            {dimensions.length === 0 ? (
+              <p className="text-xs text-gray-500 italic">No inline dimensions defined.</p>
             ) : (
-              'Save'
+              <div className="space-y-1">
+                {dimensions.map((dim, index) => {
+                  const dimTypeConfig = getTypeByValue('dimension');
+                  const DimIcon = dimTypeConfig?.icon;
+                  return (
+                    <div key={index} className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedDimension(expandedDimension === index ? null : index)
+                        }
+                        className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${dimTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${dimTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
+                      >
+                        {DimIcon && <DimIcon fontSize="small" className={dimTypeConfig?.colors?.text || 'text-gray-600'} />}
+                        <span className={`text-sm font-medium truncate ${dimTypeConfig?.colors?.text || 'text-gray-700'}`}>
+                          {dim.name || `Dimension ${index + 1}`}
+                        </span>
+                        <ChevronRightIcon fontSize="small" className={`ml-auto flex-shrink-0 ${dimTypeConfig?.colors?.text || 'text-gray-600'}`} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDimensions(dimensions.filter((_, i) => i !== index))}
+                        className="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
+                        title="Remove dimension"
+                      >
+                        <RemoveIcon fontSize="small" />
+                      </button>
+                    </div>
+                    {expandedDimension === index && (
+                      <InlineFieldEditor
+                        kind="dimension"
+                        value={dim}
+                        onChange={next =>
+                          setDimensions(dimensions.map((d, i) => (i === index ? next : d)))
+                        }
+                      />
+                    )}
+                    </div>
+                  );
+                })}
+              </div>
             )}
-          </Button>
-        </div>
-      </div>
+          </div>
+        )}
+
+        {/* Inline Metrics Section */}
+        {!isCreate && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="block text-sm font-medium text-gray-700">
+                Inline Metrics
+              </label>
+              <button
+                type="button"
+                onClick={() => {
+                  const newIndex = metrics.length;
+                  setMetrics([...metrics, { name: '', expression: '' }]);
+                  setExpandedMetric(newIndex);
+                }}
+                className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+              >
+                <AddIcon fontSize="small" />
+                Add
+              </button>
+            </div>
+            {metrics.length === 0 ? (
+              <p className="text-xs text-gray-500 italic">No inline metrics defined.</p>
+            ) : (
+              <div className="space-y-1">
+                {metrics.map((metric, index) => {
+                  const metricTypeConfig = getTypeByValue('metric');
+                  const MetricIcon = metricTypeConfig?.icon;
+                  return (
+                    <div key={index} className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setExpandedMetric(expandedMetric === index ? null : index)}
+                        className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-md border transition-colors text-left ${metricTypeConfig?.colors?.node || 'bg-gray-50 border-gray-200'} ${metricTypeConfig?.colors?.bgHover || 'hover:bg-gray-100'}`}
+                      >
+                        {MetricIcon && <MetricIcon fontSize="small" className={metricTypeConfig?.colors?.text || 'text-gray-600'} />}
+                        <span className={`text-sm font-medium truncate ${metricTypeConfig?.colors?.text || 'text-gray-700'}`}>
+                          {metric.name || `Metric ${index + 1}`}
+                        </span>
+                        <ChevronRightIcon fontSize="small" className={`ml-auto flex-shrink-0 ${metricTypeConfig?.colors?.text || 'text-gray-600'}`} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setMetrics(metrics.filter((_, i) => i !== index))}
+                        className="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors"
+                        title="Remove metric"
+                      >
+                        <RemoveIcon fontSize="small" />
+                      </button>
+                    </div>
+                    {expandedMetric === index && (
+                      <InlineFieldEditor
+                        kind="metric"
+                        value={metric}
+                        onChange={next =>
+                          setMetrics(metrics.map((m, i) => (i === index ? next : m)))
+                        }
+                      />
+                    )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+      </FormLayout>
+
+      {/* The shared footer, like every other leaf form — it owns the delete
+          affordance, its confirmation, and the Discard/Save pair, so this form
+          stops re-implementing all three with its own spacing and colours. */}
+      <FormFooter
+        onCancel={isCreate ? onCancel : discard}
+        cancelLabel={isCreate ? 'Cancel' : 'Discard'}
+        cancelDisabled={saving || deleting || (!isCreate && !dirty)}
+        onSave={handleSave}
+        saving={saving}
+        saveDisabled={!isValid || deleting || (!isCreate && !dirty)}
+        showDelete={!isCreate && !showDeleteConfirm}
+        onDeleteClick={() => setShowDeleteConfirm(true)}
+        deleteConfirm={
+          showDeleteConfirm && !isCreate
+            ? {
+                show: true,
+                message: isNewObject
+                  ? 'Are you sure you want to delete this model? This will discard your unsaved changes.'
+                  : 'Are you sure you want to delete this model? This will mark it for deletion and remove it from YAML when you commit.',
+                onConfirm: handleDelete,
+                onCancel: () => setShowDeleteConfirm(false),
+                deleting,
+              }
+            : undefined
+        }
+      />
     </form>
   );
 };

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -37,7 +37,7 @@ jest.mock('./RefSelector', () => ({
 }));
 
 const setName = value =>
-  fireEvent.change(screen.getByLabelText('Name'), { target: { value } });
+  fireEvent.change(screen.getByLabelText(/Model Name/), { target: { value } });
 const setSql = value =>
   fireEvent.change(screen.getByLabelText('code'), { target: { value } });
 const clickSave = () => fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -147,8 +147,8 @@ describe('ModelEditForm — create mode', () => {
 describe('ModelEditForm — edit mode initialization and save', () => {
   it('initializes fields from the model and locks the name', () => {
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
-    expect(screen.getByLabelText('Name')).toHaveValue('orders');
-    expect(screen.getByLabelText('Name')).toBeDisabled();
+    expect(screen.getByLabelText(/Model Name/)).toHaveValue('orders');
+    expect(screen.getByLabelText(/Model Name/)).toBeDisabled();
     expect(screen.getByLabelText('code')).toHaveValue('select * from orders');
     expect(screen.getByTestId('ref-selector')).toHaveValue('ref(warehouse)');
     expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();
@@ -176,11 +176,11 @@ describe('ModelEditForm — edit mode initialization and save', () => {
     const { rerender } = render(
       <ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />
     );
-    expect(screen.getByLabelText('Name')).toHaveValue('orders');
+    expect(screen.getByLabelText(/Model Name/)).toHaveValue('orders');
 
     rerender(<ModelEditForm model={null} onSave={jest.fn()} onCancel={jest.fn()} />);
-    expect(screen.getByLabelText('Name')).toHaveValue('');
-    expect(screen.getByLabelText('Name')).toBeEnabled();
+    expect(screen.getByLabelText(/Model Name/)).toHaveValue('');
+    expect(screen.getByLabelText(/Model Name/)).toBeEnabled();
     expect(screen.getByLabelText('code')).toHaveValue('');
   });
 });
@@ -376,7 +376,7 @@ describe('ModelEditForm — inline metrics', () => {
 describe('ModelEditForm — delete flow', () => {
   it('shows the published-model confirmation and can be cancelled', () => {
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
-    fireEvent.click(screen.getByTitle('Delete model'));
+    fireEvent.click(screen.getByTitle('Delete'));
     expect(
       screen.getByText(/mark it for deletion and remove it from YAML/)
     ).toBeInTheDocument();
@@ -387,18 +387,44 @@ describe('ModelEditForm — delete flow', () => {
     expect(mockState.deleteModel).not.toHaveBeenCalled();
   });
 
+  it('confirming a delete does not also submit the form', async () => {
+    // This form is the only one that wraps FormFooter in a <form>, and a
+    // <button> with no type inside a form defaults to submit — so Confirm
+    // Delete fired the save path too, and the panel showed "Failed to save
+    // model" on top of the delete.
+    const onSave = jest.fn();
+    mockState.deleteModel.mockResolvedValue({ success: true });
+    render(<ModelEditForm model={editModel()} onSave={onSave} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getByTitle('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
+
+    await waitFor(() => expect(mockState.deleteModel).toHaveBeenCalled());
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('cancelling a delete does not submit either', () => {
+    const onSave = jest.fn();
+    render(<ModelEditForm model={editModel()} onSave={onSave} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getByTitle('Delete'));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel' })[0]);
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
   it('shows the discard-changes confirmation for a new model', () => {
     const model = editModel();
     model.status = 'new';
     render(<ModelEditForm model={model} onSave={jest.fn()} onCancel={jest.fn()} />);
-    fireEvent.click(screen.getByTitle('Delete model'));
+    fireEvent.click(screen.getByTitle('Delete'));
     expect(screen.getByText(/discard your unsaved changes/)).toBeInTheDocument();
   });
 
   it('deletes the model, refreshes commit status, and closes on success', async () => {
     const onCancel = jest.fn();
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={onCancel} />);
-    fireEvent.click(screen.getByTitle('Delete model'));
+    fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
 
     await waitFor(() => expect(mockState.deleteModel).toHaveBeenCalledWith('orders'));
@@ -410,7 +436,7 @@ describe('ModelEditForm — delete flow', () => {
     mockState.deleteModel.mockResolvedValueOnce({ success: false, error: 'model in use' });
     const onCancel = jest.fn();
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={onCancel} />);
-    fireEvent.click(screen.getByTitle('Delete model'));
+    fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
 
     expect(await screen.findByText('model in use')).toBeInTheDocument();
@@ -422,7 +448,7 @@ describe('ModelEditForm — delete flow', () => {
   it('surfaces a thrown delete error', async () => {
     mockState.deleteModel.mockRejectedValueOnce(new Error('network down'));
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
-    fireEvent.click(screen.getByTitle('Delete model'));
+    fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
 
     expect(await screen.findByText('network down')).toBeInTheDocument();
@@ -431,7 +457,7 @@ describe('ModelEditForm — delete flow', () => {
 
   it('does not offer delete in create mode', () => {
     render(<ModelEditForm model={null} onSave={jest.fn()} onCancel={jest.fn()} />);
-    expect(screen.queryByTitle('Delete model')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
   });
 });
 
@@ -452,16 +478,16 @@ describe('ModelEditForm — Discard (edit mode)', () => {
     const { unmount } = render(
       <ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />
     );
-    expect(screen.getByTestId('model-form-discard')).toHaveTextContent('Discard');
+    expect(screen.getByTestId('form-footer-cancel')).toHaveTextContent('Discard');
     unmount();
 
     render(<ModelEditForm model={null} onSave={jest.fn()} onCancel={jest.fn()} />);
-    expect(screen.getByTestId('model-form-discard')).toHaveTextContent('Cancel');
+    expect(screen.getByTestId('form-footer-cancel')).toHaveTextContent('Cancel');
   });
 
   it('disables Save and Discard on an untouched form', () => {
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
-    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+    expect(screen.getByTestId('form-footer-cancel')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
@@ -470,14 +496,14 @@ describe('ModelEditForm — Discard (edit mode)', () => {
 
     makeDirty('select 1');
     expect(screen.getByLabelText('code')).toHaveValue('select 1');
-    expect(screen.getByTestId('model-form-discard')).toBeEnabled();
+    expect(screen.getByTestId('form-footer-cancel')).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
 
-    fireEvent.click(screen.getByTestId('model-form-discard'));
+    fireEvent.click(screen.getByTestId('form-footer-cancel'));
 
     expect(screen.getByLabelText('code')).toHaveValue('select * from orders');
     // Back to clean, so both go inert again.
-    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+    expect(screen.getByTestId('form-footer-cancel')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
@@ -488,9 +514,9 @@ describe('ModelEditForm — Discard (edit mode)', () => {
     expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
-    expect(screen.getByTestId('model-form-discard')).toBeEnabled();
+    expect(screen.getByTestId('form-footer-cancel')).toBeEnabled();
 
-    fireEvent.click(screen.getByTestId('model-form-discard'));
+    fireEvent.click(screen.getByTestId('form-footer-cancel'));
 
     expect(screen.queryByTestId('inline-dimension-editor')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();
@@ -512,7 +538,7 @@ describe('ModelEditForm — Discard (edit mode)', () => {
     rerender(<ModelEditForm model={saved} onSave={jest.fn()} onCancel={jest.fn()} />);
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-    expect(screen.getByTestId('model-form-discard')).toBeDisabled();
+    expect(screen.getByTestId('form-footer-cancel')).toBeDisabled();
   });
 
   it('reports dirtiness upward so the tab strip can show its unsaved dot', () => {
@@ -530,7 +556,7 @@ describe('ModelEditForm — Discard (edit mode)', () => {
     makeDirty('select 1');
     expect(onDirtyChange).toHaveBeenLastCalledWith(true);
 
-    fireEvent.click(screen.getByTestId('model-form-discard'));
+    fireEvent.click(screen.getByTestId('form-footer-cancel'));
     expect(onDirtyChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -271,9 +271,10 @@ describe('Library', () => {
       type: 'source',
       name: 'local-duck',
     });
+    // Selecting is all it does — expanding is its own control.
     expect(screen.getByTestId('library-row-source-local-duck-toggle')).toHaveAttribute(
       'aria-expanded',
-      'true'
+      'false'
     );
   });
 

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -415,22 +415,6 @@ const LibraryRow = ({
             className="absolute left-0 top-1 bottom-1 w-[2px] rounded-r bg-primary"
           />
         )}
-        {expandable && (
-          <button
-            type="button"
-            onClick={onToggleExpand}
-            aria-expanded={expanded}
-            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${obj.name}`}
-            data-testid={`${tid}-toggle`}
-            className="-ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center text-gray-500 hover:text-gray-900"
-          >
-            {expanded ? (
-              <PiCaretDown className="h-3 w-3" />
-            ) : (
-              <PiCaretRight className="h-3 w-3" />
-            )}
-          </button>
-        )}
         {/* Reserve the drag-handle slot for every row so Layout-Items and
             Data-Layer rows share the same icon indent. Only droppable rows
             fill the slot with the grip dots (visible on hover). */}
@@ -462,9 +446,37 @@ const LibraryRow = ({
         <div
           className={[
             'flex shrink-0 items-center gap-0.5 transition-opacity',
-            showActions ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            showActions || (expandable && expanded)
+              ? 'opacity-100'
+              : 'opacity-0 pointer-events-none',
           ].join(' ')}
         >
+          {/* Expand lives with the other row actions rather than as a leading
+              caret: a caret in the first slot aligned the row with its CATEGORY
+              header instead of its siblings, so an expandable row read as being
+              one level further out than it is. Unlike the others this stays
+              visible while expanded — otherwise the only way to collapse a
+              drill-down is to hover the row it is pushing off screen. */}
+          {expandable && (
+            <button
+              type="button"
+              onClick={onToggleExpand}
+              aria-expanded={expanded}
+              aria-label={`${expanded ? 'Collapse' : 'Expand'} ${obj.name}`}
+              title={expanded ? 'Collapse' : 'Expand'}
+              data-testid={`${tid}-toggle`}
+              className={[
+                'inline-flex h-6 w-6 items-center justify-center rounded text-gray-500 hover:bg-white hover:text-gray-900',
+                expanded ? 'opacity-100' : '',
+              ].join(' ')}
+            >
+              {expanded ? (
+                <PiCaretDown className="h-3.5 w-3.5" />
+              ) : (
+                <PiCaretRight className="h-3.5 w-3.5" />
+              )}
+            </button>
+          )}
           {EXPLORE_THIS_TYPES.includes(obj.type) && (
             <button
               type="button"

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.jsx
@@ -403,13 +403,11 @@ const LibrarySourceDrilldown = ({ sourceName }) => {
  * renders `LibraryRow` and contributes only what is genuinely source-specific:
  * a caret and the lazily-mounted drill-down beneath it.
  *
- * Phase 6c-T5 made the row body EXPAND rather than open, because an auditor
- * hunting for a column to drag found that clicking the name yanked them out of
- * their in-progress exploration. Consistency won here — every other row type
- * opens on click — but that complaint is answered rather than ignored: the
- * body click opens AND expands, and never collapses. The columns arrive from
- * the same click that opens the source, so the gesture no longer costs the
- * user their place. Collapsing stays on the caret.
+ * The row body simply selects the source, like every other row type. It used
+ * to expand instead (Phase 6c-T5), then briefly did both; expanding is now its
+ * own control in the row's action cluster, which keeps selection meaning one
+ * thing and leaves the drill-down reachable without a click that does two
+ * things at once.
  */
 const LibrarySourceRow = ({
   obj,
@@ -430,22 +428,12 @@ const LibrarySourceRow = ({
     [obj.name, toggleExpanded]
   );
 
-  // Opens like every other row, and reveals the schema on the way — but never
-  // collapses, so a second click on the name can't take the columns away.
-  const handleOpen = useCallback(
-    (o, e) => {
-      if (!expanded) toggleExpanded(o.name);
-      onClick && onClick(o, e);
-    },
-    [expanded, onClick, toggleExpanded]
-  );
-
   return (
     <LibraryRow
       obj={obj}
       selected={selected}
       draggable={draggable}
-      onClick={handleOpen}
+      onClick={onClick}
       onContextAction={onContextAction}
       canAddToExploration={canAddToExploration}
       expandable

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
@@ -87,6 +87,9 @@ describe('LibrarySourceRow', () => {
     // The hover-only "Open" icon button is gone — the row body opens now. What
     // hover reveals is the same cluster every other row type has.
     expect(screen.queryByTestId('library-row-source-warehouse-open')).not.toBeInTheDocument();
+    // Expand is a row action now, not a leading caret — so an expandable row
+    // has the same leading geometry (and therefore indent) as its siblings.
+    expect(screen.getByTestId('library-row-source-warehouse-toggle')).toBeInTheDocument();
     expect(screen.getByTestId('library-row-source-warehouse-explore')).toBeInTheDocument();
     expect(screen.getByTestId('library-row-source-warehouse-flip')).toBeInTheDocument();
     expect(screen.getByTestId('library-row-source-warehouse-kebab')).toBeInTheDocument();
@@ -117,58 +120,47 @@ describe('LibrarySourceRow', () => {
     expect(onContextAction).toHaveBeenCalledWith('openInNewTab', SOURCE);
   });
 
-  test('Enter on the focused row opens it — sources had no keyboard activation at all', async () => {
-    // Enter routes through the same handler as a body click, so it also
-    // expands — mock the feed and let the drill-down settle.
-    fetchSourceSchemaJobs.mockResolvedValue([
-      { source_name: 'warehouse', has_cached_schema: true },
-    ]);
-    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+  test('Enter on the focused row selects it — sources had no keyboard activation at all', () => {
     const onClick = jest.fn();
     render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
 
     fireEvent.keyDown(screen.getByTestId('library-row-source-warehouse'), { key: 'Enter' });
 
     expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
-    await screen.findByTestId('library-source-table-warehouse-orders');
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
   });
 
-  // VIS-1134, inverting Phase 6c-T5. Consistency won — every other row type
-  // opens on click — but the complaint that drove 6c-T5 (clicking the name
-  // yanked you out of your exploration while hunting for a column) is
-  // answered, not ignored: the click opens AND reveals the schema.
-  test('clicking the row body opens the source AND reveals its schema', async () => {
-    fetchSourceSchemaJobs.mockResolvedValue([
-      { source_name: 'warehouse', has_cached_schema: true },
-    ]);
-    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+  // Selecting and expanding are separate gestures. The body used to expand
+  // (Phase 6c-T5), then briefly did both; one click doing two things made
+  // "selected" ambiguous and left no way to select without also fetching.
+  test('clicking the row body selects the source and does NOT expand it', () => {
     const onClick = jest.fn();
     render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
 
     fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
 
     expect(onClick).toHaveBeenCalledWith(SOURCE, expect.anything());
-    await screen.findByTestId('library-source-table-warehouse-orders');
+    expect(screen.getByTestId('library-row-source-warehouse-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    // Selecting must not reach for the schema — that fetch belongs to expand.
+    expect(fetchSourceSchemaJobs).not.toHaveBeenCalled();
   });
 
-  test('a second body click does not collapse — the columns cannot be taken away', async () => {
-    // The mitigation for the 6c-T5 regression: only the caret collapses, so a
-    // user clicking the name twice never loses the columns they were reaching
-    // for.
-    fetchSourceSchemaJobs.mockResolvedValue([
-      { source_name: 'warehouse', has_cached_schema: true },
-    ]);
-    fetchSourceSchema.mockResolvedValue(ORDERS_4);
+  test('repeated body clicks keep selecting; they never toggle anything', () => {
     const onClick = jest.fn();
     render(withDnd(<LibrarySourceRow obj={SOURCE} onClick={onClick} />));
+    const row = screen.getByTestId('library-row-source-warehouse');
 
-    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
-    await screen.findByTestId('library-source-table-warehouse-orders');
+    fireEvent.click(row);
+    fireEvent.click(row);
 
-    fireEvent.click(screen.getByTestId('library-row-source-warehouse'));
-
-    expect(screen.getByTestId('library-source-table-warehouse-orders')).toBeInTheDocument();
     expect(onClick).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('library-row-source-warehouse-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
   });
 
   test('the caret still collapses, and toggling it never opens the source', async () => {

--- a/viewer/src/components/views/workspace/library/useLibraryData.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import useStore from '../../../../stores/store';
+import useStore, { ObjectStatus } from '../../../../stores/store';
 
 /**
  * useLibraryData — VIS-769 / Track C C1.
@@ -52,6 +52,34 @@ import useStore from '../../../../stores/store';
  */
 const safeArray = v => (Array.isArray(v) ? v : []);
 
+// A row with unpublished changes — exactly what StatusDot paints a dot for, so
+// "has a dot" and "sorts to the top" can never disagree.
+const isUnpublished = row => Boolean(row.status) && row.status !== ObjectStatus.PUBLISHED;
+
+// Unpublished first, then by name. Your own edits are the rows you came back to
+// find, and in a project with 124 models they were wherever the API happened to
+// return them — which is insertion order, so a rename could move a row and a
+// refetch could reorder the list under you.
+//
+// `localeCompare` with numeric collation so model_2 precedes model_10, and base
+// sensitivity so casing doesn't split otherwise-adjacent names.
+const byUnpublishedThenName = (a, b) => {
+  const dirtyDelta = Number(isUnpublished(b)) - Number(isUnpublished(a));
+  if (dirtyDelta !== 0) return dirtyDelta;
+  return String(a.name).localeCompare(String(b.name), undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+};
+
+// Sorting happens once here rather than in each subsection, so every type is
+// ordered the same way and the row components stay presentational.
+const sorted = rows => [...rows].sort(byUnpublishedThenName);
+
+// A soft-deleted object is still returned by the list endpoints; rendering it
+// left the row sitting in the tree as though the delete had failed.
+const notDeleted = o => o.status !== 'deleted';
+
 // Map a plain store collection into Library rows of a single type.
 //
 // Objects marked for deletion are dropped. A delete is a SOFT delete — the
@@ -64,14 +92,16 @@ const safeArray = v => (Array.isArray(v) ? v : []);
 // every staged change with a DELETED badge, which is where "what will this
 // commit do" belongs.
 const mapRows = (list, type) =>
-  safeArray(list)
-    .filter(o => o.status !== 'deleted')
-    .map(o => ({
-      id: `${type}:${o.name}`,
-      type,
-      name: o.name,
-      status: o.status || null,
-    }));
+  sorted(
+    safeArray(list)
+      .filter(notDeleted)
+      .map(o => ({
+        id: `${type}:${o.name}`,
+        type,
+        name: o.name,
+        status: o.status || null,
+      }))
+  );
 
 export function useLibraryData() {
   // Layout-item collections.
@@ -90,33 +120,45 @@ export function useLibraryData() {
   const insights = useStore(s => s.insights);
 
   return useMemo(() => {
-    const modelRows = safeArray(models).map(m => ({
-      id: `model:${m.name}`,
-      type: 'model',
-      canonicalType: 'model',
-      name: m.name,
-      subtype: 'sql_model',
-      status: m.status || null,
-    }));
+    const modelRows = sorted(
+      safeArray(models)
+        .filter(notDeleted)
+        .map(m => ({
+          id: `model:${m.name}`,
+          type: 'model',
+          canonicalType: 'model',
+          name: m.name,
+          subtype: 'sql_model',
+          status: m.status || null,
+        }))
+    );
 
-    const sourceRows = safeArray(sources).map(s => ({
-      id: `source:${s.name}`,
-      type: 'source',
-      name: s.name,
-      subtype: s.type || null,
-      status: s.status || null,
-    }));
+    const sourceRows = sorted(
+      safeArray(sources)
+        .filter(notDeleted)
+        .map(s => ({
+          id: `source:${s.name}`,
+          type: 'source',
+          name: s.name,
+          subtype: s.type || null,
+          status: s.status || null,
+        }))
+    );
 
     // Inputs carry `inputType` (single-select | multi-select) — the Explore
     // 2.0 Phase 3a DnD payload gap (02-architecture.md §4): a dropped input's
     // accessor (`.value` vs `.values`) depends on it.
-    const inputRows = safeArray(inputs).map(i => ({
-      id: `input:${i.name}`,
-      type: 'input',
-      name: i.name,
-      status: i.status || null,
-      inputType: i.config?.type || i.type || null,
-    }));
+    const inputRows = sorted(
+      safeArray(inputs)
+        .filter(notDeleted)
+        .map(i => ({
+          id: `input:${i.name}`,
+          type: 'input',
+          name: i.name,
+          status: i.status || null,
+          inputType: i.config?.type || i.type || null,
+        }))
+    );
 
     // Dimensions/metrics carry `parentModel` (the owning model's name, when
     // model-scoped) — the same Phase 3a payload gap: a dropped field's ref
@@ -125,23 +167,22 @@ export function useLibraryData() {
     // side decide which. Mirrors `useFieldParentModel.js`'s own resolution
     // (`fieldRecord.parentModel || fieldRecord.config?.model`).
     const withParentModel = (list, type) =>
-      safeArray(list)
-        // Same soft-delete filter as mapRows — this is the mapper dimensions
-        // and metrics actually go through, and it is where the reported bug
-        // showed: a deleted dimension stayed in the tree.
-        .filter(f => f.status !== 'deleted')
-        .map(f => ({
-          id: `${type}:${f.name}`,
-          type,
-          name: f.name,
-          status: f.status || null,
-          parentModel: f.parentModel || f.config?.model || null,
-          // The field's own expression — carried so a metric/dimension dropped
-          // onto the results grid's computed-column zone can be replicated as
-          // a computed column bound to a DIFFERENT model (mirrors the legacy
-          // `ExplorerLeftPanel.DraggableItem`'s `item.config?.expression`).
-          expression: f.config?.expression || null,
-        }));
+      sorted(
+        safeArray(list)
+          .filter(notDeleted)
+          .map(f => ({
+            id: `${type}:${f.name}`,
+            type,
+            name: f.name,
+            status: f.status || null,
+            parentModel: f.parentModel || f.config?.model || null,
+            // The field's own expression — carried so a metric/dimension dropped
+            // onto the results grid's computed-column zone can be replicated as
+            // a computed column bound to a DIFFERENT model (mirrors the legacy
+            // `ExplorerLeftPanel.DraggableItem`'s `item.config?.expression`).
+            expression: f.config?.expression || null,
+          }))
+      );
 
     return {
       layoutItems: {

--- a/viewer/src/components/views/workspace/library/useLibraryData.test.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.test.js
@@ -84,9 +84,10 @@ describe('useLibraryData', () => {
       });
     });
     const { result } = renderHook(() => useLibraryData());
+    // Ordered, not insertion order: 'sales' is unpublished so it leads.
     expect(result.current.layoutItems.dashboard).toEqual([
-      { id: 'dashboard:overview', type: 'dashboard', name: 'overview', status: 'published' },
       { id: 'dashboard:sales', type: 'dashboard', name: 'sales', status: 'new' },
+      { id: 'dashboard:overview', type: 'dashboard', name: 'overview', status: 'published' },
     ]);
   });
 
@@ -134,7 +135,11 @@ describe('useLibraryData', () => {
       });
     });
     const { result } = renderHook(() => useLibraryData());
-    const [scoped, refScoped, unscoped] = result.current.dataLayer.dimension;
+    // Alphabetical now, so name them rather than relying on seed order.
+    const byName = Object.fromEntries(
+      result.current.dataLayer.dimension.map(d => [d.name, d])
+    );
+    const { scoped_dim: scoped, ref_scoped_dim: refScoped, unscoped_dim: unscoped } = byName;
     expect(scoped.parentModel).toBe('orders');
     expect(scoped.expression).toBe('UPPER(region)');
     // Falls back to config.model (a ref string) when parentModel isn't set
@@ -145,6 +150,103 @@ describe('useLibraryData', () => {
     const [scopedMetric] = result.current.dataLayer.metric;
     expect(scopedMetric.parentModel).toBe('orders');
     expect(scopedMetric.expression).toBe('sum(amount)');
+  });
+
+  // Ordering — unpublished first, then by name. Rows previously came back in
+  // whatever order the API returned, which is insertion order: in a project
+  // with 124 models, the one you had just edited was wherever it happened to
+  // land, and a refetch could reorder the list under you.
+  describe('row ordering', () => {
+    const names = rows => rows.map(r => r.name);
+
+    test('rows with unpublished changes sort above published ones', () => {
+      act(() => {
+        useStore.setState({
+          charts: [
+            { name: 'alpha', status: 'published' },
+            { name: 'zulu', status: 'modified' },
+            { name: 'bravo', status: 'published' },
+            { name: 'yankee', status: 'new' },
+          ],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      // Both dot states (new AND modified) lead — the rule is "has a dot",
+      // matching StatusDot, so the sort can never disagree with the UI.
+      expect(names(result.current.layoutItems.chart)).toEqual([
+        'yankee',
+        'zulu',
+        'alpha',
+        'bravo',
+      ]);
+    });
+
+    test('a missing status counts as published, not as an edit', () => {
+      act(() => {
+        useStore.setState({
+          charts: [{ name: 'zebra' }, { name: 'apple', status: 'modified' }, { name: 'mango' }],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      expect(names(result.current.layoutItems.chart)).toEqual(['apple', 'mango', 'zebra']);
+    });
+
+    test('names sort naturally, so model_2 precedes model_10', () => {
+      act(() => {
+        useStore.setState({
+          models: [{ name: 'model_10' }, { name: 'model_2' }, { name: 'model_1' }],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      expect(names(result.current.dataLayer.model)).toEqual(['model_1', 'model_2', 'model_10']);
+    });
+
+    test('casing does not split otherwise-adjacent names', () => {
+      act(() => {
+        useStore.setState({
+          models: [{ name: 'beta' }, { name: 'Alpha' }, { name: 'gamma' }],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      expect(names(result.current.dataLayer.model)).toEqual(['Alpha', 'beta', 'gamma']);
+    });
+
+    test('every type is ordered, not just the ones sharing a mapper', () => {
+      // sources / models / inputs are built by their own inline mappers, so
+      // they can drift from mapRows if the sort is applied per-mapper.
+      act(() => {
+        useStore.setState({
+          sources: [{ name: 'z_src' }, { name: 'a_src', status: 'modified' }],
+          models: [{ name: 'z_model' }, { name: 'a_model', status: 'modified' }],
+          inputs: [{ name: 'z_in' }, { name: 'a_in', status: 'modified' }],
+          dimensions: [{ name: 'z_dim' }, { name: 'a_dim', status: 'modified' }],
+          tables: [{ name: 'z_tbl' }, { name: 'a_tbl', status: 'modified' }],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      expect(names(result.current.dataLayer.source)).toEqual(['a_src', 'z_src']);
+      expect(names(result.current.dataLayer.model)).toEqual(['a_model', 'z_model']);
+      expect(names(result.current.layoutItems.input)).toEqual(['a_in', 'z_in']);
+      expect(names(result.current.dataLayer.dimension)).toEqual(['a_dim', 'z_dim']);
+      expect(names(result.current.layoutItems.table)).toEqual(['a_tbl', 'z_tbl']);
+    });
+
+    test('sources, models and inputs hide soft-deleted rows like every other type', () => {
+      // Their inline mappers never had the filter mapRows/withParentModel got,
+      // so a deleted source or model stayed in the tree after a confirmed
+      // delete — the same bug, in the three places it was not fixed.
+      act(() => {
+        useStore.setState({
+          sources: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
+          models: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
+          inputs: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
+        });
+      });
+      const { result } = renderHook(() => useLibraryData());
+      expect(names(result.current.dataLayer.source)).toEqual(['kept']);
+      expect(names(result.current.dataLayer.model)).toEqual(['kept']);
+      expect(names(result.current.layoutItems.input)).toEqual(['kept']);
+    });
   });
 
   test('inputs carry inputType (single-select | multi-select)', () => {
@@ -158,7 +260,8 @@ describe('useLibraryData', () => {
       });
     });
     const { result } = renderHook(() => useLibraryData());
-    const [single, multi, noConfig] = result.current.layoutItems.input;
+    const byName = Object.fromEntries(result.current.layoutItems.input.map(i => [i.name, i]));
+    const { region: single, products: multi, no_config: noConfig } = byName;
     expect(single.inputType).toBe('single-select');
     expect(multi.inputType).toBe('multi-select');
     expect(noConfig.inputType).toBeNull();


### PR DESCRIPTION
Four things from the tree.

### 1. Rows are ordered — unpublished first, then by name

They came back in whatever order the API returned, which is insertion order. In a project with **124 models**, the one you just edited was wherever it happened to land, and a refetch could reorder the list under you.

"Has unpublished changes" is the **same predicate `StatusDot` paints its dot from**, so the sort and the dot can't disagree. Both dot states lead (`new` and `modified`), names collate numerically (`model_2` before `model_10`) and case-insensitively.

**This surfaced a bug.** Applying the sort in one place made it obvious that `sources`, `models` and `inputs` are built by their own inline mappers and never got the soft-delete filter `mapRows`/`withParentModel` have — so a deleted source or model **stayed in the tree after a confirmed delete**. Same bug that was already fixed elsewhere, in the three places it was missed. Fixed, with a test.

### 2 + 3. Same fix: the expand control moves to the action cluster

These turned out to be one change. As a **leading** caret, expand aligned the row with its **category header** instead of its siblings — which is exactly why a source read as one level further out than a model.

Moving it into the hover action cluster gives source rows the identical leading geometry as every other row, so they line up **by construction** — there's no per-type indent to keep in step. Sources now carry all four: expand, explore, lineage, kebab.

Unlike the other actions, expand **stays visible while expanded** — otherwise the only way to collapse a long drill-down is to hover the row it's pushing off screen.

The body click now **only selects**. It expanded (Phase 6c-T5), then briefly did both; one gesture doing two things made "selected" ambiguous and left no way to select a source without also fetching its schema. The old concern — that clicking a name costs you your place — is now answered by a visible affordance rather than an overloaded click.

### 4. The model form uses the shared shell

`ModelEditForm` was a bare `<form>` with its own spacing, delete button, confirmation and button row. It now renders through `FormLayout` + `FormFooter` like every other leaf form, which restores the missing `p-4`, and the field is **"Model Name"** to match Chart Name / Source Name / Insight Name.

**That change surfaced a real bug in `FormFooter`:** its delete-confirm buttons carry no `type`, and a `<button>` inside a `<form>` defaults to **submit**. `ModelEditForm` is the only form wrapping the footer in a `<form>`, so confirming a delete *also ran the save* and the panel showed "Failed to save model" on top of the delete. Both are `type="button"` now — and I verified the regression test fails without the fix by temporarily reverting it.

### Testing

**6722 passing** (358 suites), lint clean. Baseline on main is 6714, so **+8**.

New coverage: unpublished-before-published ordering, missing status treated as published, natural numeric sort, case-insensitive collation, every type ordered (not just the ones sharing a mapper), soft-deleted sources/models/inputs hidden, and the two form-submit regressions.

Rewritten rather than deleted, since the contract changed: the source-row body-click tests (unit + integration + e2e) now assert select-without-expand, and the e2e drives the toggle through a `toggleSource` helper that hovers first — the control is hover-revealed now, so a bare click would miss it.

**Not run:** the Playwright story (needs a sandbox). Flagging that explicitly.

One known flake, **not from this change**: `ExplorationPromoteModal` failed in 2 of 4 full runs, matching the ~1-in-3 rate I reproduced on clean `main` earlier. Nothing here touches that file or anything it imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)