### PR TITLE
VIS-1190: Nuitka standalone build of the CLI (spike) — it works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ test-resulsts/
 
 # Playwright story QA screenshots (regenerated locally; not snapshot baselines)
 **/__screens__/
+
+# Nuitka standalone build output (VIS-1190 spike)
+dist-nuitka/

--- a/docs/nuitka-spike-findings.md
+++ b/docs/nuitka-spike-findings.md
@@ -1,0 +1,70 @@
+# Nuitka spike (VIS-1190) — findings
+
+**Result: a Nuitka `--standalone` build of the Visivo CLI works.** It compiles,
+links, and is functionally faithful to the interpreted CLI. The historical
+sqlglot fear did not materialize. See `visivo/build_nuitka.py` for the build.
+
+Environment: macOS arm64, pyenv CPython 3.14.6, Nuitka **4.1.3**, clang 21.
+
+## What it took to build (four fixes from a naive `--standalone`)
+
+1. **Nuitka must be >= 4.x.** The repo pins `nuitka = "^2.7.6"` (2.8.10). On 2.8.10
+   the build failed twice — `--enable-plugin=pydantic` is not a valid plugin
+   (pydantic_core is handled automatically now), and pyenv's `--enable-shared`
+   CPython tripped static-libpython detection. `pip install -U 'nuitka>=4.1'`
+   fixed both. **Bumping the pin cleanly (without the lock re-resolving and
+   downgrading redshift/snowflake/bigquery/tornado) is left to VIS-1192.**
+2. **`--static-libpython=no`** — required for pyenv's shared CPython. CI's Python
+   flavor may not need it; keep it conditional in the real pipeline.
+3. **No `--enable-plugin=pydantic`** — there is no such plugin in 4.x; pydantic_core
+   is bundled automatically. (matplotlib self-activated its plugin too.)
+4. **The binary cannot be named `visivo`.** In standalone, Nuitka compiles the
+   `visivo` package into `<dist>/visivo/` (where `importlib.resources.files("visivo")`
+   resolves data), and an executable named `visivo` collides with that dir
+   (`FATAL: data file ... 'visivo' conflicts with executable 'visivo'`). Built as
+   `visivo-app`; presenting the final `visivo` command (symlink/wrapper) is a
+   packaging step for VIS-1192. PyInstaller sidesteps this by nesting under
+   `_internal/`.
+
+## What works (smoke, against the built binary)
+
+- `--version`, `--help`, `init` (scaffold), `compile`.
+- `run` against a seeded DuckDB file — **identical output to the interpreted CLI**
+  (a bare model with no consumer writes only schemas; verified interpreted does
+  the same, so it's faithful, not a Nuitka gap).
+- `serve` — HTTP 200, serves the bundled React viewer (`<div id="root">`),
+  "Initial Data Refresh Complete." This proves `importlib.resources.files("visivo")`
+  resolves the bundled `viewers/` and `schema/` data under Nuitka.
+- The risky native/dynamic deps all load: **pydantic_core, jsonschema_rs, sqlglot,
+  duckdb, matplotlib, snowflake.connector, socketio**. sqlglot was a non-issue
+  (27.29.0, pure-Python, no `sqlglotrs`) — as predicted.
+
+## Caveats / follow-ups
+
+- **Python 3.14 is only *experimental* in Nuitka 4.1.3** (it recommends 3.13).
+  The build worked on 3.14 anyway, but the **release + runner builds should target
+  3.13** (the runner already runs 3.13). Feeds VIS-1192/1193.
+- **Size is large: 270 MB binary, 859 MB dist folder.** Heavy deps (matplotlib,
+  snowflake, pandas, duckdb, plotly) dominate. This matters for the runner
+  image-size goal (VIS-1193) — measure vs PyInstaller and trim
+  (`--nofollow-import-to` for genuinely-unused packages, drop matplotlib if the
+  CLI never renders with it, etc.).
+- **`plotly` package-data was not located** ("Failed to locate package directory of
+  'plotly'", non-fatal). Charts weren't exercised end-to-end (serve renders the
+  React viewer, not plotly.py figures). **Verify a chart/insight-bearing project**
+  before trusting the build for real projects.
+- **First-run was 31 s** — macOS Gatekeeper scanning the unsigned 859 MB dist.
+  Warm `--version` is ~2.5 s. Distribution needs code-signing/notarization on mac.
+
+## Startup numbers (macOS arm64, warm)
+
+| | `--version` wall-clock |
+|---|---|
+| Nuitka binary (warm) | ~2.5–2.8 s |
+| `poetry run visivo` (interpreted) | ~6.3 s |
+
+**~2.5 s is dominated by the eager import of all 14 subcommands** in
+`command_line.py` — Nuitka compiles that graph but can't skip it. **VIS-1191
+(lazy-load subcommands) is the bigger startup lever** and is freezer-independent.
+A fair Nuitka-vs-PyInstaller comparison (build PyInstaller too) is the next
+measurement, on Linux, once lazy-loading lands.

--- a/visivo/build_nuitka.py
+++ b/visivo/build_nuitka.py
@@ -1,0 +1,86 @@
+"""Nuitka build of the Visivo CLI — spike for VIS-1190.
+
+Parallel to build.py (PyInstaller). Standalone mode (a dist folder, no runtime
+extraction) is the fair comparison to the current PyInstaller `--onedir` and the
+fast-start option. Mirrors build.py's directives:
+
+  PyInstaller                          Nuitka
+  --onedir                             --standalone
+  --collect-submodules X               --include-package=X
+  --collect-all jsonschema_rs          --include-package[-data]=jsonschema_rs
+  --collect-all pydantic_core          --enable-plugin=pydantic
+  --add-data visivo/schema/*:...       --include-data-dir=.../schema=visivo/schema
+  --add-data visivo/viewers/*:...      --include-data-dir=.../viewers=visivo/viewers
+
+Data is resolved at runtime via importlib.resources.files("visivo") (utils.py),
+which Nuitka supports — so the data must land under the visivo package dir.
+
+Requires Nuitka >= 4.1 (the repo's pinned 2.x fails: no such --enable-plugin,
+and pyenv's --enable-shared trips static-libpython detection). Bumping the pin
+without disturbing other deps is deferred to VIS-1192 — for now:
+    poetry run pip install -U 'nuitka>=4.1'
+
+Run:  poetry run python visivo/build_nuitka.py
+Out:  dist-nuitka/command_line.dist/visivo-app
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).parent.absolute()  # .../visivo
+REPO = HERE.parent  # repo root
+OUTPUT_DIR = REPO / "dist-nuitka"
+
+
+def build():
+    args = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--standalone",
+        "--assume-yes-for-downloads",
+        # pyenv builds CPython with --enable-shared and ships no static
+        # libpython, which Nuitka prefers. Link the shared one instead (Nuitka
+        # bundles it into the standalone dist). CI's python may differ.
+        "--static-libpython=no",
+        f"--output-dir={OUTPUT_DIR}",
+        # NB: the binary CANNOT be named 'visivo' in --standalone: Nuitka compiles
+        # the 'visivo' package into <dist>/visivo/ (where importlib.resources
+        # looks), and an executable named 'visivo' collides with that dir.
+        # PyInstaller avoids this by nesting everything under _internal/. Build
+        # under a distinct name; presenting the final `visivo` command (symlink
+        # or wrapper) is a packaging step for VIS-1192.
+        "--output-filename=visivo-app",
+        "--remove-output",
+        # NB: pydantic_core (the pyo3 wheel PyInstaller --collect-all'd) needs no
+        # plugin flag — Nuitka 2.8 handles it automatically via its built-in
+        # package config (there is no --enable-plugin=pydantic).
+        # Dynamically-imported packages Nuitka's import-following can miss — the
+        # same set build.py had to --collect-submodules.
+        "--include-package=engineio",
+        "--include-package=socketio",
+        "--include-package=flask_socketio",
+        "--include-package=sqlglot",
+        "--include-package=snowflake.connector",
+        "--include-package=jsonschema_rs",
+        # Native/data-bearing packages: force their non-.py payload in.
+        # jsonschema_rs is a Rust .so; plotly ships JSON validators/templates.
+        "--include-package-data=jsonschema_rs",
+        "--include-package-data=plotly",
+        # Data files build.py shipped, placed under the visivo package dir so
+        # importlib.resources.files("visivo") finds them.
+        f"--include-data-dir={HERE / 'schema'}=visivo/schema",
+        f"--include-data-dir={HERE / 'viewers'}=visivo/viewers",
+        str(HERE / "command_line.py"),
+    ]
+    print("Nuitka:", " ".join(args), flush=True)
+    started = time.time()
+    subprocess.run(args, check=True)
+    print(f"\nNuitka build finished in {time.time() - started:.0f}s", flush=True)
+    print(f"Binary: {OUTPUT_DIR / 'command_line.dist' / 'visivo'}", flush=True)
+
+
+if __name__ == "__main__":
+    build()


### PR DESCRIPTION
**Spike result: a Nuitka `--standalone` build of the Visivo CLI works** — it compiles, links, and is functionally faithful to the interpreted CLI. The historical **sqlglot** fear did not materialize (27.29.0 is pure-Python, no `sqlglotrs`), exactly as the planning predicted.

Environment: macOS arm64, pyenv CPython 3.14.6, Nuitka **4.1.3**, clang 21. Full write-up: `docs/nuitka-spike-findings.md`; the build is `visivo/build_nuitka.py`.

## Four fixes vs a naive `--standalone`

1. **Nuitka must be ≥ 4.x.** The repo pins `^2.7.6`; on 2.8.10 the build failed on a non-existent `--enable-plugin=pydantic` and on pyenv's `--enable-shared` (static-libpython detection). `pip install -U 'nuitka>=4.1'` fixed both.
2. **`--static-libpython=no`** for pyenv's shared CPython.
3. **No `--enable-plugin=pydantic`** — pydantic_core is bundled automatically now (matplotlib self-activated its plugin too).
4. **The binary can't be named `visivo`** — Nuitka compiles the `visivo` package into `<dist>/visivo/` (where `importlib.resources.files("visivo")` resolves), which collides with an executable named `visivo`. Built as `visivo-app`; presenting the final `visivo` command (symlink/wrapper) is a packaging step for VIS-1192.

## Smoke (against the built binary)

- `--version`, `--help`, `init`, `compile` ✅
- `run` on a seeded DuckDB file → **identical output to the interpreted CLI** ✅
- `serve` → HTTP 200 serving the bundled React viewer ✅ (proves `importlib.resources` data resolution)
- pydantic_core / jsonschema_rs / sqlglot / duckdb / matplotlib / snowflake / socketio all load ✅

## Caveats → feed the follow-ups

- **Python 3.14 is only *experimental* in Nuitka 4.1.3** (it recommends 3.13); build the release + runner on **3.13** (the runner already runs 3.13). → VIS-1192/1193
- **Large: 270 MB binary / 859 MB dist** — matters for the runner image-size goal. → VIS-1193
- **`plotly` package-data warning** (non-fatal) — verify a chart-bearing project before trusting real projects.
- **mac needs signing/notarization** (31 s Gatekeeper first-run; ~2.5 s warm).
- **Startup ~2.5 s warm is dominated by eager subcommand imports** — VIS-1191 (lazy-load) is the real startup lever, and Nuitka can't fix it alone.

## Not included on purpose

The `nuitka` pin bump — `poetry add` re-resolved and downgraded unrelated deps (redshift/snowflake/bigquery/tornado), so a controlled bump belongs in **VIS-1192**.

Closes VIS-1190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)