### PR TITLE
Read Postgres columns from pg_catalog instead of SQLAlchemy reflection

### DIFF
--- a/tests/models/sources/test_postgresql_source_schema.py
+++ b/tests/models/sources/test_postgresql_source_schema.py
@@ -1,0 +1,196 @@
+"""Postgres reads its columns from pg_catalog instead of SQLAlchemy reflection.
+
+SQLAlchemy's batched ``get_multi_columns`` joins ``pg_collation`` and
+``pg_constraint``. A locked-down server denies those while still allowing
+ordinary reflection, which drops the source onto the per-table fallback —
+~1.9s/table, so a 186-table schema takes ~6 minutes and the caller times out
+first and reports an empty schema. The override reads only pg_attribute,
+pg_class and pg_namespace, so it cannot hit that wall.
+
+The rows below are real ``format_type`` output, taken from a live Postgres
+database, so the type assertions pin what Postgres actually emits rather than
+what it is assumed to emit.
+"""
+
+import pytest
+
+from visivo.models.sources.postgresql_source import PostgresqlSource
+
+
+@pytest.fixture
+def source():
+    return PostgresqlSource(
+        name="pg",
+        type="postgresql",
+        database="db",
+        username="u",
+        password="p",
+        host="localhost",
+        port=5432,
+    )
+
+
+# (table_name, column_name, format_type(...), NOT attnotnull)
+_CATALOG_ROWS = [
+    ("account", "id", "uuid", False),
+    ("account", "created_at", "timestamp with time zone", False),
+    ("account", "slug", "character varying(128)", False),
+    ("account", "auto_associate_domain", "character varying(128)", True),
+    ("dashboard", "config", "jsonb", True),
+    ("dashboard", "position", "numeric(10,2)", True),
+    ("dashboard", "tags", "integer[]", True),
+]
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _Connection:
+    """Stands in for the DBAPI connection, recording what it was asked."""
+
+    def __init__(self, rows, raises=None):
+        self._rows = rows
+        self._raises = raises
+        self.executed = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        if self._raises:
+            raise self._raises
+        self.executed.append((str(statement), params))
+        return _Result(self._rows)
+
+
+class _Inspector:
+    def __init__(self, connection):
+        self.engine = self
+        self._connection = connection
+
+    def connect(self):
+        return self._connection
+
+
+def test_groups_catalog_rows_by_table(source):
+    connection = _Connection(_CATALOG_ROWS)
+    errors = []
+
+    columns = source._columns_by_table(_Inspector(connection), "public", errors)
+
+    assert sorted(columns) == ["account", "dashboard"]
+    assert [c["name"] for c in columns["account"]] == [
+        "id",
+        "created_at",
+        "slug",
+        "auto_associate_domain",
+    ]
+    assert errors == []
+
+
+def test_nullability_survives_the_not_attnotnull_inversion(source):
+    """The catalog stores attnotnull; the schema wants nullable. Inverting that
+    in SQL is easy to get backwards and nothing downstream would notice."""
+    connection = _Connection(_CATALOG_ROWS)
+
+    columns = source._columns_by_table(_Inspector(connection), "public", [])
+
+    by_name = {c["name"]: c for c in columns["account"]}
+    assert by_name["id"]["nullable"] is False
+    assert by_name["auto_associate_domain"]["nullable"] is True
+
+
+def test_scopes_the_query_to_the_requested_schema(source):
+    connection = _Connection(_CATALOG_ROWS)
+
+    source._columns_by_table(_Inspector(connection), "analytics", [])
+
+    _statement, params = connection.executed[0]
+    assert params == {"schema": "analytics"}
+
+
+def test_passes_none_through_for_the_default_schema(source):
+    """``_schemas_to_scan`` yields None when it cannot enumerate schemas. The
+    query resolves that with current_schema(), so None must reach the bind
+    rather than being turned into a literal."""
+    connection = _Connection(_CATALOG_ROWS)
+
+    source._columns_by_table(_Inspector(connection), None, [])
+
+    _statement, params = connection.executed[0]
+    assert params == {"schema": None}
+
+
+def test_query_avoids_the_catalogs_that_forced_this_override(source):
+    """The whole point: no pg_collation, no pg_constraint, no pg_attrdef."""
+    connection = _Connection(_CATALOG_ROWS)
+
+    source._columns_by_table(_Inspector(connection), "public", [])
+
+    statement = connection.executed[0][0]
+    for catalog in ("pg_collation", "pg_constraint", "pg_attrdef"):
+        assert catalog not in statement
+    assert "has_table_privilege" in statement
+
+
+def test_falls_back_to_generic_reflection_and_says_so(source, monkeypatch):
+    """An unexpected catalog restriction should degrade to the generic path,
+    which has its own batched attempt and per-table fallback — not fail the
+    source."""
+    from visivo.models.sources.sqlalchemy_source import SqlalchemySource
+
+    monkeypatch.setattr(
+        SqlalchemySource,
+        "_columns_by_table",
+        lambda self, inspector, schema, errors: {"from_generic": []},
+    )
+    connection = _Connection([], raises=PermissionError("permission denied for pg_class"))
+    errors = []
+
+    columns = source._columns_by_table(_Inspector(connection), "public", errors)
+
+    assert columns == {"from_generic": []}
+    assert any("fell back to generic reflection" in e for e in errors)
+    assert any("permission denied for pg_class" in e for e in errors)
+
+
+@pytest.mark.parametrize(
+    "column, expected",
+    [
+        ("id", "UUID"),
+        ("created_at", "TIMESTAMPTZ"),
+        ("slug", "VARCHAR(128)"),
+    ],
+)
+def test_format_type_strings_resolve_to_sqlglot_types(source, column, expected):
+    """Types arrive as format_type strings, not SQLAlchemy objects.
+    ``_build_table_schema`` handles that through its string fallback, so the
+    override needs no change to the shared builder — pin it."""
+    columns = source._columns_by_table(_Inspector(_Connection(_CATALOG_ROWS)), "public", [])
+
+    built = source._build_table_schema("account", "public", columns["account"], [])
+
+    assert str(built["columns"][column]["sqlglot_datatype"]) == expected
+
+
+def test_postgres_specific_spellings_are_not_flattened(source):
+    """jsonb, numeric(p,s) and array types are where a naive string mapper
+    quietly degrades everything to VARCHAR."""
+    columns = source._columns_by_table(_Inspector(_Connection(_CATALOG_ROWS)), "public", [])
+
+    built = source._build_table_schema("dashboard", "public", columns["dashboard"], [])
+    types = {name: str(info["sqlglot_datatype"]) for name, info in built["columns"].items()}
+
+    assert types == {
+        "config": "JSON",
+        "position": "DECIMAL(10, 2)",
+        "tags": "ARRAY<INT>",
+    }

--- a/visivo/models/sources/postgresql_source.py
+++ b/visivo/models/sources/postgresql_source.py
@@ -1,10 +1,41 @@
-from typing import Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from visivo.models.sources.sqlalchemy_source import SqlalchemySource
 from visivo.models.sources.source import ServerSource
 from visivo.logger.logger import Logger
 from pydantic import Field
 
 PostgresqlType = Literal["postgresql"]
+
+# One round trip per schema, reading only pg_attribute/pg_class/pg_namespace.
+#
+# relkind covers ordinary ('r'), partitioned ('p'), view ('v'), materialized
+# view ('m') and foreign ('f') tables — everything a query can name. attnum > 0
+# skips system columns (ctid, xmin, ...); attisdropped skips the tombstones a
+# DROP COLUMN leaves behind, which still occupy an attnum.
+#
+# has_table_privilege keeps the answer to what this role can actually SELECT.
+# That is the honest schema for query planning, and it means a restricted
+# account gets a clean smaller schema rather than a schema plus a page of
+# permission-denied warnings for tables it was never going to read.
+#
+# The literal relkinds are constants, not input, so they are inlined; the schema
+# is bound. CAST is needed because psycopg2 sends an untyped NULL for None,
+# which COALESCE cannot resolve on its own.
+_COLUMNS_FOR_SCHEMA = """
+    SELECT c.relname AS table_name,
+           a.attname AS column_name,
+           pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+           NOT a.attnotnull AS is_nullable
+    FROM pg_catalog.pg_attribute a
+    JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = COALESCE(CAST(:schema AS text), current_schema())
+      AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND pg_catalog.has_table_privilege(c.oid, 'SELECT')
+    ORDER BY c.relname, a.attnum
+"""
 
 
 class PostgresqlSource(ServerSource, SqlalchemySource):
@@ -40,6 +71,65 @@ class PostgresqlSource(ServerSource, SqlalchemySource):
 
     def get_dialect(self):
         return "postgresql"
+
+    def _columns_by_table(self, inspector, schema, errors: List[str]) -> Dict[str, Any]:
+        """``{table_name: [column_info, ...]}`` from pg_catalog directly.
+
+        Overrides the generic reflection because SQLAlchemy's batched
+        ``get_multi_columns`` joins ``pg_collation`` and ``pg_constraint`` for
+        collation and constraint detail this schema never uses. A locked-down
+        server can deny exactly those catalogs while still permitting ordinary
+        reflection, which drops the source onto the per-table fallback — around
+        1.9s per table, so a 186-table schema takes ~6 minutes and the caller
+        times out long before it finishes, reporting an empty schema that reads
+        like an empty database. This query cannot hit that wall: it touches
+        ``pg_attribute``, ``pg_class`` and ``pg_namespace`` and nothing else.
+
+        Not ``information_schema.columns``, despite being the portable spelling
+        and what the Snowflake source uses. Two reasons, both specific to
+        Postgres: its ``columns`` view joins ``pg_collation`` itself (check
+        ``pg_get_viewdef``), so it fails on the same servers this exists to
+        rescue; and it reports every enum, domain and extension type as the
+        literal string ``USER-DEFINED``, where ``format_type`` gives the real
+        type name for SQLGlot to resolve.
+
+        Column defaults are not fetched. Nothing downstream reads them, and
+        collecting them means joining ``pg_attrdef`` — another catalog to be
+        denied, for a field no caller uses.
+
+        Types come back as ``format_type`` strings rather than SQLAlchemy type
+        objects. ``_build_table_schema`` handles that unchanged: its mapper
+        falls through to ``_parse_type_string``, which resolves the Postgres
+        spellings correctly (``character varying(100)`` -> VARCHAR(100),
+        ``timestamp with time zone`` -> TIMESTAMPTZ, ``integer[]`` ->
+        ARRAY<INT>, ``numeric(10,2)`` -> DECIMAL(10, 2)).
+        """
+        from sqlalchemy import text
+
+        try:
+            with inspector.engine.connect() as connection:
+                rows = connection.execute(text(_COLUMNS_FOR_SCHEMA), {"schema": schema}).fetchall()
+        except Exception as e:
+            # Fall back rather than fail: an unexpected catalog restriction
+            # should degrade to the generic path, which has its own batched
+            # attempt and per-table fallback, not take the source down.
+            errors.append(
+                f"catalog column query failed for schema {schema or 'default'} "
+                f"({self._concise_error(e)}); fell back to generic reflection"
+            )
+            return super()._columns_by_table(inspector, schema, errors)
+
+        columns: Dict[str, Any] = {}
+        for table_name, column_name, data_type, is_nullable in rows:
+            columns.setdefault(table_name, []).append(
+                {
+                    "name": column_name,
+                    "type": data_type,
+                    "nullable": bool(is_nullable),
+                    "default": None,
+                }
+            )
+        return columns
 
     def list_databases(self):
         """Return list of databases for PostgreSQL server."""

--- a/visivo/models/sources/sqlalchemy_source.py
+++ b/visivo/models/sources/sqlalchemy_source.py
@@ -738,9 +738,16 @@ class SqlalchemySource(Source, ABC):
             col_type = col_info["type"]
 
             try:
-                # Convert SQLAlchemy type to SQLGlot DataType
+                # The SQLGLOT dialect, not get_dialect(): the mapper passes this
+                # straight to exp.DataType.build, and "postgresql" is not a
+                # SQLGlot dialect ("postgres" is). Building with an unknown
+                # dialect raises, which the except below turns into VARCHAR — so
+                # every Postgres type that reached the mapper's string fallback
+                # (jsonb, numeric(p,s), int[], enums) silently became VARCHAR.
+                # postgresql is the only name VISIVO_TO_SQLGLOT_DIALECT remaps,
+                # which is why no other source noticed.
                 sqlglot_datatype = SqlglotTypeMapper.sqlalchemy_to_sqlglot_type(
-                    col_type, dialect=self.get_dialect()
+                    col_type, dialect=self.get_sqlglot_dialect()
                 )
                 table_schema["columns"][col_name] = {
                     "type": str(col_type),


### PR DESCRIPTION
Follows up on Jared's review of #597. Snowflake, Redshift and DuckDB already override `get_schema()` with a source-specific read; this adds one for Postgres, which is the source most people actually point at.

## Why not just use the generic path

SQLAlchemy's batched `get_multi_columns` joins `pg_collation` and `pg_constraint` for collation and constraint detail this schema never uses. A locked-down server denies exactly those catalogs while still permitting ordinary reflection — so the source drops onto the per-table fallback at ~1.9s/table. A 186-table schema takes ~6 minutes, the caller times out first, and the result is an empty schema that reads like an empty database.

The new query touches `pg_attribute`, `pg_class` and `pg_namespace` and nothing else, so it can't hit that wall.

`has_table_privilege` also scopes the answer to what the connecting role can actually `SELECT`. That's the honest schema for query planning, and a restricted account now gets a smaller clean schema instead of a schema plus a page of permission-denied warnings for tables it was never going to read.

## Why not `information_schema.columns`

It's the portable spelling and it's what the Snowflake source uses, so it was the obvious first choice. Two Postgres-specific reasons against it:

**It joins `pg_collation` itself.** Checked rather than assumed — `pg_get_viewdef('information_schema.columns')` on a live server references:

```
pg_attribute, pg_class, pg_collation, pg_depend, pg_namespace, pg_sequence, ...
```

So it fails on exactly the servers this exists to rescue.

**It flattens user types.** Every enum, domain and extension type comes back as the literal string `USER-DEFINED`, where `format_type` gives the real type name for SQLGlot to resolve.

## Scope

Only the column fetch is overridden. Schema enumeration, the bare-vs-qualified name convention, the `table_names` filter, error collection and SQLGlot assembly all stay in the shared path, so the two can't drift — that's what `_build_table_schema`'s docstring warns about. Any failure falls back to the generic path and says so in `errors`.

Types arrive as `format_type` strings rather than SQLAlchemy objects, which the shared builder already handles through its string fallback — so no shared-code change was needed for that.

## A bug this exposed

`_build_table_schema` passed `get_dialect()` to the type mapper, which forwards it to `exp.DataType.build`. **`"postgresql"` is not a SQLGlot dialect — `"postgres"` is.** Building with an unknown dialect raises, and the `except` turns that into `VARCHAR`.

So every Postgres type that reached the mapper's string fallback silently became `VARCHAR`:

| Column type | Before | After |
| --- | --- | --- |
| `jsonb` | `VARCHAR` | `JSON` |
| `numeric(10,2)` | `VARCHAR` | `DECIMAL(10, 2)` |
| `integer[]` | `VARCHAR` | `ARRAY<INT>` |

`get_sqlglot_dialect()` already existed for this translation and `get_schema` was already using it for metadata. `postgresql` is the only name `VISIVO_TO_SQLGLOT_DIALECT` remaps, which is why no other source noticed.

## Tests

`tests/models/sources/test_postgresql_source_schema.py` — 10 tests. The catalog rows in the fixture are **real `format_type` output captured from a live Postgres database**, so the type assertions pin what Postgres actually emits rather than what it's assumed to emit.

Covered: row grouping, the `NOT attnotnull` → `nullable` inversion (easy to get backwards, and nothing downstream would notice), schema binding including the `None` → `current_schema()` case, an assertion that the SQL names none of `pg_collation`/`pg_constraint`/`pg_attrdef`, the fallback path and its error text, and the type resolutions in the table above.

I also ran the query itself against a live Postgres — 53 tables, 449 columns, correct types and nullability.

Full suite: **2359 passed**. `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
