### PR TITLE
VIS-1230: unique, space-numbered names for source-seeded explorations

### DIFF
--- a/viewer/src/components/views/workspace/explorationLifecycle.js
+++ b/viewer/src/components/views/workspace/explorationLifecycle.js
@@ -106,7 +106,15 @@ export const hasMeaningfulExplorationContent = record => {
 export const isExplorationRenamedFromSeedDefault = record => {
   if (!record?.seededFrom) return false;
   const expected = seedDefaultName(record.seededFrom);
-  return !!expected && record.name !== expected;
+  if (!expected) return false;
+  if (record.name === expected) return false;
+  // VIS-1230: the auto-numbered duplicate names ("<default> 2", "<default> 3")
+  // this same seed default produces are NOT user renames — a browse-seed that
+  // happens to be the 2nd click for its source must still garbage-collect when
+  // closed untouched, exactly like the 1st. Escape the source-derived name so
+  // its own regex metacharacters can't widen the match.
+  const escaped = expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return !new RegExp(`^${escaped} \\d+$`).test(record.name);
 };
 
 /**

--- a/viewer/src/components/views/workspace/explorationLifecycle.test.js
+++ b/viewer/src/components/views/workspace/explorationLifecycle.test.js
@@ -233,6 +233,39 @@ describe('isExplorationRenamedFromSeedDefault', () => {
     expect(isExplorationRenamedFromSeedDefault(record)).toBe(true);
   });
 
+  it('is false for an auto-numbered duplicate of the default (VIS-1230)', () => {
+    // "<default> 2"/"<default> 3" are what the store's unique-naming produces
+    // for repeat source clicks — still the seed default, not a user rename, so
+    // an untouched one must still garbage-collect on close.
+    const base = { type: 'source', name: 'local-duckdb' };
+    expect(
+      isExplorationRenamedFromSeedDefault({ name: 'local-duckdb exploration 2', seededFrom: base })
+    ).toBe(false);
+    expect(
+      isExplorationRenamedFromSeedDefault({ name: 'local-duckdb exploration 3', seededFrom: base })
+    ).toBe(false);
+  });
+
+  it('is true for a rename that merely starts with the default (not the " N" pattern)', () => {
+    const base = { type: 'source', name: 'local-duckdb' };
+    expect(
+      isExplorationRenamedFromSeedDefault({
+        name: 'local-duckdb exploration notes',
+        seededFrom: base,
+      })
+    ).toBe(true);
+  });
+
+  it('does not let a regex-metachar source name widen the numbered match', () => {
+    // A source literally named "a.b" must not make "aXb exploration 2" read as
+    // its own numbered default (the "." would match any char if unescaped).
+    const record = {
+      name: 'aXb exploration 2',
+      seededFrom: { type: 'source', name: 'a.b' },
+    };
+    expect(isExplorationRenamedFromSeedDefault(record)).toBe(true);
+  });
+
   it('is false when the seed itself cannot produce a default name (no name on the seed)', () => {
     const record = { name: 'Exploration 2', seededFrom: { type: 'source' } };
     expect(isExplorationRenamedFromSeedDefault(record)).toBe(false);

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -348,8 +348,28 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         // 'Exploration N' counter — this is also the SAME name
         // `isExplorationRenamedFromSeedDefault` (explorationLifecycle.js)
         // compares against to detect an explicit rename.
+        // VIS-1230: a seeded create sends a human-readable name derived from
+        // what was explored ("test-source exploration") instead of the backend's
+        // generic "Exploration N" counter. But that name was FIXED, so clicking
+        // the same source twice produced two identically-named explorations.
+        // Number duplicates "<name>", "<name> 2", "<name> 3" so they're
+        // distinguishable — with a SPACE, since explorations aren't YAML objects
+        // and allow spaces (mirrors the backend's own "Exploration N").
         const defaultName = seed ? seedDefaultName(seed) : null;
-        if (defaultName) payload.name = defaultName;
+        if (defaultName) {
+          const takenNames = new Set(
+            Object.values(get().workspaceExplorations.byId || {})
+              .map(e => e?.name)
+              .filter(Boolean)
+          );
+          let uniqueName = defaultName;
+          let suffix = 2;
+          while (takenNames.has(uniqueName)) {
+            uniqueName = `${defaultName} ${suffix}`;
+            suffix += 1;
+          }
+          payload.name = uniqueName;
+        }
         const seedLegacyState = legacyStateOverride || (seed ? legacyStateForSeed(seed) : null);
         if (seedLegacyState) payload.draft = mapDraftToApi(legacyStateToDraft(seedLegacyState));
         const created = await explorationsApi.createExploration(payload, get().project?.id);

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -255,6 +255,52 @@ describe('createExploration', () => {
     });
   });
 
+  // VIS-1230: a second seed with the SAME default name is numbered " 2" so
+  // clicking a source twice yields distinguishable explorations, not two
+  // identically-named ones. The space separator is intentional — explorations
+  // aren't YAML objects and allow spaces.
+  test('numbers a seed whose default name is already taken (" 2", " 3", …)', async () => {
+    seedRecord({ id: 'exp_existing', name: 'orders exploration' });
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ id: 'exp_2', name: 'orders exploration 2' })
+    );
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'model', name: 'orders' });
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'orders exploration 2' }),
+      undefined
+    );
+  });
+
+  test('numbers past a run of taken names to the first free slot', async () => {
+    act(() => {
+      useStore.setState({
+        workspaceExplorations: {
+          byId: {
+            a: mappedRecord({ id: 'a', name: 'orders exploration' }),
+            b: mappedRecord({ id: 'b', name: 'orders exploration 2' }),
+          },
+          order: ['a', 'b'],
+        },
+      });
+    });
+    explorationsApi.createExploration.mockResolvedValueOnce(
+      wireExploration({ id: 'exp_3', name: 'orders exploration 3' })
+    );
+
+    await act(async () => {
+      await useStore.getState().createExploration({ type: 'model', name: 'orders' });
+    });
+
+    expect(explorationsApi.createExploration).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'orders exploration 3' }),
+      undefined
+    );
+  });
+
   // Phase 6c-T1 (ux-audit.md existing-objects #8, drift detection): a
   // hashable seed type (model/insight/chart) whose object IS loaded in the
   // store at seed time gets its content hashed into `content_signature` —


### PR DESCRIPTION
## Problem

Clicking **"+ New exploration"** gets the backend's unique `Exploration N` counter, but clicking a **source** tile overrode the name with a **fixed** `seedDefaultName` (`"test-source exploration"`). So clicking the same source twice produced two **identically-named** explorations — confusing and indistinguishable.

## Fix

The seeded name is now **numbered against existing exploration names**: `"<name>"`, `"<name> 2"`, `"<name> 3"`, … Space-separated on purpose — explorations aren't YAML objects, so spaces are fine (and it matches the backend's own `Exploration N`).

`isExplorationRenamedFromSeedDefault` now treats those `"<default> N"` duplicates as **still the seed default** (not a user rename), so an untouched 2nd/3rd browse-seed still **garbage-collects on close** exactly like the 1st — the auto-numbering doesn't accidentally promote a throwaway browse into the gallery. The source name is regex-escaped so a source literally named `a.b` can't widen the match.

## Tests
- store: numbers a taken seed name to ` 2`, and past a run of taken names to the first free slot.
- lifecycle: `"<default> 2"`/`"3"` are not treated as renames; a name that merely *starts with* the default still is; a regex-metachar source name (`a.b`) doesn't widen the numbered match.
- `explorationLifecycle` + `workspaceExplorationsStore` suites green (145 passed); lint clean.

Part of VIS-1230. (A separate fix is coming for the state-leak where a new exploration also inherits a prior one's query.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)