### PR TITLE
VIS-1235: promote stops at the draft/cache layer, not commit

### DIFF
--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -128,7 +128,6 @@ const URL_PATTERNS = {
 
     // ---- Local working copy ---------------------------------------------
     // The local server's git-ish surface: staged edits and how they land.
-    writeChanges: '/api/project/write_changes/',
     commitStatus: '/api/commit/status/',
     commitPending: '/api/commit/pending/',
     commit: '/api/commit/',

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -879,28 +879,17 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         });
       }
 
-      // Persist the just-promoted drafts to the project's YAML files. The
-      // per-type `saveX` actions above only write each manager's *cached*
-      // (draft) tier (POST /api/<type>/<name>/ -> save_from_config -> in-memory
-      // cache); they never touch YAML. The commit endpoint
-      // (/api/projects/<id>/commit/ -> ProjectWriter) is the ONLY path that
-      // writes project files under `visivo serve`, so without this "Save to
-      // project" reported success while project.visivo.yml was never written —
-      // a new-user blocker on a fresh, empty project. Gated on an actual save
-      // so an all-invalid promote never fires a no-op commit. commitChanges
-      // itself no-ops when there is no active project (e.g. trimmed test
-      // stores), so this is safe.
-      if (results.some(r => r.success)) {
-        // A commit (write-to-disk) failure must NOT abort the promote flow: the
-        // objects are already saved to the draft cache, commitChanges records
-        // its own error in `commitError`, and downstream steps (dashboard
-        // placement, return_to consumption) must still run.
-        try {
-          await get().commitChanges?.();
-        } catch {
-          /* best-effort persist; see commitError */
-        }
-      }
+      // VIS-1235: promote deliberately STOPS at the draft/cache layer. The
+      // per-type `saveX` actions above write each manager's *cached* (draft)
+      // tier (POST /api/<type>/<name>/ -> save_from_config -> in-memory cache);
+      // they never touch YAML. Promoted objects therefore land as PENDING
+      // CHANGES in the commit panel, alongside every other workspace edit, and
+      // the Commit button writes them to project.visivo.yml — once,
+      // deliberately, like the rest of the workspace. Promote no longer
+      // force-calls commitChanges() here (which wrote YAML on every "Save to
+      // project" and swallowed any commit failure in a bare `catch {}`). The
+      // returned `success` reflects the per-row SAVE results below, so a save
+      // that doesn't land is surfaced to the caller.
 
       return {
         success: results.length > 0 && results.every(r => r.success),

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -1707,7 +1707,7 @@ describe('promoteExploration', () => {
     ...overrides,
   });
 
-  test('flushes promoted drafts to disk by committing after a successful save loop', async () => {
+  test('saves promoted rows to the draft/cache layer but never force-commits (VIS-1235)', async () => {
     buildPromoteChecklist.mockResolvedValue([checklistRow()]);
     const saveModel = jest.fn().mockResolvedValue({ success: true });
     const commitChanges = jest.fn().mockResolvedValue({ success: true });
@@ -1719,12 +1719,14 @@ describe('promoteExploration', () => {
       await useStore.getState().promoteExploration('exp_1', [{ type: 'model', name: 'orders_q' }]);
     });
     expect(saveModel).toHaveBeenCalledWith('orders_q', { sql: 'select 1' });
-    // commit is the ONLY path that writes project YAML under `visivo serve`;
-    // without it "Save to project" reported success while nothing hit disk.
-    expect(commitChanges).toHaveBeenCalledTimes(1);
+    // VIS-1235: promote stops at the draft/cache tier. Saved objects land as
+    // PENDING CHANGES in the commit panel; the Commit button — not promote —
+    // writes YAML, once and deliberately. Promote must never force a commit
+    // (the old force-commit also swallowed commit failures in a bare `catch {}`).
+    expect(commitChanges).not.toHaveBeenCalled();
   });
 
-  test('does NOT commit when nothing was actually saved (all rows invalid)', async () => {
+  test('does not save (or commit) when nothing is valid to promote (all rows invalid)', async () => {
     buildPromoteChecklist.mockResolvedValue([checklistRow({ valid: false })]);
     const saveModel = jest.fn().mockResolvedValue({ success: true });
     const commitChanges = jest.fn().mockResolvedValue({ success: true });

--- a/visivo/server/views/project_views.py
+++ b/visivo/server/views/project_views.py
@@ -15,7 +15,6 @@ from visivo.models.row import Row
 from visivo.models.source import CreateSourceRequest, SourceTypeEnum
 from visivo.models.table import Table
 from visivo.parsers.parser_factory import ParserFactory
-from visivo.server.project_writer import ProjectWriter
 from visivo.server.views.utils import (
     create_source_dashboard,
     externalize_source_credentials,
@@ -41,21 +40,6 @@ def register_project_views(app, flask_app, output_dir):
             return jsonify(project_file_path)
         else:
             return jsonify({})
-
-    @app.route("/api/project/write_changes/", methods=["POST"])
-    def write_changes():
-        data = request.get_json()
-        if not data:
-            return jsonify({"message": "No data provided"}), 400
-
-        try:
-            project_writer = ProjectWriter(data)
-            project_writer.update_file_contents()
-            project_writer.write()
-            return jsonify({"message": "Changes written successfully"}), 200
-        except Exception as e:
-            Logger.instance().error(f"Error writing changes: {str(e)}")
-            return jsonify({"message": str(e)}), 500
 
     @app.route("/api/project/load_example/", methods=["POST"])
     def load_example_project():


### PR DESCRIPTION
## VIS-1235 — Explorer promote force-commits: stop at the draft/cache layer

Promoting an exploration ("Save to project") saved each object to the draft
cache **and then force-called `commitChanges()`**, writing YAML on every
promote and swallowing any commit failure in a bare `catch {}` (promote still
reported `success: true`). This diverges from how every other workspace edit
works — save to the draft cache, review in the commit panel, then commit
deliberately.

### What changed
1. **Promote no longer commits.** Dropped the force-commit block in
   `promoteExploration` (`viewer/src/stores/workspaceExplorationsStore.js`).
   Promoted objects now land as **pending changes** in the commit panel; the
   Commit button writes them to `project.visivo.yml` once, deliberately.
2. **Failure is surfaced, not swallowed.** With the `catch {}` gone, the
   returned `success` reflects the per-row save results — a save that doesn't
   land is reported to the caller (already covered by the store's
   partial-failure tests).
3. **Dead endpoint removed.** `POST /api/project/write_changes/`
   (`visivo/server/views/project_views.py`) was a caller-less direct
   `ProjectWriter` YAML write that bypassed the draft layer — deleted along with
   its now-unused import and the `writeChanges` viewer URL key
   (`viewer/src/config/urls.js`).

### Acceptance
- Promoting leaves promoted objects as pending changes in the commit panel and
  writes **no** YAML.
- Committing afterward writes them once.
- A save that doesn't land makes promote report failure.

### Tests
- `workspaceExplorationsStore.test.js` — rewrote the two commit-behavior tests
  to assert promote **never** force-commits; the existing partial-failure tests
  already cover `success` reflecting per-row saves. **100 store tests pass.**
- `yarn lint` clean.
- `poetry run black --check` clean; **798 server tests pass** (no test covered
  the removed endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
