### PR TITLE
VIS-1208: let you change a source's type when editing

### DIFF
--- a/viewer/src/components/sources/SourceEditorModal.jsx
+++ b/viewer/src/components/sources/SourceEditorModal.jsx
@@ -203,9 +203,8 @@ const SourceEditorModal = () => {
               value={sourceType}
               onChange={type => {
                 setSourceType(type);
-                setFormValues({}); // Reset form values when type changes
+                setFormValues({}); // the old type's fields don't apply to the new one
               }}
-              disabled={isEditMode}
             />
             {errors.type && <p className="mt-1 text-xs text-red-500">{errors.type}</p>}
           </div>

--- a/viewer/src/components/sources/SourceTypeSelector.jsx
+++ b/viewer/src/components/sources/SourceTypeSelector.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import Select from '../common/Select';
 
-// Available source types matching backend Pydantic models
+// Available source types — must stay in sync with visivo's SourceField union
+// (visivo/models/sources/fields.py) AND the field schemas in
+// SourceFormGenerator's SOURCE_SCHEMAS. Every entry here needs a schema there,
+// or the form shows "Configuration schema not available". (trino/databricks are
+// NOT visivo source types; redshift/clickhouse are, and have schemas.)
 export const SOURCE_TYPES = [
   { value: 'postgresql', label: 'PostgreSQL' },
   { value: 'mysql', label: 'MySQL' },
+  { value: 'redshift', label: 'Redshift' },
   { value: 'snowflake', label: 'Snowflake' },
   { value: 'bigquery', label: 'BigQuery' },
+  { value: 'clickhouse', label: 'ClickHouse' },
   { value: 'duckdb', label: 'DuckDB' },
   { value: 'sqlite', label: 'SQLite' },
   { value: 'csv', label: 'CSV' },
-  { value: 'trino', label: 'Trino' },
-  { value: 'databricks', label: 'Databricks' },
 ];
 
 const SourceTypeSelector = ({ value, onChange, disabled = false }) => {

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -241,15 +241,18 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
           />
         )}
 
-          {/* Source Type Selector */}
+          {/* Source Type Selector — switchable even when editing an existing
+              source (VIS-1208). The name stays locked (it's the record key), but
+              the type isn't: changing it swaps to the new type's connection
+              fields below. Only the type-specific values are reset; the name is
+              kept. */}
           <div>
             <SourceTypeSelector
               value={sourceType}
               onChange={type => {
                 setSourceType(type);
-                setFormValues({}); // Reset form values when type changes
+                setFormValues({}); // the old type's fields don't apply to the new one
               }}
-              disabled={isEditMode}
             />
             {errors.type && <p className="mt-1 text-xs text-red-500">{errors.type}</p>}
           </div>

--- a/viewer/src/components/views/common/SourceEditForm.test.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.test.jsx
@@ -163,6 +163,24 @@ describe('SourceEditForm — edit mode', () => {
     );
   });
 
+  test('lets you switch the source type when editing, keeping the name locked (VIS-1208)', () => {
+    renderForm({ source: publishedSqlite, isCreate: false });
+    // Name stays locked (it's the record key)...
+    expect(screen.getByLabelText(/Source Name/)).toBeDisabled();
+    expect(screen.getByLabelText(/Database Path/)).toHaveValue('prod.db');
+
+    // ...but the type is switchable now (previously disabled in edit mode).
+    const pickPostgres = screen.getByRole('button', { name: 'pick-postgresql' });
+    expect(pickPostgres).toBeEnabled();
+    fireEvent.click(pickPostgres);
+
+    // The form swaps to the new type's fields: sqlite's Database Path is gone,
+    // postgres fields appear.
+    expect(screen.getByTestId('source-type-value')).toHaveTextContent('postgresql');
+    expect(screen.queryByLabelText(/Database Path/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Host/)).toBeInTheDocument();
+  });
+
   test('falls back to flat source fields when config is missing (type recovered from the flat object)', () => {
     renderForm({
       source: { name: 'flat1', type: 'duckdb', database: ':memory:', status: 'PUBLISHED' },


### PR DESCRIPTION
## Problem

You can't change a source's `type` when editing an existing source — the type dropdown is greyed out.

## Root cause

`disabled={isEditMode}` on `<SourceTypeSelector>` in `SourceEditForm.jsx`, and the right rail always renders existing sources with `isCreate:false` → the selector is always locked. The **field-swap logic was already correct** (on type change the form clears the old fields and `SourceFormGenerator` re-derives the new type's fields) — it was just gated off in edit mode.

## Change

- **Drop `disabled={isEditMode}`** from the type selector in `SourceEditForm.jsx` (and the orphaned `SourceEditorModal.jsx`). The **name** field stays locked (it's the record key); only the type is switchable.
- **Sync `SOURCE_TYPES`** with visivo's actual `SourceField` union (`models/sources/fields.py`) + the field schemas in `SourceFormGenerator`:
  - **Remove** `trino`/`databricks` — not visivo source types, and they had no field schema (showed "Configuration schema not available").
  - **Add** `redshift`/`clickhouse` — real visivo types that already have schemas.
  - Now every selectable type has a field schema.

## Backend

No change needed. Core stores source `config` as a `JSONField` with `type` inside it (no pinned discriminator column); the source save only rejects plaintext credentials, so a changed `type` is upserted freely (by name, keeping the pk). Local `visivo serve` is the same — config is just YAML.

## Tests

- New: `SourceEditForm.test` — editing a source lets you switch the type (name stays disabled), and the connection fields swap (sqlite `Database Path` → postgres `Host`).
- Full Source suite green (313), lint clean.

Closes VIS-1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)