### PR TITLE
VIS-1224: Explorer panes reuse the standard edit panel (+ ⋮ Rename, insight-above-chart)

### DIFF
--- a/viewer/e2e/stories/exploration-build-rail.spec.mjs
+++ b/viewer/e2e/stories/exploration-build-rail.spec.mjs
@@ -7,7 +7,7 @@
  * `ExplorerRightPanel`). Covers 03-delivery-plan.md's Phase 3b gate:
  *
  *   1. Rail CRUD — Add Insight stacks a new section; Chart always renders
- *      above the Insight sections.
+ *      below the Insight sections (VIS-1224: insight panes stack on top).
  *   2. Type-switch cache — TracePropsEditor's own preserveTraceProps carries
  *      x/y across a scatter -> bar -> scatter round trip.
  *   3. Drop targets on TracePropsEditor fields render D8 typed ref pills —
@@ -139,7 +139,7 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     }
   });
 
-  test('Add Insight stacks a new section; Chart section always renders above the Insight sections', async ({
+  test('Add Insight stacks a new section; the Insight sections render above the Chart section', async ({
     page,
   }) => {
     await gotoExplorerHome(page);
@@ -166,7 +166,37 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
       .locator('[data-testid^="insight-build-section-"]')
       .first()
       .boundingBox();
-    expect(chartBox.y).toBeLessThan(firstInsightBox.y);
+    // VIS-1224: insight sections now stack ABOVE the chart section.
+    expect(firstInsightBox.y).toBeLessThan(chartBox.y);
+  });
+
+  // VIS-1224: the ⋮ panel menu must open VISIBLY — the panes are
+  // `overflow-hidden`, so an in-flow menu would be clipped; PanelMenu portals
+  // to the body. This exercises that in real layout (no DnD involved).
+  test('the insight pane ⋮ menu opens un-clipped and Rename enters inline edit', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+    const rail = page.getByTestId('exploration-build-rail');
+    await expect(rail).toBeVisible({ timeout: 15000 });
+
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames?.[0]
+    );
+    expect(insightName).toBeTruthy();
+
+    await page.getByTestId(`panel-menu-trigger-insight-${insightName}`).click();
+    const rename = page.getByTestId(`panel-menu-item-rename-insight-${insightName}`);
+    await expect(rename).toBeVisible();
+    // The portaled menu is NOT nested inside the overflow-hidden section.
+    const escaped = await page.evaluate(name => {
+      const section = document.querySelector(`[data-testid="insight-build-section-${name}"]`);
+      const item = document.querySelector(`[data-testid="panel-menu-item-rename-insight-${name}"]`);
+      return section && item ? !section.contains(item) : false;
+    }, insightName);
+    expect(escaped).toBe(true);
+
+    await rename.click();
+    await expect(page.getByTestId(`insight-rename-input-${insightName}`)).toBeVisible();
   });
 
   test('drop targets on TracePropsEditor fields render D8 typed pills — never raw ?{ syntax', async ({

--- a/viewer/e2e/stories/exploration-build-rail.spec.mjs
+++ b/viewer/e2e/stories/exploration-build-rail.spec.mjs
@@ -150,12 +150,6 @@ test.describe('Exploration Build rail (Explore 2.0 Phase 3b)', () => {
     const before = await rail.locator('[data-testid^="insight-build-section-"]').count();
 
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     await expect(rail.locator('[data-testid^="insight-build-section-"]')).toHaveCount(
       before + 1,
       { timeout: 10000 }

--- a/viewer/e2e/stories/exploration-preview.spec.mjs
+++ b/viewer/e2e/stories/exploration-preview.spec.mjs
@@ -558,12 +558,6 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
     // Add a SECOND insight with a permanently dangling ref — its compile
     // pass will keep erroring.
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     const insightNames = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames
     );
@@ -688,12 +682,6 @@ test.describe('Exploration live draft preview (Explore 2.0 Phase 4 — S2)', () 
     // to A's elements below is now scoped to A's own section testid, and A
     // is explicitly re-expanded before being touched again.
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     const insightNames = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames
     );

--- a/viewer/e2e/stories/exploration-promote.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote.spec.mjs
@@ -405,12 +405,6 @@ test.describe('Exploration promote (Explore 2.0 Phase 4)', () => {
     // `insight-toggle-${badInsightName}` COLLAPSED the already-open section
     // instead of opening it, hiding the y-slot and hanging the next locator.
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     const insightNames = await page.evaluate(() => window.useStore.getState().explorerChartInsightNames);
     const badInsightName = insightNames[insightNames.length - 1];
     const ySlot = page

--- a/viewer/e2e/stories/save-as-metric.spec.mjs
+++ b/viewer/e2e/stories/save-as-metric.spec.mjs
@@ -272,12 +272,6 @@ test.describe('Save as metric (Explore 2.0 Phase 4 — 06 §4/§8)', () => {
     );
 
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     const insightNames = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames
     );
@@ -347,12 +341,6 @@ test.describe('Save as metric (Explore 2.0 Phase 4 — 06 §4/§8)', () => {
     );
 
     await page.getByTestId('right-panel-add-insight').click();
-    // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight instead
-    // of letting you pick an existing one"): the button now opens a picker
-    // (existing insights + "New blank insight"); these specs want the OLD
-    // "always create a fresh blank insight" behavior, so drive the new
-    // secondary action explicitly.
-    await page.getByTestId('add-insight-menu-create-new').click();
     const insightNames = await page.evaluate(
       () => window.useStore.getState().explorerChartInsightNames
     );

--- a/viewer/src/components/common/PanelMenu.jsx
+++ b/viewer/src/components/common/PanelMenu.jsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { PiDotsThreeVertical } from 'react-icons/pi';
+
+/**
+ * PanelMenu — VIS-1224. A reusable "⋮" (vertical dots) overflow menu for a
+ * panel / row header. Built to be reused beyond the Explorer (the Build rail's
+ * insight & chart panes are the first consumers), which is why it lives in the
+ * app-wide `common/` home rather than next to any one surface.
+ *
+ * The menu list is rendered into `document.body` via a portal, positioned off
+ * the trigger's bounding box (re-measured on scroll / resize while open). This
+ * is REQUIRED here, not cosmetic: the panes it sits inside are `overflow-hidden`
+ * (rounded cards) and the rail body is `overflow-y-auto`, so an in-flow
+ * absolutely-positioned menu would be clipped out of sight — the same class of
+ * bug that made the query-chip menu invisible (VIS-1228). Portaling escapes
+ * every ancestor's overflow (and any transformed ancestor that would trap
+ * `position: fixed`).
+ *
+ * @param {object} props
+ * @param {string} props.testId - unique suffix so each menu is greppable
+ *   (`panel-menu-trigger-${testId}`, `panel-menu-${testId}`, and per-item
+ *   `panel-menu-item-${item.id}-${testId}`).
+ * @param {Array<{id,label,icon,onSelect,destructive,disabled}>} props.items -
+ *   menu rows. `icon` is a react-icons component; `destructive` styles the row
+ *   red (for a later "Delete…" reuse); a `disabled` row is shown but inert.
+ * @param {string} [props.ariaLabel='Options'] - trigger aria-label / title.
+ * @param {number} [props.menuWidth=160]
+ */
+const PanelMenu = ({ testId, items = [], ariaLabel = 'Options', menuWidth = 160 }) => {
+  const triggerRef = useRef(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState(null);
+
+  const reposition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    // Right-align the menu to the trigger (clamped to the viewport), dropping
+    // below it. Small enough that a flip-up isn't worth the complexity here.
+    setPos({
+      top: r.bottom + 6,
+      left: Math.max(4, Math.min(r.right - menuWidth, window.innerWidth - menuWidth - 4)),
+      width: menuWidth,
+    });
+  }, [menuWidth]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    reposition();
+    const onScroll = () => reposition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [open, reposition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = e => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  return (
+    <span className="inline-flex" onClick={e => e.stopPropagation()}>
+      <button
+        ref={triggerRef}
+        type="button"
+        data-testid={`panel-menu-trigger-${testId}`}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        onClick={e => {
+          e.stopPropagation();
+          setOpen(o => !o);
+        }}
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+      >
+        <PiDotsThreeVertical size={16} />
+      </button>
+
+      {open &&
+        pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <>
+            {/* Outside-click backdrop. */}
+            <div
+              data-testid={`panel-menu-backdrop-${testId}`}
+              onClick={e => {
+                e.stopPropagation();
+                close();
+              }}
+              style={{ position: 'fixed', inset: 0, zIndex: 80 }}
+            />
+            <div
+              data-testid={`panel-menu-${testId}`}
+              onClick={e => e.stopPropagation()}
+              style={{ position: 'fixed', top: pos.top, left: pos.left, width: pos.width, zIndex: 90 }}
+              className="overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+            >
+              {items.map(item => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    data-testid={`panel-menu-item-${item.id}-${testId}`}
+                    disabled={item.disabled}
+                    onClick={e => {
+                      e.stopPropagation();
+                      close();
+                      item.onSelect?.();
+                    }}
+                    className={[
+                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] disabled:cursor-not-allowed disabled:opacity-40',
+                      item.destructive
+                        ? 'text-highlight-600 hover:bg-highlight-50'
+                        : 'text-gray-800 hover:bg-gray-50',
+                    ].join(' ')}
+                  >
+                    {Icon && (
+                      <Icon
+                        className={`h-3.5 w-3.5 shrink-0 ${item.destructive ? '' : 'text-gray-500'}`}
+                      />
+                    )}
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+          </>,
+          document.body
+        )}
+    </span>
+  );
+};
+
+export default PanelMenu;

--- a/viewer/src/components/common/PanelMenu.test.jsx
+++ b/viewer/src/components/common/PanelMenu.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelMenu from './PanelMenu';
+
+const renderMenu = (items, extra = {}) =>
+  render(
+    // A deliberately `overflow-hidden` wrapper — the raison d'être of this
+    // component is that its menu must escape such a container via a portal.
+    <div data-testid="clip-wrapper" style={{ overflow: 'hidden' }}>
+      <PanelMenu testId="x" items={items} {...extra} />
+    </div>
+  );
+
+describe('PanelMenu', () => {
+  it('is closed initially; clicking the ⋮ trigger opens the menu', () => {
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect: jest.fn() }]);
+    expect(screen.queryByTestId('panel-menu-x')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    expect(screen.getByTestId('panel-menu-x')).toBeInTheDocument();
+    expect(screen.getByTestId('panel-menu-item-rename-x')).toHaveTextContent('Rename');
+  });
+
+  it('portals the menu OUTSIDE the overflow-hidden wrapper (escapes the clip)', () => {
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect: jest.fn() }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    const wrapper = screen.getByTestId('clip-wrapper');
+    const menu = screen.getByTestId('panel-menu-x');
+    expect(wrapper.contains(menu)).toBe(false);
+  });
+
+  it('selecting an item fires onSelect and closes the menu', () => {
+    const onSelect = jest.fn();
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    fireEvent.click(screen.getByTestId('panel-menu-item-rename-x'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('panel-menu-x')).not.toBeInTheDocument();
+  });
+
+  it('a disabled item is inert (no onSelect, stays open is irrelevant — it never fires)', () => {
+    const onSelect = jest.fn();
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect, disabled: true }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    const item = screen.getByTestId('panel-menu-item-rename-x');
+    expect(item).toBeDisabled();
+    fireEvent.click(item);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('a destructive item gets the highlight (red) treatment', () => {
+    renderMenu([{ id: 'delete', label: 'Delete', onSelect: jest.fn(), destructive: true }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    expect(screen.getByTestId('panel-menu-item-delete-x').className).toContain('text-highlight-600');
+  });
+
+  it('Escape closes the menu', () => {
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect: jest.fn() }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    expect(screen.getByTestId('panel-menu-x')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('panel-menu-x')).not.toBeInTheDocument();
+  });
+
+  it('clicking the backdrop closes the menu', () => {
+    renderMenu([{ id: 'rename', label: 'Rename', onSelect: jest.fn() }]);
+    fireEvent.click(screen.getByTestId('panel-menu-trigger-x'));
+    expect(screen.getByTestId('panel-menu-x')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('panel-menu-backdrop-x'));
+    expect(screen.queryByTestId('panel-menu-x')).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -8,6 +8,7 @@ import PreviewInputControls from '../views/workspace/PreviewInputControls';
 import useStore from '../../stores/store';
 import { emitTimeToFirstChart } from '../views/workspace/telemetry';
 import { buildInsightFreshnessSignature } from '../../utils/insightFreshnessSignature';
+import { isMeaningfulInsightState } from '../../stores/explorerStore';
 
 // Stable empty-array reference (avoids a fresh `[]` literal defeating memoized
 // selectors/`useMemo` deps every render — see ExplorationBuildRail.jsx's
@@ -214,9 +215,29 @@ const ExplorerChartPreview = () => {
   // triggered recapture here at all — `promotedSignatures` is only ever
   // written by `promoteExploration` (see `explorerStore.js`'s
   // `recordPromotedInsightSignature` and this file's docstring).
+  // VIS-1224 — Bug 1: an empty draft insight (isNew with no props/interactions)
+  // can never produce data, so including it would block `Chart.jsx`'s
+  // all-or-nothing `hasAllInsightData` FOREVER (infinite spinner) the moment
+  // it's added to a chart that's already rendering. Render only the insights
+  // that can actually contribute a figure; the empty one is still being built
+  // in its own pane and simply isn't on the chart yet. This also removes the
+  // Loading↔Plot flip that left the plot stale-sized on removal (Bug 2), since
+  // adding/removing an empty insight no longer changes the rendered set.
+  const renderableInsightNames = useMemo(
+    () =>
+      chartInsightNames.filter(name => {
+        const is = insightStates[name];
+        // Only exclude a name we KNOW is an empty draft scaffold. Keep promoted
+        // insights and any without a draft state at all — their data comes from
+        // the promoted lane, not `explorerInsightStates`.
+        return !(is && !isMeaningfulInsightState(is) && !promotedNames.includes(name));
+      }),
+    [chartInsightNames, insightStates, promotedNames]
+  );
+
   const previewInsightKeys = useMemo(
     () =>
-      chartInsightNames.map(name => {
+      renderableInsightNames.map(name => {
         if (!promotedNames.includes(name)) return draftInsightKey(name);
         const data = storeInsightJobs?.[name]?.data;
         if (!data) return draftInsightKey(name);
@@ -226,7 +247,7 @@ const ExplorerChartPreview = () => {
         return recordedSig === insightSignature(name) ? name : draftInsightKey(name);
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [chartInsightNames, promotedNames, storeInsightJobs, promotedSignatures, insightStates, modelStates]
+    [renderableInsightNames, promotedNames, storeInsightJobs, promotedSignatures, insightStates, modelStates]
   );
 
   // VIS-1092 — `<ChartPreview>` (unlike `Chart.jsx`) gates its ENTIRE render
@@ -246,8 +267,8 @@ const ExplorerChartPreview = () => {
   //      "Loading" state, never an alarming error, until every insight has
   //      data again.)
   const draftLaneNames = useMemo(
-    () => chartInsightNames.filter((name, idx) => previewInsightKeys[idx] === draftInsightKey(name)),
-    [chartInsightNames, previewInsightKeys]
+    () => renderableInsightNames.filter((name, idx) => previewInsightKeys[idx] === draftInsightKey(name)),
+    [renderableInsightNames, previewInsightKeys]
   );
   const anyInsightAlreadyHasData = previewInsightKeys.some(key => storeInsightJobs?.[key]?.data != null);
   const draftLaneIsLoading =
@@ -317,6 +338,24 @@ const ExplorerChartPreview = () => {
         data-testid="chart-empty-no-insights"
       >
         <span className="text-sm text-secondary-400">Add an insight to see chart preview</span>
+      </div>
+    );
+  }
+
+  // VIS-1224 — Bug 1: the chart has insights, but they're all empty scaffolds
+  // (nothing to draw yet). Show a guided empty state rather than a spinner that
+  // would block forever on data that can never arrive.
+  if (renderableInsightNames.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full bg-gray-50 gap-2 p-6 text-center"
+        data-testid="chart-preview-empty-no-props"
+      >
+        <PiCursorClick className="h-5 w-5 text-secondary-300" aria-hidden="true" />
+        <span className="text-sm font-medium text-secondary-600">Nothing to preview yet</span>
+        <span className="text-xs text-secondary-400 max-w-sm">
+          Drag a column from the results grid onto a field (like x or y) to see a chart preview.
+        </span>
       </div>
     );
   }

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -145,6 +145,37 @@ describe('ExplorerChartPreview', () => {
     );
   });
 
+  // VIS-1224 Bug 1: an empty draft insight (isNew, no props) can never produce
+  // data — it must be excluded from the chart's keys so it can't block
+  // Chart.jsx's all-or-nothing data gate (the infinite-spinner bug).
+  it('excludes an empty draft insight from the chart keys (does not block a rendering chart)', () => {
+    useStore.setState({
+      explorerInsightStates: {
+        ins_1: { type: 'scatter', props: { x: '?{${ref(sales).date}}' }, interactions: [], isNew: true },
+        empty_ins: { type: 'scatter', props: {}, interactions: [], isNew: true },
+      },
+      explorerChartInsightNames: ['ins_1', 'empty_ins'],
+    });
+    render(<ExplorerChartPreview />);
+    expect(screen.getByTestId('chart-preview-component')).toBeInTheDocument();
+    // Only the meaningful insight's key is forwarded — the empty one is dropped.
+    expect(screen.getByTestId('cp-insight-keys')).toHaveTextContent(
+      JSON.stringify(['__draft__:ins_1'])
+    );
+  });
+
+  it('shows the guided empty state (not a spinner) when every chart insight is an empty scaffold', () => {
+    useStore.setState({
+      explorerInsightStates: {
+        empty_ins: { type: 'scatter', props: {}, interactions: [], isNew: true },
+      },
+      explorerChartInsightNames: ['empty_ins'],
+    });
+    render(<ExplorerChartPreview />);
+    expect(screen.getByTestId('chart-preview-empty-no-props')).toBeInTheDocument();
+    expect(screen.queryByTestId('chart-preview-component')).not.toBeInTheDocument();
+  });
+
   it('falls back to a default chart name when explorerChartName is unset', () => {
     useStore.setState({ explorerChartName: undefined });
     render(<ExplorerChartPreview />);

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -12,11 +12,9 @@ import { getSchema, isSchemaLoaded } from '../../../schemas/schemas';
 import { getTypeByValue } from './objectTypeConfigs';
 import { setAtPath } from './embeddedObjectUtils';
 import { parseRefValue, formatRef } from '../../../utils/refString';
-import { unwrapConfig } from '../workspace/unwrapRecordConfig';
 import EmbeddedPill from '../lineage/EmbeddedPill';
-import Select from '../../common/Select';
-import TracePropsEditor from './TracePropsEditor';
-import useRecordSave from '../../../hooks/useRecordSave';
+import Dropdown from '../../common/Dropdown';
+import AddInsightMenu from '../workspace/AddInsightMenu';
 
 /**
  * ChartEditForm - Form component for editing/creating charts
@@ -38,10 +36,11 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
   const [insights, setInsights] = useState([]);
   const [layoutValues, setLayoutValues] = useState({});
 
-  // The insight whose props are currently being edited via TracePropsEditor.
-  // For a ref insight this is its name; for an embedded insight it is the
-  // synthetic key `__embedded__:<index>` (so the picker can address either).
-  const [selectedInsightName, setSelectedInsightName] = useState('');
+  // VIS-1224: "New blank insight" (the Add Insight menu) stages a blank
+  // EMBEDDED insight on the chart; staged entries merge into the save and count
+  // toward dirty. (The chart no longer edits insight props inline — that's the
+  // insight's own edit panel.)
+  const [stagedEmbedded, setStagedEmbedded] = useState([]);
 
   // UI state
   const [errors, setErrors] = useState({});
@@ -57,9 +56,6 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   const isEditMode = !!chart && !isCreate;
   const isNewObject = chart?.status === ObjectStatus.NEW;
-
-  // Get available insights from the insight store
-  const availableInsights = storeInsights?.map(i => i.name) || [];
 
   // Load layout schema on mount
   useEffect(() => {
@@ -108,60 +104,6 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
     .map((insight, index) => ({ insight, index }))
     .filter(({ insight }) => typeof insight === 'object');
 
-  // Prefix that marks the picker value of an EMBEDDED insight (vs a ref name).
-  const EMBEDDED_PREFIX = '__embedded__:';
-  const isEmbeddedSelection =
-    typeof selectedInsightName === 'string' && selectedInsightName.startsWith(EMBEDDED_PREFIX);
-  const selectedEmbeddedIndex = isEmbeddedSelection
-    ? Number(selectedInsightName.slice(EMBEDDED_PREFIX.length))
-    : null;
-
-  // The store record for the currently-selected REF insight (envelope-or-bare
-  // unwrapped to its config). Used to seed TracePropsEditor and as the base for
-  // the persisted insight write.
-  const selectedInsightRecord =
-    !isEmbeddedSelection && selectedInsightName
-      ? storeInsights?.find(i => i.name === selectedInsightName)
-      : null;
-  const selectedInsightConfig = selectedInsightRecord ? unwrapConfig(selectedInsightRecord) : null;
-
-  // Optimistic + debounced persist for the SELECTED ref insight. The chart record
-  // is untouched — we write the insight record through the unified backbone.
-  const { scheduleSave: scheduleInsightSave } = useRecordSave('insight', selectedInsightName);
-
-  // Build the props object handed to TracePropsEditor for whichever insight is
-  // selected (ref record's config.props, or the embedded insight's props).
-  let selectedInsightProps = null;
-  if (isEmbeddedSelection && selectedEmbeddedIndex != null) {
-    const embedded = rawInsights[selectedEmbeddedIndex];
-    selectedInsightProps =
-      (embedded && typeof embedded === 'object' ? embedded.props : null) || { type: 'scatter' };
-  } else if (selectedInsightConfig) {
-    selectedInsightProps = selectedInsightConfig.props || { type: 'scatter' };
-  }
-
-  // Persist a props edit for the selected insight. Ref insights write the insight
-  // record (backbone); embedded insights edit inline + persist the CHART.
-  const handleInsightPropsChange = nextProps => {
-    if (isEmbeddedSelection && selectedEmbeddedIndex != null) {
-      const updatedInsights = rawInsights.map((insight, index) =>
-        index === selectedEmbeddedIndex && typeof insight === 'object'
-          ? { ...insight, props: nextProps }
-          : insight
-      );
-      // Inline-edit the embedded insight and persist the chart via its save path.
-      const config = { name, insights: updatedInsights };
-      if (Object.keys(layoutValues).length > 0) {
-        config.layout = layoutValues;
-      }
-      if (onSave) onSave('chart', name, config);
-      return;
-    }
-    if (selectedInsightRecord) {
-      scheduleInsightSave({ ...selectedInsightConfig, props: nextProps });
-    }
-  };
-
   // VIS-1133: the values that constitute "the saved chart", as form state.
   // Kept as a pure function so the seeding effect and the dirty check agree by
   // construction rather than by inspection.
@@ -193,40 +135,13 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chart, isCreate]);
 
-  const dirty = isDirtyAgainst({ name, insights, layoutValues });
+  const dirty = isDirtyAgainst({ name, insights, layoutValues }) || stagedEmbedded.length > 0;
 
   // Report upward so the tab strip's unsaved dot and its guarded close reflect
   // real edits (VIS-1133) — the rail clears it on unmount.
   useEffect(() => {
     if (onDirtyChange) onDirtyChange(dirty);
   }, [dirty, onDirtyChange]);
-
-  // Build the options for the insight props picker: every ref insight by name,
-  // plus an entry per embedded insight. Keeps a stable identity so the picker
-  // can default-select the lone insight and stay in sync as refs change.
-  const insightPickerOptions = [
-    ...insights.map(i => ({ value: i, label: i })),
-    ...embeddedInsights.map(({ insight, index }) => ({
-      value: `${EMBEDDED_PREFIX}${index}`,
-      label: insight.name || `(embedded insight ${index + 1})`,
-    })),
-  ];
-
-  // Default-select the chart's only insight; otherwise keep the selection valid
-  // as the refs/embedded lists change (drop a stale selection).
-  useEffect(() => {
-    const validValues = insightPickerOptions.map(o => o.value);
-    if (selectedInsightName && validValues.includes(selectedInsightName)) {
-      return; // current selection still valid
-    }
-    if (insightPickerOptions.length === 1) {
-      setSelectedInsightName(insightPickerOptions[0].value);
-    } else if (selectedInsightName) {
-      // Selection no longer exists (e.g. its ref was removed/swapped).
-      setSelectedInsightName('');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [insights, embeddedInsights.length, selectedInsightName]);
 
   const validateForm = () => {
     const newErrors = {};
@@ -236,7 +151,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
       newErrors.name = nameError;
     }
 
-    if (insights.length === 0 && embeddedInsights.length === 0) {
+    if (insights.length === 0 && embeddedInsights.length === 0 && stagedEmbedded.length === 0) {
       newErrors.data = 'At least one insight is required';
     }
 
@@ -274,6 +189,9 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
       rebuiltInsights.push(refInsights[refIdx]);
     }
 
+    // VIS-1224: append any "New blank insight" the Add-Insight menu staged.
+    stagedEmbedded.forEach(embedded => rebuiltInsights.push(embedded));
+
     if (rebuiltInsights.length > 0) {
       config.insights = rebuiltInsights;
     }
@@ -310,22 +228,23 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
     }
   };
 
-  // Insight management
-  const addInsight = () => {
-    const availableToAdd = availableInsights.filter(i => !insights.includes(i));
-    if (availableToAdd.length > 0) {
-      setInsights([...insights, availableToAdd[0]]);
-    }
+  // Insight management (VIS-1224: add via the AddInsightMenu dropdown — pick an
+  // existing project insight, or stage a New blank embedded insight).
+  const addExistingInsight = insightName => {
+    if (!insightName || insights.includes(insightName)) return;
+    setInsights([...insights, insightName]);
+  };
+
+  const addBlankInsight = () => {
+    setStagedEmbedded([...stagedEmbedded, { props: { type: 'scatter' } }]);
   };
 
   const removeInsight = index => {
     setInsights(insights.filter((_, i) => i !== index));
   };
 
-  const updateInsight = (index, value) => {
-    const updated = [...insights];
-    updated[index] = value;
-    setInsights(updated);
+  const removeStagedEmbedded = index => {
+    setStagedEmbedded(stagedEmbedded.filter((_, i) => i !== index));
   };
 
   return (
@@ -374,60 +293,80 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
             </div>
           </div>
 
-          {/* Insights Section */}
+          {/* Insights Section — VIS-1224: compose the chart's insights. The
+              chart no longer edits insight props inline (that's each insight's
+              own edit panel); "+ Add Insight" opens the same picker the
+              Explorer uses — pick an existing project insight, or add a New
+              blank one. */}
           <div className="space-y-4">
             <div className="flex items-center justify-between border-b border-gray-200 pb-2">
               <h3 className="text-sm font-medium text-gray-700">Insights</h3>
-              <button
-                type="button"
-                onClick={addInsight}
-                disabled={availableInsights.filter(i => !insights.includes(i)).length === 0}
-                className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              <Dropdown
+                align="right"
+                width={260}
+                trigger={
+                  <button
+                    type="button"
+                    data-testid="chart-add-insight"
+                    className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+                  >
+                    <AddIcon fontSize="small" />
+                    Add Insight
+                  </button>
+                }
               >
-                <AddIcon fontSize="small" />
-                Add Insight
-              </button>
+                {close => (
+                  <AddInsightMenu
+                    excludeNames={insights}
+                    onPickExisting={addExistingInsight}
+                    onCreateNew={addBlankInsight}
+                    close={close}
+                  />
+                )}
+              </Dropdown>
             </div>
 
-            {availableInsights.length === 0 ? (
+            {insights.length === 0 && embeddedInsights.length === 0 && stagedEmbedded.length === 0 ? (
               <p className="text-sm text-gray-500 italic">
-                No insights available. Create insights first to add them to charts.
-              </p>
-            ) : insights.length === 0 ? (
-              <p className="text-sm text-gray-500 italic">
-                No insights added. Add insights to visualize data in this chart.
+                No insights yet. Use “Add Insight” to add one.
               </p>
             ) : (
-              insights.map((insight, index) => (
-                <div
-                  key={index}
-                  className="flex items-center gap-2"
-                  data-testid={`ref-insight-row-${index}`}
-                >
-                  <EmbeddedPill
-                    objectType="insight"
-                    label={insight}
-                    size="md"
-                    as="div"
-                    tooltip={`Insight: ${insight}`}
-                    onRemove={() => removeInsight(index)}
-                    className="flex-1 min-w-0"
-                  />
-                  <Select
-                    aria-label={`Change insight ${index + 1}`}
-                    data-testid={`change-insight-select-${index}`}
-                    size="sm"
-                    className="min-w-[160px]"
-                    value={insight}
-                    options={availableInsights.map(i => ({
-                      value: i,
-                      label: i,
-                      isDisabled: insights.includes(i) && i !== insight,
-                    }))}
-                    onChange={value => updateInsight(index, value)}
-                  />
-                </div>
-              ))
+              <div className="space-y-2">
+                {insights.map((insight, index) => (
+                  <div
+                    key={`ref-${index}`}
+                    className="flex items-center gap-2"
+                    data-testid={`ref-insight-row-${index}`}
+                  >
+                    <EmbeddedPill
+                      objectType="insight"
+                      label={insight}
+                      size="md"
+                      as="div"
+                      tooltip={`Insight: ${insight}`}
+                      onRemove={() => removeInsight(index)}
+                      className="flex-1 min-w-0"
+                    />
+                  </div>
+                ))}
+                {stagedEmbedded.map((_, index) => (
+                  <div
+                    key={`staged-${index}`}
+                    className="flex items-center gap-2"
+                    data-testid={`staged-insight-row-${index}`}
+                  >
+                    <EmbeddedPill
+                      objectType="insight"
+                      label="New insight (blank)"
+                      size="md"
+                      as="div"
+                      tooltip="A new blank embedded insight — saved with the chart"
+                      onRemove={() => removeStagedEmbedded(index)}
+                      className="flex-1 min-w-0"
+                    />
+                  </div>
+                ))}
+              </div>
             )}
 
             {errors.data && <p className="text-xs text-red-500">{errors.data}</p>}
@@ -476,55 +415,6 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
               );
             })()}
           </div>
-
-          {/* Insight Props Section — edit the selected insight's Plotly props.
-              This is an ADDITION to the chart's own fields (refs + layout); the
-              chart record is unchanged for ref insights — the insight record is
-              persisted through the unified backbone. */}
-          {insightPickerOptions.length > 0 && (
-            <div className="space-y-4">
-              <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">
-                Insight Props
-              </h3>
-
-              {/* Insight picker */}
-              <div className="relative">
-                <Select
-                  aria-label="Insight"
-                  data-testid="insight-props-select"
-                  value={selectedInsightName}
-                  options={insightPickerOptions}
-                  onChange={value => setSelectedInsightName(value || '')}
-                  placeholder="Select an insight to edit…"
-                />
-                <label className="absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white px-1 left-2 text-gray-500">
-                  Insight
-                </label>
-              </div>
-
-              {/* Selected insight's grouped props editor (controlled). */}
-              {selectedInsightName && selectedInsightProps ? (
-                <TracePropsEditor
-                  ownerName={
-                    isEmbeddedSelection
-                      ? insightPickerOptions.find(o => o.value === selectedInsightName)?.label ||
-                        'insight'
-                      : selectedInsightName
-                  }
-                  props={selectedInsightProps}
-                  onChange={handleInsightPropsChange}
-                />
-              ) : selectedInsightName ? (
-                <p className="text-sm text-gray-500 italic" data-testid="insight-props-unloaded">
-                  Loading insight…
-                </p>
-              ) : (
-                <p className="text-sm text-gray-500 italic">
-                  Select an insight above to edit its visualization props.
-                </p>
-              )}
-            </div>
-          )}
 
           {/* Layout Section */}
           <div className="space-y-4">

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -436,7 +436,6 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
                 schema={layoutSchema}
                 value={layoutValues}
                 onChange={setLayoutValues}
-                hideEmptyState
               />
             ) : null}
             <p className="text-xs text-gray-500">

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -436,6 +436,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
                 schema={layoutSchema}
                 value={layoutValues}
                 onChange={setLayoutValues}
+                hideEmptyState
               />
             ) : null}
             <p className="text-xs text-gray-500">

--- a/viewer/src/components/views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
-import selectEvent from 'react-select-event';
 import ChartEditForm from './ChartEditForm';
 import useStore from '../../../stores/store';
 
@@ -25,38 +24,6 @@ jest.mock('./SchemaEditor', () => ({
       clear layout
     </button>
   ),
-}));
-
-// TracePropsEditor stub: echo ownerName + props.type, and expose a button that
-// drives onChange so we can assert the parent persists the edited props.
-jest.mock('./TracePropsEditor', () => ({
-  __esModule: true,
-  default: ({ ownerName, props, onChange }) => (
-    <div data-testid="trace-props-editor" data-owner={ownerName}>
-      <span data-testid="tpe-type">{props?.type}</span>
-      <button
-        type="button"
-        data-testid="tpe-add-prop"
-        onClick={() => onChange({ ...props, marker: { color: 'red' } })}
-      >
-        add prop
-      </button>
-    </div>
-  ),
-}));
-
-// useRecordSave stub: capture (type, name) per instance + expose scheduleSave so
-// we can assert the selected insight record is persisted through the backbone.
-const mockScheduleSave = jest.fn();
-const mockUseRecordSave = jest.fn(() => ({
-  status: 'idle',
-  scheduleSave: mockScheduleSave,
-  saveNow: jest.fn(),
-  reset: jest.fn(),
-}));
-jest.mock('../../../hooks/useRecordSave', () => ({
-  __esModule: true,
-  default: (...args) => mockUseRecordSave(...args),
 }));
 
 const mockFetchInsights = jest.fn();
@@ -135,26 +102,26 @@ describe('ChartEditForm — ref insight pills', () => {
     fireEvent.click(removeBtn);
 
     expect(screen.queryByTestId('ref-insight-row-0')).not.toBeInTheDocument();
-    expect(screen.getByText(/No insights added/i)).toBeInTheDocument();
+    expect(screen.getByText(/No insights yet/i)).toBeInTheDocument();
   });
 
-  test('Add Insight appends another ref insight pill', async () => {
+  // VIS-1224: "+ Add Insight" opens the shared AddInsightMenu — pick an existing
+  // project insight (added as a ref pill) or "New blank insight" (staged).
+  test('the Add Insight menu adds an existing project insight as a ref pill', async () => {
     await renderForm();
     expect(screen.queryByTestId('ref-insight-row-1')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('Add Insight'));
+    fireEvent.click(screen.getByTestId('chart-add-insight'));
+    // revenue_insight is already on the chart (excluded); cost_insight is offered.
+    fireEvent.click(screen.getByTestId('add-insight-menu-existing-cost_insight'));
     expect(screen.getByTestId('ref-insight-row-1')).toBeInTheDocument();
   });
 
-  test('the change-select still lets you swap which insight is referenced', async () => {
+  test('the Add Insight menu "New blank insight" stages a blank embedded insight', async () => {
     await renderForm();
-    const select = screen.getByTestId('change-insight-select-0');
-    // The brand <Select> shows the current ref as its selected value.
-    expect(select).toHaveTextContent('revenue_insight');
-    await selectEvent.select(within(select).getByRole('combobox'), 'cost_insight', {
-      container: document.body,
-    });
-    const row = screen.getByTestId('ref-insight-row-0');
-    expect(getPillLabel(row, 'cost_insight')).toBeInTheDocument();
+    expect(screen.queryByTestId('staged-insight-row-0')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('chart-add-insight'));
+    fireEvent.click(screen.getByTestId('add-insight-menu-create-new'));
+    expect(screen.getByTestId('staged-insight-row-0')).toBeInTheDocument();
   });
 });
 
@@ -179,7 +146,7 @@ describe('ChartEditForm — insight fetch guard', () => {
       onNavigateToEmbedded: jest.fn(),
     };
     const { rerender } = render(<ChartEditForm {...props} />);
-    await screen.findByText(/No insights available/i);
+    await screen.findByText(/No insights yet/i);
     expect(mockFetchInsights).toHaveBeenCalledTimes(1);
 
     // Each re-render delivers a new empty-array identity (an empty fetch
@@ -256,7 +223,7 @@ describe('ChartEditForm — validation & save paths', () => {
     render(
       <ChartEditForm chart={null} isCreate onClose={jest.fn()} onSave={onSave} onNavigateToEmbedded={jest.fn()} />
     );
-    await screen.findByText(/No insights added/i);
+    await screen.findByText(/No insights yet/i);
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -270,10 +237,11 @@ describe('ChartEditForm — validation & save paths', () => {
     render(
       <ChartEditForm chart={null} isCreate onClose={jest.fn()} onSave={onSave} onNavigateToEmbedded={jest.fn()} />
     );
-    await screen.findByText(/No insights added/i);
+    await screen.findByText(/No insights yet/i);
 
     fireEvent.change(screen.getByLabelText(/Chart Name/), { target: { value: 'new_chart' } });
-    fireEvent.click(screen.getByText('Add Insight'));
+    fireEvent.click(screen.getByTestId('chart-add-insight'));
+    fireEvent.click(screen.getByTestId('add-insight-menu-existing-revenue_insight'));
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -423,83 +391,9 @@ describe('ChartEditForm — embedded insight navigation', () => {
   });
 });
 
-describe('ChartEditForm — insight props editor (TracePropsEditor)', () => {
-  test("default-selects the chart's only insight and renders TracePropsEditor for it", async () => {
-    await renderForm();
-
-    // The lone ref insight (revenue_insight) is auto-selected → editor mounts.
-    const editor = screen.getByTestId('trace-props-editor');
-    expect(editor).toBeInTheDocument();
-    expect(editor).toHaveAttribute('data-owner', 'revenue_insight');
-    // Props are seeded from that insight record's config.props.
-    expect(screen.getByTestId('tpe-type')).toHaveTextContent('bar');
-  });
-
-  test('selecting a different insight renders TracePropsEditor for that insight', async () => {
-    await renderForm();
-    // Add a second insight ref so the picker has a choice.
-    fireEvent.click(screen.getByText('Add Insight'));
-    expect(screen.getByTestId('ref-insight-row-1')).toBeInTheDocument();
-
-    const select = screen.getByTestId('insight-props-select');
-    await selectEvent.select(within(select).getByRole('combobox'), 'cost_insight', {
-      container: document.body,
-    });
-
-    const editor = screen.getByTestId('trace-props-editor');
-    expect(editor).toHaveAttribute('data-owner', 'cost_insight');
-    expect(screen.getByTestId('tpe-type')).toHaveTextContent('scatter');
-  });
-
-  test("editing props persists via useRecordSave('insight', selectedName)", async () => {
-    await renderForm();
-
-    // The hook is instantiated for the selected ref insight.
-    expect(mockUseRecordSave).toHaveBeenCalledWith('insight', 'revenue_insight');
-
-    fireEvent.click(screen.getByTestId('tpe-add-prop'));
-
-    // The whole insight record config is written back with the edited props,
-    // through the unified backbone — not the chart save path.
-    expect(mockScheduleSave).toHaveBeenCalledWith({
-      props: { type: 'bar', x: ['q1'], marker: { color: 'red' } },
-    });
-  });
-
-  test('an embedded insight edits inline and persists the CHART via onSave', async () => {
-    const onSave = jest.fn(() => Promise.resolve({ success: true }));
-    const chartWithEmbedded = {
-      name: 'rev_chart',
-      status: 'published',
-      config: {
-        insights: [{ name: 'inline_one', props: { type: 'bar' } }],
-        layout: {},
-      },
-    };
-    render(
-      <ChartEditForm
-        chart={chartWithEmbedded}
-        isCreate={false}
-        onClose={jest.fn()}
-        onSave={onSave}
-        onNavigateToEmbedded={jest.fn()}
-      />
-    );
-    await screen.findByTestId('trace-props-editor');
-
-    // The lone embedded insight is auto-selected; the editor seeds from its props.
-    expect(screen.getByTestId('tpe-type')).toHaveTextContent('bar');
-
-    fireEvent.click(screen.getByTestId('tpe-add-prop'));
-
-    // Embedded insight is edited inline; the CHART (not an insight record) saves.
-    expect(mockScheduleSave).not.toHaveBeenCalled();
-    expect(onSave).toHaveBeenCalledWith('chart', 'rev_chart', {
-      name: 'rev_chart',
-      insights: [{ name: 'inline_one', props: { type: 'bar', marker: { color: 'red' } } }],
-    });
-  });
-});
+// VIS-1224: the chart no longer edits insight props inline (the "Insight Props"
+// picker + its embedded-inline edit path were removed). Each insight's props are
+// edited in the insight's OWN edit panel — covered by InsightEditForm.test.jsx.
 
 describe('ChartEditForm — layout schema load failure', () => {
   test('shows the schema error when the layout schema cannot load', async () => {

--- a/viewer/src/components/views/common/ChartEditFormFields.jsx
+++ b/viewer/src/components/views/common/ChartEditFormFields.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import { SchemaEditor } from './SchemaEditor/SchemaEditor';
+
+/**
+ * ChartEditFormFields — VIS-1224. The shared, fully-controlled chrome of the
+ * chart edit panel: "Basic Information" (name), an insight-selection SLOT, and
+ * "Layout Configuration", rendered by both the standard RightRail form
+ * (`ChartEditForm`) and the Explorer Build-rail draft pane (`ChartBuildSection`)
+ * so the two show the same panel.
+ *
+ * The insight selection genuinely differs between the two surfaces — the
+ * standard form offers ref-swap Selects + an inline per-insight props picker,
+ * while the Explorer edits insights in their own stacked panes and needs a
+ * drop zone + click-to-activate — so it is passed in as `insightsSection`
+ * rather than shared. Layout `SchemaEditor` extras (droppable, hidePropertyCount…)
+ * are forwarded via `layoutEditorProps`.
+ */
+const ChartEditFormFields = ({
+  // ---- Basic Information · name ----
+  showName = true,
+  nameId = 'chartName',
+  nameLabel = 'Chart Name',
+  nameRequired = true,
+  nameValue,
+  onNameChange,
+  onNameBlur,
+  onNameFocus,
+  onNameKeyDown,
+  nameDisabled = false,
+  nameError,
+  nameErrorTestId,
+  nameInputRef,
+  nameTestId,
+  // ---- Insight selection (host-provided) ----
+  insightsSection,
+  // ---- Layout Configuration ----
+  layoutTitle = 'Layout Configuration (Optional)',
+  layoutSchema,
+  layoutValues,
+  onLayoutChange,
+  layoutLoading = false,
+  layoutError,
+  layoutEditorProps = {},
+}) => (
+  <>
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">
+        Basic Information
+      </h3>
+
+      {showName && (
+        <div className="relative">
+          <input
+            ref={nameInputRef}
+            type="text"
+            id={nameId}
+            data-testid={nameTestId}
+            value={nameValue}
+            onChange={onNameChange}
+            onBlur={onNameBlur}
+            onFocus={onNameFocus}
+            onKeyDown={onNameKeyDown}
+            disabled={nameDisabled}
+            placeholder=" "
+            className={`
+              block w-full px-3 py-2.5 text-sm text-gray-900
+              bg-white rounded-md border appearance-none
+              focus:outline-none focus:ring-2 focus:border-primary-500
+              peer placeholder-transparent
+              ${nameDisabled ? 'bg-gray-100 cursor-not-allowed' : ''}
+              ${nameError ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}
+            `}
+          />
+          <label
+            htmlFor={nameId}
+            className={`
+              absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0]
+              bg-white px-1 left-2
+              peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2
+              peer-placeholder-shown:top-1/2
+              peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4
+              ${nameError ? 'text-red-500' : 'text-gray-500 peer-focus:text-primary-500'}
+            `}
+          >
+            {nameLabel}
+            {nameRequired && <span className="text-red-500 ml-0.5">*</span>}
+          </label>
+          {nameError && (
+            <p className="mt-1 text-xs text-red-500" data-testid={nameErrorTestId}>
+              {nameError}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+
+    {insightsSection}
+
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">
+        {layoutTitle}
+      </h3>
+      {layoutLoading ? (
+        <div className="flex items-center justify-center py-8">
+          <CircularProgress size={24} />
+          <span className="ml-2 text-sm text-gray-600">Loading schema...</span>
+        </div>
+      ) : layoutError ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+          <p className="text-sm text-red-700">{layoutError}</p>
+        </div>
+      ) : layoutSchema ? (
+        <SchemaEditor
+          schema={layoutSchema}
+          value={layoutValues}
+          onChange={onLayoutChange}
+          {...layoutEditorProps}
+        />
+      ) : null}
+    </div>
+  </>
+);
+
+export default ChartEditFormFields;

--- a/viewer/src/components/views/common/ChartEditFormFields.jsx
+++ b/viewer/src/components/views/common/ChartEditFormFields.jsx
@@ -115,6 +115,7 @@ const ChartEditFormFields = ({
           schema={layoutSchema}
           value={layoutValues}
           onChange={onLayoutChange}
+          hideEmptyState
           {...layoutEditorProps}
         />
       ) : null}

--- a/viewer/src/components/views/common/ChartEditFormFields.jsx
+++ b/viewer/src/components/views/common/ChartEditFormFields.jsx
@@ -115,7 +115,6 @@ const ChartEditFormFields = ({
           schema={layoutSchema}
           value={layoutValues}
           onChange={onLayoutChange}
-          hideEmptyState
           {...layoutEditorProps}
         />
       ) : null}

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -8,7 +8,7 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import RefTextArea from './RefTextArea';
 import Select from '../../common/Select';
-import TracePropsEditor from './TracePropsEditor';
+import InsightEditFormFields from './InsightEditFormFields';
 import { validateName } from './namedModel';
 import { getTypeByValue } from './objectTypeConfigs';
 import { isEmbeddedObject } from './embeddedObjectUtils';
@@ -16,7 +16,6 @@ import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
 import {
   SectionContainer,
-  SectionTitle,
   EmptyState,
   AlertContainer,
   AlertText
@@ -252,89 +251,27 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
             />
           )}
 
-          {/* Basic Fields Section */}
-          <SectionContainer>
-            <SectionTitle>
-              Basic Information
-            </SectionTitle>
-
-            {/* Name field - hidden for embedded insights */}
-            {!isEmbedded && (
-              <div className="relative">
-                <input
-                  type="text"
-                  id="insightName"
-                  value={name}
-                  onChange={e => setName(e.target.value)}
-                  disabled={isEditMode}
-                  placeholder=" "
-                  className={`
-                    block w-full px-3 py-2.5 text-sm text-gray-900
-                    bg-white rounded-md border appearance-none
-                    focus:outline-none focus:ring-2 focus:border-primary-500
-                    peer placeholder-transparent
-                    ${isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''}
-                    ${errors.name ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}
-                  `}
-                />
-                <label
-                  htmlFor="insightName"
-                  className={`
-                    absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0]
-                    bg-white px-1 left-2
-                    peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2
-                    peer-placeholder-shown:top-1/2
-                    peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4
-                    ${errors.name ? 'text-red-500' : 'text-gray-500 peer-focus:text-primary-500'}
-                  `}
-                >
-                  Insight Name<span className="text-red-500 ml-0.5">*</span>
-                </label>
-                {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
-              </div>
-            )}
-
-            {/* Description (optional) */}
-            <div className="relative">
-              <textarea
-                id="insightDescription"
-                value={description}
-                onChange={e => setDescription(e.target.value)}
-                placeholder=" "
-                rows={2}
-                className="block w-full px-3 py-2.5 text-sm text-gray-900 bg-white rounded-md border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 peer placeholder-transparent resize-y"
-              />
-              <label
-                htmlFor="insightDescription"
-                className="absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white px-1 left-2 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-3 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 text-gray-500 peer-focus:text-primary-500"
-              >
-                Description
-              </label>
-            </div>
-
-          </SectionContainer>
-
-          {/* Props Section */}
-          <SectionContainer>
-            <SectionTitle>
-              Visualization Props
-            </SectionTitle>
-
-            {/* Grouped, schema-driven, AJV-validated props editor. Fully controlled:
-                it owns no persistence — this form persists `props` on save. */}
-            <TracePropsEditor
-              ownerName={name || 'insight'}
-              props={props}
-              onChange={setProps}
-              onValidityChange={(ok) => setPropsValid(ok)}
-            />
-            {errors.props && (
-              <p className="mt-1 text-xs text-red-500" data-testid="insight-props-invalid">
-                {errors.props}
-              </p>
-            )}
-            {errors.propsType && <p className="mt-1 text-xs text-red-500">{errors.propsType}</p>}
-          </SectionContainer>
+          {/* Basic Information + Visualization Props — the shared inner panel
+              (VIS-1224), also rendered by the Explorer's InsightBuildSection so
+              both surfaces show the same edit form. Name is a plain live-edit
+              field here (persisted on Save); disabled in edit mode. */}
+          <InsightEditFormFields
+            showName={!isEmbedded}
+            nameId="insightName"
+            nameValue={name}
+            onNameChange={e => setName(e.target.value)}
+            nameDisabled={isEditMode}
+            nameError={errors.name}
+            showDescription
+            description={description}
+            onDescriptionChange={e => setDescription(e.target.value)}
+            ownerName={name || 'insight'}
+            props={props}
+            onPropsChange={setProps}
+            onValidityChange={ok => setPropsValid(ok)}
+            propsError={errors.props}
+            propsTypeError={errors.propsType}
+          />
 
           {/* Interactions Section */}
           <SectionContainer>

--- a/viewer/src/components/views/common/InsightEditFormFields.jsx
+++ b/viewer/src/components/views/common/InsightEditFormFields.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import TracePropsEditor from './TracePropsEditor';
+import { SectionContainer, SectionTitle } from '../../styled/FormLayoutComponents';
+
+/**
+ * InsightEditFormFields — VIS-1224. The shared, fully-controlled body of the
+ * insight edit panel: the "Basic Information" (name + description) and
+ * "Visualization Props" sections that the standard RightRail form
+ * (`InsightEditForm`) and the Explorer Build-rail draft pane
+ * (`InsightBuildSection`) both render, so the two surfaces show the SAME panel
+ * (the ticket's parity ask — no more colored-sidebar divergence).
+ *
+ * It owns NO state and NO persistence — every value/handler is a prop, so each
+ * host keeps its own model: the saved-record form persists on Save via a
+ * baseline; the Explorer writes through to `explorerStore` live and threads its
+ * drag-and-drop (`droppable`/`onDropField`) + Save-as-metric
+ * (`onSaveAsMetric`) into the shared `TracePropsEditor`. Interactions diverge
+ * enough (DnD zones, ref-wrap convention) that each host renders its own
+ * Interactions section AFTER this one.
+ */
+const InsightEditFormFields = ({
+  // ---- Basic Information · name ----
+  showName = true,
+  nameId = 'insightName',
+  nameLabel = 'Insight Name',
+  nameRequired = true,
+  nameValue,
+  onNameChange,
+  onNameBlur,
+  onNameKeyDown,
+  nameDisabled = false,
+  nameError,
+  nameErrorTestId,
+  nameInputRef,
+  nameTestId,
+  // ---- Basic Information · description ----
+  showDescription = true,
+  description,
+  onDescriptionChange,
+  // ---- Visualization Props ----
+  ownerName,
+  props,
+  onPropsChange,
+  onValidityChange,
+  droppable = false,
+  onDropField,
+  onSaveAsMetric,
+  externalErrors,
+  propsError,
+  propsTypeError,
+}) => (
+  <>
+    <SectionContainer>
+      <SectionTitle>Basic Information</SectionTitle>
+
+      {showName && (
+        <div className="relative">
+          <input
+            ref={nameInputRef}
+            type="text"
+            id={nameId}
+            data-testid={nameTestId}
+            value={nameValue}
+            onChange={onNameChange}
+            onBlur={onNameBlur}
+            onKeyDown={onNameKeyDown}
+            disabled={nameDisabled}
+            placeholder=" "
+            className={`
+              block w-full px-3 py-2.5 text-sm text-gray-900
+              bg-white rounded-md border appearance-none
+              focus:outline-none focus:ring-2 focus:border-primary-500
+              peer placeholder-transparent
+              ${nameDisabled ? 'bg-gray-100 cursor-not-allowed' : ''}
+              ${nameError ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}
+            `}
+          />
+          <label
+            htmlFor={nameId}
+            className={`
+              absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0]
+              bg-white px-1 left-2
+              peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2
+              peer-placeholder-shown:top-1/2
+              peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4
+              ${nameError ? 'text-red-500' : 'text-gray-500 peer-focus:text-primary-500'}
+            `}
+          >
+            {nameLabel}
+            {nameRequired && <span className="text-red-500 ml-0.5">*</span>}
+          </label>
+          {nameError && (
+            <p className="mt-1 text-xs text-red-500" data-testid={nameErrorTestId}>
+              {nameError}
+            </p>
+          )}
+        </div>
+      )}
+
+      {showDescription && (
+        <div className="relative">
+          <textarea
+            id={`${nameId}Description`}
+            value={description}
+            onChange={onDescriptionChange}
+            placeholder=" "
+            rows={2}
+            className="block w-full px-3 py-2.5 text-sm text-gray-900 bg-white rounded-md border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 peer placeholder-transparent resize-y"
+          />
+          <label
+            htmlFor={`${nameId}Description`}
+            className="absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white px-1 left-2 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-3 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 text-gray-500 peer-focus:text-primary-500"
+          >
+            Description
+          </label>
+        </div>
+      )}
+    </SectionContainer>
+
+    <SectionContainer>
+      <SectionTitle>Visualization Props</SectionTitle>
+      {/* Grouped, schema-driven, AJV-validated props editor. Fully controlled;
+          the Explorer additionally threads its DnD + Save-as-metric here. */}
+      <TracePropsEditor
+        ownerName={ownerName}
+        props={props}
+        onChange={onPropsChange}
+        onValidityChange={onValidityChange}
+        droppable={droppable}
+        onDropField={onDropField}
+        onSaveAsMetric={onSaveAsMetric}
+        externalErrors={externalErrors}
+      />
+      {propsError && (
+        <p className="mt-1 text-xs text-red-500" data-testid="insight-props-invalid">
+          {propsError}
+        </p>
+      )}
+      {propsTypeError && <p className="mt-1 text-xs text-red-500">{propsTypeError}</p>}
+    </SectionContainer>
+  </>
+);
+
+export default InsightEditFormFields;

--- a/viewer/src/components/views/common/InsightEditFormFields.test.jsx
+++ b/viewer/src/components/views/common/InsightEditFormFields.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InsightEditFormFields from './InsightEditFormFields';
+
+// TracePropsEditor is heavy (schema fetch, AJV) — stub it and assert the
+// controlled props are forwarded, which is all this component is responsible
+// for.
+jest.mock('./TracePropsEditor', () => props => (
+  <div
+    data-testid="mock-trace-props"
+    data-owner={props.ownerName}
+    data-droppable={String(!!props.droppable)}
+    data-type={props.props?.type}
+    onClick={() => props.onDropField && props.onDropField('x', { name: 'col' })}
+  />
+));
+
+const baseProps = {
+  nameValue: 'my_insight',
+  onNameChange: jest.fn(),
+  ownerName: 'my_insight',
+  props: { type: 'scatter' },
+  onPropsChange: jest.fn(),
+};
+
+describe('InsightEditFormFields', () => {
+  it('renders the Basic Information + Visualization Props sections', () => {
+    render(<InsightEditFormFields {...baseProps} nameTestId="name-input" />);
+    expect(screen.getByText('Basic Information')).toBeInTheDocument();
+    expect(screen.getByText('Visualization Props')).toBeInTheDocument();
+    expect(screen.getByTestId('name-input')).toHaveValue('my_insight');
+    expect(screen.getByTestId('mock-trace-props')).toHaveAttribute('data-owner', 'my_insight');
+  });
+
+  it('controls the name field (value / onChange / disabled / error)', () => {
+    const onNameChange = jest.fn();
+    render(
+      <InsightEditFormFields
+        {...baseProps}
+        onNameChange={onNameChange}
+        nameTestId="name-input"
+        nameDisabled
+        nameError="Bad name"
+        nameErrorTestId="name-err"
+      />
+    );
+    const input = screen.getByTestId('name-input');
+    expect(input).toBeDisabled();
+    fireEvent.change(input, { target: { value: 'x' } });
+    expect(onNameChange).toHaveBeenCalled();
+    expect(screen.getByTestId('name-err')).toHaveTextContent('Bad name');
+  });
+
+  it('hides the name field when showName is false, and description when showDescription is false', () => {
+    render(
+      <InsightEditFormFields
+        {...baseProps}
+        showName={false}
+        showDescription={false}
+        nameTestId="name-input"
+      />
+    );
+    expect(screen.queryByTestId('name-input')).not.toBeInTheDocument();
+    expect(screen.queryByText('Description')).not.toBeInTheDocument();
+  });
+
+  it('forwards droppable + onDropField to the props editor', () => {
+    const onDropField = jest.fn();
+    render(
+      <InsightEditFormFields {...baseProps} droppable onDropField={onDropField} />
+    );
+    const tp = screen.getByTestId('mock-trace-props');
+    expect(tp).toHaveAttribute('data-droppable', 'true');
+    fireEvent.click(tp); // the stub calls onDropField on click
+    expect(onDropField).toHaveBeenCalledWith('x', { name: 'col' });
+  });
+});

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
@@ -35,7 +35,6 @@ export function SchemaEditor({
   disabled = false,
   droppable = false,
   hidePropertyCount = false,
-  hideEmptyState = false,
 }) {
   const [addedProperties, setAddedProperties] = useState(() => new Set(initiallyExpanded));
   const [showPropertyPicker, setShowPropertyPicker] = useState(false);
@@ -170,21 +169,11 @@ export function SchemaEditor({
         />
       )}
 
-      {/* Displayed properties */}
-      {sortedDisplayedProperties.length === 0 ? (
-        // `hideEmptyState` (VIS-1224): the chart Layout section suppresses the
-        // "No properties added yet" placeholder — the "+ Add Properties" button
-        // above already conveys the affordance, and the empty dashed box just
-        // added vertical noise to an already-optional section.
-        hideEmptyState ? null : (
-          <div className="p-4 text-center bg-gray-50 rounded-md border border-dashed border-gray-300">
-            <p className="text-sm text-gray-500 mb-1">No properties added yet</p>
-            <p className="text-xs text-gray-400">
-              Click &quot;Add Properties&quot; to select which fields to configure
-            </p>
-          </div>
-        )
-      ) : (
+      {/* Displayed properties. VIS-1224: when nothing is added yet we render
+          nothing — the "+ Add Properties" button above already conveys the
+          affordance, so the old "No properties added yet" dashed box was just
+          vertical noise. */}
+      {sortedDisplayedProperties.length > 0 && (
         <div className="flex flex-col gap-1.5">
           {sortedDisplayedProperties.map(prop => (
             <PropertyRow

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.jsx
@@ -35,6 +35,7 @@ export function SchemaEditor({
   disabled = false,
   droppable = false,
   hidePropertyCount = false,
+  hideEmptyState = false,
 }) {
   const [addedProperties, setAddedProperties] = useState(() => new Set(initiallyExpanded));
   const [showPropertyPicker, setShowPropertyPicker] = useState(false);
@@ -171,12 +172,18 @@ export function SchemaEditor({
 
       {/* Displayed properties */}
       {sortedDisplayedProperties.length === 0 ? (
-        <div className="p-4 text-center bg-gray-50 rounded-md border border-dashed border-gray-300">
-          <p className="text-sm text-gray-500 mb-1">No properties added yet</p>
-          <p className="text-xs text-gray-400">
-            Click &quot;Add Properties&quot; to select which fields to configure
-          </p>
-        </div>
+        // `hideEmptyState` (VIS-1224): the chart Layout section suppresses the
+        // "No properties added yet" placeholder — the "+ Add Properties" button
+        // above already conveys the affordance, and the empty dashed box just
+        // added vertical noise to an already-optional section.
+        hideEmptyState ? null : (
+          <div className="p-4 text-center bg-gray-50 rounded-md border border-dashed border-gray-300">
+            <p className="text-sm text-gray-500 mb-1">No properties added yet</p>
+            <p className="text-xs text-gray-400">
+              Click &quot;Add Properties&quot; to select which fields to configure
+            </p>
+          </div>
+        )
       ) : (
         <div className="flex flex-col gap-1.5">
           {sortedDisplayedProperties.map(prop => (

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
@@ -91,14 +91,10 @@ describe('SchemaEditor', () => {
     expect(screen.queryByText(/of.*properties/)).not.toBeInTheDocument();
   });
 
-  it('shows empty state when no properties added', () => {
+  // VIS-1224: no "No properties added yet" placeholder — the "+ Add Properties"
+  // button conveys the affordance; the empty dashed box was just noise.
+  it('renders no empty-state placeholder when no properties are added', () => {
     render(<SchemaEditor {...defaultProps} />);
-    expect(screen.getByText(/No properties added yet/)).toBeInTheDocument();
-  });
-
-  // VIS-1224: the chart Layout section suppresses the empty-state placeholder.
-  it('hides the empty state when `hideEmptyState` is set', () => {
-    render(<SchemaEditor {...defaultProps} hideEmptyState />);
     expect(screen.queryByText(/No properties added yet/)).not.toBeInTheDocument();
   });
 
@@ -278,9 +274,9 @@ describe('SchemaEditor', () => {
     // Click it again in the picker to toggle it back OFF.
     fireEvent.click(within(picker).getByText('mode'));
 
-    // The displayed property ROW ('No properties added yet' comes back since
-    // mode was the only one) is gone; only the picker's own listing remains.
-    expect(screen.getByText(/No properties added yet/)).toBeInTheDocument();
+    // The displayed property ROW is gone (mode was the only one) — only the
+    // picker's own listing remains, so 'mode' appears exactly once now.
+    expect(screen.getAllByText('mode').length).toBe(1);
   });
 
   it('a previously-added property that is no longer valid under a NEW schema is dropped on re-sync', () => {

--- a/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/SchemaEditor.test.jsx
@@ -96,6 +96,12 @@ describe('SchemaEditor', () => {
     expect(screen.getByText(/No properties added yet/)).toBeInTheDocument();
   });
 
+  // VIS-1224: the chart Layout section suppresses the empty-state placeholder.
+  it('hides the empty state when `hideEmptyState` is set', () => {
+    render(<SchemaEditor {...defaultProps} hideEmptyState />);
+    expect(screen.queryByText(/No properties added yet/)).not.toBeInTheDocument();
+  });
+
   it('shows initially expanded properties', () => {
     render(<SchemaEditor {...defaultProps} initiallyExpanded={['x', 'y']} />);
 

--- a/viewer/src/components/views/workspace/AddInsightMenu.jsx
+++ b/viewer/src/components/views/workspace/AddInsightMenu.jsx
@@ -1,0 +1,88 @@
+import React, { useMemo, useState } from 'react';
+import { PiMagnifyingGlass, PiSparkle } from 'react-icons/pi';
+import useStore from '../../../stores/store';
+import { getTypeIcon } from '../common/objectTypeConfigs';
+
+const InsightIcon = getTypeIcon('insight');
+
+/**
+ * AddInsightMenu — the "+ Add Insight" dropdown body (Phase 6c-T5). "New blank
+ * insight" is a clearly-labeled primary action; below it, a searchable list of
+ * EXISTING project insights not already on the chart. VIS-1224: extracted from
+ * ExplorationBuildRail so the standard RightRail `ChartEditForm` can offer the
+ * same add-to-chart menu the Explorer's Add-Insight used to.
+ *
+ * @param {string[]} excludeNames - insight names already on the chart (hidden
+ *   from the pick-existing list).
+ * @param {(name: string) => void} onPickExisting
+ * @param {() => void} onCreateNew
+ * @param {() => void} close - dismiss the surrounding dropdown after a choice.
+ */
+const AddInsightMenu = ({ excludeNames = [], onPickExisting, onCreateNew, close }) => {
+  const allInsights = useStore(s => s.insights || []);
+  const [query, setQuery] = useState('');
+
+  const pickable = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allInsights
+      .filter(i => !excludeNames.includes(i.name))
+      .filter(i => !q || i.name.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [allInsights, excludeNames, query]);
+
+  return (
+    <div data-testid="add-insight-menu" className="flex max-h-80 flex-col">
+      <button
+        type="button"
+        data-testid="add-insight-menu-create-new"
+        onClick={() => {
+          onCreateNew();
+          close?.();
+        }}
+        className="flex w-full items-center gap-2 border-b border-gray-100 px-3 py-2 text-left text-xs font-medium text-purple-600 hover:bg-purple-50"
+      >
+        <PiSparkle size={14} />
+        New blank insight
+      </button>
+      <div className="flex items-center gap-1.5 border-b border-gray-100 px-2 py-1.5">
+        <PiMagnifyingGlass size={12} className="shrink-0 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Find an insight to add…"
+          data-testid="add-insight-menu-search"
+          className="w-full border-none bg-transparent text-xs text-gray-700 outline-none placeholder:text-gray-400"
+          autoFocus
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto py-1">
+        {pickable.length === 0 ? (
+          <p className="px-3 py-2 text-xs text-gray-400">
+            {allInsights.length === 0
+              ? 'No other insights in this project yet.'
+              : 'No matches — every other insight is already on this chart.'}
+          </p>
+        ) : (
+          pickable.map(insight => (
+            <button
+              key={insight.name}
+              type="button"
+              data-testid={`add-insight-menu-existing-${insight.name}`}
+              onClick={() => {
+                onPickExisting(insight.name);
+                close?.();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-50"
+            >
+              {InsightIcon && <InsightIcon size={13} className="shrink-0 text-purple-500" />}
+              <span className="truncate">{insight.name}</span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AddInsightMenu;

--- a/viewer/src/components/views/workspace/ChartBuildSection.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.jsx
@@ -4,6 +4,10 @@ import useStore from '../../../stores/store';
 import PanelMenu from '../../common/PanelMenu';
 import { getSchema } from '../../../schemas/schemas';
 import ChartEditFormFields from '../common/ChartEditFormFields';
+import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
+
+const CHART_COLORS = getTypeColors('chart');
+const ChartTypeIcon = getTypeIcon('chart');
 
 /**
  * ChartBuildSection — the Explorer Build-rail chart pane. VIS-1224: renders the
@@ -121,9 +125,24 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
           {isExpanded ? <PiCaretDown size={14} /> : <PiCaretRight size={14} />}
         </button>
 
-        <span className="flex-1 truncate text-sm font-medium text-secondary-900" data-testid="chart-header-label">
-          {chartName ? `Chart: ${chartName}` : 'Chart'}
+        {/* VIS-1224: SelectionChip-style identity (type icon + name + TYPE),
+            matching the standard RightRail edit-panel header. */}
+        <span
+          className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border ${CHART_COLORS.bg} ${CHART_COLORS.text} ${CHART_COLORS.border}`}
+        >
+          {ChartTypeIcon && <ChartTypeIcon style={{ fontSize: 14 }} />}
         </span>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span
+            className="truncate text-[13px] font-semibold text-secondary-900"
+            data-testid="chart-header-label"
+            title={chartName || 'Chart'}
+          >
+            {chartName || 'Chart'}
+          </span>
+          <span className="truncate text-[10.5px] uppercase tracking-wide text-gray-400">Chart</span>
+        </div>
 
         <PanelMenu
           testId="chart"

--- a/viewer/src/components/views/workspace/ChartBuildSection.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { PiCaretDown, PiCaretRight, PiPlus, PiX } from 'react-icons/pi';
+import { PiCaretDown, PiCaretRight, PiPlus, PiX, PiPencilSimple } from 'react-icons/pi';
 import { useDroppable } from '@dnd-kit/core';
 import EmbeddedPill from '../lineage/EmbeddedPill';
 import useStore from '../../../stores/store';
+import PanelMenu from '../../common/PanelMenu';
 import { selectInsightStatus } from '../../../stores/explorerStore';
 import { getSchema } from '../../../schemas/schemas';
 import { SchemaEditor } from '../common/SchemaEditor/SchemaEditor';
@@ -52,6 +53,18 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
   const [renameError, setRenameError] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
   const skipNextCommitRef = useRef(false);
+  const nameInputRef = useRef(null);
+
+  // VIS-1224: the ⋮ menu's "Rename" focuses the existing inline name field
+  // (selecting its text). A loaded/saved chart's name is not editable here
+  // (the field is `disabled`), so the menu item is disabled in that case —
+  // renaming a promoted chart is VIS-1209's project-wide ${ref()} rewrite.
+  const startRename = useCallback(() => {
+    const el = nameInputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
 
   useEffect(() => {
     if (!isEditing) {
@@ -167,6 +180,7 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
 
         <span className="flex-1 flex flex-col">
           <input
+            ref={nameInputRef}
             data-testid="chart-name-input"
             value={renameValue}
             disabled={isLoadedChart}
@@ -203,6 +217,20 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
             </span>
           )}
         </span>
+
+        <PanelMenu
+          testId="chart"
+          ariaLabel="Chart options"
+          items={[
+            {
+              id: 'rename',
+              label: 'Rename',
+              icon: PiPencilSimple,
+              disabled: isLoadedChart,
+              onSelect: startRename,
+            },
+          ]}
+        />
 
         <button
           data-testid="chart-close"

--- a/viewer/src/components/views/workspace/ChartBuildSection.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.jsx
@@ -6,7 +6,7 @@ import useStore from '../../../stores/store';
 import PanelMenu from '../../common/PanelMenu';
 import { selectInsightStatus } from '../../../stores/explorerStore';
 import { getSchema } from '../../../schemas/schemas';
-import { SchemaEditor } from '../common/SchemaEditor/SchemaEditor';
+import ChartEditFormFields from '../common/ChartEditFormFields';
 import { recordOnboardingAction } from '../../onboarding/onboardingState';
 
 const InsightPillItem = ({ name, isActive, onRemove, onClick }) => {
@@ -26,14 +26,14 @@ const InsightPillItem = ({ name, isActive, onRemove, onClick }) => {
 };
 
 /**
- * ChartBuildSection — Explore 2.0 Phase 3b (VIS-1059). Replaces
- * `ChartCRUDSection` on the exploration Build rail. Behaviorally identical
- * to the retired component (chart name/rename, insight list + drop zone,
- * Layout Properties) — this section's own body has no ref-valued/pillable
- * slots (chart Layout properties are static Plotly layout knobs, not query
- * expressions), so it stays on `SchemaEditor` with `droppable={false}`
- * exactly as before; the D8/D10 pill + `property-zone` DnD rebuild's target
- * is `InsightBuildSection`'s per-insight props, not this section.
+ * ChartBuildSection — the Explorer Build-rail chart pane. VIS-1224: the colored
+ * side-bar body is gone; it now renders the SAME standard chart edit panel as
+ * the RightRail (`ChartEditFormFields` — Basic Information + Layout) with the
+ * Explorer's own insight-selection section (drop zone + activate-on-click pills
+ * + Add Insight) passed in as the shared panel's `insightsSection` slot. Name
+ * edits write through `setChartName` live (no Save button); the ⋮ menu's
+ * "Rename" focuses the Basic Information name field (disabled for a loaded/saved
+ * chart — that rename is VIS-1209's project-wide ${ref()} rewrite).
  */
 const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
   const isLoadedChart = useStore(s => (s.charts || []).some(c => c.name === s.explorerChartName));
@@ -49,26 +49,17 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
   const closeChart = useStore(s => s.closeChart);
 
   const [layoutSchema, setLayoutSchema] = useState(null);
-  const [renameValue, setRenameValue] = useState('');
+  const [renameValue, setRenameValue] = useState(chartName || '');
   const [renameError, setRenameError] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
-  const skipNextCommitRef = useRef(false);
   const nameInputRef = useRef(null);
 
-  // VIS-1224: the ⋮ menu's "Rename" focuses the existing inline name field
-  // (selecting its text). A loaded/saved chart's name is not editable here
-  // (the field is `disabled`), so the menu item is disabled in that case —
-  // renaming a promoted chart is VIS-1209's project-wide ${ref()} rewrite.
-  const startRename = useCallback(() => {
-    const el = nameInputRef.current;
-    if (!el) return;
-    el.focus();
-    el.select();
-  }, []);
-
+  // Keep the name buffer synced to the store while the user isn't actively
+  // editing — the chart can be auto-named by ExplorationBuildRail's naming
+  // effect (`setChartName`), and the field must reflect that.
   useEffect(() => {
     if (!isEditing) {
-      setRenameValue(chartName || 'Untitled');
+      setRenameValue(chartName || '');
       setRenameError(null);
     }
   }, [chartName, isEditing]);
@@ -87,6 +78,33 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
       cancelled = true;
     };
   }, []);
+
+  // The ⋮ "Rename" action focuses the Basic Information name field.
+  const startRename = useCallback(() => {
+    nameInputRef.current?.focus();
+    nameInputRef.current?.select();
+  }, []);
+
+  const commitRename = useCallback(() => {
+    setIsEditing(false);
+    const trimmed = renameValue.trim();
+    if (!trimmed || trimmed === (chartName || '')) {
+      setRenameError(null);
+      setRenameValue(chartName || '');
+      return;
+    }
+    try {
+      setChartName(trimmed);
+      setRenameError(null);
+    } catch (err) {
+      if (err?.code === 'NAME_COLLISION') {
+        setRenameError(err.message);
+        setIsEditing(true);
+        return;
+      }
+      throw err;
+    }
+  }, [renameValue, chartName, setChartName]);
 
   const handleLayoutChange = useCallback(
     newValue => {
@@ -132,30 +150,45 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
     [closeChart]
   );
 
-  const commitRename = useCallback(() => {
-    if (skipNextCommitRef.current) {
-      skipNextCommitRef.current = false;
-      return;
-    }
-    setIsEditing(false);
-    const trimmed = renameValue.trim();
-    if (!trimmed || trimmed === (chartName || 'Untitled') || trimmed === 'Untitled') {
-      setRenameError(null);
-      setRenameValue(chartName || 'Untitled');
-      return;
-    }
-    try {
-      setChartName(trimmed);
-      setRenameError(null);
-    } catch (err) {
-      if (err?.code === 'NAME_COLLISION') {
-        setRenameError(err.message);
-        setIsEditing(true);
-        return;
-      }
-      throw err;
-    }
-  }, [renameValue, chartName, setChartName]);
+  // The Explorer-specific insight selection — a drop zone (chart-insight-zone),
+  // activate-on-click pills, and Add Insight — handed to the shared panel as
+  // its insight-selection slot.
+  const insightsSection = (
+    <div
+      ref={setInsightDropRef}
+      data-testid="chart-insight-drop-zone"
+      className={`space-y-1 rounded p-2 transition-all ${
+        isInsightOver ? 'ring-2 ring-primary-400 ring-offset-1 bg-primary-50/50' : ''
+      }`}
+    >
+      <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">Insights</h3>
+      {chartInsightNames.length === 0 ? (
+        <p className="text-xs text-gray-400 py-2">
+          No insights added yet. Drag from the Library or click below.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {chartInsightNames.map(name => (
+            <InsightPillItem
+              key={name}
+              name={name}
+              isActive={name === activeInsightName}
+              onClick={() => handleInsightClick(name)}
+              onRemove={e => handleRemoveInsight(e, name)}
+            />
+          ))}
+        </div>
+      )}
+      <button
+        data-testid="chart-add-insight"
+        onClick={handleAddInsight}
+        className="flex items-center gap-1 mt-2 text-xs text-primary-600 hover:text-primary-800 transition-colors"
+      >
+        <PiPlus size={12} />
+        Add Insight
+      </button>
+    </div>
+  );
 
   return (
     <div
@@ -163,10 +196,13 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
       data-onb-target="chart-crud-section"
       className="border border-gray-200 rounded-lg overflow-hidden"
     >
+      {/* VIS-1224: neutral collapsible header (the colored side-bar is gone —
+          the body now renders the same standard chart edit panel as the
+          RightRail). The editable name lives in the Basic Information field. */}
       <div
         data-testid="chart-header"
         onClick={onToggleExpand}
-        className="flex items-center gap-2 px-3 py-2 bg-pink-50/50 border-l-4 border-pink-400 cursor-pointer hover:bg-pink-50 transition-colors duration-150"
+        className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200 cursor-pointer hover:bg-gray-100 transition-colors duration-150"
       >
         <button
           data-testid="chart-toggle"
@@ -176,46 +212,8 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
           {isExpanded ? <PiCaretDown size={14} /> : <PiCaretRight size={14} />}
         </button>
 
-        <span className="text-sm text-pink-600 flex-shrink-0">{'Chart: '}</span>
-
-        <span className="flex-1 flex flex-col">
-          <input
-            ref={nameInputRef}
-            data-testid="chart-name-input"
-            value={renameValue}
-            disabled={isLoadedChart}
-            onFocus={() => setIsEditing(true)}
-            onChange={e => {
-              setRenameValue(e.target.value);
-              if (renameError) setRenameError(null);
-            }}
-            onBlur={() => commitRename()}
-            onKeyDown={e => {
-              if (e.key === 'Enter') e.target.blur();
-              if (e.key === 'Escape') {
-                skipNextCommitRef.current = true;
-                setRenameError(null);
-                setRenameValue(chartName || 'Untitled');
-                setIsEditing(false);
-                e.target.blur();
-              }
-            }}
-            onClick={e => e.stopPropagation()}
-            // D12: an unnamed chart's fallback text ('Untitled') is styled as
-            // a lighter, italic placeholder rather than a solid committed
-            // name — "Chart: Untitled" previously read like a real, boring
-            // title rather than "you haven't named this yet". Purely visual;
-            // the underlying rename/sentinel logic (commitRename treating a
-            // re-typed 'Untitled' as a no-op) is unchanged.
-            className={`text-sm bg-transparent border-0 border-b border-transparent px-0 py-0 outline-none focus:border-pink-400 disabled:cursor-default ${
-              !chartName && !isEditing ? 'italic text-gray-400 font-normal' : 'font-medium text-pink-800'
-            } ${renameError ? 'border-highlight-400 focus:border-highlight-400' : ''}`}
-          />
-          {renameError && (
-            <span data-testid="chart-rename-error" className="text-xs text-highlight-600 mt-0.5">
-              {renameError}
-            </span>
-          )}
+        <span className="flex-1 truncate text-sm font-medium text-secondary-900" data-testid="chart-header-label">
+          {chartName ? `Chart: ${chartName}` : 'Chart'}
         </span>
 
         <PanelMenu
@@ -243,60 +241,45 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
       </div>
 
       {isExpanded && (
-        <div className="px-3 py-3 space-y-4 border-l-4 border-pink-400">
-          <div
-            ref={setInsightDropRef}
-            data-testid="chart-insight-drop-zone"
-            className={`rounded p-2 transition-all ${
-              isInsightOver ? 'ring-2 ring-pink-400 ring-offset-1 bg-pink-50/50' : ''
-            }`}
-          >
-            <label className="block text-xs font-medium text-gray-600 mb-1">Insights</label>
-            {chartInsightNames.length === 0 ? (
-              <p className="text-xs text-gray-400 py-2">
-                No insights added yet. Drag from the Library or click below.
-              </p>
-            ) : (
-              <div className="flex flex-wrap gap-1.5">
-                {chartInsightNames.map(name => (
-                  <InsightPillItem
-                    key={name}
-                    name={name}
-                    isActive={name === activeInsightName}
-                    onClick={() => handleInsightClick(name)}
-                    onRemove={e => handleRemoveInsight(e, name)}
-                  />
-                ))}
-              </div>
-            )}
-            <button
-              data-testid="chart-add-insight"
-              onClick={handleAddInsight}
-              className="flex items-center gap-1 mt-2 text-xs text-pink-600 hover:text-pink-800 transition-colors"
-            >
-              <PiPlus size={12} />
-              Add Insight
-            </button>
-          </div>
-
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Layout Properties</label>
-            {/* D12 (pills-buildrail #8/#9): the Plotly layout schema has
-                1300+ leaves — "0 of 1366 properties" is the single most-
-                quoted "raw schema dump" moment in the audit. Curated
-                cleanup, not a picker redesign: hide the count, keep the
-                existing search-driven "Add Properties" picker as the one
-                path into the long tail. */}
-            <SchemaEditor
-              schema={layoutSchema}
-              value={chartLayout}
-              onChange={handleLayoutChange}
-              excludeProperties={[]}
-              initiallyExpanded={Object.keys(chartLayout || {})}
-              droppable={false}
-              hidePropertyCount
-            />
-          </div>
+        <div className="p-3 space-y-4">
+          <ChartEditFormFields
+            showName
+            nameId="chart-name-field"
+            nameLabel="Chart Name"
+            nameValue={renameValue}
+            onNameChange={e => {
+              setRenameValue(e.target.value);
+              if (renameError) setRenameError(null);
+            }}
+            onNameFocus={() => setIsEditing(true)}
+            onNameBlur={commitRename}
+            onNameKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitRename();
+              } else if (e.key === 'Escape') {
+                setRenameError(null);
+                setRenameValue(chartName || '');
+                setIsEditing(false);
+              }
+            }}
+            nameDisabled={isLoadedChart}
+            nameError={renameError}
+            nameErrorTestId="chart-rename-error"
+            nameInputRef={nameInputRef}
+            nameTestId="chart-name-input"
+            insightsSection={insightsSection}
+            layoutTitle="Layout Properties"
+            layoutSchema={layoutSchema}
+            layoutValues={chartLayout}
+            onLayoutChange={handleLayoutChange}
+            layoutEditorProps={{
+              excludeProperties: [],
+              initiallyExpanded: Object.keys(chartLayout || {}),
+              droppable: false,
+              hidePropertyCount: true,
+            }}
+          />
         </div>
       )}
     </div>

--- a/viewer/src/components/views/workspace/ChartBuildSection.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.jsx
@@ -1,51 +1,25 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { PiCaretDown, PiCaretRight, PiPlus, PiX, PiPencilSimple } from 'react-icons/pi';
-import { useDroppable } from '@dnd-kit/core';
-import EmbeddedPill from '../lineage/EmbeddedPill';
+import { PiCaretDown, PiCaretRight, PiX, PiPencilSimple } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import PanelMenu from '../../common/PanelMenu';
-import { selectInsightStatus } from '../../../stores/explorerStore';
 import { getSchema } from '../../../schemas/schemas';
 import ChartEditFormFields from '../common/ChartEditFormFields';
-import { recordOnboardingAction } from '../../onboarding/onboardingState';
-
-const InsightPillItem = ({ name, isActive, onRemove, onClick }) => {
-  const status = useStore(selectInsightStatus(name));
-  return (
-    <span data-testid={`chart-insight-pill-${name}`}>
-      <EmbeddedPill
-        objectType="insight"
-        label={name}
-        isActive={isActive}
-        onClick={onClick}
-        onRemove={onRemove}
-        statusDot={status}
-      />
-    </span>
-  );
-};
 
 /**
- * ChartBuildSection — the Explorer Build-rail chart pane. VIS-1224: the colored
- * side-bar body is gone; it now renders the SAME standard chart edit panel as
- * the RightRail (`ChartEditFormFields` — Basic Information + Layout) with the
- * Explorer's own insight-selection section (drop zone + activate-on-click pills
- * + Add Insight) passed in as the shared panel's `insightsSection` slot. Name
- * edits write through `setChartName` live (no Save button); the ⋮ menu's
- * "Rename" focuses the Basic Information name field (disabled for a loaded/saved
- * chart — that rename is VIS-1209's project-wide ${ref()} rewrite).
+ * ChartBuildSection — the Explorer Build-rail chart pane. VIS-1224: renders the
+ * SAME standard chart edit panel as the RightRail (`ChartEditFormFields` —
+ * Basic Information + Layout). It has NO insight-selection section: in the
+ * Explorer the chart's insights ARE the stacked insight panes above it (added
+ * via the rail's "+ Add Insight"), so there is nothing to pick or drop here.
+ * Name edits write through `setChartName` live (editable only for an unsaved
+ * chart; the ⋮ Rename focuses the Basic Information field).
  */
 const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
   const isLoadedChart = useStore(s => (s.charts || []).some(c => c.name === s.explorerChartName));
   const chartName = useStore(s => s.explorerChartName);
   const chartLayout = useStore(s => s.explorerChartLayout);
-  const chartInsightNames = useStore(s => s.explorerChartInsightNames);
-  const activeInsightName = useStore(s => s.explorerActiveInsightName);
   const setChartName = useStore(s => s.setChartName);
   const replaceChartLayout = useStore(s => s.replaceChartLayout);
-  const createInsight = useStore(s => s.createInsight);
-  const removeInsightFromChart = useStore(s => s.removeInsightFromChart);
-  const setActiveInsight = useStore(s => s.setActiveInsight);
   const closeChart = useStore(s => s.closeChart);
 
   const [layoutSchema, setLayoutSchema] = useState(null);
@@ -63,11 +37,6 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
       setRenameError(null);
     }
   }, [chartName, isEditing]);
-
-  const { setNodeRef: setInsightDropRef, isOver: isInsightOver } = useDroppable({
-    id: 'chart-insight-zone',
-    data: { type: 'insight-zone' },
-  });
 
   useEffect(() => {
     let cancelled = false;
@@ -114,26 +83,6 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
     [replaceChartLayout]
   );
 
-  const handleAddInsight = useCallback(() => {
-    createInsight();
-    recordOnboardingAction('insight_added');
-  }, [createInsight]);
-
-  const handleRemoveInsight = useCallback(
-    (e, name) => {
-      e.stopPropagation();
-      removeInsightFromChart(name);
-    },
-    [removeInsightFromChart]
-  );
-
-  const handleInsightClick = useCallback(
-    name => {
-      setActiveInsight(name);
-    },
-    [setActiveInsight]
-  );
-
   const handleToggle = useCallback(
     e => {
       e.stopPropagation();
@@ -148,46 +97,6 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
       closeChart?.();
     },
     [closeChart]
-  );
-
-  // The Explorer-specific insight selection — a drop zone (chart-insight-zone),
-  // activate-on-click pills, and Add Insight — handed to the shared panel as
-  // its insight-selection slot.
-  const insightsSection = (
-    <div
-      ref={setInsightDropRef}
-      data-testid="chart-insight-drop-zone"
-      className={`space-y-1 rounded p-2 transition-all ${
-        isInsightOver ? 'ring-2 ring-primary-400 ring-offset-1 bg-primary-50/50' : ''
-      }`}
-    >
-      <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">Insights</h3>
-      {chartInsightNames.length === 0 ? (
-        <p className="text-xs text-gray-400 py-2">
-          No insights added yet. Drag from the Library or click below.
-        </p>
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {chartInsightNames.map(name => (
-            <InsightPillItem
-              key={name}
-              name={name}
-              isActive={name === activeInsightName}
-              onClick={() => handleInsightClick(name)}
-              onRemove={e => handleRemoveInsight(e, name)}
-            />
-          ))}
-        </div>
-      )}
-      <button
-        data-testid="chart-add-insight"
-        onClick={handleAddInsight}
-        className="flex items-center gap-1 mt-2 text-xs text-primary-600 hover:text-primary-800 transition-colors"
-      >
-        <PiPlus size={12} />
-        Add Insight
-      </button>
-    </div>
   );
 
   return (
@@ -268,7 +177,6 @@ const ChartBuildSection = ({ isExpanded, onToggleExpand }) => {
             nameErrorTestId="chart-rename-error"
             nameInputRef={nameInputRef}
             nameTestId="chart-name-input"
-            insightsSection={insightsSection}
             layoutTitle="Layout Properties"
             layoutSchema={layoutSchema}
             layoutValues={chartLayout}

--- a/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
@@ -260,6 +260,22 @@ describe('ChartBuildSection', () => {
   });
 
   describe('rename flow', () => {
+    // VIS-1224: the ⋮ panel menu is the discoverable rename entry point; it
+    // focuses the existing inline name field.
+    it('the ⋮ menu Rename item focuses the chart name field', async () => {
+      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      fireEvent.click(await screen.findByTestId('panel-menu-trigger-chart'));
+      fireEvent.click(screen.getByTestId('panel-menu-item-rename-chart'));
+      expect(screen.getByTestId('chart-name-input')).toHaveFocus();
+    });
+
+    it('the ⋮ menu Rename item is disabled for a loaded chart', async () => {
+      useStore.setState({ charts: [{ name: 'test_chart' }] });
+      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
+      fireEvent.click(await screen.findByTestId('panel-menu-trigger-chart'));
+      expect(screen.getByTestId('panel-menu-item-rename-chart')).toBeDisabled();
+    });
+
     it('commits a trimmed rename on blur', async () => {
       const setChartName = jest.fn();
       useStore.setState({ setChartName });

--- a/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
@@ -133,34 +133,6 @@ describe('ChartBuildSection', () => {
     expect(nameEl).toBeDisabled();
   });
 
-  it('renders insight list with pills', async () => {
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    expect(await screen.findByTestId('chart-insight-pill-insight_1')).toBeInTheDocument();
-    expect(screen.getByTestId('chart-insight-pill-insight_2')).toBeInTheDocument();
-  });
-
-  it('active insight is highlighted', async () => {
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    const activePill = await screen.findByTestId('embedded-pill-insight-insight_1');
-    expect(activePill.dataset.active).toBe('true');
-  });
-
-  it('remove button on pill calls removeInsightFromChart', async () => {
-    const removeInsightFromChart = jest.fn();
-    useStore.setState({ removeInsightFromChart });
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    fireEvent.click(await screen.findByTestId('embedded-pill-remove-insight_2'));
-    expect(removeInsightFromChart).toHaveBeenCalledWith('insight_2');
-  });
-
-  it('add insight button calls createInsight', async () => {
-    const createInsight = jest.fn();
-    useStore.setState({ createInsight });
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    fireEvent.click(await screen.findByTestId('chart-add-insight'));
-    expect(createInsight).toHaveBeenCalled();
-  });
-
   it('renders layout SchemaEditor when expanded', async () => {
     renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
     expect(await screen.findByTestId('chart-schema-editor')).toBeInTheDocument();
@@ -194,46 +166,6 @@ describe('ChartBuildSection', () => {
     renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
     fireEvent.click(await screen.findByTestId('chart-close'));
     expect(closeChart).toHaveBeenCalled();
-  });
-
-  it('clicking an insight pill calls setActiveInsight', async () => {
-    const setActiveInsight = jest.fn();
-    useStore.setState({ setActiveInsight });
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    fireEvent.click(await screen.findByTestId('embedded-pill-insight-insight_2'));
-    expect(setActiveInsight).toHaveBeenCalledWith('insight_2');
-  });
-
-  it('renders empty insights message when no insights', async () => {
-    useStore.setState({ explorerChartInsightNames: [], explorerInsightStates: {} });
-    renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-    expect(await screen.findByText(/no insights/i)).toBeInTheDocument();
-  });
-
-  describe('insight drop zone', () => {
-    it('renders the drop zone with correct test id when expanded', async () => {
-      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-      expect(await screen.findByTestId('chart-insight-drop-zone')).toBeInTheDocument();
-    });
-
-    it('does not render the drop zone when collapsed', async () => {
-      renderInDnd(<ChartBuildSection isExpanded={false} onToggleExpand={jest.fn()} />);
-      await screen.findByTestId('chart-header-label');
-      expect(screen.queryByTestId('chart-insight-drop-zone')).not.toBeInTheDocument();
-    });
-
-    it('drop zone wraps the insights list and add button', async () => {
-      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-      const dropZone = await screen.findByTestId('chart-insight-drop-zone');
-      expect(dropZone).toContainElement(screen.getByTestId('chart-add-insight'));
-      expect(dropZone).toContainElement(screen.getByTestId('chart-insight-pill-insight_1'));
-    });
-
-    it('drop zone shows updated empty hint with drag instruction', async () => {
-      useStore.setState({ explorerChartInsightNames: [], explorerInsightStates: {} });
-      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-      expect(await screen.findByText(/drag from the library/i)).toBeInTheDocument();
-    });
   });
 
   describe('layout changes', () => {

--- a/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
@@ -150,7 +150,7 @@ describe('ChartBuildSection', () => {
   // collapsed header shows the name as a read-only identity label.
   it('chart name appears in the collapsed header label', async () => {
     renderInDnd(<ChartBuildSection isExpanded={false} onToggleExpand={jest.fn()} />);
-    expect(await screen.findByTestId('chart-header-label')).toHaveTextContent('Chart: test_chart');
+    expect(await screen.findByTestId('chart-header-label')).toHaveTextContent('test_chart');
   });
 
   it('collapse/expand toggle works', async () => {

--- a/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/ChartBuildSection.test.jsx
@@ -168,15 +168,17 @@ describe('ChartBuildSection', () => {
 
   it('does not render SchemaEditor when collapsed', async () => {
     renderInDnd(<ChartBuildSection isExpanded={false} onToggleExpand={jest.fn()} />);
-    // Wait for the always-rendered chart name input so the schema-fetch
-    // effect settles before we assert the absence of the schema editor.
-    await screen.findByDisplayValue('test_chart');
+    // Wait for the always-rendered header so the schema-fetch effect settles
+    // before we assert the absence of the schema editor.
+    await screen.findByTestId('chart-header-label');
     expect(screen.queryByTestId('chart-schema-editor')).not.toBeInTheDocument();
   });
 
-  it('chart name is always visible in header even when collapsed', async () => {
+  // VIS-1224: the editable name lives in the Basic Information body now; the
+  // collapsed header shows the name as a read-only identity label.
+  it('chart name appears in the collapsed header label', async () => {
     renderInDnd(<ChartBuildSection isExpanded={false} onToggleExpand={jest.fn()} />);
-    expect(await screen.findByDisplayValue('test_chart')).toBeInTheDocument();
+    expect(await screen.findByTestId('chart-header-label')).toHaveTextContent('Chart: test_chart');
   });
 
   it('collapse/expand toggle works', async () => {
@@ -216,7 +218,7 @@ describe('ChartBuildSection', () => {
 
     it('does not render the drop zone when collapsed', async () => {
       renderInDnd(<ChartBuildSection isExpanded={false} onToggleExpand={jest.fn()} />);
-      await screen.findByDisplayValue('test_chart');
+      await screen.findByTestId('chart-header-label');
       expect(screen.queryByTestId('chart-insight-drop-zone')).not.toBeInTheDocument();
     });
 
@@ -315,20 +317,6 @@ describe('ChartBuildSection', () => {
       expect(input).toHaveValue('test_chart');
     });
 
-    it('does not commit the placeholder name "Untitled"', async () => {
-      const setChartName = jest.fn();
-      useStore.setState({ setChartName });
-      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-
-      const input = await screen.findByTestId('chart-name-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: 'Untitled' } });
-      fireEvent.blur(input);
-
-      expect(setChartName).not.toHaveBeenCalled();
-      expect(input).toHaveValue('test_chart');
-    });
-
     it('commits rename on Enter via blur', async () => {
       const setChartName = jest.fn();
       useStore.setState({ setChartName });
@@ -418,17 +406,17 @@ describe('ChartBuildSection', () => {
     expect(nameEl).not.toBeDisabled();
   });
 
-  describe('chartName unset (Untitled fallback branches)', () => {
-    it('renders "Untitled" in italic placeholder styling when there is no chart name yet', async () => {
+  // VIS-1224: an unnamed chart shows an EMPTY Basic Information name field (the
+  // floating "Chart Name" label carries the affordance) — the old "Untitled"
+  // sentinel is gone.
+  describe('chartName unset (empty name field)', () => {
+    it('renders an empty name field when there is no chart name yet', async () => {
       useStore.setState({ explorerChartName: '' });
       renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-      const input = await screen.findByTestId('chart-name-input');
-      expect(input).toHaveValue('Untitled');
-      expect(input.className).toContain('italic');
-      expect(input.className).toContain('text-gray-400');
+      expect(await screen.findByTestId('chart-name-input')).toHaveValue('');
     });
 
-    it('committing an empty/whitespace name while unset resets to "Untitled" (chartName||"Untitled" fallback)', async () => {
+    it('committing an empty/whitespace name while unset does not call setChartName', async () => {
       const setChartName = jest.fn();
       useStore.setState({ explorerChartName: '', setChartName });
       renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
@@ -437,29 +425,17 @@ describe('ChartBuildSection', () => {
       fireEvent.change(input, { target: { value: '   ' } });
       fireEvent.blur(input);
       expect(setChartName).not.toHaveBeenCalled();
-      expect(input).toHaveValue('Untitled');
+      expect(input).toHaveValue('');
     });
 
-    it('Escape while unset restores "Untitled" (chartName||"Untitled" fallback in the Escape handler)', async () => {
+    it('Escape while unset restores the empty field', async () => {
       useStore.setState({ explorerChartName: '' });
       renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
       const input = await screen.findByTestId('chart-name-input');
       fireEvent.focus(input);
       fireEvent.change(input, { target: { value: 'abandoned' } });
       fireEvent.keyDown(input, { key: 'Escape' });
-      expect(input).toHaveValue('Untitled');
-    });
-
-    it('re-typing "Untitled" verbatim while unset is a no-op (matches the chartName||"Untitled" fallback, not just the literal check)', async () => {
-      const setChartName = jest.fn();
-      useStore.setState({ explorerChartName: '', setChartName });
-      renderInDnd(<ChartBuildSection isExpanded={true} onToggleExpand={jest.fn()} />);
-      const input = await screen.findByTestId('chart-name-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: 'Untitled' } });
-      fireEvent.blur(input);
-      expect(setChartName).not.toHaveBeenCalled();
-      expect(input).toHaveValue('Untitled');
+      expect(input).toHaveValue('');
     });
   });
 

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
-import { PiPlus, PiFloppyDisk, PiCheckCircle, PiMagnifyingGlass, PiSparkle } from 'react-icons/pi';
+import { PiPlus, PiFloppyDisk, PiCheckCircle } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import {
   selectHasModifications,
@@ -13,85 +13,6 @@ import InsightBuildSection from './InsightBuildSection';
 import ChartBuildSection from './ChartBuildSection';
 import ExplorationPromoteModal from './ExplorationPromoteModal';
 import { recordOnboardingAction } from '../../onboarding/onboardingState';
-import Dropdown from '../../common/Dropdown';
-import { getTypeIcon } from '../common/objectTypeConfigs';
-
-const InsightIcon = getTypeIcon('insight');
-
-/**
- * AddInsightMenu — Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank
- * insight instead of letting you pick an existing one" finding). The picker
- * is primary (project insights not already on this chart, searchable); "New
- * blank insight" is a clearly-labeled secondary action, not the only option
- * a click on "+ Add Insight" ever produced.
- */
-const AddInsightMenu = ({ onPickExisting, onCreateNew, close }) => {
-  const allInsights = useStore(s => s.insights || []);
-  const chartInsightNames = useStore(s => s.explorerChartInsightNames);
-  const [query, setQuery] = useState('');
-
-  const pickable = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return allInsights
-      .filter(i => !chartInsightNames.includes(i.name))
-      .filter(i => !q || i.name.toLowerCase().includes(q))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [allInsights, chartInsightNames, query]);
-
-  return (
-    <div data-testid="add-insight-menu" className="flex max-h-80 flex-col">
-      <button
-        type="button"
-        data-testid="add-insight-menu-create-new"
-        onClick={() => {
-          onCreateNew();
-          close();
-        }}
-        className="flex w-full items-center gap-2 border-b border-gray-100 px-3 py-2 text-left text-xs font-medium text-purple-600 hover:bg-purple-50"
-      >
-        <PiSparkle size={14} />
-        New blank insight
-      </button>
-      <div className="flex items-center gap-1.5 border-b border-gray-100 px-2 py-1.5">
-        <PiMagnifyingGlass size={12} className="shrink-0 text-gray-400" />
-        <input
-          type="text"
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          placeholder="Find an insight to add…"
-          data-testid="add-insight-menu-search"
-          className="w-full border-none bg-transparent text-xs text-gray-700 outline-none placeholder:text-gray-400"
-          autoFocus
-        />
-      </div>
-      <div className="flex-1 overflow-y-auto py-1">
-        {pickable.length === 0 ? (
-          <p className="px-3 py-2 text-xs text-gray-400">
-            {allInsights.length === 0
-              ? 'No other insights in this project yet.'
-              : 'No matches — every other insight is already on this chart.'}
-          </p>
-        ) : (
-          pickable.map(insight => (
-            <button
-              key={insight.name}
-              type="button"
-              data-testid={`add-insight-menu-existing-${insight.name}`}
-              onClick={() => {
-                onPickExisting(insight.name);
-                close();
-              }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-50"
-            >
-              {InsightIcon && <InsightIcon size={13} className="shrink-0 text-purple-500" />}
-              <span className="truncate">{insight.name}</span>
-            </button>
-          ))
-        )}
-      </div>
-    </div>
-  );
-};
 
 // A single stable reference for the "no promoted entries" case — a fresh `[]`
 // literal returned from a Zustand selector on every render breaks the
@@ -137,7 +58,6 @@ const ExplorationBuildRail = ({ explorationId }) => {
   const activeInsightName = useStore(s => s.explorerActiveInsightName);
   const setActiveInsight = useStore(s => s.setActiveInsight);
   const createInsight = useStore(s => s.createInsight);
-  const addExistingInsightToChart = useStore(s => s.addExistingInsightToChart);
   const hasChanges = useStore(selectHasModifications);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const promotedRaw = useStore(s =>
@@ -373,19 +293,6 @@ const ExplorationBuildRail = ({ explorationId }) => {
     recordOnboardingAction('insight_added');
   }, [createInsight]);
 
-  // Phase 6c-T5 (ux-audit.md "'+ Add Insight' creates a blank insight
-  // instead of letting you pick an existing one" finding): reuses the SAME
-  // pull-in logic the Library's "Add to exploration" context action and
-  // drag-and-drop already go through — an existing insight added this way
-  // brings its referenced models along automatically.
-  const handlePickExistingInsight = useCallback(
-    insightName => {
-      addExistingInsightToChart?.(insightName);
-      recordOnboardingAction('insight_added');
-    },
-    [addExistingInsightToChart]
-  );
-
   return (
     <div
       data-testid="exploration-build-rail"
@@ -408,28 +315,21 @@ const ExplorationBuildRail = ({ explorationId }) => {
           />
         ))}
 
-        <Dropdown
-          width={260}
-          trigger={
-            <button
-              type="button"
-              data-testid="right-panel-add-insight"
-              data-onb-target="right-panel-add-insight"
-              className="flex items-center gap-1.5 w-full px-3 py-2 text-xs font-medium text-purple-600 hover:text-purple-800 hover:bg-purple-50 rounded-md border border-dashed border-purple-300 transition-colors"
-            >
-              <PiPlus size={14} />
-              Add Insight
-            </button>
-          }
+        {/* VIS-1224: in the Explorer you CREATE insights (you don't pick
+            existing ones — that's the chart edit panel's job), so this is a
+            plain "+ Add Insight" that appends a new blank insight below the
+            stack. The pick-existing menu (AddInsightMenu) now lives on the
+            standard chart edit form. */}
+        <button
+          type="button"
+          data-testid="right-panel-add-insight"
+          data-onb-target="right-panel-add-insight"
+          onClick={handleCreateNewInsight}
+          className="flex items-center gap-1.5 w-full px-3 py-2 text-xs font-medium text-purple-600 hover:text-purple-800 hover:bg-purple-50 rounded-md border border-dashed border-purple-300 transition-colors"
         >
-          {close => (
-            <AddInsightMenu
-              onPickExisting={handlePickExistingInsight}
-              onCreateNew={handleCreateNewInsight}
-              close={close}
-            />
-          )}
-        </Dropdown>
+          <PiPlus size={14} />
+          Add Insight
+        </button>
 
         <div className="border-t-2 border-gray-200" />
 

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
@@ -396,10 +396,9 @@ const ExplorationBuildRail = ({ explorationId }) => {
           `autoScroll.canScroll`) — auto-scrolling THIS container mid-drag is
           what moved x/y drop targets out from under the cursor. */}
       <div className="flex-1 overflow-y-auto p-3 space-y-3" data-dnd-freeze-scroll>
-        <ChartBuildSection isExpanded={chartExpanded} onToggleExpand={handleToggleChart} />
-
-        <div className="border-t-2 border-gray-200" />
-
+        {/* VIS-1224: the insight pane(s) stack ABOVE the chart pane — the
+            chart aggregates the insights listed above it, so building an
+            insight then seeing it fold into the chart below reads top-down. */}
         {chartInsightNames.map(name => (
           <InsightBuildSection
             key={name}
@@ -431,6 +430,10 @@ const ExplorationBuildRail = ({ explorationId }) => {
             />
           )}
         </Dropdown>
+
+        <div className="border-t-2 border-gray-200" />
+
+        <ChartBuildSection isExpanded={chartExpanded} onToggleExpand={handleToggleChart} />
 
         {/* Saved-to-project trail (01-ux-spec.md §3b) — each entry links to
             its real, now-published object. D11: "promote" is internal-only

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
@@ -164,84 +164,18 @@ describe('ExplorationBuildRail', () => {
   // opens a picker offering "New blank insight" alongside existing insights
   // in the project not already on this chart, instead of instantly
   // manufacturing a blank one.
-  describe('"+ Add Insight" picker (Phase 6c-T5)', () => {
-    it('clicking the button opens a menu instead of immediately creating a blank insight', () => {
+  // VIS-1224: in the Explorer you CREATE insights (the pick-existing menu moved
+  // to the standard chart edit panel), so "+ Add Insight" is a plain button
+  // that appends a new blank insight below the stack — no dropdown.
+  describe('"+ Add Insight" (create-only in the Explorer)', () => {
+    it('clicking the button immediately creates a blank insight (no menu)', () => {
       const createInsight = jest.fn();
       useStore.setState({ createInsight, insights: [] });
       render(<ExplorationBuildRail />);
       fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-      expect(screen.getByTestId('add-insight-menu')).toBeInTheDocument();
-      expect(createInsight).not.toHaveBeenCalled();
-    });
-
-    it('"New blank insight" still creates a blank insight (secondary action, not gone)', () => {
-      const createInsight = jest.fn();
-      useStore.setState({ createInsight, insights: [] });
-      render(<ExplorationBuildRail />);
-      fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-      fireEvent.click(screen.getByTestId('add-insight-menu-create-new'));
       expect(createInsight).toHaveBeenCalled();
       expect(screen.queryByTestId('add-insight-menu')).not.toBeInTheDocument();
     });
-
-    it('offers existing project insights NOT already on this chart, and picking one adds it via addExistingInsightToChart', () => {
-      const addExistingInsightToChart = jest.fn();
-      useStore.setState({
-        addExistingInsightToChart,
-        insights: [
-          { name: 'insight_a', config: {} }, // already on the chart — excluded
-          { name: 'churn_by_cohort', config: {} },
-          { name: 'revenue_over_time', config: {} },
-        ],
-      });
-      render(<ExplorationBuildRail />);
-      fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-
-      expect(screen.queryByTestId('add-insight-menu-existing-insight_a')).not.toBeInTheDocument();
-      expect(screen.getByTestId('add-insight-menu-existing-churn_by_cohort')).toBeInTheDocument();
-      expect(screen.getByTestId('add-insight-menu-existing-revenue_over_time')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId('add-insight-menu-existing-churn_by_cohort'));
-      expect(addExistingInsightToChart).toHaveBeenCalledWith('churn_by_cohort');
-      expect(screen.queryByTestId('add-insight-menu')).not.toBeInTheDocument();
-    });
-
-    it('the search box filters the pickable list by name', () => {
-      useStore.setState({
-        insights: [
-          { name: 'churn_by_cohort', config: {} },
-          { name: 'revenue_over_time', config: {} },
-        ],
-      });
-      render(<ExplorationBuildRail />);
-      fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-      fireEvent.change(screen.getByTestId('add-insight-menu-search'), {
-        target: { value: 'churn' },
-      });
-      expect(screen.getByTestId('add-insight-menu-existing-churn_by_cohort')).toBeInTheDocument();
-      expect(
-        screen.queryByTestId('add-insight-menu-existing-revenue_over_time')
-      ).not.toBeInTheDocument();
-    });
-
-    it('shows an honest empty state when there are no other insights to pick', () => {
-      useStore.setState({ insights: [] });
-      render(<ExplorationBuildRail />);
-      fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-      expect(screen.getByTestId('add-insight-menu')).toHaveTextContent(
-        'No other insights in this project yet.'
-      );
-    });
-
-    it('shows a distinct "no matches" message when every OTHER insight is already on this chart', () => {
-      useStore.setState({ insights: [{ name: 'insight_a', config: {} }] });
-      render(<ExplorationBuildRail />);
-      fireEvent.click(screen.getByTestId('right-panel-add-insight'));
-      expect(screen.getByTestId('add-insight-menu')).toHaveTextContent(
-        'No matches — every other insight is already on this chart.'
-      );
-    });
-
   });
 
   it('toggling the active insight deactivates it; toggling an inactive one activates it', () => {

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
@@ -121,13 +121,15 @@ describe('ExplorationBuildRail', () => {
     expect(screen.getByTestId('insight-build-insight_b')).toHaveAttribute('data-expanded', 'false');
   });
 
-  it('renders ChartBuildSection ABOVE the insight sections', () => {
+  // VIS-1224: the insight pane(s) now stack ABOVE the chart pane (the chart
+  // aggregates the insights listed above it).
+  it('renders the insight sections ABOVE the ChartBuildSection', () => {
     const { container } = render(<ExplorationBuildRail />);
     const fullText = container.textContent;
     const chartPos = fullText.indexOf('ChartBuildSection');
     const insightPos = fullText.indexOf('InsightBuildSection:');
-    expect(chartPos).toBeGreaterThanOrEqual(0);
-    expect(insightPos).toBeGreaterThan(chartPos);
+    expect(insightPos).toBeGreaterThanOrEqual(0);
+    expect(chartPos).toBeGreaterThan(insightPos);
   });
 
   it('renders save button disabled when no modifications', () => {

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
 import { PiCaretDown, PiCaretRight, PiX, PiPlus, PiPencilSimple } from 'react-icons/pi';
 import { useDroppable } from '@dnd-kit/core';
 import useStore from '../../../stores/store';
@@ -8,7 +8,7 @@ import {
   selectInsightStatus,
   expandDotNotationProps,
 } from '../../../stores/explorerStore';
-import TracePropsEditor from '../common/TracePropsEditor';
+import InsightEditFormFields from '../common/InsightEditFormFields';
 import RefTextArea from '../common/RefTextArea';
 import Select from '../../common/Select';
 import { checkRefTargets } from './refPreflight';
@@ -125,9 +125,12 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
   const models = useStore(s => s.models);
   const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
 
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState('');
+  // The name lives in the shared Basic Information field now (editable only for
+  // a still-draft insight). `renameValue` buffers keystrokes; the commit fires
+  // on blur/Enter. Re-mounts on rename (parent keys by name) reset the buffer.
+  const [renameValue, setRenameValue] = useState(insightName);
   const [renameError, setRenameError] = useState(null);
+  const nameInputRef = useRef(null);
 
   // Explore 2.0 Phase 4 (06 §4): "Save as metric…" prompt state — at most
   // one slot's flow is in progress at a time per insight section.
@@ -348,28 +351,31 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
     [insightName, removeInsightInteraction]
   );
 
+  // The ⋮ "Rename" action: make sure the pane is expanded (so the field is
+  // mounted) and focus/select the Basic Information name input.
   const startRename = useCallback(() => {
-    setIsRenaming(true);
+    setActiveInsight(insightName);
     setRenameValue(insightName);
-  }, [insightName]);
+    nameInputRef.current?.focus();
+    nameInputRef.current?.select();
+  }, [insightName, setActiveInsight]);
 
   const commitRename = useCallback(() => {
     const trimmed = renameValue.trim();
-    if (trimmed && trimmed !== insightName) {
-      try {
-        renameInsight(insightName, trimmed);
-        setRenameError(null);
-        setIsRenaming(false);
-      } catch (err) {
-        if (err?.code === 'NAME_COLLISION') {
-          setRenameError(err.message);
-          return;
-        }
-        throw err;
-      }
-    } else {
+    if (!trimmed || trimmed === insightName) {
       setRenameError(null);
-      setIsRenaming(false);
+      setRenameValue(insightName);
+      return;
+    }
+    try {
+      renameInsight(insightName, trimmed);
+      setRenameError(null);
+    } catch (err) {
+      if (err?.code === 'NAME_COLLISION') {
+        setRenameError(err.message);
+        return;
+      }
+      throw err;
     }
   }, [renameValue, insightName, renameInsight]);
 
@@ -380,10 +386,14 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
       data-testid={`insight-build-section-${insightName}`}
       className="border border-gray-200 rounded-lg overflow-hidden"
     >
+      {/* VIS-1224: neutral collapsible header (the colored side-bar is gone —
+          the body now renders the same standard edit panel as the RightRail).
+          The header carries only the pane's identity + controls; the editable
+          name lives in the Basic Information field below. */}
       <div
         data-testid={`insight-header-${insightName}`}
         onClick={handleHeaderClick}
-        className="flex items-center gap-2 px-3 py-2 bg-purple-50/50 border-l-4 border-purple-400 cursor-pointer hover:bg-purple-50 transition-colors duration-150"
+        className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200 cursor-pointer hover:bg-gray-100 transition-colors duration-150"
       >
         <button
           data-testid={`insight-toggle-${insightName}`}
@@ -393,50 +403,12 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
           {isExpanded ? <PiCaretDown size={14} /> : <PiCaretRight size={14} />}
         </button>
 
-        {isRenaming ? (
-          <span className="flex-1 flex flex-col">
-            <input
-              autoFocus
-              data-testid={`insight-rename-input-${insightName}`}
-              value={renameValue}
-              onChange={e => {
-                setRenameValue(e.target.value);
-                if (renameError) setRenameError(null);
-              }}
-              onBlur={() => commitRename()}
-              onKeyDown={e => {
-                if (e.key === 'Enter') commitRename();
-                if (e.key === 'Escape') {
-                  setRenameError(null);
-                  setIsRenaming(false);
-                }
-              }}
-              onClick={e => e.stopPropagation()}
-              className={`text-sm font-medium text-purple-800 bg-white border rounded px-1 py-0 outline-none focus:ring-1 ${
-                renameError ? 'border-highlight-400 focus:ring-highlight-400' : 'border-purple-300 focus:ring-purple-400'
-              }`}
-            />
-            {renameError && (
-              <span
-                data-testid={`insight-rename-error-${insightName}`}
-                className="text-xs text-highlight-600 mt-0.5"
-              >
-                {renameError}
-              </span>
-            )}
-          </span>
-        ) : (
-          <span
-            className="text-sm font-medium text-purple-800 truncate flex-1 cursor-pointer"
-            data-testid={`insight-name-${insightName}`}
-            onClick={e => {
-              e.stopPropagation();
-              if (insightState?.isNew) startRename();
-            }}
-          >
-            {insightName}
-          </span>
-        )}
+        <span
+          className="text-sm font-medium text-secondary-900 truncate flex-1"
+          data-testid={`insight-name-${insightName}`}
+        >
+          {insightName}
+        </span>
 
         {status && (
           <span
@@ -445,10 +417,9 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
           />
         )}
 
-        {/* VIS-1224: reusable ⋮ menu. Rename only applies to a still-draft
-            insight — a promoted/loaded insight's inline rename is VIS-1209's
-            project-wide ${ref()} rewrite, out of scope here (matches
-            `renameInsight`'s own `isNew` guard). */}
+        {/* Rename only applies to a still-draft insight — a promoted/loaded
+            insight's inline rename is VIS-1209's project-wide ${ref()} rewrite,
+            out of scope here (matches `renameInsight`'s own `isNew` guard). */}
         <PanelMenu
           testId={`insight-${insightName}`}
           ariaLabel={`Options for ${insightName}`}
@@ -473,31 +444,50 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
       </div>
 
       {isExpanded && (
-        <div className="px-3 py-3 space-y-4 border-l-4 border-purple-400">
-          {/* D12 (grounding diagnosis #4): the legacy top-level Type <Select>
-              that used to live here was a byte-for-byte duplicate of
-              TracePropsEditor's OWN <TypeSelector> just below — both wrote
-              through the same handler and always agreed, so the second
-              control was pure confusion ("Type: Scatter/Line" stacked on
-              "Properties: Scatter/Line"). Deleted; TracePropsEditor's
-              TypeSelector (data-testid `type-selector-${ownerName}`) is now
-              the ONLY place type switching happens. */}
-          <div>
-            <TracePropsEditor
-              ownerName={insightName}
-              props={tracePropsValue}
-              onChange={handleTracePropsChange}
-              droppable
-              onDropField={handleDropField}
-              onSaveAsMetric={handleOpenSaveAsMetric}
-              externalErrors={advisoryErrors}
-            />
-            {dedupOffers.length > 0 && (
-              <div className="mt-2">
-                <FieldSwapOfferBanner offers={dedupOffers} onDismiss={handleDismissDedupOffer} />
-              </div>
-            )}
-          </div>
+        <div className="p-3 space-y-4">
+          {/* Shared edit panel (VIS-1224) — the same Basic Information +
+              Visualization Props the standard InsightEditForm renders. Name is
+              editable only for a still-draft insight; committing renames the
+              draft (renameInsight rewrites sibling refs). The Explorer threads
+              its property-zone DnD + Save-as-metric into the shared props
+              editor; type switching stays owned by TracePropsEditor's own
+              TypeSelector (`type-selector-${insightName}`). */}
+          <InsightEditFormFields
+            showName
+            nameId={`insight-name-field-${insightName}`}
+            nameValue={renameValue}
+            onNameChange={e => {
+              setRenameValue(e.target.value);
+              if (renameError) setRenameError(null);
+            }}
+            onNameBlur={commitRename}
+            onNameKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitRename();
+              } else if (e.key === 'Escape') {
+                setRenameError(null);
+                setRenameValue(insightName);
+              }
+            }}
+            nameDisabled={!insightState?.isNew}
+            nameError={renameError}
+            nameErrorTestId={`insight-rename-error-${insightName}`}
+            nameInputRef={nameInputRef}
+            nameTestId={`insight-rename-input-${insightName}`}
+            showDescription={false}
+            ownerName={insightName}
+            props={tracePropsValue}
+            onPropsChange={handleTracePropsChange}
+            droppable
+            onDropField={handleDropField}
+            onSaveAsMetric={handleOpenSaveAsMetric}
+            externalErrors={advisoryErrors}
+          />
+
+          {dedupOffers.length > 0 && (
+            <FieldSwapOfferBanner offers={dedupOffers} onDismiss={handleDismissDedupOffer} />
+          )}
 
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">Interactions</label>

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -9,6 +9,7 @@ import {
   expandDotNotationProps,
 } from '../../../stores/explorerStore';
 import InsightEditFormFields from '../common/InsightEditFormFields';
+import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
 import RefTextArea from '../common/RefTextArea';
 import Select from '../../common/Select';
 import { checkRefTargets } from './refPreflight';
@@ -17,6 +18,9 @@ import { isNumericColumnType } from '../../../utils/columnType';
 import SaveAsMetricPrompt from './SaveAsMetricPrompt';
 import FieldSwapOfferBanner from './FieldSwapOfferBanner';
 import { saveAsMetric, suggestMetricName } from './saveAsMetricFlow';
+
+const INSIGHT_COLORS = getTypeColors('insight');
+const InsightTypeIcon = getTypeIcon('insight');
 
 const INTERACTION_TYPES = [
   { value: 'filter', label: 'Filter' },
@@ -403,12 +407,26 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
           {isExpanded ? <PiCaretDown size={14} /> : <PiCaretRight size={14} />}
         </button>
 
+        {/* VIS-1224: SelectionChip-style identity (type icon + name + TYPE),
+            matching the standard RightRail edit-panel header. */}
         <span
-          className="text-sm font-medium text-secondary-900 truncate flex-1"
-          data-testid={`insight-name-${insightName}`}
+          className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border ${INSIGHT_COLORS.bg} ${INSIGHT_COLORS.text} ${INSIGHT_COLORS.border}`}
         >
-          {insightName}
+          {InsightTypeIcon && <InsightTypeIcon style={{ fontSize: 14 }} />}
         </span>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span
+            className="truncate text-[13px] font-semibold text-secondary-900"
+            data-testid={`insight-name-${insightName}`}
+            title={insightName}
+          >
+            {insightName}
+          </span>
+          <span className="truncate text-[10.5px] uppercase tracking-wide text-gray-400">
+            Insight
+          </span>
+        </div>
 
         {status && (
           <span

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { PiCaretDown, PiCaretRight, PiX, PiPlus } from 'react-icons/pi';
+import { PiCaretDown, PiCaretRight, PiX, PiPlus, PiPencilSimple } from 'react-icons/pi';
 import { useDroppable } from '@dnd-kit/core';
 import useStore from '../../../stores/store';
+import PanelMenu from '../../common/PanelMenu';
 import {
   getSourceDialect,
   selectInsightStatus,
@@ -347,6 +348,11 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
     [insightName, removeInsightInteraction]
   );
 
+  const startRename = useCallback(() => {
+    setIsRenaming(true);
+    setRenameValue(insightName);
+  }, [insightName]);
+
   const commitRename = useCallback(() => {
     const trimmed = renameValue.trim();
     if (trimmed && trimmed !== insightName) {
@@ -425,10 +431,7 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
             data-testid={`insight-name-${insightName}`}
             onClick={e => {
               e.stopPropagation();
-              if (insightState?.isNew) {
-                setIsRenaming(true);
-                setRenameValue(insightName);
-              }
+              if (insightState?.isNew) startRename();
             }}
           >
             {insightName}
@@ -441,6 +444,24 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
             className={`w-2 h-2 rounded-full flex-shrink-0 ${status === 'new' ? 'bg-green-500' : 'bg-amber-500'}`}
           />
         )}
+
+        {/* VIS-1224: reusable ⋮ menu. Rename only applies to a still-draft
+            insight — a promoted/loaded insight's inline rename is VIS-1209's
+            project-wide ${ref()} rewrite, out of scope here (matches
+            `renameInsight`'s own `isNew` guard). */}
+        <PanelMenu
+          testId={`insight-${insightName}`}
+          ariaLabel={`Options for ${insightName}`}
+          items={[
+            {
+              id: 'rename',
+              label: 'Rename',
+              icon: PiPencilSimple,
+              disabled: !insightState?.isNew,
+              onSelect: startRename,
+            },
+          ]}
+        />
 
         <button
           data-testid={`insight-remove-${insightName}`}

--- a/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
@@ -110,13 +110,15 @@ describe('InsightBuildSection', () => {
     setupStore();
   });
 
-  it('renders insight name with purple styling', async () => {
+  // VIS-1224: the colored side-bar header is gone — the body now renders the
+  // same standard edit panel as the RightRail; the header is neutral.
+  it('renders the insight name in a neutral header (no colored side-bar)', async () => {
     render(
       <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
     );
-    expect(await screen.findByText('test_insight')).toBeInTheDocument();
+    expect(await screen.findByTestId('insight-name-test_insight')).toHaveTextContent('test_insight');
     const header = screen.getByTestId('insight-header-test_insight');
-    expect(header.className).toContain('border-purple');
+    expect(header.className).not.toContain('border-purple');
   });
 
   // D12 (grounding diagnosis #4): the legacy top-level Type <Select> — a
@@ -912,34 +914,37 @@ describe('InsightBuildSection', () => {
   });
 
   describe('rename flow', () => {
-    it('clicking the name enters rename mode ONLY when the insight isNew', async () => {
+    // VIS-1224: the name now lives in the Basic Information field of the shared
+    // panel — always present when the pane is expanded, editable only for a
+    // still-draft (isNew) insight; committing on blur/Enter renames the draft.
+    it('the name field is disabled for a non-new (loaded) insight', async () => {
       useStore.setState({
         explorerInsightStates: { test_insight: { ...defaultInsightState, isNew: false } },
       });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      expect(screen.queryByTestId('insight-rename-input-test_insight')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('insight-rename-input-test_insight')).toBeDisabled();
     });
 
-    it('clicking the name on a NEW insight enters rename mode, pre-filled with the current name', async () => {
+    it('the name field is editable for a NEW insight, pre-filled with the current name', async () => {
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
+      expect(input).toBeEnabled();
       expect(input).toHaveValue('test_insight');
     });
 
-    // VIS-1224: the ⋮ panel menu is the discoverable rename entry point.
-    it('the ⋮ menu Rename item enters rename mode for a new insight', async () => {
+    // VIS-1224: the ⋮ panel menu is the discoverable rename entry point; it
+    // focuses the Basic Information name field.
+    it('the ⋮ menu Rename item focuses the name field for a new insight', async () => {
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
       fireEvent.click(await screen.findByTestId('panel-menu-trigger-insight-test_insight'));
       fireEvent.click(screen.getByTestId('panel-menu-item-rename-insight-test_insight'));
-      expect(screen.getByTestId('insight-rename-input-test_insight')).toHaveValue('test_insight');
+      expect(screen.getByTestId('insight-rename-input-test_insight')).toHaveFocus();
     });
 
     it('the ⋮ menu Rename item is disabled for a non-new (loaded) insight', async () => {
@@ -953,62 +958,56 @@ describe('InsightBuildSection', () => {
       expect(screen.getByTestId('panel-menu-item-rename-insight-test_insight')).toBeDisabled();
     });
 
-    it('committing a trimmed, changed name on blur calls renameInsight and exits rename mode', async () => {
+    it('committing a trimmed, changed name on blur calls renameInsight', async () => {
       const renameInsight = jest.fn();
       useStore.setState({ renameInsight });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: '  renamed_insight  ' } });
       fireEvent.blur(input);
       expect(renameInsight).toHaveBeenCalledWith('test_insight', 'renamed_insight');
-      expect(screen.queryByTestId('insight-rename-input-test_insight')).not.toBeInTheDocument();
     });
 
-    it('committing the SAME (or empty/whitespace) name is a no-op that just exits rename mode', async () => {
+    it('committing the SAME (or empty/whitespace) name is a no-op', async () => {
       const renameInsight = jest.fn();
       useStore.setState({ renameInsight });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: '   ' } });
       fireEvent.blur(input);
       expect(renameInsight).not.toHaveBeenCalled();
-      expect(screen.queryByTestId('insight-rename-input-test_insight')).not.toBeInTheDocument();
     });
 
-    it('Enter commits the rename (same path as blur)', async () => {
+    it('Enter commits the rename', async () => {
       const renameInsight = jest.fn();
       useStore.setState({ renameInsight });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: 'enter_name' } });
       fireEvent.keyDown(input, { key: 'Enter' });
       expect(renameInsight).toHaveBeenCalledWith('test_insight', 'enter_name');
     });
 
-    it('Escape cancels the rename without committing', async () => {
+    it('Escape reverts the buffered name without committing', async () => {
       const renameInsight = jest.fn();
       useStore.setState({ renameInsight });
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: 'abandoned' } });
       fireEvent.keyDown(input, { key: 'Escape' });
       expect(renameInsight).not.toHaveBeenCalled();
-      expect(screen.queryByTestId('insight-rename-input-test_insight')).not.toBeInTheDocument();
+      expect(input).toHaveValue('test_insight');
     });
 
-    it('a NAME_COLLISION error shows inline and keeps the rename input open', async () => {
+    it('a NAME_COLLISION error shows inline and keeps the buffered name', async () => {
       const renameInsight = jest.fn(() => {
         const err = new Error('Name "dupe" is already in use. Choose a different name.');
         err.code = 'NAME_COLLISION';
@@ -1018,8 +1017,7 @@ describe('InsightBuildSection', () => {
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: 'dupe' } });
       fireEvent.blur(input);
       const error = screen.getByTestId('insight-rename-error-test_insight');
@@ -1037,8 +1035,7 @@ describe('InsightBuildSection', () => {
       render(
         <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
       );
-      fireEvent.click(await screen.findByTestId('insight-name-test_insight'));
-      const input = screen.getByTestId('insight-rename-input-test_insight');
+      const input = await screen.findByTestId('insight-rename-input-test_insight');
       fireEvent.change(input, { target: { value: 'dupe' } });
       fireEvent.blur(input);
       expect(screen.getByTestId('insight-rename-error-test_insight')).toBeInTheDocument();

--- a/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
@@ -932,6 +932,27 @@ describe('InsightBuildSection', () => {
       expect(input).toHaveValue('test_insight');
     });
 
+    // VIS-1224: the ⋮ panel menu is the discoverable rename entry point.
+    it('the ⋮ menu Rename item enters rename mode for a new insight', async () => {
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      fireEvent.click(await screen.findByTestId('panel-menu-trigger-insight-test_insight'));
+      fireEvent.click(screen.getByTestId('panel-menu-item-rename-insight-test_insight'));
+      expect(screen.getByTestId('insight-rename-input-test_insight')).toHaveValue('test_insight');
+    });
+
+    it('the ⋮ menu Rename item is disabled for a non-new (loaded) insight', async () => {
+      useStore.setState({
+        explorerInsightStates: { test_insight: { ...defaultInsightState, isNew: false } },
+      });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      fireEvent.click(await screen.findByTestId('panel-menu-trigger-insight-test_insight'));
+      expect(screen.getByTestId('panel-menu-item-rename-insight-test_insight')).toBeDisabled();
+    });
+
     it('committing a trimmed, changed name on blur calls renameInsight and exits rename mode', async () => {
       const renameInsight = jest.fn();
       useStore.setState({ renameInsight });

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -873,7 +873,16 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
           </div>
         )}
         <RecordRunStatus name={name} />
-        <div data-testid="right-rail-edit-leaf-form" className="flex-1 overflow-y-auto">
+        <div
+          data-testid="right-rail-edit-leaf-form"
+          // `flex flex-col min-h-0` (not a plain block): the leaf forms render a
+          // `flex-1` scroll body followed by a fixed footer (Save/Discard/Delete);
+          // without a flex column here that `flex-1` can't expand, so the footer
+          // trailed short content mid-panel instead of sitting at the bottom.
+          // `overflow-y-auto` stays for the forms that scroll at this level
+          // rather than in their own body.
+          className="flex flex-1 flex-col min-h-0 overflow-y-auto"
+        >
           {/* None of the leaf forms take a disabled prop, so read-only uses the
               one mechanism that covers them all: a disabled <fieldset> (native
               controls + keyboard) with pointer-events held (react-select /


### PR DESCRIPTION
## VIS-1224 — Explorer panes reuse the standard edit panels

Brings the Explorer Build-rail insight & chart panes fully in line with the standard RightRail edit panels — same panel, shared internals — while keeping everything the Explorer needs (stacked collapsible insights, live write-through, drag-and-drop, Save-as-metric).

### Shared inner panels (rendered by both surfaces)
- **`InsightEditFormFields`** — Basic Information + Visualization Props (controlled, with DnD passthrough). Used by the standard `InsightEditForm` **and** the Explorer `InsightBuildSection`.
- **`ChartEditFormFields`** — Basic Information + insight-selection slot + Layout. Used by the Explorer `ChartBuildSection`.

### Explorer panes (colored sidebar → SelectionChip header)
- The bespoke panes are thinned to a neutral collapsible shell; the body is the shared standard panel. Headers now show the **SelectionChip identity** (type icon + name + TYPE), keeping collapse / status dot / ⋮ menu / remove.
- Name edits write through live (no Save button — "Save to project" stays the promote step); editable only for unsaved objects; the ⋮ Rename focuses the Basic Information field.
- Draft **DnD preserved**: property-zone, interaction-zone (insight), plus Save-as-metric + advisory validation.
- Insight panes stack **above** the chart; a reusable portaled **`PanelMenu`** backs the ⋮ menus.

### Insight-on-chart model
- **Explorer chart pane** no longer has an insight section — its insights ARE the stacked panes above it. The rail's **"+ Add Insight"** is a plain create.
- **Standard chart edit panel** drops the inline per-insight props editor and gains the shared **`AddInsightMenu`** ("+ Add Insight" → New blank / Find existing) to compose the chart's insights. Extracted `AddInsightMenu` to a shared component.

### Verification
- Full `workspace` / `explorer` / `common` sweep: **4517 tests pass**, lint clean.
- Sandbox e2e: reorder + "⋮ menu opens un-clipped" pass; a parity probe confirms both panes render "Basic Information" + name fields + neutral headers.
- DnD-drag e2e stories fail **identically on `main`** in this sandbox (pre-existing/environmental) — this change doesn't touch the DnD router.

### Follow-ups (not in this PR)
- Default-item naming: use `-` (not `_`) in the Explorer's auto-generated names, and give the chart a default name. (Reverted a first attempt — a blind `_`→`-` pass hyphenated JS object keys; needs a targeted change + test-fixture migration. Small, deferred to keep this PR green.)
- Fully DRY the standard `ChartEditForm`/`InsightEditForm` onto the shared `…Fields` components (Explorer already consumes them; `InsightEditForm` already shares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
