### PR TITLE
VIS-1210: probe capabilities on Workspace mount so the source secret picker renders in core

### DIFF
--- a/viewer/src/components/sources/SourceFormGenerator.jsx
+++ b/viewer/src/components/sources/SourceFormGenerator.jsx
@@ -182,44 +182,66 @@ const SecretField = ({ field, value, onChange, secretKeys, error }) => {
     onChange(field.name, key ? toSecretRef(key) : '');
   };
 
+  // Match the floating notched-border label used by the other source fields.
+  const controlClass = `block w-full px-3 py-2.5 text-sm text-gray-900 bg-white rounded-md border focus:outline-none focus:ring-2 focus:border-primary-500 ${
+    error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'
+  }`;
+  const labelBase = 'absolute left-2 z-10 origin-[0] bg-white px-1 text-sm duration-200 transform';
+  const labelColor = error ? 'text-red-500' : 'text-gray-500';
+  const labelText = (
+    <>
+      {field.label}
+      {field.required && <span className="text-red-500 ml-0.5">*</span>}
+    </>
+  );
+
   return (
     <div>
-      <label htmlFor={field.name} className="block text-sm text-gray-700 mb-1">
-        {field.label}
-        {field.required && <span className="text-red-500 ml-0.5">*</span>}
-      </label>
-      {addingNew ? (
-        <input
-          type="text"
-          autoFocus
-          id={field.name}
-          name={field.name}
-          value={selected}
-          onChange={e => onChange(field.name, e.target.value ? toSecretRef(e.target.value) : '')}
-          placeholder="SECRET_NAME"
-          className={`block w-full px-3 py-2.5 text-sm rounded-md border focus:outline-none focus:ring-2 ${
-            error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'
-          }`}
-        />
-      ) : (
-        <select
-          id={field.name}
-          name={field.name}
-          value={selected}
-          onChange={e => choose(e.target.value)}
-          className={`block w-full px-3 py-2.5 text-sm rounded-md border focus:outline-none focus:ring-2 ${
-            error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'
-          }`}
-        >
-          <option value="">Select a secret…</option>
-          {secretKeys.map(key => (
-            <option key={key} value={key}>
-              {key}
-            </option>
-          ))}
-          <option value="__new__">New secret…</option>
-        </select>
-      )}
+      <div className="relative">
+        {addingNew ? (
+          <>
+            <input
+              type="text"
+              autoFocus
+              id={field.name}
+              name={field.name}
+              value={selected}
+              onChange={e => onChange(field.name, e.target.value ? toSecretRef(e.target.value) : '')}
+              placeholder="SECRET_NAME"
+              className={`${controlClass} appearance-none peer placeholder-transparent`}
+            />
+            {/* Floats down as the placeholder when empty, up into the border otherwise. */}
+            <label
+              htmlFor={field.name}
+              className={`${labelBase} ${labelColor} top-2 -translate-y-4 scale-75 peer-focus:text-primary-500 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:scale-100 peer-focus:top-2 peer-focus:-translate-y-4 peer-focus:scale-75`}
+            >
+              {labelText}
+            </label>
+          </>
+        ) : (
+          <>
+            <select
+              id={field.name}
+              name={field.name}
+              value={selected}
+              onChange={e => choose(e.target.value)}
+              className={controlClass}
+            >
+              <option value="">Select a secret…</option>
+              {secretKeys.map(key => (
+                <option key={key} value={key}>
+                  {key}
+                </option>
+              ))}
+              <option value="__new__">New secret…</option>
+            </select>
+            {/* A select always holds a value, so the label stays notched up. */}
+            <label htmlFor={field.name} className={`${labelBase} ${labelColor} top-2 -translate-y-4 scale-75`}>
+              {labelText}
+            </label>
+          </>
+        )}
+      </div>
       <p className="mt-1 text-xs text-gray-500">
         Stored as a reference. Add the value under account settings — it is never
         saved with the project.

--- a/viewer/src/components/views/workspace/Workspace.jsx
+++ b/viewer/src/components/views/workspace/Workspace.jsx
@@ -40,6 +40,7 @@ const Workspace = () => {
   const restoreWorkspaceTabs = useStore(s => s.restoreWorkspaceTabs);
   const setWorkspaceLens = useStore(s => s.setWorkspaceLens);
   const checkCommitStatus = useStore(s => s.checkCommitStatus);
+  const fetchCapabilities = useStore(s => s.fetchCapabilities);
   const scope = useWorkspaceScope();
 
   // H-2: soft-refresh on backend `project_changed` events (and show the
@@ -66,6 +67,7 @@ const Workspace = () => {
   const fetchExplorations = useStore(s => s.fetchExplorations);
 
   const projectName = project?.name || 'project';
+  const projectId = project?.id;
 
   // Fire every collection load when the workspace mounts. Per-slice fetches
   // record their own errors; the `.catch` just guards against an unhandled
@@ -99,6 +101,16 @@ const Workspace = () => {
     fetchDashboards,
     fetchExplorations,
   ]);
+
+  // Probe capabilities on mount / when the project changes. Under `visivo serve`
+  // the Home shell already does this, but core mounts the Workspace directly
+  // (no Home wrapper), so without this the viewer's `capabilities` stays null
+  // and capability-gated UI silently falls back to its no-capabilities default —
+  // e.g. the source secret field renders as a plain masked box instead of the
+  // secret picker (secrets_required/secret_keys never reach SourceFormGenerator).
+  useEffect(() => {
+    if (projectId) fetchCapabilities?.();
+  }, [projectId, fetchCapabilities]);
 
   // The mount prefix for this Workspace's tab URLs. Prefer what the host told
   // us (contexts/viewerBase) — it is correct before the first navigation and

--- a/viewer/src/components/views/workspace/Workspace.test.jsx
+++ b/viewer/src/components/views/workspace/Workspace.test.jsx
@@ -108,6 +108,9 @@ const resetWorkspaceStore = () => {
       // Workspace mount effect doesn't throw.
       checkCommitStatus: jest.fn(),
       openCommitModal: jest.fn(),
+      // Capabilities probe fired on mount (VIS-1210) — stubbed so the real
+      // fetch isn't attempted and the call is assertable.
+      fetchCapabilities: jest.fn(),
       // Stub the 12 collection fetches that the route container fires on
       // mount — keeps the test focused on shell behaviour, not data load.
       fetchCharts: jest.fn(),
@@ -160,6 +163,11 @@ const renderAt = (entry) => {
 describe('VIS-775 Workspace shell', () => {
   beforeEach(() => {
     resetWorkspaceStore();
+  });
+
+  test('probes capabilities on mount so capability-gated UI (e.g. the source secret picker) works when core mounts the Workspace directly without the Home shell (VIS-1210)', () => {
+    renderAt('/workspace');
+    expect(useStore.getState().fetchCapabilities).toHaveBeenCalled();
   });
 
   test('mounts the shell at /workspace (unscoped) on the Project destination by default', () => {


### PR DESCRIPTION
## What & why

In cloud (and any core-embedded workspace), editing a source's secret field (e.g. Postgres **Password**, `type: 'secret'`) rendered as a plain **masked text box** instead of the **secret picker** — no dropdown of the account's secrets, and a literal you type is rejected on commit.

Root cause: the viewer reads `secrets_required` / `secret_keys` from its Zustand `capabilities` store (`SourceEditForm` → `SourceFormGenerator`). That store slice is populated **only** by `Home.jsx`'s on-mount `fetchCapabilities()`. Under `visivo serve`, `Home` is the shell wrapping every project sub-view, so it's always populated. **Core embeds the viewer and mounts `<Workspace>` directly** (its own shell, no `Home`), so `capabilities` stayed `null` → `secrets_required` defaulted to `false` → masked box + empty picker. (Core's own react-query capabilities drive the top-bar Discard/Commit, which is why those worked and masked the bug.)

## Fix
Probe capabilities on `Workspace` mount, mirroring `Home`:
```js
useEffect(() => {
  if (projectId) fetchCapabilities?.();
}, [projectId, fetchCapabilities]);
```
- `fetchCapabilities` reads `project.id` from the store and no-ops without one, so it's safe and idempotent.
- Works in both contexts; under `visivo serve` (Home + Workspace) it's a harmless idempotent GET.

## Testing
- `yarn lint` clean; `Workspace.test.jsx` green (22 tests) incl. a new regression test asserting the Workspace probes capabilities on mount.

Fixes the cloud + local symptom in VIS-1210. Core picks this up when it next vendors visivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)