### PR TITLE
VIS-1230: reopen an untouched source browse-seed instead of duplicating it

### DIFF
--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.jsx
@@ -144,6 +144,22 @@ const ExplorerHomePane = () => {
 
   const handleSourceTile = async sourceName => {
     if (creatingRef.current) return;
+    // VIS-1230: reuse an existing UNTOUCHED browse-seed for this source instead
+    // of minting another exploration with the identical seed-derived name
+    // (`<source> exploration`). Clicking a source is a browse gesture, so a
+    // second click should reopen the browse you already have, not pile up
+    // indistinguishable same-named copies. A seed the user has actually worked
+    // in is gallery-visible — leave it be and start a genuinely new one.
+    const existingSeed = orderedExplorations.find(
+      e =>
+        e.seededFrom?.type === 'source' &&
+        e.seededFrom?.name === sourceName &&
+        !isExplorationVisibleInGallery(e)
+    );
+    if (existingSeed) {
+      openExploration(existingSeed.id);
+      return;
+    }
     creatingRef.current = true;
     setCreating(true);
     try {

--- a/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
+++ b/viewer/src/components/views/workspace/homes/ExplorerHomePane.test.jsx
@@ -163,6 +163,89 @@ describe('ExplorerHomePane — VIS-1084 stale create-completion navigation', () 
   });
 });
 
+// VIS-1230: clicking a source is a browse gesture, so a SEQUENTIAL second
+// click (after the first exploration was created and its tab left open) must
+// reopen that untouched browse-seed rather than pile up indistinguishable
+// same-named explorations. The in-flight guard below only covers rapid/
+// concurrent clicks — this covers deliberate repeat clicks.
+describe('ExplorerHomePane — VIS-1230 source-tile dedup', () => {
+  test('reopens an existing untouched browse-seed for the source instead of creating a duplicate', () => {
+    const createExploration = jest.fn();
+    const openWorkspaceTab = jest.fn();
+    // name === seedDefaultName('warehouse') and empty draft → untouched.
+    const untouched = explorationRecord({
+      id: 'exp_seed',
+      name: 'warehouse exploration',
+      seededFrom: { type: 'source', name: 'warehouse' },
+      draft: { queries: [], insights: [], chart: null, computedColumns: [] },
+    });
+    seed({
+      workspaceExplorations: { byId: { exp_seed: untouched }, order: ['exp_seed'] },
+      sources: [{ name: 'warehouse' }],
+      createExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-source-tile-warehouse'));
+
+    expect(createExploration).not.toHaveBeenCalled();
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'exploration:exp_seed',
+      type: 'exploration',
+      name: 'exp_seed',
+    });
+  });
+
+  test('a source whose only exploration has been worked in still creates a fresh one', async () => {
+    const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+    const openWorkspaceTab = jest.fn();
+    // Renamed away from the seed default → gallery-visible (a "real" one).
+    const touched = explorationRecord({
+      id: 'exp_touched',
+      name: 'My warehouse analysis',
+      seededFrom: { type: 'source', name: 'warehouse' },
+    });
+    seed({
+      workspaceExplorations: { byId: { exp_touched: touched }, order: ['exp_touched'] },
+      sources: [{ name: 'warehouse' }],
+      createExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-source-tile-warehouse'));
+
+    await waitFor(() =>
+      expect(createExploration).toHaveBeenCalledWith({ type: 'source', name: 'warehouse' })
+    );
+  });
+
+  test('an untouched seed for a DIFFERENT source is not reused', async () => {
+    const createExploration = jest.fn().mockResolvedValue({ success: true, id: 'exp_new' });
+    const openWorkspaceTab = jest.fn();
+    const otherSeed = explorationRecord({
+      id: 'exp_other',
+      name: 'other-db exploration',
+      seededFrom: { type: 'source', name: 'other-db' },
+      draft: { queries: [], insights: [], chart: null, computedColumns: [] },
+    });
+    seed({
+      workspaceExplorations: { byId: { exp_other: otherSeed }, order: ['exp_other'] },
+      sources: [{ name: 'warehouse' }, { name: 'other-db' }],
+      createExploration,
+      openWorkspaceTab,
+    });
+    render(<ExplorerHomePane />);
+
+    fireEvent.click(screen.getByTestId('explorer-home-source-tile-warehouse'));
+
+    await waitFor(() =>
+      expect(createExploration).toHaveBeenCalledWith({ type: 'source', name: 'warehouse' })
+    );
+  });
+});
+
 // VIS-1086: every create door needs an in-flight guard — a rapid double
 // click (or two different doors clicked in quick succession) must never
 // mint two records.


### PR DESCRIPTION
## Problem

Clicking a source tile in the Explorer always minted a **new** exploration seeded from that source — and because the name is derived from the source (`"<source> exploration"`), repeated clicks piled up **indistinguishable same-named explorations**. The existing guard (`creatingRef`, VIS-1084/1086) only blocks *rapid/concurrent* clicks; a **deliberate** second click (create tile → go back to Explorer Home → click the same source again) still created a duplicate.

## Fix

`handleSourceTile` now first looks for an existing **untouched browse-seed** for that source — `seededFrom` is `{type:'source', name}` and it isn't yet "real" per `isExplorationVisibleInGallery` — and **reopens** it instead of creating another. Clicking a source is a browse gesture, so a second click reopens the browse you already have.

A seed you've actually worked in *is* gallery-visible, so it's left alone and a genuinely new exploration is created — you can still keep several explorations of the same source once you've started using the earlier one. An untouched seed for a *different* source is never reused.

## Tests

Three new cases in `ExplorerHomePane.test.jsx`:
- reopens an existing untouched browse-seed (no `createExploration`, focuses the existing tab),
- still creates fresh when the only existing exploration for that source has been worked in (renamed away from the seed default),
- doesn't reuse an untouched seed belonging to a different source.

Full suite green (38 passed); lint clean.

Closes VIS-1230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
