### PR TITLE
VIS-1216: externalize source credentials to .env + onboarding fixes

### DIFF
--- a/tests/server/test_flask_app.py
+++ b/tests/server/test_flask_app.py
@@ -133,6 +133,36 @@ def test_create_postgres_source_externalizes_credentials(client):
         os.environ.update(saved_env)
 
 
+def test_finalize_makes_source_immediately_listable(client):
+    """After /api/project/finalize/, the new source must be listable via
+    /api/sources/ right away — without waiting for the file-watcher recompile
+    (which is what ran the schema job and made the sidebar row appear late)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source = {
+            "name": "warehouse",
+            "type": "postgresql",
+            "host": "db.internal",
+            "database": "analytics",
+            "username": "${env.WAREHOUSE_USERNAME}",
+            "password": "${env.WAREHOUSE_PASSWORD}",
+        }
+        res = client.post(
+            "/api/project/finalize/",
+            json={
+                "project_name": "PG Project",
+                "project_dir": tmpdir,
+                "sources": [source],
+                "dashboards": [],
+            },
+        )
+        assert res.status_code == 200
+
+        listed = client.get("/api/sources/")
+        assert listed.status_code == 200
+        names = [s["name"] for s in json.loads(listed.data)["sources"]]
+        assert "warehouse" in names
+
+
 def test_load_example_project_success(client, monkeypatch):
     """Test POST /api/project/load_example with a github release clone."""
     # Mock request payload

--- a/tests/server/test_flask_app.py
+++ b/tests/server/test_flask_app.py
@@ -91,6 +91,48 @@ def test_create_sqlite_project_source_only(client):
         assert b"Source created" in res.data
 
 
+def test_create_postgres_source_externalizes_credentials(client):
+    """POST /api/source/create with a postgres source must move the entered
+    credentials into .env, reference them via ${env.*} in the returned source,
+    and load them into the running process so the refs resolve (VIS-1216)."""
+    saved_env = dict(os.environ)
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            res = client.post(
+                "/api/source/create/",
+                data={
+                    "project_name": "PG Project",
+                    "source_type": "postgresql",
+                    "source_name": "warehouse",
+                    "host": "db.internal",
+                    "database": "analytics",
+                    "username": "admin",
+                    "password": "hunter2",
+                    "project_dir": tmpdir,
+                },
+            )
+            assert res.status_code == 200
+            source = json.loads(res.data)["source"]
+
+            # returned source references env, never the real secret (or the old
+            # hardcoded "postgres")
+            assert source["password"] == "${env.WAREHOUSE_PASSWORD}"
+            assert source["username"] == "${env.WAREHOUSE_USERNAME}"
+            assert "hunter2" not in res.data.decode()
+            assert "postgres" != source["password"]
+
+            # .env holds the real values
+            env_text = (Path(tmpdir) / ".env").read_text()
+            assert "WAREHOUSE_PASSWORD=hunter2" in env_text
+            assert "WAREHOUSE_USERNAME=admin" in env_text
+
+            # loaded into os.environ so ${env.*} resolves in this same process
+            assert os.environ["WAREHOUSE_PASSWORD"] == "hunter2"
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
+
+
 def test_load_example_project_success(client, monkeypatch):
     """Test POST /api/project/load_example with a github release clone."""
     # Mock request payload

--- a/tests/server/views/test_utils.py
+++ b/tests/server/views/test_utils.py
@@ -1,0 +1,182 @@
+import os
+
+import pytest
+import yaml
+
+from visivo.models.sources.bigquery_source import BigQuerySource
+from visivo.models.sources.postgresql_source import PostgresqlSource
+from visivo.models.sources.sqlite_source import SqliteSource
+from visivo.models.defaults import Defaults
+from visivo.models.project import Project
+from visivo.server.views.utils import (
+    _env_var_name,
+    externalize_source_credentials,
+    merge_env_file,
+    write_project_file,
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_environ():
+    """externalize_source_credentials mutates os.environ directly, so snapshot
+    and restore it around every test."""
+    saved = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(saved)
+
+
+def _read_env(project_dir):
+    env_path = os.path.join(project_dir, ".env")
+    values = {}
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if "=" in line and not line.startswith("#"):
+                k, v = line.split("=", 1)
+                values[k] = v
+    return values
+
+
+def test_env_var_name_sanitizes_and_uppercases():
+    assert _env_var_name("my-source", "password") == "MY_SOURCE_PASSWORD"
+    assert _env_var_name("Prod DB", "username") == "PROD_DB_USERNAME"
+    assert _env_var_name("__weird__", "password") == "WEIRD_PASSWORD"
+
+
+def test_merge_env_file_creates_and_upserts(tmp_path):
+    project_dir = str(tmp_path)
+    (tmp_path / ".env").write_text("# a comment\nEXISTING=keep\nMY_SOURCE_PASSWORD=old\n")
+
+    merge_env_file(project_dir, {"MY_SOURCE_PASSWORD": "new", "OTHER_USERNAME": "svc"})
+
+    values = _read_env(project_dir)
+    assert values["MY_SOURCE_PASSWORD"] == "new"  # updated in place
+    assert values["EXISTING"] == "keep"  # untouched
+    assert values["OTHER_USERNAME"] == "svc"  # appended
+    # the comment survives the merge (no clobber)
+    assert "# a comment" in (tmp_path / ".env").read_text()
+
+
+def test_merge_env_file_noop_on_empty(tmp_path):
+    project_dir = str(tmp_path)
+    merge_env_file(project_dir, {})
+    assert not (tmp_path / ".env").exists()
+
+
+def test_externalize_postgres_moves_password_and_username(tmp_path):
+    project_dir = str(tmp_path)
+    source = PostgresqlSource(
+        name="warehouse",
+        type="postgresql",
+        host="db.internal",
+        database="analytics",
+        username="admin",
+        password="hunter2",
+    )
+
+    source_dict = externalize_source_credentials(source, project_dir)
+
+    # YAML-bound dict references env, never the real secret
+    assert source_dict["password"] == "${env.WAREHOUSE_PASSWORD}"
+    assert source_dict["username"] == "${env.WAREHOUSE_USERNAME}"
+    assert "hunter2" not in yaml.dump(source_dict)
+    assert "admin" not in source_dict["username"]
+
+    # .env holds the real values
+    values = _read_env(project_dir)
+    assert values["WAREHOUSE_PASSWORD"] == "hunter2"
+    assert values["WAREHOUSE_USERNAME"] == "admin"
+
+    # loaded into the running process so ${env.*} resolves immediately (the bug)
+    assert os.environ["WAREHOUSE_PASSWORD"] == "hunter2"
+    assert os.environ["WAREHOUSE_USERNAME"] == "admin"
+
+
+def test_externalize_bigquery_moves_credentials_base64(tmp_path):
+    project_dir = str(tmp_path)
+    source = BigQuerySource(
+        name="bq",
+        type="bigquery",
+        project="my-project",
+        database="my_dataset",
+        credentials_base64="c2VjcmV0LWtleQ==",
+    )
+
+    source_dict = externalize_source_credentials(source, project_dir)
+
+    assert source_dict["credentials_base64"] == "${env.BQ_CREDENTIALS_BASE64}"
+    assert _read_env(project_dir)["BQ_CREDENTIALS_BASE64"] == "c2VjcmV0LWtleQ=="
+    assert os.environ["BQ_CREDENTIALS_BASE64"] == "c2VjcmV0LWtleQ=="
+
+
+def test_externalize_drops_empty_password_without_masking(tmp_path):
+    project_dir = str(tmp_path)
+    source = PostgresqlSource(
+        name="nopass",
+        type="postgresql",
+        host="db.internal",
+        database="analytics",
+        username="admin",
+        password="",
+    )
+
+    source_dict = externalize_source_credentials(source, project_dir)
+
+    # An empty secret must not leak as a masked "**********" literal
+    assert "password" not in source_dict
+    assert source_dict["username"] == "${env.NOPASS_USERNAME}"
+
+
+def test_externalize_leaves_existing_env_ref_untouched(tmp_path):
+    project_dir = str(tmp_path)
+    source = PostgresqlSource(
+        name="ref",
+        type="postgresql",
+        host="db.internal",
+        database="analytics",
+        username="admin",
+        password="${env.PRESET_PASSWORD}",
+    )
+
+    source_dict = externalize_source_credentials(source, project_dir)
+
+    assert source_dict["password"] == "${env.PRESET_PASSWORD}"
+    # a pre-existing ref is not re-written into .env under a new name
+    assert not os.path.exists(os.path.join(project_dir, ".env")) or (
+        "PRESET_PASSWORD" not in _read_env(project_dir)
+    )
+
+
+def test_externalize_noop_for_credential_free_source(tmp_path):
+    project_dir = str(tmp_path)
+    source = SqliteSource(name="s", type="sqlite", database="local.db")
+
+    source_dict = externalize_source_credentials(source, project_dir)
+
+    assert source_dict["database"] == "local.db"
+    assert not (tmp_path / ".env").exists()
+
+
+def test_write_project_file_keeps_env_refs_and_no_mask(tmp_path):
+    project_dir = str(tmp_path)
+    source = {
+        "name": "warehouse",
+        "type": "postgresql",
+        "host": "db.internal",
+        "database": "analytics",
+        "username": "${env.WAREHOUSE_USERNAME}",
+        "password": "${env.WAREHOUSE_PASSWORD}",
+    }
+    project = Project(
+        name="p",
+        defaults=Defaults(source_name="warehouse"),
+        sources=[source],
+    )
+
+    write_project_file(project, project_dir)
+
+    written = (tmp_path / "project.visivo.yml").read_text()
+    assert "${env.WAREHOUSE_PASSWORD}" in written
+    assert "${env.WAREHOUSE_USERNAME}" in written
+    assert "**********" not in written

--- a/viewer/src/components/onboarding/OnboardingFlow.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.jsx
@@ -462,7 +462,8 @@ export default function OnboardingFlow() {
                 <div>
                   <h3 className="onb-modal__title">Add a Source</h3>
                   <div style={{ fontSize: 12, color: 'var(--onb-fg-muted)', marginTop: 2 }}>
-                    Credentials never leave your machine.
+                    Credentials are saved to a local <code>.env</code> file and referenced securely
+                    — never written into your project.
                   </div>
                 </div>
                 <button

--- a/viewer/src/components/onboarding/OnboardingFlow.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.jsx
@@ -116,12 +116,19 @@ export default function OnboardingFlow() {
   // keyboard nav: ← goes back, except on welcome/handoff
   useEffect(() => {
     const onKey = e => {
+      // Don't hijack arrow keys while a modal is open (the source/skip dialogs
+      // sit on top of the flow) or while the user is typing in a field —
+      // otherwise ← quietly navigates the flow behind the open form.
+      if (showSourceModal || showSkipConfirm) return;
+      const el = e.target;
+      const tag = el?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return;
       if (e.key === 'ArrowLeft' && stepIdx > 0 && current?.kind !== 'handoff') handleBack();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stepIdx, current]);
+  }, [stepIdx, current, showSourceModal, showSkipConfirm]);
 
   const completeAndNavigate = useCallback(
     destination => {

--- a/visivo/commands/utils.py
+++ b/visivo/commands/utils.py
@@ -161,10 +161,11 @@ def create_source(
     default_db_name = f"{database or 'local'}.db"
 
     local_db_path = Path(project_dir) / default_db_name if project_dir else default_db_name
-    env_path = Path(project_dir) / ".env" if project_dir else Path(".env")
 
-    def write_env(var: str, value: str):
-        env_path.write_text(f"{var}={value}")
+    # Credentials are NOT written to .env here — the server does that once the
+    # source is built, via externalize_source_credentials (VIS-1216). That keeps
+    # the .env write in one place, merges instead of clobbering, and loads the
+    # values into os.environ so the ${env.*} refs resolve in the running server.
 
     if source_type in {
         SourceTypeEnum.duckdb,
@@ -178,30 +179,25 @@ def create_source(
         if source_type == SourceTypeEnum.duckdb:
             create_file_database(source.url(), project_dir)
 
-        write_env("DB_PASSWORD", "EXAMPLE_password_l0cation")
         return source
 
     if source_type == SourceTypeEnum.sqlite:
         source = SqliteSource(name=source_name, database=str(local_db_path), type=source_type)
         create_file_database(source.url(), project_dir)
-        write_env("DB_PASSWORD", "EXAMPLE_password_l0cation")
         return source
 
     if source_type == SourceTypeEnum.postgresql:
-        write_env("DB_PASSWORD", "postgres")
-        source = PostgresqlSource(
+        return PostgresqlSource(
             name=source_name,
             host=host,
             port=port or 5432,
             database=database,
             type=source_type,
-            password="postgres",
+            password=password,
             username=username,
         )
-        return source
 
     if source_type == SourceTypeEnum.mysql:
-        write_env("DB_PASSWORD", password)
         return MysqlSource(
             name=source_name,
             host=host,
@@ -212,7 +208,6 @@ def create_source(
         )
 
     if source_type == SourceTypeEnum.snowflake:
-        write_env("DB_PASSWORD", password)
         return SnowflakeSource(
             name=source_name,
             database=database,
@@ -224,7 +219,6 @@ def create_source(
         )
 
     if source_type == SourceTypeEnum.bigquery:
-        write_env("DB_PASSWORD", credentials_base64)
         return BigQuerySource(
             name=source_name,
             project=project,
@@ -234,7 +228,6 @@ def create_source(
         )
 
     if source_type == SourceTypeEnum.redshift:
-        write_env("DB_PASSWORD", password)
         return RedshiftSource(
             name=source_name,
             host=host,

--- a/visivo/server/views/project_views.py
+++ b/visivo/server/views/project_views.py
@@ -230,4 +230,11 @@ def register_project_views(app, flask_app, output_dir):
 
         write_project_file(project, project_dir)
 
+        # Refresh the in-memory project so the new source is immediately listable
+        # via /api/sources/ (which reads the SourceManager cache). Without this,
+        # the source only appears once the file-watcher recompile lands — the same
+        # recompile that runs the schema job — so the sidebar row looked like it
+        # was waiting on the job to finish.
+        flask_app.project = project
+
         return jsonify({"message": "Project finalized"})

--- a/visivo/server/views/project_views.py
+++ b/visivo/server/views/project_views.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import re
 from flask import jsonify, request
-import json
 from visivo.commands.utils import create_source
 from visivo.discovery.discover import Discover
 from visivo.logger.logger import Logger
@@ -17,7 +16,12 @@ from visivo.models.source import CreateSourceRequest, SourceTypeEnum
 from visivo.models.table import Table
 from visivo.parsers.parser_factory import ParserFactory
 from visivo.server.project_writer import ProjectWriter
-from visivo.server.views.utils import create_source_dashboard, load_csv, write_project_file
+from visivo.server.views.utils import (
+    create_source_dashboard,
+    externalize_source_credentials,
+    load_csv,
+    write_project_file,
+)
 from visivo.models.example_type import ExampleTypeEnum
 
 
@@ -151,8 +155,11 @@ def register_project_views(app, flask_app, output_dir):
         if isinstance(source, str):
             return jsonify({"message": source}), 400
 
-        json_dump = source.model_dump_json(exclude_none=True)
-        return jsonify({"message": "Source created", "source": json.loads(json_dump)})
+        # Move any credentials the user entered out of the project YAML and into
+        # .env, referencing them via ${env.*}. This also loads them into the
+        # running server's os.environ so the refs resolve immediately (VIS-1216).
+        source_dict = externalize_source_credentials(source, form.get("project_dir", ""))
+        return jsonify({"message": "Source created", "source": source_dict})
 
     @app.route("/api/source/upload/", methods=["POST"])
     def upload_file():

--- a/visivo/server/views/utils.py
+++ b/visivo/server/views/utils.py
@@ -1,11 +1,88 @@
 import json
 import os
+import re
+from pathlib import Path
 
 import yaml
+from pydantic import SecretStr
 from visivo.logger.logger import Logger
 from visivo.models.dashboard import Dashboard
 from visivo.models.item import Item
 from visivo.models.row import Row
+from visivo.query.patterns import ENV_VAR_CONTEXT_PATTERN
+
+# Fields on a source that hold a credential we never want written into the
+# project YAML. Anything present here is moved to .env and referenced via
+# ${env.*} instead (VIS-1216).
+CREDENTIAL_FIELDS = ("username", "password", "credentials_base64")
+
+
+def _env_var_name(source_name: str, field: str) -> str:
+    """A per-source, per-field env var name, e.g. "my-source" + password ->
+    MY_SOURCE_PASSWORD. Per-source so multiple sources never collide on a
+    single shared DB_PASSWORD."""
+    prefix = re.sub(r"\W", "_", source_name).strip("_").upper()
+    return f"{prefix}_{field.upper()}" if prefix else field.upper()
+
+
+def merge_env_file(project_dir, env_values):
+    """Upsert KEY=VALUE pairs into the project's .env, preserving any existing
+    keys, comments, and unrelated vars (the old code clobbered the whole file)."""
+    if not env_values:
+        return
+    env_path = Path(project_dir) / ".env" if project_dir else Path(".env")
+    lines = env_path.read_text().splitlines() if env_path.exists() else []
+
+    seen = set()
+    out = []
+    for line in lines:
+        stripped = line.strip()
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip()
+            if key in env_values:
+                out.append(f"{key}={env_values[key]}")
+                seen.add(key)
+                continue
+        out.append(line)
+    for key, value in env_values.items():
+        if key not in seen:
+            out.append(f"{key}={value}")
+
+    env_path.write_text("\n".join(out) + "\n")
+
+
+def externalize_source_credentials(source, project_dir):
+    """Move a freshly-built source's credentials out of the project YAML.
+
+    For every credential field present, the real value is written to .env
+    (merged, not clobbered), loaded into os.environ so the ${env.*} ref resolves
+    in this same running server process, and the field on the returned dict is
+    replaced with a ${env.<NAME>} reference. Returns the source as a JSON-ready
+    dict with the credentials swapped for refs.
+    """
+    source_dict = json.loads(source.model_dump_json(exclude_none=True))
+
+    env_values = {}
+    for field in CREDENTIAL_FIELDS:
+        value = getattr(source, field, None)
+        if value is None:
+            continue
+        raw = value.get_secret_value() if isinstance(value, SecretStr) else str(value)
+        if not raw:
+            # An empty credential must not survive as a masked "**********"
+            # literal in the YAML — drop it entirely.
+            source_dict.pop(field, None)
+            continue
+        if re.search(ENV_VAR_CONTEXT_PATTERN, raw):
+            continue  # already a ${env.*} ref — leave it be
+
+        var_name = _env_var_name(source.name, field)
+        env_values[var_name] = raw
+        source_dict[field] = f"${{env.{var_name}}}"
+
+    merge_env_file(project_dir, env_values)
+    os.environ.update(env_values)
+    return source_dict
 
 
 def load_csv(conn, file_path, table_name):
@@ -60,7 +137,6 @@ def write_project_file(project, project_dir):
 
     with open(project.project_file_path, "w") as f:
         content = yaml.dump(json.loads(project.model_dump_json(exclude_none=True)), sort_keys=False)
-        content = content.replace("'**********'", "${env.DB_PASSWORD}")
         f.write(content)
 
     if project_dir:


### PR DESCRIPTION
## VIS-1216 — externalize source credentials to `.env`

Onboarding wrote DB credentials **straight into the project YAML**, then string-replaced the masked `'**********'` to a bare `${env.DB_PASSWORD}` — but it **never wrote the real value to `.env`** and **never loaded it into the running `serve` process**. So a source that tested fine on the form **errored the moment the project ran**, because `${env.DB_PASSWORD}` resolved against an `os.environ` that didn't have it. (`.env` is only read at CLI startup — `command_line.py:84` — so a long-lived server never picks up a file written after it booted.) Postgres was worse: `create_source` **hardcoded `password="postgres"`** and ignored what the user typed.

When a source is created, the new `externalize_source_credentials` moves **every credential field** (`username`, `password`, `credentials_base64`, across **all** source types) out of the YAML:
- writes the real value to `.env` under a **per-source name** (`<SOURCE>_<FIELD>`, so multiple sources never collide on one shared `DB_PASSWORD`), **merging** instead of clobbering the file;
- `os.environ.update()`s it so the `${env.*}` ref resolves **in the same running server**;
- swaps the field in the returned source for `${env.<NAME>}`.

`create_source` no longer touches `.env` or hardcodes postgres creds; `write_project_file` drops the brittle `'**********'` → `${env.DB_PASSWORD}` string-replace.

## Also in this PR — onboarding fixes surfaced while testing

1. **Form wording** — "Add a Source" subtitle now states credentials are saved to a local `.env` and referenced, never written into the project.
2. **Arrow keys no longer navigate the flow behind an open modal** — the flow's window-level `←` listener now bails when a modal is open or focus is in an input/textarea/select/contenteditable.
3. **A finalized source appears in the sidebar immediately** — `finalize` now refreshes the server's in-memory project (`flask_app.project = project`), which reloads the SourceManager, so `/api/sources/` knows the source right away instead of waiting for the file-watcher recompile (the same recompile that ran the schema job, which is why the row looked gated on the job).

## Tests
- `tests/server/views/test_utils.py` (new): env-var naming, `merge_env_file` upsert/preserve, `externalize_source_credentials` (postgres + bigquery), empty-secret drop, existing-ref pass-through, credential-free no-op, `write_project_file` keeps refs with no `**********`.
- `tests/server/test_flask_app.py` (new): postgres `/api/source/create/` externalization end-to-end; **finalize → source immediately listable via `/api/sources/`**.
- Full `tests/server/` green (775 passed); viewer `OnboardingFlow` (21) + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
