### PR TITLE
Keep unsaved edits per object, across navigation and reloads

### DIFF
--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -112,7 +112,11 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
     setInsights(values.insights);
     setLayoutValues(values.layoutValues);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // VIS-1133 + per-object drafts: unsaved edits survive navigating away and
+  // reloads, keyed on this chart. Only a standalone, named record in edit mode
+  // has a stable identity to key on.
+  const draftKey = isEditMode && chart?.name ? `chart:${chart.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   // Initialize form when chart changes
   useEffect(() => {

--- a/viewer/src/components/views/common/InputEditForm.jsx
+++ b/viewer/src/components/views/common/InputEditForm.jsx
@@ -141,7 +141,9 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
     setRangeEnd(values.rangeEnd);
     setRangeStep(values.rangeStep);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  const draftKey = isEditMode && input?.name ? `input:${input.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   useEffect(() => {
     hydratedRef.current = false;

--- a/viewer/src/components/views/common/InputEditForm.test.jsx
+++ b/viewer/src/components/views/common/InputEditForm.test.jsx
@@ -110,6 +110,101 @@ describe('InputEditForm — footer + save gating', () => {
   });
 });
 
+/**
+ * The user journey this exists for: "if I make changes to an object, then click
+ * away, then click back it discards all the changes." The right rail is a
+ * SINGLE instance bound to the active object, so clicking away really does
+ * unmount the form — unmount/remount here is that round trip.
+ */
+describe('InputEditForm — unsaved edits survive clicking away and back', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    seed();
+  });
+  afterEach(() => window.localStorage.clear());
+
+  const renderForm = () =>
+    render(<InputEditForm input={makeInput()} onSave={jest.fn()} onClose={jest.fn()} />);
+
+  it('restores the in-progress edit when the object is re-opened', () => {
+    const view = renderForm();
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Half-typed edit' } });
+    view.unmount(); // click away
+
+    renderForm(); // click back
+    expect(screen.getByLabelText('Label')).toHaveValue('Half-typed edit');
+    // Still reported as unsaved, against the values that were actually saved.
+    expect(screen.getByTestId('form-footer-save')).not.toBeDisabled();
+    expect(screen.getByTestId('form-footer-cancel')).not.toBeDisabled();
+  });
+
+  it('Discard after returning reverts to the saved values, and they stay reverted', () => {
+    const view = renderForm();
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Half-typed edit' } });
+    view.unmount();
+
+    const { unmount: leaveAgain } = renderForm();
+    fireEvent.click(screen.getByTestId('form-footer-cancel')); // Discard
+    expect(screen.getByLabelText('Label')).toHaveValue('Split Threshold');
+    leaveAgain();
+
+    renderForm();
+    expect(screen.getByLabelText('Label')).toHaveValue('Split Threshold');
+    expect(screen.getByTestId('form-footer-save')).toBeDisabled();
+  });
+
+  it('a saved edit leaves no draft behind', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    const view = render(
+      <InputEditForm input={makeInput()} onSave={onSave} onClose={jest.fn()} />
+    );
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Saved Label' } });
+    fireEvent.click(screen.getByTestId('form-footer-save'));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+
+    // The rail re-seeds the form from the saved record; nothing is left over.
+    const savedInput = makeInput({ label: 'Saved Label' });
+    view.rerender(<InputEditForm input={savedInput} onSave={onSave} onClose={jest.fn()} />);
+    view.unmount();
+
+    render(<InputEditForm input={savedInput} onSave={onSave} onClose={jest.fn()} />);
+    expect(screen.getByLabelText('Label')).toHaveValue('Saved Label');
+    expect(screen.getByTestId('form-footer-save')).toBeDisabled();
+  });
+
+  it('edits are kept per object — two inputs do not bleed into each other', () => {
+    const other = {
+      name: 'other_input',
+      status: 'PUBLISHED',
+      config: { name: 'other_input', type: 'single-select', label: 'Other', options: ['a'] },
+    };
+
+    const view = renderForm();
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'Edit on A' } });
+    view.unmount();
+
+    // Open a DIFFERENT input: it must be untouched by A's draft.
+    const { unmount: leaveOther } = render(
+      <InputEditForm input={other} onSave={jest.fn()} onClose={jest.fn()} />
+    );
+    expect(screen.getByLabelText('Label')).toHaveValue('Other');
+    leaveOther();
+
+    // …and A's edit is still waiting.
+    renderForm();
+    expect(screen.getByLabelText('Label')).toHaveValue('Edit on A');
+  });
+
+  it('a corrupt stored draft is dropped and the saved values render', () => {
+    // Failure rule, end to end: a bad entry never surfaces as a broken form.
+    window.localStorage.setItem('visivo.draft.local.input:split_threshold', 'not json at all');
+    renderForm();
+    expect(screen.getByLabelText('Label')).toHaveValue('Split Threshold');
+    expect(screen.getByTestId('form-footer-save')).toBeDisabled();
+    expect(window.localStorage.getItem('visivo.draft.local.input:split_threshold')).toBeNull();
+  });
+});
+
 describe('InputEditForm — hydration variants', () => {
   beforeEach(() => seed());
 

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -98,7 +98,11 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
     setProps(values.props);
     setInteractions(values.interactions);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  // Embedded insights have no standalone identity, so they opt out.
+  const draftKey =
+    isEditMode && !isEmbedded && insight?.name ? `insight:${insight.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   useEffect(() => {
     if (insight) {

--- a/viewer/src/components/views/common/MarkdownEditForm.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.jsx
@@ -66,7 +66,9 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
     setAlign(values.align);
     setJustify(values.justify);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  const draftKey = isEditMode && markdown?.name ? `markdown:${markdown.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   // Initialize form when markdown changes
   useEffect(() => {

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -59,7 +59,9 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
     setDimensions(values.dimensions);
     setMetrics(values.metrics);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  const draftKey = !isCreate && model?.name ? `model:${model.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   useEffect(() => {
     if (model) {

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -58,7 +58,11 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
     setSourceType(values.sourceType);
     setFormValues(values.formValues);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  // Embedded sources (inline on a model) have no standalone identity.
+  const draftKey =
+    isEditMode && !isEmbedded && source?.name ? `source:${source.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   // Initialize form when source changes
   useEffect(() => {

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -93,7 +93,9 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
     setRows(values.rows);
     setValues(values.values);
   }, []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  const draftKey = isEditMode && table?.name ? `table:${table.name}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   useEffect(() => {
     if (table) {

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -133,7 +133,10 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   // VIS-1133: snapshot the last-saved config so Discard reverts to it and the
   // footer's Save/Discard gate on real edits.
   const applyValues = useCallback(cfg => setConfig(cfg), []);
-  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues);
+  // Per-object drafts: unsaved edits survive navigating away and reloads.
+  // Embedded (inline-on-a-model) records have no standalone identity.
+  const draftKey = isEditMode && recordName ? `${type}:${recordName}` : undefined;
+  const { seed, discard, isDirtyAgainst } = useFormBaseline(applyValues, draftKey);
 
   useEffect(() => {
     if (record) {

--- a/viewer/src/hooks/useFormBaseline.js
+++ b/viewer/src/hooks/useFormBaseline.js
@@ -1,8 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import isEqual from 'lodash/isEqual';
+import { restoreDraft, syncDraft } from '../utils/formDrafts';
 
 /**
- * Track a form's last-saved values so it can report dirtiness and revert.
+ * Track a form's last-saved values so it can report dirtiness, revert, and
+ * KEEP its unsaved edits when the user navigates away or reloads.
  *
  * The right rail's Cancel button was `() => {}` — modal-dismiss plumbing that
  * was stubbed out when the forms moved into the persistent rail and never
@@ -21,19 +23,52 @@ import isEqual from 'lodash/isEqual';
  * effect re-runs and calls `seed` again. Same mechanism that re-seeds when the
  * user switches to a different record.
  *
+ * ### Draft persistence (`draftKey`)
+ *
+ * Pass a stable per-object key (`chart:revenue`) and the form's unsaved values
+ * are mirrored to localStorage and restored the next time that object seeds —
+ * so clicking away and back, or reloading, no longer discards edits. The rail
+ * still destroys the form on every object switch; the draft is what survives.
+ *
+ * Only STANDALONE, named records in edit mode should pass a key — create-mode
+ * and embedded forms have no stable identity to key on, so they pass undefined
+ * and behave exactly as before. See `utils/formDrafts` for the staleness rule
+ * (a draft is dropped when the saved record moved on) and the failure rule
+ * (any load error clears that object's draft).
+ *
  * @param {(values: object) => void} apply - push a value set into form state.
  *   Setters are stable, so this can safely be a `useCallback(..., [])`.
+ * @param {string} [draftKey] - stable per-object key for draft persistence.
+ *   Omit to disable persistence for this form instance.
  */
-export default function useFormBaseline(apply) {
+export default function useFormBaseline(apply, draftKey) {
   const [baseline, setBaseline] = useState(null);
 
-  /** Seed form state AND record it as the clean baseline. */
+  // The values the form last rendered with, captured by `isDirtyAgainst` (which
+  // every consumer calls each render with exactly those values) so the sync
+  // effect below can mirror them without changing the hook's call signature.
+  // Written during render on purpose — it is a pure derivation of this render,
+  // read only afterwards, in an effect.
+  const latestValuesRef = useRef(undefined);
+  // Last state written for this key, so a re-render that changed nothing the
+  // draft cares about does not touch storage.
+  const lastSyncedRef = useRef(null);
+
+  /**
+   * Seed form state AND record it as the clean baseline. When a draft for this
+   * object is still valid (its baseline matches these saved values), the form
+   * is seeded with the DRAFT instead — the user's unsaved edits come back —
+   * while the baseline stays the saved values, so dirty/Discard keep pointing
+   * at the last save.
+   */
   const seed = useCallback(
     values => {
       setBaseline(values);
-      apply(values);
+      const restored = draftKey ? restoreDraft(draftKey, values) : values;
+      latestValuesRef.current = restored;
+      apply(restored);
     },
-    [apply]
+    [apply, draftKey]
   );
 
   /** Put every field back to the baseline. No-op before the first seed. */
@@ -46,9 +81,39 @@ export default function useFormBaseline(apply) {
    * the first seed, so a form mid-mount never flashes its buttons enabled.
    */
   const isDirtyAgainst = useCallback(
-    values => baseline !== null && !isEqual(values, baseline),
+    values => {
+      latestValuesRef.current = values;
+      return baseline !== null && !isEqual(values, baseline);
+    },
     [baseline]
   );
+
+  // Mirror the form's unsaved values to storage after each render: stored while
+  // they differ from the baseline, removed once they match again (a save
+  // advanced the baseline, or Discard reverted). No dep array — the values are
+  // read from the ref the render just wrote — with a signature guard so an
+  // unrelated re-render is not a storage write.
+  useEffect(() => {
+    if (!draftKey || baseline === null) return;
+    const values = latestValuesRef.current;
+    if (values === undefined) return;
+    let signature;
+    try {
+      signature = JSON.stringify([baseline, values]);
+    } catch {
+      signature = null; // unserialisable — let syncDraft's own guard handle it
+    }
+    if (signature !== null && signature === lastSyncedRef.current) return;
+    lastSyncedRef.current = signature;
+    syncDraft(draftKey, baseline, values);
+  });
+
+  // Switching objects (or leaving create mode) must not carry the previous
+  // key's write-guard forward, or the first sync for the new object can be
+  // skipped as a false "already written".
+  useEffect(() => {
+    lastSyncedRef.current = null;
+  }, [draftKey]);
 
   return { seed, discard, isDirtyAgainst, baseline };
 }

--- a/viewer/src/hooks/useFormBaseline.test.js
+++ b/viewer/src/hooks/useFormBaseline.test.js
@@ -8,14 +8,17 @@
  */
 import { renderHook, act } from '@testing-library/react';
 import useFormBaseline from './useFormBaseline';
+import { readDraft, writeDraft } from '../utils/formDrafts';
 
 /** Drive the hook with a spy `apply` so we can see what it pushes back. */
-const setup = () => {
+const setup = (draftKey) => {
   const applied = [];
   const apply = values => applied.push(values);
-  const view = renderHook(() => useFormBaseline(apply));
+  const view = renderHook(() => useFormBaseline(apply, draftKey));
   return { view, applied };
 };
+
+beforeEach(() => window.localStorage.clear());
 
 describe('useFormBaseline', () => {
   it('reports clean before the first seed, so a mounting form never flashes enabled', () => {
@@ -75,6 +78,13 @@ describe('useFormBaseline', () => {
     expect(applied).toEqual([]);
   });
 
+  it('with no draftKey nothing is ever written to storage (create/embedded forms)', () => {
+    const { view } = setup(undefined);
+    act(() => view.result.current.seed({ name: 'orders' }));
+    view.rerender();
+    expect(window.localStorage.length).toBe(0);
+  });
+
   it('re-seeding advances the baseline — this is what clears dirty after a save', () => {
     // The rail persists through useRecordSave, whose optimistic write replaces
     // the store record with a NEW object; the form's [record]-keyed effect then
@@ -91,5 +101,113 @@ describe('useFormBaseline', () => {
     applied.length = 0;
     act(() => view.result.current.discard());
     expect(applied).toEqual([{ name: 'edited' }]);
+  });
+});
+
+/**
+ * Per-object draft persistence. These drive the hook the way a real form does:
+ * every render calls `isDirtyAgainst` with the form's CURRENT values, which is
+ * how the hook learns what to mirror. `rerender({ values })` therefore stands
+ * in for "the user typed".
+ */
+describe('useFormBaseline — per-object drafts', () => {
+  const KEY = 'chart:revenue';
+  const SAVED = { name: 'revenue', layout: { title: 'Q1' } };
+  const EDITED = { name: 'revenue', layout: { title: 'EDITED' } };
+
+  /** A form: seeds from its record, and reports dirty on every render. */
+  const setupForm = (draftKey = KEY) => {
+    const applied = [];
+    const apply = values => applied.push(values);
+    const view = renderHook(
+      ({ values }) => {
+        const baseline = useFormBaseline(apply, draftKey);
+        return {
+          ...baseline,
+          dirty: values === undefined ? false : baseline.isDirtyAgainst(values),
+        };
+      },
+      { initialProps: { values: undefined } }
+    );
+    /** Seed, then render with whatever `apply` pushed (what a real form does). */
+    const seedWith = saved => {
+      act(() => view.result.current.seed(saved));
+      view.rerender({ values: applied[applied.length - 1] });
+    };
+    return { view, applied, seedWith };
+  };
+
+  it('mirrors unsaved values to storage once the form goes dirty', () => {
+    const { view, seedWith } = setupForm();
+    seedWith(SAVED);
+    expect(readDraft(KEY)).toBeNull(); // clean form stores nothing
+
+    view.rerender({ values: EDITED }); // the user types
+    expect(readDraft(KEY)).toEqual({ baseline: SAVED, values: EDITED });
+  });
+
+  it('restores the unsaved values when the object is opened again', () => {
+    // The rail destroys the form on every object switch; the DRAFT is what
+    // survives. Simulate: a draft exists, and a fresh form seeds the record.
+    writeDraft(KEY, SAVED, EDITED);
+
+    const { view, applied, seedWith } = setupForm();
+    seedWith(SAVED);
+
+    // The form comes back with the user's edits…
+    expect(applied[applied.length - 1]).toEqual(EDITED);
+    // …reported as unsaved (the baseline is still the SAVED values)…
+    expect(view.result.current.dirty).toBe(true);
+    // …and Discard returns to what was actually saved.
+    applied.length = 0;
+    act(() => view.result.current.discard());
+    expect(applied).toEqual([SAVED]);
+  });
+
+  it('drops a draft whose record moved on rather than pasting stale edits over it', () => {
+    writeDraft(KEY, SAVED, EDITED);
+    const movedOn = { name: 'revenue', layout: { title: 'SOMEONE ELSE SAVED THIS' } };
+
+    const { view, applied, seedWith } = setupForm();
+    seedWith(movedOn);
+
+    expect(applied[applied.length - 1]).toEqual(movedOn);
+    expect(view.result.current.dirty).toBe(false);
+    expect(readDraft(KEY)).toBeNull();
+  });
+
+  it('clears the draft when Discard reverts the form', () => {
+    const { view, applied, seedWith } = setupForm();
+    seedWith(SAVED);
+    view.rerender({ values: EDITED });
+    expect(readDraft(KEY)).not.toBeNull();
+
+    act(() => view.result.current.discard());
+    view.rerender({ values: applied[applied.length - 1] }); // back to SAVED
+    expect(readDraft(KEY)).toBeNull();
+  });
+
+  it('clears the draft when a save advances the baseline', () => {
+    const { view, seedWith } = setupForm();
+    seedWith(SAVED);
+    view.rerender({ values: EDITED });
+    expect(readDraft(KEY)).not.toBeNull();
+
+    // A save persists EDITED; the store's optimistic write re-seeds the form.
+    seedWith(EDITED);
+    expect(view.result.current.dirty).toBe(false);
+    expect(readDraft(KEY)).toBeNull();
+  });
+
+  it('a corrupt stored draft is discarded, leaving the form on the saved record', () => {
+    // The failure rule end-to-end: nothing surfaces to the user but the saved
+    // values, and the bad entry is gone.
+    window.localStorage.setItem(`visivo.draft.local.${KEY}`, '{{ not json');
+    const { view, applied, seedWith } = setupForm();
+    seedWith(SAVED);
+
+    expect(applied[applied.length - 1]).toEqual(SAVED);
+    expect(view.result.current.dirty).toBe(false);
+    expect(readDraft(KEY)).toBeNull();
   });
 });

--- a/viewer/src/setupTests.js
+++ b/viewer/src/setupTests.js
@@ -128,4 +128,16 @@ beforeEach(() => {
   // Set up a test URL config
   const testConfig = createURLConfig({ environment: 'server' });
   setGlobalURLConfig(testConfig);
+
+  // jsdom keeps ONE localStorage for the whole file, so persistent browser
+  // state (per-object edit drafts, workspace tabs, field-finder MRU) would leak
+  // from one test into the next — a test that leaves a form dirty would seed
+  // the following test's form with those edits. Each test starts from a clean
+  // browser. Test files that need seeded storage write it in their own
+  // beforeEach, which runs after this one.
+  try {
+    window.localStorage.clear();
+  } catch {
+    // Storage unavailable in this environment — nothing to reset.
+  }
 });

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -53,6 +53,10 @@ const createDashboardSlice = (set, get) => ({
       // captured baseline, #46) is replaced wholesale, so drop every baseline
       // to keep a stale one from reporting false dirtiness on the fresh config.
       set({ dashboards: data.dashboards || [], dashboardsLoading: false, dashboardBaselines: {} });
+      // …then re-apply any UNSAVED working copy still valid for this server
+      // state, so an open editing session survives both a reload and an
+      // unrelated mid-edit refetch.
+      get().hydrateDashboardDrafts?.();
     } catch (error) {
       console.error('dashboardStore: fetch error', error);
       set({ dashboardsError: error.message, dashboardsLoading: false });

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -44,6 +44,7 @@
  */
 
 import isEqual from 'lodash/isEqual';
+import { clearDraft, restoreDraft, syncDraft } from '../utils/formDrafts';
 import { emitWorkspaceEvent } from '../components/views/workspace/telemetry';
 import { generateUniqueName } from '../utils/uniqueName';
 import { COLLECTION_KEY } from '../components/views/workspace/collectionKeys';
@@ -1025,6 +1026,14 @@ const createWorkspaceSlice = (set, get) => ({
     const nextList = [...list];
     nextList[idx] = nextEntry;
     set({ dashboards: nextList });
+    // Mirror the working copy to storage while an editing session is open (a
+    // baseline exists), so unsaved dashboard edits survive a reload the same
+    // way the leaf panels' do. Non-editing optimistic writes have no baseline
+    // and are not drafts.
+    const baseline = (state.dashboardBaselines || {})[dashboardName];
+    if (baseline !== undefined) {
+      syncDraft(`dashboard:${dashboardName}`, baseline, nextConfig);
+    }
     return true;
   },
 
@@ -1085,6 +1094,7 @@ const createWorkspaceSlice = (set, get) => ({
     }
     const result = await state.saveDashboard(dashboardName, unwrapConfig(entry));
     if (result?.success) {
+      clearDraft(`dashboard:${dashboardName}`);
       set((s) => {
         const next = { ...(s.dashboardBaselines || {}) };
         delete next[dashboardName];
@@ -1096,18 +1106,53 @@ const createWorkspaceSlice = (set, get) => ({
 
   /**
    * Revert a dashboard's working copy to its captured baseline (explicit
-   * Discard) and drop the baseline. No-op when there's nothing to discard.
+   * Discard) and drop the baseline + stored draft. No-op when there's nothing
+   * to discard.
    */
   discardDashboardEdits: (dashboardName) => {
     if (!dashboardName) return;
     const baseline = (get().dashboardBaselines || {})[dashboardName];
     if (baseline === undefined) return;
     get().updateDashboardConfigOptimistic(dashboardName, baseline);
+    clearDraft(`dashboard:${dashboardName}`);
     set((s) => {
       const next = { ...(s.dashboardBaselines || {}) };
       delete next[dashboardName];
       return { dashboardBaselines: next };
     });
+  },
+
+  /**
+   * Re-apply stored dashboard drafts over a freshly-fetched collection.
+   *
+   * `fetchDashboards` replaces the list with server truth and drops every
+   * baseline, which would silently throw away an open editing session — both
+   * across a reload AND when an unrelated action (a level rename saving a
+   * DIFFERENT dashboard) refetches mid-edit. A draft is only re-applied when
+   * the saved values it was taken against still match what the server just
+   * returned; otherwise the record moved on and the draft is dropped
+   * (`restoreDraft`'s staleness rule).
+   */
+  hydrateDashboardDrafts: () => {
+    const list = get().dashboards || [];
+    if (!list.length) return;
+    const restoredBaselines = {};
+    let changed = false;
+    const nextList = list.map((entry) => {
+      const saved = unwrapConfig(entry);
+      const restored = restoreDraft(`dashboard:${entry.name}`, saved);
+      // `restoreDraft` hands back the SAME reference when there was no usable
+      // draft, so identity is the "nothing restored" signal.
+      if (restored === saved) return entry;
+      changed = true;
+      restoredBaselines[entry.name] = saved;
+      return withConfig(entry, restored);
+    });
+    if (!changed) return;
+    set((s) => ({
+      dashboards: nextList,
+      dashboardBaselines: { ...(s.dashboardBaselines || {}), ...restoredBaselines },
+    }));
   },
 
   /**

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -1977,6 +1977,112 @@ describe('workspace store slice', () => {
       const dash = useStore.getState().dashboards.find(d => d.name === 'd1');
       expect(dash.config.rows[0].height).toBe('small');
     });
+
+    // The dashboard working copy gets the same per-object draft persistence as
+    // the leaf panels: an open editing session survives a reload AND an
+    // unrelated mid-edit refetch (a level rename saving a DIFFERENT dashboard
+    // refetches the whole collection).
+    describe('draft persistence across a refetch', () => {
+      const startEditing = () => {
+        seedDashboard({ rows: [{ height: 'small', items: [] }] });
+        act(() => useStore.getState().captureDashboardBaseline('d1'));
+        act(() =>
+          useStore.getState().updateDashboardConfigOptimistic('d1', {
+            name: 'd1',
+            rows: [{ height: 'large', items: [] }],
+          })
+        );
+      };
+
+      test('an unsaved working copy is restored over a fresh server list', () => {
+        startEditing();
+        // A refetch replaces the list with server truth and drops every
+        // baseline (what dashboardStore.fetchDashboards does)…
+        act(() => {
+          useStore.setState({
+            dashboards: [{ name: 'd1', config: { name: 'd1', rows: [{ height: 'small', items: [] }] } }],
+            dashboardBaselines: {},
+          });
+          useStore.getState().hydrateDashboardDrafts();
+        });
+
+        // …and the unsaved edit comes back, still marked unsaved.
+        const dash = useStore.getState().dashboards.find(d => d.name === 'd1');
+        expect(dash.config.rows[0].height).toBe('large');
+        expect(useStore.getState().isDashboardDirty('d1')).toBe(true);
+      });
+
+      test('a draft is dropped when the server config moved on underneath', () => {
+        startEditing();
+        act(() => {
+          useStore.setState({
+            // Someone else saved this dashboard while we were editing.
+            dashboards: [
+              { name: 'd1', config: { name: 'd1', rows: [{ height: 'xlarge', items: [] }] } },
+            ],
+            dashboardBaselines: {},
+          });
+          useStore.getState().hydrateDashboardDrafts();
+        });
+
+        const dash = useStore.getState().dashboards.find(d => d.name === 'd1');
+        expect(dash.config.rows[0].height).toBe('xlarge'); // server truth wins
+        expect(useStore.getState().isDashboardDirty('d1')).toBe(false);
+      });
+
+      test('Discard clears the stored draft, so a refetch does not resurrect it', () => {
+        startEditing();
+        act(() => useStore.getState().discardDashboardEdits('d1'));
+        act(() => {
+          useStore.setState({
+            dashboards: [{ name: 'd1', config: { name: 'd1', rows: [{ height: 'small', items: [] }] } }],
+            dashboardBaselines: {},
+          });
+          useStore.getState().hydrateDashboardDrafts();
+        });
+        const dash = useStore.getState().dashboards.find(d => d.name === 'd1');
+        expect(dash.config.rows[0].height).toBe('small');
+      });
+
+      test('a successful Save clears the stored draft', async () => {
+        const saveDashboard = jest.fn(() => Promise.resolve({ success: true }));
+        startEditing();
+        act(() => useStore.setState({ saveDashboard }));
+        await act(async () => {
+          await useStore.getState().commitDashboardEdits('d1');
+        });
+
+        act(() => {
+          useStore.setState({
+            dashboards: [{ name: 'd1', config: { name: 'd1', rows: [{ height: 'large', items: [] }] } }],
+            dashboardBaselines: {},
+          });
+          useStore.getState().hydrateDashboardDrafts();
+        });
+        expect(useStore.getState().isDashboardDirty('d1')).toBe(false);
+      });
+
+      test('an optimistic write with no open editing session stores nothing', () => {
+        seedDashboard({ rows: [{ height: 'small', items: [] }] });
+        // No captureDashboardBaseline → not an editing session (this is the
+        // path useRecordSave takes for its own optimistic writes).
+        act(() =>
+          useStore.getState().updateDashboardConfigOptimistic('d1', {
+            name: 'd1',
+            rows: [{ height: 'large', items: [] }],
+          })
+        );
+        act(() => {
+          useStore.setState({
+            dashboards: [{ name: 'd1', config: { name: 'd1', rows: [{ height: 'small', items: [] }] } }],
+            dashboardBaselines: {},
+          });
+          useStore.getState().hydrateDashboardDrafts();
+        });
+        const dash = useStore.getState().dashboards.find(d => d.name === 'd1');
+        expect(dash.config.rows[0].height).toBe('small');
+      });
+    });
   });
 
   test('updateRecordConfigOptimistic replaces a non-dashboard record config without saving (VIS-1018)', () => {

--- a/viewer/src/utils/formDrafts.js
+++ b/viewer/src/utils/formDrafts.js
@@ -1,0 +1,165 @@
+import isEqual from 'lodash/isEqual';
+import useStore from '../stores/store';
+
+/**
+ * formDrafts — per-object unsaved-edit persistence (localStorage).
+ *
+ * THE PROBLEM: every edit panel holds its in-progress edits in local component
+ * state seeded from the record (`useFormBaseline`), and the right rail is a
+ * SINGLE instance bound to the active object. Clicking away unmounted the form
+ * and threw the edits away; a reload did the same. Users lost work by doing the
+ * most natural thing in a workspace — looking at something else mid-edit.
+ *
+ * THE FIX: each object's unsaved values are mirrored to localStorage under its
+ * own key (`type:name`, project-scoped) and restored when that object is opened
+ * again — across navigation AND across reloads.
+ *
+ * ### Staleness rule (why a draft carries its baseline)
+ *
+ * A stored draft is `{ baseline, values }`: the values the user is editing AND
+ * the last-saved values they were edited FROM. On restore we only re-apply the
+ * draft when its `baseline` still deep-equals what the record currently seeds —
+ * i.e. the saved object has not moved on underneath. If it HAS (someone else
+ * saved it, a run rewrote it, the name now belongs to a different object in
+ * another project), the draft is dropped rather than silently pasted over newer
+ * truth. This is also what keeps same-named objects in different projects from
+ * bleeding into each other beyond the project scoping below.
+ *
+ * ### Failure rule
+ *
+ * Any failure to load a draft — unreadable storage, malformed JSON, a shape
+ * this version doesn't recognise — CLEARS that object's stored draft and
+ * reports "no draft". A corrupt entry never surfaces as a broken form and never
+ * lingers to fail again on the next open.
+ */
+
+const PREFIX = 'visivo.draft.';
+const VERSION = 1;
+
+/**
+ * The localStorage handle, or null when storage is unavailable (SSR, Safari
+ * private mode, storage disabled). Every access below tolerates null so a
+ * missing storage engine degrades to "no drafts", never a thrown render.
+ */
+const storage = () => {
+  try {
+    return typeof window !== 'undefined' && window.localStorage ? window.localStorage : null;
+  } catch {
+    // Access itself can throw when cookies/storage are blocked.
+    return null;
+  }
+};
+
+/**
+ * Project scope for the key. The viewer is mounted per project in cloud
+ * (`/:account/:stage/:project/workspace`) on ONE origin, so an unscoped
+ * `chart:revenue` would be shared by every project the user opens.
+ *
+ * Read lazily through `getState()` rather than a reactive selector: this is
+ * called from event/effect paths, not during render, and the optional call
+ * keeps the util working under the partial store mocks the form suites use.
+ */
+const projectScope = () => {
+  try {
+    return useStore.getState?.()?.project?.id || 'local';
+  } catch {
+    return 'local';
+  }
+};
+
+/** Full storage key for an object draft key (`chart:revenue`). */
+export const draftStorageKey = key => `${PREFIX}${projectScope()}.${key}`;
+
+/** Remove an object's stored draft. Safe to call when none exists. */
+export const clearDraft = key => {
+  if (!key) return;
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(draftStorageKey(key));
+  } catch {
+    // Nothing more we can do; a draft we cannot remove is one we also cannot
+    // read (readDraft clears on any failure), so it stays inert.
+  }
+};
+
+/**
+ * Read an object's stored draft.
+ *
+ * @returns {{baseline: any, values: any}|null} the draft, or null when there
+ *   is none. ANY problem loading — storage error, bad JSON, unknown version,
+ *   wrong shape — clears the entry and returns null (never a broken form).
+ */
+export const readDraft = key => {
+  if (!key) return null;
+  const store = storage();
+  if (!store) return null;
+  let raw;
+  try {
+    raw = store.getItem(draftStorageKey(key));
+  } catch {
+    clearDraft(key);
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const usable =
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.v === VERSION &&
+      'baseline' in parsed &&
+      'values' in parsed;
+    if (!usable) {
+      clearDraft(key);
+      return null;
+    }
+    return { baseline: parsed.baseline, values: parsed.values };
+  } catch {
+    clearDraft(key);
+    return null;
+  }
+};
+
+/**
+ * Mirror an object's unsaved values to storage, tagged with the saved values
+ * they were edited from. A write that fails (quota, unserialisable value)
+ * clears the entry rather than leaving a half-written or stale one behind.
+ */
+export const writeDraft = (key, baseline, values) => {
+  if (!key) return;
+  const store = storage();
+  if (!store) return;
+  try {
+    store.setItem(draftStorageKey(key), JSON.stringify({ v: VERSION, baseline, values }));
+  } catch {
+    clearDraft(key);
+  }
+};
+
+/**
+ * Restore a draft for a record that is seeding with `savedValues`.
+ *
+ * @returns {any} the draft's values when it is still valid for these saved
+ *   values, otherwise `savedValues` unchanged (dropping a stale draft).
+ */
+export const restoreDraft = (key, savedValues) => {
+  const draft = readDraft(key);
+  if (!draft) return savedValues;
+  if (isEqual(draft.baseline, savedValues)) return draft.values;
+  // The saved record moved on underneath this draft — drop it rather than
+  // paste stale edits over newer truth.
+  clearDraft(key);
+  return savedValues;
+};
+
+/**
+ * Sync an object's draft to match its current state: stored while the values
+ * differ from the last-saved baseline, removed the moment they match again
+ * (a save advanced the baseline, or Discard reverted).
+ */
+export const syncDraft = (key, baseline, values) => {
+  if (!key || baseline === undefined || baseline === null) return;
+  if (isEqual(values, baseline)) clearDraft(key);
+  else writeDraft(key, baseline, values);
+};

--- a/viewer/src/utils/formDrafts.test.js
+++ b/viewer/src/utils/formDrafts.test.js
@@ -1,0 +1,175 @@
+/**
+ * formDrafts — per-object unsaved-edit persistence.
+ *
+ * Two rules carry the weight here:
+ *   - STALENESS: a draft only restores while the saved values it was taken
+ *     against still match, so unsaved edits are never pasted over a record that
+ *     moved on underneath (a concurrent save, a run, another project's
+ *     same-named object).
+ *   - FAILURE: any problem loading a draft CLEARS that object's entry and
+ *     reports "no draft" — a corrupt entry never surfaces as a broken form and
+ *     never lingers to fail again.
+ */
+import {
+  clearDraft,
+  draftStorageKey,
+  readDraft,
+  restoreDraft,
+  syncDraft,
+  writeDraft,
+} from './formDrafts';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  jest.restoreAllMocks();
+});
+
+describe('formDrafts — round trip', () => {
+  it('writes and reads back a draft', () => {
+    writeDraft('chart:revenue', { name: 'revenue' }, { name: 'revenue_edited' });
+    expect(readDraft('chart:revenue')).toEqual({
+      baseline: { name: 'revenue' },
+      values: { name: 'revenue_edited' },
+    });
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(readDraft('chart:nothing')).toBeNull();
+  });
+
+  it('clearDraft removes the entry', () => {
+    writeDraft('chart:revenue', { a: 1 }, { a: 2 });
+    clearDraft('chart:revenue');
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+
+  it('namespaces keys so an unrelated localStorage entry is never touched', () => {
+    window.localStorage.setItem('chart:revenue', 'someone-elses-value');
+    writeDraft('chart:revenue', { a: 1 }, { a: 2 });
+    expect(window.localStorage.getItem('chart:revenue')).toBe('someone-elses-value');
+    expect(draftStorageKey('chart:revenue')).toContain('visivo.draft.');
+  });
+
+  it('keeps drafts for different objects independent', () => {
+    writeDraft('chart:a', { n: 'a' }, { n: 'a2' });
+    writeDraft('chart:b', { n: 'b' }, { n: 'b2' });
+    expect(readDraft('chart:a').values).toEqual({ n: 'a2' });
+    expect(readDraft('chart:b').values).toEqual({ n: 'b2' });
+  });
+
+  it('a falsy key is a no-op in every direction', () => {
+    expect(readDraft('')).toBeNull();
+    expect(() => writeDraft('', { a: 1 }, { a: 2 })).not.toThrow();
+    expect(() => clearDraft('')).not.toThrow();
+  });
+});
+
+describe('formDrafts — failure rule: any load error clears the object', () => {
+  it('malformed JSON is cleared and reported as no draft', () => {
+    window.localStorage.setItem(draftStorageKey('chart:revenue'), '{not json');
+    expect(readDraft('chart:revenue')).toBeNull();
+    // …and the bad entry is GONE, so it cannot fail again on the next open.
+    expect(window.localStorage.getItem(draftStorageKey('chart:revenue'))).toBeNull();
+  });
+
+  it('an entry from an unknown version is cleared', () => {
+    window.localStorage.setItem(
+      draftStorageKey('chart:revenue'),
+      JSON.stringify({ v: 999, baseline: {}, values: {} })
+    );
+    expect(readDraft('chart:revenue')).toBeNull();
+    expect(window.localStorage.getItem(draftStorageKey('chart:revenue'))).toBeNull();
+  });
+
+  it('an entry missing the baseline/values shape is cleared', () => {
+    window.localStorage.setItem(
+      draftStorageKey('chart:revenue'),
+      JSON.stringify({ v: 1, values: { a: 1 } }) // no baseline
+    );
+    expect(readDraft('chart:revenue')).toBeNull();
+    expect(window.localStorage.getItem(draftStorageKey('chart:revenue'))).toBeNull();
+  });
+
+  it('a non-object payload (bare string/null) is cleared', () => {
+    window.localStorage.setItem(draftStorageKey('chart:revenue'), JSON.stringify('nope'));
+    expect(readDraft('chart:revenue')).toBeNull();
+    expect(window.localStorage.getItem(draftStorageKey('chart:revenue'))).toBeNull();
+  });
+
+  it('a throwing getItem clears the entry instead of propagating', () => {
+    writeDraft('chart:revenue', { a: 1 }, { a: 2 });
+    const removeSpy = jest.spyOn(Storage.prototype, 'removeItem');
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    expect(readDraft('chart:revenue')).toBeNull();
+    expect(removeSpy).toHaveBeenCalled();
+  });
+
+  it('a failed write (quota) clears rather than leaving a half-written entry', () => {
+    writeDraft('chart:revenue', { a: 1 }, { a: 2 });
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    writeDraft('chart:revenue', { a: 1 }, { a: 3 });
+    jest.restoreAllMocks();
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+
+  it('a circular value cannot be stored and leaves no entry behind', () => {
+    const circular = { name: 'x' };
+    circular.self = circular;
+    expect(() => writeDraft('chart:revenue', { name: 'x' }, circular)).not.toThrow();
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+});
+
+describe('formDrafts — staleness rule (restoreDraft)', () => {
+  const saved = { name: 'revenue', layout: { title: 'Q1' } };
+
+  it('restores the unsaved values when the saved record has not moved on', () => {
+    writeDraft('chart:revenue', saved, { ...saved, layout: { title: 'EDITED' } });
+    expect(restoreDraft('chart:revenue', { ...saved })).toEqual({
+      ...saved,
+      layout: { title: 'EDITED' },
+    });
+  });
+
+  it('drops the draft when the saved record changed underneath', () => {
+    writeDraft('chart:revenue', saved, { ...saved, layout: { title: 'EDITED' } });
+    const movedOn = { name: 'revenue', layout: { title: 'SOMEONE ELSE SAVED THIS' } };
+    expect(restoreDraft('chart:revenue', movedOn)).toBe(movedOn);
+    // Dropped, not just skipped — it can never resurface.
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+
+  it('returns the saved values unchanged (same reference) when there is no draft', () => {
+    const values = { ...saved };
+    expect(restoreDraft('chart:revenue', values)).toBe(values);
+  });
+
+  it('with no key it is a pass-through', () => {
+    const values = { ...saved };
+    expect(restoreDraft(undefined, values)).toBe(values);
+  });
+});
+
+describe('formDrafts — syncDraft mirrors edit state', () => {
+  it('stores while the values differ from the baseline', () => {
+    syncDraft('chart:revenue', { n: 1 }, { n: 2 });
+    expect(readDraft('chart:revenue')).toEqual({ baseline: { n: 1 }, values: { n: 2 } });
+  });
+
+  it('removes the draft the moment the values match the baseline again', () => {
+    syncDraft('chart:revenue', { n: 1 }, { n: 2 });
+    // A save advances the baseline, or Discard reverts — either way: clean.
+    syncDraft('chart:revenue', { n: 2 }, { n: 2 });
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+
+  it('is a no-op before a baseline exists (a form mid-mount stores nothing)', () => {
+    syncDraft('chart:revenue', null, { n: 2 });
+    syncDraft('chart:revenue', undefined, { n: 2 });
+    expect(readDraft('chart:revenue')).toBeNull();
+  });
+});


### PR DESCRIPTION
Final piece of the edit-panel work, on top of the now-merged #616 (leaf panels → Delete·Discard·Save) and #617 (dashboard working copy).

## What

> "if I make changes to an object, then click away, then click back it discards all the changes. I want to store that state per object, and have it reload."

Each edit panel held its edits in local state seeded from the record, and the right rail is a **single instance bound to the active object** — so clicking away unmounted the form and threw the edits out. A reload did the same.

Now each object's unsaved values are mirrored to **localStorage** under its own key (`type:name`, project-scoped) and restored when that object is opened again — across navigation **and** across reloads.

## The two rules that keep it safe

**Staleness** — a draft stores the saved values it was edited *from*, and only restores while those still match what the record seeds. If the saved object moved on (a concurrent save, a run, a same-named object in another project), the draft is **dropped** rather than pasted over newer truth.

**Failure** — any problem loading a draft (unreadable storage, malformed JSON, an unrecognized shape/version, a throwing `getItem`) **clears that object's entry** and reports "no draft". A corrupt entry never surfaces as a broken form and never lingers to fail again. Write failures (quota, circular value) clear too, rather than leaving a half-written entry.

## Wiring

- **`utils/formDrafts`** (new) — the storage layer: namespaced + project-scoped keys, `restoreDraft` (staleness), `syncDraft` (mirror while dirty / remove when clean), clear-on-any-error.
- **`useFormBaseline(apply, draftKey)`** — restores a valid draft on seed (the **baseline stays the SAVED values**, so dirty/Discard still point at the last save) and mirrors the form's values after each render. Create-mode and embedded forms pass no key and behave exactly as before.
- **All 8 leaf panels** pass their `type:name` key — 4–6 lines each, because #616 made them uniform.
- **The dashboard working copy** (#617) gets the same treatment: optimistic writes during an editing session mirror to storage, Save/Discard clear it, and `fetchDashboards` re-applies any still-valid draft.
  - **This also closes an edge I flagged in #617**: an unrelated mid-edit refetch (e.g. a level rename saving a *different* dashboard) no longer silently drops the open editing session.

## Note on tests
`setupTests` now clears localStorage between tests. Drafts are persistent browser state, so without it a test that left a form dirty seeded the *next* test's form with those edits — two existing tests caught exactly that.

## Test Strategy
- **New tests (37)**: `formDrafts.test.js` (20) — round trip, namespacing, staleness, and every failure path clearing the entry; `useFormBaseline` draft suite (7) — restore / mirror / drop-stale / clear-on-Discard / clear-on-save / corrupt entry; `InputEditForm` journey suite (5) — **unmount → remount keeps the edit**, Discard sticks, a saved edit leaves nothing behind, two objects don't bleed into each other, a corrupt draft renders saved values; workspaceStore (5) — dashboard draft across a refetch.
- **Full viewer suite green**: 359 suites / 6834 tests; `yarn lint` clean.
- **Not run here**: Playwright (needs a sandbox). Worth a manual pass on the real journey — edit a chart, click to another object, click back; then reload mid-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
