### PR TITLE
VIS-1218: keep FormFooter buttons stable (no grow/wrap/jump on Test or Save)

### DIFF
--- a/viewer/src/components/styled/FormFooter.jsx
+++ b/viewer/src/components/styled/FormFooter.jsx
@@ -103,7 +103,7 @@ const FormFooter = ({
               onClick={onCancel}
               disabled={cancelDisabled}
               data-testid="form-footer-cancel"
-              className="text-sm"
+              className="text-sm whitespace-nowrap"
             >
               {cancelLabel}
             </ButtonOutline>
@@ -112,7 +112,9 @@ const FormFooter = ({
               onClick={onSave}
               disabled={saving || saveDisabled}
               data-testid="form-footer-save"
-              className="text-sm"
+              // Fixed width + centered so the "Saving..." spinner state doesn't
+              // grow the button and reflow the footer row (VIS-1218).
+              className="text-sm min-w-[6.5rem] inline-flex items-center justify-center whitespace-nowrap"
             >
               {saving ? (
                 <>

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -348,7 +348,7 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
               !connectionTestable
             }
             title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
-            className="text-sm"
+            className="text-sm whitespace-nowrap"
           >
             Test Connection
           </ButtonOutline>


### PR DESCRIPTION
## What & why
In the narrow source-edit rail, clicking **Save** swaps the button to a wider `⟳ Saving...` state — growing it and reflowing the footer row so **Test Connection** wraps to two lines and the whole bar jumps around.

## Fix (shared `FormFooter`, so all edit forms benefit)
- **Save button**: fixed `min-w-[6.5rem]` + `inline-flex items-center justify-center` so `Save` and `Saving...` occupy the same box — no growth between states.
- **`whitespace-nowrap`** on Save, Cancel, and Test Connection so a tight row never wraps a label to two lines.

## Testing
`SourceEditForm` + `SourceEditorModal` suites (52) green — including the "Saving..." spinner test; eslint clean.