### PR TITLE
Library row menu: drop redundant open items, Show lineage opens + centers

### DIFF
--- a/viewer/src/components/views/lineage/Lineage.jsx
+++ b/viewer/src/components/views/lineage/Lineage.jsx
@@ -104,6 +104,12 @@ const Lineage = ({
   const [fixedNode, setFixedNode] = useState(null); // { id, position } for keeping clicked node in place
 
   const reactFlowInstance = useRef(null);
+  // React Flow calls `onInit` AFTER the first render, and on a fresh mount
+  // (opening straight onto the Lineage lens — e.g. the Library row's "Show
+  // lineage") that can land after the reframe effect below has already run its
+  // single pass, leaving the subject un-centred. Flip this in `onInit` and key
+  // the reframe on it so the camera lands on the subject once the flow is ready.
+  const [flowReady, setFlowReady] = useState(false);
 
 
   // Standalone (`/editor`): fetch every collection on mount and flip
@@ -377,7 +383,7 @@ const Lineage = ({
 
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialLoadDone, nodeSignature, selector]);
+  }, [initialLoadDone, nodeSignature, selector, flowReady]);
 
   // Global keyboard handler for Escape key
   useEffect(() => {
@@ -600,6 +606,7 @@ const Lineage = ({
             onEdgesDelete={handleEdgesDelete}
             onInit={instance => {
               reactFlowInstance.current = instance;
+              setFlowReady(true);
             }}
             minZoom={0.1}
             maxZoom={2}

--- a/viewer/src/components/views/workspace/ObjectCanvasFrame.jsx
+++ b/viewer/src/components/views/workspace/ObjectCanvasFrame.jsx
@@ -118,8 +118,16 @@ const ObjectCanvasFrame = ({ activeObject, projectId }) => {
     }
   }, [objectKey, requestedLens, defaultLens]);
 
+  // Apply + consume a one-shot lens intent. The object-change effect above
+  // already handles the case where the intent arrives together with a NEW
+  // selection; this covers an intent that arrives for the object ALREADY open
+  // (e.g. "Show lineage" on the object you're currently viewing) — objectKey
+  // doesn't change, so the re-default effect never fires and, without applying
+  // it here, the intent would be cleared un-honoured (a silent no-op).
   React.useEffect(() => {
-    if (intentLens && clearWorkspaceLensIntent) clearWorkspaceLensIntent();
+    if (!intentLens) return;
+    setLensEffective(intentLens);
+    if (clearWorkspaceLensIntent) clearWorkspaceLensIntent();
   }, [intentLens, clearWorkspaceLensIntent]);
 
   // Clamp any stale / invalid lens to the type's default (a fallback type can

--- a/viewer/src/components/views/workspace/ObjectCanvasFrame.test.jsx
+++ b/viewer/src/components/views/workspace/ObjectCanvasFrame.test.jsx
@@ -82,6 +82,29 @@ describe('ObjectCanvasFrame', () => {
     expect(screen.queryByTestId('canvas-readonly-pill')).not.toBeInTheDocument();
   });
 
+  test('a lens intent for the ALREADY-open object switches to Lineage (no objectKey change)', async () => {
+    const clearWorkspaceLensIntent = jest.fn();
+    act(() => {
+      useStore.setState({ workspaceLensIntent: null, clearWorkspaceLensIntent });
+    });
+    render(frameFor('chart', 'revenue'));
+    // Starts on the canvas/preview lens, not lineage.
+    await screen.findByTestId('chart-preview-mock');
+    expect(screen.queryByTestId('lineage-canvas-mock')).not.toBeInTheDocument();
+
+    // "Show lineage" on the object you're ALREADY viewing sets a one-shot intent
+    // for the SAME objectKey — no selection change, so the re-default effect
+    // never fires. It must still switch to Lineage (VIS: same-object no-op fix).
+    act(() => {
+      useStore.setState({
+        workspaceLensIntent: { objectKey: 'chart:revenue', lens: 'lineage' },
+      });
+    });
+
+    expect(screen.getByTestId('lineage-canvas-mock')).toBeInTheDocument();
+    expect(clearWorkspaceLensIntent).toHaveBeenCalled();
+  });
+
   test('a serve-only canvas degrades to the unavailable state on the dist build', async () => {
     isAvailable.mockReturnValue(false);
     render(frameFor('model', 'orders'));

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -86,6 +86,10 @@ const Library = () => {
   // required props (the parent LeftRail mounts it as `<Library />`).
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const openWorkspaceTabBackground = useStore(s => s.openWorkspaceTabBackground);
+  // "Show lineage" opens the object on its Lineage lens (same mechanism the
+  // lineage-node click / MiniLineageCard use).
+  const setWorkspaceLensIntent = useStore(s => s.setWorkspaceLensIntent);
+  const setWorkspaceLens = useStore(s => s.setWorkspaceLens);
   const createExploration = useStore(s => s.createExploration);
   const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
   const addObjectToActiveExploration = useStore(s => s.addObjectToActiveExploration);
@@ -259,9 +263,9 @@ const Library = () => {
         name: obj.name,
         action,
       });
-      // VIS-811 / O-2: the open actions are live; `wrapInChart`/`showLineage`/
-      // `delete` stay telemetry-only until their tracks wire them. VIS-1067
-      // wires `exploreThis`/`addToExploration`.
+      // VIS-811 / O-2: the open actions are live; `wrapInChart`/`delete` stay
+      // telemetry-only until their tracks wire them. VIS-1067 wires
+      // `exploreThis`/`addToExploration`; `showLineage` is wired below.
       const type = routeType(obj);
       if (action === 'edit' && openWorkspaceTab) {
         openWorkspaceTab({ id: `${type}:${obj.name}`, type, name: obj.name });
@@ -271,6 +275,17 @@ const Library = () => {
           type,
           name: obj.name,
         });
+      } else if (action === 'showLineage' && openWorkspaceTab) {
+        // Open the object AND land on its Lineage lens. Per-object panes track
+        // their lens locally and ignore the store lens, so a non-dashboard
+        // subject needs the one-shot object-scoped intent to actually open on
+        // Lineage; setWorkspaceLens covers the dashboard pane. Mirrors
+        // MiniLineageCard's `handleOpenNode` / LineageCanvas node-open.
+        if (setWorkspaceLensIntent && type !== 'dashboard') {
+          setWorkspaceLensIntent({ objectKey: `${type}:${obj.name}`, lens: 'lineage' });
+        }
+        openWorkspaceTab({ id: `${type}:${obj.name}`, type, name: obj.name });
+        if (setWorkspaceLens) setWorkspaceLens('lineage');
       } else if (action === 'exploreThis' && createExploration && openWorkspaceTab) {
         const seed = { type, name: obj.name };
         const legacyStateOverride = buildExplorationSeedState
@@ -289,6 +304,8 @@ const Library = () => {
     [
       openWorkspaceTab,
       openWorkspaceTabBackground,
+      setWorkspaceLensIntent,
+      setWorkspaceLens,
       createExploration,
       buildExplorationSeedState,
       addObjectToActiveExploration,

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -282,12 +282,12 @@ describe('Library', () => {
     // `onContextAction` was already being passed to the source row by
     // LibrarySubsection — the old component just never accepted it, so the
     // whole menu was dead for sources.
-    const openWorkspaceTabBackground = jest.fn();
-    seedStore({ openWorkspaceTabBackground });
+    const openWorkspaceTab = jest.fn();
+    seedStore({ openWorkspaceTab });
     renderLibrary();
     fireEvent.contextMenu(screen.getByTestId('library-row-source-local-duck'));
-    fireEvent.click(screen.getByText('Open in new tab'));
-    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
+    fireEvent.click(screen.getByText('Show lineage'));
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
       id: 'source:local-duck',
       type: 'source',
       name: 'local-duck',
@@ -311,50 +311,19 @@ describe('Library', () => {
 
   // Right-click context actions (VIS-811 / Track O O-2) ----------------------
 
-  test('row context "Open in new tab" background-opens (openWorkspaceTabBackground), not openWorkspaceTab', () => {
-    const openWorkspaceTab = jest.fn();
-    const openWorkspaceTabBackground = jest.fn();
-    seedStore({ openWorkspaceTab, openWorkspaceTabBackground });
-    renderLibrary();
-
-    fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
-    const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
-    fireEvent.click(within(menu).getByText('Open in new tab'));
-
-    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
-      id: 'chart:waterfall',
-      type: 'chart',
-      name: 'waterfall',
-    });
-    expect(openWorkspaceTab).not.toHaveBeenCalled();
-  });
-
-  test('row context "Open in right rail" focuses the tab via openWorkspaceTab', () => {
-    const openWorkspaceTab = jest.fn();
-    const openWorkspaceTabBackground = jest.fn();
-    seedStore({ openWorkspaceTab, openWorkspaceTabBackground });
-    renderLibrary();
-
-    fireEvent.contextMenu(screen.getByTestId('library-row-model-monthly_revenue'));
-    const menu = screen.getByTestId('library-row-model-monthly_revenue-context-menu');
-    fireEvent.click(within(menu).getByText('Open in right rail'));
-
-    expect(openWorkspaceTab).toHaveBeenCalledWith({
-      id: 'model:monthly_revenue',
-      type: 'model',
-      name: 'monthly_revenue',
-    });
-    expect(openWorkspaceTabBackground).not.toHaveBeenCalled();
-  });
+  // "Open in right rail" / "Open in new tab" removed (VIS-1234 follow-up):
+  // clicking a row already opens it (covered above), so those items only
+  // duplicated the click. The remaining live menu action tested here is
+  // "Show lineage".
 
   test('a mousedown INSIDE the row menu does not dismiss it (real-cursor click sequence)', () => {
-    const openWorkspaceTabBackground = jest.fn();
-    seedStore({ openWorkspaceTab: jest.fn(), openWorkspaceTabBackground });
+    const openWorkspaceTab = jest.fn();
+    seedStore({ openWorkspaceTab });
     renderLibrary();
 
     fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
     const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
-    const item = within(menu).getByText('Open in new tab');
+    const item = within(menu).getByText('Show lineage');
 
     // A REAL cursor fires mousedown → mouseup → click. If the mousedown
     // dismisses (unmounts) the menu, the click never lands and the action is
@@ -365,7 +334,7 @@ describe('Library', () => {
     ).toBeInTheDocument();
     fireEvent.mouseUp(item);
     fireEvent.click(item);
-    expect(openWorkspaceTabBackground).toHaveBeenCalledWith({
+    expect(openWorkspaceTab).toHaveBeenCalledWith({
       id: 'chart:waterfall',
       type: 'chart',
       name: 'waterfall',
@@ -397,11 +366,11 @@ describe('Library', () => {
 
     fireEvent.contextMenu(screen.getByTestId('library-row-chart-waterfall'));
     const menu = screen.getByTestId('library-row-chart-waterfall-context-menu');
-    fireEvent.click(within(menu).getByText('Open in new tab'));
+    fireEvent.click(within(menu).getByText('Show lineage'));
 
     const ctx = events.find(e => e.eventName === 'library_row_context_action');
     expect(ctx).toBeTruthy();
-    expect(ctx.payload).toEqual({ type: 'chart', name: 'waterfall', action: 'openInNewTab' });
+    expect(ctx.payload).toEqual({ type: 'chart', name: 'waterfall', action: 'showLineage' });
     unsubscribe();
   });
 
@@ -468,24 +437,29 @@ describe('Library', () => {
       expect(openWorkspaceTab).not.toHaveBeenCalled();
     });
 
-    test('a context action with no wired handler (e.g. "Show lineage") only emits telemetry — no crash, no store call', () => {
-      const events = [];
-      const unsubscribe = setWorkspaceTelemetryListener(e => events.push(e));
+    test('"Show lineage" opens the object AND lands on its Lineage lens', () => {
       const openWorkspaceTab = jest.fn();
-      const createExploration = jest.fn();
-      const addObjectToActiveExploration = jest.fn();
-      seedStore({ openWorkspaceTab, createExploration, addObjectToActiveExploration });
+      const setWorkspaceLensIntent = jest.fn();
+      const setWorkspaceLens = jest.fn();
+      seedStore({ openWorkspaceTab, setWorkspaceLensIntent, setWorkspaceLens });
       renderLibrary();
 
       fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
       const menu = screen.getByTestId('library-row-insight-revenue_growth-context-menu');
-      expect(() => fireEvent.click(within(menu).getByText('Show lineage'))).not.toThrow();
+      fireEvent.click(within(menu).getByText('Show lineage'));
 
-      expect(createExploration).not.toHaveBeenCalled();
-      expect(addObjectToActiveExploration).not.toHaveBeenCalled();
-      const ctx = events.find(e => e.eventName === 'library_row_context_action');
-      expect(ctx.payload).toEqual({ type: 'insight', name: 'revenue_growth', action: 'showLineage' });
-      unsubscribe();
+      // One-shot object-scoped intent so the per-object pane opens on Lineage,
+      // the tab is opened, and the store lens is set for the dashboard pane.
+      expect(setWorkspaceLensIntent).toHaveBeenCalledWith({
+        objectKey: 'insight:revenue_growth',
+        lens: 'lineage',
+      });
+      expect(openWorkspaceTab).toHaveBeenCalledWith({
+        id: 'insight:revenue_growth',
+        type: 'insight',
+        name: 'revenue_growth',
+      });
+      expect(setWorkspaceLens).toHaveBeenCalledWith('lineage');
     });
 
     test('"Add to exploration" is offered only when the active tab is an exploration, and calls addObjectToActiveExploration', () => {

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -4,8 +4,6 @@ import {
   PiTreeStructure,
   PiDotsThreeOutlineVertical,
   PiDotsSix,
-  PiPencil,
-  PiArrowSquareOut,
   PiTrash,
   PiCompass,
   PiPlusCircle,
@@ -192,22 +190,8 @@ const ContextMenu = ({ obj, onAction, onDismiss, canAddToExploration = false }) 
             />
           </li>
         )}
-        <li>
-          <ContextMenuItem
-            icon={PiPencil}
-            label="Open in right rail"
-            hint="↵"
-            onClick={handle('edit')}
-          />
-        </li>
-        <li>
-          <ContextMenuItem
-            icon={PiArrowSquareOut}
-            label="Open in new tab"
-            hint="⌘↵"
-            onClick={handle('openInNewTab')}
-          />
-        </li>
+        {/* "Open in right rail" / "Open in new tab" removed — clicking the row
+            already opens the object, so those items just duplicated the click. */}
         <li>
           <ContextMenuItem
             icon={PiTreeStructure}

--- a/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.test.jsx
@@ -163,7 +163,7 @@ describe('LibraryRow', () => {
     // onMouseDown must preventDefault (never lose focus) and the doc-level
     // outside-click guard must see the target is INSIDE the menu and leave
     // it open.
-    const menuItem = within(menu).getByText('Open in right rail');
+    const menuItem = within(menu).getByText('Show lineage');
     fireEvent.mouseDown(menuItem);
     expect(screen.getByTestId('library-row-insight-revenue_growth-context-menu')).toBeInTheDocument();
   });
@@ -210,21 +210,20 @@ describe('LibraryRow', () => {
     ).not.toHaveTextContent('Wrap in Chart');
   });
 
-  test('context menu carries the Open-in-new-tab + Delete items and kbd hints', () => {
-    // Regression: menu was missing Open-in-new-tab + Delete… (with divider)
-    // and the keyboard hints per the C-1 design.
+  test('context menu carries Show-lineage + Delete (no redundant open items), with kbd hints', () => {
     render(withDnd(<LibraryRow obj={MODEL} />));
     fireEvent.mouseEnter(screen.getByTestId('library-row-model-monthly_revenue'));
     fireEvent.click(screen.getByTestId('library-row-model-monthly_revenue-kebab'));
     const menu = screen.getByTestId('library-row-model-monthly_revenue-context-menu');
-    expect(menu).toHaveTextContent('Open in right rail');
-    expect(menu).toHaveTextContent('Open in new tab');
+    // "Open in right rail" / "Open in new tab" removed — clicking the row
+    // already opens it, so those items only duplicated the click.
+    expect(menu).not.toHaveTextContent('Open in right rail');
+    expect(menu).not.toHaveTextContent('Open in new tab');
     expect(menu).toHaveTextContent('Show lineage');
     expect(menu).toHaveTextContent('Delete…');
-    // Keyboard hints — the design's discoverability cue.
-    expect(menu).toHaveTextContent('↵');
-    expect(menu).toHaveTextContent('⌘↵');
-    expect(menu).toHaveTextContent('⌫');
+    // Remaining keyboard hints — the design's discoverability cue.
+    expect(menu).toHaveTextContent('F'); // Show lineage
+    expect(menu).toHaveTextContent('⌫'); // Delete
   });
 
   // VIS-1067 — "Explore this" / "Add to exploration" context-menu entries.

--- a/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySourceRow.test.jsx
@@ -116,8 +116,8 @@ describe('LibrarySourceRow', () => {
       )
     );
     fireEvent.contextMenu(screen.getByTestId('library-row-source-warehouse'));
-    fireEvent.click(screen.getByText('Open in new tab'));
-    expect(onContextAction).toHaveBeenCalledWith('openInNewTab', SOURCE);
+    fireEvent.click(screen.getByText('Show lineage'));
+    expect(onContextAction).toHaveBeenCalledWith('showLineage', SOURCE);
   });
 
   test('Enter on the focused row selects it — sources had no keyboard activation at all', () => {


### PR DESCRIPTION
## What

Fixes to the left-sidebar row **"⋯" menu** on an item, plus the lineage it opens onto:

1. **Removed "Open in right rail" and "Open in new tab".** They only duplicated what clicking the row already does. Clicking a row still opens it; the underlying `edit`/`openInNewTab` handlers are unchanged (just no longer have redundant menu triggers).
2. **"Show lineage" now works.** It was wired to nothing (`handleContextAction` had no `showLineage` branch — telemetry only). It now **opens the object AND lands on its Lineage lens**, using the same mechanism a lineage-node click / `MiniLineageCard` use: `setWorkspaceLensIntent({ objectKey, lens: 'lineage' })` + `openWorkspaceTab` + `setWorkspaceLens('lineage')`.
3. **The lineage now centers on the object.** The reframe effect already pans to the scoped subject, but it bailed when the React Flow instance wasn't ready yet — and on a fresh mount straight onto the Lineage lens (exactly the "Show lineage" path) `onInit` fires *after* that effect's single pass, so it never centered. A `flowReady` flag (set in `onInit`, keyed into the reframe effect) re-runs the pan once the flow is ready, so `setCenter` lands on the subject. Node-click / filter reframing is unchanged.

Source rows share `LibraryRow`'s menu, so they get the same treatment.

## Tests
- `Library` / `LibraryRow` / `LibrarySourceRow`: removed items asserted **gone**; "Show lineage" asserted to open + set the lineage lens intent + lens.
- `Lineage` suite green (134) after the centering change; the camera pan itself is React-Flow viewport behavior (not unit-testable in jsdom) — the fix is a logical close of the fresh-mount init race in the existing, node-click-proven centering effect.
- 176 library tests + 134 lineage tests green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
