### PR TITLE
Tell the diff endpoint which project to compare against

### DIFF
--- a/viewer/src/api/explorer.js
+++ b/viewer/src/api/explorer.js
@@ -1,8 +1,15 @@
+import { getUrl } from '../contexts/URLContext';
+import { withProjectId } from './projectScope';
 import { apiFetch } from './utils';
 
 // POST for read: payload contains full working state (SQL, props, layout) that exceeds GET URL length limits.
-export const fetchDiff = async (payload) => {
-  const response = await apiFetch('/api/explorer/diff/', {
+//
+// `projectId` scopes the comparison. Studio serves one project per server and
+// ignores the param; cloud serves many and REQUIRES it — the endpoint 400s
+// without one.
+export const fetchDiff = async (payload, projectId = null) => {
+  const url = withProjectId(getUrl('explorerDiff'), projectId);
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/viewer/src/api/explorer.test.js
+++ b/viewer/src/api/explorer.test.js
@@ -40,3 +40,35 @@ describe('fetchDiff', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('fetchDiff project scoping', () => {
+  // Cloud hosts many projects and answers 400 without this; local serve has
+  // one and ignores it. Sending it unconditionally would put `?project_id=`
+  // on every local request for no reason, so it is opt-in.
+  it('scopes the request to the project when one is known', async () => {
+    apiFetch.mockResolvedValue({ status: 200, json: async () => ({}) });
+    await fetchDiff({ models: {} }, 'proj-1');
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/explorer/diff/?project_id=proj-1',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('omits the param when there is no project', async () => {
+    apiFetch.mockResolvedValue({ status: 200, json: async () => ({}) });
+    await fetchDiff({ models: {} });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/explorer/diff/',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('encodes a project id that needs it', async () => {
+    apiFetch.mockResolvedValue({ status: 200, json: async () => ({}) });
+    await fetchDiff({ models: {} }, 'a b/c');
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/explorer/diff/?project_id=a%20b%2Fc',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -139,6 +139,10 @@ const URL_PATTERNS = {
     // why they are verbs on their own segment rather than nested under the
     // resource they happen to concern.
     queryExecution: '/api/query/{projectId}/',
+    // Compares the explorer's unsaved working state against the project's
+    // saved objects — the badges' source of truth. Project-scoped via
+    // `withProjectId`, not a path param: the body already carries the state.
+    explorerDiff: '/api/explorer/diff/',
     expressionsTranslate: '/api/expressions/translate/',
     // VIS-993 gate; server-only — dist/cloud fail open.
     expressionsValidate: '/api/expressions/validate/',

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -1900,7 +1900,7 @@ const createExplorerSlice = (set, get) => ({
 
     try {
       const { fetchDiff } = await import('../api/explorer');
-      const result = await fetchDiff(payload);
+      const result = await fetchDiff(payload, state.project?.id || null);
       set({ explorerDiffResult: result });
       return result;
     } catch (err) {


### PR DESCRIPTION
Pairs with **[core#343](https://github.com/visivo-io/core/pull/343)**, which implements `/api/explorer/diff/` in cloud. Land them together — core's endpoint answers 400 without this.

`fetchDiff` posted to `/api/explorer/diff/` with no scope. Studio serves one project per server so it never needed one; cloud serves many and can't answer without knowing which.

### Uses the existing mechanisms, not new ones

Two, both already in the repo:

- **`getUrl('explorerDiff')`** — the endpoint is now declared in `config/urls.js` with every other one, instead of being a string literal in the api module. It was the only endpoint bypassing the registry.
- **`withProjectId(url, projectId)`** — the shared helper five api modules already use.

`withProjectId`'s own docstring is the argument against hand-rolling it: *"hand-rolling it once per function is how four modules ended up never doing it at all."* It also handles the `?`-vs-`&` that this call would have got wrong the moment the URL grew a second param.

### One consequence worth naming

Registering the URL means that in `dist` — where the key resolves to `null` — `getUrl` **throws** rather than returning a path that 404s. The call already sits inside the store's `try`/`catch`, so it still lands on the same `explorerDiffResult: null`. The failure mode is unchanged, only its shape.

### Testing

**6725 passing** (358 suites), lint clean.

New: the param is sent when a project is known, omitted when it isn't, and encoded when it needs to be. These genuinely exercise `getUrl` — `setupTests.js` installs a real URL config globally, so they aren't asserting against a mock.

One flake in the first full run (`RightRailEditPanel`, 64s under load vs 16s in isolation); a re-run was clean. Same contention flakiness I measured on `main` earlier, where three different suites flaked across five runs.

### Context

Replaces visivo#579, which gated the call off in the viewer instead. That removed the 404 but left cloud without the badges — and the badges are the point of the endpoint, so fixing it in core was the better call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
