### PR TITLE
VIS-1221: model Run executes the live editor SQL, not the saved query

### DIFF
--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -29,6 +29,8 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
   const deleteModel = useStore(state => state.deleteModel);
   const checkCommitStatus = useStore(state => state.checkCommitStatus);
   const fetchSources = useStore(state => state.fetchSources);
+  const setWorkspaceModelSqlDraft = useStore(state => state.setWorkspaceModelSqlDraft);
+  const clearWorkspaceModelSqlDraft = useStore(state => state.clearWorkspaceModelSqlDraft);
 
   const isCreate = !model;
 
@@ -78,6 +80,16 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
   }, [model]);
 
   const dirty = isDirtyAgainst({ name, sql, source, dimensions, metrics });
+
+  // VIS-1221: mirror the live SQL into the store so the center-canvas
+  // ModelPreview's Run executes what's in the editor, not the saved config.sql.
+  // Cleared on unmount so a non-editing preview falls back to the saved SQL.
+  useEffect(() => {
+    if (name) setWorkspaceModelSqlDraft(name, sql);
+  }, [name, sql, setWorkspaceModelSqlDraft]);
+  useEffect(() => {
+    return () => clearWorkspaceModelSqlDraft();
+  }, [clearWorkspaceModelSqlDraft]);
 
   // Report upward so the tab strip's unsaved dot and its guarded close reflect
   // real edits (VIS-1133) — the rail clears it on unmount.

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -8,6 +8,8 @@ const mockState = {
   deleteModel: jest.fn(),
   checkCommitStatus: jest.fn(),
   fetchSources: jest.fn(),
+  setWorkspaceModelSqlDraft: jest.fn(),
+  clearWorkspaceModelSqlDraft: jest.fn(),
 };
 jest.mock('../../../stores/store', () => ({
   __esModule: true,
@@ -182,6 +184,22 @@ describe('ModelEditForm — edit mode initialization and save', () => {
     expect(screen.getByLabelText(/Model Name/)).toHaveValue('');
     expect(screen.getByLabelText(/Model Name/)).toBeEnabled();
     expect(screen.getByLabelText('code')).toHaveValue('');
+  });
+});
+
+describe('ModelEditForm — live SQL mirror (VIS-1221)', () => {
+  it('mirrors the edited SQL into the workspace store so the preview Run uses it', () => {
+    render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText('code'), { target: { value: 'SELECT 42 AS len' } });
+    expect(mockState.setWorkspaceModelSqlDraft).toHaveBeenCalledWith('orders', 'SELECT 42 AS len');
+  });
+
+  it('clears the mirrored SQL draft when the editor unmounts', () => {
+    const { unmount } = render(
+      <ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />
+    );
+    unmount();
+    expect(mockState.clearWorkspaceModelSqlDraft).toHaveBeenCalled();
   });
 });
 

--- a/viewer/src/components/views/workspace/ModelPreview.jsx
+++ b/viewer/src/components/views/workspace/ModelPreview.jsx
@@ -109,6 +109,9 @@ const ModelPreview = ({ activeObject, record: providedRecord }) => {
   const fetchSources = useStore(s => s.fetchSources);
   const defaults = useStore(s => s.defaults);
   const fetchDefaults = useStore(s => s.fetchDefaults);
+  // The live SQL from the rail editor, if this model is the one being edited
+  // (VIS-1221) — so Run executes what's on screen, not the last-saved config.
+  const modelSqlDraft = useStore(s => s.workspaceModelSqlDraft);
 
   const { status, progress, progressMessage, result, error, isRunning, executeQuery } =
     useModelQueryJob();
@@ -144,7 +147,12 @@ const ModelPreview = ({ activeObject, record: providedRecord }) => {
     () => providedRecord || (record ? record.config || record : null),
     [providedRecord, record]
   );
-  const sql = config?.sql || '';
+  // Prefer the rail editor's live SQL when it's editing THIS model, so a single
+  // Run executes the on-screen query with no save-then-run round trip (VIS-1221).
+  const modelName = config?.name || name;
+  const draftSql =
+    modelSqlDraft && modelSqlDraft.name === modelName ? modelSqlDraft.sql : null;
+  const sql = draftSql != null ? draftSql : config?.sql || '';
 
   const sourceName = useMemo(() => {
     if (config?.source && typeof config.source === 'string') {

--- a/viewer/src/components/views/workspace/ModelPreview.test.jsx
+++ b/viewer/src/components/views/workspace/ModelPreview.test.jsx
@@ -34,6 +34,7 @@ const seed = (models = [], sources = [], defaults = null, fields = {}) => {
       fetchDefaults: jest.fn(),
       fetchDimensions: jest.fn(),
       fetchMetrics: jest.fn(),
+      workspaceModelSqlDraft: null,
     });
   });
 };
@@ -86,6 +87,26 @@ describe('ModelPreview (VIS-801)', () => {
 
   test('Run executes the model SQL against its resolved source', () => {
     seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('db', 'SELECT 1');
+  });
+
+  test('Run executes the live rail-editor SQL over the saved config SQL (VIS-1221)', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    act(() => {
+      useStore.setState({ workspaceModelSqlDraft: { name: 'orders', sql: 'SELECT 2 AS len' } });
+    });
+    render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
+    fireEvent.click(screen.getByTestId('model-preview-run'));
+    expect(mockExecuteQuery).toHaveBeenCalledWith('db', 'SELECT 2 AS len');
+  });
+
+  test('ignores a draft scoped to a DIFFERENT model — runs the saved SQL', () => {
+    seed([{ name: 'orders', config: { sql: 'SELECT 1', source: '${ref(db)}' } }], [{ name: 'db' }]);
+    act(() => {
+      useStore.setState({ workspaceModelSqlDraft: { name: 'other', sql: 'SELECT 999' } });
+    });
     render(<ModelPreview activeObject={{ type: 'model', name: 'orders' }} />);
     fireEvent.click(screen.getByTestId('model-preview-run'));
     expect(mockExecuteQuery).toHaveBeenCalledWith('db', 'SELECT 1');

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -184,6 +184,17 @@ const createWorkspaceSlice = (set, get) => ({
   // open. Scoped by `tableName` so it can't leak across object selections.
   workspacePivotDraft: null,
 
+  // Live model SQL draft (VIS-1221) -----------------------------------------
+  // The unsaved SQL currently in the rail's ModelEditForm, mirrored here so the
+  // center-canvas ModelPreview's Run executes what's ON SCREEN rather than the
+  // last-saved `config.sql`. Scoped by model name so it can't leak onto a
+  // different model's preview; `{ name, sql } | null`. Deliberately NOT the
+  // shared `models` collection (updateRecordConfigOptimistic) — this is a
+  // manual-save form, so writing edits there would let a close-without-save
+  // reseed its own baseline from the discarded text. The editor clears this on
+  // unmount, so a non-editing preview falls back to the saved SQL.
+  workspaceModelSqlDraft: null,
+
   // Outline tree (right-rail Outline tab, VIS-793 / Track F F-3) ------------
   // Selected node key — `'dashboard'` | `'row.N'` | `'row.N.item.M'`. Defaults
   // to the dashboard root so the scoped dashboard reads as selected on entry.
@@ -843,6 +854,22 @@ const createWorkspaceSlice = (set, get) => ({
   setWorkspaceOutlineSelectedKey: (key) => {
     if (typeof key !== 'string' || !key) return;
     set({ workspaceOutlineSelectedKey: key });
+  },
+
+  // VIS-1221 — mirror the rail editor's live SQL so the preview Run uses it.
+  setWorkspaceModelSqlDraft: (name, sql) => {
+    if (!name) return;
+    set({ workspaceModelSqlDraft: { name, sql: sql ?? '' } });
+  },
+
+  // Drop the live SQL draft (editor unmount). Name-guarded so a stale unmount
+  // can't wipe a draft that already belongs to a newly-opened model.
+  clearWorkspaceModelSqlDraft: (name) => {
+    set(state =>
+      !name || state.workspaceModelSqlDraft?.name === name
+        ? { workspaceModelSqlDraft: null }
+        : state
+    );
   },
 
   /**


### PR DESCRIPTION
## Problem

Editing a model's SQL and clicking **Run** executed the **saved** query, not the unsaved edits in the editor. The center-canvas `ModelPreview` ran `config.sql` (the last-saved model from the store) while the rail's `ModelEditForm` held the in-progress SQL in local `useState` — two copies of the query. You had to **Save, then Run**, turning one intent into two steps, and running before saving silently ran stale SQL.

## Fix

Mirror the editor's live SQL into a **scoped workspace-store draft** that the preview reads:

- `workspaceStore.js` — new `workspaceModelSqlDraft` (`{ name, sql } | null`) + `setWorkspaceModelSqlDraft` / `clearWorkspaceModelSqlDraft` (name-guarded).
- `ModelEditForm.jsx` — mirrors its live `sql` into the draft as you type; clears it on unmount.
- `ModelPreview.jsx` — prefers the draft over `config.sql` when it's editing **this** model (name-scoped), so a single **Run** executes what's on screen.

Deliberately **not** the shared `models` collection (`updateRecordConfigOptimistic`): this is a manual-save form, so writing edits there would let a close-without-save reseed its own baseline from the discarded text. The scoped draft avoids polluting the collection, and clearing on unmount means a non-editing preview falls back to the saved SQL.

## Tests
- `ModelPreview.test.jsx` — Run uses the live draft SQL over the saved config; ignores a draft scoped to a different model.
- `ModelEditForm.test.jsx` — mirrors edited SQL into the store; clears the draft on unmount.
- `workspaceStore.test.js` + all three suites green (228 passed); `yarn lint` clean.

Closes VIS-1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
