### PR TITLE
Lineage gets the lineage icon, not the refresh one

### DIFF
--- a/viewer/src/components/project/ProjectViewFlipLayer.jsx
+++ b/viewer/src/components/project/ProjectViewFlipLayer.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { PiArrowsClockwise, PiLink } from 'react-icons/pi';
+import { PiTreeStructure, PiLink } from 'react-icons/pi';
 import { parseRefValue } from '../../utils/refString';
 import { parseCanvasPath } from '../views/project/canvas/canvasReorder';
 import ItemFlipCard from './ItemFlipCard';
@@ -237,7 +237,7 @@ const ProjectViewFlipLayer = ({ rootRef, dashboardConfig }) => {
           {
             id: 'flip',
             label: isFlipped ? 'Hide lineage' : 'Flip to lineage',
-            icon: PiArrowsClockwise,
+            icon: PiTreeStructure,
             active: isFlipped,
             onSelect: () => toggleFlip(key),
           },

--- a/viewer/src/components/views/project/canvas/CanvasItemFlipLayer.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasItemFlipLayer.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { PiArrowsClockwise, PiLink } from 'react-icons/pi';
+import { PiTreeStructure, PiLink } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import { useWorkspaceDrag } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
@@ -254,7 +254,7 @@ const CanvasItemFlipLayer = ({ rootRef, dashboardName }) => {
             {
               id: 'flip',
               label: isFlipped ? 'Hide lineage' : 'Flip to lineage',
-              icon: PiArrowsClockwise,
+              icon: PiTreeStructure,
               active: isFlipped,
               onSelect: () => toggleFlip(key),
             },

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import {
-  PiArrowsClockwise,
+  PiTreeStructure,
   PiDotsThreeOutlineVertical,
   PiDotsSix,
   PiPencil,
@@ -210,7 +210,7 @@ const ContextMenu = ({ obj, onAction, onDismiss, canAddToExploration = false }) 
         </li>
         <li>
           <ContextMenuItem
-            icon={PiArrowsClockwise}
+            icon={PiTreeStructure}
             label="Show lineage"
             hint="F"
             onClick={handle('showLineage')}
@@ -489,6 +489,10 @@ const LibraryRow = ({
               <PiCompass className="h-3.5 w-3.5" />
             </button>
           )}
+          {/* PiTreeStructure, not the clockwise arrows: those read as refresh —
+              which is what they still mean elsewhere in the app (regenerate
+              schema, exploration staleness, field swap). It is also already
+              the icon LineageCanvas uses for the surface this opens. */}
           <button
             type="button"
             onClick={handleFlipClick}
@@ -503,7 +507,7 @@ const LibraryRow = ({
                 : 'text-gray-500 hover:bg-white hover:text-gray-900',
             ].join(' ')}
           >
-            <PiArrowsClockwise className="h-3.5 w-3.5" />
+            <PiTreeStructure className="h-3.5 w-3.5" />
           </button>
           <button
             type="button"


### PR DESCRIPTION
The "show lineage" controls used `PiArrowsClockwise` — clockwise arrows, which read as refresh.

That's not a guess about what the glyph evokes: **the same icon means exactly that in three other places**, and those stay put:

| Site | Meaning | Icon |
|---|---|---|
| `LibraryRow` flip button + "Show lineage" menu item | lineage | **changed** |
| `ProjectViewFlipLayer` / `CanvasItemFlipLayer` "Flip to lineage" | lineage | **changed** |
| `SourceOutlineTreePanel`, `LibrarySourceRow` | regenerate schema | unchanged |
| `ExplorationStalenessBanner` | staleness / refresh | unchanged |
| `FieldSwapOfferBanner` | swap | unchanged |

One glyph was carrying two unrelated meanings; now it carries one.

### Why `PiTreeStructure`

Not a new pick — **`LineageCanvas.jsx` already uses it** for the surface these controls open. So the button now matches what it opens, rather than matching the refresh buttons it has nothing to do with. The rationale is recorded next to the flip button so the next person doesn't "unify" it back.

### Testing

**6722 passing** (358 suites), lint clean — no count change, since this is a glyph swap and the existing tests key on labels and testids rather than on the icon component.

One failure in the run: `ExplorationPromoteModal`, the pre-existing flake I reproduced on clean `main` at roughly 1 run in 3. Nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)