### PR TITLE
Move Test Connection out of the footer and under the source properties

### DIFF
--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -267,16 +267,28 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             secretKeys={capabilities?.secret_keys ?? []}
           />
 
-          {/* Seeds — only on source types the backend accepts them on */}
-          {sourceTypeSupportsSeeds(sourceType) && (
-            <div>
-              <SeedsEditor
-                seeds={formValues.seeds}
-                onChange={seeds => setFormValues({ ...formValues, seeds })}
-              />
-              {errors.seeds && <p className="mt-1 text-xs text-red-500">{errors.seeds}</p>}
-            </div>
-          )}
+          {/* Test Connection sits directly under the connection properties it
+              tests and above the status it produces — properties, test, result
+              — with seeds after, since a seed is not a connection property.
+              Not in the footer: that is shared by every object type and no
+              other one can test a connection, so a source-only action there
+              both widened the footer past a narrow rail and put the button a
+              long way from the fields it acts on. */}
+          <div>
+            <ButtonOutline
+              type="button"
+              onClick={handleTestConnection}
+              disabled={
+                !sourceType ||
+                currentConnectionStatus?.status === 'testing' ||
+                !connectionTestable
+              }
+              title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
+              className="text-sm whitespace-nowrap"
+            >
+              Test Connection
+            </ButtonOutline>
+          </div>
 
           {/* Connection Status */}
           {currentConnectionStatus && (
@@ -313,6 +325,17 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             </div>
           )}
 
+          {/* Seeds — only on source types the backend accepts them on */}
+          {sourceTypeSupportsSeeds(sourceType) && (
+            <div>
+              <SeedsEditor
+                seeds={formValues.seeds}
+                onChange={seeds => setFormValues({ ...formValues, seeds })}
+              />
+              {errors.seeds && <p className="mt-1 text-xs text-red-500">{errors.seeds}</p>}
+            </div>
+          )}
+
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
       </FormLayout>
 
@@ -337,21 +360,6 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
                 deleting,
               }
             : null
-        }
-        leftActions={
-          <ButtonOutline
-            type="button"
-            onClick={handleTestConnection}
-            disabled={
-              !sourceType ||
-              currentConnectionStatus?.status === 'testing' ||
-              !connectionTestable
-            }
-            title={connectionTestable ? undefined : CONNECTION_TEST_UNAVAILABLE}
-            className="text-sm whitespace-nowrap"
-          >
-            Test Connection
-          </ButtonOutline>
         }
       />
     </>


### PR DESCRIPTION
## The problem

The source form's footer carried four controls — Test Connection, Delete, Discard, Save — and in the narrow editor rail they overflowed onto two lines. Test Connection is the reason: it's the only one of the four that isn't a form action, and it's the widest.

It also sat a long way from the fields it acts on. You fill in host/port/credentials at the top of the form, then hunt to the bottom of the panel for the button that tests them, and the result renders back up in the body.

## The change

Test Connection moves out of `FormFooter`'s `leftActions` and into the form body, directly under the connection properties and above the status it produces:

```
source properties  ->  Test Connection  ->  connection status  ->  seeds
```

Seeds come after, since a seed isn't a connection property.

`FormFooter` is untouched, so it goes back to being just the shared form actions — Delete, Discard, Save — which is what every other object type already gets from it. A source-only action there both widened the footer past what the rail can hold and put the control far from its inputs.

## Notes

This supersedes two earlier attempts at the same symptom (stacking the button groups when narrow, then hiding Test/Delete behind a `...` menu). Both added layout machinery to keep a button somewhere it didn't belong. Moving it is smaller and fixes the proximity problem as well as the overflow.

## Tests

`yarn test --testPathPattern="SourceEditForm"` → **29 passed**. `yarn lint` clean.

The existing tests find the button with `getByRole`, so they're placement-agnostic — they confirm the move preserved behavior (disabled until a type is chosen, disabled while a test is in flight, click wiring, the unavailable-for-file-sources case) but don't pin where it renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
