### PR TITLE
Make cli_version compatibility major-based, not exact-match

### DIFF
--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -506,3 +506,29 @@ def test_named_child_nodes_keeps_duplicate_model_scoped_names_distinct():
     assert "model_a" in named_nodes
     assert "model_a.avg_total" in named_nodes["model_a"]["direct_children"]
     assert "model_b.avg_total" not in named_nodes["model_a"]["direct_children"]
+
+
+def test_cli_version_same_major_runs_even_when_minor_differs():
+    """Compatibility is by major version: a project authored on an older 2.x
+    still runs on a newer 2.x, so a run isn't pinned to the exact version that
+    wrote the project (the cloud runner runs projects deployed by older CLIs)."""
+    from visivo.version import VISIVO_VERSION
+
+    major = int(VISIVO_VERSION.split(".")[0])
+    # Same major, deliberately different minor/patch — must construct (run) fine.
+    project = Project(name="p", cli_version=f"{major}.99.99")
+    assert project.cli_version == f"{major}.99.99"
+
+
+def test_cli_version_different_major_is_incompatible():
+    """A cross-major project can't run and must be upgraded (1.x can't run on
+    2.x). Checked on the validator directly, since construction runs it."""
+    from click import ClickException
+    from visivo.models.validators import CliVersionValidator
+    from visivo.version import VISIVO_VERSION
+
+    major = int(VISIVO_VERSION.split(".")[0])
+    project = Project(name="p", cli_version=f"{major}.0.0")  # valid to construct
+    project.cli_version = f"{major + 1}.0.0"  # now a different major
+    with pytest.raises(ClickException):
+        CliVersionValidator().validate(project)

--- a/visivo/models/validators/cli_version_validator.py
+++ b/visivo/models/validators/cli_version_validator.py
@@ -3,18 +3,35 @@
 from click import ClickException
 from visivo.models.validators.base_validator import BaseProjectValidator
 from visivo.version import VISIVO_VERSION
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from visivo.models.project import Project
 
 
+def _major(version) -> Optional[int]:
+    """The major version component of a version string, or None if unparseable."""
+    try:
+        return int(str(version).split(".")[0])
+    except (AttributeError, ValueError, IndexError):
+        return None
+
+
 class CliVersionValidator(BaseProjectValidator):
-    """Validates that the project CLI version matches the installed version."""
+    """Validates that the project is compatible with the installed CLI version.
+
+    Compatibility is by MAJOR version. A breaking change bumps the major, so a
+    project authored on a different major can't run on this one and must be
+    upgraded — but within a major, minor/patch differences run fine (a 2.0.x
+    project runs on 2.1.x). That's deliberately looser than an exact match: a
+    run should use whatever visivo is installed, not be pinned to the exact
+    version that authored the project (e.g. the cloud runner runs projects
+    deployed by older 2.x CLIs).
+    """
 
     def validate(self, project: "Project") -> "Project":
         """
-        Validate that project CLI version matches installed CLI version.
+        Validate that the project's major version matches the installed CLI's.
 
         Args:
             project: The project to validate
@@ -23,10 +40,23 @@ class CliVersionValidator(BaseProjectValidator):
             The validated project
 
         Raises:
-            ClickException: If versions don't match
+            ClickException: If the major versions are incompatible
         """
-        if project.cli_version != VISIVO_VERSION:
+        project_major = _major(project.cli_version)
+        current_major = _major(VISIVO_VERSION)
+
+        # Only a major-version boundary is incompatible. Unparseable versions are
+        # left alone rather than blocked — better to attempt the run than to fail
+        # on a version string we didn't understand.
+        if (
+            project_major is not None
+            and current_major is not None
+            and project_major != current_major
+        ):
             raise ClickException(
-                f"The project specifies {project.cli_version}, but the current version of visivo installed is {VISIVO_VERSION}. Your project version needs to match your CLI version."
+                f"This project was built with visivo {project.cli_version}, which is "
+                f"not compatible with the installed visivo {VISIVO_VERSION} (major "
+                f"version {project_major} vs {current_major}). Upgrade the project to "
+                f"v{current_major}.x to run it."
             )
         return project


### PR DESCRIPTION
## Why

`CliVersionValidator` required `project.cli_version == VISIVO_VERSION` **exactly**, and it runs on every `Project` construction (run/compile/serve). So the cloud runner (2.1.0) refused a project deployed by an older **2.0.x** CLI:

> Error: The project specifies 2.0.3, but the current version of visivo installed is 2.1.0.

Exact-match is the wrong bar. Real incompatibility is a **major-version** boundary — a breaking change bumps the major. Within a major, minor/patch differences run fine (2.0.x runs on 2.1.x); only a cross-major project (1.x on 2.x) can't run and must be upgraded.

## Change

Compare **major** versions instead of the exact string. The check **stays on run** (it's still in the always-on validator list) — this only loosens the comparison. Unparseable versions are left alone rather than blocked.

- `2.0.3` on `2.1.0` → runs ✅
- `1.0.0` on `2.1.0` → rejected with an upgrade message ❌

## Tests

- `test_cli_version_same_major_runs_even_when_minor_differs` — a same-major, different-minor project constructs/runs.
- `test_cli_version_different_major_is_incompatible` — the validator rejects a cross-major project.
- Full project + validators + serializer suites green (63).
- **Verified via the real parse path** (`parser.parse()`): a `2.0.3` project parses/runs on 2.1.0; a `1.0.0` project raises.

Supersedes #587 (which moved the check to deploy-only — this keeps it on run, per review, and just fixes the comparison).