### PR TITLE
The collapsed rail opens on a phone, and keeps the tree's order

### DIFF
--- a/viewer/e2e/stories/left-rail-phone-popout.spec.mjs
+++ b/viewer/e2e/stories/left-rail-phone-popout.spec.mjs
@@ -1,0 +1,133 @@
+/**
+ * Story: opening the Library on a phone-sized viewport (user-reported).
+ *
+ * `WorkspaceShell` auto-collapses the left rail once the canvas would drop
+ * below `CENTER_MIN_WIDTH` (480px). At phone widths it is collapsed the whole
+ * time — and clicking anything in the 48px strip appeared to do nothing.
+ *
+ * Nothing was wrong with the click. Expanding set `workspaceLeftCollapsed =
+ * false`; the shell's width effect lists that flag in its deps, so it re-ran,
+ * measured that the rail still doesn't fit, and collapsed it again before
+ * paint. The strip's buttons render hover and title states that promise
+ * interactivity, so they read as broken rather than as refused.
+ *
+ * The rail now opens as a POPOUT drawn over the content when it cannot be
+ * seated in flow. That costs no layout width, so the measurement that used to
+ * undo it has nothing to undo.
+ *
+ * Covers:
+ *   1. At 390px (iPhone-ish) the rail starts collapsed and a type button opens
+ *      the popout — the case that read as dead.
+ *   2. The popout actually covers the content (it is not squeezed into the
+ *      48px strip's own box), which is the half unit tests cannot see.
+ *   3. Tapping the content beside it, and Escape, dismiss it.
+ *   4. Opening an object dismisses it — otherwise it sits on top of the thing
+ *      it just opened.
+ *   5. At a desktop width the same button expands in flow, with no popout.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=leftRailPhone VISIVO_SANDBOX_BACKEND_PORT=8046 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3046 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3046 npx playwright test left-rail-phone-popout
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || process.env.VISIVO_BASE_URL || 'http://localhost:3001';
+
+const PHONE = { width: 390, height: 844 };
+const DESKTOP = { width: 1600, height: 1000 };
+
+async function gotoWorkspace(page) {
+  await page.goto(`${BASE_URL}/workspace`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-left-rail')).toBeVisible({ timeout: 30000 });
+}
+
+test.describe('Left rail on a phone-sized viewport', () => {
+  test('a collapsed type button opens the Library instead of doing nothing', async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await gotoWorkspace(page);
+
+    // Collapsed by the shell, not by the user.
+    await expect(page.getByTestId('workspace-left-rail')).toHaveAttribute(
+      'data-collapsed',
+      'true'
+    );
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toHaveCount(0);
+
+    await page.getByTestId('workspace-left-rail-collapsed-model').click();
+
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toBeVisible();
+    // ...and it landed on the section the button names.
+    await expect(page.getByTestId('library-subsection-model')).toHaveAttribute(
+      'data-collapsed',
+      'false'
+    );
+  });
+
+  test('the popout covers the content rather than being squeezed into the strip', async ({
+    page,
+  }) => {
+    // The half the unit tests cannot check: it is positioned against the shell
+    // row, not its own 48px container, so it has room to be a drawer.
+    await page.setViewportSize(PHONE);
+    await gotoWorkspace(page);
+    await page.getByTestId('workspace-left-rail-expand').click();
+
+    const panel = page.getByTestId('workspace-left-rail-overlay');
+    await expect(panel).toBeVisible();
+    const box = await panel.boundingBox();
+    expect(box.width).toBeGreaterThan(200);
+    // Starts after the 48px strip, so the icons stay reachable underneath it.
+    expect(box.x).toBeGreaterThanOrEqual(40);
+  });
+
+  test('tapping beside it, or pressing Escape, dismisses it', async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await gotoWorkspace(page);
+
+    await page.getByTestId('workspace-left-rail-expand').click();
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toBeVisible();
+    await page.getByTestId('workspace-left-rail-overlay-backdrop').click();
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toHaveCount(0);
+
+    await page.getByTestId('workspace-left-rail-expand').click();
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toHaveCount(0);
+  });
+
+  test('opening an object dismisses it, so it does not cover what it just opened', async ({
+    page,
+  }) => {
+    await page.setViewportSize(PHONE);
+    await gotoWorkspace(page);
+    await page.getByTestId('workspace-left-rail-collapsed-model').click();
+
+    const overlay = page.getByTestId('workspace-left-rail-overlay');
+    await expect(overlay).toBeVisible();
+
+    // Any model row will do — this story is about the panel, not the object.
+    await overlay.locator('[data-testid^="library-row-model-"]').first().click();
+
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test('at a desktop width the same button expands in flow, with no popout', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await gotoWorkspace(page);
+
+    // Wide enough that the rail is already expanded; collapse it first so the
+    // strip is what we click.
+    const rail = page.getByTestId('workspace-left-rail');
+    if ((await rail.getAttribute('data-collapsed')) !== 'true') {
+      await page.getByTestId('workspace-left-rail-collapse').click();
+    }
+    await page.getByTestId('workspace-left-rail-collapsed-model').click();
+
+    await expect(page.getByTestId('workspace-left-rail-overlay')).toHaveCount(0);
+    await expect(page.getByTestId('library-subsection-model')).toBeVisible();
+  });
+});

--- a/viewer/src/components/views/workspace/LeftRail.jsx
+++ b/viewer/src/components/views/workspace/LeftRail.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { PiMagnifyingGlass, PiSidebar } from 'react-icons/pi';
 import Library from './library/Library';
 import ViewSwitcher from './ViewSwitcher';
@@ -14,10 +14,16 @@ import { LAYOUT_TYPES, DATA_TYPES, getTypeDef } from './library/LibraryRow';
  *   - Collapsed (48-px icon strip): the switcher's three icons (fixed
  *     positions, tooltips), then one icon per Library subsection so the user
  *     can identify what's in the rail at a glance. The two-section
- *     vocabulary matches the Library — Layout Items above the divider,
- *     Data Layer below. Icons come from the canonical `objectTypeConfigs.js`
- *     (MUI) via `getTypeDef`, so the collapsed and expanded views read as
- *     the same Library.
+ *     vocabulary matches the Library — Data Layer above the divider, Layout
+ *     Items below, the SAME order the expanded tree renders (Library.jsx
+ *     composes `[...DATA_TYPES, ...LAYOUT_TYPES]`). The strip used to run the
+ *     other way round, so collapsing the rail reordered it. Icons come from
+ *     the canonical `objectTypeConfigs.js` (MUI) via `getTypeDef`, so the two
+ *     views read as the same Library.
+ *   - Popped out: on a viewport too narrow to host the rail in flow, opening
+ *     it draws the Library OVER the content instead of beside it. Expanding
+ *     in flow there would leave the canvas below its minimum, which is why
+ *     the shell used to undo it immediately — see `expandWorkspaceLeft`.
  */
 
 const TypeBtn = ({ typeKey, active, onClick }) => {
@@ -40,6 +46,51 @@ const TypeBtn = ({ typeKey, active, onClick }) => {
     >
       <Icon aria-hidden="true" style={{ fontSize: 18 }} />
     </button>
+  );
+};
+
+/**
+ * The Library drawn over the content, for viewports that cannot seat it.
+ *
+ * Dismisses on backdrop click, on Escape, and on navigation — opening an
+ * object is the whole point of the panel, and on a phone it would otherwise
+ * sit on top of the thing it just opened.
+ */
+const LeftRailOverlay = ({ onClose }) => {
+  const activeTabId = useStore(s => s.workspaceActiveTabId);
+  const openedWith = useRef(activeTabId);
+
+  useEffect(() => {
+    // Not on mount — only once the selection actually moves.
+    if (activeTabId !== openedWith.current) onClose();
+  }, [activeTabId, onClose]);
+
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute inset-y-0 left-12 right-0 z-40 flex"
+      data-testid="workspace-left-rail-overlay"
+    >
+      <div className="h-full w-72 max-w-[85vw] border-r border-gray-200 bg-white shadow-xl">
+        <Library />
+      </div>
+      {/* Sits beside the panel rather than under it, so a tap anywhere on the
+          content dismisses without also reaching the content. */}
+      <button
+        type="button"
+        aria-label="Close navigator"
+        data-testid="workspace-left-rail-overlay-backdrop"
+        onClick={onClose}
+        className="h-full flex-1 cursor-default bg-gray-900/20"
+      />
+    </div>
   );
 };
 
@@ -97,14 +148,14 @@ const LeftRailCollapsed = ({ onExpand }) => {
         >
           <PiMagnifyingGlass className="h-[18px] w-[18px]" />
         </button>
-        {/* Layout Items group — droppable types. */}
-        <div className="my-1 h-px w-6 bg-gray-200" aria-hidden="true" />
-        {LAYOUT_TYPES.map(t => (
-          <TypeBtn key={t} typeKey={t} active={t === activeType} onClick={() => handleTypeClick(t)} />
-        ))}
-        {/* Data Layer group — click-to-edit types. */}
+        {/* Data Layer first, then Layout Items — the order Library.jsx
+            renders, so collapsing the rail no longer reshuffles it. */}
         <div className="my-1 h-px w-6 bg-gray-200" aria-hidden="true" />
         {DATA_TYPES.map(t => (
+          <TypeBtn key={t} typeKey={t} active={t === activeType} onClick={() => handleTypeClick(t)} />
+        ))}
+        <div className="my-1 h-px w-6 bg-gray-200" aria-hidden="true" />
+        {LAYOUT_TYPES.map(t => (
           <TypeBtn key={t} typeKey={t} active={t === activeType} onClick={() => handleTypeClick(t)} />
         ))}
       </div>
@@ -114,11 +165,18 @@ const LeftRailCollapsed = ({ onExpand }) => {
 
 const LeftRail = () => {
   const collapsed = useStore(s => s.workspaceLeftCollapsed);
-  const toggleCollapsed = useStore(s => s.toggleWorkspaceLeftCollapsed);
-  return collapsed ? (
-    <LeftRailCollapsed onExpand={toggleCollapsed} />
-  ) : (
-    <Library />
+  const overlayOpen = useStore(s => s.workspaceLeftOverlayOpen);
+  // Not the plain toggle: on a narrow viewport the rail opens over the content
+  // instead of beside it, and only the store knows which case applies.
+  const expandLeft = useStore(s => s.expandWorkspaceLeft);
+  const closeOverlay = useStore(s => s.closeWorkspaceLeftOverlay);
+
+  if (!collapsed) return <Library />;
+  return (
+    <>
+      <LeftRailCollapsed onExpand={expandLeft} />
+      {overlayOpen && <LeftRailOverlay onClose={closeOverlay} />}
+    </>
   );
 };
 

--- a/viewer/src/components/views/workspace/LeftRail.test.jsx
+++ b/viewer/src/components/views/workspace/LeftRail.test.jsx
@@ -8,7 +8,7 @@
  * button focuses the Library search input.
  */
 import React from 'react';
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, act, fireEvent, waitFor, within } from '@testing-library/react';
 import {
   createMemoryRouter,
   Route,
@@ -19,11 +19,17 @@ import { DndContext } from '@dnd-kit/core';
 import { futureFlags } from '../../../router-config';
 import LeftRail from './LeftRail';
 import useStore from '../../../stores/store';
+import { LAYOUT_TYPES, DATA_TYPES } from './library/LibraryRow';
 
 const seedStore = (extra = {}) => {
   act(() => {
     useStore.setState({
       workspaceLeftCollapsed: true,
+      // Reset explicitly: these persist across tests otherwise, and a leaked
+      // open popout renders a SECOND Library (so a second view switcher).
+      workspaceLeftMustCollapse: false,
+      workspaceLeftOverlayOpen: false,
+      workspaceActiveTabId: null,
       workspaceActiveObject: null,
       libraryCollapsedSections: {},
       libraryCollapsedSubsections: {},
@@ -93,6 +99,89 @@ describe('LeftRail collapsed strip', () => {
     fireEvent.click(screen.getByTestId('workspace-left-rail-collapsed-search'));
     expect(useStore.getState().workspaceLeftCollapsed).toBe(false);
     await waitFor(() => expect(screen.getByTestId('library-search')).toHaveFocus());
+  });
+
+  // The strip's icons ran Layout-Items-first while the expanded tree renders
+  // Data-Layer-first (Library.jsx composes `[...DATA_TYPES, ...LAYOUT_TYPES]`),
+  // so collapsing the rail silently reordered it.
+  test('type icons appear in the same order as the expanded tree', () => {
+    renderRail();
+    const strip = screen.getByTestId('workspace-left-rail');
+    const order = within(strip)
+      .getAllByRole('button')
+      .map(b => b.getAttribute('data-testid'))
+      .filter(id => id && id.startsWith('workspace-left-rail-collapsed-'))
+      .map(id => id.replace('workspace-left-rail-collapsed-', ''))
+      .filter(t => t !== 'search');
+
+    expect(order).toEqual([...DATA_TYPES, ...LAYOUT_TYPES]);
+  });
+
+  // On a viewport too narrow to seat the rail, expanding in flow would starve
+  // the canvas — the shell measured that and collapsed it again on the very
+  // next effect run, so every button in the strip looked dead.
+  describe('when the viewport cannot seat the rail', () => {
+    const seedNarrow = (extra = {}) =>
+      seedStore({ workspaceLeftMustCollapse: true, ...extra });
+
+    test('a type button pops the Library out over the content instead of doing nothing', () => {
+      seedNarrow();
+      renderRail();
+
+      fireEvent.click(screen.getByTestId('workspace-left-rail-collapsed-model'));
+
+      expect(screen.getByTestId('workspace-left-rail-overlay')).toBeInTheDocument();
+      // The strip keeps its place — the popout costs no layout width, which is
+      // what stops the shell undoing it.
+      expect(useStore.getState().workspaceLeftCollapsed).toBe(true);
+      expect(screen.getByTestId('library-subsection-model')).toHaveAttribute(
+        'data-collapsed',
+        'false'
+      );
+    });
+
+    test('the expand button pops out too', () => {
+      seedNarrow();
+      renderRail();
+      fireEvent.click(screen.getByTestId('workspace-left-rail-expand'));
+      expect(screen.getByTestId('workspace-left-rail-overlay')).toBeInTheDocument();
+    });
+
+    test('tapping the content beside it dismisses the popout', () => {
+      seedNarrow({ workspaceLeftOverlayOpen: true });
+      renderRail();
+
+      fireEvent.click(screen.getByTestId('workspace-left-rail-overlay-backdrop'));
+
+      expect(screen.queryByTestId('workspace-left-rail-overlay')).not.toBeInTheDocument();
+    });
+
+    test('Escape dismisses the popout', () => {
+      seedNarrow({ workspaceLeftOverlayOpen: true });
+      renderRail();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByTestId('workspace-left-rail-overlay')).not.toBeInTheDocument();
+    });
+
+    test('opening an object dismisses it — otherwise it covers what you just opened', () => {
+      seedNarrow({ workspaceLeftOverlayOpen: true, workspaceActiveTabId: null });
+      renderRail();
+      expect(screen.getByTestId('workspace-left-rail-overlay')).toBeInTheDocument();
+
+      act(() => {
+        useStore.setState({ workspaceActiveTabId: 'model:orders' });
+      });
+
+      expect(screen.queryByTestId('workspace-left-rail-overlay')).not.toBeInTheDocument();
+    });
+
+    test('the popout does not close on mount just because a tab is already active', () => {
+      seedNarrow({ workspaceLeftOverlayOpen: true, workspaceActiveTabId: 'model:orders' });
+      renderRail();
+      expect(screen.getByTestId('workspace-left-rail-overlay')).toBeInTheDocument();
+    });
   });
 
   test('renders the collapsed destination switcher above the type-button strip (D1, Explore 2.0 Phase 0)', () => {

--- a/viewer/src/components/views/workspace/WorkspaceShell.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceShell.jsx
@@ -130,7 +130,10 @@ const WorkspaceShell = ({ testId = 'workspace-shell' }) => {
           ProjectEditor's former context (which is why the middle pane is inside
           it too); see WorkspaceDndContext for the routing decision. */}
       <WorkspaceDndContext>
-        <div className="flex min-h-0 flex-1">
+        {/* `relative` so the left rail's narrow-viewport popout can position
+            against this row — it has to reach past its own 48px container to
+            cover the content it is drawn over. */}
+        <div className="relative flex min-h-0 flex-1">
           {/* Left rail — project-wide, full-height anchor. */}
           <div
             style={{ width: leftCollapsed ? RAIL_COLLAPSED_WIDTH : leftWidth }}

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -131,6 +131,17 @@ const createWorkspaceSlice = (set, get) => ({
   workspaceRightCollapsed: false,
   workspaceRightTab: 'edit', // 'outline' | 'edit' | 'build'
 
+  // Whether the viewport is currently too narrow to host the expanded left
+  // rail IN FLOW, as last measured by `WorkspaceShell`. Recorded so an expand
+  // request can pick the right presentation instead of the shell and the user
+  // fighting over one boolean.
+  workspaceLeftMustCollapse: false,
+  // The expanded rail drawn OVER the content rather than beside it. On a phone
+  // the rail cannot take its 288px without starving the canvas, which is why
+  // expanding used to be undone the instant it happened; as an overlay it
+  // costs no layout width, so nothing needs to undo it.
+  workspaceLeftOverlayOpen: false,
+
   // Narrow-viewport AUTO collapse bookkeeping (6c-T2 responsive shell,
   // BLOCKER at 1100px) — NOT read by LeftRail/RightRail (they only ever read
   // the `workspace{Left,Right}Collapsed` flags above, unchanged). This just
@@ -667,15 +678,52 @@ const createWorkspaceSlice = (set, get) => ({
   // Rail / lens actions
   // ------------------------------------------------------------------------
 
+  /**
+   * Open the left rail, in whichever form actually fits.
+   *
+   * Wide enough → expand in flow. Too narrow → open as an overlay.
+   *
+   * The collapsed strip's buttons used to call the plain toggle, which set
+   * `workspaceLeftCollapsed = false`. On a narrow viewport `WorkspaceShell`'s
+   * width effect re-ran on exactly that change, measured that the rail still
+   * doesn't fit, and collapsed it again before paint — so every button in the
+   * strip looked dead. Nothing was broken about the click; the layout was
+   * answering a question the user had already overruled.
+   */
+  expandWorkspaceLeft: () => {
+    set((s) =>
+      s.workspaceLeftMustCollapse
+        ? { workspaceLeftOverlayOpen: true }
+        : {
+            workspaceLeftCollapsed: false,
+            workspaceLeftAutoCollapsedByShell: false,
+            workspaceLeftOverlayOpen: false,
+          }
+    );
+  },
+
+  closeWorkspaceLeftOverlay: () => {
+    set({ workspaceLeftOverlayOpen: false });
+  },
+
   toggleWorkspaceLeftCollapsed: () => {
     // A manual toggle always wins — clear the auto-collapse bookkeeping so
     // `applyWorkspaceAutoCollapse` never later "auto-expands" a rail the
     // user just explicitly collapsed (or re-collapses one they just opened,
     // as long as space allows — see that action's docstring).
-    set((s) => ({
-      workspaceLeftCollapsed: !s.workspaceLeftCollapsed,
-      workspaceLeftAutoCollapsedByShell: false,
-    }));
+    set((s) => {
+      // While popped out the rail is ALREADY flagged collapsed (the strip is
+      // what occupies the layout), so flipping that flag would expand it in
+      // flow — the opposite of what the close button means. Dismiss the
+      // overlay instead.
+      if (s.workspaceLeftOverlayOpen) {
+        return { workspaceLeftOverlayOpen: false };
+      }
+      return {
+        workspaceLeftCollapsed: !s.workspaceLeftCollapsed,
+        workspaceLeftAutoCollapsedByShell: false,
+      };
+    });
   },
 
   toggleWorkspaceRightCollapsed: () => {
@@ -705,6 +753,16 @@ const createWorkspaceSlice = (set, get) => ({
   applyWorkspaceAutoCollapse: ({ left, right }) => {
     set((s) => {
       const update = {};
+      // Remember whether the rail fits, so `expandWorkspaceLeft` can choose a
+      // presentation rather than being immediately reversed by this action.
+      if (s.workspaceLeftMustCollapse !== left) update.workspaceLeftMustCollapse = left;
+      // Room again: an overlay is only a workaround for not having any, so it
+      // graduates to a normal in-flow rail instead of lingering over content.
+      if (!left && s.workspaceLeftOverlayOpen) {
+        update.workspaceLeftOverlayOpen = false;
+        update.workspaceLeftCollapsed = false;
+        update.workspaceLeftAutoCollapsedByShell = false;
+      }
       if (left && !s.workspaceLeftCollapsed) {
         update.workspaceLeftCollapsed = true;
         update.workspaceLeftAutoCollapsedByShell = true;

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -831,6 +831,81 @@ describe('workspace store slice', () => {
   // 6c-T2 responsive shell (BLOCKER at 1100px): applyWorkspaceAutoCollapse is
   // a one-way NUDGE reconciled against current state, not a continuous
   // override — see its docstring for the full contract.
+  describe('expandWorkspaceLeft (narrow-viewport popout)', () => {
+    test('expands in flow when the rail fits', () => {
+      act(() => {
+        useStore.setState({ workspaceLeftCollapsed: true, workspaceLeftMustCollapse: false });
+        useStore.getState().expandWorkspaceLeft();
+      });
+      const s = useStore.getState();
+      expect(s.workspaceLeftCollapsed).toBe(false);
+      expect(s.workspaceLeftOverlayOpen).toBe(false);
+      // Cleared so a later widen doesn't treat this as the shell's doing.
+      expect(s.workspaceLeftAutoCollapsedByShell).toBe(false);
+    });
+
+    test('pops out instead when it does not fit, leaving the layout alone', () => {
+      // The bug: expanding in flow here set workspaceLeftCollapsed=false, the
+      // shell's width effect re-ran on that very change, measured that the
+      // rail still doesn't fit, and collapsed it again before paint.
+      act(() => {
+        useStore.setState({ workspaceLeftCollapsed: true, workspaceLeftMustCollapse: true });
+        useStore.getState().expandWorkspaceLeft();
+      });
+      const s = useStore.getState();
+      expect(s.workspaceLeftOverlayOpen).toBe(true);
+      // Still "collapsed" as far as layout is concerned — which is exactly why
+      // the shell has nothing to undo.
+      expect(s.workspaceLeftCollapsed).toBe(true);
+    });
+
+    test('a popped-out rail survives the shell re-asserting that it must collapse', () => {
+      act(() => {
+        useStore.setState({ workspaceLeftCollapsed: true, workspaceLeftMustCollapse: true });
+        useStore.getState().expandWorkspaceLeft();
+        useStore.getState().applyWorkspaceAutoCollapse({ left: true, right: false });
+      });
+      expect(useStore.getState().workspaceLeftOverlayOpen).toBe(true);
+    });
+
+    test('the close control dismisses the popout rather than expanding in flow', () => {
+      // `workspaceLeftCollapsed` is already true while popped out, so the plain
+      // toggle would flip it to false — the opposite of closing.
+      act(() => {
+        useStore.setState({ workspaceLeftCollapsed: true, workspaceLeftOverlayOpen: true });
+        useStore.getState().toggleWorkspaceLeftCollapsed();
+      });
+      const s = useStore.getState();
+      expect(s.workspaceLeftOverlayOpen).toBe(false);
+      expect(s.workspaceLeftCollapsed).toBe(true);
+    });
+
+    test('room again promotes the popout to an ordinary in-flow rail', () => {
+      act(() => {
+        useStore.setState({
+          workspaceLeftCollapsed: true,
+          workspaceLeftMustCollapse: true,
+          workspaceLeftOverlayOpen: true,
+        });
+        useStore.getState().applyWorkspaceAutoCollapse({ left: false, right: false });
+      });
+      const s = useStore.getState();
+      expect(s.workspaceLeftOverlayOpen).toBe(false);
+      expect(s.workspaceLeftCollapsed).toBe(false);
+    });
+
+    test('applyWorkspaceAutoCollapse records whether the rail fits', () => {
+      act(() => {
+        useStore.getState().applyWorkspaceAutoCollapse({ left: true, right: false });
+      });
+      expect(useStore.getState().workspaceLeftMustCollapse).toBe(true);
+      act(() => {
+        useStore.getState().applyWorkspaceAutoCollapse({ left: false, right: false });
+      });
+      expect(useStore.getState().workspaceLeftMustCollapse).toBe(false);
+    });
+  });
+
   describe('applyWorkspaceAutoCollapse (6c-T2 responsive shell)', () => {
     test('collapses a rail that is not already collapsed, tagging it as shell-driven', () => {
       act(() => {


### PR DESCRIPTION
Two things about the 48px strip.

### 1. Every button in it looked dead on a narrow viewport

Nothing was wrong with the click. Expanding set `workspaceLeftCollapsed = false`, and `WorkspaceShell`'s width effect **lists that flag in its own deps** (`WorkspaceShell.jsx:115`) — so it re-ran, measured that the rail still doesn't fit beside a 480px canvas, and collapsed it again before paint. The strip renders hover and title states that promise interactivity, so a refusal read as a breakage.

Two comments in the codebase describe this behaviour and **disagree**; the shell's won. `applyWorkspaceAutoCollapse`'s docstring says it never fights a manual choice and that "a rail the user manually expands while still narrow stays expanded" — but only its **re-expand** branch checks who collapsed the rail. The collapse branch fires whenever the shell says there's no room, manual choice or not.

**The rail now opens as a popout over the content when it can't be seated in flow.** That costs no layout width, so the measurement that used to undo it has nothing to undo, and the canvas keeps its minimum.

Which presentation to use is a property of the viewport, not of the click — so the shell records whether the rail fits and `expandWorkspaceLeft` picks: in flow when there's room, popped out when there isn't. Given room again, the popout becomes an ordinary in-flow rail rather than lingering over content.

It dismisses on backdrop tap, on Escape, and **on navigation** — opening an object is the point of the panel, and on a phone it would otherwise sit on top of the thing it just opened.

One case needed explicit handling: while popped out the rail is *already* flagged collapsed (the strip is what occupies the layout), so the plain toggle would have expanded it **in flow** — the opposite of what the close control means.

### 2. Collapsing the rail silently reordered it

The strip listed Layout Items before Data Layer; the expanded tree renders Data Layer first (`Library.jsx` composes `[...DATA_TYPES, ...LAYOUT_TYPES]`). The strip follows the tree now, asserted against those same constants so they can't drift apart again.

### Testing

**6735 passing** (358 suites), lint clean. Baseline on main is 6722, so **+13**.

Store: expand-in-flow vs pop-out; a popout survives the shell re-asserting that it must collapse (the exact fight this fixes); the close control dismisses rather than expanding; room again promotes it to in-flow; the fit measurement is recorded.

Component: type button and expand button both pop out when narrow; dismissal via backdrop, Escape and navigation; it does *not* dismiss on mount just because a tab is already active; and icon order equals `[...DATA_TYPES, ...LAYOUT_TYPES]`.

I also found `seedStore` in `LeftRail.test.jsx` wasn't resetting the rail flags, so a leaked-open popout rendered a second `<Library>` and broke an unrelated test. It resets them now.

New Playwright story at **390px** for the reported case, including that the popout is positioned against the shell row rather than its own 48px container — the half unit tests can't see. **Not run** (needs a sandbox); flagging that explicitly.

### Suite flakiness — worth its own look

Not from this change, but I measured it while verifying: across five full runs I saw **three different suites** flake (`ExplorationPromoteModal`, `ChartEditForm`, `useSourceSchema`), each passing in isolation. Two of those runs were on **clean `main`**, which failed 2-for-2 with a different suite each time. It looks like general worker-contention marginality rather than any one bad test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)