### PR TITLE
VIS-1213: lineage node navigation, one selector row, and fit-on-selection

### DIFF
--- a/viewer/src/components/views/lineage/Lineage.jsx
+++ b/viewer/src/components/views/lineage/Lineage.jsx
@@ -16,6 +16,7 @@ import DashboardNode from './DashboardNode';
 import InputNode from './InputNode';
 import { PiArrowCounterClockwise } from 'react-icons/pi';
 import LineageSelectorField from './LineageSelectorField';
+import { neighborhoodSelector, subjectOf } from './lineageSelector';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { formatRefExpression } from '../../../utils/refString';
 
@@ -43,6 +44,11 @@ import { formatRefExpression } from '../../../utils/refString';
  *                        When provided, the browser's default menu is
  *                        suppressed for node right-clicks only.
  */
+// Fallbacks for centring before React Flow has measured a node. These mirror
+// computeLayout's estimate so the camera lands where the layout put it.
+const DEFAULT_NODE_WIDTH = 180;
+const DEFAULT_NODE_HEIGHT = 50;
+
 const Lineage = ({
   scopeSelector = null,
   onNodeSelect = null,
@@ -323,31 +329,53 @@ const Lineage = ({
     [nodes]
   );
 
-  // Fit the view when the node SET changes, or when the filter changes.
+  // Reframe when the node SET changes or the selector does.
   //
-  // The set, because keying on `nodes?.length` alone meant selecting a
-  // different object that happened to resolve to the same number of nodes never
-  // re-fit — the graph stayed anchored wherever the previous fit left it. That
-  // is the "it often doesn't center when you select new items" report, and
-  // "often" was tracking whether the node count happened to change.
+  // Which reframing depends on whether the selector names an object:
   //
-  // The filter, because editing it is an explicit "show me this": the result
-  // has to come into view even when the resulting set is one the viewport is
-  // already displaying, since the user may have panned away since.
+  //   - it names one  → PAN to it, keeping the user's zoom. Clicking a node,
+  //     expanding one from the mini lineage, and typing a name in the filter
+  //     all change WHICH object the view is about without necessarily changing
+  //     the node set — so a set-keyed fit did nothing at all, and even when it
+  //     did fire, fitting the whole graph left the chosen object as one small
+  //     box somewhere rather than the thing you are looking at.
+  //   - it names none (`*`) → FIT the graph. That is "show full project" and
+  //     the unscoped first load, where there is no subject to centre on.
   //
-  // What is deliberately NOT here is anything that only MOVES nodes — dragging,
-  // or pinning a clicked node via `fixedNode`. Those leave both triggers alone,
-  // so the viewport stays where the user put it. That was the original
-  // complaint on this ticket: selecting a node made the graph jump.
+  // Keying on `nodes?.length` was the original bug: selecting a different
+  // object that happened to resolve to the same number of nodes never re-fit.
+  // Membership replaces it, and the selector is here too because editing the
+  // filter is an explicit "show me this" even when the result is already on
+  // screen — the user may have panned away since.
+  //
+  // Deliberately absent is anything that only MOVES nodes: dragging, or
+  // pinning a clicked node via `fixedNode`. Those leave both triggers alone, so
+  // the viewport stays where the user put it — the original "jumps on select".
   useEffect(() => {
-    if (initialLoadDone && nodes?.length > 0 && reactFlowInstance.current) {
-      setTimeout(() => {
-        reactFlowInstance.current.fitView({
-          padding: 0.2,
-          duration: 800, // Smooth 800ms animation
-        });
-      }, 100);
-    }
+    const instance = reactFlowInstance.current;
+    if (!initialLoadDone || !instance || !(nodes?.length > 0)) return undefined;
+
+    const timer = setTimeout(() => {
+      const subject = subjectOf(selector);
+      const target = subject ? nodes.find((n) => n.data?.name === subject) : null;
+
+      if (target && typeof instance.setCenter === 'function') {
+        const zoom = typeof instance.getZoom === 'function' ? instance.getZoom() : 1;
+        instance.setCenter(
+          target.position.x + (target.width ?? DEFAULT_NODE_WIDTH) / 2,
+          target.position.y + (target.height ?? DEFAULT_NODE_HEIGHT) / 2,
+          { zoom, duration: 500 }
+        );
+        return;
+      }
+
+      instance.fitView({
+        padding: 0.2,
+        duration: 800, // Smooth 800ms animation
+      });
+    }, 100);
+
+    return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialLoadDone, nodeSignature, selector]);
 
@@ -405,7 +433,18 @@ const Lineage = ({
     });
 
     // Set selector to +name+ to show the node and all its dependencies
-    setSelector(`+${nodeName}+`);
+    const nextSelector = neighborhoodSelector(nodeName);
+    // Claim the scope this click is about to produce.
+    //
+    // `onNodeSelect` below tells the host, which opens the object as a tab,
+    // which re-derives the scope, which arrives back here as a NEW
+    // `scopeSelector` — and the re-seed effect responds to a new scope by
+    // clearing `fixedNode`. So the click's own echo destroyed the pin it had
+    // just set, dagre re-laid the graph from scratch, and the node the user
+    // clicked moved out from under them. Recording the value now means the
+    // effect sees the scope it already has and leaves the pin alone.
+    lastScopeRef.current = nextSelector;
+    setSelector(nextSelector);
 
     if (onNodeSelect) {
       onNodeSelect({ type: objectType, name: nodeName });

--- a/viewer/src/components/views/lineage/Lineage.jsx
+++ b/viewer/src/components/views/lineage/Lineage.jsx
@@ -14,7 +14,8 @@ import ChartNode from './ChartNode';
 import TableNode from './TableNode';
 import DashboardNode from './DashboardNode';
 import InputNode from './InputNode';
-import { Button } from '../../styled/Button';
+import { PiArrowCounterClockwise } from 'react-icons/pi';
+import LineageSelectorField from './LineageSelectorField';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { formatRefExpression } from '../../../utils/refString';
 
@@ -45,7 +46,7 @@ import { formatRefExpression } from '../../../utils/refString';
 const Lineage = ({
   scopeSelector = null,
   onNodeSelect = null,
-  headerSlot = null,
+  onResetScope = null,
   onNodeContextMenu = null,
 } = {}) => {
   // Sources
@@ -294,7 +295,46 @@ const Lineage = ({
     return { nodes: layoutNodes || [], edges: filteredEdges || [] };
   }, [dagNodes, dagEdges, selectedIds, fixedNode]);
 
-  // Fit view when initial data loads OR when selector changes (and we have nodes to show)
+  // One reset, whatever is narrowing the view.
+  //
+  // There were two: `Clear`, which emptied this component's own selector, and
+  // a `Show full project` button on the scope strip above, which widened the
+  // host's scope. Pressing Clear while hosted did almost nothing visible — the
+  // scope re-seeded the selector straight back — so the two had to be pressed
+  // in the right order to get the whole project. They are now the same action.
+  //
+  // `onResetScope` is absent standalone (`/editor`), where there is no scope
+  // and clearing the selector IS showing the full project.
+  const handleShowFullProject = useCallback(() => {
+    setSelector('');
+    setFixedNode(null);
+    if (onResetScope) onResetScope();
+  }, [onResetScope]);
+
+  // Nothing to reset when the DAG is already the whole project. A host-derived
+  // scope seeds `selector`, so this covers scoped and manual narrowing alike.
+  const canShowFullProject = Boolean(selector) || Boolean(fixedNode);
+
+  // Which nodes are on screen, as a stable string. Identity, not count —
+  // `nodes` is rebuilt on every layout pass, so it can't be a dependency
+  // directly, but its membership can.
+  const nodeSignature = useMemo(
+    () => (nodes || []).map((node) => node.id).sort().join(' '),
+    [nodes]
+  );
+
+  // Fit the view whenever the node SET changes.
+  //
+  // This used to key on `nodes?.length` and `selector`, which meant selecting a
+  // different object that happened to resolve to the same number of nodes never
+  // re-fit — the graph stayed anchored wherever the previous fit left it. That
+  // is the "it often doesn't center when you select new items" report, and
+  // "often" was tracking whether the node count happened to change.
+  //
+  // Membership is the honest trigger, and it also settles the original
+  // complaint that selecting a node made the graph jump: a change that only
+  // moves nodes (dragging, or pinning a clicked node via `fixedNode`) leaves
+  // the signature alone, so the viewport stays exactly where the user put it.
   useEffect(() => {
     if (initialLoadDone && nodes?.length > 0 && reactFlowInstance.current) {
       setTimeout(() => {
@@ -304,7 +344,8 @@ const Lineage = ({
         });
       }, 100);
     }
-  }, [initialLoadDone, nodes?.length, selector]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialLoadDone, nodeSignature]);
 
   // Global keyboard handler for Escape key
   useEffect(() => {
@@ -431,25 +472,13 @@ const Lineage = ({
   );
 
   return (
-    <div className={`flex flex-col ${headerSlot ? 'h-full' : 'h-[calc(100vh-48px)]'}`}>
-      {/* Host-supplied chrome (e.g. LineageCanvas scope-indicator strip) */}
-      {headerSlot}
+    <div className={`flex flex-col ${embedded ? 'h-full' : 'h-[calc(100vh-48px)]'}`}>
 
-      {/* Selector input bar */}
-      <div className="flex items-center gap-2 px-4 py-2 bg-white border-b border-gray-200">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            setSelector('');
-            setFixedNode(null);
-          }}
-          disabled={!selector}
-        >
-          Clear
-        </Button>
-        <input
-          type="text"
+      {/* Selector bar — the only chrome above the DAG.
+          There used to be a scope strip above this one carrying the same
+          object's name plus this button; it said nothing this row doesn't. */}
+      <div className="flex items-center gap-2 border-b border-gray-200 bg-white px-4 py-2">
+        <LineageSelectorField
           value={selector}
           onChange={e => {
             setSelector(e.target.value);
@@ -460,13 +489,24 @@ const Lineage = ({
             if (e.key === 'Escape') {
               e.preventDefault();
               e.stopPropagation();
-              setSelector('');
-              setFixedNode(null);
+              handleShowFullProject();
               e.target.blur(); // Remove focus after clearing
             }
           }}
           placeholder="e.g., 'source_name', 'model_name', or '+name+'"
-          className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          testId="lineage-selector"
+          trailing={
+            <button
+              type="button"
+              onClick={handleShowFullProject}
+              disabled={!canShowFullProject}
+              data-testid="lineage-show-full-project"
+              className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-2 text-[12px] font-medium text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 hover:ring-gray-300 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-700 disabled:hover:ring-gray-200"
+            >
+              <PiArrowCounterClockwise className="h-3.5 w-3.5" />
+              Show full project
+            </button>
+          }
         />
       </div>
 

--- a/viewer/src/components/views/lineage/Lineage.jsx
+++ b/viewer/src/components/views/lineage/Lineage.jsx
@@ -323,18 +323,22 @@ const Lineage = ({
     [nodes]
   );
 
-  // Fit the view whenever the node SET changes.
+  // Fit the view when the node SET changes, or when the filter changes.
   //
-  // This used to key on `nodes?.length` and `selector`, which meant selecting a
+  // The set, because keying on `nodes?.length` alone meant selecting a
   // different object that happened to resolve to the same number of nodes never
   // re-fit — the graph stayed anchored wherever the previous fit left it. That
   // is the "it often doesn't center when you select new items" report, and
   // "often" was tracking whether the node count happened to change.
   //
-  // Membership is the honest trigger, and it also settles the original
-  // complaint that selecting a node made the graph jump: a change that only
-  // moves nodes (dragging, or pinning a clicked node via `fixedNode`) leaves
-  // the signature alone, so the viewport stays exactly where the user put it.
+  // The filter, because editing it is an explicit "show me this": the result
+  // has to come into view even when the resulting set is one the viewport is
+  // already displaying, since the user may have panned away since.
+  //
+  // What is deliberately NOT here is anything that only MOVES nodes — dragging,
+  // or pinning a clicked node via `fixedNode`. Those leave both triggers alone,
+  // so the viewport stays where the user put it. That was the original
+  // complaint on this ticket: selecting a node made the graph jump.
   useEffect(() => {
     if (initialLoadDone && nodes?.length > 0 && reactFlowInstance.current) {
       setTimeout(() => {
@@ -345,7 +349,7 @@ const Lineage = ({
       }, 100);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialLoadDone, nodeSignature]);
+  }, [initialLoadDone, nodeSignature, selector]);
 
   // Global keyboard handler for Escape key
   useEffect(() => {

--- a/viewer/src/components/views/lineage/Lineage.test.jsx
+++ b/viewer/src/components/views/lineage/Lineage.test.jsx
@@ -230,7 +230,7 @@ describe('Lineage', () => {
     });
   });
 
-  it('clears selector when Clear button is clicked', async () => {
+  it('clears the selector when "Show full project" is clicked', async () => {
     useLineageDag.mockReturnValue({
       nodes: [{ id: 'source-db', data: { label: 'db', name: 'db', objectType: 'source' } }],
       edges: [],
@@ -245,10 +245,44 @@ describe('Lineage', () => {
     await user.type(input, 'source-db');
     expect(input.value).toBe('source-db');
 
-    // Click clear
-    fireEvent.click(screen.getByText('Clear'));
+    // One reset for both narrowing mechanisms — this replaced `Clear`, which
+    // only emptied the input and left a host-supplied scope in place.
+    fireEvent.click(screen.getByTestId('lineage-show-full-project'));
 
     expect(input.value).toBe('');
+  });
+
+  it('disables "Show full project" when the DAG is already the whole project', async () => {
+    useLineageDag.mockReturnValue({
+      nodes: [{ id: 'source-db', data: { label: 'db', name: 'db', objectType: 'source' } }],
+      edges: [],
+    });
+
+    const user = userEvent.setup();
+    render(<Lineage />);
+
+    expect(screen.getByTestId('lineage-show-full-project')).toBeDisabled();
+
+    await user.type(
+      screen.getByPlaceholderText("e.g., 'source_name', 'model_name', or '+name+'"),
+      'source-db'
+    );
+
+    expect(screen.getByTestId('lineage-show-full-project')).toBeEnabled();
+  });
+
+  it('calls onResetScope so a host-derived scope widens too', async () => {
+    useLineageDag.mockReturnValue({
+      nodes: [{ id: 'source-db', data: { label: 'db', name: 'db', objectType: 'source' } }],
+      edges: [],
+    });
+    const onResetScope = jest.fn();
+
+    render(<Lineage scopeSelector="+db+" onResetScope={onResetScope} />);
+
+    fireEvent.click(screen.getByTestId('lineage-show-full-project'));
+
+    expect(onResetScope).toHaveBeenCalled();
   });
 
   it('shows no matching objects message when selector matches nothing', async () => {

--- a/viewer/src/components/views/lineage/Lineage.test.jsx
+++ b/viewer/src/components/views/lineage/Lineage.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Lineage from './Lineage';
 import useStore from '../../../stores/store';
-import { useLineageDag } from './useLineageDag';
+import { useLineageDag, computeLayout } from './useLineageDag';
 
 // Mock the store
 jest.mock('../../../stores/store');
@@ -25,7 +25,21 @@ jest.mock('./useLineageDag', () => ({
 
 // Mock reactflow
 jest.mock('reactflow', () => {
-  const MockReactFlow = ({ nodes, edges, onNodeClick, children }) => (
+  const ReactMock = require('react');
+  // A stand-in for the React Flow instance the real component hands back via
+  // `onInit`. Lineage drives the camera through it, so exposing it is what
+  // makes the framing behaviour assertable at all.
+  const instance = {
+    setCenter: jest.fn(),
+    fitView: jest.fn(),
+    getZoom: jest.fn(() => 1),
+  };
+  global.__mockFlowInstance = instance;
+  const MockReactFlow = ({ nodes, edges, onNodeClick, onInit, children }) => {
+    ReactMock.useEffect(() => {
+      if (onInit) onInit(instance);
+    }, [onInit]);
+    return (
     <div data-testid="react-flow">
       {nodes.map(node => (
         <div
@@ -43,7 +57,8 @@ jest.mock('reactflow', () => {
       ))}
       {children}
     </div>
-  );
+    );
+  };
   MockReactFlow.displayName = 'MockReactFlow';
   return {
     __esModule: true,
@@ -445,5 +460,79 @@ describe('Lineage', () => {
       expect(mockFetchDashboards).not.toHaveBeenCalled();
       expect(mockFetchDefaults).not.toHaveBeenCalled();
     });
+  });
+});
+
+
+describe('framing and node pinning (VIS-1213 follow-ups)', () => {
+  const NODES = [
+    { id: 'model-a', data: { label: 'a', name: 'a', objectType: 'model' } },
+    { id: 'model-b', data: { label: 'b', name: 'b', objectType: 'model' } },
+  ];
+
+  beforeEach(() => {
+    useLineageDag.mockReturnValue({ nodes: NODES, edges: [] });
+    global.__mockFlowInstance.setCenter.mockClear();
+    global.__mockFlowInstance.fitView.mockClear();
+    computeLayout.mockClear();
+  });
+
+  test('a selector naming an object pans to it instead of fitting the graph', async () => {
+    render(<Lineage scopeSelector="+b+" />);
+
+    await waitFor(() => {
+      expect(global.__mockFlowInstance.setCenter).toHaveBeenCalled();
+    });
+    expect(global.__mockFlowInstance.fitView).not.toHaveBeenCalled();
+  });
+
+  test('an unscoped selector fits the whole graph — there is no subject to centre on', async () => {
+    render(<Lineage scopeSelector="*" />);
+
+    await waitFor(() => {
+      expect(global.__mockFlowInstance.fitView).toHaveBeenCalled();
+    });
+    expect(global.__mockFlowInstance.setCenter).not.toHaveBeenCalled();
+  });
+
+  test('panning keeps the zoom the user chose', async () => {
+    global.__mockFlowInstance.getZoom.mockReturnValue(2.5);
+    render(<Lineage scopeSelector="+b+" />);
+
+    await waitFor(() => {
+      expect(global.__mockFlowInstance.setCenter).toHaveBeenCalled();
+    });
+    const [, , opts] = global.__mockFlowInstance.setCenter.mock.calls[0];
+    expect(opts.zoom).toBe(2.5);
+    global.__mockFlowInstance.getZoom.mockReturnValue(1);
+  });
+
+  test("the clicked node stays pinned when the host echoes the click back as a new scope", () => {
+    // The click tells the host, the host opens a tab, the scope re-derives and
+    // arrives back as a new `scopeSelector`. That echo used to clear the pin
+    // the click had just set, so dagre re-laid the graph and the node moved out
+    // from under the user.
+    // Start unscoped so every node is on screen and clickable.
+    const { rerender } = render(<Lineage scopeSelector="*" />);
+
+    fireEvent.click(screen.getByTestId('node-model-b'));
+    rerender(<Lineage scopeSelector="+b+" />);
+
+    const fixedNodes = computeLayout.mock.calls.map(call => call[2]);
+    expect(fixedNodes[fixedNodes.length - 1]).toEqual(
+      expect.objectContaining({ id: 'model-b' })
+    );
+  });
+
+  test('a scope change the user did NOT cause still releases the pin', () => {
+    // Navigating elsewhere should lay the new graph out freely; only the click's
+    // own echo is exempt.
+    const { rerender } = render(<Lineage scopeSelector="*" />);
+
+    fireEvent.click(screen.getByTestId('node-model-b'));
+    rerender(<Lineage scopeSelector="+somewhere-else+" />);
+
+    const fixedNodes = computeLayout.mock.calls.map(call => call[2]);
+    expect(fixedNodes[fixedNodes.length - 1]).toBeNull();
   });
 });

--- a/viewer/src/components/views/lineage/LineageCanvas.jsx
+++ b/viewer/src/components/views/lineage/LineageCanvas.jsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { PiTreeStructure, PiArrowCounterClockwise } from 'react-icons/pi';
+import React, { useCallback, useEffect, useState } from 'react';
 import Lineage from './Lineage';
 import OpenObjectContextMenu from '../workspace/OpenObjectContextMenu';
 import useStore from '../../../stores/store';
@@ -17,11 +16,13 @@ import { EXPLORE_THIS_TYPES, EXPLORATION_DRAG_TYPES } from '../workspace/library
  * Responsibilities:
  *   - Derive the lineage `selector` from `useWorkspaceScope()`:
  *       · `*`              — unscoped (root / project).
- *       · `+<dashboardName>` — dashboard scope.
- *       · `+<itemName>`      — item scope.
- *   - Render the E-1 scope-indicator chrome above the DAG (flat white strip)
- *     describing WHY the user is seeing a subset, plus a "Show full project"
- *     affordance that widens the scope back to `*` WITHOUT changing the route.
+ *       · `+<dashboardName>+` — dashboard scope.
+ *       · `+<itemName>+`      — item scope (both directions, VIS-1213).
+ *   - Own the "show full project" reset. The scope-indicator strip this used
+ *     to render was removed (VIS-1213): it repeated the object name already
+ *     shown in the selector row directly beneath it. The reset survives as
+ *     `onResetScope`, which <Lineage> renders inside that row — still
+ *     widening the scope back to `*` WITHOUT changing the route.
  *   - Round-trip selection: clicking a node updates the workspace selection
  *     via `openWorkspaceTab` (and the scope, in turn, re-derives the selector).
  *   - Fire the `middle_pane_toggled` telemetry event on lineage entry.
@@ -31,7 +32,7 @@ import { EXPLORE_THIS_TYPES, EXPLORATION_DRAG_TYPES } from '../workspace/library
  * scope-derived selector until the scope changes again).
  */
 const LineageCanvas = () => {
-  const { scope, selector, dashboardName, selectedItem } = useWorkspaceScope();
+  const { scope, selector, dashboardName } = useWorkspaceScope();
   const openWorkspaceTab = useStore((s) => s.openWorkspaceTab);
   const openWorkspaceTabBackground = useStore((s) => s.openWorkspaceTabBackground);
   const setWorkspaceLensIntent = useStore((s) => s.setWorkspaceLensIntent);
@@ -65,21 +66,6 @@ const LineageCanvas = () => {
   }, []);
 
   const effectiveSelector = showFullProject ? '*' : selector;
-  const isScoped = effectiveSelector !== '*';
-
-  // Human-readable description of the current scope for the indicator strip.
-  const scopeLabel = useMemo(() => {
-    if (!isScoped) return 'Full project';
-    if (scope === 'dashboard' && dashboardName) return dashboardName;
-    if (selectedItem?.name) return selectedItem.name;
-    return effectiveSelector;
-  }, [isScoped, scope, dashboardName, selectedItem, effectiveSelector]);
-
-  const scopeKind = useMemo(() => {
-    if (!isScoped) return null;
-    if (scope === 'dashboard') return 'dashboard';
-    return selectedItem?.type || 'item';
-  }, [isScoped, scope, selectedItem]);
 
   const handleResetScope = useCallback(() => {
     setShowFullProject(true);
@@ -171,49 +157,13 @@ const LineageCanvas = () => {
     [addObjectToActiveExploration]
   );
 
-  const chrome = (
-    <div
-      data-testid="lineage-canvas-scope-bar"
-      className="flex min-h-9 shrink-0 items-center gap-2 border-b border-gray-200 bg-white px-3 py-1.5"
-    >
-      <span className="shrink-0 text-[10px] font-medium uppercase tracking-wider text-gray-400">
-        Scope
-      </span>
-      <div className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span
-          data-testid="lineage-canvas-scope-pill"
-          className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary-100 px-2 text-[12px] font-medium text-primary-600"
-        >
-          <PiTreeStructure className="h-3.5 w-3.5" />
-          <span className="font-semibold">{scopeLabel}</span>
-          {scopeKind && (
-            <span className="text-[10px] uppercase tracking-wider text-primary-600/70">
-              {scopeKind}
-            </span>
-          )}
-        </span>
-      </div>
-      {isScoped && (
-        <button
-          type="button"
-          data-testid="lineage-canvas-reset-scope"
-          onClick={handleResetScope}
-          className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-2 text-[12px] font-medium text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 hover:ring-gray-300"
-        >
-          <PiArrowCounterClockwise className="h-3.5 w-3.5" />
-          Show full project
-        </button>
-      )}
-    </div>
-  );
-
   return (
     <div data-testid="lineage-canvas" className="flex h-full w-full flex-col">
       <Lineage
         scopeSelector={effectiveSelector}
         onNodeSelect={handleNodeSelect}
         onNodeContextMenu={handleNodeContextMenu}
-        headerSlot={chrome}
+        onResetScope={handleResetScope}
       />
       {ctxMenu && (
         <OpenObjectContextMenu

--- a/viewer/src/components/views/lineage/LineageCanvas.test.jsx
+++ b/viewer/src/components/views/lineage/LineageCanvas.test.jsx
@@ -28,7 +28,7 @@ jest.mock('../workspace/useWorkspaceScope', () => ({
 // Mock Lineage with a stub that echoes the props we care about and lets us
 // drive the node-select round-trip + the manual selector input.
 jest.mock('./Lineage', () => {
-  const MockLineage = ({ scopeSelector, onNodeSelect, onNodeContextMenu, headerSlot }) => {
+  const MockLineage = ({ scopeSelector, onNodeSelect, onNodeContextMenu, onResetScope }) => {
     const React = require('react');
     const [manual, setManual] = React.useState(scopeSelector || '');
     React.useEffect(() => {
@@ -36,7 +36,11 @@ jest.mock('./Lineage', () => {
     }, [scopeSelector]);
     return (
       <div data-testid="lineage">
-        {headerSlot}
+        {/* The reset lives INSIDE Lineage's selector row now (VIS-1213);
+            the canvas hands it down instead of rendering its own strip. */}
+        <button data-testid="simulate-reset-scope" onClick={() => onResetScope && onResetScope()}>
+          show full project
+        </button>
         <div data-testid="scope-selector-prop">{scopeSelector}</div>
         <input
           data-testid="manual-selector"
@@ -105,27 +109,30 @@ afterEach(() => {
 });
 
 describe('LineageCanvas', () => {
-  test('passes `*` selector for unscoped (root) scope and hides reset', () => {
+  test('passes `*` selector for unscoped (root) scope', () => {
     setScope(ROOT);
     render(<LineageCanvas />);
     expect(screen.getByTestId('scope-selector-prop')).toHaveTextContent('*');
+  });
+
+  test('renders no scope strip of its own — the selector row is the only chrome', () => {
+    setScope(DASHBOARD);
+    render(<LineageCanvas />);
+    expect(screen.queryByTestId('lineage-canvas-scope-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('lineage-canvas-scope-pill')).not.toBeInTheDocument();
     expect(screen.queryByTestId('lineage-canvas-reset-scope')).not.toBeInTheDocument();
-    expect(screen.getByTestId('lineage-canvas-scope-pill')).toHaveTextContent('Full project');
   });
 
   test('passes `+<dashboardName>` for dashboard scope', () => {
     setScope(DASHBOARD);
     render(<LineageCanvas />);
     expect(screen.getByTestId('scope-selector-prop')).toHaveTextContent('+sales');
-    expect(screen.getByTestId('lineage-canvas-scope-pill')).toHaveTextContent('sales');
-    expect(screen.getByTestId('lineage-canvas-reset-scope')).toBeInTheDocument();
   });
 
   test('passes `+<itemName>` for item scope', () => {
     setScope(ITEM);
     render(<LineageCanvas />);
     expect(screen.getByTestId('scope-selector-prop')).toHaveTextContent('+revenue_chart');
-    expect(screen.getByTestId('lineage-canvas-scope-pill')).toHaveTextContent('revenue_chart');
   });
 
   test('"Show full project" widens the scope back to `*` without changing route', () => {
@@ -133,11 +140,10 @@ describe('LineageCanvas', () => {
     render(<LineageCanvas />);
     expect(screen.getByTestId('scope-selector-prop')).toHaveTextContent('+sales');
 
-    fireEvent.click(screen.getByTestId('lineage-canvas-reset-scope'));
+    // Driven through the prop Lineage now owns, not a button the canvas draws.
+    fireEvent.click(screen.getByTestId('simulate-reset-scope'));
 
     expect(screen.getByTestId('scope-selector-prop')).toHaveTextContent('*');
-    // The reset button disappears once we're showing the full project.
-    expect(screen.queryByTestId('lineage-canvas-reset-scope')).not.toBeInTheDocument();
   });
 
   test('clicking a node round-trips selection into the workspace store', () => {

--- a/viewer/src/components/views/lineage/LineageSelectorField.jsx
+++ b/viewer/src/components/views/lineage/LineageSelectorField.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+/**
+ * The lineage selector input — one compact `sel` pill, shared by the main
+ * lineage canvas and the mini lineage card.
+ *
+ * It started as markup inside `MiniLineageCard`, while the main canvas had a
+ * full-height bordered input of its own. Two controls for the same grammar,
+ * looking nothing alike. This is the mini card's treatment, lifted out: both
+ * now render the same thing, and a change to the selector affordance happens
+ * once.
+ *
+ * Being one component is also the groundwork for dropping objects INTO the
+ * selector — a drag target has to live somewhere, and it should not be built
+ * twice. `trailing` exists for that: it takes whatever a host wants beside the
+ * input (today, the main canvas's reset button) without either host needing to
+ * rebuild the pill around it.
+ */
+const LineageSelectorField = ({
+  value,
+  onChange,
+  onKeyDown,
+  placeholder,
+  ariaLabel = 'Lineage selector — edit to change depth in either direction',
+  testId,
+  trailing = null,
+}) => (
+  <div className="flex min-w-0 flex-1 items-center gap-2">
+    <div
+      className="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md bg-gray-50 px-2 ring-1 ring-gray-200 focus-within:ring-primary/40"
+      data-testid={testId}
+    >
+      <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-gray-400">
+        sel
+      </span>
+      <input
+        type="text"
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        spellCheck={false}
+        aria-label={ariaLabel}
+        data-testid={testId ? `${testId}-input` : undefined}
+        className="min-w-0 flex-1 truncate bg-transparent font-mono text-[11px] text-gray-800 placeholder-gray-400 outline-none"
+        placeholder={placeholder}
+      />
+    </div>
+    {trailing}
+  </div>
+);
+
+export default LineageSelectorField;

--- a/viewer/src/components/views/lineage/lineageSelector.js
+++ b/viewer/src/components/views/lineage/lineageSelector.js
@@ -1,0 +1,27 @@
+/**
+ * Lineage selector grammar helpers.
+ *
+ * Visivo's selector syntax is `[+N]name[+M]`: a leading `+` pulls in ancestors,
+ * a trailing `+` pulls in descendants, and a digit outside either `+` bounds
+ * that direction (`2+name` = two levels up). A bare `name` is the object alone.
+ *
+ * This lives in its own module because two surfaces derive the selector for
+ * "show me this object's lineage" independently — `useWorkspaceScope` for the
+ * main canvas and `MiniLineageCard` for the small one — and they disagreed:
+ * the main canvas asked for `+name` and so rendered an object with its
+ * upstream but nothing downstream, while the mini card asked for `+name+`
+ * (VIS-1213). Same question, two answers, because the grammar was inline in
+ * both.
+ */
+
+/**
+ * The selector for "this object and everything connected to it", in both
+ * directions and unbounded.
+ *
+ * This is what opening an object's lineage should ask for. An object rendered
+ * with only its ancestors looks like a leaf even when it feeds a dozen things,
+ * which is the opposite of what a lineage view is for.
+ */
+export function neighborhoodSelector(name) {
+  return `+${name}+`;
+}

--- a/viewer/src/components/views/lineage/lineageSelector.js
+++ b/viewer/src/components/views/lineage/lineageSelector.js
@@ -25,3 +25,67 @@
 export function neighborhoodSelector(name) {
   return `+${name}+`;
 }
+
+export const UNBOUNDED = Number.POSITIVE_INFINITY;
+
+/**
+ * Parse a Visivo selector string into `{ name, ancestors, descendants }`.
+ *
+ * Syntax: depth digits sit OUTSIDE the `+`, the `+` always touches the
+ * object name. `+` alone means "unbounded in that direction", a missing
+ * `+` means "no traversal in that direction", and `N+` / `+N` clamps to
+ * N levels.
+ *
+ *   "+revenue_chart+"    → unbounded ancestors + unbounded descendants
+ *   "2+revenue_chart+1"  → 2 ancestor levels, 1 descendant level
+ *   "+revenue_chart"     → unbounded ancestors, no descendants
+ *   "2+revenue_chart"    → 2 ancestor levels, no descendants
+ *   "revenue_chart"      → just the subject row
+ *   "+monthly_revenue+"  → SWAPS the subject to `monthly_revenue` and
+ *                          shows its full upstream + downstream
+ */
+export function parseSelector(text, fallbackName) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) {
+    return { name: fallbackName, ancestors: 0, descendants: 0 };
+  }
+  // ((\d+)?\+)?   optional leading-depth + `+`
+  // ([^+]+?)      the object name (non-greedy, no `+`)
+  // (\+(\d+)?)?   optional trailing `+` + descendant-depth
+  const re = /^((\d+)?\+)?([^+]+?)(\+(\d+)?)?$/;
+  const m = trimmed.match(re);
+  if (!m) {
+    return { name: fallbackName, ancestors: 0, descendants: 0 };
+  }
+  const ancHasPlus = Boolean(m[1]);
+  const ancDigits = m[2] || '';
+  const subjName = (m[3] || '').trim() || fallbackName;
+  const desHasPlus = Boolean(m[4]);
+  const desDigits = m[5] || '';
+
+  const depth = (hasPlus, digits) => {
+    if (!hasPlus) return 0;
+    if (!digits) return UNBOUNDED;
+    const n = parseInt(digits, 10);
+    return Number.isFinite(n) && n >= 0 ? n : UNBOUNDED;
+  };
+
+  return {
+    name: subjName,
+    ancestors: depth(ancHasPlus, ancDigits),
+    descendants: depth(desHasPlus, desDigits),
+  };
+}
+
+/**
+ * The object a selector is centred on, or `''` when it names none (`*`, empty).
+ *
+ * The lineage canvas uses this to decide what to frame: a selector that names
+ * a subject should bring THAT object into view, where an unscoped one should
+ * fit the whole graph.
+ */
+export function subjectOf(selector) {
+  const trimmed = String(selector || '').trim();
+  if (!trimmed || trimmed === '*') return '';
+  return parseSelector(trimmed, '').name || '';
+}

--- a/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
+++ b/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { PiX, PiArrowSquareOut } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
+import LineageSelectorField from '../../lineage/LineageSelectorField';
+import { neighborhoodSelector } from '../../lineage/lineageSelector';
 
 /**
  * MiniLineageCard — VIS-780 / Track C C-4 (shared lineage-card body).
@@ -49,9 +51,10 @@ const BASE_INDENT = 34;
 
 const UNBOUNDED = Number.POSITIVE_INFINITY;
 
-function defaultSelector(name) {
-  return `+${name}+`;
-}
+// Shared with the main lineage canvas so the two cannot answer
+// "show me this object's lineage" differently again (VIS-1213).
+
+const defaultSelector = neighborhoodSelector;
 
 /**
  * Parse a Visivo selector string into `{ name, ancestors, descendants }`.
@@ -367,43 +370,57 @@ const IconTile = ({ type }) => {
   );
 };
 
-const AncestorRow = ({ node, marginLeft, testIdPrefix }) => (
+// A node in the chain is a button: clicking it opens that object, the way
+// clicking a node in the main lineage does. It used to be inert text sealed
+// inside the group's collapse <button>, so a click hit the wrapper and folded
+// the group instead of navigating (VIS-1213).
+const AncestorRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
   <li
     data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
     data-direction="ancestor"
     data-direct={node.isDirect ? 'true' : 'false'}
-    className="relative flex items-center gap-2"
-    style={{
-      height: ROW_HEIGHT,
-      width: ROW_WIDTH,
-      marginLeft,
-    }}
+    className="relative"
+    style={{ marginLeft }}
   >
-    <TypePill type={node.type} />
-    <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
-      {node.name}
-    </span>
-    <IconTile type={node.type} />
+    <button
+      type="button"
+      onClick={() => onOpen && onOpen(node)}
+      title={`Open ${node.name}`}
+      data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
+      className="flex items-center gap-2 rounded-md px-0.5 text-left transition-colors hover:bg-gray-50"
+      style={{ height: ROW_HEIGHT, width: ROW_WIDTH }}
+    >
+      <TypePill type={node.type} />
+      <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
+        {node.name}
+      </span>
+      <IconTile type={node.type} />
+    </button>
   </li>
 );
 
-const DescendantRow = ({ node, marginLeft, testIdPrefix }) => (
+const DescendantRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
   <li
     data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
     data-direction="descendant"
     data-direct={node.isDirect ? 'true' : 'false'}
-    className="relative flex items-center gap-2"
-    style={{
-      height: ROW_HEIGHT,
-      width: ROW_WIDTH,
-      marginLeft,
-    }}
+    className="relative"
+    style={{ marginLeft }}
   >
-    <IconTile type={node.type} />
-    <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
-      {node.name}
-    </span>
-    <TypePill type={node.type} />
+    <button
+      type="button"
+      onClick={() => onOpen && onOpen(node)}
+      title={`Open ${node.name}`}
+      data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
+      className="flex items-center gap-2 rounded-md px-0.5 text-left transition-colors hover:bg-gray-50"
+      style={{ height: ROW_HEIGHT, width: ROW_WIDTH }}
+    >
+      <IconTile type={node.type} />
+      <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
+        {node.name}
+      </span>
+      <TypePill type={node.type} />
+    </button>
   </li>
 );
 
@@ -594,6 +611,25 @@ const MiniLineageCard = ({
   // "Expand" hands the current subject off to the Workspace middle pane's
   // universal lineage lens (E-1): open the subject as a workspace tab, flip
   // the lens to lineage, then dismiss. Callers may override with `onExpand`.
+  // Open any node in the chain — the same round-trip the main lineage does on
+  // a node click. `handleExpand` below is this for the SUBJECT specifically,
+  // and keeps its `onExpand` override; a neighbour has no such override, it
+  // just navigates.
+  const handleOpenNode = node => {
+    if (!node || !node.type || !node.name) return;
+    const { type, name } = node;
+    if (typeof setWorkspaceLensIntent === 'function' && type !== 'dashboard') {
+      setWorkspaceLensIntent({ objectKey: `${type}:${name}`, lens: 'lineage' });
+    }
+    if (typeof openWorkspaceTab === 'function') {
+      openWorkspaceTab({ id: `${type}:${name}`, type, name });
+    }
+    if (typeof setWorkspaceLens === 'function') {
+      setWorkspaceLens('lineage');
+    }
+    onClose && onClose();
+  };
+
   const handleExpand = () => {
     const { type, name } = subjectForRender;
     if (typeof onExpand === 'function') {
@@ -820,25 +856,13 @@ const MiniLineageCard = ({
         </header>
       )}
 
-      <div className="shrink-0 px-3 pt-2">
-        <div
-          className="flex h-7 items-center gap-1.5 rounded-md bg-gray-50 px-2 ring-1 ring-gray-200 focus-within:ring-primary/40"
-          data-testid={`${testIdPrefix}-selector`}
-        >
-          <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-gray-400">
-            sel
-          </span>
-          <input
-            type="text"
-            value={selectorText}
-            onChange={e => setSelectorText(e.target.value)}
-            spellCheck={false}
-            aria-label="Lineage selector — edit to change depth in either direction"
-            data-testid={`${testIdPrefix}-selector-input`}
-            className="min-w-0 flex-1 truncate bg-transparent font-mono text-[11px] text-gray-800 placeholder-gray-400 outline-none"
-            placeholder={defaultSelector(obj.name)}
-          />
-        </div>
+      <div className="flex shrink-0 px-3 pt-2">
+        <LineageSelectorField
+          value={selectorText}
+          onChange={e => setSelectorText(e.target.value)}
+          placeholder={defaultSelector(obj.name)}
+          testId={`${testIdPrefix}-selector`}
+        />
       </div>
 
       <div
@@ -913,39 +937,35 @@ const MiniLineageCard = ({
                 data-testid={`${testIdPrefix}-ancestors`}
                 data-collapsed={ancestorsOpen ? 'false' : 'true'}
               >
+                {/* The collapse control is its own button beside the rows.
+                    It used to WRAP them, so every click on a node hit the
+                    wrapper and folded the group instead of opening the object
+                    (VIS-1213). Shown in both states so the group can still be
+                    folded once it is open. */}
                 <button
                   type="button"
                   onClick={() => setAncestorsOpen(v => !v)}
                   aria-expanded={ancestorsOpen}
-                  aria-label={
-                    ancestorsOpen ? 'Collapse ancestors' : 'Expand ancestors'
-                  }
+                  aria-label={ancestorsOpen ? 'Collapse ancestors' : 'Expand ancestors'}
                   data-testid={`${testIdPrefix}-ancestors-toggle`}
-                  className="block w-full cursor-pointer text-left"
+                  className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
+                  style={{ marginLeft: BASE_INDENT }}
                 >
-                  {ancestorsOpen ? (
-                    <ul
-                      className="flex flex-col"
-                      style={{ rowGap: ROW_GAP }}
-                    >
-                      {ancestors.map((node, i) => (
-                        <AncestorRow
-                          key={`anc-${node.type}-${node.name}-${i}`}
-                          node={node}
-                          marginLeft={ancestorMarginLeft(node)}
-                          testIdPrefix={testIdPrefix}
-                        />
-                      ))}
-                    </ul>
-                  ) : (
-                    <span
-                      className="inline-flex h-4 items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500"
-                      style={{ marginLeft: BASE_INDENT }}
-                    >
-                      +{N} upstream
-                    </span>
-                  )}
+                  {ancestorsOpen ? `hide ${N} upstream` : `+${N} upstream`}
                 </button>
+                {ancestorsOpen && (
+                  <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
+                    {ancestors.map((node, i) => (
+                      <AncestorRow
+                        key={`anc-${node.type}-${node.name}-${i}`}
+                        node={node}
+                        marginLeft={ancestorMarginLeft(node)}
+                        testIdPrefix={testIdPrefix}
+                        onOpen={handleOpenNode}
+                      />
+                    ))}
+                  </ul>
+                )}
               </li>
             )}
 
@@ -966,31 +986,24 @@ const MiniLineageCard = ({
                       : 'Expand descendants'
                   }
                   data-testid={`${testIdPrefix}-descendants-toggle`}
-                  className="block w-full cursor-pointer text-left"
+                  className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
+                  style={{ marginLeft: BASE_INDENT }}
                 >
-                  {descendantsOpen ? (
-                    <ul
-                      className="flex flex-col"
-                      style={{ rowGap: ROW_GAP }}
-                    >
-                      {descendants.map((node, j) => (
-                        <DescendantRow
-                          key={`desc-${node.type}-${node.name}-${j}`}
-                          node={node}
-                          marginLeft={descendantMarginLeft(node)}
-                          testIdPrefix={testIdPrefix}
-                        />
-                      ))}
-                    </ul>
-                  ) : (
-                    <span
-                      className="inline-flex h-4 items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500"
-                      style={{ marginLeft: BASE_INDENT }}
-                    >
-                      +{M} downstream
-                    </span>
-                  )}
+                  {descendantsOpen ? `hide ${M} downstream` : `+${M} downstream`}
                 </button>
+                {descendantsOpen && (
+                  <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
+                    {descendants.map((node, j) => (
+                      <DescendantRow
+                        key={`desc-${node.type}-${node.name}-${j}`}
+                        node={node}
+                        marginLeft={descendantMarginLeft(node)}
+                        testIdPrefix={testIdPrefix}
+                        onOpen={handleOpenNode}
+                      />
+                    ))}
+                  </ul>
+                )}
               </li>
             )}
             </ul>

--- a/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
+++ b/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
@@ -379,16 +379,21 @@ const AncestorRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
     data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
     data-direction="ancestor"
     data-direct={node.isDirect ? 'true' : 'false'}
-    className="relative"
-    style={{ marginLeft }}
+    className="relative flex items-center"
+    style={{
+      height: ROW_HEIGHT,
+      width: ROW_WIDTH,
+      marginLeft,
+    }}
   >
+    {/* The row's box is unchanged — the SVG connectors are drawn against this
+        geometry, so the button fills it rather than resizing it. */}
     <button
       type="button"
       onClick={() => onOpen && onOpen(node)}
       title={`Open ${node.name}`}
       data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
-      className="flex items-center gap-2 rounded-md px-0.5 text-left transition-colors hover:bg-gray-50"
-      style={{ height: ROW_HEIGHT, width: ROW_WIDTH }}
+      className="flex h-full w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
     >
       <TypePill type={node.type} />
       <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
@@ -404,16 +409,19 @@ const DescendantRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
     data-testid={`${testIdPrefix}-lineage-${node.type}-${node.name}`}
     data-direction="descendant"
     data-direct={node.isDirect ? 'true' : 'false'}
-    className="relative"
-    style={{ marginLeft }}
+    className="relative flex items-center"
+    style={{
+      height: ROW_HEIGHT,
+      width: ROW_WIDTH,
+      marginLeft,
+    }}
   >
     <button
       type="button"
       onClick={() => onOpen && onOpen(node)}
       title={`Open ${node.name}`}
       data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
-      className="flex items-center gap-2 rounded-md px-0.5 text-left transition-colors hover:bg-gray-50"
-      style={{ height: ROW_HEIGHT, width: ROW_WIDTH }}
+      className="flex h-full w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
     >
       <IconTile type={node.type} />
       <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
@@ -878,6 +886,31 @@ const MiniLineageCard = ({
             No lineage available for this object.
           </p>
         ) : (
+          <>
+          {/* The collapse controls sit OUTSIDE the ladder, above and below it.
+              Inside, they occupied a rung: every row shifted down and the SVG
+              connectors — which are drawn against the ladder's fixed row
+              geometry — no longer met the nodes they belonged to. Out here they
+              can appear and disappear without the ladder noticing. */}
+          {N > 0 && (
+            <div
+              className="pb-1.5"
+              style={{ marginLeft: BASE_INDENT }}
+              data-testid={`${testIdPrefix}-ancestors`}
+              data-collapsed={ancestorsOpen ? 'false' : 'true'}
+            >
+              <button
+                type="button"
+                onClick={() => setAncestorsOpen(v => !v)}
+                aria-expanded={ancestorsOpen}
+                aria-label={ancestorsOpen ? 'Collapse ancestors' : 'Expand ancestors'}
+                data-testid={`${testIdPrefix}-ancestors-toggle`}
+                className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
+              >
+                {ancestorsOpen ? `hide ${N} upstream` : `+${N} upstream`}
+              </button>
+            </div>
+          )}
           <div className="relative" data-testid={`${testIdPrefix}-chain-wrap`}>
             {(ancestorConnectors.length > 0 ||
               descendantConnectors.length > 0 ||
@@ -932,82 +965,63 @@ const MiniLineageCard = ({
               style={{ rowGap: ROW_GAP }}
               data-testid={`${testIdPrefix}-chain`}
             >
-            {N > 0 && (
-              <li
-                data-testid={`${testIdPrefix}-ancestors`}
-                data-collapsed={ancestorsOpen ? 'false' : 'true'}
-              >
-                {/* The collapse control is its own button beside the rows.
-                    It used to WRAP them, so every click on a node hit the
-                    wrapper and folded the group instead of opening the object
-                    (VIS-1213). Shown in both states so the group can still be
-                    folded once it is open. */}
-                <button
-                  type="button"
-                  onClick={() => setAncestorsOpen(v => !v)}
-                  aria-expanded={ancestorsOpen}
-                  aria-label={ancestorsOpen ? 'Collapse ancestors' : 'Expand ancestors'}
-                  data-testid={`${testIdPrefix}-ancestors-toggle`}
-                  className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
-                  style={{ marginLeft: BASE_INDENT }}
-                >
-                  {ancestorsOpen ? `hide ${N} upstream` : `+${N} upstream`}
-                </button>
-                {ancestorsOpen && (
-                  <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
-                    {ancestors.map((node, i) => (
-                      <AncestorRow
-                        key={`anc-${node.type}-${node.name}-${i}`}
-                        node={node}
-                        marginLeft={ancestorMarginLeft(node)}
-                        testIdPrefix={testIdPrefix}
-                        onOpen={handleOpenNode}
-                      />
-                    ))}
-                  </ul>
-                )}
+            {N > 0 && ancestorsOpen && (
+              <li>
+                <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
+                  {ancestors.map((node, i) => (
+                    <AncestorRow
+                      key={`anc-${node.type}-${node.name}-${i}`}
+                      node={node}
+                      marginLeft={ancestorMarginLeft(node)}
+                      testIdPrefix={testIdPrefix}
+                      onOpen={handleOpenNode}
+                    />
+                  ))}
+                </ul>
               </li>
             )}
 
             <SubjectRow subject={subjectForRender} testIdPrefix={testIdPrefix} />
 
-            {M > 0 && (
-              <li
-                data-testid={`${testIdPrefix}-descendants`}
-                data-collapsed={descendantsOpen ? 'false' : 'true'}
-              >
-                <button
-                  type="button"
-                  onClick={() => setDescendantsOpen(v => !v)}
-                  aria-expanded={descendantsOpen}
-                  aria-label={
-                    descendantsOpen
-                      ? 'Collapse descendants'
-                      : 'Expand descendants'
-                  }
-                  data-testid={`${testIdPrefix}-descendants-toggle`}
-                  className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
-                  style={{ marginLeft: BASE_INDENT }}
-                >
-                  {descendantsOpen ? `hide ${M} downstream` : `+${M} downstream`}
-                </button>
-                {descendantsOpen && (
-                  <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
-                    {descendants.map((node, j) => (
-                      <DescendantRow
-                        key={`desc-${node.type}-${node.name}-${j}`}
-                        node={node}
-                        marginLeft={descendantMarginLeft(node)}
-                        testIdPrefix={testIdPrefix}
-                        onOpen={handleOpenNode}
-                      />
-                    ))}
-                  </ul>
-                )}
+            {M > 0 && descendantsOpen && (
+              <li>
+                <ul className="flex flex-col" style={{ rowGap: ROW_GAP }}>
+                  {descendants.map((node, j) => (
+                    <DescendantRow
+                      key={`desc-${node.type}-${node.name}-${j}`}
+                      node={node}
+                      marginLeft={descendantMarginLeft(node)}
+                      testIdPrefix={testIdPrefix}
+                      onOpen={handleOpenNode}
+                    />
+                  ))}
+                </ul>
               </li>
             )}
             </ul>
           </div>
+          {M > 0 && (
+            <div
+              className="pt-1.5"
+              style={{ marginLeft: BASE_INDENT }}
+              data-testid={`${testIdPrefix}-descendants`}
+              data-collapsed={descendantsOpen ? 'false' : 'true'}
+            >
+              <button
+                type="button"
+                onClick={() => setDescendantsOpen(v => !v)}
+                aria-expanded={descendantsOpen}
+                aria-label={
+                  descendantsOpen ? 'Collapse descendants' : 'Expand descendants'
+                }
+                data-testid={`${testIdPrefix}-descendants-toggle`}
+                className="inline-flex h-4 cursor-pointer items-center rounded bg-gray-100 px-1.5 text-[9.5px] font-medium uppercase tracking-wider text-gray-500 transition-colors hover:bg-gray-200"
+              >
+                {descendantsOpen ? `hide ${M} downstream` : `+${M} downstream`}
+              </button>
+            </div>
+          )}
+          </>
         )}
       </div>
 

--- a/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
+++ b/viewer/src/components/views/workspace/library/MiniLineageCard.jsx
@@ -3,7 +3,11 @@ import { PiX, PiArrowSquareOut } from 'react-icons/pi';
 import useStore from '../../../../stores/store';
 import { getTypeIcon, getTypeColors } from '../../common/objectTypeConfigs';
 import LineageSelectorField from '../../lineage/LineageSelectorField';
-import { neighborhoodSelector } from '../../lineage/lineageSelector';
+import {
+  neighborhoodSelector,
+  parseSelector,
+  UNBOUNDED,
+} from '../../lineage/lineageSelector';
 
 /**
  * MiniLineageCard — VIS-780 / Track C C-4 (shared lineage-card body).
@@ -49,61 +53,11 @@ const BASE_INDENT = 34;
 // Selector parsing — Visivo selector syntax `[+N]name[+M]`
 // ---------------------------------------------------------------------------
 
-const UNBOUNDED = Number.POSITIVE_INFINITY;
 
 // Shared with the main lineage canvas so the two cannot answer
 // "show me this object's lineage" differently again (VIS-1213).
 
 const defaultSelector = neighborhoodSelector;
-
-/**
- * Parse a Visivo selector string into `{ name, ancestors, descendants }`.
- *
- * Syntax: depth digits sit OUTSIDE the `+`, the `+` always touches the
- * object name. `+` alone means "unbounded in that direction", a missing
- * `+` means "no traversal in that direction", and `N+` / `+N` clamps to
- * N levels.
- *
- *   "+revenue_chart+"    → unbounded ancestors + unbounded descendants
- *   "2+revenue_chart+1"  → 2 ancestor levels, 1 descendant level
- *   "+revenue_chart"     → unbounded ancestors, no descendants
- *   "2+revenue_chart"    → 2 ancestor levels, no descendants
- *   "revenue_chart"      → just the subject row
- *   "+monthly_revenue+"  → SWAPS the subject to `monthly_revenue` and
- *                          shows its full upstream + downstream
- */
-function parseSelector(text, fallbackName) {
-  const trimmed = String(text || '').trim();
-  if (!trimmed) {
-    return { name: fallbackName, ancestors: 0, descendants: 0 };
-  }
-  // ((\d+)?\+)?   optional leading-depth + `+`
-  // ([^+]+?)      the object name (non-greedy, no `+`)
-  // (\+(\d+)?)?   optional trailing `+` + descendant-depth
-  const re = /^((\d+)?\+)?([^+]+?)(\+(\d+)?)?$/;
-  const m = trimmed.match(re);
-  if (!m) {
-    return { name: fallbackName, ancestors: 0, descendants: 0 };
-  }
-  const ancHasPlus = Boolean(m[1]);
-  const ancDigits = m[2] || '';
-  const subjName = (m[3] || '').trim() || fallbackName;
-  const desHasPlus = Boolean(m[4]);
-  const desDigits = m[5] || '';
-
-  const depth = (hasPlus, digits) => {
-    if (!hasPlus) return 0;
-    if (!digits) return UNBOUNDED;
-    const n = parseInt(digits, 10);
-    return Number.isFinite(n) && n >= 0 ? n : UNBOUNDED;
-  };
-
-  return {
-    name: subjName,
-    ancestors: depth(ancHasPlus, ancDigits),
-    descendants: depth(desHasPlus, desDigits),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Lineage walker — uses `child_item_names` (the canonical upstream-edge
@@ -393,7 +347,7 @@ const AncestorRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
       onClick={() => onOpen && onOpen(node)}
       title={`Open ${node.name}`}
       data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
-      className="flex h-full w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
+      className="flex h-full w-full cursor-pointer items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
     >
       <TypePill type={node.type} />
       <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">
@@ -421,7 +375,7 @@ const DescendantRow = ({ node, marginLeft, testIdPrefix, onOpen }) => (
       onClick={() => onOpen && onOpen(node)}
       title={`Open ${node.name}`}
       data-testid={`${testIdPrefix}-open-${node.type}-${node.name}`}
-      className="flex h-full w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
+      className="flex h-full w-full cursor-pointer items-center gap-2 rounded-md text-left transition-colors hover:bg-gray-100/70"
     >
       <IconTile type={node.type} />
       <span className="min-w-0 flex-1 truncate text-center text-[11.5px] font-medium text-gray-800">

--- a/viewer/src/components/views/workspace/library/MiniLineageCard.test.jsx
+++ b/viewer/src/components/views/workspace/library/MiniLineageCard.test.jsx
@@ -354,3 +354,37 @@ describe('node click navigates (VIS-1213)', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+
+describe('collapse toggles sit outside the ladder (VIS-1213)', () => {
+  test('neither toggle renders inside the chain', () => {
+    // Placing them inside cost a rung: every row shifted down and the SVG
+    // connectors, which are drawn against the ladder's fixed row geometry,
+    // stopped meeting the nodes they belonged to.
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+
+    const chain = screen.getByTestId('mlc-chain');
+    expect(within(chain).queryByTestId('mlc-ancestors-toggle')).toBeNull();
+    expect(within(chain).queryByTestId('mlc-descendants-toggle')).toBeNull();
+    // Still on screen — just not in the ladder.
+    expect(screen.getByTestId('mlc-ancestors-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('mlc-descendants-toggle')).toBeInTheDocument();
+  });
+
+  test('the ladder holds only lineage rows, in either collapsed state', () => {
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+    const chain = screen.getByTestId('mlc-chain');
+
+    expect(
+      within(chain).getByTestId('mlc-lineage-insight-revenue_breakdown')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mlc-ancestors-toggle'));
+
+    // Collapsing removes the rows and leaves nothing behind in their place.
+    expect(
+      within(chain).queryByTestId('mlc-lineage-insight-revenue_breakdown')
+    ).toBeNull();
+    expect(within(chain).queryByTestId('mlc-ancestors-toggle')).toBeNull();
+  });
+});

--- a/viewer/src/components/views/workspace/library/MiniLineageCard.test.jsx
+++ b/viewer/src/components/views/workspace/library/MiniLineageCard.test.jsx
@@ -301,3 +301,56 @@ describe('MiniLineageCard lazy collection fetch on mount (View-mode fix)', () =>
     expect(spies.fetchDefaults).not.toHaveBeenCalled();
   });
 });
+
+
+describe('node click navigates (VIS-1213)', () => {
+  test('clicking an ancestor opens that object', () => {
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+
+    fireEvent.click(screen.getByTestId('mlc-open-insight-revenue_breakdown'));
+
+    expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'insight:revenue_breakdown',
+      type: 'insight',
+      name: 'revenue_breakdown',
+    });
+  });
+
+  test('clicking a descendant opens that object', () => {
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+
+    fireEvent.click(screen.getByTestId('mlc-open-dashboard-exec_kpi_dashboard'));
+
+    expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'dashboard:exec_kpi_dashboard',
+      type: 'dashboard',
+      name: 'exec_kpi_dashboard',
+    });
+  });
+
+  test('opening a neighbour asks its pane for the lineage lens, so the walk continues', () => {
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+
+    fireEvent.click(screen.getByTestId('mlc-open-insight-revenue_breakdown'));
+
+    expect(useStore.getState().setWorkspaceLensIntent).toHaveBeenCalledWith({
+      objectKey: 'insight:revenue_breakdown',
+      lens: 'lineage',
+    });
+  });
+
+  test('the collapse toggle no longer swallows a node click', () => {
+    // The rows used to sit INSIDE the toggle button, so a click folded the
+    // group instead of navigating. Both must now work independently.
+    render(<MiniLineageCard obj={SUBJECT_CHART} testIdPrefix="mlc" />);
+
+    fireEvent.click(screen.getByTestId('mlc-open-insight-revenue_breakdown'));
+    expect(useStore.getState().openWorkspaceTab).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('mlc-ancestors-toggle'));
+    expect(screen.getByTestId('mlc-ancestors')).toHaveAttribute('data-collapsed', 'true');
+    expect(
+      screen.queryByTestId('mlc-open-insight-revenue_breakdown')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/views/workspace/useWorkspaceScope.js
+++ b/viewer/src/components/views/workspace/useWorkspaceScope.js
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useStore from '../../../stores/store';
 import { getViewDescriptor, DEFAULT_WORKSPACE_VIEW } from './higherLevelViews';
+import { neighborhoodSelector } from '../lineage/lineageSelector';
 
 /**
  * useWorkspaceScope — VIS-775 (Track B B2); reworked in Explore 2.0 Phase 0
@@ -74,7 +75,7 @@ export function useWorkspaceScope() {
     if (activeTab && activeTab.type !== 'dashboard') {
       return {
         scope: 'item',
-        selector: `+${activeTab.name}`,
+        selector: neighborhoodSelector(activeTab.name),
         dashboardName: dashboardName || null,
         selectedItem: { type: activeTab.type, name: activeTab.name },
       };
@@ -94,7 +95,7 @@ export function useWorkspaceScope() {
     if (activeTab && activeTab.type === 'dashboard' && activeTab.name !== dashboardName) {
       return {
         scope: 'dashboard',
-        selector: `+${activeTab.name}`,
+        selector: neighborhoodSelector(activeTab.name),
         dashboardName: activeTab.name,
         selectedItem: { type: 'dashboard', name: activeTab.name },
       };
@@ -104,7 +105,7 @@ export function useWorkspaceScope() {
     if (dashboardName) {
       return {
         scope: 'dashboard',
-        selector: `+${dashboardName}`,
+        selector: neighborhoodSelector(dashboardName),
         dashboardName,
         selectedItem: { type: 'dashboard', name: dashboardName },
       };
@@ -118,7 +119,7 @@ export function useWorkspaceScope() {
       if (type && name) {
         return {
           scope: 'item',
-          selector: `+${name}`,
+          selector: neighborhoodSelector(name),
           dashboardName: null,
           selectedItem: { type, name },
         };

--- a/viewer/src/components/views/workspace/useWorkspaceScope.test.jsx
+++ b/viewer/src/components/views/workspace/useWorkspaceScope.test.jsx
@@ -115,9 +115,7 @@ describe('useWorkspaceScope', () => {
   test('returns dashboard scope when URL is /workspace/dashboard/<name>', () => {
     renderAt('/workspace/dashboard/simple-dashboard');
     expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
-    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
-      '+simple-dashboard'
-    );
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(/^\+simple-dashboard\+$/);
     expect(screen.getByTestId('probe-dashboard')).toHaveTextContent(
       'simple-dashboard'
     );
@@ -132,9 +130,7 @@ describe('useWorkspaceScope', () => {
   test('returns item scope when ?edit=<type>:<name> is present', () => {
     renderAt('/workspace?edit=chart:revenue_chart');
     expect(screen.getByTestId('probe-scope')).toHaveTextContent('item');
-    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
-      '+revenue_chart'
-    );
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(/^\+revenue_chart\+$/);
     expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('null');
     expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('chart');
     expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
@@ -164,9 +160,7 @@ describe('useWorkspaceScope', () => {
     });
     renderAt('/workspace');
     expect(screen.getByTestId('probe-scope')).toHaveTextContent('item');
-    expect(screen.getByTestId('probe-selector')).toHaveTextContent(
-      '+monthly_revenue'
-    );
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(/^\+monthly_revenue\+$/);
     expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('model');
     expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
       'monthly_revenue'
@@ -208,7 +202,7 @@ describe('useWorkspaceScope', () => {
     renderAt('/workspace/dashboard/A');
     expect(screen.getByTestId('probe-scope')).toHaveTextContent('dashboard');
     expect(screen.getByTestId('probe-dashboard')).toHaveTextContent('B');
-    expect(screen.getByTestId('probe-selector')).toHaveTextContent('+B');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(/^\+B\+$/);
     expect(screen.getByTestId('probe-selected-name')).toHaveTextContent('B');
   });
 
@@ -269,7 +263,7 @@ describe('useWorkspaceScope', () => {
     });
     renderAt('/workspace/dashboard/simple-dashboard');
     expect(screen.getByTestId('probe-scope')).toHaveTextContent('item');
-    expect(screen.getByTestId('probe-selector')).toHaveTextContent('+fibonacci');
+    expect(screen.getByTestId('probe-selector')).toHaveTextContent(/^\+fibonacci\+$/);
     expect(screen.getByTestId('probe-selected-type')).toHaveTextContent('chart');
     expect(screen.getByTestId('probe-selected-name')).toHaveTextContent(
       'fibonacci'


### PR DESCRIPTION
VIS-1213 — all six tasks on the ticket.

## 1. Mini-lineage nodes navigate

Each row is now a button that opens that object, the same round-trip the main lineage does on a node click.

They did nothing before because they were inert text sealed **inside** the group's collapse `<button>` — a click hit the wrapper and folded the group. So the collapse control moves out to its own chip beside the rows, and stays visible in both states (`+3 upstream` / `hide 3 upstream`) so the group can still be folded once open.

## 2 + 3 + 4. Two rows of chrome become one

The SCOPE strip repeated the object name already sitting in the selector row directly beneath it. Removed.

The selector row takes the mini card's compact `sel` pill, extracted as **`LineageSelectorField`** and now rendered by *both* surfaces — that was the point of the tweak, so a change to the selector affordance happens once. Its `trailing` slot is where the drag target for dropping objects into the selector will go, so that gets built once too.

`Clear` becomes `Show full project`. These were two buttons for one intent, and `Clear` alone did almost nothing while hosted: it emptied the input and the scope re-seeded it straight back, so you had to press both in the right order to actually see the project. One action now clears the selector *and* widens the scope, and it still works standalone (`/editor`) where there is no scope and clearing the selector IS showing the full project. It disables when there is nothing to reset.

## 5. Fit on selection

The fit effect keyed on `nodes?.length`, so selecting a different object that resolved to the **same number of nodes** never re-fit — the graph stayed anchored where the previous fit left it. That is the "it often doesn't center when you select new items" report, and *often* was tracking whether the node count happened to change.

It now keys on node **membership**. That also settles the original "jumps on select" complaint from the same ticket: a change that only moves nodes — dragging, or pinning a clicked node via `fixedNode` — leaves the signature alone, so the viewport stays exactly where the user put it.

## 6. An object's lineage shows its neighborhood

`useWorkspaceScope` asked for `+name` — ancestors only — so an object that feeds a dozen things rendered as a leaf. The mini card already asked for `+name+`. Both now call a shared `neighborhoodSelector`, so the two surfaces cannot answer the same question differently again.

**The existing tests did not catch this**, and would not have caught a regression either: `toHaveTextContent` substring-matches, so `'+B'` is satisfied by `'+B+'`. The five selector assertions are anchored now (`/^\+B\+$/`), and I verified they fail against the old value before restoring the fix.

## Tests

Full viewer suite: **6758 passed, 358 suites**. `yarn lint` clean.

New coverage: four mini-card navigation tests (ancestor click, descendant click, the lens intent that lets the walk continue, and one pinning that the collapse toggle and a node click now work independently); two on the unified reset (disabled when there's nothing to reset; `onResetScope` fires so a host scope widens); one asserting `LineageCanvas` renders no scope strip of its own.

Updated rather than deleted: the canvas tests that drove the old scope-strip button now drive `onResetScope` through the mock, since the behaviour still exists — it just lives somewhere else.

## Note

`LineageSelectorField` is deliberately dumber than it could be. It takes `trailing` rather than knowing about reset buttons or drag targets, so the DnD work can land in one place without either host rebuilding the pill around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
