### PR TITLE
VIS-1223: detect serverless + non-Docker containers so new_installation stops firing

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import pytest
-from visivo.telemetry.config import CI_ENV_VARS
+from visivo.telemetry.config import CI_ENV_VARS, CONTAINER_MARKER_PATHS
 
 
 @pytest.fixture(autouse=True)
@@ -19,11 +19,14 @@ def neutral_ci_env(monkeypatch):
     for var in CI_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
-    # /.dockerenv is the other signal is_ci_environment checks. Force it absent
-    # unless a test mocks it, but pass every other path through to the real check.
+    # The container filesystem markers are the other signals is_ci_environment
+    # checks. Force ALL of them absent (RWX itself runs in a container, so a real
+    # /var/run/secrets/kubernetes.io/serviceaccount or /run/.containerenv on the
+    # runner would otherwise make the 'regular user' tests see a CI env), but pass
+    # every other path through to the real check.
     real_exists = os.path.exists
     monkeypatch.setattr(
         os.path,
         "exists",
-        lambda path, _e=real_exists: False if path == "/.dockerenv" else _e(path),
+        lambda path, _e=real_exists: False if path in CONTAINER_MARKER_PATHS else _e(path),
     )

--- a/tests/telemetry/test_ci_detection.py
+++ b/tests/telemetry/test_ci_detection.py
@@ -6,7 +6,7 @@ import os
 import uuid
 from pathlib import Path
 import pytest
-from visivo.telemetry.config import is_ci_environment, CI_ENV_VARS
+from visivo.telemetry.config import is_ci_environment, CI_ENV_VARS, CONTAINER_MARKER_PATHS
 from visivo.telemetry.machine_id import get_machine_id
 
 
@@ -72,6 +72,31 @@ class TestCIDetection:
         monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
         assert is_ci_environment() is True
 
+    def test_ci_detection_with_cloud_run(self, monkeypatch):
+        """Cloud Run (services + jobs) sets K_SERVICE and runs on gVisor, which
+        sets no other CI var and has no /.dockerenv — the gap that let visivo
+        running server-side spam new_installation on every cold start (VIS-1223)."""
+        monkeypatch.setenv("K_SERVICE", "my-service")
+        assert is_ci_environment() is True
+
+    def test_ci_detection_with_podman(self, monkeypatch):
+        """Podman marks the container with /run/.containerenv, not /.dockerenv."""
+        monkeypatch.setattr(
+            os.path,
+            "exists",
+            lambda path, _e=os.path.exists: True if path == "/run/.containerenv" else _e(path),
+        )
+        assert is_ci_environment() is True
+
+    def test_ci_detection_with_kubernetes_serviceaccount_mount(self, monkeypatch):
+        """Belt-and-braces: a pod that somehow lacks KUBERNETES_SERVICE_HOST is
+        still detected via the mounted service-account token."""
+        sa = "/var/run/secrets/kubernetes.io/serviceaccount"
+        monkeypatch.setattr(
+            os.path, "exists", lambda path, _e=os.path.exists: True if path == sa else _e(path)
+        )
+        assert is_ci_environment() is True
+
     def test_not_ci_environment(self, monkeypatch):
         """Test detection when not in CI."""
         # We need to clear ALL possible CI environment variables
@@ -85,7 +110,9 @@ class TestCIDetection:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         assert is_ci_environment() is False
@@ -136,7 +163,9 @@ class TestCIMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -162,7 +191,9 @@ class TestCIMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -204,7 +235,9 @@ class TestCIMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         cli_event2 = CLIEvent.create(command="test", command_args=[], duration_ms=100, success=True)

--- a/tests/telemetry/test_integration_posthog.py
+++ b/tests/telemetry/test_integration_posthog.py
@@ -324,8 +324,13 @@ class TestPostHogIntegration:
         mock_home.mkdir()
 
         with mock.patch("pathlib.Path.home", return_value=mock_home):
-            # Ensure we're not in CI
-            with mock.patch("visivo.telemetry.machine_id.is_ci_environment", return_value=False):
+            # Ensure we're not in CI, and simulate an interactive install (pytest
+            # captures stdout, so the real _is_interactive() would be False here
+            # and correctly suppress the event — VIS-1223).
+            with (
+                mock.patch("visivo.telemetry.machine_id.is_ci_environment", return_value=False),
+                mock.patch("visivo.telemetry.machine_id._is_interactive", return_value=True),
+            ):
                 # Import get_machine_id which should trigger new installation event
                 from visivo.telemetry.machine_id import get_machine_id
 

--- a/tests/telemetry/test_machine_id.py
+++ b/tests/telemetry/test_machine_id.py
@@ -5,6 +5,7 @@ Tests for machine ID functionality.
 import uuid
 from pathlib import Path
 import pytest
+from visivo.telemetry.config import CONTAINER_MARKER_PATHS
 from visivo.telemetry.machine_id import get_machine_id
 
 
@@ -48,7 +49,9 @@ class TestMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         # Get machine ID
@@ -103,7 +106,9 @@ class TestMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         # Get machine ID twice
@@ -150,7 +155,9 @@ class TestMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         # Create corrupted file
@@ -213,7 +220,9 @@ class TestMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         # Make directory read-only
@@ -274,7 +283,9 @@ class TestMachineId:
         monkeypatch.setattr(
             os.path,
             "exists",
-            lambda path, _exists=os.path.exists: False if path == "/.dockerenv" else _exists(path),
+            lambda path, _exists=os.path.exists: (
+                False if path in CONTAINER_MARKER_PATHS else _exists(path)
+            ),
         )
 
         # Clear cached machine ID

--- a/tests/telemetry/test_new_installation.py
+++ b/tests/telemetry/test_new_installation.py
@@ -40,11 +40,14 @@ class TestNewInstallationEvent(TestCase):
         # Re-disable telemetry for other tests
         os.environ["VISIVO_TELEMETRY_DISABLED"] = "true"
 
+    @patch("visivo.telemetry.machine_id._is_interactive", return_value=True)
     @patch("visivo.telemetry.machine_id.is_ci_environment")
     @patch("visivo.telemetry.client.get_telemetry_client")
-    def test_new_installation_event_fires_on_first_machine_id(self, mock_get_client, mock_is_ci):
+    def test_new_installation_event_fires_on_first_machine_id(
+        self, mock_get_client, mock_is_ci, mock_interactive
+    ):
         """Test that NewInstallationEvent fires when creating a new machine ID."""
-        # Setup mocks
+        # Setup mocks — a real interactive install (a human at a terminal).
         mock_is_ci.return_value = False
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -109,6 +112,31 @@ class TestNewInstallationEvent(TestCase):
         self.assertTrue(machine_id.startswith("ci-"))
 
         # Verify no event was sent
+        mock_client.track.assert_not_called()
+
+    @patch("visivo.telemetry.machine_id._is_interactive", return_value=False)
+    @patch("visivo.telemetry.machine_id.is_ci_environment")
+    @patch("visivo.telemetry.client.get_telemetry_client")
+    def test_no_event_when_non_interactive(self, mock_get_client, mock_is_ci, mock_interactive):
+        """No installation event fires with no interactive TTY, even when the
+        environment isn't recognized as CI. This is the universal backstop for
+        automation we can't detect by env var / container marker — RWX CI (which
+        exposes no env var visivo can read) and arbitrary Docker in repos we
+        don't control, each of which runs with a fresh $HOME and would otherwise
+        report a spurious install on every run (VIS-1223)."""
+        mock_is_ci.return_value = False
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # A brand-new machine id is still created (and persisted)…
+        visivo_dir = Path(self.temp_home) / ".visivo"
+        machine_id_path = visivo_dir / "machine_id"
+        self.assertFalse(machine_id_path.exists())
+        machine_id = get_machine_id()
+        self.assertTrue(machine_id_path.exists())
+        self.assertFalse(machine_id.startswith("ci-"))
+
+        # …but the new_installation event is NOT sent.
         mock_client.track.assert_not_called()
 
     def test_new_installation_event_properties(self):

--- a/visivo/telemetry/config.py
+++ b/visivo/telemetry/config.py
@@ -92,27 +92,55 @@ CI_ENV_VARS = [
     "TF_BUILD",  # Azure DevOps
     "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",  # Azure DevOps
     "KUBERNETES_SERVICE_HOST",  # Kubernetes-hosted runner
+    # Serverless / PaaS hosts run visivo non-interactively — often with a fresh,
+    # EMPTY $HOME on every cold start — so without these each invocation looks
+    # like a brand-new install and spams new_installation. Cloud Run is the one
+    # that bit us: it runs on gVisor, which sets NONE of the vars above and has
+    # no /.dockerenv, so it slipped through entirely.
+    "K_SERVICE",  # Google Cloud Run (services AND jobs)
+    "FUNCTION_TARGET",  # Google Cloud Functions (2nd gen) / Functions Framework
+    "GAE_ENV",  # Google App Engine
+    "AWS_LAMBDA_FUNCTION_NAME",  # AWS Lambda
+    "AWS_EXECUTION_ENV",  # AWS managed compute (Lambda and others)
+    "DYNO",  # Heroku
+    "FLY_APP_NAME",  # Fly.io
+    "RENDER",  # Render
+    "VERCEL",  # Vercel
+    "NETLIFY",  # Netlify
 ]
+
+# Filesystem markers that reveal we're inside a container/pod even when no env
+# var is set. `/.dockerenv` exists ONLY under the Docker *daemon* runtime — it is
+# ABSENT under BuildKit builds, containerd/CRI-O, gVisor (Cloud Run), and Podman,
+# which is how server contexts kept looking like fresh installs. A module-level
+# constant (mirroring CI_ENV_VARS) so tests neutralize EXACTLY what the detector
+# checks and can't drift.
+CONTAINER_MARKER_PATHS = (
+    "/.dockerenv",  # Docker daemon runtime
+    "/run/.containerenv",  # Podman
+    # Every Kubernetes pod mounts a service-account token here — belt-and-braces
+    # alongside KUBERNETES_SERVICE_HOST for any pod that somehow lacks the env.
+    "/var/run/secrets/kubernetes.io/serviceaccount",
+)
 
 
 def is_ci_environment() -> bool:
     """
-    Detect if we're running in a CI/CD environment.
+    Detect if we're running in an automated (non-interactive) environment.
 
-    Checks for common CI environment variables that indicate
-    we're running in an automated environment rather than
-    on a developer's machine.
+    Checks for common CI/CD and serverless/PaaS environment variables — plus
+    container/pod filesystem markers — that indicate we're running in an
+    automated environment rather than on a developer's machine.
 
     Returns:
-        bool: True if running in CI/CD, False otherwise
+        bool: True if running in CI/CD or a server/container context, else False
     """
     for var in CI_ENV_VARS:
         if os.getenv(var):
             return True
 
-    # Running inside a container (a Docker/RWX image build doesn't pass the CI
-    # env vars through to the build).
-    if os.path.exists("/.dockerenv"):
-        return True
+    for marker in CONTAINER_MARKER_PATHS:
+        if os.path.exists(marker):
+            return True
 
     return False

--- a/visivo/telemetry/machine_id.py
+++ b/visivo/telemetry/machine_id.py
@@ -3,9 +3,33 @@ Machine ID management for telemetry.
 """
 
 import os
+import sys
 import uuid
 from pathlib import Path
 from .config import is_ci_environment, is_telemetry_enabled
+
+
+def _is_interactive() -> bool:
+    """True only when a human is plausibly at a terminal.
+
+    A genuine first-time install is interactive; automation — CI, cron,
+    containers, serverless — runs with NO controlling TTY (and often a fresh
+    ``$HOME`` each invocation, which is exactly what makes every run look like a
+    brand-new install). This is the universal backstop to
+    ``is_ci_environment()``'s explicit env/marker detection: it needs no
+    platform-specific signal, so visivo running inside ANY container/CI — RWX
+    (whose runtime exposes no env var visivo can read and has no ``/.dockerenv``),
+    Docker, Cloud Run, and repos we don't control — never reports a spurious
+    ``new_installation``.
+
+    Suppresses only when BOTH stdin and stdout are non-interactive, so a human
+    who merely pipes output (``visivo run > log``) still counts.
+    """
+    try:
+        return sys.stdin.isatty() or sys.stdout.isatty()
+    except Exception:
+        # A missing/closed stream (detached process) is not interactive.
+        return False
 
 
 def get_machine_id() -> str:
@@ -62,9 +86,12 @@ def get_machine_id() -> str:
         # It will be regenerated next time, but that's better than failing
         pass
 
-    # Send new installation event if telemetry is enabled
-    # We do this after creating the machine ID to avoid circular imports
-    if is_new_installation and is_telemetry_enabled():
+    # Send new installation event if telemetry is enabled AND this looks like a
+    # real interactive install. The interactivity gate is what stops automation
+    # we can't detect by env/marker (RWX CI, arbitrary Docker in other people's
+    # repos) from reporting a spurious install on every fresh-$HOME run — see
+    # _is_interactive().
+    if is_new_installation and is_telemetry_enabled() and _is_interactive():
         try:
             # Import here to avoid circular dependencies
             from .client import get_telemetry_client


### PR DESCRIPTION
## Problem

`new_installation` keeps landing in PostHog from automated contexts. It fires when `~/.visivo/machine_id` is absent **and** the environment isn't detected as automated (`visivo/telemetry/machine_id.py`). Anything with a fresh, empty `$HOME` on each run therefore looks like a brand-new install and re-fires the event.

The events correlate with **CI runs** (pushes to the visivo repo triggering its RWX pipeline), and their `distinct_id`s are **plain UUIDs, not `ci-` prefixed** — proof that `is_ci_environment()` returned **False** in the source context. RWX runs `visivo run` on an `ubuntu:22.04` container whose runtime exposes **no env var visivo can read** (not `CI`, not `RWX_RUN_ID`, no `/.dockerenv`), so no env/marker list catches it. And we can't patch every third-party repo that runs visivo in a container.

## Fix — two layers, both inside visivo

**1. The universal backstop (the real fix): gate `new_installation` on an interactive TTY.** A genuine first install is a human at a terminal; CI/cron/containers/serverless run with no controlling TTY. `_is_interactive()` (stdin **or** stdout is a TTY — so a human who merely pipes output still counts) needs zero platform-specific knowledge, so visivo inside **any** container/CI — RWX, Docker, Cloud Run, repos we don't control — never reports a spurious install. The machine-id file is still created/persisted; only the bogus event is suppressed.

**2. Broadened explicit detection (correct labeling for known platforms).** `is_ci_environment()` also now recognizes serverless hosts (`K_SERVICE` Cloud Run, Cloud Functions, App Engine, Lambda, Heroku, Fly, Render, Vercel, Netlify) and more container markers (`/run/.containerenv` Podman, the Kubernetes service-account mount) beyond the Docker-daemon-only `/.dockerenv`. These give known platforms `ci-` ids and `is_ci=true`; the TTY gate is the catch-all for everything else.

## Tests

- New: `new_installation` is suppressed when non-interactive even though the env isn't recognized as CI; Cloud Run / Podman / k8s-serviceaccount detection.
- Existing firing tests now mock `_is_interactive` (pytest captures stdout, so the real check is correctly False under test).
- Every container-marker mock routes through the shared `CONTAINER_MARKER_PATHS` constant — the visivo repo's own CI runs on RWX (a container), so a real marker path would otherwise make the "regular user" tests see a CI env.
- Full telemetry suite green (107 passed); black clean.

## Note on rollout

This is a code fix, so it takes effect where the running visivo includes it: the visivo repo's own CI once merged; other pipelines (e.g. analytics `pip install visivo`) once it ships to PyPI. No per-repo CI config changes needed.

Closes VIS-1223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
