### PR TITLE
VIS-1224 follow-ups: hyphenated Explorer names + default chart name + DRY ChartEditForm

### DIFF
--- a/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
+++ b/viewer/e2e/stories/exploration-chart-build-updates.spec.mjs
@@ -244,7 +244,7 @@ test.describe('Chart-building keeps the preview in sync with every edit', () => 
   // story starts with, "Save to project" used to silently drop the chart —
   // no row, no notice — because the live auto-naming effect
   // (ExplorationBuildRail.jsx) carried the naming cascade through
-  // `<source>_query` -> `<...>_insight` but never took the last step to the
+  // `<source>-query` -> `<...>-insight` but never took the last step to the
   // chart, so `explorerChartName` stayed `null` forever (the Build rail
   // showed "Chart: Untitled") and `buildPromoteChecklist` gates the chart's
   // entire checklist row on that name being truthy. This never renames the

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -7,7 +7,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { validateName } from './namedModel';
-import { SchemaEditor } from './SchemaEditor';
+import ChartEditFormFields from './ChartEditFormFields';
 import { getSchema, isSchemaLoaded } from '../../../schemas/schemas';
 import { getTypeByValue } from './objectTypeConfigs';
 import { setAtPath } from './embeddedObjectUtils';
@@ -252,52 +252,38 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
-          {/* Basic Fields Section */}
-          <div className="space-y-4">
-            <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">
-              Basic Information
-            </h3>
-
-            {/* Name field */}
-            <div className="relative">
-              <input
-                type="text"
-                id="chartName"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                disabled={isEditMode}
-                placeholder=" "
-                className={`
-                  block w-full px-3 py-2.5 text-sm text-gray-900
-                  bg-white rounded-md border appearance-none
-                  focus:outline-none focus:ring-2 focus:border-primary-500
-                  peer placeholder-transparent
-                  ${isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''}
-                  ${errors.name ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}
-                `}
-              />
-              <label
-                htmlFor="chartName"
-                className={`
-                  absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0]
-                  bg-white px-1 left-2
-                  peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2
-                  peer-placeholder-shown:top-1/2
-                  peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4
-                  ${errors.name ? 'text-red-500' : 'text-gray-500 peer-focus:text-primary-500'}
-                `}
-              >
-                Chart Name<span className="text-red-500 ml-0.5">*</span>
-              </label>
-              {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
-            </div>
-          </div>
-
-          {/* Insights Section — VIS-1224: compose the chart's insights. The
-              chart no longer edits insight props inline (that's each insight's
-              own edit panel); "+ Add Insight" opens the same picker the
-              Explorer uses — pick an existing project insight, or add a New
-              blank one. */}
+          {/* Basic Information + Layout are the shared ChartEditFormFields
+              panel (VIS-1224); the chart's own insight-selection section (Add
+              Insight menu + ref/embedded pills) is passed in as its slot. */}
+          <ChartEditFormFields
+            showName
+            nameId="chartName"
+            nameLabel="Chart Name"
+            nameValue={name}
+            onNameChange={e => setName(e.target.value)}
+            nameDisabled={isEditMode}
+            nameError={errors.name}
+            layoutTitle="Layout Configuration (Optional)"
+            layoutSchema={layoutSchema}
+            layoutValues={layoutValues}
+            onLayoutChange={setLayoutValues}
+            layoutLoading={schemaLoading}
+            layoutError={schemaError}
+            layoutHint={
+              <p className="text-xs text-gray-500">
+                Plotly layout configuration. See{' '}
+                <a
+                  href="https://plotly.com/javascript/reference/layout/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 hover:underline"
+                >
+                  Plotly docs
+                </a>{' '}
+                for options.
+              </p>
+            }
+            insightsSection={
           <div className="space-y-4">
             <div className="flex items-center justify-between border-b border-gray-200 pb-2">
               <h3 className="text-sm font-medium text-gray-700">Insights</h3>
@@ -415,42 +401,8 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
               );
             })()}
           </div>
-
-          {/* Layout Section */}
-          <div className="space-y-4">
-            <h3 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-2">
-              Layout Configuration (Optional)
-            </h3>
-
-            {schemaLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <CircularProgress size={24} />
-                <span className="ml-2 text-sm text-gray-600">Loading schema...</span>
-              </div>
-            ) : schemaError ? (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-                <p className="text-sm text-red-700">{schemaError}</p>
-              </div>
-            ) : layoutSchema ? (
-              <SchemaEditor
-                schema={layoutSchema}
-                value={layoutValues}
-                onChange={setLayoutValues}
-              />
-            ) : null}
-            <p className="text-xs text-gray-500">
-              Plotly layout configuration. See{' '}
-              <a
-                href="https://plotly.com/javascript/reference/layout/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary-600 hover:underline"
-              >
-                Plotly docs
-              </a>{' '}
-              for options.
-            </p>
-          </div>
+            }
+          />
 
           {/* Save Error */}
           {saveError && <div className="p-3 rounded-md bg-red-50 text-red-700 text-sm">{saveError}</div>}

--- a/viewer/src/components/views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.test.jsx
@@ -17,7 +17,9 @@ jest.mock('../../../schemas/schemas', () => ({
 
 // Stand-in SchemaEditor exposing the "remove the last layout property" path:
 // the real editor emits `undefined` (cleanEmptyObjects) when it empties out.
-jest.mock('./SchemaEditor', () => ({
+// The layout editor is now rendered by ChartEditFormFields, which imports the
+// SchemaEditor from './SchemaEditor/SchemaEditor' — mock THAT path.
+jest.mock('./SchemaEditor/SchemaEditor', () => ({
   __esModule: true,
   SchemaEditor: ({ onChange }) => (
     <button type="button" data-testid="mock-schema-clear" onClick={() => onChange(undefined)}>

--- a/viewer/src/components/views/common/ChartEditFormFields.jsx
+++ b/viewer/src/components/views/common/ChartEditFormFields.jsx
@@ -42,6 +42,7 @@ const ChartEditFormFields = ({
   layoutLoading = false,
   layoutError,
   layoutEditorProps = {},
+  layoutHint,
 }) => (
   <>
     <div className="space-y-4">
@@ -118,6 +119,7 @@ const ChartEditFormFields = ({
           {...layoutEditorProps}
         />
       ) : null}
+      {layoutHint}
     </div>
   </>
 );

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.jsx
@@ -163,7 +163,7 @@ const ExplorationBuildRail = ({ explorationId }) => {
       // `name` (already established above to be exactly `model` or
       // `query_<digits>`) — and `renameModelTab` already no-ops on an
       // identical name anyway, so there's nothing to guard twice.
-      const suggested = generateUniqueName(`${sourceName}_query`, used);
+      const suggested = generateUniqueName(`${sourceName}-query`, used);
       used.add(suggested);
       try {
         renameModelTab(name, suggested);
@@ -182,7 +182,7 @@ const ExplorationBuildRail = ({ explorationId }) => {
       // is always `<modelAnchor>_insight`(`_N`), which can't equal `name`
       // (already `insight`/`insight_<digits>`) — `renameInsight` no-ops on
       // an identical name regardless.
-      const suggested = generateUniqueName(`${modelAnchor}_insight`, used);
+      const suggested = generateUniqueName(`${modelAnchor}-insight`, used);
       used.add(suggested);
       try {
         renameInsight(name, suggested);
@@ -198,7 +198,14 @@ const ExplorationBuildRail = ({ explorationId }) => {
     // while it's still unnamed; once named, `explorerChartNameForNaming`
     // flips truthy and this branch naturally stops re-firing, exactly like
     // the model/insight loops above.
-    if (!explorerChartNameForNaming) {
+    // Runs while the chart is unnamed OR still carries a generic placeholder
+    // (`chart`/`chart_N`) — so the default name below can later be REFINED to
+    // the real cascade name once content arrives, exactly like the model/
+    // insight loops refine `model`/`insight`.
+    if (
+      !explorerChartNameForNaming ||
+      isGenericPromoteName('chart', explorerChartNameForNaming)
+    ) {
       // Read fresh, post-rename state — the loops above may have just
       // renamed the very insight(s) this reads by name via `renameInsight`
       // (a synchronous `set()`), so `chartInsightNames`/
@@ -215,12 +222,10 @@ const ExplorationBuildRail = ({ explorationId }) => {
         // covers a chart made valid by real layout config alone (D12-style
         // "chart with a title but no insight bound yet").
         const base = insightAnchor
-          ? `${insightAnchor}_chart`
+          ? `${insightAnchor}-chart`
           : modelAnchor
-            ? `${modelAnchor}_chart`
+            ? `${modelAnchor}-chart`
             : null;
-        // No usable anchor at all (no model loaded either) — leave it
-        // unnamed/editable rather than guessing, same as the loops above.
         if (base) {
           const suggested = generateUniqueName(base, used);
           used.add(suggested);
@@ -228,9 +233,22 @@ const ExplorationBuildRail = ({ explorationId }) => {
             setChartName(suggested);
           } catch {
             // A collision the suggestion logic couldn't see — fail open,
-            // leave the chart unnamed; still editable by hand via
+            // leave the current name; still editable by hand via
             // `ChartBuildSection`'s own rename input.
           }
+        }
+      } else if (!explorerChartNameForNaming) {
+        // Not content-bearing yet and still nameless — give it a generic
+        // default so the pane never shows a blank name (like a fresh model
+        // tab shows `model`). It stays out of "Save to project" (that gate
+        // also requires real content), and gets refined to `<anchor>-chart`
+        // by the branch above once content arrives.
+        const suggested = generateUniqueName('chart', used);
+        used.add(suggested);
+        try {
+          setChartName(suggested);
+        } catch {
+          /* fail open — leave unnamed, still editable by hand */
         }
       }
     }

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
@@ -384,16 +384,16 @@ describe('ExplorationBuildRail', () => {
       });
       render(<ExplorationBuildRail />);
       await waitFor(() => {
-        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db_query']);
+        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query']);
       });
-      expect(useStore.getState().explorerModelStates['orders_db_query']).toBeTruthy();
+      expect(useStore.getState().explorerModelStates['orders_db-query']).toBeTruthy();
       expect(useStore.getState().explorerModelStates.model).toBeUndefined();
     });
 
     it('renames a generic-named insight to <model>_insight once its model already has a real name', async () => {
       useStore.setState({
-        explorerModelTabs: ['orders_db_query'],
-        explorerModelStates: { orders_db_query: { isNew: true, sourceName: 'orders_db' } },
+        explorerModelTabs: ['orders_db-query'],
+        explorerModelStates: { 'orders_db-query': { isNew: true, sourceName: 'orders_db' } },
         explorerChartInsightNames: ['insight'],
         explorerActiveInsightName: 'insight',
         explorerInsightStates: {
@@ -402,7 +402,7 @@ describe('ExplorationBuildRail', () => {
       });
       render(<ExplorationBuildRail />);
       await waitFor(() => {
-        expect(useStore.getState().explorerChartInsightNames).toEqual(['orders_db_query_insight']);
+        expect(useStore.getState().explorerChartInsightNames).toEqual(['orders_db-query-insight']);
       });
     });
 
@@ -481,7 +481,7 @@ describe('ExplorationBuildRail', () => {
         useStore.setState({ defaults: { source_name: 'orders_db' } });
       });
       await waitFor(() => {
-        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db_query']);
+        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query']);
       });
     });
 
@@ -493,11 +493,11 @@ describe('ExplorationBuildRail', () => {
       });
       const { rerender } = render(<ExplorationBuildRail />);
       await waitFor(() => {
-        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db_query']);
+        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query']);
       });
       rerender(<ExplorationBuildRail />);
       await screen.findByTestId('exploration-build-rail');
-      expect(useStore.getState().explorerModelTabs).toEqual(['orders_db_query']);
+      expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query']);
     });
 
     it('leaves a generic-named insight untouched when there is no model tab at all to anchor on', async () => {
@@ -519,12 +519,12 @@ describe('ExplorationBuildRail', () => {
       useStore.setState({
         explorerModelTabs: ['model'],
         explorerModelStates: { model: { isNew: true, sourceName: 'orders_db' } },
-        models: [{ name: 'orders_db_query' }],
+        models: [{ name: 'orders_db-query' }],
         defaults: { source_name: 'orders_db' },
       });
       render(<ExplorationBuildRail />);
       await waitFor(() => {
-        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db_query_2']);
+        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query_2']);
       });
     });
 
@@ -542,16 +542,16 @@ describe('ExplorationBuildRail', () => {
     describe('chart naming (VIS-1109 — the chart used to be the one link in the cascade that never fired)', () => {
       it('auto-names the chart <insightAnchor>_chart the moment it has real bound content', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
           },
-          explorerChartInsightNames: ['orders_db_query_insight'],
-          explorerActiveInsightName: 'orders_db_query_insight',
+          explorerChartInsightNames: ['orders_db-query-insight'],
+          explorerActiveInsightName: 'orders_db-query-insight',
           explorerInsightStates: {
-            orders_db_query_insight: {
+            'orders_db-query-insight': {
               type: 'scatter',
-              props: { x: '?{${ref(orders_db_query).x}}' },
+              props: { x: '?{${ref(orders_db-query).x}}' },
               interactions: [],
               typePropsCache: {},
               isNew: true,
@@ -563,15 +563,15 @@ describe('ExplorationBuildRail', () => {
         });
         render(<ExplorationBuildRail />);
         await waitFor(() => {
-          expect(useStore.getState().explorerChartName).toBe('orders_db_query_insight_chart');
+          expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart');
         });
       });
 
       it('falls back to <modelAnchor>_chart when there is no meaningful insight to anchor on but the chart has real layout content', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
           },
           explorerChartInsightNames: ['insight'],
           explorerInsightStates: {
@@ -583,15 +583,15 @@ describe('ExplorationBuildRail', () => {
         });
         render(<ExplorationBuildRail />);
         await waitFor(() => {
-          expect(useStore.getState().explorerChartName).toBe('orders_db_query_chart');
+          expect(useStore.getState().explorerChartName).toBe('orders_db-query-chart');
         });
       });
 
-      it('leaves the chart unnamed while it is still pure scaffolding (VIS-1102 gating must still hold — never offers a scaffold chart)', async () => {
+      it('gives a pure-scaffold chart the generic default name "chart" (but never a cascade name — VIS-1102 gating still holds)', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: '' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: '' },
           },
           explorerChartInsightNames: ['insight'],
           explorerInsightStates: {
@@ -603,18 +603,20 @@ describe('ExplorationBuildRail', () => {
         });
         render(<ExplorationBuildRail />);
         await screen.findByTestId('exploration-build-rail');
-        expect(useStore.getState().explorerChartName).toBeNull();
+        // A generic default (so the pane isn't blank) — NOT the cascade name,
+        // and it stays out of "Save to project" (see the VIS-1102 checklist pin).
+        expect(useStore.getState().explorerChartName).toBe('chart');
       });
 
       it('never renames a chart that already has a real name, even once content is bound', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
           },
-          explorerChartInsightNames: ['orders_db_query_insight'],
+          explorerChartInsightNames: ['orders_db-query-insight'],
           explorerInsightStates: {
-            orders_db_query_insight: {
+            'orders_db-query-insight': {
               type: 'scatter',
               props: { x: '?{1}' },
               interactions: [],
@@ -633,13 +635,13 @@ describe('ExplorationBuildRail', () => {
 
       it('a suggested chart name that collides with an existing object falls back to a disambiguated one', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
           },
-          explorerChartInsightNames: ['orders_db_query_insight'],
+          explorerChartInsightNames: ['orders_db-query-insight'],
           explorerInsightStates: {
-            orders_db_query_insight: {
+            'orders_db-query-insight': {
               type: 'scatter',
               props: { x: '?{1}' },
               interactions: [],
@@ -649,24 +651,24 @@ describe('ExplorationBuildRail', () => {
           },
           explorerChartName: null,
           explorerChartLayout: {},
-          charts: [{ name: 'orders_db_query_insight_chart' }],
+          charts: [{ name: 'orders_db-query-insight-chart' }],
           defaults: { source_name: 'orders_db' },
         });
         render(<ExplorationBuildRail />);
         await waitFor(() => {
-          expect(useStore.getState().explorerChartName).toBe('orders_db_query_insight_chart_2');
+          expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart_2');
         });
       });
 
       it('is idempotent — the chart auto-name fires once and does not oscillate on re-render', async () => {
         useStore.setState({
-          explorerModelTabs: ['orders_db_query'],
+          explorerModelTabs: ['orders_db-query'],
           explorerModelStates: {
-            orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
+            'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x' },
           },
-          explorerChartInsightNames: ['orders_db_query_insight'],
+          explorerChartInsightNames: ['orders_db-query-insight'],
           explorerInsightStates: {
-            orders_db_query_insight: {
+            'orders_db-query-insight': {
               type: 'scatter',
               props: { x: '?{1}' },
               interactions: [],
@@ -680,11 +682,11 @@ describe('ExplorationBuildRail', () => {
         });
         const { rerender } = render(<ExplorationBuildRail />);
         await waitFor(() => {
-          expect(useStore.getState().explorerChartName).toBe('orders_db_query_insight_chart');
+          expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart');
         });
         rerender(<ExplorationBuildRail />);
         await screen.findByTestId('exploration-build-rail');
-        expect(useStore.getState().explorerChartName).toBe('orders_db_query_insight_chart');
+        expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart');
       });
     });
   });
@@ -719,18 +721,18 @@ describe('VIS-1109 — a bound-but-unnamed chart is no longer silently dropped f
 
   it('produces a chart-tier checklist row once the mounted build rail has auto-named the content-bearing chart', async () => {
     useStore.setState({
-      explorerModelTabs: ['orders_db_query'],
+      explorerModelTabs: ['orders_db-query'],
       explorerModelStates: {
-        orders_db_query: { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x, 10 as y' },
+        'orders_db-query': { isNew: true, sourceName: 'orders_db', sql: 'select 1 as x, 10 as y' },
       },
-      explorerChartInsightNames: ['orders_db_query_insight'],
-      explorerActiveInsightName: 'orders_db_query_insight',
+      explorerChartInsightNames: ['orders_db-query-insight'],
+      explorerActiveInsightName: 'orders_db-query-insight',
       explorerInsightStates: {
-        orders_db_query_insight: {
+        'orders_db-query-insight': {
           type: 'scatter',
           props: {
-            x: '?{${ref(orders_db_query).x}}',
-            y: '?{${ref(orders_db_query).y}}',
+            x: '?{${ref(orders_db-query).x}}',
+            y: '?{${ref(orders_db-query).y}}',
           },
           interactions: [],
           typePropsCache: {},
@@ -758,7 +760,7 @@ describe('VIS-1109 — a bound-but-unnamed chart is no longer silently dropped f
     const rows = await buildPromoteChecklist(() => useStore.getState());
     const chartRow = rows.find(r => r.tier === 'chart');
     expect(chartRow).toBeTruthy();
-    expect(chartRow.name).toBe('orders_db_query_insight_chart');
+    expect(chartRow.name).toBe('orders_db-query-insight-chart');
     expect(chartRow.status).toBe('new');
   });
 
@@ -786,7 +788,10 @@ describe('VIS-1109 — a bound-but-unnamed chart is no longer silently dropped f
     // fired.
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(useStore.getState().explorerChartName).toBeNull();
+    // The chart gets the generic default name "chart" (never a cascade name
+    // for scaffolding) — and the promote checklist is STILL empty: the chart
+    // row is gated on real content, not merely on having a name.
+    expect(useStore.getState().explorerChartName).toBe('chart');
     const rows = await buildPromoteChecklist(() => useStore.getState());
     expect(rows).toEqual([]);
   });

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -1095,11 +1095,11 @@ describe('ExplorationPromoteModal', () => {
       // assumed-instant window and timed them out).
       buildPromoteChecklist.mockResolvedValue([row({ name: 'query_1' })]);
       render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
-      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders_query'));
+      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders-query'));
       expect(buildPromoteChecklist).toHaveBeenCalledTimes(1);
       expect(
-        await screen.findByTestId('promote-row-model-orders_query-name-input')
-      ).toHaveValue('orders_query');
+        await screen.findByTestId('promote-row-model-orders-query-name-input')
+      ).toHaveValue('orders-query');
     });
 
     test('a field row referencing a just-renamed model shows the model\'s NEW name in its "(→ …)" suffix', async () => {
@@ -1113,9 +1113,9 @@ describe('ExplorationPromoteModal', () => {
         row({ tier: 'field', type: 'metric', name: 'total', parentModel: 'query_1' }),
       ]);
       render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
-      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders_query'));
+      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders-query'));
       expect(await screen.findByTestId('promote-row-metric-total')).toHaveTextContent(
-        '(→ orders_query)'
+        '(→ orders-query)'
       );
     });
 
@@ -1183,7 +1183,7 @@ describe('ExplorationPromoteModal', () => {
     // placeholder name stays and the row is still a normal editable field.
     test('a collision during auto-suggestion (initial load) fails open — no crash, placeholder name stays editable', async () => {
       const renameModelTab = jest.fn(() => {
-        throw Object.assign(new Error('Name "orders_query" is already in use. Choose a different name.'), {
+        throw Object.assign(new Error('Name "orders-query" is already in use. Choose a different name.'), {
           code: 'NAME_COLLISION',
         });
       });
@@ -1193,7 +1193,7 @@ describe('ExplorationPromoteModal', () => {
       });
       buildPromoteChecklist.mockResolvedValue([row({ name: 'query_1' })]);
       render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
-      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders_query'));
+      await waitFor(() => expect(renameModelTab).toHaveBeenCalledWith('query_1', 'orders-query'));
       // The collision means the suggestion never "took" — the row keeps its
       // original (still-editable) name rather than the modal crashing.
       expect(

--- a/viewer/src/components/views/workspace/promoteNaming.js
+++ b/viewer/src/components/views/workspace/promoteNaming.js
@@ -87,11 +87,11 @@ export function suggestPromoteNames(rows, getModelSourceName, knownNames) {
     let base = null;
     if (row.tier === 'model') {
       const sourceName = getModelSourceName ? getModelSourceName(row.name) : null;
-      base = sourceName ? `${sourceName}_query` : null;
+      base = sourceName ? `${sourceName}-query` : null;
     } else if (row.tier === 'insight') {
-      base = modelAnchor ? `${modelAnchor}_insight` : null;
+      base = modelAnchor ? `${modelAnchor}-insight` : null;
     } else if (row.tier === 'chart') {
-      base = insightAnchor ? `${insightAnchor}_chart` : modelAnchor ? `${modelAnchor}_chart` : null;
+      base = insightAnchor ? `${insightAnchor}-chart` : modelAnchor ? `${modelAnchor}-chart` : null;
     }
 
     // No usable anchor (e.g. a model with no source bound yet) — leave the

--- a/viewer/src/components/views/workspace/promoteNaming.test.js
+++ b/viewer/src/components/views/workspace/promoteNaming.test.js
@@ -30,7 +30,7 @@ describe('suggestPromoteNames', () => {
   test('suggests <source>_query for a generically-named new model bound to a source', () => {
     const rows = [row({ name: 'query_1' })];
     const suggestions = suggestPromoteNames(rows, () => 'orders', []);
-    expect(suggestions.get('model:query_1')).toBe('orders_query');
+    expect(suggestions.get('model:query_1')).toBe('orders-query');
   });
 
   test('leaves a model with no bound source unsuggested (still editable, never guessed)', () => {
@@ -64,9 +64,9 @@ describe('suggestPromoteNames', () => {
       row({ tier: 'chart', type: 'chart', name: 'chart' }),
     ];
     const suggestions = suggestPromoteNames(rows, () => 'orders', []);
-    expect(suggestions.get('model:query_1')).toBe('orders_query');
-    expect(suggestions.get('insight:insight')).toBe('orders_query_insight');
-    expect(suggestions.get('chart:chart')).toBe('orders_query_insight_chart');
+    expect(suggestions.get('model:query_1')).toBe('orders-query');
+    expect(suggestions.get('insight:insight')).toBe('orders-query-insight');
+    expect(suggestions.get('chart:chart')).toBe('orders-query-insight-chart');
   });
 
   test('chart anchors on the model when no insight anchor is available', () => {
@@ -75,13 +75,13 @@ describe('suggestPromoteNames', () => {
       row({ tier: 'chart', type: 'chart', name: 'chart' }),
     ];
     const suggestions = suggestPromoteNames(rows, () => 'orders', []);
-    expect(suggestions.get('chart:chart')).toBe('orders_query_chart');
+    expect(suggestions.get('chart:chart')).toBe('orders-query-chart');
   });
 
   test('avoids colliding with a known existing name by suffixing', () => {
     const rows = [row({ name: 'query_1' })];
-    const suggestions = suggestPromoteNames(rows, () => 'orders', ['orders_query']);
-    expect(suggestions.get('model:query_1')).toBe('orders_query_2');
+    const suggestions = suggestPromoteNames(rows, () => 'orders', ['orders-query']);
+    expect(suggestions.get('model:query_1')).toBe('orders-query_2');
   });
 
   test('an already-meaningful model still anchors a generic insight/chart', () => {
@@ -90,7 +90,7 @@ describe('suggestPromoteNames', () => {
       row({ tier: 'insight', type: 'insight', name: 'insight' }),
     ];
     const suggestions = suggestPromoteNames(rows, () => null, []);
-    expect(suggestions.get('insight:insight')).toBe('orders_q_insight');
+    expect(suggestions.get('insight:insight')).toBe('orders_q-insight');
   });
 
   test('returns an empty map for an empty checklist', () => {
@@ -131,7 +131,7 @@ describe('suggestPromoteNames', () => {
     ];
     const suggestions = suggestPromoteNames(rows, () => 'orders', []);
     expect(suggestions.has('insight:insight')).toBe(false);
-    expect(suggestions.get('chart:chart')).toBe('insight_chart');
+    expect(suggestions.get('chart:chart')).toBe('insight-chart');
   });
 
   test('isGenericPromoteName never throws on a nullish name', () => {


### PR DESCRIPTION
## VIS-1224 follow-ups

The two follow-ups noted on #612 (which has merged).

### A. Explorer auto-names use hyphens + the chart gets a default name
- The Explorer's auto-naming cascade now joins with `-` instead of `_`:
  `<source>-query` → `<source>-query-insight` → `<source>-query-insight-chart`, matching the app's `new-<type>` convention. Changed both the live-naming effect (`ExplorationBuildRail`) and the save-time suggestions (`promoteNaming`).
- The Explorer **chart now gets a generic default name** (`chart`) the moment it mounts nameless, so the pane is never blank; the naming effect refines it to the `<anchor>-chart` cascade name once the chart has real content. **VIS-1102 still holds**: the promote checklist gates the chart row on real content, so a default-named empty chart is never offered to "Save to project".
- Careful test-fixture migration for the hyphenated names (quoting the now-hyphenated object keys; leaving user-named fixtures like `churn_chart`/`test_chart` untouched).

### B. DRY the standard ChartEditForm onto ChartEditFormFields
- `ChartEditForm` now renders its **Basic Information (name) + Layout** through the shared `ChartEditFormFields` (the same component the Explorer chart pane uses), passing its insight-selection section (Add Insight menu + ref/embedded pills) as the `insightsSection` slot. Removes the duplicated name-field + layout-SchemaEditor JSX; added a `layoutHint` slot for the "Plotly docs" link.
- `InsightEditForm` already consumed `InsightEditFormFields`, so **both standard forms now share their …Fields components** with the Explorer.

### Verification
- ~4000 common/workspace tests pass, lint clean. Fixture migrations for both the hyphenated cascade names and the repointed SchemaEditor mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
