### PR TITLE
Unify leaf edit panels on Delete · Discard · Save (Input + dimension/metric/relation)

### DIFF
--- a/viewer/e2e/stories/input-edit-form.spec.mjs
+++ b/viewer/e2e/stories/input-edit-form.spec.mjs
@@ -1,15 +1,15 @@
 /**
- * Story: Right-rail Input edit form auto-save + inline validation
- * (VIS-898 / Track G — input slice).
+ * Story: Right-rail Input edit form — explicit Delete · Discard · Save
+ * (VIS-898 / Track G — input slice; unified panels).
  *
- * G-1 (VIS-802) built the right-rail Edit seam but routed input selections to
- * the LEGACY InputEditForm (Save button, no live validation). VIS-898 rewires
- * the Input form to AUTO-SAVE on a ~500ms debounce (no Save button) with inline,
- * non-blocking validation — matching the dashboard-structure form UX.
+ * The Input edit panel is a standard leaf form: edits are held locally and
+ * persisted only on an explicit Save through the shared Delete · Discard · Save
+ * footer (matching chart/insight/source/…). Save is gated on real edits, Discard
+ * reverts to the last-saved values, and validation is inline + non-blocking.
  *
- * This story selects an `input` Library object, confirms the inline form has NO
- * Save button, edits the Label, and confirms the change debounce-persists
- * (the SelectionChip save indicator transitions and the edit survives).
+ * This story selects an `input` Library object, confirms the footer, edits the
+ * Label, saves, and confirms the edit persists. It also confirms Discard reverts
+ * an in-progress edit and that inline validation surfaces without trapping.
  *
  * Precondition: an isolated sandbox running the integration project. BASE
  * defaults to :3047 but is env-overridable:
@@ -17,11 +17,6 @@
  *   VISIVO_SANDBOX_NAME=vis898 bash scripts/sandbox.sh start
  *   # then: VIS_INPUT_EDIT_FORM_BASE=http://localhost:3047 \
  *   #         npx playwright test input-edit-form
- *
- * NOTE: the sandbox backend runs from the `main` editable install, where the
- * VIS-902 validator fix is NOT present — so a "default not in options" backend
- * error may still surface. That is expected; this story exercises the FORM
- * (auto-save + inline display), not the validator.
  */
 
 import { test, expect } from '@playwright/test';
@@ -48,7 +43,7 @@ test.describe('Right-rail Input edit form (VIS-898)', () => {
   test.describe.configure({ mode: 'serial' });
   test.setTimeout(90000);
 
-  test('input form auto-saves a label edit with NO Save button', async ({ page }) => {
+  test('input form saves a label edit through the Delete · Discard · Save footer', async ({ page }) => {
     await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
     await page.waitForLoadState('networkidle');
 
@@ -62,33 +57,53 @@ test.describe('Right-rail Input edit form (VIS-898)', () => {
     const leafForm = page.getByTestId('right-rail-edit-leaf-form');
     await expect(leafForm).toBeVisible({ timeout: WAIT });
 
-    // The SelectionChip identifies the input (rainbow type colour from
-    // objectTypeConfigs — indigo for inputs).
+    // The SelectionChip identifies the input.
     const chip = page.getByTestId('right-rail-selection-chip');
     await expect(chip).toHaveAttribute('data-object-type', 'input');
     await expect(chip).toContainText(INPUT_NAME);
 
-    // There is NO Save button in the auto-save form.
-    await expect(
-      leafForm.getByRole('button', { name: /^save$/i })
-    ).toHaveCount(0);
+    // The shared footer: Save is present and disabled until an edit is made.
+    const saveBtn = page.getByTestId('form-footer-save');
+    const discardBtn = page.getByTestId('form-footer-cancel');
+    await expect(saveBtn).toBeVisible({ timeout: WAIT });
+    await expect(discardBtn).toHaveText(/discard/i);
+    await expect(saveBtn).toBeDisabled();
 
-    // Edit the Label → debounced auto-save kicks in.
+    // Edit the Label → Save enables.
     const labelField = page.locator('#input-label');
     await expect(labelField).toBeVisible({ timeout: WAIT });
     const newLabel = `Split Threshold ${Date.now() % 10000}`;
     await labelField.fill(newLabel);
+    await expect(saveBtn).toBeEnabled();
 
-    // The auto-save indicator appears (pending → saving → saved). We assert it
-    // reaches a terminal state and the field keeps the edited value.
-    const indicator = page.getByTestId('right-rail-save-state');
-    await expect(indicator).toBeVisible({ timeout: WAIT });
-    await expect
-      .poll(() => indicator.getAttribute('data-status'), { timeout: WAIT })
-      .toMatch(/saved|error/);
+    // Save → the edit persists (the field keeps its value and Save re-disables
+    // once the baseline advances to the saved value).
+    await saveBtn.click();
     await expect(labelField).toHaveValue(newLabel);
+    await expect(saveBtn).toBeDisabled({ timeout: WAIT });
 
-    await page.screenshot({ path: `${SCREENS}/input-edit-form-autosave.png`, fullPage: false });
+    await page.screenshot({ path: `${SCREENS}/input-edit-form-save.png`, fullPage: false });
+  });
+
+  test('Discard reverts an in-progress label edit to the last-saved value', async ({ page }) => {
+    await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('workspace-right-rail-tab-edit').click();
+    await expect(page.getByTestId('workspace-right-rail-edit')).toBeVisible({ timeout: WAIT });
+
+    await selectInput(page, INPUT_NAME);
+    await expect(page.getByTestId('right-rail-edit-leaf-form')).toBeVisible({ timeout: WAIT });
+
+    const labelField = page.locator('#input-label');
+    await expect(labelField).toBeVisible({ timeout: WAIT });
+    const saved = await labelField.inputValue();
+
+    await labelField.fill('Scratch edit — should not stick');
+    const discardBtn = page.getByTestId('form-footer-cancel');
+    await expect(discardBtn).toBeEnabled();
+    await discardBtn.click();
+
+    await expect(labelField).toHaveValue(saved);
   });
 
   test('inline validation: a default not in the options is shown without trapping the user', async ({

--- a/viewer/e2e/stories/validation-as-save.spec.mjs
+++ b/viewer/e2e/stories/validation-as-save.spec.mjs
@@ -1,12 +1,12 @@
 /**
  * Story: validation-as-save (VIS-993).
  *
- * The rail is AUTO-SAVE with a gated backbone: there is no Save button in edit
- * mode — every field change debounces through useRecordSave, where a
- * semantically doomed edit (dangling ref, unparseable SQL expression) never
- * POSTs — no draft-cache write, no run under runs-on-changes, no cloud commit
- * block — and the blocking reason renders on the field. Fixing the value
- * auto-saves and the change lands in the backend pending set.
+ * The rail persists on an explicit Save through a gated backbone: Save flushes
+ * through useRecordSave, where a semantically doomed edit (dangling ref,
+ * unparseable SQL expression) never POSTs — no draft-cache write, no run under
+ * runs-on-changes, no cloud commit block — and the blocking reason renders on
+ * the field. Fixing the value and saving lands the change in the backend
+ * pending set.
  *
  * Runs in the `state-mutating` playwright project (the valid-save steps write
  * the in-memory draft cache; discarded in afterAll).
@@ -16,8 +16,8 @@ import { API } from '../helpers/sandbox.mjs';
 
 const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3001';
 const WAIT = 20000;
-// The backbone debounces 500ms, then the async gate (schema + refs + backend
-// sqlglot) must run before any POST could fire. 1500ms comfortably covers it.
+// After the Save click the async gate (schema + refs + backend sqlglot) must run
+// before any POST could fire. 1500ms comfortably covers it.
 const SETTLE = 1500;
 
 const DIMENSION = 'x_rounded';
@@ -67,6 +67,14 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     await editable.pressSequentially(text, { delay: 10 });
   };
 
+  // Save is gated on real edits; an edit enables it, then it flushes the config
+  // through the gated backbone.
+  const clickSave = async () => {
+    const save = page.getByTestId('form-footer-save');
+    await expect(save).toBeEnabled({ timeout: WAIT });
+    await save.click();
+  };
+
   const backendPending = async name => {
     const changes = await page.request
       .get(`${API}/api/commit/pending/`)
@@ -75,14 +83,18 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     return (changes.pending || []).some(c => c.name === name);
   };
 
-  test('there is no Save button — the rail is auto-save', async () => {
+  test('the rail has an explicit Save, gated until an edit is made', async () => {
     await openForm('dimension', DIMENSION);
-    await expect(page.getByRole('button', { name: 'Save' })).toHaveCount(0);
+    const save = page.getByTestId('form-footer-save');
+    await expect(save).toBeVisible();
+    // Untouched edit form → nothing to save.
+    await expect(save).toBeDisabled();
   });
 
-  test('a dangling ref blocks the auto-save: inline reason, zero POSTs', async () => {
+  test('a dangling ref blocks the save: inline reason, zero POSTs', async () => {
     const postsBefore = posts.dimensions.length;
     await setExpression('${ref(ghost_model)}');
+    await clickSave();
     await page.waitForTimeout(SETTLE);
 
     // The gate's reason lands on the expression field.
@@ -93,10 +105,11 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     expect(await backendPending(DIMENSION)).toBe(false);
   });
 
-  test('fixing the expression auto-saves: POST fires without any Save click', async () => {
+  test('fixing the expression and saving persists: POST fires', async () => {
     const postsBefore = posts.dimensions.length;
 
     await setExpression('ROUND(x, 1)');
+    await clickSave();
 
     await expect
       .poll(() => posts.dimensions.length, { timeout: WAIT })
@@ -109,6 +122,7 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
 
     const postsBefore = posts.metrics.length;
     await setExpression('AVG(value)}');
+    await clickSave();
     await page.waitForTimeout(SETTLE);
 
     // The backend sqlglot parse error surfaces on the expression field.
@@ -120,10 +134,11 @@ test.describe('Validation-as-save gates the rail (VIS-993)', () => {
     expect(await backendPending(METRIC)).toBe(false);
   });
 
-  test('fixing the metric expression auto-saves through', async () => {
+  test('fixing the metric expression and saving persists', async () => {
     const postsBefore = posts.metrics.length;
 
     await setExpression('AVG(value)');
+    await clickSave();
 
     await expect
       .poll(() => posts.metrics.length, { timeout: WAIT })

--- a/viewer/src/components/views/common/InputEditForm.jsx
+++ b/viewer/src/components/views/common/InputEditForm.jsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
-import { FormInput, FormAlert } from '../../styled/FormComponents';
-import { Button, ButtonOutline } from '../../styled/Button';
-import CircularProgress from '@mui/material/CircularProgress';
+import { FormInput, FormAlert, FormFooter } from '../../styled/FormComponents';
 import { ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
@@ -12,9 +9,9 @@ import CodeIcon from '@mui/icons-material/Code';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import RefTextArea from './RefTextArea';
 import Select from '../../common/Select';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import { validateName } from './namedModel';
 import { validateInputDraft, buildInputConfig } from './inputConfigValidation';
-import useDebouncedSave from '../workspace/useDebouncedSave';
 
 const INPUT_TYPES = [
   { value: 'single-select', label: 'Single Select' },
@@ -24,26 +21,79 @@ const INPUT_TYPES = [
 const SINGLE_SELECT_DISPLAY_TYPES = ['dropdown', 'radio', 'toggle', 'tabs', 'autocomplete', 'slider'];
 const MULTI_SELECT_DISPLAY_TYPES = ['dropdown', 'checkboxes', 'chips', 'tags', 'range-slider', 'date-range'];
 
+/** The blank draft for create mode / a not-yet-seeded form. */
+const BLANK_INPUT_VALUES = {
+  name: '',
+  inputType: 'single-select',
+  label: '',
+  optionsMode: 'list',
+  options: [],
+  optionsQuery: '',
+  rangeStart: '',
+  rangeEnd: '',
+  rangeStep: '',
+  displayType: 'dropdown',
+  defaultValue: '',
+};
+
+/**
+ * Derive the flat form-state values from a stored input record. Kept pure and
+ * beside the component so the seeding effect and the dirty check agree by
+ * construction (VIS-1133 baseline pattern) — snapshot the form's own values,
+ * not its built config, so a freshly-loaded form never reports itself dirty.
+ */
+const deriveInputValues = input => {
+  const config = input.config || {};
+  const values = { ...BLANK_INPUT_VALUES };
+  values.name = input.name || '';
+  values.inputType = config.type || 'single-select';
+  values.label = config.label || '';
+
+  if (config.range) {
+    values.optionsMode = 'range';
+    values.rangeStart = config.range.start != null ? String(config.range.start) : '';
+    values.rangeEnd = config.range.end != null ? String(config.range.end) : '';
+    values.rangeStep = config.range.step != null ? String(config.range.step) : '';
+  } else if (typeof config.options === 'string') {
+    // Query string options (e.g., "?{ SELECT ... }")
+    values.optionsMode = 'query';
+    values.optionsQuery = config.options;
+  } else {
+    values.optionsMode = 'list';
+    values.options = Array.isArray(config.options) ? config.options : [];
+  }
+
+  const display = config.display || {};
+  values.displayType = display.type || 'dropdown';
+
+  if (config.type === 'single-select') {
+    values.defaultValue = display.default?.value != null ? String(display.default.value) : '';
+  } else {
+    const def = display.default || {};
+    if (def.values && Array.isArray(def.values)) {
+      values.defaultValue = def.values.join(', ');
+    } else if (typeof def.values === 'string') {
+      values.defaultValue = def.values;
+    }
+  }
+
+  return values;
+};
+
 /**
  * InputEditForm — VIS-898 / Track G (input slice).
  *
- * The Input editor, with two modes:
+ * The Input editor for the right rail. Edits are held locally and persisted
+ * only on an explicit Save through the shared Delete · Discard · Save footer,
+ * matching every other leaf edit panel (chart/insight/source/…): Save is gated
+ * on real edits, Discard reverts to the last-saved values via `useFormBaseline`,
+ * and Delete marks the input for removal on the next commit.
  *
- *  - `autoSave` (the right rail): edits (name/label/type/options/display/default)
- *    AUTO-SAVE on a ~500ms debounce through the shared `onSave` handler — there
- *    is NO Save button, matching the structure-form UX wired by G-1
- *    (RightRailEditPanel). The auto-save status is reported up via
- *    `onSaveStatusChange` so the SelectionChip header can render the indicator.
- *
- *  - legacy modal hosts (removed): kept the explicit
- *    Save/Cancel footer so the modal can be dismissed as before.
- *
- * In both modes validation is inline and non-blocking: obvious mistakes
- * (invalid name, default not in options, …) are caught client-side and shown
- * near the field without trapping the user, and any backend rejection is
- * surfaced inline too.
+ * Validation is inline and non-blocking: obvious mistakes (invalid name,
+ * default not in options, …) are caught client-side and shown near the field,
+ * and any backend rejection is surfaced in the form-level alert.
  */
-const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, autoSave = false }) => {
+const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
   const deleteInput = useStore(state => state.deleteInput);
   const checkCommitStatus = useStore(state => state.checkCommitStatus);
 
@@ -69,101 +119,71 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  // Guards: don't auto-save the initial hydration from props, and skip the very
-  // first display-type reset that fires when `inputType` initialises.
+  // Skip the display-type reset that fires when `inputType` initialises during
+  // hydration — it would clobber a hydrated display type.
   const hydratedRef = useRef(false);
 
   const isEditMode = !!input && !isCreate;
   const isNewObject = input?.status === ObjectStatus.NEW;
 
-  // Debounced auto-save bound to this input by name.
-  const saveFn = useCallback(
-    config => {
-      if (typeof onSave !== 'function') return undefined;
-      return onSave('input', config.name, config);
-    },
-    [onSave]
-  );
-  const { status: saveStatus, scheduleSave, reset } = useDebouncedSave(saveFn, { delay: 500 });
-
-  // Surface the auto-save status to the parent (SelectionChip indicator).
-  useEffect(() => {
-    if (autoSave && typeof onSaveStatusChange === 'function') onSaveStatusChange(saveStatus);
-  }, [autoSave, saveStatus, onSaveStatusChange]);
+  // VIS-1133: snapshot the last-saved values so the form can report dirtiness
+  // and Discard can revert to them.
+  const applyValues = useCallback(values => {
+    setName(values.name);
+    setInputType(values.inputType);
+    setLabel(values.label);
+    setOptions(values.options);
+    setOptionsQuery(values.optionsQuery);
+    setOptionsMode(values.optionsMode);
+    setDisplayType(values.displayType);
+    setDefaultValue(values.defaultValue);
+    setRangeStart(values.rangeStart);
+    setRangeEnd(values.rangeEnd);
+    setRangeStep(values.rangeStep);
+  }, []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
 
   useEffect(() => {
     hydratedRef.current = false;
     if (input) {
-      setName(input.name || '');
-      const config = input.config || {};
-      setInputType(config.type || 'single-select');
-      setLabel(config.label || '');
-
-      if (config.range) {
-        setOptionsMode('range');
-        setRangeStart(config.range.start != null ? String(config.range.start) : '');
-        setRangeEnd(config.range.end != null ? String(config.range.end) : '');
-        setRangeStep(config.range.step != null ? String(config.range.step) : '');
-        setOptions([]);
-        setOptionsQuery('');
-      } else if (typeof config.options === 'string') {
-        // Query string options (e.g., "?{ SELECT ... }")
-        setOptionsMode('query');
-        setOptionsQuery(config.options);
-        setOptions([]);
-        setRangeStart('');
-        setRangeEnd('');
-        setRangeStep('');
-      } else {
-        setOptionsMode('list');
-        setOptions(Array.isArray(config.options) ? config.options : []);
-        setOptionsQuery('');
-        setRangeStart('');
-        setRangeEnd('');
-        setRangeStep('');
-      }
-
-      const display = config.display || {};
-      setDisplayType(display.type || 'dropdown');
-
-      if (config.type === 'single-select') {
-        setDefaultValue(display.default?.value != null ? String(display.default.value) : '');
-      } else {
-        const def = display.default || {};
-        if (def.values && Array.isArray(def.values)) {
-          setDefaultValue(def.values.join(', '));
-        } else if (typeof def.values === 'string') {
-          setDefaultValue(def.values);
-        } else {
-          setDefaultValue('');
-        }
-      }
+      seed(deriveInputValues(input));
     } else if (isCreate) {
-      setName('');
-      setInputType('single-select');
-      setLabel('');
-      setOptions([]);
-      setNewOption('');
-      setOptionsQuery('');
-      setOptionsMode('list');
-      setDisplayType('dropdown');
-      setDefaultValue('');
-      setRangeStart('');
-      setRangeEnd('');
-      setRangeStep('');
+      seed({ ...BLANK_INPUT_VALUES });
     }
+    setNewOption('');
     setErrors({});
     setSaveError(null);
-    reset();
-    // Mark hydration complete on the next tick so the field-change effect that
-    // schedules the save ignores this prop-driven reset.
+    // Mark hydration complete on the next tick so the display-type reset effect
+    // ignores this prop-driven seed.
     const id = setTimeout(() => {
       hydratedRef.current = true;
     }, 0);
     return () => clearTimeout(id);
-    // input identity (name) drives re-hydration; reset is stable.
+    // Re-seed when the record IDENTITY (or mode) changes — including the fresh
+    // object our own save writes back optimistically, which is how the baseline
+    // advances after a save. `seed` is stable per `applyValues`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [input?.name, isCreate]);
+  }, [input, isCreate]);
+
+  const dirty = isDirtyAgainst({
+    name,
+    inputType,
+    label,
+    optionsMode,
+    options,
+    optionsQuery,
+    rangeStart,
+    rangeEnd,
+    rangeStep,
+    displayType,
+    defaultValue,
+  });
+
+  // Report upward so the tab strip's unsaved dot and its guarded close reflect
+  // real edits (VIS-1133) — the rail clears it on unmount.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Reset display type to a valid value when the input type changes (after the
   // initial hydration so we don't clobber a hydrated display type). Range
@@ -178,9 +198,8 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputType]);
 
-  // Auto-save: whenever an editable field changes (post-hydration), validate and
-  // — when valid — schedule the debounced persist. Invalid drafts show inline
-  // errors and are NOT round-tripped, but the form stays fully editable.
+  // Live inline validation (post-hydration): keep field errors current as the
+  // user edits, without persisting anything — Save is the only write path.
   useEffect(() => {
     if (!hydratedRef.current) return;
     const draft = {
@@ -196,12 +215,8 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
       displayType,
       defaultValue,
     };
-    const nextErrors = validateInputDraft(draft, validateName);
-    setErrors(nextErrors);
+    setErrors(validateInputDraft(draft, validateName));
     setSaveError(null);
-    if (autoSave && Object.keys(nextErrors).length === 0) {
-      scheduleSave(buildInputConfig(draft));
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     name,
@@ -216,35 +231,6 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
     displayType,
     defaultValue,
   ]);
-
-  // Reflect a backend rejection inline (the debounced save sets status 'error';
-  // we re-run the save once on demand to capture its message).
-  const surfaceBackendError = useCallback(async () => {
-    if (!autoSave || saveStatus !== 'error' || typeof onSave !== 'function') return;
-    const draft = {
-      name,
-      inputType,
-      label,
-      optionsMode,
-      options,
-      optionsQuery,
-      rangeStart,
-      rangeEnd,
-      rangeStep,
-      displayType,
-      defaultValue,
-    };
-    if (Object.keys(validateInputDraft(draft, validateName)).length > 0) return;
-    const result = await onSave('input', name, buildInputConfig(draft));
-    if (result && result.success === false) {
-      setSaveError(result.error || 'Failed to save input');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [saveStatus, onSave]);
-
-  useEffect(() => {
-    surfaceBackendError();
-  }, [surfaceBackendError]);
 
   const displayTypes = inputType === 'single-select' ? SINGLE_SELECT_DISPLAY_TYPES : MULTI_SELECT_DISPLAY_TYPES;
 
@@ -267,7 +253,6 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
     }
   };
 
-  // Legacy modal (non-autoSave) explicit save.
   const handleSave = async () => {
     const draft = {
       name,
@@ -290,8 +275,8 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
     setSaveError(null);
     const result = await onSave('input', name, buildInputConfig(draft));
     setSaving(false);
-    if (!result?.success) {
-      setSaveError(result?.error || 'Failed to save input');
+    if (result && result.success === false) {
+      setSaveError(result.error || 'Failed to save input');
     }
   };
 
@@ -321,276 +306,215 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onSaveStatusChange, a
   };
 
   return (
-    <div className="flex-1 overflow-y-auto p-4">
-      <div className="space-y-4">
-        {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
+    <>
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="space-y-4">
+          {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
 
-        <FormInput
-          id="input-name"
-          label="Name"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          disabled={isEditMode}
-          error={errors.name}
-          helperText={isEditMode ? 'Input names cannot be changed after creation.' : undefined}
-        />
-
-        <div className="space-y-1">
-          <label className="block text-sm font-medium text-gray-700" id="input-type-label">
-            Type
-          </label>
-          <Select
-            aria-label="Type"
-            value={inputType}
-            options={INPUT_TYPES}
-            onChange={setInputType}
+          <FormInput
+            id="input-name"
+            label="Name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            disabled={isEditMode}
+            error={errors.name}
+            helperText={isEditMode ? 'Input names cannot be changed after creation.' : undefined}
           />
-        </div>
 
-        <FormInput
-          id="input-label"
-          label="Label"
-          value={label}
-          onChange={e => setLabel(e.target.value)}
-          placeholder="Optional display label"
-        />
-
-        {/* Options Mode Toggle */}
-        <div className="flex items-center justify-between">
-          <label className="text-sm font-medium text-gray-700">Options</label>
-          <ToggleButtonGroup
-            value={optionsMode}
-            exclusive
-            onChange={(e, newMode) => {
-              if (newMode !== null) setOptionsMode(newMode);
-            }}
-            size="small"
-          >
-            <ToggleButton value="list" aria-label="static list">
-              <Tooltip title="Static list">
-                <TuneIcon fontSize="small" />
-              </Tooltip>
-            </ToggleButton>
-            <ToggleButton value="query" aria-label="query string">
-              <Tooltip title="Query expression">
-                <CodeIcon fontSize="small" />
-              </Tooltip>
-            </ToggleButton>
-            {inputType === 'multi-select' && (
-              <ToggleButton value="range" aria-label="range">
-                <Tooltip title="Numeric range">
-                  <SwapHorizIcon fontSize="small" />
-                </Tooltip>
-              </ToggleButton>
-            )}
-          </ToggleButtonGroup>
-        </div>
-
-        {optionsMode === 'range' ? (
-          <div className="space-y-2">
-            <label className="block text-sm font-medium text-gray-700">Range</label>
-            <div className="grid grid-cols-3 gap-2">
-              <FormInput
-                id="range-start"
-                label="Start"
-                value={rangeStart}
-                onChange={e => setRangeStart(e.target.value)}
-                error={errors.rangeStart}
-              />
-              <FormInput
-                id="range-end"
-                label="End"
-                value={rangeEnd}
-                onChange={e => setRangeEnd(e.target.value)}
-                error={errors.rangeEnd}
-              />
-              <FormInput
-                id="range-step"
-                label="Step"
-                value={rangeStep}
-                onChange={e => setRangeStep(e.target.value)}
-                error={errors.rangeStep}
-              />
-            </div>
-          </div>
-        ) : optionsMode === 'query' ? (
-          <div className="space-y-2">
-            {errors.optionsQuery && <p className="text-xs text-red-600">{errors.optionsQuery}</p>}
-            <RefTextArea
-              value={optionsQuery}
-              onChange={val => setOptionsQuery(val)}
-              allowedTypes={['model']}
-              label=""
-              rows={3}
-              // eslint-disable-next-line no-template-curly-in-string
-              helperText={'Use ${ref(model_name)} to reference a model'}
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-gray-700" id="input-type-label">
+              Type
+            </label>
+            <Select
+              aria-label="Type"
+              value={inputType}
+              options={INPUT_TYPES}
+              onChange={setInputType}
             />
           </div>
-        ) : (
-          <div className="space-y-2">
-            {errors.options && (
-              <p className="text-xs text-red-600" data-testid="input-edit-options-error">
-                {errors.options}
-              </p>
-            )}
 
-            <div className="border border-gray-300 rounded-md max-h-40 overflow-y-auto">
-              {options.length === 0 ? (
-                <div className="px-3 py-2 text-sm text-gray-500 italic">No options added</div>
-              ) : (
-                options.map((opt, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 last:border-b-0"
-                  >
-                    <span className="text-sm text-gray-900">{opt}</span>
-                    <button
-                      type="button"
-                      onClick={() => removeOption(i)}
-                      className="p-0.5 text-red-400 hover:text-red-600 rounded"
-                    >
-                      <RemoveIcon style={{ fontSize: 14 }} />
-                    </button>
-                  </div>
-                ))
-              )}
-            </div>
-
-            <div className="flex gap-1">
-              <input
-                type="text"
-                value={newOption}
-                onChange={e => setNewOption(e.target.value)}
-                onKeyDown={handleOptionKeyDown}
-                placeholder="Add option..."
-                className="flex-1 text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary-500"
-              />
-              <button
-                type="button"
-                onClick={addOption}
-                disabled={!newOption.trim()}
-                className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <AddIcon style={{ fontSize: 14 }} />
-                Add
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Display Type */}
-        <div className="space-y-1">
-          <label className="block text-sm font-medium text-gray-700">Display</label>
-          <Select
-            aria-label="Display"
-            value={displayType}
-            options={displayTypes.map(d => ({ value: d, label: d }))}
-            onChange={setDisplayType}
+          <FormInput
+            id="input-label"
+            label="Label"
+            value={label}
+            onChange={e => setLabel(e.target.value)}
+            placeholder="Optional display label"
           />
-        </div>
 
-        {/* Default Value */}
-        <FormInput
-          id="input-default"
-          label={inputType === 'single-select' ? 'Default Value' : 'Default Values'}
-          value={defaultValue}
-          onChange={e => setDefaultValue(e.target.value)}
-          error={errors.defaultValue}
-          placeholder={
-            inputType === 'single-select'
-              ? 'Optional default value'
-              : 'Optional comma-separated defaults'
-          }
-        />
-
-        {/* Delete Confirmation */}
-        {showDeleteConfirm && !isCreate && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded-md">
-            <p className="text-sm text-red-700 mb-2">
-              {isNewObject
-                ? 'Are you sure you want to delete this input? This will discard your unsaved changes.'
-                : 'Are you sure you want to delete this input? This will mark it for deletion and remove it from YAML when you commit.'}
-            </p>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(false)}
-                disabled={deleting}
-                className="px-3 py-1 text-sm text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleDelete}
-                disabled={deleting}
-                className="px-3 py-1 text-sm text-white bg-red-600 rounded hover:bg-red-700 disabled:opacity-50"
-              >
-                {deleting ? 'Deleting...' : 'Confirm Delete'}
-              </button>
-            </div>
+          {/* Options Mode Toggle */}
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium text-gray-700">Options</label>
+            <ToggleButtonGroup
+              value={optionsMode}
+              exclusive
+              onChange={(e, newMode) => {
+                if (newMode !== null) setOptionsMode(newMode);
+              }}
+              size="small"
+            >
+              <ToggleButton value="list" aria-label="static list">
+                <Tooltip title="Static list">
+                  <TuneIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+              <ToggleButton value="query" aria-label="query string">
+                <Tooltip title="Query expression">
+                  <CodeIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+              {inputType === 'multi-select' && (
+                <ToggleButton value="range" aria-label="range">
+                  <Tooltip title="Numeric range">
+                    <SwapHorizIcon fontSize="small" />
+                  </Tooltip>
+                </ToggleButton>
+              )}
+            </ToggleButtonGroup>
           </div>
-        )}
 
-        {autoSave ? (
-          // Auto-save mode: no Save button. Delete stays as a distinct action.
-          isEditMode &&
-          !showDeleteConfirm && (
-            <div className="flex justify-start pt-4 border-t border-gray-200">
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                className="p-1.5 text-red-600 hover:text-red-700 border border-red-300 hover:bg-red-50 rounded transition-colors"
-                title="Delete input"
-              >
-                <DeleteOutlineIcon fontSize="small" />
-              </button>
+          {optionsMode === 'range' ? (
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-gray-700">Range</label>
+              <div className="grid grid-cols-3 gap-2">
+                <FormInput
+                  id="range-start"
+                  label="Start"
+                  value={rangeStart}
+                  onChange={e => setRangeStart(e.target.value)}
+                  error={errors.rangeStart}
+                />
+                <FormInput
+                  id="range-end"
+                  label="End"
+                  value={rangeEnd}
+                  onChange={e => setRangeEnd(e.target.value)}
+                  error={errors.rangeEnd}
+                />
+                <FormInput
+                  id="range-step"
+                  label="Step"
+                  value={rangeStep}
+                  onChange={e => setRangeStep(e.target.value)}
+                  error={errors.rangeStep}
+                />
+              </div>
             </div>
-          )
-        ) : (
-          // Legacy modal mode: explicit Save / Cancel footer.
-          <div className="flex justify-between gap-3 pt-4 border-t border-gray-200">
-            <div>
-              {isEditMode && !showDeleteConfirm && (
+          ) : optionsMode === 'query' ? (
+            <div className="space-y-2">
+              {errors.optionsQuery && <p className="text-xs text-red-600">{errors.optionsQuery}</p>}
+              <RefTextArea
+                value={optionsQuery}
+                onChange={val => setOptionsQuery(val)}
+                allowedTypes={['model']}
+                label=""
+                rows={3}
+                // eslint-disable-next-line no-template-curly-in-string
+                helperText={'Use ${ref(model_name)} to reference a model'}
+              />
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {errors.options && (
+                <p className="text-xs text-red-600" data-testid="input-edit-options-error">
+                  {errors.options}
+                </p>
+              )}
+
+              <div className="border border-gray-300 rounded-md max-h-40 overflow-y-auto">
+                {options.length === 0 ? (
+                  <div className="px-3 py-2 text-sm text-gray-500 italic">No options added</div>
+                ) : (
+                  options.map((opt, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 last:border-b-0"
+                    >
+                      <span className="text-sm text-gray-900">{opt}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeOption(i)}
+                        className="p-0.5 text-red-400 hover:text-red-600 rounded"
+                      >
+                        <RemoveIcon style={{ fontSize: 14 }} />
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              <div className="flex gap-1">
+                <input
+                  type="text"
+                  value={newOption}
+                  onChange={e => setNewOption(e.target.value)}
+                  onKeyDown={handleOptionKeyDown}
+                  placeholder="Add option..."
+                  className="flex-1 text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                />
                 <button
                   type="button"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  className="p-1.5 text-red-600 hover:text-red-700 border border-red-300 hover:bg-red-50 rounded transition-colors"
-                  title="Delete input"
+                  onClick={addOption}
+                  disabled={!newOption.trim()}
+                  className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  <DeleteOutlineIcon fontSize="small" />
+                  <AddIcon style={{ fontSize: 14 }} />
+                  Add
                 </button>
-              )}
+              </div>
             </div>
-            <div className="flex gap-3">
-              <ButtonOutline
-                type="button"
-                onClick={onClose}
-                disabled={saving || deleting}
-                className="text-sm"
-              >
-                Cancel
-              </ButtonOutline>
-              <Button
-                type="button"
-                onClick={handleSave}
-                disabled={saving || deleting}
-                className="text-sm"
-              >
-                {saving ? (
-                  <>
-                    <CircularProgress size={14} className="mr-1" style={{ color: 'white' }} />
-                    Saving...
-                  </>
-                ) : (
-                  'Save'
-                )}
-              </Button>
-            </div>
+          )}
+
+          {/* Display Type */}
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-gray-700">Display</label>
+            <Select
+              aria-label="Display"
+              value={displayType}
+              options={displayTypes.map(d => ({ value: d, label: d }))}
+              onChange={setDisplayType}
+            />
           </div>
-        )}
+
+          {/* Default Value */}
+          <FormInput
+            id="input-default"
+            label={inputType === 'single-select' ? 'Default Value' : 'Default Values'}
+            value={defaultValue}
+            onChange={e => setDefaultValue(e.target.value)}
+            error={errors.defaultValue}
+            placeholder={
+              inputType === 'single-select'
+                ? 'Optional default value'
+                : 'Optional comma-separated defaults'
+            }
+          />
+        </div>
       </div>
-    </div>
+
+      <FormFooter
+        onCancel={isEditMode ? discard : onClose}
+        onSave={handleSave}
+        saving={saving}
+        cancelLabel={isEditMode ? 'Discard' : 'Cancel'}
+        cancelDisabled={isEditMode && (!dirty || saving || deleting)}
+        saveDisabled={isEditMode && !dirty}
+        showDelete={isEditMode && !showDeleteConfirm}
+        onDeleteClick={() => setShowDeleteConfirm(true)}
+        deleteConfirm={
+          showDeleteConfirm && isEditMode
+            ? {
+                show: true,
+                message: isNewObject
+                  ? 'Are you sure you want to delete this input? This will discard your unsaved changes.'
+                  : 'Are you sure you want to delete this input? This will mark it for deletion and remove it from YAML when you commit.',
+                onConfirm: handleDelete,
+                onCancel: () => setShowDeleteConfirm(false),
+                deleting,
+              }
+            : null
+        }
+      />
+    </>
   );
 };
 

--- a/viewer/src/components/views/common/InputEditForm.test.jsx
+++ b/viewer/src/components/views/common/InputEditForm.test.jsx
@@ -1,11 +1,10 @@
 /**
  * InputEditForm tests (VIS-898 / Track G — input slice).
  *
- * Covers the two modes:
- *  - autoSave (right rail): edits debounce-persist through onSave with NO Save
- *    button; status is reported via onSaveStatusChange; inline validation is
- *    non-blocking and skips the round-trip for obvious errors.
- *  - legacy modal: keeps the explicit Save button.
+ * The Input editor is a standard leaf edit panel: edits are held locally and
+ * persisted only on an explicit Save through the shared Delete · Discard · Save
+ * footer. Save is gated on real edits, Discard reverts to the last-saved values,
+ * and inline validation is non-blocking (shown near the field, blocks the save).
  */
 import React from 'react';
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
@@ -35,40 +34,36 @@ const makeInput = (configOverrides = {}) => ({
   },
 });
 
-describe('InputEditForm — autoSave mode', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    seed();
+// Let the 0ms hydration guard settle so post-hydration validation/reset effects run.
+const flushHydration = async () => {
+  await act(async () => {
+    await new Promise(r => setTimeout(r, 0));
   });
-  afterEach(() => {
-    if (jest.isMockFunction(setTimeout)) {
-      act(() => jest.runOnlyPendingTimers());
-    }
-    jest.useRealTimers();
-  });
+};
 
-  test('renders WITHOUT a Save button in autoSave mode', () => {
-    render(<InputEditForm input={makeInput()} onSave={jest.fn()} autoSave />);
-    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+describe('InputEditForm — footer + save gating', () => {
+  beforeEach(() => seed());
+
+  test('renders the Delete · Discard · Save footer in edit mode', () => {
+    render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByTestId('form-footer-save')).toHaveTextContent('Save');
+    expect(screen.getByTestId('form-footer-cancel')).toHaveTextContent('Discard');
+    expect(screen.getByTitle('Delete')).toBeInTheDocument();
     // Fields are seeded from the input config.
     expect(screen.getByLabelText('Label')).toHaveValue('Split Threshold');
   });
 
-  test('editing a field debounce-persists through onSave (no Save button)', async () => {
+  test('Save is disabled until an edit is made, then persists through onSave', async () => {
     const onSave = jest.fn(async () => ({ success: true }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} autoSave />);
+    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
 
-    // Allow hydration (setTimeout(...,0)) to complete.
-    act(() => jest.advanceTimersByTime(1));
+    const saveBtn = screen.getByTestId('form-footer-save');
+    expect(saveBtn).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'New Label' } });
+    expect(saveBtn).not.toBeDisabled();
 
-    // No save before the debounce window elapses.
-    expect(onSave).not.toHaveBeenCalled();
-
-    act(() => jest.advanceTimersByTime(500));
-
+    fireEvent.click(saveBtn);
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     const [type, name, config] = onSave.mock.calls[0];
     expect(type).toBe('input');
@@ -77,148 +72,43 @@ describe('InputEditForm — autoSave mode', () => {
     expect(config.options).toEqual(['3', '5', '7']);
   });
 
-  test('reports save status to onSaveStatusChange', async () => {
-    const onSave = jest.fn(async () => ({ success: true }));
-    const onSaveStatusChange = jest.fn();
-    render(
-      <InputEditForm
-        input={makeInput()}
-        onSave={onSave}
-        onSaveStatusChange={onSaveStatusChange}
-        autoSave
-      />
-    );
-    act(() => jest.advanceTimersByTime(1));
-    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Z' } });
-    act(() => jest.advanceTimersByTime(500));
-    await waitFor(() => expect(onSave).toHaveBeenCalled());
-    // 'pending' is fired on schedule, then 'saving'/'saved' as it resolves.
-    expect(onSaveStatusChange).toHaveBeenCalledWith('pending');
+  test('Discard reverts an edit to the last-saved value', () => {
+    render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
+    const labelField = screen.getByLabelText('Label');
+    expect(labelField).toHaveValue('Split Threshold');
+
+    fireEvent.change(labelField, { target: { value: 'Changed' } });
+    expect(labelField).toHaveValue('Changed');
+    // Discard is enabled once dirty, and reverts to the baseline.
+    fireEvent.click(screen.getByTestId('form-footer-cancel'));
+    expect(screen.getByLabelText('Label')).toHaveValue('Split Threshold');
   });
 
-  test('inline validation: invalid default is shown and is NOT round-tripped', async () => {
+  test('a failed save surfaces the backend error', async () => {
+    const onSave = jest.fn(async () => ({ success: false, error: 'input rejected upstream' }));
+    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByTestId('form-footer-save'));
+
+    expect(await screen.findByText('input rejected upstream')).toBeInTheDocument();
+    // Save recovered to its idle label so the user can retry.
+    expect(screen.getByTestId('form-footer-save')).toHaveTextContent('Save');
+  });
+
+  test('an invalid default is shown inline and blocks the save', async () => {
     const onSave = jest.fn(async () => ({ success: true }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} autoSave />);
-    act(() => jest.advanceTimersByTime(1));
+    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
 
     fireEvent.change(screen.getByLabelText('Default Value'), { target: { value: 'not_an_option' } });
-    act(() => jest.advanceTimersByTime(500));
+    fireEvent.click(screen.getByTestId('form-footer-save'));
 
     // Error shown inline near the field; form stays editable; no save attempted.
-    expect(screen.getByText(/not in the options/i)).toBeInTheDocument();
-    expect(onSave).not.toHaveBeenCalled();
-    // The field is still editable (not disabled).
-    expect(screen.getByLabelText('Default Value')).not.toBeDisabled();
-  });
-
-  test('surfaces a backend rejection inline without trapping the user', async () => {
-    // Real timers so the async save promise + the on-error re-fetch settle.
-    jest.useRealTimers();
-    const onSave = jest.fn(async () => ({ success: false, error: 'default value not in options' }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} autoSave />);
-
-    // Let the 0ms hydration guard settle so field edits schedule a save.
-    await act(async () => {
-      await new Promise(r => setTimeout(r, 0));
-    });
-    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Backend Boom' } });
-
-    await waitFor(() => expect(onSave).toHaveBeenCalled(), { timeout: 2000 });
-    expect(await screen.findByText(/default value not in options/i)).toBeInTheDocument();
-    expect(screen.getByLabelText('Label')).not.toBeDisabled();
-  });
-});
-
-describe('InputEditForm — legacy modal mode', () => {
-  beforeEach(() => seed());
-
-  test('renders a Save button and persists on click', async () => {
-    const onSave = jest.fn(async () => ({ success: true }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
-
-    const saveBtn = screen.getByRole('button', { name: /^save$/i });
-    expect(saveBtn).toBeInTheDocument();
-
-    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Legacy' } });
-    fireEvent.click(saveBtn);
-
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave.mock.calls[0][2].label).toBe('Legacy');
-  });
-
-  test('blocks save on invalid default and shows inline error', async () => {
-    const onSave = jest.fn(async () => ({ success: true }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
-
-    fireEvent.change(screen.getByLabelText('Default Value'), { target: { value: 'bad' } });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
-
     expect(await screen.findByText(/not in the options/i)).toBeInTheDocument();
     expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Default Value')).not.toBeDisabled();
   });
 });
-
-describe('InputEditForm — switching a range multi-select to single-select', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    seed();
-  });
-  afterEach(() => {
-    if (jest.isMockFunction(setTimeout)) {
-      act(() => jest.runOnlyPendingTimers());
-    }
-    jest.useRealTimers();
-  });
-
-  const rangeInput = {
-    name: 'price_range',
-    status: 'PUBLISHED',
-    config: {
-      name: 'price_range',
-      type: 'multi-select',
-      range: { start: 0, end: 100, step: 10 },
-      display: { type: 'range-slider' },
-    },
-  };
-
-  test('never auto-saves a single-select config carrying `range`, and exits range mode', async () => {
-    const onSave = jest.fn(async () => ({ success: true }));
-    render(<InputEditForm input={rangeInput} onSave={onSave} autoSave />);
-
-    // Allow hydration (setTimeout(...,0)) to complete; range fields present.
-    act(() => jest.advanceTimersByTime(1));
-    expect(screen.getByLabelText('Start')).toHaveValue('0');
-
-    // Drive the (portaled) brand Select synchronously — selectEvent's async
-    // waits don't advance fake timers here.
-    const typeInput = screen.getByLabelText('Type');
-    fireEvent.focus(typeInput);
-    fireEvent.keyDown(typeInput, { key: 'ArrowDown', keyCode: 40 });
-    fireEvent.click(screen.getByText('Single Select'));
-
-    // Flush past the auto-save debounce window.
-    act(() => jest.advanceTimersByTime(600));
-
-    // `range` is multi-select only (SingleSelectInput has no range field and
-    // requires options) — no save may round-trip it on a single-select.
-    const badCalls = onSave.mock.calls.filter(
-      ([, , config]) => config.type === 'single-select' && config.range
-    );
-    expect(badCalls).toHaveLength(0);
-
-    // The stranded 'range' mode exits to the static list editor instead of
-    // lingering with no toggle selected.
-    expect(screen.queryByLabelText('Start')).not.toBeInTheDocument();
-    expect(screen.getByText('No options added')).toBeInTheDocument();
-  });
-});
-
-// Let the 0ms hydration guard settle so post-hydration validation/edit effects run.
-const flushHydration = async () => {
-  await act(async () => {
-    await new Promise(r => setTimeout(r, 0));
-  });
-};
 
 describe('InputEditForm — hydration variants', () => {
   beforeEach(() => seed());
@@ -269,7 +159,7 @@ describe('InputEditForm — hydration variants', () => {
   });
 });
 
-describe('InputEditForm — static list editing (legacy mode)', () => {
+describe('InputEditForm — static list editing', () => {
   beforeEach(() => seed());
 
   test('adds options via the Add button and Enter, ignoring duplicates', () => {
@@ -310,7 +200,7 @@ describe('InputEditForm — static list editing (legacy mode)', () => {
     fireEvent.click(removeButtons[1]);
     expect(screen.queryByText('5')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByTestId('form-footer-save'));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave.mock.calls[0][2].options).toEqual(['3', '7']);
   });
@@ -324,27 +214,16 @@ describe('InputEditForm — static list editing (legacy mode)', () => {
     fireEvent.change(optionInput, { target: { value: 'east' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByTestId('form-footer-save'));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     const [type, name, config] = onSave.mock.calls[0];
     expect(type).toBe('input');
     expect(name).toBe('region_filter');
     expect(config).toEqual({ name: 'region_filter', type: 'single-select', options: ['east'] });
   });
-
-  test('a failed legacy save surfaces the backend error', async () => {
-    const onSave = jest.fn(async () => ({ success: false, error: 'input rejected upstream' }));
-    render(<InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
-
-    expect(await screen.findByText('input rejected upstream')).toBeInTheDocument();
-    // Save recovered to its idle label so the user can retry.
-    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument();
-  });
 });
 
-describe('InputEditForm — options mode switching, query & range editing (legacy mode)', () => {
+describe('InputEditForm — options mode switching, query & range editing', () => {
   beforeEach(() => seed());
 
   test('switching to query mode requires a query, then serializes the edited query', async () => {
@@ -360,7 +239,7 @@ describe('InputEditForm — options mode switching, query & range editing (legac
     fireEvent.input(editor);
     await waitFor(() => expect(screen.queryByText('Query is required')).not.toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByTestId('form-footer-save'));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave.mock.calls[0][2].options).toBe('?{ SELECT DISTINCT region FROM orders }');
   });
@@ -393,9 +272,43 @@ describe('InputEditForm — options mode switching, query & range editing (legac
     fireEvent.change(screen.getByLabelText('End'), { target: { value: '50' } });
     fireEvent.change(screen.getByLabelText('Step'), { target: { value: '5' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByTestId('form-footer-save'));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave.mock.calls[0][2].range).toEqual({ start: 5, end: 50, step: 5 });
+  });
+
+  test('switching a range multi-select to single-select exits range mode', async () => {
+    render(
+      <InputEditForm
+        input={{
+          name: 'price_range',
+          status: 'PUBLISHED',
+          config: {
+            name: 'price_range',
+            type: 'multi-select',
+            range: { start: 0, end: 100, step: 10 },
+            display: { type: 'range-slider' },
+          },
+        }}
+        onSave={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    // Hydration must complete before the display-reset effect will fire.
+    await flushHydration();
+    expect(screen.getByLabelText('Start')).toHaveValue('0');
+
+    // Drive the (portaled) brand Select synchronously.
+    const typeInput = screen.getByLabelText('Type');
+    fireEvent.focus(typeInput);
+    fireEvent.keyDown(typeInput, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.click(screen.getByText('Single Select'));
+
+    // The stranded 'range' mode exits to the static list editor instead of
+    // lingering with no toggle selected.
+    expect(screen.queryByLabelText('Start')).not.toBeInTheDocument();
+    expect(screen.getByText('No options added')).toBeInTheDocument();
   });
 });
 
@@ -406,7 +319,7 @@ describe('InputEditForm — delete flows', () => {
     seed({ deleteInput, checkCommitStatus });
     render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
 
-    fireEvent.click(screen.getByTitle('Delete input'));
+    fireEvent.click(screen.getByTitle('Delete'));
     expect(screen.getByText(/mark it for deletion/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Confirm Delete'));
@@ -422,7 +335,7 @@ describe('InputEditForm — delete flows', () => {
     });
     render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
 
-    fireEvent.click(screen.getByTitle('Delete input'));
+    fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByText('Confirm Delete'));
 
     expect(await screen.findByText('input is referenced by a dashboard')).toBeInTheDocument();
@@ -437,7 +350,7 @@ describe('InputEditForm — delete flows', () => {
     });
     render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
 
-    fireEvent.click(screen.getByTitle('Delete input'));
+    fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByText('Confirm Delete'));
 
     expect(await screen.findByText('gateway timeout')).toBeInTheDocument();
@@ -449,22 +362,22 @@ describe('InputEditForm — delete flows', () => {
     seed({ deleteInput });
     render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
 
-    fireEvent.click(screen.getByTitle('Delete input'));
+    fireEvent.click(screen.getByTitle('Delete'));
     expect(screen.getByText(/mark it for deletion/i)).toBeInTheDocument();
-    // The confirm box renders above the footer, so its Cancel comes first.
-    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel' })[0]);
+    // The confirm box's Cancel (the footer button reads "Discard" in edit mode).
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(screen.queryByText(/mark it for deletion/i)).not.toBeInTheDocument();
     expect(deleteInput).not.toHaveBeenCalled();
     // The delete affordance returns once the confirm is dismissed.
-    expect(screen.getByTitle('Delete input')).toBeInTheDocument();
+    expect(screen.getByTitle('Delete')).toBeInTheDocument();
   });
 
-  test('autoSave mode: a NEW input warns about discarding unsaved changes', () => {
+  test('a NEW input warns about discarding unsaved changes', () => {
     seed();
-    render(<InputEditForm input={{ ...makeInput(), status: 'new' }} onSave={jest.fn()} autoSave />);
+    render(<InputEditForm input={{ ...makeInput(), status: 'new' }} onSave={jest.fn()} onClose={jest.fn()} />);
 
-    fireEvent.click(screen.getByTitle('Delete input'));
+    fireEvent.click(screen.getByTitle('Delete'));
     expect(screen.getByText(/discard your unsaved changes/i)).toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -646,15 +646,7 @@ const INLINE_LEAF_FORMS = {
   chart: (record, common) => <ChartEditForm chart={record} {...common} />,
   table: (record, common) => <TableEditForm table={record} {...common} />,
   markdown: (record, common) => <MarkdownEditForm markdown={record} {...common} />,
-  input: (record, common) => (
-    <InputEditForm
-      input={record}
-      isCreate={common.isCreate}
-      onSave={common.onSave}
-      onSaveStatusChange={common.onSaveStatusChange}
-      autoSave
-    />
-  ),
+  input: (record, common) => <InputEditForm input={record} {...common} />,
   source: (record, common) => <SourceEditForm source={record} {...common} />,
   insight: (record, common) => <InsightEditForm insight={record} {...common} />,
   model: (record, common) => (
@@ -686,11 +678,6 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   );
   const typeDef = getTypeByValue(type);
   const singular = typeDef?.singularLabel || type;
-
-  // Auto-saving leaf forms (currently Input — VIS-898) report their debounced
-  // save status up so the SelectionChip header renders the indicator, mirroring
-  // the dashboard-structure forms.
-  const [leafSaveStatus, setLeafSaveStatus] = useState(undefined);
 
   // No modal to close in the rail. This used to be handed to the forms as
   // `onClose`/`onCancel`, which made their Cancel button a literal no-op —
@@ -734,9 +721,10 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   //
   // Two `onSave` conventions exist across the leaf forms:
   //   - DELEGATING (chart/source/table/model/insight/input): call
-  //     `onSave(type, name, config)` and rely on the rail to persist → saveNow.
+  //     `onSave(type, name, config)` on Save and rely on the rail to persist →
+  //     saveNow.
   //   - SELF-SAVING (relation/dimension/metric/markdown): persist via their own
-  //     store action / `useRecordSave` FIRST, then call `onSave(config)` purely
+  //     store action / `useRecordSave` on Save, then call `onSave(config)` purely
   //     as a post-save NOTIFICATION. Re-persisting that here double-fired `saveX`
   //     (VIS-1018 adversarial-review fix), so the single-arg notification is a
   //     no-op — the form already wrote the record.
@@ -747,9 +735,7 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
     [saveNow]
   );
 
-  // Prefer a leaf form's own auto-save status (Input reports its debounce via
-  // onSaveStatusChange) and otherwise surface this record's save status.
-  const saveStatus = leafSaveStatus !== undefined ? leafSaveStatus : recordSaveStatus;
+  const saveStatus = recordSaveStatus;
 
   const renderForm = INLINE_LEAF_FORMS[type];
 
@@ -845,7 +831,6 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
       onSave: handleObjectSave,
       onNavigateToEmbedded: noop,
       onGoBack: noop,
-      onSaveStatusChange: setLeafSaveStatus,
       onDirtyChange: setLeafDirty,
     };
     return (

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import useStore, { ObjectStatus } from '../../../stores/store';
 import useRecordSave from '../../../hooks/useRecordSave';
-import SaveStateIndicator from './SaveStateIndicator';
+import useFormBaseline from '../../../hooks/useFormBaseline';
 import { FormInput, FormFooter, FormLayout, FormAlert } from '../../styled/FormComponents';
 import RefTextArea from '../common/RefTextArea';
 import { validateName } from '../common/namedModel';
@@ -29,8 +29,9 @@ import { useFieldParentModel } from './fields/useFieldParentModel';
  * The chrome the bespoke forms each hand-rolled is owned ONCE here:
  *   - name identity input (read-only in edit mode, validateName on create)
  *   - create mode: explicit Save via the store's SAVE_ACTION[type]
- *   - edit mode: auto-save through the gated useRecordSave backbone (VIS-993) —
- *     no Save button; SaveStateIndicator reports the debounce
+ *   - edit mode: explicit Delete · Discard · Save (matching every other leaf
+ *     panel). Save flushes through the gated useRecordSave backbone (VIS-993),
+ *     Discard reverts to the last-saved values, Save is gated on real edits
  *   - embedded mode (inline object within a model): back-nav + delegating
  *     `onSave(type, name, config)` contract, plain-SQL-only expressions
  *   - delete with confirm (DELETE_ACTION[type]) incl. the NEW-object
@@ -85,7 +86,7 @@ const fieldLabel = (schema, name) =>
   schema?.properties?.[name]?.title ||
   name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, ' ');
 
-const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoBack }) => {
+const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoBack, onDirtyChange }) => {
   const store = useStore();
   const checkCommitStatus = store.checkCommitStatus;
 
@@ -120,42 +121,48 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
     return t === 'postgresql' ? 'postgres' : t;
   }, [sourceName, store.sources]);
 
-  // VIS-993: edit mode is AUTO-SAVE through the gated optimistic backbone.
-  const {
-    scheduleSave,
-    status: autoSaveStatus,
-    errors: gateErrors,
-  } = useRecordSave(type, isEditMode ? recordName || null : null, { sourceDialect });
+  // VIS-993: Save flushes through the gated optimistic backbone (schema + refs +
+  // expressions). Bound to this record only in edit mode; create/embedded persist
+  // through their own paths below.
+  const { saveNow, errors: gateErrors } = useRecordSave(
+    type,
+    isEditMode ? recordName || null : null,
+    { sourceDialect }
+  );
+
+  // VIS-1133: snapshot the last-saved config so Discard reverts to it and the
+  // footer's Save/Discard gate on real edits.
+  const applyValues = useCallback(cfg => setConfig(cfg), []);
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
 
   useEffect(() => {
     if (record) {
       const cfg = unwrapConfig(record) || {};
       // Embedded records keep their identity in config.name; standalone records
       // may only carry it at the record level.
-      setConfig({ ...cfg, name: cfg.name || record.name || '' });
+      seed({ ...cfg, name: cfg.name || record.name || '' });
     } else {
-      setConfig({});
+      seed({});
     }
     setLocalErrors({});
     setSaveError(null);
-    // Re-seed only when the record IDENTITY (or mode) changes — not on every
-    // optimistic store write our own scheduleSave round-trips back in.
+    // Re-seed when the record IDENTITY (or mode) changes — including the fresh
+    // object our own Save writes back optimistically, which is how the baseline
+    // advances after a save. `seed` is stable per `applyValues`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recordName, isCreate, type]);
+  }, [record, isCreate, type]);
 
   const name = config.name || '';
 
-  const applyChange = useCallback(
-    nextConfig => {
-      setConfig(nextConfig);
-      if (isEditMode) {
-        // Auto-save; the gate (schema + refs + expressions) decides persistence.
-        const { name: _n, ...body } = nextConfig;
-        scheduleSave({ name: recordName, ...body });
-      }
-    },
-    [isEditMode, scheduleSave, recordName]
-  );
+  // Edits update the working config; nothing persists until an explicit Save.
+  const applyChange = useCallback(nextConfig => setConfig(nextConfig), []);
+
+  const dirty = isDirtyAgainst(config);
+
+  // Report upward so the tab strip's unsaved dot + guarded close reflect edits.
+  useEffect(() => {
+    if (onDirtyChange) onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
 
   // ---- validation (create/embedded save path; edit mode is gate-driven) ----
   // FormShell warms the per-type schema cache on mount, so a sync read at
@@ -196,6 +203,17 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
         const result = await onSave(type, name, body);
         setSaving(false);
         if (!result?.success) setSaveError(result?.error || `Failed to save ${type}`);
+      } else if (isEditMode) {
+        // Standalone edit — flush through the gated optimistic backbone. The
+        // saveX refetch writes the record back, re-seeding the baseline so the
+        // form goes clean. A gate block surfaces inline via `gateErrors`, so
+        // only a hard failure gets the generic form-level message.
+        const { name: _n, ...rest } = body;
+        const result = await saveNow({ name: recordName, ...rest });
+        setSaving(false);
+        if (result && result.success === false && !result.validation) {
+          setSaveError(result.error || `Failed to save ${type}`);
+        }
       } else {
         // Create mode — persist through the type's store action.
         const saveAction = store[SAVE_ACTION[type]];
@@ -319,11 +337,12 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
       </FormLayout>
 
       <FormFooter
-        autoSave={isEditMode}
-        rightContent={isEditMode ? <SaveStateIndicator status={autoSaveStatus} /> : undefined}
-        onCancel={onClose}
+        onCancel={isEditMode ? discard : onClose}
         onSave={handleSave}
         saving={saving}
+        cancelLabel={isEditMode ? 'Discard' : 'Cancel'}
+        cancelDisabled={isEditMode && (!dirty || saving || deleting)}
+        saveDisabled={isEditMode && !dirty}
         showDelete={isEditMode && !showDeleteConfirm}
         onDeleteClick={() => setShowDeleteConfirm(true)}
         deleteConfirm={

--- a/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
@@ -256,26 +256,48 @@ describe.each(CASES)('SchemaLeafForm $label', ({ type, word, nameLabel, save, de
     });
   });
 
-  describe('edit mode auto-saves through the gated backbone (VIS-993)', () => {
+  describe('edit mode — explicit Save through the gated backbone (VIS-993)', () => {
     const record = { name: 'existing', config: { name: 'existing', expression: 'ROUND(x, 2)' } };
 
-    test('renders NO Save button — persistence is debounced auto-save', async () => {
+    test('renders the Delete · Discard · Save footer', async () => {
       await renderAndSettle(
         <SchemaLeafForm type={type} record={record} onClose={jest.fn()} onSave={jest.fn()} />
       );
-      expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
     });
 
-    test('an expression edit schedules a debounced save with the full config', async () => {
+    test('Save is gated on edits, then flushes the full config through saveNow', async () => {
       await renderAndSettle(
         <SchemaLeafForm type={type} record={record} onClose={jest.fn()} onSave={jest.fn()} />
       );
+      // Untouched: Save disabled, nothing persists.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
       fireEvent.change(screen.getByLabelText('Expression'), { target: { value: 'ROUND(x, 3)' } });
-      expect(mockScheduleSave).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'existing', expression: 'ROUND(x, 3)' })
-      );
+      expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+      // No auto-save — nothing persists on keystroke.
       expect(mockSaveNow).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() =>
+        expect(mockSaveNow).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'existing', expression: 'ROUND(x, 3)' })
+        )
+      );
+    });
+
+    test('Discard reverts an edit to the last-saved value', async () => {
+      await renderAndSettle(
+        <SchemaLeafForm type={type} record={record} onClose={jest.fn()} onSave={jest.fn()} />
+      );
+      const expr = screen.getByLabelText('Expression');
+      expect(expr).toHaveValue('ROUND(x, 2)');
+      fireEvent.change(expr, { target: { value: 'ROUND(x, 9)' } });
+      expect(screen.getByLabelText('Expression')).toHaveValue('ROUND(x, 9)');
+      fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+      expect(screen.getByLabelText('Expression')).toHaveValue('ROUND(x, 2)');
     });
 
     test('gate errors surface on the expression field', async () => {
@@ -328,7 +350,7 @@ describe('SchemaLeafForm Relation', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it('edit mode auto-saves a condition edit through the gated backbone', async () => {
+  it('edit mode — a Save flushes the condition edit through the gated backbone', async () => {
     const record = {
       name: 'rel1',
       config: { name: 'rel1', condition: 'a = b', join_type: 'inner' },
@@ -336,10 +358,13 @@ describe('SchemaLeafForm Relation', () => {
     await renderAndSettle(
       <SchemaLeafForm type="relation" record={record} onClose={jest.fn()} onSave={jest.fn()} />
     );
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
     fireEvent.change(screen.getByLabelText('Condition'), { target: { value: 'a = c' } });
-    expect(mockScheduleSave).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'rel1', condition: 'a = c' })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(mockSaveNow).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'rel1', condition: 'a = c' })
+      )
     );
   });
 


### PR DESCRIPTION
## What

Unifies the last two edit panels still on **auto-save** onto the shared **Delete · Discard · Save** footer that every other leaf panel already uses (chart/insight/source/table/model/markdown).

Part of the **Post Runner Clean Up** effort — "audit all the edit panels; they should all work the same." This is **Phase 1a**: the leaf-object panels. Dashboard full explicit-save (#46) and per-object draft persistence (localStorage) follow as separate PRs.

### Before
- **Input** debounced through `useDebouncedSave` (~500ms), no Save button.
- **dimension / metric / relation** (`SchemaLeafForm`) auto-saved edit-mode changes through `useRecordSave` on every keystroke.

### After — both match the others
- Edits are held locally and persist only on an explicit **Save**.
- A last-saved **baseline** (`useFormBaseline`) gates **Save**/**Discard** on real edits; **Discard** reverts to the saved values. The baseline advances on the post-save optimistic re-seed (both forms now key their seeding effect on the record identity, like every other form).
- **Input** drops `useDebouncedSave` and the `autoSave`/`onSaveStatusChange` plumbing; the rail passes it the standard `common` props.
- **SchemaLeafForm** keeps its gated `useRecordSave` (preserving the `sourceDialect` expression gate + inline field-error mapping) but flips it from a debounced `scheduleSave` to an explicit `saveNow` on Save.
- Removes the now-dead `leafSaveStatus`/`onSaveStatusChange` path from `RightRailEditPanel`.

## Test Strategy
- **Unit**: `InputEditForm.test.jsx` (19) rewritten for footer + dirty-gating + Discard; `SchemaLeafForm.test.jsx` (40) edit-mode tests flipped from auto-save to explicit Save + Discard; `RightRailEditPanel.test.jsx` (77) unchanged and green.
- **Full viewer suite**: 358 suites / 6790 tests pass; lint clean.
- **E2E stories updated** to the explicit-save contract (need a live sandbox to run): `input-edit-form.spec.mjs`, `validation-as-save.spec.mjs` (the validation gate now fires on Save rather than on keystroke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
