### PR TITLE
VIS-1231: a new dashboard starts with a row; empty state asks for one

### DIFF
--- a/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
@@ -18,8 +18,10 @@ import RowTemplateMenu from './RowTemplateMenu';
  *   - A between-rows "+ Add row" pill revealed on hover in each top-level row
  *     gap (measured from the live `data-canvas-path` row boxes, the same scheme
  *     CanvasDndLayer reads).
- *   - The EMPTY-canvas CTA (D-8): a prominent mulberry "Add row" button +
- *     helper copy, shown when the dashboard has zero rows.
+ *   - The EMPTY-canvas CTA (D-8), shown when the dashboard has zero rows:
+ *     helper copy with the SAME dashed "Add row" button under it (one shared
+ *     <AddRowButton>, not a look-alike — the empty state used to render its own
+ *     solid mulberry variant).
  *
  * Each trigger opens <RowTemplateMenu>; selecting a template builds a row of
  * empty slots (canvasReorder.buildTemplateRow) and inserts it at the trigger's
@@ -43,6 +45,25 @@ const PlusIcon = ({ className }) => (
   <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
     <path d="M12 5v14M5 12h14" />
   </svg>
+);
+
+/**
+ * The dashed "+ Add row" button. ONE component for both the end-of-canvas
+ * trigger and the empty-canvas CTA, so the two are literally the same button
+ * rather than two look-alikes that drift (the empty state used to render a
+ * solid mulberry variant of its own).
+ */
+const AddRowButton = ({ testId, onClick }) => (
+  <button
+    type="button"
+    data-testid={testId}
+    onClick={onClick}
+    className="inline-flex h-9 items-center gap-1.5 rounded-lg border-2 border-dashed bg-white px-4 text-[13px] font-medium transition-colors hover:bg-primary-50"
+    style={{ borderColor: MULBERRY, color: 'var(--color-primary-600)' }}
+  >
+    <PlusIcon className="h-4 w-4" />
+    Add row
+  </button>
 );
 
 const measure = (el, rootEl) => {
@@ -200,28 +221,32 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
     return (
       <div
         data-testid="canvas-add-row-empty"
-        className={`pointer-events-none absolute inset-0 flex flex-col items-center justify-center ${
+        // Anchored to the TOP with its own height, NOT `inset-0` + centering.
+        // With zero rows <Dashboard> renders nothing and the canvas root's
+        // `flex-1` is inert inside MiddlePane's plain `overflow-auto` wrapper,
+        // so the root collapses to ~0px. Centering inside that box spilled half
+        // the CTA UPWARD, behind the breadcrumb/lens chrome — whichever element
+        // sat on top was invisible (first the button, then the helper text).
+        // A real min-height gives the CTA somewhere to live.
+        className={`pointer-events-none absolute inset-x-0 top-0 flex min-h-[320px] flex-col items-center justify-center ${
           openMenu ? 'z-[100]' : 'z-10'
         }`}
       >
         <div className="pointer-events-auto relative flex flex-col items-center">
-          <button
-            type="button"
-            data-testid="canvas-add-row-empty-button"
-            onClick={() => setOpenMenu(o => (o?.kind === 'empty' ? null : { kind: 'empty' }))}
-            className="inline-flex h-12 items-center gap-2 rounded-lg px-6 text-[14px] font-semibold text-white shadow-md transition-colors"
-            style={{ backgroundColor: MULBERRY }}
-          >
-            <PlusIcon className="h-4 w-4" />
-            Add row
-          </button>
           {/* VIS-1231: this used to read "Drag a chart from the Library to
               begin", but an empty dashboard has no row to drop INTO — the drag
-              silently did nothing. Rows come first; say so. */}
-          <p className="mt-3 max-w-[360px] text-center text-[12.5px] leading-relaxed text-gray-500">
+              silently did nothing. Rows come first; say so, then offer the
+              action directly under it. */}
+          <p className="max-w-[360px] text-center text-[12.5px] leading-relaxed text-gray-500">
             Dashboards are built from rows. Add one to start, then drag charts,
             tables, and markdown from the Library into it.
           </p>
+          <div className="mt-4">
+            <AddRowButton
+              testId="canvas-add-row-empty-button"
+              onClick={() => setOpenMenu(o => (o?.kind === 'empty' ? null : { kind: 'empty' }))}
+            />
+          </div>
           {openMenu?.kind === 'empty' && (
             <RowTemplateMenu
               anchor="top"
@@ -307,16 +332,10 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
         }
       >
         <div className="relative flex items-center justify-center">
-          <button
-            type="button"
-            data-testid="canvas-add-row-end-button"
+          <AddRowButton
+            testId="canvas-add-row-end-button"
             onClick={() => setOpenMenu(o => (o?.kind === 'end' ? null : { kind: 'end' }))}
-            className="inline-flex h-9 items-center gap-1.5 rounded-lg border-2 border-dashed bg-white px-4 text-[13px] font-medium transition-colors hover:bg-primary-50"
-            style={{ borderColor: MULBERRY, color: 'var(--color-primary-600)' }}
-          >
-            <PlusIcon className="h-4 w-4" />
-            Add row
-          </button>
+          />
           {openMenu?.kind === 'end' && (
             <RowTemplateMenu
               anchor="bottom"

--- a/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasAddRow.jsx
@@ -13,29 +13,32 @@ import RowTemplateMenu from './RowTemplateMenu';
  * selection + DnD overlays), it provides three surfaces from the D-7/D-8 briefs:
  *
  *   - A dashed "+ Add row" button at the END of the canvas (always present when
- *     the dashboard has ≥1 row).
+ *     the dashboard has ≥1 row), measured to sit just BELOW the last row rather
+ *     than pinned to the canvas floor, where it overlapped the last cell.
  *   - A between-rows "+ Add row" pill revealed on hover in each top-level row
  *     gap (measured from the live `data-canvas-path` row boxes, the same scheme
  *     CanvasDndLayer reads).
- *   - The EMPTY-canvas CTA (D-8): a prominent mulberry "Add row" button + helper
- *     copy + a one-time directional cue toward the Library, shown when the
- *     dashboard has zero rows.
+ *   - The EMPTY-canvas CTA (D-8): a prominent mulberry "Add row" button +
+ *     helper copy, shown when the dashboard has zero rows.
  *
  * Each trigger opens <RowTemplateMenu>; selecting a template builds a row of
  * empty slots (canvasReorder.buildTemplateRow) and inserts it at the trigger's
  * target index (insertRowAtIndex), committing through the shell's shared
- * `commitCanvasConfig` (optimistic → validate → save) — the SAME path the DnD
- * router uses. It also exposes the inline-create entry points (+ New Chart /
- * Table / Markdown): Explore 2.0 Phase 3b cutover (B5) replaced the old dead
- * `/explorer?create=<type>` navigation with the return_to placement-intent
- * mechanism — a fresh exploration is minted carrying `{dashboard}` and its
- * tab opens. Consuming the intent to place a promoted chart back into this
- * dashboard is Phase 4/5 (02-architecture.md §5); this only persists it.
+ * `commitCanvasConfig` — the SAME path the DnD router uses.
+ *
+ * VIS-1231: the empty state used to advertise dragging from the Library and
+ * offer "+ New chart / table / markdown" shortcuts into the Explorer. Neither
+ * worked from an empty dashboard — there is no row to drop into — so the copy
+ * promised something the canvas could not do. A row is the one thing that has
+ * to exist first, so the empty state now says exactly that, and a dashboard
+ * created from "+ New" starts with a row (see `inlineCreateStore`).
  *
  * Mulberry (`primary`) is the active/CTA colour (NOT a type colour).
  */
 
 const MULBERRY = 'var(--color-primary-500)';
+// Clearance between the last row and the end-of-canvas "Add row" button.
+const END_BUTTON_GAP = 12;
 const PlusIcon = ({ className }) => (
   <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
     <path d="M12 5v14M5 12h14" />
@@ -54,26 +57,18 @@ const measure = (el, rootEl) => {
   };
 };
 
-// Inline-create object types offered at the empty state / menus (D-7 AC). These
-// route to the Explorer to author a new layout item; the round-trip back to the
-// canvas is VIS-J2.
-const INLINE_CREATE_TYPES = [
-  { type: 'chart', label: 'New chart' },
-  { type: 'table', label: 'New table' },
-  { type: 'markdown', label: 'New markdown' },
-];
-
 const CanvasAddRow = ({ rootRef, dashboardName }) => {
   const dashboards = useStore(s => s.dashboards);
   const commitCanvasConfig = useWorkspaceCommit();
-  const createExploration = useStore(s => s.createExploration);
-  const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
 
   // openMenu: which trigger's menu is open. null | { kind: 'end' } |
   // { kind: 'between', index } | { kind: 'empty' }.
   const [openMenu, setOpenMenu] = useState(null);
   const [hoverGap, setHoverGap] = useState(null);
   const [gapBoxes, setGapBoxes] = useState([]);
+  // Where the end-of-canvas button sits: measured from the last row so it
+  // never overlaps it. Null until the first measure (or with no rows).
+  const [endBox, setEndBox] = useState(null);
 
   const dashboardConfig = useMemo(() => {
     const entry = (dashboards || []).find(d => d.name === dashboardName);
@@ -93,6 +88,7 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
     const root = rootRef.current;
     if (!root || !rows.length) {
       setGapBoxes([]);
+      setEndBox(null);
       return;
     }
     const at = path => {
@@ -109,6 +105,16 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
       boxes.push({ index: ri, top: gapCenter, left: rowBox.left, width: rowBox.width });
     });
     setGapBoxes(boxes);
+
+    // Park the end button just BELOW the last row rather than pinned to the
+    // canvas floor. Pinned to the floor it sat on top of whatever row happened
+    // to reach the bottom — the dashed button straddling the last cell.
+    const lastBox = at(`row.${rows.length - 1}`);
+    setEndBox(
+      lastBox
+        ? { top: lastBox.top + lastBox.height + END_BUTTON_GAP, left: lastBox.left, width: lastBox.width }
+        : null
+    );
   }, [rootRef, rows]);
 
   useEffect(() => {
@@ -187,33 +193,6 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
     [dashboardConfig, dashboardName, commitCanvasConfig, targetIndex]
   );
 
-  const handleInlineCreate = useCallback(
-    async type => {
-      // §3.4 payload convention: `source` (where the create was initiated) +
-      // `kind` (the object type), matching the Library / broken-ref /
-      // project-editor inline-create sites.
-      emitWorkspaceEvent('inline_create_used', { source: 'canvas', kind: type, dashboardName });
-      setOpenMenu(null);
-      // Explore 2.0 Phase 3b cutover (B5): the old `/explorer?create=<type>`
-      // dead param (Explorer never read it) is replaced by the SAME
-      // return_to placement-intent mechanism the dashboard-scoped
-      // `/workspace/dashboard/:name/explorer` route uses — mint a fresh
-      // exploration carrying `{ dashboard: dashboardName }` and open its
-      // tab. Consuming the intent ("Place in <dashboard>") is Phase 4/5;
-      // this only persists it via the existing field.
-      if (!createExploration || !openWorkspaceTab) return;
-      const result = await createExploration(null, { dashboard: dashboardName });
-      if (result?.success) {
-        openWorkspaceTab({
-          id: `exploration:${result.id}`,
-          type: 'exploration',
-          name: result.id,
-        });
-      }
-    },
-    [createExploration, openWorkspaceTab, dashboardName]
-  );
-
   if (!dashboardConfig) return null;
 
   // ── Empty-canvas state (D-8) ───────────────────────────────────────────────
@@ -236,22 +215,13 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
             <PlusIcon className="h-4 w-4" />
             Add row
           </button>
+          {/* VIS-1231: this used to read "Drag a chart from the Library to
+              begin", but an empty dashboard has no row to drop INTO — the drag
+              silently did nothing. Rows come first; say so. */}
           <p className="mt-3 max-w-[360px] text-center text-[12.5px] leading-relaxed text-gray-500">
-            Drag a chart from the Library to begin, or pick a row template.
+            Dashboards are built from rows. Add one to start, then drag charts,
+            tables, and markdown from the Library into it.
           </p>
-          <div className="mt-2 flex items-center gap-3 text-[11.5px]">
-            {INLINE_CREATE_TYPES.map(({ type, label }) => (
-              <button
-                key={type}
-                type="button"
-                data-testid={`canvas-inline-create-${type}`}
-                onClick={() => handleInlineCreate(type)}
-                className="font-medium text-primary hover:underline"
-              >
-                {label}
-              </button>
-            ))}
-          </div>
           {openMenu?.kind === 'empty' && (
             <RowTemplateMenu
               anchor="top"
@@ -323,8 +293,19 @@ const CanvasAddRow = ({ rootRef, dashboardName }) => {
         );
       })}
 
-      {/* End-of-canvas "+ Add row" dashed button. */}
-      <div className="pointer-events-auto absolute inset-x-0 bottom-2 flex items-center justify-center">
+      {/* End-of-canvas "+ Add row" dashed button, parked below the last row.
+          It used to be pinned to the canvas floor (`bottom-2`), so on a
+          dashboard whose rows reached the bottom it rendered ON TOP of the last
+          cell. Falls back to the floor only until the first measurement. */}
+      <div
+        data-testid="canvas-add-row-end"
+        className="pointer-events-auto absolute flex items-center justify-center"
+        style={
+          endBox
+            ? { top: endBox.top, left: endBox.left, width: endBox.width }
+            : { left: 0, right: 0, bottom: 8 }
+        }
+      >
         <div className="relative flex items-center justify-center">
           <button
             type="button"

--- a/viewer/src/components/views/project/canvas/CanvasAddRow.test.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasAddRow.test.jsx
@@ -8,7 +8,7 @@
  * inline-create telemetry.
  */
 import React, { useRef } from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import CanvasAddRow from './CanvasAddRow';
 import useStore from '../../../../stores/store';
 import { setWorkspaceTelemetryListener } from '../../workspace/telemetry';
@@ -86,6 +86,34 @@ describe('CanvasAddRow — empty canvas (D-8)', () => {
     // does nothing on a dashboard with no row to drop into.
     expect(screen.getByText(/built from rows/i)).toBeInTheDocument();
     expect(screen.queryByText(/drag a chart from the library to begin/i)).not.toBeInTheDocument();
+  });
+
+  // The canvas root collapses to ~0px height when the dashboard has no rows
+  // (nothing renders inside it), so an `inset-0` + `justify-center` CTA spilled
+  // half its content UPWARD behind the breadcrumb/lens chrome — the helper text
+  // and the button took turns being invisible depending on their order.
+  test('gives the CTA its own height instead of centering in a zero-height root', () => {
+    render(<Harness dashboardName="empty-dash" />);
+    const layer = screen.getByTestId('canvas-add-row-empty');
+    expect(layer.className).toContain('top-0');
+    expect(layer.className).toMatch(/min-h-\[\d+px\]/);
+    // Not stretched to a root that has no height to stretch to.
+    expect(layer.className).not.toContain('inset-0');
+  });
+
+  // The empty CTA and the end-of-canvas trigger render the SAME dashed button,
+  // so the canvas offers one recognisable "Add row" affordance everywhere.
+  test('uses the same dashed Add row button as the rest of the canvas', () => {
+    render(<Harness dashboardName="empty-dash" />);
+    const emptyBtn = screen.getByTestId('canvas-add-row-empty-button');
+    expect(emptyBtn).toHaveTextContent('Add row');
+    expect(emptyBtn.className).toContain('border-dashed');
+
+    // Same classes the populated canvas's end button carries.
+    cleanup();
+    setDashboards([{ name: 'dash', config: { rows: [{ height: 'medium', items: [{ width: 1 }] }] } }]);
+    render(<Harness dashboardName="dash" />);
+    expect(screen.getByTestId('canvas-add-row-end-button').className).toBe(emptyBtn.className);
   });
 
   // VIS-1231: the "+ New chart / table / markdown" shortcuts are gone — they

--- a/viewer/src/components/views/project/canvas/CanvasAddRow.test.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasAddRow.test.jsx
@@ -8,7 +8,7 @@
  * inline-create telemetry.
  */
 import React, { useRef } from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import CanvasAddRow from './CanvasAddRow';
 import useStore from '../../../../stores/store';
 import { setWorkspaceTelemetryListener } from '../../workspace/telemetry';
@@ -78,11 +78,24 @@ describe('CanvasAddRow — empty canvas (D-8)', () => {
     setDashboards([{ name: 'empty-dash', config: { rows: [] } }]);
   });
 
-  test('renders the prominent empty CTA + helper copy', () => {
+  test('renders the prominent empty CTA, and copy that names the row as the first step', () => {
     render(<Harness dashboardName="empty-dash" />);
     expect(screen.getByTestId('canvas-add-row-empty')).toBeInTheDocument();
     expect(screen.getByTestId('canvas-add-row-empty-button')).toBeInTheDocument();
-    expect(screen.getByText(/pick a row template/i)).toBeInTheDocument();
+    // VIS-1231: it used to say "drag a chart from the Library to begin", which
+    // does nothing on a dashboard with no row to drop into.
+    expect(screen.getByText(/built from rows/i)).toBeInTheDocument();
+    expect(screen.queryByText(/drag a chart from the library to begin/i)).not.toBeInTheDocument();
+  });
+
+  // VIS-1231: the "+ New chart / table / markdown" shortcuts are gone — they
+  // bounced the user to the Explorer from a dashboard that still had no row to
+  // place anything into.
+  test('offers no inline-create shortcuts', () => {
+    render(<Harness dashboardName="empty-dash" />);
+    ['chart', 'table', 'markdown'].forEach(type => {
+      expect(screen.queryByTestId(`canvas-inline-create-${type}`)).not.toBeInTheDocument();
+    });
   });
 
   test('opening the menu then picking a template commits a templated row at index 0', () => {
@@ -109,37 +122,6 @@ describe('CanvasAddRow — empty canvas (D-8)', () => {
     expect(addRow.payload).toMatchObject({ kind: 'add_row', template: 'blank' });
   });
 
-  // Explore 2.0 Phase 3b cutover (B5): the old dead `/explorer?create=<type>`
-  // navigation is replaced by the return_to placement-intent mechanism —
-  // mint a fresh exploration carrying `{dashboard}` and open its tab.
-  test('inline-create fires inline_create_used and mints a return_to-carrying exploration tab', async () => {
-    const events = [];
-    const unsub = setWorkspaceTelemetryListener(e => events.push(e));
-    render(<Harness dashboardName="empty-dash" />);
-    fireEvent.click(screen.getByTestId('canvas-inline-create-chart'));
-    await waitFor(() => expect(mockOpenWorkspaceTab).toHaveBeenCalled());
-    unsub();
-    // §3.4 payload convention: source (initiating surface) + kind (object type).
-    expect(events.find(e => e.eventName === 'inline_create_used')?.payload).toEqual({
-      source: 'canvas',
-      kind: 'chart',
-      dashboardName: 'empty-dash',
-    });
-    expect(mockCreateExploration).toHaveBeenCalledWith(null, { dashboard: 'empty-dash' });
-    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith({
-      id: 'exploration:exp_new1',
-      type: 'exploration',
-      name: 'exp_new1',
-    });
-  });
-
-  test('inline-create does not open a tab when minting the exploration fails', async () => {
-    mockCreateExploration.mockResolvedValueOnce({ success: false });
-    render(<Harness dashboardName="empty-dash" />);
-    fireEvent.click(screen.getByTestId('canvas-inline-create-chart'));
-    await waitFor(() => expect(mockCreateExploration).toHaveBeenCalled());
-    expect(mockOpenWorkspaceTab).not.toHaveBeenCalled();
-  });
 });
 
 describe('CanvasAddRow — populated canvas (D-7)', () => {
@@ -162,6 +144,33 @@ describe('CanvasAddRow — populated canvas (D-7)', () => {
     expect(screen.getByTestId('canvas-add-row-end-button')).toBeInTheDocument();
     // The empty CTA is NOT shown when rows exist.
     expect(screen.queryByTestId('canvas-add-row-empty')).not.toBeInTheDocument();
+  });
+
+  // VIS-1231: the end button used to be pinned to the canvas floor
+  // (`bottom-2`), so on a dashboard whose rows reached the bottom the dashed
+  // button rendered ON TOP of the last cell. It is now measured from the last
+  // row's box.
+  test('parks the end button BELOW the last row, not pinned to the canvas floor', () => {
+    const BOXES = {
+      root: { top: 0, left: 0, width: 800, height: 600, bottom: 600, right: 800 },
+      'row-el-0': { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+      'row-el-1': { top: 210, left: 0, width: 800, height: 190, bottom: 400, right: 800 },
+    };
+    const original = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function () {
+      const tid = this.getAttribute && this.getAttribute('data-testid');
+      return BOXES[tid] || BOXES.root;
+    };
+    try {
+      render(<DomHarness dashboardName="dash" />);
+      const holder = screen.getByTestId('canvas-add-row-end');
+      // Last row spans 210 → 400, so the button clears it by END_BUTTON_GAP.
+      expect(holder.style.top).toBe('412px');
+      // …and is no longer floor-pinned.
+      expect(holder.style.bottom).toBe('');
+    } finally {
+      Element.prototype.getBoundingClientRect = original;
+    }
   });
 
   test('end trigger → pick template → appends a row at the end', () => {

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -19,13 +19,15 @@ const seed = (dashboards, saveDashboard) => {
 };
 
 describe('dashboardStore createDashboard (Project Editor "+ New Dashboard")', () => {
-  test('creates an empty draft with a unique name and returns it', async () => {
+  // VIS-1231: the draft is no longer EMPTY — it starts with one row, because a
+  // zero-row dashboard cannot accept a drag.
+  test('creates a draft with one row and a unique name, and returns it', async () => {
     const saveDashboard = jest.fn(async () => ({ success: true }));
     seed([{ name: 'exec', config: {} }], saveDashboard);
 
     const result = await useStore.getState().createDashboard();
 
-    expect(saveDashboard).toHaveBeenCalledWith('new-dashboard', { rows: [] });
+    expect(saveDashboard).toHaveBeenCalledWith('new-dashboard', { rows: [{ height: 'medium', items: [{ width: 1 }] }] });
     expect(result).toMatchObject({ success: true, name: 'new-dashboard' });
   });
 
@@ -35,9 +37,10 @@ describe('dashboardStore createDashboard (Project Editor "+ New Dashboard")', ()
 
     const result = await useStore.getState().createDashboard();
 
-    expect(saveDashboard).toHaveBeenCalledWith(expect.not.stringMatching(/^new-dashboard$/), {
-      rows: [],
-    });
+    expect(saveDashboard).toHaveBeenCalledWith(
+      expect.not.stringMatching(/^new-dashboard$/),
+      { rows: [{ height: 'medium', items: [{ width: 1 }] }] }
+    );
     expect(result.success).toBe(true);
     expect(result.name).not.toBe('new-dashboard');
   });

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -1,4 +1,5 @@
 import { generateUniqueName } from '../utils/uniqueName';
+import { createRow } from '../components/views/workspace/itemMutations';
 
 /**
  * Inline-create Store Slice
@@ -23,7 +24,12 @@ export const CREATE_TEMPLATES = {
     namePrefix: 'new-dashboard',
     collectionKey: 'dashboards',
     saveKey: 'saveDashboard',
-    config: () => ({ rows: [] }),
+    // VIS-1231: starts with ONE row, not zero. An empty dashboard can't accept
+    // a drag (there is no row to drop into), so a brand-new one landed the user
+    // on a canvas whose only useful action was "add a row" — the row is a
+    // prerequisite, not a choice. Born valid: one row holding one empty slot,
+    // which is also a live drop target (VIS-989).
+    config: () => ({ rows: [createRow()] }),
   },
   chart: {
     namePrefix: 'new-chart',

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -22,6 +22,20 @@ describe('createWorkspaceObject', () => {
     expect(result).toMatchObject({ success: true, name: template.namePrefix, type });
   });
 
+  // VIS-1231: a zero-row dashboard can't accept a drag (nothing to drop into),
+  // so "+ New" hands back one that is already usable.
+  test('a new dashboard starts with one row holding an empty slot', async () => {
+    const save = jest.fn(async () => ({ success: true }));
+    useStore.setState({ dashboards: [], saveDashboard: save });
+
+    await useStore.getState().createWorkspaceObject('dashboard');
+
+    const [, config] = save.mock.calls[0];
+    expect(config.rows).toHaveLength(1);
+    // Born valid, and a live drop target (VIS-989) rather than `items: []`.
+    expect(config.rows[0]).toEqual({ height: 'medium', items: [{ width: 1 }] });
+  });
+
   test('deduplicates against the existing collection', async () => {
     const save = jest.fn(async () => ({ success: true }));
     useStore.setState({


### PR DESCRIPTION
Closes VIS-1231.

## The problem

An empty dashboard **advertised a drop target it didn't have**. The canvas said *"Drag a chart from the Library to begin"* and offered **+ New chart / table / markdown** shortcuts — but with zero rows there's nothing to drop **into**, so the drag silently did nothing, and the shortcuts bounced you to the Explorer with the same problem waiting when you came back.

A row is a **prerequisite, not a choice**. So:

## Changes

**1. "+ New" dashboards start with one row.** One row holding one empty slot — born valid, and a live drop target (VIS-989). The canvas is usable on arrival, which is the real fix for "drag doesn't work on a new dashboard".

**2. The empty state asks for a row.** Still reachable by deleting every row, it keeps the "Add row" CTA and now says what has to happen first:

> Dashboards are built from rows. Add one to start, then drag charts, tables, and markdown from the Library into it.

**3. Removed the "+ New chart / table / markdown" shortcuts** entirely, along with the inline-create handler and store reads behind them.

**4. Fixed the Add Row button overlapping the cell above.** It was pinned to the canvas floor (`bottom-2`), so on a dashboard whose rows reached the bottom the dashed button rendered *on top of* the last cell — exactly what you screenshotted. It's now measured from the last row's box and parked `12px` below it, falling back to the floor only until the first measurement.

## Verification
- New tests: the empty state names the row as step one and offers **no** inline-create shortcuts; the end button parks below the last row (geometry mocked — last row spans 210→400, button lands at `412px`, with no floor pin); a new dashboard's payload is exactly one row with one empty slot.
- Updated `dashboardStore` create tests (the draft is no longer empty).
- Checked against a **live sandbox**: the one-row payload POSTs `201` and reads back as `[{"height": "medium", "items": [{"width": 1}]}]`.
- Full viewer suite **6798 passed**; `yarn lint` clean.

## Note
Touches `inlineCreateStore.js`, which #619 and #620 also edit (different hunks — the dashboard template vs. the relation template / separator). Should merge cleanly in any order; happy to rebase if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
