### PR TITLE
Fix "+ New" relation (VIS-1237) and the semantic layer 404 on draft models

### DIFF
--- a/tests/server/views/test_model_schema_views.py
+++ b/tests/server/views/test_model_schema_views.py
@@ -65,6 +65,11 @@ def app(output_dir, model, source):
     flask_app = Mock()
     flask_app.project.models = [model]
     flask_app.project.sources = [source]
+    # The managers hold published objects too, so a committed model resolves
+    # through them in production. Mock() would otherwise hand back a truthy
+    # Mock for every name, including ones that should 404.
+    flask_app.model_manager.get.side_effect = lambda n: model if n == model.name else None
+    flask_app.source_manager.get.side_effect = lambda n: source if n == source.name else None
     register_model_schema_views(app, flask_app, output_dir)
     return app
 
@@ -190,3 +195,117 @@ class TestAgreementWithTheRun:
 
         assert [c["name"] for c in endpoint] == sorted(persisted.keys())
         assert [c["type"] for c in endpoint] == [str(persisted[c["name"]]) for c in endpoint]
+
+
+class TestUncommittedModels:
+    """A model created in the editor lives in the DRAFT CACHE until Commit.
+
+    ``/api/models/`` serves cached + published (that is what the Library and the
+    semantic layer render from), so the viewer shows models that
+    ``flask_app.project`` — compiled from YAML — has never heard of. Schema
+    inference used to scan only the committed project, so every one of those
+    models 404'd: "Model 'test-source_query' not found" the moment the ERD asked
+    for its columns.
+    """
+
+    @pytest.fixture
+    def draft_model(self):
+        # A ref STRING, not an embedded object: this is how the editor saves a
+        # model that points at a source, and it is what makes DAG-based source
+        # resolution impossible for a model the DAG has never seen.
+        return SqlModelFactory(
+            name="test-source_query",
+            sql="SELECT id, amount FROM orders",
+            source="ref(wh)",
+        )
+
+    @pytest.fixture
+    def draft_app(self, output_dir, source, draft_model):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        # Nothing committed to YAML yet — the draft exists only in the cache,
+        # and the compiled DAG has never seen it, so DAG-based source
+        # resolution cannot answer for it.
+        flask_app.project.models = []
+        flask_app.project.sources = [source]
+        flask_app.project.dag.return_value = None
+        flask_app.model_manager.get.side_effect = lambda n: (
+            draft_model if n == draft_model.name else None
+        )
+        flask_app.source_manager.get.side_effect = lambda n: source if n == source.name else None
+        register_model_schema_views(app, flask_app, output_dir)
+        return app
+
+    @pytest.fixture
+    def draft_client(self, draft_app):
+        return draft_app.test_client()
+
+    def test_an_uncommitted_model_reports_its_columns(self, draft_client, output_dir):
+        """The reported bug: a 404 in the semantic layer for a draft model."""
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = draft_client.post("/api/model-schemas/test-source_query/")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert [c["name"] for c in body["columns"]] == ["amount", "id"]
+        assert body["source_name"] == "wh"
+
+    def test_a_context_string_source_resolves_too(self, output_dir, source):
+        """``${ref(wh)}`` is the serialized form the same field round-trips as."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        model = SqlModelFactory(name="ctx_query", sql="SELECT id FROM orders", source="${ref(wh)}")
+        flask_app = Mock()
+        flask_app.project.models = []
+        flask_app.project.sources = [source]
+        flask_app.project.dag.return_value = None
+        flask_app.model_manager.get.side_effect = lambda n: model if n == "ctx_query" else None
+        flask_app.source_manager.get.side_effect = lambda n: source if n == "wh" else None
+        register_model_schema_views(app, flask_app, output_dir)
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = app.test_client().post("/api/model-schemas/ctx_query/")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source_name"] == "wh"
+
+    def test_a_genuinely_missing_model_still_404s(self, draft_client):
+        """The draft lookup must not turn "not found" into something else."""
+        resp = draft_client.post("/api/model-schemas/no_such_model/")
+        assert resp.status_code == 404
+
+    def test_an_uncommitted_source_resolves_for_a_body_override(
+        self, draft_client, output_dir, source
+    ):
+        """A draft SOURCE is equally invisible to the committed project."""
+        _write_source_schema(output_dir, "wh", ORDERS)
+        resp = draft_client.post(
+            "/api/model-schemas/test-source_query/",
+            json={"source_name": "wh"},
+        )
+        assert resp.status_code == 200
+
+    def test_falls_back_to_the_committed_project_when_no_manager_answers(
+        self, output_dir, model, source
+    ):
+        """The managers are the primary lookup, not the only one.
+
+        A host that wires the views without object managers (or whose manager
+        raises) must still resolve committed models from the project.
+        """
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        flask_app.project.models = [model]
+        flask_app.project.sources = [source]
+        flask_app.model_manager.get.side_effect = RuntimeError("no cache here")
+        flask_app.source_manager.get.side_effect = RuntimeError("no cache here")
+        register_model_schema_views(app, flask_app, output_dir)
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = app.test_client().post("/api/model-schemas/rev/")
+
+        assert resp.status_code == 200
+        assert [c["name"] for c in resp.get_json()["columns"]] == ["amount", "id"]

--- a/tests/server/views/test_model_schema_views.py
+++ b/tests/server/views/test_model_schema_views.py
@@ -65,9 +65,7 @@ def app(output_dir, model, source):
     flask_app = Mock()
     flask_app.project.models = [model]
     flask_app.project.sources = [source]
-    # The managers hold published objects too, so a committed model resolves
-    # through them in production. Mock() would otherwise hand back a truthy
-    # Mock for every name, including ones that should 404.
+    # Mock() would otherwise hand back a truthy Mock for every name.
     flask_app.model_manager.get.side_effect = lambda n: model if n == model.name else None
     flask_app.source_manager.get.side_effect = lambda n: source if n == source.name else None
     register_model_schema_views(app, flask_app, output_dir)
@@ -198,21 +196,12 @@ class TestAgreementWithTheRun:
 
 
 class TestUncommittedModels:
-    """A model created in the editor lives in the DRAFT CACHE until Commit.
-
-    ``/api/models/`` serves cached + published (that is what the Library and the
-    semantic layer render from), so the viewer shows models that
-    ``flask_app.project`` — compiled from YAML — has never heard of. Schema
-    inference used to scan only the committed project, so every one of those
-    models 404'd: "Model 'test-source_query' not found" the moment the ERD asked
-    for its columns.
-    """
+    """A model created in the editor lives in the draft cache until Commit;
+    ``flask_app.project`` is compiled from YAML and has never heard of it."""
 
     @pytest.fixture
     def draft_model(self):
-        # A ref STRING, not an embedded object: this is how the editor saves a
-        # model that points at a source, and it is what makes DAG-based source
-        # resolution impossible for a model the DAG has never seen.
+        # A ref STRING (how the editor saves it), not an embedded Source object.
         return SqlModelFactory(
             name="test-source_query",
             sql="SELECT id, amount FROM orders",
@@ -224,9 +213,7 @@ class TestUncommittedModels:
         app = Flask(__name__)
         app.config["TESTING"] = True
         flask_app = Mock()
-        # Nothing committed to YAML yet — the draft exists only in the cache,
-        # and the compiled DAG has never seen it, so DAG-based source
-        # resolution cannot answer for it.
+        # Nothing committed — the DAG has never seen this model.
         flask_app.project.models = []
         flask_app.project.sources = [source]
         flask_app.project.dag.return_value = None
@@ -272,14 +259,12 @@ class TestUncommittedModels:
         assert resp.get_json()["source_name"] == "wh"
 
     def test_a_genuinely_missing_model_still_404s(self, draft_client):
-        """The draft lookup must not turn "not found" into something else."""
         resp = draft_client.post("/api/model-schemas/no_such_model/")
         assert resp.status_code == 404
 
     def test_an_uncommitted_source_resolves_for_a_body_override(
         self, draft_client, output_dir, source
     ):
-        """A draft SOURCE is equally invisible to the committed project."""
         _write_source_schema(output_dir, "wh", ORDERS)
         resp = draft_client.post(
             "/api/model-schemas/test-source_query/",
@@ -290,11 +275,6 @@ class TestUncommittedModels:
     def test_falls_back_to_the_committed_project_when_no_manager_answers(
         self, output_dir, model, source
     ):
-        """The managers are the primary lookup, not the only one.
-
-        A host that wires the views without object managers (or whose manager
-        raises) must still resolve committed models from the project.
-        """
         app = Flask(__name__)
         app.config["TESTING"] = True
         flask_app = Mock()

--- a/viewer/e2e/stories/library-inline-create.spec.mjs
+++ b/viewer/e2e/stories/library-inline-create.spec.mjs
@@ -54,9 +54,7 @@ test.describe('Library inline create', () => {
     await page.getByTestId('library-new-object-button').hover();
     await page.getByTestId('library-new-object-button').click();
     await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
-    // Every creatable type is listed — relation included (VIS-1237): it used
-    // to be listed but wired to open the Semantic Layer instead of creating
-    // anything, which read as a dead menu item.
+    // Every creatable type is listed, relation included (VIS-1237).
     for (const t of ['chart', 'table', 'markdown', 'input', 'dashboard', 'source', 'model', 'dimension', 'metric', 'insight', 'relation']) {
       await expect(page.getByTestId(`library-new-object-${t}`)).toBeVisible();
     }
@@ -99,8 +97,7 @@ test.describe('Library inline create', () => {
     expect(name).toMatch(/^new-insight/);
   });
 
-  // VIS-1237: the reported bug — picking Relation created nothing.
-  test('the header "+ New" menu drafts a relation joining two real models', async () => {
+  test('the header "+ New" menu drafts a relation joining two real models (VIS-1237)', async () => {
     await page.getByTestId('library-new-object-button').click();
     await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
     await page.getByTestId('library-new-object-relation').click();
@@ -113,8 +110,6 @@ test.describe('Library inline create', () => {
     const name = await readStore(page, 's.workspaceActiveObject.name');
     expect(name).toMatch(/^new_relation/);
 
-    // It really landed in the draft cache, with a condition referencing two
-    // real models (what the backend validator requires).
     await expect
       .poll(() => readStore(page, `(s.relations || []).some(r => r.name === '${name}')`), {
         timeout: WAIT,

--- a/viewer/e2e/stories/library-inline-create.spec.mjs
+++ b/viewer/e2e/stories/library-inline-create.spec.mjs
@@ -54,11 +54,12 @@ test.describe('Library inline create', () => {
     await page.getByTestId('library-new-object-button').hover();
     await page.getByTestId('library-new-object-button').click();
     await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
-    // Every creatable type is listed; relation (untemplatable) is not.
-    for (const t of ['chart', 'table', 'markdown', 'input', 'dashboard', 'source', 'model', 'dimension', 'metric', 'insight']) {
+    // Every creatable type is listed — relation included (VIS-1237): it used
+    // to be listed but wired to open the Semantic Layer instead of creating
+    // anything, which read as a dead menu item.
+    for (const t of ['chart', 'table', 'markdown', 'input', 'dashboard', 'source', 'model', 'dimension', 'metric', 'insight', 'relation']) {
       await expect(page.getByTestId(`library-new-object-${t}`)).toBeVisible();
     }
-    await expect(page.getByTestId('library-new-object-relation')).toHaveCount(0);
     await page.screenshot({ path: `${SCREENS}/inline-create-01-menu.png` });
 
     await page.getByTestId('library-new-object-model').click();
@@ -96,6 +97,34 @@ test.describe('Library inline create', () => {
       .toBe('insight');
     const name = await readStore(page, 's.workspaceActiveObject.name');
     expect(name).toMatch(/^new-insight/);
+  });
+
+  // VIS-1237: the reported bug — picking Relation created nothing.
+  test('the header "+ New" menu drafts a relation joining two real models', async () => {
+    await page.getByTestId('library-new-object-button').click();
+    await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
+    await page.getByTestId('library-new-object-relation').click();
+
+    await expect
+      .poll(() => readStore(page, "s.workspaceActiveObject && s.workspaceActiveObject.type"), {
+        timeout: WAIT,
+      })
+      .toBe('relation');
+    const name = await readStore(page, 's.workspaceActiveObject.name');
+    expect(name).toMatch(/^new_relation/);
+
+    // It really landed in the draft cache, with a condition referencing two
+    // real models (what the backend validator requires).
+    await expect
+      .poll(() => readStore(page, `(s.relations || []).some(r => r.name === '${name}')`), {
+        timeout: WAIT,
+      })
+      .toBe(true);
+    const condition = await readStore(
+      page,
+      `(() => { const r = (s.relations || []).find(x => x.name === '${name}'); const c = r && (r.config || r); return c && c.condition; })()`
+    );
+    expect(condition).toMatch(/ref\([^)]+\).*=.*ref\([^)]+\)/);
   });
 
   test('no console errors across the create gestures', async () => {

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -429,9 +429,6 @@ const Library = () => {
           });
           return;
         }
-        // A create that cannot happen has to SAY so. This used to fall through
-        // silently, which is what made "+ New" read as a dead button (VIS-1237)
-        // rather than an action with a precondition.
         if (result?.error && showWorkspaceToast) {
           showWorkspaceToast(result.error);
         }
@@ -446,12 +443,8 @@ const Library = () => {
     ]
   );
 
-  // "+ New" menu pick — every type, relation included, drafts through the one
-  // shared inline-create flow and opens in the edit panel. Relations used to be
-  // special-cased into opening the Semantic Layer instead, which read as "+ New
-  // does nothing" (VIS-1237): a relation IS templatable, seeded with the
-  // project's first two models, and the ERD stays the way to author one
-  // visually rather than the only way.
+  // Every type, relation included, drafts through the shared inline-create flow
+  // (VIS-1237) — the ERD/Semantic Layer remains an alternate way to author one.
   const handleNewPick = useCallback(
     typeKey => {
       setNewMenuOpen(false);

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -260,6 +260,9 @@ const Library = () => {
   // `openCreate*Modal` flags had no mounted modal in the Workspace — every
   // "+ New X" was a silent no-op.)
   const createWorkspaceObject = useStore(s => s.createWorkspaceObject);
+  // A create with an unmet precondition (a relation needs two models) reports
+  // it through the shared workspace toast rather than failing silently.
+  const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
   // Resolved at call time rather than subscribed per-type: there are eleven
   // delete actions and a row only ever needs the one matching its type.
   const storeApi = useStore;
@@ -424,30 +427,37 @@ const Library = () => {
             type: typeKey,
             name: result.name,
           });
+          return;
+        }
+        // A create that cannot happen has to SAY so. This used to fall through
+        // silently, which is what made "+ New" read as a dead button (VIS-1237)
+        // rather than an action with a precondition.
+        if (result?.error && showWorkspaceToast) {
+          showWorkspaceToast(result.error);
         }
       });
     },
-    [createWorkspaceObject, openWorkspaceTab, createExploration, scope.dashboardName]
+    [
+      createWorkspaceObject,
+      openWorkspaceTab,
+      createExploration,
+      scope.dashboardName,
+      showWorkspaceToast,
+    ]
   );
 
-  // "+ New" menu pick. Everything templatable goes through `handleCreate`; a
-  // relation can't be templated (its condition needs two real models), so
-  // "Relation" opens the Semantic Layer, where you author it by connecting two
-  // models — the same surface MiddlePane opens for relations.
+  // "+ New" menu pick — every type, relation included, drafts through the one
+  // shared inline-create flow and opens in the edit panel. Relations used to be
+  // special-cased into opening the Semantic Layer instead, which read as "+ New
+  // does nothing" (VIS-1237): a relation IS templatable, seeded with the
+  // project's first two models, and the ERD stays the way to author one
+  // visually rather than the only way.
   const handleNewPick = useCallback(
     typeKey => {
       setNewMenuOpen(false);
-      if (typeKey === 'relation') {
-        openWorkspaceTab({
-          id: 'semantic-layer:semantic-layer',
-          type: 'semantic-layer',
-          name: 'semantic-layer',
-        });
-        return;
-      }
       handleCreate(typeKey, 'library-menu');
     },
-    [openWorkspaceTab, handleCreate]
+    [handleCreate]
   );
 
   return (

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -665,10 +665,7 @@ describe('Library', () => {
     }
   });
 
-  // VIS-1237: Relation used to be special-cased into opening the Semantic
-  // Layer, which read as "+ New does nothing". It now drafts like every other
-  // type and opens in the edit panel.
-  test('"+ New" → Relation drafts a relation and opens it', async () => {
+  test('"+ New" → Relation drafts a relation and opens it (VIS-1237)', async () => {
     const createWorkspaceObject = jest.fn(async () => ({
       success: true,
       name: 'new_relation',

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -665,19 +665,49 @@ describe('Library', () => {
     }
   });
 
-  test('"+ New" → Relation opens the Semantic Layer (a relation can\'t be templated)', () => {
-    const createWorkspaceObject = jest.fn();
+  // VIS-1237: Relation used to be special-cased into opening the Semantic
+  // Layer, which read as "+ New does nothing". It now drafts like every other
+  // type and opens in the edit panel.
+  test('"+ New" → Relation drafts a relation and opens it', async () => {
+    const createWorkspaceObject = jest.fn(async () => ({
+      success: true,
+      name: 'new_relation',
+      type: 'relation',
+    }));
     const openWorkspaceTab = jest.fn();
     seedStore({ createWorkspaceObject, openWorkspaceTab });
     renderLibrary();
     openNewMenu();
     fireEvent.click(screen.getByTestId('library-new-object-relation'));
-    expect(createWorkspaceObject).not.toHaveBeenCalled();
-    expect(openWorkspaceTab).toHaveBeenCalledWith({
-      id: 'semantic-layer:semantic-layer',
-      type: 'semantic-layer',
-      name: 'semantic-layer',
-    });
+
+    expect(createWorkspaceObject).toHaveBeenCalledWith('relation');
+    await waitFor(() =>
+      expect(openWorkspaceTab).toHaveBeenCalledWith({
+        id: 'relation:new_relation',
+        type: 'relation',
+        name: 'new_relation',
+      })
+    );
+  });
+
+  test('a create blocked by its precondition surfaces the reason instead of doing nothing', async () => {
+    const createWorkspaceObject = jest.fn(async () => ({
+      success: false,
+      error: 'A relation joins two models. Create at least two models first.',
+    }));
+    const openWorkspaceTab = jest.fn();
+    const showWorkspaceToast = jest.fn();
+    seedStore({ createWorkspaceObject, openWorkspaceTab, showWorkspaceToast });
+    renderLibrary();
+    openNewMenu();
+    fireEvent.click(screen.getByTestId('library-new-object-relation'));
+
+    await waitFor(() =>
+      expect(showWorkspaceToast).toHaveBeenCalledWith(
+        expect.stringMatching(/two models/i)
+      )
+    );
+    expect(openWorkspaceTab).not.toHaveBeenCalled();
   });
 
   test('the header "+ New" menu dismisses on Escape', () => {

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -11,13 +11,27 @@ import { generateUniqueName } from '../utils/uniqueName';
  * the editing surface.
  *
  * The templates were validated against the live save endpoints — each is the
- * smallest config the backend's Pydantic model accepts. `relation` is absent
- * by design: its condition must reference two real models, so there is no
- * meaningful empty draft.
+ * smallest config the backend's Pydantic model accepts.
+ *
+ * `config` receives the store state, because one type cannot be templated from
+ * a constant: a `relation`'s condition must reference TWO REAL models (the
+ * backend's `validate_condition_has_models`), so its draft is built from the
+ * project's own models. Every other template ignores the argument.
  *
  * Dimension/metric names use underscores — the backend rejects dashes for
  * semantic-layer names (they must be valid SQL identifiers).
  */
+
+/**
+ * Two model names to seed a relation's condition with, oldest-first so the
+ * choice is stable rather than dependent on fetch order. Returns null when the
+ * project has fewer than two models — there is no valid relation to draft, and
+ * the caller says so instead of failing at the backend.
+ */
+const firstTwoModelNames = state => {
+  const names = (state.models || []).map(m => m?.name).filter(Boolean);
+  return names.length >= 2 ? [names[0], names[1]] : null;
+};
 export const CREATE_TEMPLATES = {
   dashboard: {
     namePrefix: 'new-dashboard',
@@ -79,6 +93,27 @@ export const CREATE_TEMPLATES = {
     saveKey: 'saveMetric',
     config: () => ({ expression: 'count(*)' }),
   },
+  relation: {
+    namePrefix: 'new_relation',
+    collectionKey: 'relations',
+    saveKey: 'saveRelation',
+    // Seeded with the project's first two models joined on `id` — a starting
+    // point the user re-points in the edit panel, exactly like every other
+    // "+ New" draft. The join keys are a guess; the MODEL references are real,
+    // which is what the backend validator requires.
+    requires: state =>
+      firstTwoModelNames(state)
+        ? null
+        : 'A relation joins two models. Create at least two models first.',
+    config: state => {
+      const [left, right] = firstTwoModelNames(state);
+      return {
+        join_type: 'inner',
+        // eslint-disable-next-line no-template-curly-in-string
+        condition: `\${ref(${left}).id} = \${ref(${right}).id}`,
+      };
+    },
+  },
 };
 
 const createInlineCreateSlice = (set, get) => ({
@@ -98,9 +133,16 @@ const createInlineCreateSlice = (set, get) => ({
     if (typeof save !== 'function') {
       return { success: false, error: `${template.saveKey} unavailable` };
     }
+    // A type whose draft depends on other objects existing (relation → two
+    // models) reports WHY it can't be drafted, rather than posting a config
+    // the backend will reject with a validator message.
+    const blocked = template.requires ? template.requires(get()) : null;
+    if (blocked) {
+      return { success: false, error: blocked };
+    }
     const existing = (get()[template.collectionKey] || []).map(o => o.name);
     const name = generateUniqueName(template.namePrefix, existing);
-    const result = await save(name, template.config());
+    const result = await save(name, template.config(get()));
     return result?.success ? { ...result, name, type } : result;
   },
 });

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -11,23 +11,16 @@ import { generateUniqueName } from '../utils/uniqueName';
  * the editing surface.
  *
  * The templates were validated against the live save endpoints — each is the
- * smallest config the backend's Pydantic model accepts.
- *
- * `config` receives the store state, because one type cannot be templated from
- * a constant: a `relation`'s condition must reference TWO REAL models (the
- * backend's `validate_condition_has_models`), so its draft is built from the
- * project's own models. Every other template ignores the argument.
+ * smallest config the backend's Pydantic model accepts. `config` receives the
+ * store state because `relation` needs it (its condition must reference two
+ * real models); every other template ignores the argument.
  *
  * Dimension/metric names use underscores — the backend rejects dashes for
  * semantic-layer names (they must be valid SQL identifiers).
  */
 
-/**
- * Two model names to seed a relation's condition with, oldest-first so the
- * choice is stable rather than dependent on fetch order. Returns null when the
- * project has fewer than two models — there is no valid relation to draft, and
- * the caller says so instead of failing at the backend.
- */
+// Oldest-first for a stable pick. Null when the project has fewer than two
+// models, so the caller can say so instead of failing at the backend.
 const firstTwoModelNames = state => {
   const names = (state.models || []).map(m => m?.name).filter(Boolean);
   return names.length >= 2 ? [names[0], names[1]] : null;
@@ -97,10 +90,6 @@ export const CREATE_TEMPLATES = {
     namePrefix: 'new_relation',
     collectionKey: 'relations',
     saveKey: 'saveRelation',
-    // Seeded with the project's first two models joined on `id` — a starting
-    // point the user re-points in the edit panel, exactly like every other
-    // "+ New" draft. The join keys are a guess; the MODEL references are real,
-    // which is what the backend validator requires.
     requires: state =>
       firstTwoModelNames(state)
         ? null
@@ -133,9 +122,6 @@ const createInlineCreateSlice = (set, get) => ({
     if (typeof save !== 'function') {
       return { success: false, error: `${template.saveKey} unavailable` };
     }
-    // A type whose draft depends on other objects existing (relation → two
-    // models) reports WHY it can't be drafted, rather than posting a config
-    // the backend will reject with a validator message.
     const blocked = template.requires ? template.requires(get()) : null;
     if (blocked) {
       return { success: false, error: blocked };

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -12,13 +12,17 @@ describe('createWorkspaceObject', () => {
     const template = CREATE_TEMPLATES[type];
     const save = jest.fn(async () => ({ success: true }));
     useStore.setState({
+      // Two models exist so every template's precondition is satisfiable —
+      // a relation's draft is built FROM the project's models.
+      models: [{ name: 'orders' }, { name: 'users' }],
       [template.collectionKey]: [],
       [template.saveKey]: save,
     });
+    const expectedConfig = template.config(useStore.getState());
 
     const result = await useStore.getState().createWorkspaceObject(type);
 
-    expect(save).toHaveBeenCalledWith(template.namePrefix, template.config());
+    expect(save).toHaveBeenCalledWith(template.namePrefix, expectedConfig);
     expect(result).toMatchObject({ success: true, name: template.namePrefix, type });
   });
 
@@ -41,10 +45,44 @@ describe('createWorkspaceObject', () => {
     expect(CREATE_TEMPLATES.metric.namePrefix).not.toMatch(/-/);
   });
 
-  test('relation has no template (cannot draft a valid empty relation)', async () => {
-    expect(CREATE_TEMPLATES.relation).toBeUndefined();
-    const result = await useStore.getState().createWorkspaceObject('relation');
-    expect(result.success).toBe(false);
+  // VIS-1237: "+ New" → Relation was a dead affordance. A relation IS
+  // templatable — its condition just has to be built from real models, because
+  // the backend requires two distinct model references.
+  describe('relation', () => {
+    test('drafts a condition joining the project\'s first two models', async () => {
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({
+        models: [{ name: 'orders' }, { name: 'users' }, { name: 'events' }],
+        relations: [],
+        saveRelation: save,
+      });
+
+      const result = await useStore.getState().createWorkspaceObject('relation');
+
+      expect(result).toMatchObject({ success: true, type: 'relation' });
+      const [, config] = save.mock.calls[0];
+      expect(config.join_type).toBe('inner');
+      // Real model refs — what the backend's validator requires. The join keys
+      // are a starting point the user re-points in the edit panel.
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(config.condition).toBe('${ref(orders).id} = ${ref(users).id}');
+    });
+
+    test('says WHY it cannot draft one when the project has fewer than two models', async () => {
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({ models: [{ name: 'orders' }], relations: [], saveRelation: save });
+
+      const result = await useStore.getState().createWorkspaceObject('relation');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/two models/i);
+      // Nothing is posted that the backend would only reject.
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    test('names stay SQL-identifier safe', () => {
+      expect(CREATE_TEMPLATES.relation.namePrefix).not.toMatch(/-/);
+    });
   });
 
   test('propagates a failed save', async () => {

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -12,8 +12,6 @@ describe('createWorkspaceObject', () => {
     const template = CREATE_TEMPLATES[type];
     const save = jest.fn(async () => ({ success: true }));
     useStore.setState({
-      // Two models exist so every template's precondition is satisfiable —
-      // a relation's draft is built FROM the project's models.
       models: [{ name: 'orders' }, { name: 'users' }],
       [template.collectionKey]: [],
       [template.saveKey]: save,
@@ -45,9 +43,6 @@ describe('createWorkspaceObject', () => {
     expect(CREATE_TEMPLATES.metric.namePrefix).not.toMatch(/-/);
   });
 
-  // VIS-1237: "+ New" → Relation was a dead affordance. A relation IS
-  // templatable — its condition just has to be built from real models, because
-  // the backend requires two distinct model references.
   describe('relation', () => {
     test('drafts a condition joining the project\'s first two models', async () => {
       const save = jest.fn(async () => ({ success: true }));
@@ -62,8 +57,6 @@ describe('createWorkspaceObject', () => {
       expect(result).toMatchObject({ success: true, type: 'relation' });
       const [, config] = save.mock.calls[0];
       expect(config.join_type).toBe('inner');
-      // Real model refs — what the backend's validator requires. The join keys
-      // are a starting point the user re-points in the edit panel.
       // eslint-disable-next-line no-template-curly-in-string
       expect(config.condition).toBe('${ref(orders).id} = ${ref(users).id}');
     });
@@ -76,7 +69,6 @@ describe('createWorkspaceObject', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/two models/i);
-      // Nothing is posted that the backend would only reject.
       expect(save).not.toHaveBeenCalled();
     });
 

--- a/visivo/server/views/model_schema_views.py
+++ b/visivo/server/views/model_schema_views.py
@@ -29,12 +29,16 @@ The run still writes the artifact: the field resolver and
 POST rather than GET because the draft form carries SQL in the body.
 """
 
+import re
+
 from flask import jsonify, request
 
 from visivo.jobs.utils import get_source_for_model
 from visivo.logger.logger import Logger
+from visivo.models.base.context_string import ContextString
 from visivo.models.models.sql_model import SqlModel
 from visivo.query.model_schema_inference import infer_model_columns
+from visivo.query.patterns import REF_PROPERTY_PATTERN, extract_ref_names
 from visivo.query.schema_aggregator import SchemaAggregator
 
 
@@ -57,18 +61,76 @@ def _columns_payload(column_map: dict) -> list:
     )
 
 
-def _find_model(project, model_name: str):
-    """Find a model by name on the project. Returns None when absent."""
+def _from_manager(flask_app, manager_name: str, name: str):
+    """Look a name up in an object manager (draft cache first, then published).
+
+    The managers are the same source of truth ``/api/models/`` and
+    ``/api/sources/`` serve, so anything the viewer can SEE resolves here —
+    including objects that exist only as uncommitted drafts.
+    """
+    manager = getattr(flask_app, manager_name, None)
+    getter = getattr(manager, "get", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter(name)
+    except Exception:
+        # A manager that cannot answer is not a reason to fail the request —
+        # the committed-project scan below is still a valid answer.
+        return None
+
+
+def _find_model(flask_app, project, model_name: str):
+    """Find a model by name — DRAFT CACHE FIRST, then the committed project.
+
+    A model created in the editor lives in the draft cache until Commit writes
+    it to YAML, and ``flask_app.project`` is compiled from YAML. Scanning only
+    the project meant every uncommitted model 404'd here while being perfectly
+    visible in the Library and the semantic layer, which is exactly what the
+    ERD's column hydration asks about.
+    """
+    model = _from_manager(flask_app, "model_manager", model_name)
+    if model is not None:
+        return model
     for model in project.models or []:
         if getattr(model, "name", None) == model_name:
             return model
     return None
 
 
-def _find_source(project, source_name: str):
+def _find_source(flask_app, project, source_name: str):
+    """Find a source by name — draft cache first, then the committed project."""
+    source = _from_manager(flask_app, "source_manager", source_name)
+    if source is not None:
+        return source
     for source in project.sources or []:
-        if source.name == source_name:
+        if getattr(source, "name", None) == source_name:
             return source
+    return None
+
+
+def _referenced_source_name(model) -> str:
+    """The source NAME a model points at, read off the model itself.
+
+    Source resolution normally walks the DAG, but a draft model is not IN the
+    DAG — it has never been compiled — so that walk returns nothing and the
+    request 400s with "No source resolved". The model's own ``source`` field
+    still names its source, in either of the two forms the field round-trips
+    as (``ref(wh)`` and ``${ref(wh)}``). Returns None for an embedded Source
+    object (which needs no lookup) or an unparseable value.
+    """
+    source = getattr(model, "source", None)
+    if source is None:
+        return None
+    if isinstance(source, ContextString):
+        return source.get_reference()
+    if isinstance(source, str):
+        names = extract_ref_names(source)  # ${ref(wh)}
+        if names:
+            return next(iter(names))
+        match = re.match(REF_PROPERTY_PATTERN, source.strip())  # ref(wh)
+        if match:
+            return match.group("model_name")
     return None
 
 
@@ -114,7 +176,7 @@ def register_model_schema_views(app, flask_app, output_dir):
             body = request.get_json(silent=True) or {}
             project = flask_app.project
 
-            model = _find_model(project, model_name)
+            model = _find_model(flask_app, project, model_name)
             if model is None:
                 return jsonify({"error": f"Model '{model_name}' not found"}), 404
 
@@ -129,9 +191,21 @@ def register_model_schema_views(app, flask_app, output_dir):
 
             source_name = body.get("source_name")
             if source_name:
-                source = _find_source(project, source_name)
+                source = _find_source(flask_app, project, source_name)
             else:
-                source = get_source_for_model(model, project.dag(), output_dir)
+                try:
+                    source = get_source_for_model(model, project.dag(), output_dir)
+                except Exception:
+                    # The DAG walk assumes the model is IN the DAG; an
+                    # uncommitted one never is.
+                    source = None
+                if source is None:
+                    # Fall back to the name the model itself carries, resolved
+                    # through the managers — the only path that works for a
+                    # draft model whose source is a ref string.
+                    referenced = _referenced_source_name(model)
+                    if referenced:
+                        source = _find_source(flask_app, project, referenced)
 
             if source is None:
                 return (
@@ -163,7 +237,7 @@ def register_model_schema_views(app, flask_app, output_dir):
             if not sql or not source_name:
                 return jsonify({"error": "sql and source_name are required"}), 400
 
-            source = _find_source(flask_app.project, source_name)
+            source = _find_source(flask_app, flask_app.project, source_name)
             if source is None:
                 return jsonify({"error": f"Source '{source_name}' not found"}), 404
 

--- a/visivo/server/views/model_schema_views.py
+++ b/visivo/server/views/model_schema_views.py
@@ -62,12 +62,8 @@ def _columns_payload(column_map: dict) -> list:
 
 
 def _from_manager(flask_app, manager_name: str, name: str):
-    """Look a name up in an object manager (draft cache first, then published).
-
-    The managers are the same source of truth ``/api/models/`` and
-    ``/api/sources/`` serve, so anything the viewer can SEE resolves here —
-    including objects that exist only as uncommitted drafts.
-    """
+    """Look a name up in an object manager — the draft cache, checked before
+    the committed project, so an uncommitted object still resolves."""
     manager = getattr(flask_app, manager_name, None)
     getter = getattr(manager, "get", None)
     if not callable(getter):
@@ -75,20 +71,11 @@ def _from_manager(flask_app, manager_name: str, name: str):
     try:
         return getter(name)
     except Exception:
-        # A manager that cannot answer is not a reason to fail the request —
-        # the committed-project scan below is still a valid answer.
         return None
 
 
 def _find_model(flask_app, project, model_name: str):
-    """Find a model by name — DRAFT CACHE FIRST, then the committed project.
-
-    A model created in the editor lives in the draft cache until Commit writes
-    it to YAML, and ``flask_app.project`` is compiled from YAML. Scanning only
-    the project meant every uncommitted model 404'd here while being perfectly
-    visible in the Library and the semantic layer, which is exactly what the
-    ERD's column hydration asks about.
-    """
+    """Find a model by name — draft cache first, then the committed project."""
     model = _from_manager(flask_app, "model_manager", model_name)
     if model is not None:
         return model
@@ -110,14 +97,9 @@ def _find_source(flask_app, project, source_name: str):
 
 
 def _referenced_source_name(model) -> str:
-    """The source NAME a model points at, read off the model itself.
-
-    Source resolution normally walks the DAG, but a draft model is not IN the
-    DAG — it has never been compiled — so that walk returns nothing and the
-    request 400s with "No source resolved". The model's own ``source`` field
-    still names its source, in either of the two forms the field round-trips
-    as (``ref(wh)`` and ``${ref(wh)}``). Returns None for an embedded Source
-    object (which needs no lookup) or an unparseable value.
+    """The source name a model's `source` field points at — for a draft model,
+    which isn't in the DAG yet, so the normal DAG-walk resolution can't see
+    it. None for an embedded Source (no lookup needed) or an unparseable value.
     """
     source = getattr(model, "source", None)
     if source is None:
@@ -196,13 +178,8 @@ def register_model_schema_views(app, flask_app, output_dir):
                 try:
                     source = get_source_for_model(model, project.dag(), output_dir)
                 except Exception:
-                    # The DAG walk assumes the model is IN the DAG; an
-                    # uncommitted one never is.
-                    source = None
+                    source = None  # uncommitted model isn't in the DAG
                 if source is None:
-                    # Fall back to the name the model itself carries, resolved
-                    # through the managers — the only path that works for a
-                    # draft model whose source is a ref string.
                     referenced = _referenced_source_name(model)
                     if referenced:
                         source = _find_source(flask_app, project, referenced)


### PR DESCRIPTION
Two reported bugs with the same shape: an object that exists only in the **draft cache** (created in the editor, not yet committed) was invisible to code that only knows about committed state.

## 1. "+ New" → Relation created nothing — VIS-1237

`relation` had no inline-create template (the shared "+ New X" flow skipped it), and the Library **special-cased** the menu item into opening the Semantic Layer instead. The item was listed — `relation` is in `DATA_TYPES` — but did nothing recognizable, so it read as a dead button.

A relation *is* templatable; it just can't be templated from a **constant**, because the backend requires the condition to reference two distinct models (`validate_condition_has_models`).

- `CREATE_TEMPLATES.config` now receives the store state; the relation template builds `${ref(a).id} = ${ref(b).id}` from the project's first two models — **real model refs** (what the validator checks) with join keys the user re-points in the edit panel, exactly like every other "+ New" draft.
- Fewer than two models → nothing valid to draft, so the flow reports **why** through the workspace toast instead of failing silently. (Any blocked create now surfaces its reason; that silence is what made this feel dead.)
- Same path runs **locally and in cloud** — `saveRelation` already carries `project_id`. The ERD stays the way to author a relation *visually*, rather than the only way.

## 2. Local 404 in the semantic layer

`POST /api/model-schemas/test-source_query/` → **404**, from the screenshot.

`/api/models/` serves **cached + published** (what the Library and semantic layer render), but schema inference resolved models by scanning `flask_app.project` — compiled from **YAML**. So every uncommitted model 404'd the moment the ERD asked for its columns. Explorer-promoted models land in the draft cache (VIS-1235), which is exactly how the user hit this.

- Model and source lookups now go through the **object managers** (draft cache first, then published), falling back to the committed project.
- Source resolution gets the same treatment: the DAG walk can't answer for a model the DAG has never seen, so it falls back to the source **name the model itself carries**, in either ref form (`ref(wh)` / `${ref(wh)}`).

## Verification

Both confirmed against a **live sandbox**, not just mocks:

```
POST /api/models/draft_only_query/      → 201 (draft cache only, never in YAML)
POST /api/model-schemas/draft_only_query/ → 200  {"columns":[{"name":"amount"...},{"name":"id"...}]}   # was 404
POST /api/relations/new_relation/       → 201, appears in /api/relations/
```

The generated relation config was also validated directly against the real `RelationManager` Pydantic model (and a single-model condition still correctly rejected).

## Test Strategy
- **Python**: new `TestUncommittedModels` (5) — the draft-model 404 repro, `${ref()}` and `ref()` source forms, a genuinely-missing model still 404s, and the committed-project fallback when no manager answers. The repro test **failed with the exact 404** before the fix. Fixture updated so the managers behave like real ones (they hold published objects too). Full suite: **2394 passed**; `black --check` clean.
- **JS**: `inlineCreateStore` (17) — relation drafts a two-model condition, blocked-with-reason under two models, name safety; `Library` (72) — the menu item now drafts + opens, and a blocked create surfaces the reason. Full suite: **6838 passed**; `yarn lint` clean.
- **E2E**: `library-inline-create.spec.mjs` — added a relation round-trip case, and corrected a **stale** assertion that claimed the menu doesn't list relation (it has, since relation joined `DATA_TYPES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
