### PR TITLE
Save-to-project: hide "Save N to project" once every row saved

### DIFF
--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -357,6 +357,17 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     [promotedThisRun]
   );
 
+  // Once a promote run has completed with EVERY selected row saved, the submit
+  // button has nothing left to do — re-clicking would just re-save the same
+  // now-existing objects. The modal is only still open to show a post-save
+  // offer (semantic layer / dashboard placement) or the success receipt, so
+  // drop the submit button and leave "Close" as the only action. A run with a
+  // failed row keeps the button, so the user can retry after fixing it.
+  const promoteFullySucceeded = useMemo(() => {
+    const results = promotedThisRun?.results || [];
+    return results.length > 0 && results.every(r => r.success);
+  }, [promotedThisRun]);
+
   // VIS-1068 — the chart promoted THIS RUN (return_to placement only makes
   // sense for a run that actually promoted a chart; older promotes in a
   // prior session don't retroactively offer placement).
@@ -839,15 +850,17 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
           >
             {promotedThisRun ? 'Close' : 'Cancel'}
           </button>
-          <button
-            type="button"
-            data-testid="exploration-promote-submit"
-            onClick={handlePromote}
-            disabled={promoting || selectedCount === 0 || loading}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {promoting ? 'Saving…' : `Save ${selectedCount} to project ▸`}
-          </button>
+          {!promoteFullySucceeded && (
+            <button
+              type="button"
+              data-testid="exploration-promote-submit"
+              onClick={handlePromote}
+              disabled={promoting || selectedCount === 0 || loading}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {promoting ? 'Saving…' : `Save ${selectedCount} to project ▸`}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -262,6 +262,9 @@ describe('ExplorationPromoteModal', () => {
     );
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByTestId('exploration-promote-cancel')).toHaveTextContent('Close');
+    // Every selected row saved, so the submit button has nothing left to do —
+    // "Close" is the only footer action while the offer lingers.
+    expect(screen.queryByTestId('exploration-promote-submit')).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('exploration-promote-cancel'));
     expect(onClose).toHaveBeenCalled();
   });
@@ -309,6 +312,8 @@ describe('ExplorationPromoteModal', () => {
       expect(screen.getByTestId('exploration-promote-error')).toHaveTextContent('server rejected it')
     );
     expect(onClose).not.toHaveBeenCalled();
+    // A row failed, so the submit button stays available to retry after a fix.
+    expect(screen.getByTestId('exploration-promote-submit')).toBeInTheDocument();
   });
 
   // P5-D2 (e2e-gap-review.md "Final delta pass") — a partial-failure promote


### PR DESCRIPTION
## Hide "Save N to project" once the promote fully succeeds

Follow-up to VIS-1226. When a promote succeeds but the "Save to project" modal
**lingers** — to show a post-save offer (View in Semantic Layer / dashboard
placement) or the "Saved N objects to project." receipt — the primary
**"Save N to project ▸"** button stayed visible right next to **Close**.
Re-clicking it just re-saves the same now-existing objects (they'd come back as
"updates existing"), which is confusing.

### Change
Once **every** selected row has been saved, drop the submit button and leave
**Close** as the only footer action. A run with a **failed** row keeps the
button, so the user can retry after fixing it.

Before (screenshot): `Close` + `Save 3 to project ▸`
After: `Close` only.

### Tests
- `ExplorationPromoteModal.test.jsx`:
  - the model-offer lingering test now asserts the submit button is **gone**
    after a fully-successful promote;
  - the partial-failure test asserts the submit button **remains** (retry path).
- 99 modal tests pass, `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
