### PR TITLE
VIS-1226: close the Save-to-project modal on a clean success

### DIFF
--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -291,10 +291,42 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
       return { type: key.slice(0, idx), name: key.slice(idx + 1) };
     });
     const result = await promoteExploration(explorationId, selection);
-    setPromoting(false);
-    setPromotedThisRun(result);
 
-    const failed = (result.results || []).filter(r => !r.success);
+    // Decide the outcome BEFORE any setState, so the offer/failure path's state
+    // updates stay in the exact order (setPromoting -> setPromotedThisRun -> …)
+    // the downstream offer effects were tuned against — inserting work between
+    // those two setStates perturbed the fallback-dashboard default's render
+    // timing (VIS-1226 review).
+    const results = result.results || [];
+    const failed = results.filter(r => !r.success);
+    const succeeded = results.filter(r => r.success);
+    // The exact conditions under which the JSX below renders a post-save offer
+    // the user must act on: a chart it can place in a dashboard, or a
+    // model/metric/dimension it can jump to in the Semantic Layer.
+    const promotedChart = succeeded.find(r => r.type === 'chart') || null;
+    const promotedField =
+      succeeded.find(r => r.type === 'metric' || r.type === 'dimension') ||
+      succeeded.find(r => r.type === 'model') ||
+      null;
+    const hasOffer =
+      (result.reclassificationOffers?.length || 0) > 0 ||
+      (!!promotedChart && (!!returnTo?.dashboard || dashboards.length > 0)) ||
+      !!promotedField;
+
+    setPromoting(false);
+
+    // VIS-1226: a clean success closes like every other modal — no toast,
+    // because the Library and canvas already show the newly-saved objects. The
+    // modal only lingers when there's something to act on: a failed row, a
+    // reclassification decision, or one of the offers above. (Reversing the
+    // prior "never auto-close" behavior, which left the user staring at a bare
+    // "Saved N objects" receipt with a Close button on every ordinary save.)
+    if (failed.length === 0 && succeeded.length > 0 && !hasOffer) {
+      onClose?.();
+      return;
+    }
+
+    setPromotedThisRun(result);
     if (failed.length > 0) {
       setError(
         `${failed.length} object${failed.length === 1 ? '' : 's'} failed to promote: ${failed
@@ -305,17 +337,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     if (result.reclassificationOffers?.length > 0) {
       setReclassificationOffers(result.reclassificationOffers);
     }
-    // Deliberately NEVER auto-close here, even on the common all-valid,
-    // no-collision path: `setPromotedThisRun` and a same-tick `onClose()`
-    // land in the SAME React commit, so the "Saved N objects to project"
-    // success message (and its `exploration-promote-success` testid) would
-    // never actually paint — the modal would just vanish, giving the user no
-    // confirmation of what was saved. Root-caused via live reproduction
-    // against the sandbox (integration-gate fix cycle). The "Close" button's
-    // own label already switches to "Close" once `promotedThisRun` is set
-    // (see the JSX below) — that affordance is how the user dismisses after
-    // reviewing the result, for both the success and failure/offer cases.
-  }, [selected, promoteExploration, explorationId]);
+  }, [selected, promoteExploration, explorationId, returnTo, dashboards, onClose]);
 
   const dismissOffer = useCallback(index => {
     setReclassificationOffers(prev => prev.filter((_, i) => i !== index));
@@ -362,13 +384,15 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   // `return_to` intent already offering placement, and at least one
   // dashboard exists to place it in.
   const showFallbackDashboardOffer = !!promotedChart && !returnTo?.dashboard && dashboards.length > 0;
-  const [fallbackDashboardName, setFallbackDashboardName] = useState('');
-  useEffect(() => {
-    if (showFallbackDashboardOffer && !fallbackDashboardName) {
-      setFallbackDashboardName(dashboards[0]?.name || '');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showFallbackDashboardOffer, dashboards]);
+  // The user's explicit pick, or `null` until they choose one. The effective
+  // name is derived SYNCHRONOUSLY (default = first dashboard) rather than seeded
+  // via an effect: an effect costs an extra render, and the guarded placement
+  // below (whose fn is swapped in post-commit by useGuardedAsync) could capture
+  // the pre-effect empty value if the click lands in that window — which is
+  // exactly the flake a render-timing change surfaced (VIS-1226 review).
+  const [fallbackDashboardChoice, setFallbackDashboardChoice] = useState(null);
+  const fallbackDashboardName =
+    fallbackDashboardChoice != null ? fallbackDashboardChoice : dashboards[0]?.name || '';
   const [fallbackPlaceError, setFallbackPlaceError] = useState(null);
 
   // The double-click guard + `pending` flag for these placement actions lives
@@ -753,7 +777,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
               <Select
                 data-testid="exploration-promote-fallback-dashboard-select"
                 value={fallbackDashboardName}
-                onChange={setFallbackDashboardName}
+                onChange={setFallbackDashboardChoice}
                 disabled={fallbackPlacing}
                 size="sm"
                 isSearchable={false}

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -42,7 +42,7 @@ describe('ExplorationPromoteModal', () => {
     expect(screen.queryByTestId('exploration-promote-return-to-offer')).not.toBeInTheDocument();
   });
 
-  test('fails safe when the dashboards collection itself is undefined (not just empty)', async () => {
+  test('fails safe (no crash) when the dashboards collection is undefined, and closes the clean success', async () => {
     buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
     useStore.setState({
       dashboards: undefined,
@@ -52,10 +52,13 @@ describe('ExplorationPromoteModal', () => {
         reclassificationOffers: [],
       }),
     });
-    render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+    const onClose = jest.fn();
+    render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
     await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
     fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-    await screen.findByTestId('exploration-promote-success');
+    // dashboards undefined must not throw; with no dashboards and no field this
+    // is a clean success, so the modal closes rather than linger (VIS-1226).
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(
       screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
     ).not.toBeInTheDocument();
@@ -236,7 +239,7 @@ describe('ExplorationPromoteModal', () => {
     expect(screen.getByTestId('exploration-promote-submit')).toBeDisabled();
   });
 
-  test('clicking Promote calls promoteExploration with the selection, shows the success message, and stays open until the user clicks Close', async () => {
+  test('promoting a model keeps the modal open via the Semantic-Layer offer, shows the success message, and closes on Close', async () => {
     buildPromoteChecklist.mockResolvedValue([row()]);
     const promoteExploration = jest
       .fn()
@@ -251,10 +254,9 @@ describe('ExplorationPromoteModal', () => {
     await waitFor(() =>
       expect(promoteExploration).toHaveBeenCalledWith('exp_1', [{ type: 'model', name: 'orders_q' }])
     );
-    // Deliberately does NOT auto-close on the common all-valid, no-collision
-    // path: `setPromotedThisRun` and a same-tick `onClose()` would land in
-    // the same React commit, so the "Saved N objects to project" confirmation would
-    // never actually paint. The user reviews it and dismisses via "Close".
+    // VIS-1226: a clean success closes, but a promoted MODEL is an OFFER (its
+    // "View in the Semantic Layer" prompt), so THIS run legitimately stays open
+    // showing the success message + that offer until the user dismisses it.
     expect(await screen.findByTestId('exploration-promote-success')).toHaveTextContent(
       'Saved 1 object to project.'
     );
@@ -262,6 +264,28 @@ describe('ExplorationPromoteModal', () => {
     expect(screen.getByTestId('exploration-promote-cancel')).toHaveTextContent('Close');
     fireEvent.click(screen.getByTestId('exploration-promote-cancel'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  test('VIS-1226: a clean success with nothing to act on auto-closes without a receipt or toast', async () => {
+    // A promote that yields no failed row, no reclassification, no chart to
+    // place, and no model/metric/dimension to jump to = nothing to decide, so
+    // it closes immediately. (Only an insight here.)
+    buildPromoteChecklist.mockResolvedValue([row({ tier: 'insight', type: 'insight', name: 'my_insight' })]);
+    const promoteExploration = jest.fn().mockResolvedValue({
+      success: true,
+      results: [{ type: 'insight', name: 'my_insight', success: true, error: null }],
+      reclassificationOffers: [],
+    });
+    useStore.setState({ promoteExploration });
+    const onClose = jest.fn();
+    render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    // No lingering receipt: the success banner never renders on the close path.
+    expect(screen.queryByTestId('exploration-promote-success')).not.toBeInTheDocument();
   });
 
   test('a partial failure stays open and shows the error, does not auto-close', async () => {
@@ -471,14 +495,17 @@ describe('ExplorationPromoteModal', () => {
       expect(fallback).toHaveTextContent('churn_chart');
     });
 
-    test('no fallback offer when no dashboards exist at all', async () => {
+    test('closes on a clean success when a chart is promoted but no dashboards exist to place it in (VIS-1226)', async () => {
       seedReturnTo(null, { dashboards: [] });
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
       useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
-      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      await screen.findByTestId('exploration-promote-success');
+      // No dashboards to offer and no field to jump to -> nothing to act on, so
+      // the modal closes instead of lingering on a bare "Saved" receipt.
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
       expect(
         screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
       ).not.toBeInTheDocument();
@@ -907,7 +934,7 @@ describe('ExplorationPromoteModal', () => {
       expect(offer).toHaveTextContent('orders_q');
     });
 
-    test('no offer when only an insight (no model/metric/dimension) was promoted this run', async () => {
+    test('closes on a clean success when only an insight (no model/metric/dimension/chart) was promoted (VIS-1226)', async () => {
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'insight', type: 'insight', name: 'my_insight' })]);
       useStore.setState({
         promoteExploration: jest.fn().mockResolvedValue({
@@ -916,10 +943,12 @@ describe('ExplorationPromoteModal', () => {
           reclassificationOffers: [],
         }),
       });
-      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      await screen.findByTestId('exploration-promote-success');
+      // Nothing to act on -> closes like every other modal (VIS-1226).
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
       expect(
         screen.queryByTestId('exploration-promote-semantic-layer-offer')
       ).not.toBeInTheDocument();
@@ -1334,14 +1363,17 @@ describe('ExplorationPromoteModal', () => {
       expect(fallback).toHaveTextContent('churn_chart');
     });
 
-    test('no fallback offer when no dashboards exist at all', async () => {
+    test('closes on a clean success when a chart is promoted but no dashboards exist to place it in (VIS-1226)', async () => {
       seedReturnTo(null, { dashboards: [] });
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
       useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
-      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      await screen.findByTestId('exploration-promote-success');
+      // No dashboards to offer and no field to jump to -> nothing to act on, so
+      // the modal closes instead of lingering on a bare "Saved" receipt.
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
       expect(
         screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
       ).not.toBeInTheDocument();
@@ -1908,7 +1940,7 @@ describe('ExplorationPromoteModal', () => {
       expect(offer).toHaveTextContent('orders_q');
     });
 
-    test('no offer when only an insight (no model/metric/dimension) was promoted this run', async () => {
+    test('closes on a clean success when only an insight (no model/metric/dimension/chart) was promoted (VIS-1226)', async () => {
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'insight', type: 'insight', name: 'my_insight' })]);
       useStore.setState({
         promoteExploration: jest.fn().mockResolvedValue({
@@ -1917,10 +1949,12 @@ describe('ExplorationPromoteModal', () => {
           reclassificationOffers: [],
         }),
       });
-      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      await screen.findByTestId('exploration-promote-success');
+      // Nothing to act on -> closes like every other modal (VIS-1226).
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
       expect(
         screen.queryByTestId('exploration-promote-semantic-layer-offer')
       ).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem

The Save-to-project (promote) modal **deliberately never auto-closed**, so every ordinary save left the user staring at a bare "Saved N objects to project" receipt with a Close button — inconsistent with every other modal in the app.

## Fix (per the agreed decision)

It now **closes on a clean success** — no toast, since the Library and canvas already show the new objects. The modal only **lingers when there's something to act on**:
- a **failed** row (error), or
- a **reclassification** decision, or
- a post-save **offer** — place the chart in a dashboard, or view a model/metric/dimension in the Semantic Layer.

(So a query→chart promote, which creates a model, still stays open via the Semantic-Layer offer — that's an offer, not a bare receipt.)

## Also: hardened the fallback-dashboard offer

The timing-sensitivity of this change surfaced a latent flake: the fallback offer's **default dashboard selection was seeded by an effect** (an extra render), and `useGuardedAsync` swaps its `fn` in a *post-commit* effect — so a click landing in that window called `placeChartInDashboardSlot('')` with an empty name. Now the effective dashboard is derived **synchronously** (default = first dashboard), removing the effect and the race. This also fixes a **pre-existing flake** in the "coverage-push" copy of that test.

## Tests
- Offer-less successes (insight-only; chart with no dashboards) now assert the modal **closes** (`onClose` called, no receipt).
- A promoted **model** still keeps it open via the Semantic-Layer offer.
- Failures / reclassification / dashboard+semantic offers all stay open (unchanged).
- New explicit "clean success auto-closes without a receipt or toast" case.
- Full `ExplorationPromoteModal` suite green (99).

Closes VIS-1226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)