### PR TITLE
Move Test Connection out of the footer and under the source properties

### DIFF
--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -267,16 +267,28 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             secretKeys={capabilities?.secret_keys ?? []}
           />
 
-          {/* Seeds — only on source types the backend accepts them on */}
-          {sourceTypeSupportsSeeds(sourceType) && (
-            <div>
-              <SeedsEditor
-                seeds={formValues.seeds}
-                onChange={seeds => setFormValues({ ...formValues, seeds })}
-              />
-              {errors.seeds && <p className="mt-1 text-xs text-red-500">{errors.seeds}</p>}
-            </div>
-          )}
+          {/* Test Connection sits directly under the connection properties it
+              tests and above the status it produces — properties, test, result
+              — with seeds after, since a seed is not a connection property.
+              Not in the footer: that is shared by every object type and no
+              other one can test a connection, so a source-only action there
+              both widened the footer past a narrow rail and put the button a
+              long way from the fields it acts on. */}
+          <div>
+            <ButtonOutline
+              type="button"
+              onClick={handleTestConnection}
+              disabled={
+                !sourceType ||
+                currentConnectionStatus?.status === 'testing' ||
+                !connectionTestable
+              }
+              title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
+              className="text-sm whitespace-nowrap"
+            >
+              Test Connection
+            </ButtonOutline>
+          </div>
 
           {/* Connection Status */}
           {currentConnectionStatus && (
@@ -313,6 +325,17 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             </div>
           )}
 
+          {/* Seeds — only on source types the backend accepts them on */}
+          {sourceTypeSupportsSeeds(sourceType) && (
+            <div>
+              <SeedsEditor
+                seeds={formValues.seeds}
+                onChange={seeds => setFormValues({ ...formValues, seeds })}
+              />
+              {errors.seeds && <p className="mt-1 text-xs text-red-500">{errors.seeds}</p>}
+            </div>
+          )}
+
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
       </FormLayout>
 
@@ -337,21 +360,6 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
                 deleting,
               }
             : null
-        }
-        leftActions={
-          <ButtonOutline
-            type="button"
-            onClick={handleTestConnection}
-            disabled={
-              !sourceType ||
-              currentConnectionStatus?.status === 'testing' ||
-              !connectionTestable
-            }
-            title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
-            className="text-sm whitespace-nowrap"
-          >
-            Test Connection
-          </ButtonOutline>
         }
       />
     </>


### PR DESCRIPTION
The footer is shared by every object type, and no other one can test a connection. Passing a source-only action into it as leftActions made the footer's width the sum of whatever a form happened to hand it — "Test Connection" plus delete plus Discard plus Save did not fit a narrow rail, so the row overflowed its panel.

Fixing that inside the footer meant either reserving less width, wrapping the groups onto two rows, or collapsing the extras behind a "..." menu. All three work, all three complicate a component shared by every form, and the last one also puts an iterate-on-it action two clicks away behind a backdrop that blocks the form underneath.

Putting the button where it belongs removes the problem instead of managing it. It now sits with the properties it tests, directly above the status it produces: properties, test, result. The footer is left exactly as it was.

No test changes were needed — the existing coverage queries the button by role and name, so it is found wherever it lives, and all 29 source-form tests pass against the new placement.