### PR TITLE
VIS-1214: don't serialize project_file_path (breaks a shared project)

### DIFF
--- a/visivo/models/project.py
+++ b/visivo/models/project.py
@@ -93,6 +93,7 @@ class Project(NamedModel, ParentModel):
     )
     project_file_path: Optional[str] = Field(
         None,
+        exclude=True,
         description="Set automatically to the path of the root project file. You do not need to set this.",
     )
     project_dir: Optional[str] = Field(


### PR DESCRIPTION
## What & why
`project_file_path` is a runtime-only field — its own description says *"Set automatically to the path of the root project file. You do not need to set this."* `core_parser` stamps it with the **absolute** path of the root project file, and because it was included in `model_dump`, that machine-specific path got written into the project YAML:

```yaml
project_file_path: /Users/dan/gh/rwx-cloud/analysis/project.visivo.yml
```

So a **shared or moved** project pointed at a path that only exists on the author's machine.

## Fix
Mark the field `exclude=True` so it's never serialized (YAML or `project.json`). It's re-derived at parse time by `core_parser`, and `exclude` only affects serialization — the runtime `project.project_file_path` attribute is untouched.

- Verified **nothing reads `project_file_path` from a dump** (only `core_parser` sets it on the input dict; the viewer doesn't read it).
- Deliberately **did not** touch `project_dir` — it *is* read from the compiled `project.json` (`dist_phase.py:71`), so excluding it would break the dist build.

## Testing
- `tests/parsers/test_core_parser.py`, `tests/models/test_project.py` (39) and `tests/server/views/test_commit_views*.py` (36) green; black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)