### PR TITLE
Generated object names disambiguate with -2, not _2

### DIFF
--- a/tests/server/views/test_model_schema_views.py
+++ b/tests/server/views/test_model_schema_views.py
@@ -65,6 +65,11 @@ def app(output_dir, model, source):
     flask_app = Mock()
     flask_app.project.models = [model]
     flask_app.project.sources = [source]
+    # The managers hold published objects too, so a committed model resolves
+    # through them in production. Mock() would otherwise hand back a truthy
+    # Mock for every name, including ones that should 404.
+    flask_app.model_manager.get.side_effect = lambda n: model if n == model.name else None
+    flask_app.source_manager.get.side_effect = lambda n: source if n == source.name else None
     register_model_schema_views(app, flask_app, output_dir)
     return app
 
@@ -190,3 +195,117 @@ class TestAgreementWithTheRun:
 
         assert [c["name"] for c in endpoint] == sorted(persisted.keys())
         assert [c["type"] for c in endpoint] == [str(persisted[c["name"]]) for c in endpoint]
+
+
+class TestUncommittedModels:
+    """A model created in the editor lives in the DRAFT CACHE until Commit.
+
+    ``/api/models/`` serves cached + published (that is what the Library and the
+    semantic layer render from), so the viewer shows models that
+    ``flask_app.project`` — compiled from YAML — has never heard of. Schema
+    inference used to scan only the committed project, so every one of those
+    models 404'd: "Model 'test-source_query' not found" the moment the ERD asked
+    for its columns.
+    """
+
+    @pytest.fixture
+    def draft_model(self):
+        # A ref STRING, not an embedded object: this is how the editor saves a
+        # model that points at a source, and it is what makes DAG-based source
+        # resolution impossible for a model the DAG has never seen.
+        return SqlModelFactory(
+            name="test-source_query",
+            sql="SELECT id, amount FROM orders",
+            source="ref(wh)",
+        )
+
+    @pytest.fixture
+    def draft_app(self, output_dir, source, draft_model):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        # Nothing committed to YAML yet — the draft exists only in the cache,
+        # and the compiled DAG has never seen it, so DAG-based source
+        # resolution cannot answer for it.
+        flask_app.project.models = []
+        flask_app.project.sources = [source]
+        flask_app.project.dag.return_value = None
+        flask_app.model_manager.get.side_effect = lambda n: (
+            draft_model if n == draft_model.name else None
+        )
+        flask_app.source_manager.get.side_effect = lambda n: source if n == source.name else None
+        register_model_schema_views(app, flask_app, output_dir)
+        return app
+
+    @pytest.fixture
+    def draft_client(self, draft_app):
+        return draft_app.test_client()
+
+    def test_an_uncommitted_model_reports_its_columns(self, draft_client, output_dir):
+        """The reported bug: a 404 in the semantic layer for a draft model."""
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = draft_client.post("/api/model-schemas/test-source_query/")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert [c["name"] for c in body["columns"]] == ["amount", "id"]
+        assert body["source_name"] == "wh"
+
+    def test_a_context_string_source_resolves_too(self, output_dir, source):
+        """``${ref(wh)}`` is the serialized form the same field round-trips as."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        model = SqlModelFactory(name="ctx_query", sql="SELECT id FROM orders", source="${ref(wh)}")
+        flask_app = Mock()
+        flask_app.project.models = []
+        flask_app.project.sources = [source]
+        flask_app.project.dag.return_value = None
+        flask_app.model_manager.get.side_effect = lambda n: model if n == "ctx_query" else None
+        flask_app.source_manager.get.side_effect = lambda n: source if n == "wh" else None
+        register_model_schema_views(app, flask_app, output_dir)
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = app.test_client().post("/api/model-schemas/ctx_query/")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source_name"] == "wh"
+
+    def test_a_genuinely_missing_model_still_404s(self, draft_client):
+        """The draft lookup must not turn "not found" into something else."""
+        resp = draft_client.post("/api/model-schemas/no_such_model/")
+        assert resp.status_code == 404
+
+    def test_an_uncommitted_source_resolves_for_a_body_override(
+        self, draft_client, output_dir, source
+    ):
+        """A draft SOURCE is equally invisible to the committed project."""
+        _write_source_schema(output_dir, "wh", ORDERS)
+        resp = draft_client.post(
+            "/api/model-schemas/test-source_query/",
+            json={"source_name": "wh"},
+        )
+        assert resp.status_code == 200
+
+    def test_falls_back_to_the_committed_project_when_no_manager_answers(
+        self, output_dir, model, source
+    ):
+        """The managers are the primary lookup, not the only one.
+
+        A host that wires the views without object managers (or whose manager
+        raises) must still resolve committed models from the project.
+        """
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        flask_app.project.models = [model]
+        flask_app.project.sources = [source]
+        flask_app.model_manager.get.side_effect = RuntimeError("no cache here")
+        flask_app.source_manager.get.side_effect = RuntimeError("no cache here")
+        register_model_schema_views(app, flask_app, output_dir)
+        _write_source_schema(output_dir, "wh", ORDERS)
+
+        resp = app.test_client().post("/api/model-schemas/rev/")
+
+        assert resp.status_code == 200
+        assert [c["name"] for c in resp.get_json()["columns"]] == ["amount", "id"]

--- a/viewer/e2e/stories/library-inline-create.spec.mjs
+++ b/viewer/e2e/stories/library-inline-create.spec.mjs
@@ -54,11 +54,12 @@ test.describe('Library inline create', () => {
     await page.getByTestId('library-new-object-button').hover();
     await page.getByTestId('library-new-object-button').click();
     await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
-    // Every creatable type is listed; relation (untemplatable) is not.
-    for (const t of ['chart', 'table', 'markdown', 'input', 'dashboard', 'source', 'model', 'dimension', 'metric', 'insight']) {
+    // Every creatable type is listed — relation included (VIS-1237): it used
+    // to be listed but wired to open the Semantic Layer instead of creating
+    // anything, which read as a dead menu item.
+    for (const t of ['chart', 'table', 'markdown', 'input', 'dashboard', 'source', 'model', 'dimension', 'metric', 'insight', 'relation']) {
       await expect(page.getByTestId(`library-new-object-${t}`)).toBeVisible();
     }
-    await expect(page.getByTestId('library-new-object-relation')).toHaveCount(0);
     await page.screenshot({ path: `${SCREENS}/inline-create-01-menu.png` });
 
     await page.getByTestId('library-new-object-model').click();
@@ -96,6 +97,34 @@ test.describe('Library inline create', () => {
       .toBe('insight');
     const name = await readStore(page, 's.workspaceActiveObject.name');
     expect(name).toMatch(/^new-insight/);
+  });
+
+  // VIS-1237: the reported bug — picking Relation created nothing.
+  test('the header "+ New" menu drafts a relation joining two real models', async () => {
+    await page.getByTestId('library-new-object-button').click();
+    await expect(page.getByTestId('library-new-object-menu')).toBeVisible();
+    await page.getByTestId('library-new-object-relation').click();
+
+    await expect
+      .poll(() => readStore(page, "s.workspaceActiveObject && s.workspaceActiveObject.type"), {
+        timeout: WAIT,
+      })
+      .toBe('relation');
+    const name = await readStore(page, 's.workspaceActiveObject.name');
+    expect(name).toMatch(/^new_relation/);
+
+    // It really landed in the draft cache, with a condition referencing two
+    // real models (what the backend validator requires).
+    await expect
+      .poll(() => readStore(page, `(s.relations || []).some(r => r.name === '${name}')`), {
+        timeout: WAIT,
+      })
+      .toBe(true);
+    const condition = await readStore(
+      page,
+      `(() => { const r = (s.relations || []).find(x => x.name === '${name}'); const c = r && (r.config || r); return c && c.condition; })()`
+    );
+    expect(condition).toMatch(/ref\([^)]+\).*=.*ref\([^)]+\)/);
   });
 
   test('no console errors across the create gestures', async () => {

--- a/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationBuildRail.test.jsx
@@ -524,7 +524,7 @@ describe('ExplorationBuildRail', () => {
       });
       render(<ExplorationBuildRail />);
       await waitFor(() => {
-        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query_2']);
+        expect(useStore.getState().explorerModelTabs).toEqual(['orders_db-query-2']);
       });
     });
 
@@ -656,7 +656,7 @@ describe('ExplorationBuildRail', () => {
         });
         render(<ExplorationBuildRail />);
         await waitFor(() => {
-          expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart_2');
+          expect(useStore.getState().explorerChartName).toBe('orders_db-query-insight-chart-2');
         });
       });
 

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -260,6 +260,9 @@ const Library = () => {
   // `openCreate*Modal` flags had no mounted modal in the Workspace — every
   // "+ New X" was a silent no-op.)
   const createWorkspaceObject = useStore(s => s.createWorkspaceObject);
+  // A create with an unmet precondition (a relation needs two models) reports
+  // it through the shared workspace toast rather than failing silently.
+  const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
   // Resolved at call time rather than subscribed per-type: there are eleven
   // delete actions and a row only ever needs the one matching its type.
   const storeApi = useStore;
@@ -424,30 +427,37 @@ const Library = () => {
             type: typeKey,
             name: result.name,
           });
+          return;
+        }
+        // A create that cannot happen has to SAY so. This used to fall through
+        // silently, which is what made "+ New" read as a dead button (VIS-1237)
+        // rather than an action with a precondition.
+        if (result?.error && showWorkspaceToast) {
+          showWorkspaceToast(result.error);
         }
       });
     },
-    [createWorkspaceObject, openWorkspaceTab, createExploration, scope.dashboardName]
+    [
+      createWorkspaceObject,
+      openWorkspaceTab,
+      createExploration,
+      scope.dashboardName,
+      showWorkspaceToast,
+    ]
   );
 
-  // "+ New" menu pick. Everything templatable goes through `handleCreate`; a
-  // relation can't be templated (its condition needs two real models), so
-  // "Relation" opens the Semantic Layer, where you author it by connecting two
-  // models — the same surface MiddlePane opens for relations.
+  // "+ New" menu pick — every type, relation included, drafts through the one
+  // shared inline-create flow and opens in the edit panel. Relations used to be
+  // special-cased into opening the Semantic Layer instead, which read as "+ New
+  // does nothing" (VIS-1237): a relation IS templatable, seeded with the
+  // project's first two models, and the ERD stays the way to author one
+  // visually rather than the only way.
   const handleNewPick = useCallback(
     typeKey => {
       setNewMenuOpen(false);
-      if (typeKey === 'relation') {
-        openWorkspaceTab({
-          id: 'semantic-layer:semantic-layer',
-          type: 'semantic-layer',
-          name: 'semantic-layer',
-        });
-        return;
-      }
       handleCreate(typeKey, 'library-menu');
     },
-    [openWorkspaceTab, handleCreate]
+    [handleCreate]
   );
 
   return (

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -665,19 +665,49 @@ describe('Library', () => {
     }
   });
 
-  test('"+ New" → Relation opens the Semantic Layer (a relation can\'t be templated)', () => {
-    const createWorkspaceObject = jest.fn();
+  // VIS-1237: Relation used to be special-cased into opening the Semantic
+  // Layer, which read as "+ New does nothing". It now drafts like every other
+  // type and opens in the edit panel.
+  test('"+ New" → Relation drafts a relation and opens it', async () => {
+    const createWorkspaceObject = jest.fn(async () => ({
+      success: true,
+      name: 'new_relation',
+      type: 'relation',
+    }));
     const openWorkspaceTab = jest.fn();
     seedStore({ createWorkspaceObject, openWorkspaceTab });
     renderLibrary();
     openNewMenu();
     fireEvent.click(screen.getByTestId('library-new-object-relation'));
-    expect(createWorkspaceObject).not.toHaveBeenCalled();
-    expect(openWorkspaceTab).toHaveBeenCalledWith({
-      id: 'semantic-layer:semantic-layer',
-      type: 'semantic-layer',
-      name: 'semantic-layer',
-    });
+
+    expect(createWorkspaceObject).toHaveBeenCalledWith('relation');
+    await waitFor(() =>
+      expect(openWorkspaceTab).toHaveBeenCalledWith({
+        id: 'relation:new_relation',
+        type: 'relation',
+        name: 'new_relation',
+      })
+    );
+  });
+
+  test('a create blocked by its precondition surfaces the reason instead of doing nothing', async () => {
+    const createWorkspaceObject = jest.fn(async () => ({
+      success: false,
+      error: 'A relation joins two models. Create at least two models first.',
+    }));
+    const openWorkspaceTab = jest.fn();
+    const showWorkspaceToast = jest.fn();
+    seedStore({ createWorkspaceObject, openWorkspaceTab, showWorkspaceToast });
+    renderLibrary();
+    openNewMenu();
+    fireEvent.click(screen.getByTestId('library-new-object-relation'));
+
+    await waitFor(() =>
+      expect(showWorkspaceToast).toHaveBeenCalledWith(
+        expect.stringMatching(/two models/i)
+      )
+    );
+    expect(openWorkspaceTab).not.toHaveBeenCalled();
   });
 
   test('the header "+ New" menu dismisses on Escape', () => {

--- a/viewer/src/components/views/workspace/promoteNaming.js
+++ b/viewer/src/components/views/workspace/promoteNaming.js
@@ -29,10 +29,16 @@ import { generateUniqueName } from '../../../utils/uniqueName';
 // named directly (`explorerStore.js`'s `createModelTab`/`createInsight`,
 // `explorationLegacyBridge.js`'s seed path) — anything else is treated as
 // already-meaningful (a user typed it, or renamed a chip) and left alone.
+// The collision suffix these have to recognise comes from `generateUniqueName`,
+// which now mints `-2` (the hyphen house style) where it used to mint `_2`.
+// Both are accepted: a project can hold names generated before and after that
+// change, and matching only one convention would silently stop suggesting a
+// real name for half the placeholders — the failure mode is invisible, because
+// the modal just shows the placeholder as if the user had chosen it.
 const GENERIC_NAME_PATTERNS = {
-  model: /^(query_\d+|model)$/i,
-  insight: /^insight(_\d+)?$/i,
-  chart: /^chart(_\d+)?$/i,
+  model: /^(query[_-]\d+|model([_-]\d+)?)$/i,
+  insight: /^insight([_-]\d+)?$/i,
+  chart: /^chart([_-]\d+)?$/i,
 };
 
 /**

--- a/viewer/src/components/views/workspace/promoteNaming.test.js
+++ b/viewer/src/components/views/workspace/promoteNaming.test.js
@@ -81,7 +81,7 @@ describe('suggestPromoteNames', () => {
   test('avoids colliding with a known existing name by suffixing', () => {
     const rows = [row({ name: 'query_1' })];
     const suggestions = suggestPromoteNames(rows, () => 'orders', ['orders-query']);
-    expect(suggestions.get('model:query_1')).toBe('orders-query_2');
+    expect(suggestions.get('model:query_1')).toBe('orders-query-2');
   });
 
   test('an already-meaningful model still anchors a generic insight/chart', () => {

--- a/viewer/src/stores/explorerStore.test.js
+++ b/viewer/src/stores/explorerStore.test.js
@@ -238,7 +238,7 @@ describe('explorerStore', () => {
       const state = useStore.getState();
       expect(state.explorerModelTabs).toHaveLength(2);
       expect(state.explorerModelTabs[0]).toBe('model');
-      expect(state.explorerModelTabs[1]).toBe('model_2');
+      expect(state.explorerModelTabs[1]).toBe('model-2');
     });
 
     it('switches active tab to the newly created tab', () => {
@@ -810,7 +810,7 @@ describe('explorerStore', () => {
       const names = useStore.getState().explorerChartInsightNames;
       expect(names).toHaveLength(2);
       expect(names[0]).toBe('insight');
-      expect(names[1]).toBe('insight_2');
+      expect(names[1]).toBe('insight-2');
     });
 
     it('sets new insight as active', () => {
@@ -1235,13 +1235,13 @@ describe('explorerStore', () => {
         explorerChartName: null,
         models: [],
         insights: [],
-        charts: [{ name: 'chart' }, { name: 'chart_2' }],
+        charts: [{ name: 'chart' }, { name: 'chart-2' }],
       });
 
       const name = useStore.getState().ensureExplorerChartName();
 
-      expect(name).toBe('chart_3');
-      expect(useStore.getState().explorerChartName).toBe('chart_3');
+      expect(name).toBe('chart-3');
+      expect(useStore.getState().explorerChartName).toBe('chart-3');
     });
   });
 
@@ -2988,8 +2988,8 @@ describe('explorerStore', () => {
         });
         useStore.getState().createInsight();
         const state = useStore.getState();
-        // insight_2 because the explorer already has 'insight' in its working state
-        expect(state.explorerChartInsightNames).toContain('insight_2');
+        // insight-2 because the explorer already has 'insight' in its working state
+        expect(state.explorerChartInsightNames).toContain('insight-2');
       });
     });
 
@@ -3050,7 +3050,7 @@ describe('explorerStore', () => {
         });
         useStore.getState().createModelTab();
         const state = useStore.getState();
-        expect(state.explorerModelTabs).toContain('model_2');
+        expect(state.explorerModelTabs).toContain('model-2');
       });
     });
 

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -11,13 +11,27 @@ import { generateUniqueName } from '../utils/uniqueName';
  * the editing surface.
  *
  * The templates were validated against the live save endpoints — each is the
- * smallest config the backend's Pydantic model accepts. `relation` is absent
- * by design: its condition must reference two real models, so there is no
- * meaningful empty draft.
+ * smallest config the backend's Pydantic model accepts.
+ *
+ * `config` receives the store state, because one type cannot be templated from
+ * a constant: a `relation`'s condition must reference TWO REAL models (the
+ * backend's `validate_condition_has_models`), so its draft is built from the
+ * project's own models. Every other template ignores the argument.
  *
  * Dimension/metric names use underscores — the backend rejects dashes for
  * semantic-layer names (they must be valid SQL identifiers).
  */
+
+/**
+ * Two model names to seed a relation's condition with, oldest-first so the
+ * choice is stable rather than dependent on fetch order. Returns null when the
+ * project has fewer than two models — there is no valid relation to draft, and
+ * the caller says so instead of failing at the backend.
+ */
+const firstTwoModelNames = state => {
+  const names = (state.models || []).map(m => m?.name).filter(Boolean);
+  return names.length >= 2 ? [names[0], names[1]] : null;
+};
 export const CREATE_TEMPLATES = {
   dashboard: {
     namePrefix: 'new-dashboard',
@@ -79,6 +93,27 @@ export const CREATE_TEMPLATES = {
     saveKey: 'saveMetric',
     config: () => ({ expression: 'count(*)' }),
   },
+  relation: {
+    namePrefix: 'new_relation',
+    collectionKey: 'relations',
+    saveKey: 'saveRelation',
+    // Seeded with the project's first two models joined on `id` — a starting
+    // point the user re-points in the edit panel, exactly like every other
+    // "+ New" draft. The join keys are a guess; the MODEL references are real,
+    // which is what the backend validator requires.
+    requires: state =>
+      firstTwoModelNames(state)
+        ? null
+        : 'A relation joins two models. Create at least two models first.',
+    config: state => {
+      const [left, right] = firstTwoModelNames(state);
+      return {
+        join_type: 'inner',
+        // eslint-disable-next-line no-template-curly-in-string
+        condition: `\${ref(${left}).id} = \${ref(${right}).id}`,
+      };
+    },
+  },
 };
 
 const createInlineCreateSlice = (set, get) => ({
@@ -98,9 +133,16 @@ const createInlineCreateSlice = (set, get) => ({
     if (typeof save !== 'function') {
       return { success: false, error: `${template.saveKey} unavailable` };
     }
+    // A type whose draft depends on other objects existing (relation → two
+    // models) reports WHY it can't be drafted, rather than posting a config
+    // the backend will reject with a validator message.
+    const blocked = template.requires ? template.requires(get()) : null;
+    if (blocked) {
+      return { success: false, error: blocked };
+    }
     const existing = (get()[template.collectionKey] || []).map(o => o.name);
     const name = generateUniqueName(template.namePrefix, existing);
-    const result = await save(name, template.config());
+    const result = await save(name, template.config(get()));
     return result?.success ? { ...result, name, type } : result;
   },
 });

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -85,12 +85,16 @@ export const CREATE_TEMPLATES = {
     namePrefix: 'new_dimension',
     collectionKey: 'dimensions',
     saveKey: 'saveDimension',
+    // Declared, not inferred: the backend rejects a dash in a dimension name,
+    // and a user-named dimension (`region`) carries no separator to infer from.
+    nameSeparator: '_',
     config: () => ({ expression: '1' }),
   },
   metric: {
     namePrefix: 'new_metric',
     collectionKey: 'metrics',
     saveKey: 'saveMetric',
+    nameSeparator: '_',
     config: () => ({ expression: 'count(*)' }),
   },
   relation: {
@@ -141,7 +145,9 @@ const createInlineCreateSlice = (set, get) => ({
       return { success: false, error: blocked };
     }
     const existing = (get()[template.collectionKey] || []).map(o => o.name);
-    const name = generateUniqueName(template.namePrefix, existing);
+    const name = generateUniqueName(template.namePrefix, existing, {
+      separator: template.nameSeparator,
+    });
     const result = await save(name, template.config(get()));
     return result?.success ? { ...result, name, type } : result;
   },

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -45,6 +45,44 @@ describe('createWorkspaceObject', () => {
     expect(CREATE_TEMPLATES.metric.namePrefix).not.toMatch(/-/);
   });
 
+  // The collision suffix is part of the name the backend validates, so it has
+  // to respect the same rule the base name does.
+  describe('collision suffixes', () => {
+    const collisionNameFor = async type => {
+      const template = CREATE_TEMPLATES[type];
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({
+        models: [{ name: 'orders' }, { name: 'users' }],
+        [template.collectionKey]: [{ name: template.namePrefix }], // already taken
+        [template.saveKey]: save,
+      });
+      const result = await useStore.getState().createWorkspaceObject(type);
+      return result.name;
+    };
+
+    // dimension/metric must stay valid SQL identifiers — `new_dimension-2` is
+    // rejected by the backend.
+    test.each(['dimension', 'metric'])('%s disambiguates with an underscore', async type => {
+      const name = await collisionNameFor(type);
+      expect(name).toBe(`${CREATE_TEMPLATES[type].namePrefix}_2`);
+      expect(name).not.toMatch(/-/);
+    });
+
+    // Everything else follows the hyphen house style.
+    test.each(['dashboard', 'chart', 'table', 'markdown', 'input', 'insight', 'model', 'source'])(
+      '%s disambiguates with a hyphen',
+      async type => {
+        expect(await collisionNameFor(type)).toBe(`${CREATE_TEMPLATES[type].namePrefix}-2`);
+      }
+    );
+
+    // A relation name is underscore-styled (`new_relation`), and the backend
+    // accepts either — matching the base reads better than `new_relation-2`.
+    test('relation keeps its base style', async () => {
+      expect(await collisionNameFor('relation')).toBe('new_relation_2');
+    });
+  });
+
   // VIS-1237: "+ New" → Relation was a dead affordance. A relation IS
   // templatable — its condition just has to be built from real models, because
   // the backend requires two distinct model references.

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -12,13 +12,17 @@ describe('createWorkspaceObject', () => {
     const template = CREATE_TEMPLATES[type];
     const save = jest.fn(async () => ({ success: true }));
     useStore.setState({
+      // Two models exist so every template's precondition is satisfiable —
+      // a relation's draft is built FROM the project's models.
+      models: [{ name: 'orders' }, { name: 'users' }],
       [template.collectionKey]: [],
       [template.saveKey]: save,
     });
+    const expectedConfig = template.config(useStore.getState());
 
     const result = await useStore.getState().createWorkspaceObject(type);
 
-    expect(save).toHaveBeenCalledWith(template.namePrefix, template.config());
+    expect(save).toHaveBeenCalledWith(template.namePrefix, expectedConfig);
     expect(result).toMatchObject({ success: true, name: template.namePrefix, type });
   });
 
@@ -41,10 +45,44 @@ describe('createWorkspaceObject', () => {
     expect(CREATE_TEMPLATES.metric.namePrefix).not.toMatch(/-/);
   });
 
-  test('relation has no template (cannot draft a valid empty relation)', async () => {
-    expect(CREATE_TEMPLATES.relation).toBeUndefined();
-    const result = await useStore.getState().createWorkspaceObject('relation');
-    expect(result.success).toBe(false);
+  // VIS-1237: "+ New" → Relation was a dead affordance. A relation IS
+  // templatable — its condition just has to be built from real models, because
+  // the backend requires two distinct model references.
+  describe('relation', () => {
+    test('drafts a condition joining the project\'s first two models', async () => {
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({
+        models: [{ name: 'orders' }, { name: 'users' }, { name: 'events' }],
+        relations: [],
+        saveRelation: save,
+      });
+
+      const result = await useStore.getState().createWorkspaceObject('relation');
+
+      expect(result).toMatchObject({ success: true, type: 'relation' });
+      const [, config] = save.mock.calls[0];
+      expect(config.join_type).toBe('inner');
+      // Real model refs — what the backend's validator requires. The join keys
+      // are a starting point the user re-points in the edit panel.
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(config.condition).toBe('${ref(orders).id} = ${ref(users).id}');
+    });
+
+    test('says WHY it cannot draft one when the project has fewer than two models', async () => {
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({ models: [{ name: 'orders' }], relations: [], saveRelation: save });
+
+      const result = await useStore.getState().createWorkspaceObject('relation');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/two models/i);
+      // Nothing is posted that the backend would only reject.
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    test('names stay SQL-identifier safe', () => {
+      expect(CREATE_TEMPLATES.relation.namePrefix).not.toMatch(/-/);
+    });
   });
 
   test('propagates a failed save', async () => {

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -2522,7 +2522,7 @@ describe('workspace pivot draft actions (VIS-1008)', () => {
       result = await useStore.getState().commitWorkspacePivotDraftAsNew();
     });
     // sales-pivot-table_pivot is taken → _2 suffix.
-    expect(result.name).toBe('sales-pivot-table_pivot_2');
+    expect(result.name).toBe('sales-pivot-table_pivot-2');
   });
 
   test('commitWorkspacePivotDraftAsNew returns failure when there is no draft', async () => {

--- a/viewer/src/utils/uniqueName.js
+++ b/viewer/src/utils/uniqueName.js
@@ -1,10 +1,34 @@
 /**
- * Generate a unique name by appending _N suffix if the base name is taken.
+ * Generate a unique name by appending a `<separator><N>` suffix when the base
+ * name is taken.
+ *
+ * ### Which separator
+ *
+ * The house style for generated object names is HYPHENS (`orders-query`,
+ * `new-chart`), so the collision suffix is a hyphen too — `new-chart-2`, not
+ * `new-chart_2`. This used to be hard-coded to `_`, which left every "+ New"
+ * and Explorer-generated name mixing both conventions the moment a name
+ * collided.
+ *
+ * Two names CANNOT take a hyphen: `dimension` and `metric` must be valid SQL
+ * identifiers, and the backend rejects dashes for them (`region-2` is a
+ * validation error, `region_2` is fine). Those call sites pass `separator: '_'`
+ * explicitly rather than relying on the base name's shape, because a
+ * user-named dimension (`region`) carries no separator to infer from.
+ *
+ * With no explicit separator, the base name's own style wins — a hyphenated
+ * base keeps hyphens, an underscored base keeps underscores (`orders_to_users`
+ * → `orders_to_users_2`, which reads far better than `orders_to_users-2`) —
+ * falling back to the hyphen house style when the base has neither.
+ *
  * @param {string} prefix - Desired name
  * @param {Set|Array|Object} existingNames - Names already in use (Set, Array, or Object keys)
+ * @param {object} [options]
+ * @param {'-'|'_'} [options.separator] - Force the suffix separator. Required
+ *   for SQL-identifier names (dimension/metric), which must never take a dash.
  * @returns {string} Guaranteed unique name
  */
-export function generateUniqueName(prefix, existingNames) {
+export function generateUniqueName(prefix, existingNames, { separator } = {}) {
   const nameSet =
     existingNames instanceof Set
       ? existingNames
@@ -14,9 +38,31 @@ export function generateUniqueName(prefix, existingNames) {
 
   if (!nameSet.has(prefix)) return prefix;
 
+  const sep = separator || suffixSeparatorFor(prefix);
+
   let counter = 2;
-  while (nameSet.has(`${prefix}_${counter}`)) {
+  while (nameSet.has(`${prefix}${sep}${counter}`)) {
     counter++;
   }
-  return `${prefix}_${counter}`;
+  return `${prefix}${sep}${counter}`;
 }
+
+/**
+ * The separator that matches a base name's own style: hyphen when it already
+ * uses one, underscore when it only uses underscores, hyphen otherwise (the
+ * house style for a base like `chart` that carries no separator at all).
+ */
+export function suffixSeparatorFor(prefix) {
+  const base = String(prefix || '');
+  if (base.includes('-')) return '-';
+  if (base.includes('_')) return '_';
+  return '-';
+}
+
+/**
+ * Matches a generated collision suffix in EITHER convention — `_2` (what we
+ * used to mint, and what is still correct for SQL-identifier names) and `-2`.
+ * Callers that recognise auto-generated names must accept both, or a rename
+ * suggestion silently stops firing for half of them.
+ */
+export const UNIQUE_SUFFIX_PATTERN = '[_-]\\d+';

--- a/viewer/src/utils/uniqueName.test.js
+++ b/viewer/src/utils/uniqueName.test.js
@@ -1,4 +1,4 @@
-import { generateUniqueName } from './uniqueName';
+import { generateUniqueName, suffixSeparatorFor } from './uniqueName';
 
 describe('generateUniqueName', () => {
   it('returns prefix if not taken', () => {
@@ -13,21 +13,70 @@ describe('generateUniqueName', () => {
     expect(generateUniqueName('model', { other: {} })).toBe('model');
   });
 
-  it('appends _2 when prefix is taken', () => {
-    expect(generateUniqueName('model', new Set(['model']))).toBe('model_2');
-  });
-
-  it('appends _3 when _2 is also taken', () => {
-    expect(generateUniqueName('model', new Set(['model', 'model_2']))).toBe('model_3');
-  });
-
-  it('handles many conflicts', () => {
-    const names = new Set(['m', 'm_2', 'm_3', 'm_4', 'm_5']);
-    expect(generateUniqueName('m', names)).toBe('m_6');
-  });
-
   it('handles null/undefined existingNames', () => {
     expect(generateUniqueName('model', null)).toBe('model');
     expect(generateUniqueName('model', undefined)).toBe('model');
+  });
+});
+
+// The house style for generated object names is hyphens, so the collision
+// suffix is a hyphen too. This used to be hard-coded to `_`, which meant every
+// generated name mixed both conventions the moment it collided.
+describe('generateUniqueName — suffix separator', () => {
+  it('appends -2 when a separator-less prefix is taken', () => {
+    expect(generateUniqueName('model', new Set(['model']))).toBe('model-2');
+  });
+
+  it('counts up past taken suffixes', () => {
+    expect(generateUniqueName('model', new Set(['model', 'model-2']))).toBe('model-3');
+    const many = new Set(['m', 'm-2', 'm-3', 'm-4', 'm-5']);
+    expect(generateUniqueName('m', many)).toBe('m-6');
+  });
+
+  it('keeps a hyphenated base hyphenated', () => {
+    expect(generateUniqueName('orders-query', new Set(['orders-query']))).toBe('orders-query-2');
+  });
+
+  it('keeps an underscored base underscored — `a_to_b-2` would read wrong', () => {
+    expect(generateUniqueName('orders_to_users', new Set(['orders_to_users']))).toBe(
+      'orders_to_users_2'
+    );
+  });
+
+  it('prefers the hyphen when a base mixes both', () => {
+    expect(generateUniqueName('orders_db-query', new Set(['orders_db-query']))).toBe(
+      'orders_db-query-2'
+    );
+  });
+
+  it('honours an explicit separator over the inferred one', () => {
+    // dimension/metric MUST stay SQL identifiers — the backend rejects
+    // `region-2`. A user-named dimension carries no separator to infer from,
+    // so the call site declares it.
+    expect(generateUniqueName('region', new Set(['region']), { separator: '_' })).toBe('region_2');
+    expect(generateUniqueName('a-b', new Set(['a-b']), { separator: '_' })).toBe('a-b_2');
+  });
+
+  it('does not treat the other convention as taken', () => {
+    // A project can hold names minted before and after this change; `chart_2`
+    // does not block `chart-2`.
+    expect(generateUniqueName('chart', new Set(['chart', 'chart_2']))).toBe('chart-2');
+  });
+});
+
+describe('suffixSeparatorFor', () => {
+  it.each([
+    ['chart', '-'],
+    ['new-chart', '-'],
+    ['new_dimension', '_'],
+    ['orders_db-query', '-'],
+    ['', '-'],
+  ])('%s → %s', (prefix, expected) => {
+    expect(suffixSeparatorFor(prefix)).toBe(expected);
+  });
+
+  it('tolerates a null/undefined prefix', () => {
+    expect(suffixSeparatorFor(null)).toBe('-');
+    expect(suffixSeparatorFor(undefined)).toBe('-');
   });
 });

--- a/visivo/server/views/model_schema_views.py
+++ b/visivo/server/views/model_schema_views.py
@@ -29,12 +29,16 @@ The run still writes the artifact: the field resolver and
 POST rather than GET because the draft form carries SQL in the body.
 """
 
+import re
+
 from flask import jsonify, request
 
 from visivo.jobs.utils import get_source_for_model
 from visivo.logger.logger import Logger
+from visivo.models.base.context_string import ContextString
 from visivo.models.models.sql_model import SqlModel
 from visivo.query.model_schema_inference import infer_model_columns
+from visivo.query.patterns import REF_PROPERTY_PATTERN, extract_ref_names
 from visivo.query.schema_aggregator import SchemaAggregator
 
 
@@ -57,18 +61,76 @@ def _columns_payload(column_map: dict) -> list:
     )
 
 
-def _find_model(project, model_name: str):
-    """Find a model by name on the project. Returns None when absent."""
+def _from_manager(flask_app, manager_name: str, name: str):
+    """Look a name up in an object manager (draft cache first, then published).
+
+    The managers are the same source of truth ``/api/models/`` and
+    ``/api/sources/`` serve, so anything the viewer can SEE resolves here —
+    including objects that exist only as uncommitted drafts.
+    """
+    manager = getattr(flask_app, manager_name, None)
+    getter = getattr(manager, "get", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter(name)
+    except Exception:
+        # A manager that cannot answer is not a reason to fail the request —
+        # the committed-project scan below is still a valid answer.
+        return None
+
+
+def _find_model(flask_app, project, model_name: str):
+    """Find a model by name — DRAFT CACHE FIRST, then the committed project.
+
+    A model created in the editor lives in the draft cache until Commit writes
+    it to YAML, and ``flask_app.project`` is compiled from YAML. Scanning only
+    the project meant every uncommitted model 404'd here while being perfectly
+    visible in the Library and the semantic layer, which is exactly what the
+    ERD's column hydration asks about.
+    """
+    model = _from_manager(flask_app, "model_manager", model_name)
+    if model is not None:
+        return model
     for model in project.models or []:
         if getattr(model, "name", None) == model_name:
             return model
     return None
 
 
-def _find_source(project, source_name: str):
+def _find_source(flask_app, project, source_name: str):
+    """Find a source by name — draft cache first, then the committed project."""
+    source = _from_manager(flask_app, "source_manager", source_name)
+    if source is not None:
+        return source
     for source in project.sources or []:
-        if source.name == source_name:
+        if getattr(source, "name", None) == source_name:
             return source
+    return None
+
+
+def _referenced_source_name(model) -> str:
+    """The source NAME a model points at, read off the model itself.
+
+    Source resolution normally walks the DAG, but a draft model is not IN the
+    DAG — it has never been compiled — so that walk returns nothing and the
+    request 400s with "No source resolved". The model's own ``source`` field
+    still names its source, in either of the two forms the field round-trips
+    as (``ref(wh)`` and ``${ref(wh)}``). Returns None for an embedded Source
+    object (which needs no lookup) or an unparseable value.
+    """
+    source = getattr(model, "source", None)
+    if source is None:
+        return None
+    if isinstance(source, ContextString):
+        return source.get_reference()
+    if isinstance(source, str):
+        names = extract_ref_names(source)  # ${ref(wh)}
+        if names:
+            return next(iter(names))
+        match = re.match(REF_PROPERTY_PATTERN, source.strip())  # ref(wh)
+        if match:
+            return match.group("model_name")
     return None
 
 
@@ -114,7 +176,7 @@ def register_model_schema_views(app, flask_app, output_dir):
             body = request.get_json(silent=True) or {}
             project = flask_app.project
 
-            model = _find_model(project, model_name)
+            model = _find_model(flask_app, project, model_name)
             if model is None:
                 return jsonify({"error": f"Model '{model_name}' not found"}), 404
 
@@ -129,9 +191,21 @@ def register_model_schema_views(app, flask_app, output_dir):
 
             source_name = body.get("source_name")
             if source_name:
-                source = _find_source(project, source_name)
+                source = _find_source(flask_app, project, source_name)
             else:
-                source = get_source_for_model(model, project.dag(), output_dir)
+                try:
+                    source = get_source_for_model(model, project.dag(), output_dir)
+                except Exception:
+                    # The DAG walk assumes the model is IN the DAG; an
+                    # uncommitted one never is.
+                    source = None
+                if source is None:
+                    # Fall back to the name the model itself carries, resolved
+                    # through the managers — the only path that works for a
+                    # draft model whose source is a ref string.
+                    referenced = _referenced_source_name(model)
+                    if referenced:
+                        source = _find_source(flask_app, project, referenced)
 
             if source is None:
                 return (
@@ -163,7 +237,7 @@ def register_model_schema_views(app, flask_app, output_dir):
             if not sql or not source_name:
                 return jsonify({"error": "sql and source_name are required"}), 400
 
-            source = _find_source(flask_app.project, source_name)
+            source = _find_source(flask_app, flask_app.project, source_name)
             if source is None:
                 return jsonify({"error": f"Source '{source_name}' not found"}), 404
 


### PR DESCRIPTION
> **Stacked on #619** (it also edits `inlineCreateStore.js`). Retargets to `main` once that merges.

## The audit

You asked where we still mint `_2` instead of `-2`. I traced every place a new object name is created:

| Where | Mints | Suffix source |
|---|---|---|
| `inlineCreateStore` — every "+ New X" | all 11 types | `generateUniqueName` |
| `explorerStore` — Explorer tabs | model / insight / chart | `generateUniqueName` |
| `ExplorationBuildRail` — auto-naming cascade | query / insight / chart | `generateUniqueName` |
| `promoteNaming` — promote suggestions | model / insight / chart | `generateUniqueName` |
| `JoinOperatorPopover` — relation from the ERD | relation | `generateUniqueName` |
| `workspaceStore` — pivot → table | table | `generateUniqueName` |
| **backend (`visivo/`)** | — | **none** — mints no object names |

**Result: one source.** `generateUniqueName` hard-coded `` `${prefix}_${counter}` ``. PR #615 hyphenated the *base* names but never the *suffix*, so any collision produced `new-chart_2`.

## The fix, and the constraint that shapes it

It can't be a blanket swap — I checked the real Pydantic models:

```
Dimension  region-2   -> REJECTED     (must be a valid SQL identifier)
Metric     revenue-2  -> REJECTED
Relation   a_to_b-2   -> accepted
Chart      new-chart-2 -> accepted
SqlModel   new-model-2 -> accepted
```

So:
- Suffix defaults to the **hyphen** house style → `new-chart-2`.
- `dimension` / `metric` **declare** `nameSeparator: '_'` — not inferred, because a user-named dimension (`region`) has no separator to infer from and would otherwise get the rejected `region-2`.
- With no explicit separator the **base name's own style wins**: `orders_to_users` → `orders_to_users_2` (reads better than `orders_to_users-2`), `orders-query` → `orders-query-2`, and a bare `chart` → `chart-2`.

## A silent bug the audit surfaced

`promoteNaming`'s `GENERIC_NAME_PATTERNS` only matched `_\d+`:

```js
insight: /^insight(_\d+)?$/i
```

Once we started minting `insight-2`, promote would have stopped recognising it as a placeholder and **quietly stopped suggesting a real name** — no error, it just shows the placeholder as though the user chose it. Patterns now accept both conventions, which is also what a project holding names from before *and* after this change needs.

## Verification
Every generated collision name checked against the real backend models: `new-chart-2`, `new-table-2`, `new-markdown-2`, `new-dashboard-2`, `new-insight-2`, `new-model-2`, `new-source-2` all validate; `new_dimension_2`, `new_metric_2`, `new_relation_2` keep the form their validators require.

## Observation — not changed
`workspaceStore`'s pivot-table base is `` `${tableName}_pivot` ``, so a collision now reads `sales-table_pivot-2`. The suffix is right; the **base** still uses an underscore. Tables accept dashes, so `-pivot` would be a one-line change — I left it alone since it's a base-name convention rather than the `_2` you flagged. Say the word and I'll flip it.

## Test Strategy
- `uniqueName.test.js` rewritten: hyphen default, count-up, base-style inference, explicit override, and that `chart_2` (old convention) doesn't block `chart-2`.
- `inlineCreateStore.test.js`: a **per-type collision guard** — all 11 types assert the exact separator they must use, so a new type can't silently regress.
- Downstream expectations updated in `explorerStore`, `ExplorationBuildRail`, `promoteNaming`, `workspaceStore`.
- Full viewer suite **6811 passed**; `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
