### PR TITLE
Enforce cli_version match on deploy only, not on every run

### DIFF
--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -506,3 +506,25 @@ def test_named_child_nodes_keeps_duplicate_model_scoped_names_distinct():
     assert "model_a" in named_nodes
     assert "model_a.avg_total" in named_nodes["model_a"]["direct_children"]
     assert "model_b.avg_total" not in named_nodes["model_a"]["direct_children"]
+
+
+def test_cli_version_mismatch_does_not_block_construction_or_run():
+    """A run uses whatever visivo is installed, so a project recorded at another
+    CLI version must still construct (and run). Version match is deploy-only —
+    the cloud runner runs projects deployed by older CLIs."""
+    from visivo.version import VISIVO_VERSION
+
+    assert VISIVO_VERSION != "0.0.1"
+    project = Project(name="p", cli_version="0.0.1")  # must not raise
+    assert project.cli_version == "0.0.1"
+
+
+def test_cli_version_validator_still_rejects_on_demand_for_deploy():
+    """Deploy calls CliVersionValidator explicitly, so a mismatch is still
+    rejected there — just not on every construction."""
+    from click import ClickException
+    from visivo.models.validators import CliVersionValidator
+
+    project = Project(name="p", cli_version="0.0.1")
+    with pytest.raises(ClickException):
+        CliVersionValidator().validate(project)

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -1111,6 +1111,14 @@ def deploy_phase(
     parser = ParserFactory().build(project_file=discover.project_file, files=discover.files)
     project = parser.parse()
 
+    # Version match is enforced on deploy ONLY — not on run/compile (where it used
+    # to live, on every Project construction). A run uses whatever visivo is
+    # installed regardless of the version that authored the project; deploy is
+    # where a mismatch matters, since it publishes to the shared cloud project.
+    from visivo.models.validators import CliVersionValidator
+
+    CliVersionValidator().validate(project)
+
     # deploy parses directly (no compile_phase), so validate table SQL here too —
     # otherwise a table whose columns/pivot compile to invalid SQL (bug #7) would
     # be pushed to the cloud and fail only in the browser.

--- a/visivo/models/validators/project_validator.py
+++ b/visivo/models/validators/project_validator.py
@@ -1,7 +1,6 @@
 """Main project validator that orchestrates all validation."""
 
 from visivo.models.validators.base_validator import BaseProjectValidator
-from visivo.models.validators.cli_version_validator import CliVersionValidator
 from visivo.models.validators.default_names_validator import DefaultNamesValidator
 from visivo.models.validators.models_have_sources_validator import ModelsHaveSourcesValidator
 from visivo.models.validators.dag_validator import DagValidator
@@ -28,8 +27,13 @@ class ProjectValidator:
 
     def __init__(self):
         """Initialize the project validator with all validators in order."""
+        # NOTE: CliVersionValidator is deliberately NOT here. This runs on every
+        # Project construction (a @model_validator), so it fires on run/compile/
+        # serve too — but a run should use whatever visivo is installed,
+        # regardless of the version that authored the project (the cloud runner
+        # runs projects deployed by older CLIs). Version match is enforced only
+        # on deploy, in deploy_phase.
         self.validators: List[BaseProjectValidator] = [
-            CliVersionValidator(),
             DefaultNamesValidator(),
             ModelsHaveSourcesValidator(),
             DagValidator(),


### PR DESCRIPTION
## Why

Running a project in the cloud failed with:

> Error: The project specifies 2.0.3, but the current version of visivo installed is 2.1.0. Your project version needs to match your CLI version.

`CliVersionValidator` runs inside `Project`'s `@model_validator`, so it fires on **every** `Project(**data)` construction — run, compile, serve — not just deploy, and it requires an **exact** match. The cloud runner installs one visivo (2.1.0), but a project deployed by an older CLI is *recorded* at its version (2.0.3), and core's assembler writes that into the run — so the run is blocked. Every existing cloud project breaks the same way the moment the runner is upgraded.

It never bit locally because a project's `cli_version` **defaults to the installed CLI's version**, so it always matched.

## Change

A run should use whatever visivo is installed, regardless of the version that authored the project (forward *and* backward). Version match only matters when **publishing to the shared cloud project**. So:

- Remove `CliVersionValidator` from the always-on `ProjectValidator` list (it no longer runs on construction/run/compile/serve).
- Call it **explicitly in `deploy_phase`**, right after the project is parsed — deploy still rejects a mismatch.

## Tests

- `test_cli_version_mismatch_does_not_block_construction_or_run` — a project recorded at another version now constructs without raising.
- `test_cli_version_validator_still_rejects_on_demand_for_deploy` — the validator still raises when called (the deploy path).
- Full project + validators + serializer suites green (63).
- **End-to-end:** a project with `cli_version: "2.0.3"` compiles + runs on 2.1.0 with no version error.

This is what unblocks cloud runs of already-deployed projects (pairs with #586, which unblocks the runner *build*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)