### PR TITLE
Document query strings, context strings, and slices (VIS-1239)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - Source Types: topics/source-types.md
       - Semantic Layer: topics/semantic-layer.md
       - Interactivity: topics/interactivity.md
+      - Query & Context Strings: topics/query-and-context-strings.md
       - Inputs: topics/inputs.md
       - Including: topics/including.md
       - Environment Variables: topics/environment-variables.md

--- a/mkdocs/topics/query-and-context-strings.md
+++ b/mkdocs/topics/query-and-context-strings.md
@@ -1,0 +1,123 @@
+# Query & Context Strings
+
+Two kinds of string appear all over a Visivo project, and they do different jobs:
+
+| Form | Name | What it is |
+| --- | --- | --- |
+| `${ref(name).property}` | **Context string** | A reference to another object's value |
+| `?{ ... }` | **Query string** | SQL that is evaluated *in the query* |
+| `?{ ... }[0]` | **Slice** | An index into the *result* of that query |
+
+A single insight prop usually combines them — a query string wrapping one or more context strings:
+
+```yaml
+props:
+  y: ?{ sum(${ref(widget_sales).quantity}) }
+```
+
+Read that inside-out: `${ref(widget_sales).quantity}` points at a column of the
+`widget_sales` model, and the surrounding `?{ ... }` is the SQL that aggregates it.
+
+## Context strings — `${ref(name).property}`
+
+A context string references another object. The `ref(name)` part names the object; everything after
+it is a **property path** into that object's value.
+
+```yaml
+${ref(widget_sales).quantity}      # a column of a model
+${ref(region).value}               # a single-select input's selected value
+${ref(regions).values}             # a multi-select input's selected values
+```
+
+Property paths may include **indexes** and nested segments:
+
+```yaml
+${ref(my_insight).column[0]}       # first element of a property
+${ref(my_insight).list[0].prop}    # nested path
+${ref(my_insight)[0]}              # index the referenced value directly
+```
+
+## Query strings — `?{ ... }`
+
+Everything between `?{` and `}` is SQL, compiled into the query Visivo runs against your source.
+Aggregations, functions, `case` expressions and arithmetic all belong **inside** the braces:
+
+```yaml
+props:
+  x: ?{ date_trunc('week', ${ref(widget_sales).completed_at}) }
+  y: ?{ sum(${ref(widget_sales).quantity}) }
+  marker:
+    color: ?{ case when sum(${ref(widget_sales).quantity}) > 200 then 'green' else 'blue' end }
+```
+
+To divide a value by 100, the division is SQL, so it goes inside:
+
+```yaml
+y: ?{ sum(${ref(widget_sales).quantity}) / 100 }
+```
+
+## Slices — `?{ ... }[0]`
+
+A query string normally produces a **column of values**. A slice picks from that result *after* the
+query runs. It goes **outside** the closing brace, and it must be the **last** thing in the value.
+
+The common case is an [indicator](../reference/configuration/Chart/index.md), which needs a single
+number rather than a column:
+
+```yaml
+props:
+  type: indicator
+  value: ?{${ref(indicator-data).value}}[0]
+```
+
+Supported forms:
+
+| Slice | Result |
+| --- | --- |
+| *(omitted)* | The whole column |
+| `[0]`, `[-1]` | A single element, as a scalar |
+| `[1:5]`, `[:5]`, `[1:]` | A sub-range |
+| `[0:9:2]` | A strided range |
+| `[0,2,5]` | Specific indexes |
+
+Only integers are valid inside the brackets — `[a]` and `[1.5]` are rejected.
+
+## The two indexes are not the same thing
+
+This is the easiest thing to get wrong, because both are written `[0]`:
+
+```yaml
+${ref(my_insight).column[0]}   # INSIDE  → index the referenced object's property
+?{ sum(${ref(m).quantity}) }[0]  # OUTSIDE → index this query's result
+```
+
+The first is part of a reference and is resolved when the reference is looked up. The second is
+applied to the rows the query returns. If you want a scalar out of a query you wrote, you want the
+second one.
+
+## What does not work
+
+Nothing may follow the slice — the value ends there:
+
+```yaml
+# Invalid: the slice must be last
+value: ?{ sum(${ref(m).quantity}) }[0] / 100
+```
+
+Put the arithmetic inside the braces instead, where the SQL is evaluated:
+
+```yaml
+# Valid
+value: ?{ sum(${ref(m).quantity}) / 100 }[0]
+```
+
+The order to remember is **aggregate → modify → slice**: aggregate and modify inside `?{ }`, then
+slice the result outside it.
+
+## Where each form is accepted
+
+- **Insight `props` and `interactions`** accept context strings, query strings and slices.
+- **Model, dimension, metric and relation expressions** accept context strings; a dimension or metric
+  expression is SQL already, so it needs no `?{ }` wrapper.
+- **`chart.layout`** does not evaluate query strings today — a chart has no query of its own, so
+  there is no result for a slice to index.


### PR DESCRIPTION
Closes VIS-1239 — Phase 0 of **VIS-1238** (one pill editor for query/context strings).

## Why

The slice grammar (`?{expr}[0]`) shipped in PR #390 and is **documented nowhere**. Every "slice" mention in `mkdocs/` is prose about slicing data, not the grammar. `?{ }` and `${ref()}` appear throughout `how_it_works.md` and `concepts/insight.md` **by example only**, with no page stating the rules.

That gap is not academic: working out where a modifier like `/ 100` or an index `[0]` is actually allowed required reading regexes in `visivo/query/patterns.py`. The pill editor can't offer a "modifier" field until the format it generates is written down — hence this lands first.

## The two things people get wrong

**1. Both indexes are written `[0]`, and they mean different things.**

```yaml
${ref(m).column[0]}          # INSIDE  → indexes the REFERENCED OBJECT'S property
?{ sum(${ref(m).qty}) }[0]   # OUTSIDE → indexes THIS QUERY'S result
```

**2. Nothing may follow the slice.** The natural guess is wrong:

```yaml
value: ?{ sum(${ref(m).qty}) }[0] / 100   # invalid — pattern is anchored
value: ?{ sum(${ref(m).qty}) / 100 }[0]   # valid
```

Arithmetic is SQL, so it goes *inside*. The order is **aggregate → modify → slice**.

## Contents

`mkdocs/topics/query-and-context-strings.md`, in the Tutorials nav after Interactivity:

- `${ref(name).property}` — context strings, including property paths and indexes (`${ref(m).list[0].prop}`, `${ref(m)[0]}`)
- `?{ ... }` — query strings; aggregations, functions and arithmetic go inside
- `[slice]` — post-query index; a table of every supported form (`[0]`, `[-1]`, `[1:5]`, `[0:9:2]`, `[0,2,5]`) and the note that only integers are valid
- The two-indexes section and a "what does not work" section
- Where each form is accepted — including that `chart.layout` doesn't evaluate query strings (VIS-746)

## Verification

**Every example on the page was executed against the live patterns** — `QUERY_STRING_VALUE_PATTERN` and `CONTEXT_STRING_REF_PATTERN` — including the invalid one, which is confirmed *rejected*:

```
ok   ?{ sum(${ref(widget_sales).quantity}) / 100 }
ok   ?{${ref(indicator-data).value}}[0]
ok   (correctly rejected) ?{ sum(${ref(m).quantity}) }[0] / 100
ok   ${ref(my_insight).list[0].prop}
ALL DOC EXAMPLES VERIFIED
```

So the page states what the parser actually does, not what it looks like it should do. The indicator example is lifted from `test-projects/docs-examples`, so it's a real working config.

`mkdocs build` clean — no warnings, errors, or spellcheck failures for the new page; nav links render from sibling pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
