### PR TITLE
Detect rwx.com CI so visivo commands stop firing new_installation

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for telemetry tests."""
+
+import os
+import pytest
+from visivo.telemetry.config import CI_ENV_VARS
+
+
+@pytest.fixture(autouse=True)
+def neutral_ci_env(monkeypatch):
+    """Neutralize the host's CI signals so telemetry tests are deterministic.
+
+    Telemetry branches on ``is_ci_environment()``, which reads the process env —
+    and this repo's own CI runs on RWX, which sets ``RWX_RUN_ID``/``RWX_TASK_ID``.
+    Without this, the 'regular user' tests (persistent machine id, no ``ci-``
+    prefix, ``is_ci=False``) see a CI env on the runner and fail. Clear every CI
+    signal by default; a test that wants CI sets one explicitly AFTER this
+    fixture, and that ``setenv``/``setattr`` wins.
+    """
+    for var in CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    # /.dockerenv is the other signal is_ci_environment checks. Force it absent
+    # unless a test mocks it, but pass every other path through to the real check.
+    real_exists = os.path.exists
+    monkeypatch.setattr(
+        os.path,
+        "exists",
+        lambda path, _e=real_exists: False if path == "/.dockerenv" else _e(path),
+    )

--- a/tests/telemetry/test_ci_detection.py
+++ b/tests/telemetry/test_ci_detection.py
@@ -39,8 +39,15 @@ class TestCIDetection:
         assert is_ci_environment() is True
 
     def test_ci_detection_with_mint(self, monkeypatch):
-        """Test detection with Mint (rwx)."""
+        """Test detection with Mint (rwx's legacy name)."""
         monkeypatch.setenv("MINT", "true")
+        assert is_ci_environment() is True
+
+    def test_ci_detection_with_rwx(self, monkeypatch):
+        """Detection on rwx.com (current Mint): it doesn't set MINT, but always
+        sets RWX_RUN_ID/RWX_TASK_ID. Without this, visivo commands in RWX CI are
+        treated as new user installs and spam new_installation events."""
+        monkeypatch.setenv("RWX_RUN_ID", "abc123")
         assert is_ci_environment() is True
 
     def test_ci_detection_with_docker(self, monkeypatch, tmp_path):

--- a/tests/telemetry/test_ci_detection.py
+++ b/tests/telemetry/test_ci_detection.py
@@ -6,7 +6,7 @@ import os
 import uuid
 from pathlib import Path
 import pytest
-from visivo.telemetry.config import is_ci_environment
+from visivo.telemetry.config import is_ci_environment, CI_ENV_VARS
 from visivo.telemetry.machine_id import get_machine_id
 
 
@@ -75,29 +75,9 @@ class TestCIDetection:
     def test_not_ci_environment(self, monkeypatch):
         """Test detection when not in CI."""
         # We need to clear ALL possible CI environment variables
-        all_ci_vars = [
-            "CI",
-            "CONTINUOUS_INTEGRATION",
-            "GITHUB_ACTIONS",
-            "GITLAB_CI",
-            "CIRCLECI",
-            "JENKINS_HOME",
-            "JENKINS_URL",
-            "TEAMCITY_VERSION",
-            "TRAVIS",
-            "BUILDKITE",
-            "DRONE",
-            "BITBUCKET_BUILD_NUMBER",
-            "SEMAPHORE",
-            "APPVEYOR",
-            "WERCKER",
-            "MAGNUM",
-            "MINT",
-            "CODEBUILD_BUILD_ID",
-            "TF_BUILD",
-            "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-            "KUBERNETES_SERVICE_HOST",
-        ]
+        # Clear exactly what the detector checks — single source of truth so this
+        # can't drift again (a stale copy is how RWX slipped through).
+        all_ci_vars = CI_ENV_VARS
         for var in all_ci_vars:
             monkeypatch.delenv(var, raising=False)
 
@@ -146,29 +126,9 @@ class TestCIMachineId:
     def test_regular_machine_id_format(self, monkeypatch, tmp_path):
         """Test that regular machine IDs don't have prefix."""
         # Clear ALL CI environment variables
-        all_ci_vars = [
-            "CI",
-            "CONTINUOUS_INTEGRATION",
-            "GITHUB_ACTIONS",
-            "GITLAB_CI",
-            "CIRCLECI",
-            "JENKINS_HOME",
-            "JENKINS_URL",
-            "TEAMCITY_VERSION",
-            "TRAVIS",
-            "BUILDKITE",
-            "DRONE",
-            "BITBUCKET_BUILD_NUMBER",
-            "SEMAPHORE",
-            "APPVEYOR",
-            "WERCKER",
-            "MAGNUM",
-            "MINT",
-            "CODEBUILD_BUILD_ID",
-            "TF_BUILD",
-            "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-            "KUBERNETES_SERVICE_HOST",
-        ]
+        # Clear exactly what the detector checks — single source of truth so this
+        # can't drift again (a stale copy is how RWX slipped through).
+        all_ci_vars = CI_ENV_VARS
         for var in all_ci_vars:
             monkeypatch.delenv(var, raising=False)
 
@@ -192,29 +152,9 @@ class TestCIMachineId:
     def test_regular_machine_id_persistent(self, monkeypatch, tmp_path):
         """Test that regular machine IDs are persistent."""
         # Clear ALL CI environment variables
-        all_ci_vars = [
-            "CI",
-            "CONTINUOUS_INTEGRATION",
-            "GITHUB_ACTIONS",
-            "GITLAB_CI",
-            "CIRCLECI",
-            "JENKINS_HOME",
-            "JENKINS_URL",
-            "TEAMCITY_VERSION",
-            "TRAVIS",
-            "BUILDKITE",
-            "DRONE",
-            "BITBUCKET_BUILD_NUMBER",
-            "SEMAPHORE",
-            "APPVEYOR",
-            "WERCKER",
-            "MAGNUM",
-            "MINT",
-            "CODEBUILD_BUILD_ID",
-            "TF_BUILD",
-            "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-            "KUBERNETES_SERVICE_HOST",
-        ]
+        # Clear exactly what the detector checks — single source of truth so this
+        # can't drift again (a stale copy is how RWX slipped through).
+        all_ci_vars = CI_ENV_VARS
         for var in all_ci_vars:
             monkeypatch.delenv(var, raising=False)
 
@@ -254,29 +194,9 @@ class TestCIMachineId:
         assert api_event.to_dict()["properties"]["is_ci"] is True
 
         # Test without CI environment - clear ALL CI vars
-        all_ci_vars = [
-            "CI",
-            "CONTINUOUS_INTEGRATION",
-            "GITHUB_ACTIONS",
-            "GITLAB_CI",
-            "CIRCLECI",
-            "JENKINS_HOME",
-            "JENKINS_URL",
-            "TEAMCITY_VERSION",
-            "TRAVIS",
-            "BUILDKITE",
-            "DRONE",
-            "BITBUCKET_BUILD_NUMBER",
-            "SEMAPHORE",
-            "APPVEYOR",
-            "WERCKER",
-            "MAGNUM",
-            "MINT",
-            "CODEBUILD_BUILD_ID",
-            "TF_BUILD",
-            "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-            "KUBERNETES_SERVICE_HOST",
-        ]
+        # Clear exactly what the detector checks — single source of truth so this
+        # can't drift again (a stale copy is how RWX slipped through).
+        all_ci_vars = CI_ENV_VARS
         for var in all_ci_vars:
             monkeypatch.delenv(var, raising=False)
 

--- a/visivo/telemetry/config.py
+++ b/visivo/telemetry/config.py
@@ -93,7 +93,9 @@ def is_ci_environment() -> bool:
         "APPVEYOR",  # AppVeyor
         "WERCKER",  # Wercker
         "MAGNUM",  # Magnum CI
-        "MINT",  # Mint (rwx)
+        "MINT",  # Mint — rwx's legacy name (kept for older runners)
+        "RWX_RUN_ID",  # RWX (rwx.com, the current Mint) — always set in a task run
+        "RWX_TASK_ID",  # RWX — also always set; belt-and-braces alongside RWX_RUN_ID
         "CODEBUILD_BUILD_ID",  # AWS CodeBuild
         "TF_BUILD",  # Azure DevOps
         "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",  # Azure DevOps

--- a/visivo/telemetry/config.py
+++ b/visivo/telemetry/config.py
@@ -64,6 +64,37 @@ def is_telemetry_enabled(project_defaults: Optional[object] = None) -> bool:
     return True
 
 
+# Environment variables that indicate a CI/CD run. Kept as a module-level
+# constant (not inlined in is_ci_environment) so tests clear EXACTLY what the
+# detector checks — the copy hardcoded in test_ci_detection drifted from this
+# list, which is how RWX CI ended up spamming new_installation.
+CI_ENV_VARS = [
+    "CI",  # Generic CI indicator (GitHub Actions, GitLab CI, CircleCI, etc.)
+    "CONTINUOUS_INTEGRATION",  # Generic
+    "GITHUB_ACTIONS",  # GitHub Actions
+    "GITLAB_CI",  # GitLab CI
+    "CIRCLECI",  # CircleCI
+    "JENKINS_HOME",  # Jenkins
+    "JENKINS_URL",  # Jenkins
+    "TEAMCITY_VERSION",  # TeamCity
+    "TRAVIS",  # Travis CI
+    "BUILDKITE",  # Buildkite
+    "DRONE",  # Drone
+    "BITBUCKET_BUILD_NUMBER",  # Bitbucket Pipelines
+    "SEMAPHORE",  # Semaphore CI
+    "APPVEYOR",  # AppVeyor
+    "WERCKER",  # Wercker
+    "MAGNUM",  # Magnum CI
+    "MINT",  # Mint — rwx's legacy name (kept for older runners)
+    "RWX_RUN_ID",  # RWX (rwx.com, the current Mint) — always set in a task run
+    "RWX_TASK_ID",  # RWX — also always set; belt-and-braces alongside RWX_RUN_ID
+    "CODEBUILD_BUILD_ID",  # AWS CodeBuild
+    "TF_BUILD",  # Azure DevOps
+    "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",  # Azure DevOps
+    "KUBERNETES_SERVICE_HOST",  # Kubernetes-hosted runner
+]
+
+
 def is_ci_environment() -> bool:
     """
     Detect if we're running in a CI/CD environment.
@@ -75,44 +106,13 @@ def is_ci_environment() -> bool:
     Returns:
         bool: True if running in CI/CD, False otherwise
     """
-    # Common CI environment variables
-    ci_env_vars = [
-        "CI",  # Generic CI indicator (GitHub Actions, GitLab CI, CircleCI, etc.)
-        "CONTINUOUS_INTEGRATION",  # Generic
-        "GITHUB_ACTIONS",  # GitHub Actions
-        "GITLAB_CI",  # GitLab CI
-        "CIRCLECI",  # CircleCI
-        "JENKINS_HOME",  # Jenkins
-        "JENKINS_URL",  # Jenkins
-        "TEAMCITY_VERSION",  # TeamCity
-        "TRAVIS",  # Travis CI
-        "BUILDKITE",  # Buildkite
-        "DRONE",  # Drone
-        "BITBUCKET_BUILD_NUMBER",  # Bitbucket Pipelines
-        "SEMAPHORE",  # Semaphore CI
-        "APPVEYOR",  # AppVeyor
-        "WERCKER",  # Wercker
-        "MAGNUM",  # Magnum CI
-        "MINT",  # Mint — rwx's legacy name (kept for older runners)
-        "RWX_RUN_ID",  # RWX (rwx.com, the current Mint) — always set in a task run
-        "RWX_TASK_ID",  # RWX — also always set; belt-and-braces alongside RWX_RUN_ID
-        "CODEBUILD_BUILD_ID",  # AWS CodeBuild
-        "TF_BUILD",  # Azure DevOps
-        "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",  # Azure DevOps
-    ]
-
-    # Check if any CI environment variable is set
-    for var in ci_env_vars:
+    for var in CI_ENV_VARS:
         if os.getenv(var):
             return True
 
-    # Additional heuristics for container environments
-    # Check if running in Docker
+    # Running inside a container (a Docker/RWX image build doesn't pass the CI
+    # env vars through to the build).
     if os.path.exists("/.dockerenv"):
-        return True
-
-    # Check for Kubernetes
-    if os.getenv("KUBERNETES_SERVICE_HOST"):
         return True
 
     return False


### PR DESCRIPTION
## The event, tracked down

`new_installation` events with fresh anonymous UUIDs were firing in clusters that line up with CI runs. Source: **visivo's own RWX CI runs visivo commands** — `test_visivo.yml` runs `visivo run`/`test`/`serve`/`init` (and the dist binary across duckdb/postgres/mysql/clickhouse/snowflake), and `deploy_dashboard.yml` runs `visivo run` + `visivo deploy`.

`get_machine_id()` only emits `new_installation` in its **non-CI** branch. `is_ci_environment()` knew rwx's **legacy** name (`MINT`), but the current **rwx.com** doesn't set it (nor `CI`/`/.dockerenv` in these task envs — the plain, non-`ci-` UUIDs prove detection returned False). So every fresh RWX task container had no `~/.visivo/machine_id`, generated a new one, and emitted `new_installation` → the PostHog→Slack alert you kept getting.

## Fix

RWX always sets `RWX_RUN_ID` / `RWX_TASK_ID` in a task run ([RWX docs](https://www.rwx.com/docs/mint/environment-variables)), so add them to the CI-detection list. In CI, `get_machine_id()` now returns a `ci-`-prefixed id and **skips `new_installation`** (and any `cli_command` events are clearly marked `ci-`).

## Verified

- `RWX_RUN_ID=…` → `is_ci_environment()` is `True`, `get_machine_id()` returns a `ci-…` id (no `new_installation`).
- New test `test_ci_detection_with_rwx`; telemetry suite green (24).

If you'd rather CI emit **zero** telemetry (not even `ci-`-tagged `cli_command`), the alternative is `VISIVO_TELEMETRY_DISABLED=true` in those `.rwx` tasks — say the word and I'll add it instead of / alongside this.

Sources: [RWX environment variables](https://www.rwx.com/docs/mint/environment-variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)