### PR TITLE
Stop the pill/code editor flip-flopping (VIS-1240)

### DIFF
--- a/viewer/src/components/explorer/AddComputedColumnPopover.jsx
+++ b/viewer/src/components/explorer/AddComputedColumnPopover.jsx
@@ -3,6 +3,17 @@ import { createPortal } from 'react-dom';
 import { PiPlus, PiX, PiCheckCircle, PiWarningCircle, PiSpinner } from 'react-icons/pi';
 import { recordOnboardingAction } from '../onboarding/onboardingState';
 import { getTypeColors } from '../views/common/objectTypeConfigs';
+import { refKindsFor } from '../views/common/fieldTypes';
+
+// A "computed column" is the Explorer's name for a MODEL-SCOPED metric or
+// dimension: it promotes with a `parentModel`, and `project_writer._new` nests
+// it under `model.metrics` / `model.dimensions`. Nesting is what makes
+// `sql_model.py` reject any `ref()` in the expression, so this field's declared
+// ref vocabulary is empty — which is why the editor below is a bare textarea
+// and not `RefTextArea`. Read it from the registry rather than asserting it
+// here, so if the rule ever changes this surface follows. See VIS-1253.
+const COMPUTED_COLUMN_REF_KINDS = refKindsFor('metric', 'expression', { nested: true });
+const REF_PATTERN = /\$\{\s*ref\s*\(/;
 
 const DEBOUNCE_MS = 750;
 
@@ -203,6 +214,10 @@ const AddComputedColumnPopover = ({
           <label className="block text-xs font-medium text-secondary-600 mb-1">
             SQL Expression
           </label>
+          {/* Deliberately plain: no ref-insert menu, no @ mention, no drop
+              target. `COMPUTED_COLUMN_REF_KINDS` is empty, so every one of
+              those affordances would offer an insertion the backend rejects on
+              save. Do not "upgrade" this to RefTextArea. */}
           <textarea
             value={expression}
             onChange={handleExpressionChange}
@@ -211,6 +226,16 @@ const AddComputedColumnPopover = ({
             className="w-full px-2 py-1.5 text-xs font-mono border border-secondary-300 rounded bg-white focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none"
             data-testid="computed-col-expression"
           />
+          {/* Caught while typing rather than as a Pydantic error after Save. */}
+          {!COMPUTED_COLUMN_REF_KINDS.length && REF_PATTERN.test(expression) && (
+            <p
+              className="mt-1 text-xs font-medium text-highlight-600"
+              data-testid="computed-col-ref-warning"
+            >
+              References aren&apos;t available here — a computed column reads columns from its
+              model directly. Saving with a <code>ref()</code> will fail.
+            </p>
+          )}
         </div>
 
         {isValidating && (

--- a/viewer/src/components/explorer/AddComputedColumnPopover.test.jsx
+++ b/viewer/src/components/explorer/AddComputedColumnPopover.test.jsx
@@ -274,4 +274,40 @@ describe('AddComputedColumnPopover', () => {
     expect(onValidate).toHaveBeenCalledTimes(1);
     expect(onValidate).toHaveBeenCalledWith('SUM');
   });
+
+  // A computed column is a MODEL-SCOPED (nested) metric/dimension, and
+  // `sql_model.py` rejects any ref() in a nested expression. The editor must
+  // therefore offer no ref affordances — and say so before Save, not after.
+  describe('refs are not available here (VIS-1253)', () => {
+    const openPopover = () => {
+      renderPopover();
+      fireEvent.click(screen.getByTestId('add-computed-column-btn'));
+    };
+
+    test('the expression field offers no ref-insert affordance', () => {
+      openPopover();
+      expect(screen.getByTestId('computed-col-expression')).toBeInTheDocument();
+      // No RefTextArea machinery: no + ref menu, no chips, no drop target.
+      expect(screen.queryByTestId('ref-text-area')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('add-ref-button')).not.toBeInTheDocument();
+    });
+
+    test('a pasted ref is flagged inline while typing', () => {
+      openPopover();
+      fireEvent.change(screen.getByTestId('computed-col-expression'), {
+        // eslint-disable-next-line no-template-curly-in-string
+        target: { value: 'sum(${ref(orders).amount})' },
+      });
+      expect(screen.getByTestId('computed-col-ref-warning')).toBeInTheDocument();
+    });
+
+    test('a plain SQL expression is not flagged', () => {
+      openPopover();
+      fireEvent.change(screen.getByTestId('computed-col-expression'), {
+        target: { value: 'SUM(amount)' },
+      });
+      expect(screen.queryByTestId('computed-col-ref-warning')).not.toBeInTheDocument();
+    });
+  });
+
 });

--- a/viewer/src/components/views/common/ExpressionField.jsx
+++ b/viewer/src/components/views/common/ExpressionField.jsx
@@ -30,6 +30,10 @@ export function ExpressionField({
   disabled = false,
   rows = 4,
   helperText,
+  // The model this field is scoped to, when it is. Named in the copy so a user
+  // can tell at a glance WHY refs are unavailable — and can catch us being
+  // wrong about it.
+  scopedToModel = null,
   'data-testid': dataTestId,
 }) {
   const spec = useMemo(
@@ -64,6 +68,9 @@ export function ExpressionField({
         helperText={helperText}
         allowedTypes={spec.refKinds}
         acceptDrops
+        // A ref here is editable in place: click the chip to re-point it
+        // instead of deleting and retyping the whole `${ref(model).column}`.
+        configurableChips
       />
     );
   }
@@ -93,8 +100,18 @@ export function ExpressionField({
         />
         {strayRef && (
           <p className="text-xs font-medium text-highlight-600" data-testid="plain-sql-ref-warning">
-            References aren&apos;t available in this field — it reads columns from its parent model
-            directly. Saving with a <code>ref()</code> will fail.
+            {scopedToModel ? (
+              <>
+                Scoped to <strong>{scopedToModel}</strong>, so it reads that model&apos;s columns
+                directly — references aren&apos;t available here and saving with a{' '}
+                <code>ref()</code> will fail.
+              </>
+            ) : (
+              <>
+                References aren&apos;t available in this field — it reads columns from its parent
+                model directly. Saving with a <code>ref()</code> will fail.
+              </>
+            )}
           </p>
         )}
         {helperText && !strayRef && <p className="text-xs text-gray-500">{helperText}</p>}

--- a/viewer/src/components/views/common/ExpressionField.jsx
+++ b/viewer/src/components/views/common/ExpressionField.jsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react';
+import RefTextArea from './RefTextArea';
+import { fieldTypeFor, EDITORS } from './fieldTypes';
+
+/**
+ * ExpressionField — renders the right editor for a field, from its declared type.
+ *
+ * Every surface used to decide for itself which control an expression got, and
+ * which refs it could contain. They disagreed: seven different `allowedTypes`
+ * literals, a hand-maintained `TYPE_CONFIG`, and a plain textarea in the
+ * Explorer that happened to be right for reasons nobody had written down. This
+ * takes `{objectType, field, nested}`, asks `fieldTypes` what the rules are, and
+ * renders accordingly — so a rule changes in one place.
+ *
+ * Covers the two raw-SQL editors today. `query-string` slots are still rendered
+ * by `PropertyRow` (they need the JSON schema and slot shape to build the pill),
+ * and `object-ref` by `RefDropZone`; folding those in is VIS-1243. This throws
+ * on those rather than guessing, so a mis-wired call site fails loudly at the
+ * call rather than rendering a subtly wrong editor.
+ */
+export function ExpressionField({
+  objectType,
+  field,
+  nested = false,
+  value,
+  onChange,
+  label,
+  error,
+  required = false,
+  disabled = false,
+  rows = 4,
+  helperText,
+  'data-testid': dataTestId,
+}) {
+  const spec = useMemo(
+    () => fieldTypeFor(objectType, field, { nested }),
+    [objectType, field, nested]
+  );
+
+  // A ref pasted into a ref-free field is rejected by Pydantic at save time
+  // (`sql_model.py`'s nested prohibition). Say so while they're typing instead.
+  const strayRef = useMemo(() => {
+    if (!spec || spec.refKinds.length > 0) return null;
+    return /\$\{\s*ref\s*\(/.test(value || '') ? true : null;
+  }, [spec, value]);
+
+  if (!spec) {
+    throw new Error(
+      `ExpressionField: no declared field type for '${objectType}.${field}'. ` +
+        `Add it to fieldTypes.js rather than picking an editor here.`
+    );
+  }
+
+  if (spec.editor === EDITORS.CONTEXT_SQL) {
+    return (
+      <RefTextArea
+        value={value ?? ''}
+        onChange={onChange}
+        label={label}
+        required={required}
+        error={error}
+        disabled={disabled}
+        rows={rows}
+        helperText={helperText}
+        allowedTypes={spec.refKinds}
+        acceptDrops
+      />
+    );
+  }
+
+  if (spec.editor === EDITORS.PLAIN_SQL) {
+    return (
+      <div className="space-y-1" data-testid={dataTestId || 'plain-sql-field'}>
+        {label && (
+          <label className="block text-sm font-medium text-gray-700">
+            {label}
+            {required && <span className="ml-0.5 text-red-500">*</span>}
+          </label>
+        )}
+        {/* Deliberately a bare textarea: no ref-insert menu, no @ mention, no
+            drop target. This field's refKinds are empty, so every one of those
+            affordances would offer an insertion the backend rejects on save.
+            Do not "upgrade" this to RefTextArea — see VIS-1253. */}
+        <textarea
+          value={value ?? ''}
+          onChange={e => onChange(e.target.value)}
+          rows={rows}
+          disabled={disabled}
+          spellCheck={false}
+          aria-label={label || 'expression'}
+          data-testid="plain-sql-input"
+          className="w-full resize-y rounded-md border border-gray-300 px-2 py-1.5 font-mono text-xs text-gray-800 focus:border-primary-500 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
+        />
+        {strayRef && (
+          <p className="text-xs font-medium text-highlight-600" data-testid="plain-sql-ref-warning">
+            References aren&apos;t available in this field — it reads columns from its parent model
+            directly. Saving with a <code>ref()</code> will fail.
+          </p>
+        )}
+        {helperText && !strayRef && <p className="text-xs text-gray-500">{helperText}</p>}
+        {error && <p className="text-xs font-medium text-highlight-600">{error}</p>}
+      </div>
+    );
+  }
+
+  throw new Error(
+    `ExpressionField: '${spec.editor}' is still rendered by its own component ` +
+      `(${spec.editor === EDITORS.QUERY_STRING ? 'PropertyRow' : 'RefDropZone'}). ` +
+      `Folding it in is VIS-1243.`
+  );
+}
+
+export default ExpressionField;

--- a/viewer/src/components/views/common/ExpressionField.test.jsx
+++ b/viewer/src/components/views/common/ExpressionField.test.jsx
@@ -1,0 +1,117 @@
+/* eslint-disable no-template-curly-in-string -- fixtures use literal `${ref(...)}` strings */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExpressionField from './ExpressionField';
+
+// RefTextArea is a contentEditable pill editor; these tests care only about
+// WHICH editor is chosen and what it is told, not how it renders internally.
+jest.mock('./RefTextArea', () => {
+  return function MockRefTextArea({ value, onChange, allowedTypes, acceptDrops, label }) {
+    return (
+      <div
+        data-testid="ref-text-area"
+        data-allowed-types={(allowedTypes || []).join(',')}
+        data-accept-drops={acceptDrops ? 'true' : 'false'}
+      >
+        <span>{label}</span>
+        <input value={value || ''} onChange={e => onChange(e.target.value)} data-testid="ref-input" />
+      </div>
+    );
+  };
+});
+
+describe('ExpressionField — the editor comes from the declared field type', () => {
+  test('a context-sql field renders the ref editor, scoped to its own vocabulary', () => {
+    render(
+      <ExpressionField objectType="relation" field="condition" value="" onChange={jest.fn()} />
+    );
+    const editor = screen.getByTestId('ref-text-area');
+    // Models only — a metric ref is an aggregate, not a join key.
+    expect(editor).toHaveAttribute('data-allowed-types', 'model');
+    expect(editor).toHaveAttribute('data-accept-drops', 'true');
+  });
+
+  test('a different context-sql field gets a different vocabulary from the same component', () => {
+    render(<ExpressionField objectType="metric" field="expression" value="" onChange={jest.fn()} />);
+    expect(screen.getByTestId('ref-text-area').getAttribute('data-allowed-types')).toContain(
+      'metric'
+    );
+  });
+
+  test('the SAME field nested under a model becomes a plain textarea', () => {
+    const { rerender } = render(
+      <ExpressionField objectType="metric" field="expression" value="" onChange={jest.fn()} />
+    );
+    expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+
+    rerender(
+      <ExpressionField objectType="metric" field="expression" nested value="" onChange={jest.fn()} />
+    );
+    // `sql_model.py` rejects any ref in a nested expression, so there must be
+    // no ref affordance at all — not merely an empty menu.
+    expect(screen.queryByTestId('ref-text-area')).not.toBeInTheDocument();
+    expect(screen.getByTestId('plain-sql-input')).toBeInTheDocument();
+  });
+
+  test('a plain-sql field edits as text', () => {
+    const onChange = jest.fn();
+    render(
+      <ExpressionField
+        objectType="dimension"
+        field="expression"
+        nested
+        value="date_trunc(day, ts)"
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByTestId('plain-sql-input');
+    expect(input).toHaveValue('date_trunc(day, ts)');
+    fireEvent.change(input, { target: { value: 'lower(name)' } });
+    expect(onChange).toHaveBeenCalledWith('lower(name)');
+  });
+
+  test('a ref pasted into a ref-free field is flagged while typing, not at save', () => {
+    render(
+      <ExpressionField
+        objectType="metric"
+        field="expression"
+        nested
+        value="sum(${ref(orders).amount})"
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('plain-sql-ref-warning')).toBeInTheDocument();
+  });
+
+  test('a clean plain-sql value shows its helper text, not a warning', () => {
+    render(
+      <ExpressionField
+        objectType="metric"
+        field="expression"
+        nested
+        value="SUM(amount)"
+        onChange={jest.fn()}
+        helperText="Plain SQL over the parent model."
+      />
+    );
+    expect(screen.queryByTestId('plain-sql-ref-warning')).not.toBeInTheDocument();
+    expect(screen.getByText('Plain SQL over the parent model.')).toBeInTheDocument();
+  });
+
+  test('an undeclared field fails loudly rather than guessing an editor', () => {
+    // Silence React's error-boundary logging for the expected throw.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(<ExpressionField objectType="relation" field="join_type" value="" onChange={jest.fn()} />)
+    ).toThrow(/no declared field type/);
+    spy.mockRestore();
+  });
+
+  test('a query-string field names the component that still owns it', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(<ExpressionField objectType="insight" field="x" value="" onChange={jest.fn()} />)
+    ).toThrow(/PropertyRow/);
+    spy.mockRestore();
+  });
+});

--- a/viewer/src/components/views/common/ExpressionField.test.jsx
+++ b/viewer/src/components/views/common/ExpressionField.test.jsx
@@ -114,4 +114,40 @@ describe('ExpressionField — the editor comes from the declared field type', ()
     ).toThrow(/PropertyRow/);
     spy.mockRestore();
   });
+
+  // A dimension can be model-scoped or standalone, and the Library lists both in
+  // one flat DIMENSIONS section — so a user has no way to tell which they're
+  // editing. Naming the model makes the classification checkable at a glance
+  // instead of only by reading the YAML.
+  test('the ref-free warning names the model it is scoped to', () => {
+    render(
+      <ExpressionField
+        objectType="dimension"
+        field="expression"
+        nested
+        scopedToModel="new-model"
+        value="${ref(new-model)}"
+        onChange={jest.fn()}
+      />
+    );
+    const warning = screen.getByTestId('plain-sql-ref-warning');
+    expect(warning).toHaveTextContent('Scoped to');
+    expect(warning).toHaveTextContent('new-model');
+  });
+
+  test('falls back to generic copy when the model is unknown', () => {
+    render(
+      <ExpressionField
+        objectType="dimension"
+        field="expression"
+        nested
+        value="${ref(x)}"
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('plain-sql-ref-warning')).toHaveTextContent(
+      /References aren't available/
+    );
+  });
+
 });

--- a/viewer/src/components/views/common/InputEditForm.jsx
+++ b/viewer/src/components/views/common/InputEditForm.jsx
@@ -12,6 +12,7 @@ import Select from '../../common/Select';
 import useFormBaseline from '../../../hooks/useFormBaseline';
 import { validateName } from './namedModel';
 import { validateInputDraft, buildInputConfig } from './inputConfigValidation';
+import { refKindsFor } from './fieldTypes';
 
 const INPUT_TYPES = [
   { value: 'single-select', label: 'Single Select' },
@@ -407,7 +408,7 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
               <RefTextArea
                 value={optionsQuery}
                 onChange={val => setOptionsQuery(val)}
-                allowedTypes={['model']}
+                allowedTypes={refKindsFor('input', 'options')}
                 label=""
                 rows={3}
                 // eslint-disable-next-line no-template-curly-in-string

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -14,6 +14,7 @@ import { getTypeByValue } from './objectTypeConfigs';
 import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
+import { refKindsFor } from './fieldTypes';
 import {
   SectionContainer,
   EmptyState,
@@ -330,7 +331,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
                       value={interaction.value}
                       onChange={value => updateInteractionValue(index, value)}
                       label={typeConfig.label}
-                      allowedTypes={['model', 'dimension', 'metric']}
+                      allowedTypes={refKindsFor('interaction', 'filter')}
                       rows={2}
                       helperText={typeConfig.helperText}
                     />

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -15,6 +15,7 @@ import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
 import { refKindsFor } from './fieldTypes';
+import { REF_INSERT_HINT } from './RefTextArea';
 import {
   SectionContainer,
   EmptyState,
@@ -333,7 +334,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
                       label={typeConfig.label}
                       allowedTypes={refKindsFor('interaction', 'filter')}
                       rows={2}
-                      helperText={typeConfig.helperText}
+                      helperText={`${typeConfig.helperText} ${REF_INSERT_HINT}`}
                     />
                   </div>
                 );

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -35,6 +35,24 @@ const rangePartsOf = slice =>
   sliceModeOf(slice) === 'range' ? slice.slice(1, -1).split(':') : ['', ''];
 const rangeExpr = (start, end) => (start === '' && end === '' ? '' : `[${start}:${end}]`);
 
+/**
+ * The rows a PillMenu can offer. `useAs`, `index` and `modifier` only make
+ * sense when the pill owns the ENTIRE value — they serialize into the wrapper
+ * around the ref (`sum(...)`, a trailing `[0]`, a trailing `/ 100`). Inside a
+ * RefTextArea the wrapper is free text the user already controls, so a chip
+ * there asks for `property` alone.
+ */
+export const PILL_SECTIONS = {
+  PROPERTY: 'property',
+  USE_AS: 'useAs',
+  INDEX: 'index',
+  MODIFIER: 'modifier',
+  ACTIONS: 'actions',
+};
+const ALL_SECTIONS = Object.values(PILL_SECTIONS);
+/** What an embedded chip offers: re-point the ref, or remove it. */
+export const CHIP_SECTIONS = [PILL_SECTIONS.PROPERTY];
+
 const AGG_LABELS = {
   sum: 'SUM',
   avg: 'AVG',
@@ -221,6 +239,12 @@ const PillMenu = React.forwardRef(
       state,
       slice = null,
       slotShape = 'unknown',
+      // Which rows this menu offers. A pill that OWNS its whole value wants all
+      // of them; a chip embedded in free text does not — its aggregation,
+      // index and modifier are the surrounding SQL, not properties of the ref,
+      // so offering them there would ask the user to author something the
+      // editor can't place. Callers narrow rather than the menu guessing.
+      sections = ALL_SECTIONS,
       onApply,
       onManualEdit,
       onSaveAsMetric,
@@ -322,6 +346,7 @@ const PillMenu = React.forwardRef(
           <PillMenuPopover
             state={state}
             slotShape={slotShape}
+            sections={sections}
             draft={draft}
             setDraft={setDraft}
             onApply={handleApply}
@@ -359,6 +384,7 @@ PillMenu.displayName = 'PillMenu';
 const PillMenuPopover = ({
   state,
   slotShape,
+  sections,
   draft,
   setDraft,
   onApply,
@@ -583,6 +609,8 @@ const PillMenuPopover = ({
               </div>
             )}
           </div>
+          {sections.includes(PILL_SECTIONS.USE_AS) && (
+            <>
           <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
             Use as
           </div>
@@ -601,6 +629,8 @@ const PillMenuPopover = ({
               testId={`pill-menu-preset-${agg}`}
             />
           ))}
+            </>
+          )}
           <Divider />
         </>
       )}
@@ -609,6 +639,8 @@ const PillMenuPopover = ({
           setting an aggregation and an index meant two different controls.
           "All values" is the default and is deliberately NOT shown on the pill
           itself; only a real index gets a badge. */}
+      {sections.includes(PILL_SECTIONS.INDEX) && (
+        <>
       <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
         Index
       </div>
@@ -675,7 +707,11 @@ const PillMenuPopover = ({
           </div>
         )}
       </div>
+        </>
+      )}
 
+      {sections.includes(PILL_SECTIONS.MODIFIER) && (
+        <>
       {/* Modifier — trailing SQL, applied INSIDE the `?{ }` so an index can
           still follow it (`?{ sum(x) / 100 }[0]`). This is what keeps a
           modified expression a pill instead of dropping it to raw text. */}
@@ -693,6 +729,8 @@ const PillMenuPopover = ({
           className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs font-mono text-gray-800 placeholder:text-gray-300 focus:border-primary-500 focus:outline-none"
         />
       </div>
+        </>
+      )}
 
       <div className="flex items-center justify-end gap-2 px-3 pb-2 pt-1">
         <button
@@ -718,6 +756,8 @@ const PillMenuPopover = ({
           Apply
         </button>
       </div>
+      {sections.includes(PILL_SECTIONS.ACTIONS) && (
+        <>
       <Divider />
 
       <button
@@ -765,6 +805,9 @@ const PillMenuPopover = ({
           Only an aggregate pill (SUM, AVG, …) can be saved as a metric.
         </p>
       )}
+        </>
+      )}
+
       <Divider />
       <button
         type="button"

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { PiCaretDown, PiWarningCircle, PiTextAa, PiTrash } from 'react-icons/pi';
 import useStore from '../../../stores/store';
@@ -7,6 +7,7 @@ import { PRESET_AGGREGATIONS, isMedianSupported } from './pillGrammar';
 import { parseRefValue } from '../../../utils/refString';
 import { inferColumnTypes } from '../../../utils/inferColumnTypes';
 import { getSourceDialect } from '../../../stores/explorerStore';
+import { useModelColumns } from '../workspace/relations/useModelColumns';
 
 const AGG_LABELS = {
   sum: 'SUM',
@@ -189,13 +190,43 @@ function Divider() {
  */
 const PillMenu = React.forwardRef(
   (
-    { state, onSelectPreset, onCustomAggregation, onSaveAsMetric, onRemove, disabled = false },
+    {
+      state,
+      slice = null,
+      onApply,
+      onCustomAggregation,
+      onSaveAsMetric,
+      onRemove,
+      disabled = false,
+    },
     ref
   ) => {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
 
-  useImperativeHandle(ref, () => ({ open: () => setOpen(true) }), []);
+  // VIS-1241: the menu is a FORM now, not a list of instant commands. Every
+  // click used to commit and close, so changing an aggregation AND an index
+  // meant opening the menu twice, and there was no way to change the property
+  // at all. Edits collect in a draft and land on Apply.
+  const buildDraft = useCallback(
+    () => ({
+      useAs: state?.kind === 'aggregate' ? state.agg : 'dimension',
+      column: state?.column ?? '',
+      modifier: state?.modifier ?? '',
+      slice: slice ?? '',
+    }),
+    [state, slice]
+  );
+  const [draft, setDraft] = useState(buildDraft);
+
+  // Seeded on OPEN (not on every state change) so a re-render mid-edit can't
+  // stomp what the user is typing.
+  const openMenu = useCallback(() => {
+    setDraft(buildDraft());
+    setOpen(true);
+  }, [buildDraft]);
+
+  useImperativeHandle(ref, () => ({ open: openMenu }), [openMenu]);
 
   const isColumnBacked = state?.kind === 'dimension' || state?.kind === 'aggregate';
   const isNumeric = useColumnIsNumeric(isColumnBacked ? state.ref : null, state?.column);
@@ -209,13 +240,13 @@ const PillMenu = React.forwardRef(
   const saveAsMetricEnabled =
     (state?.kind === 'aggregate' || state?.kind === 'custom') && typeof onSaveAsMetric === 'function';
 
-  const presetIsSelected = preset => {
-    if (preset === 'dimension') return state?.kind === 'dimension';
-    return state?.kind === 'aggregate' && state?.agg === preset;
-  };
+  const presetIsSelected = preset => draft.useAs === preset;
 
-  const handleSelect = preset => {
-    onSelectPreset?.(preset);
+  // Selecting a preset now EDITS the draft; nothing commits until Apply.
+  const handleSelect = preset => setDraft(d => ({ ...d, useAs: preset }));
+
+  const handleApply = () => {
+    onApply?.(draft);
     setOpen(false);
   };
 
@@ -240,7 +271,8 @@ const PillMenu = React.forwardRef(
         ref={triggerRef}
         onClick={e => {
           e.stopPropagation();
-          setOpen(o => !o);
+          if (open) setOpen(false);
+          else openMenu();
         }}
         disabled={disabled}
         aria-haspopup="menu"
@@ -256,6 +288,9 @@ const PillMenu = React.forwardRef(
         createPortal(
           <PillMenuPopover
             state={state}
+            draft={draft}
+            setDraft={setDraft}
+            onApply={handleApply}
             style={menuStyle}
             onClose={() => setOpen(false)}
             isNumeric={isNumeric}
@@ -289,6 +324,9 @@ PillMenu.displayName = 'PillMenu';
 
 const PillMenuPopover = ({
   state,
+  draft,
+  setDraft,
+  onApply,
   style,
   onClose,
   isNumeric,
@@ -304,6 +342,15 @@ const PillMenuPopover = ({
   triggerRef,
 }) => {
   const containerRef = useRef(null);
+  // Column list for the property picker. Requested HERE rather than in the
+  // parent because this component is mounted only while the menu is open — a
+  // property panel full of pills would otherwise fire one schema request per
+  // row on every render.
+  const modelName = isColumnBacked ? state?.ref || null : null;
+  const modelNames = useMemo(() => (modelName ? [modelName] : []), [modelName]);
+  const { columnsByModel, loading: columnsLoading } = useModelColumns(modelNames);
+  const columns = columnsByModel?.[modelName] || [];
+
   // T4 (pills-buildrail #5): measured-then-flip. `style` is the DOWNWARD
   // guess computed before the popover's actual content (a variable-length
   // preset list + header + collision warning) has rendered anywhere, so its
@@ -410,6 +457,52 @@ const PillMenuPopover = ({
 
       {isColumnBacked && (
         <>
+          {/* VIS-1241: the property picker — the half of the pill that could
+              never be changed here. The header was static text, so re-pointing
+              a pill at a different column meant a drag or a raw-text edit.
+              Columns come from the model-schema endpoint, which only started
+              answering for uncommitted models in #619. */}
+          <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+            Property
+          </div>
+          <div className="px-3 pb-1.5">
+            {columns.length ? (
+              <select
+                value={draft.column}
+                onChange={e => setDraft(d => ({ ...d, column: e.target.value }))}
+                data-testid="pill-menu-property"
+                aria-label="Property"
+                className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+              >
+                {!columns.includes(draft.column) && draft.column && (
+                  <option value={draft.column}>{draft.column}</option>
+                )}
+                {columns.map(c => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              // No schema to offer (never-run draft, non-SQL model): keep it
+              // editable rather than trapping the pill on its current column.
+              <input
+                type="text"
+                value={draft.column}
+                onChange={e => setDraft(d => ({ ...d, column: e.target.value }))}
+                data-testid="pill-menu-property"
+                aria-label="Property"
+                className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+              />
+            )}
+            {/* A hint, not a replacement — the field stays editable while the
+                schema loads so a slow fetch never blocks the edit. */}
+            {columnsLoading && !columns.length && (
+              <div className="mt-1 text-[10px] text-gray-400" data-testid="pill-menu-columns-loading">
+                Loading columns…
+              </div>
+            )}
+          </div>
           <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
             Use as
           </div>
@@ -431,6 +524,65 @@ const PillMenuPopover = ({
           <Divider />
         </>
       )}
+
+      {/* Index — the post-query slice. Lived in a separate badge before, so
+          setting an aggregation and an index meant two different controls.
+          "All values" is the default and is deliberately NOT shown on the pill
+          itself; only a real index gets a badge. */}
+      <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        Index
+      </div>
+      <div className="px-3 pb-1.5">
+        <select
+          value={draft.slice}
+          onChange={e => setDraft(d => ({ ...d, slice: e.target.value }))}
+          data-testid="pill-menu-index"
+          aria-label="Index"
+          className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+        >
+          <option value="">All values</option>
+          <option value="[0]">First (0)</option>
+          <option value="[-1]">Last (-1)</option>
+        </select>
+      </div>
+
+      {/* Modifier — trailing SQL, applied INSIDE the `?{ }` so an index can
+          still follow it (`?{ sum(x) / 100 }[0]`). This is what keeps a
+          modified expression a pill instead of dropping it to raw text. */}
+      <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        Modifier
+      </div>
+      <div className="px-3 pb-2">
+        <input
+          type="text"
+          value={draft.modifier}
+          onChange={e => setDraft(d => ({ ...d, modifier: e.target.value }))}
+          placeholder="/ 100"
+          data-testid="pill-menu-modifier"
+          aria-label="Modifier"
+          className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs font-mono text-gray-800 placeholder:text-gray-300 focus:border-primary-500 focus:outline-none"
+        />
+      </div>
+
+      <div className="flex items-center justify-end gap-2 px-3 pb-2 pt-1">
+        <button
+          type="button"
+          onClick={onClose}
+          data-testid="pill-menu-cancel"
+          className="rounded px-2 py-1 text-[11px] font-medium text-gray-500 hover:bg-gray-100"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onApply}
+          data-testid="pill-menu-apply"
+          className="rounded bg-primary-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-primary-700"
+        >
+          Apply
+        </button>
+      </div>
+      <Divider />
 
       <button
         type="button"

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
@@ -294,8 +293,20 @@ const PillMenu = React.forwardRef(
   // 06 §4: "Save-as-metric only when state is aggregate/custom" — `custom`
   // isn't reachable via `parse()` today (see pillGrammar.js's docstring), so
   // in practice this is exactly the `aggregate` kind.
-  const saveAsMetricEnabled =
-    (state?.kind === 'aggregate' || state?.kind === 'custom') && typeof onSaveAsMetric === 'function';
+  // Review finding #3: these were ANDed into one flag, so a surface that
+  // simply doesn't wire the handler produced a disabled item blaming the pill
+  // ("Only an aggregate pill can be saved as a metric") — on a pill whose own
+  // header two lines above read `Aggregate (AVG)`. The same lying-affordance
+  // class this PR set out to kill, made newly reachable in the right rail once
+  // Phase 1 dropped the `droppable` gate on pills.
+  //
+  // They are different facts and get treated differently: a pill that isn't an
+  // aggregate CAN become one from this very menu, so the item stays visible and
+  // explains itself. A surface that doesn't offer the flow at all never will,
+  // so the item is omitted rather than shown permanently dead.
+  const saveAsMetricOffered = typeof onSaveAsMetric === 'function';
+  const pillIsAggregate = state?.kind === 'aggregate' || state?.kind === 'custom';
+  const saveAsMetricEnabled = saveAsMetricOffered && pillIsAggregate;
 
   const presetIsSelected = preset => draft.useAs === preset;
 
@@ -363,6 +374,7 @@ const PillMenu = React.forwardRef(
               setOpen(false);
             }}
             saveAsMetricEnabled={saveAsMetricEnabled}
+            saveAsMetricOffered={saveAsMetricOffered}
             onSaveAsMetric={() => {
               onSaveAsMetric?.();
               setOpen(false);
@@ -398,6 +410,7 @@ const PillMenuPopover = ({
   onSelectPreset,
   onManualEdit,
   saveAsMetricEnabled,
+  saveAsMetricOffered,
   onSaveAsMetric,
   onRemove,
   triggerRef,
@@ -412,17 +425,6 @@ const PillMenuPopover = ({
   const { columnsByModel, loading: columnsLoading } = useModelColumns(modelNames);
   const columns = useMemo(() => columnsByModel?.[modelName] || [], [columnsByModel, modelName]);
 
-  // An unbound `modelRef` (dropped model, nothing chosen yet) opens with
-  // `draft.column === ''`, which matches NO <option> — so the browser renders
-  // the FIRST column as the visible selection while the draft still says
-  // "nothing chosen". Apply then committed an empty column and the pill came
-  // back unbound, exactly as if the click had done nothing. Adopt whatever the
-  // control is actually showing the moment there is something to show, so the
-  // visible selection and the draft can never disagree.
-  useEffect(() => {
-    if (!columns.length) return;
-    setDraft(d => (d.column ? d : { ...d, column: columns[0] }));
-  }, [columns, setDraft]);
 
   // The Index row first shipped as All / First / Last only, which dropped
   // "At row…" and "Rows…" — both of which the standalone SliceMenu offered —
@@ -580,6 +582,21 @@ const PillMenuPopover = ({
                 aria-label="Dimension"
                 className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
               >
+                {/* Review finding #5: an unbound pill reads "choose a dimension"
+                    while the select showed the first column — the label and the
+                    control disagreeing about whether a choice had been made.
+                    Seeding `draft.column` from the first column fixed an
+                    earlier bug (a `value` matching no <option> let the browser
+                    DISPLAY one while the draft said "nothing chosen", so Apply
+                    committed empty) but it fixed it by making the lie true.
+                    An explicit placeholder makes the control honest instead:
+                    the displayed state and the draft agree, and Apply stays
+                    inert until the user actually picks. */}
+                {!draft.column && (
+                  <option value="" disabled>
+                    Choose a dimension…
+                  </option>
+                )}
                 {!columns.includes(draft.column) && draft.column && (
                   <option value={draft.column}>{draft.column}</option>
                 )}
@@ -770,6 +787,8 @@ const PillMenuPopover = ({
         <PiTextAa size={13} />
         Manually edit field…
       </button>
+      {saveAsMetricOffered && (
+        <>
       <button
         type="button"
         role="menuitem"
@@ -804,6 +823,8 @@ const PillMenuPopover = ({
         >
           Only an aggregate pill (SUM, AVG, …) can be saved as a metric.
         </p>
+      )}
+        </>
       )}
         </>
       )}

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { PiCaretDown, PiWarningCircle, PiTextAa, PiTrash } from 'react-icons/pi';
 import useStore from '../../../stores/store';
@@ -8,6 +16,24 @@ import { parseRefValue } from '../../../utils/refString';
 import { inferColumnTypes } from '../../../utils/inferColumnTypes';
 import { getSourceDialect } from '../../../stores/explorerStore';
 import { useModelColumns } from '../workspace/relations/useModelColumns';
+import { menuPolicyFor } from './SchemaEditor/utils/slotShape';
+
+// The Index row models the same slice shapes the standalone SliceMenu did.
+// `draft.slice` stays the literal expression (`[0]`, `[3]`, `[1:5]`, `''`);
+// these translate it to and from the control's mode + inputs.
+const sliceModeOf = slice => {
+  if (!slice) return '';
+  if (slice === '[0]' || slice === '[-1]') return slice;
+  const inner = slice.slice(1, -1);
+  if (/^-?\d+$/.test(inner)) return 'at';
+  if (/^-?\d*:-?\d*$/.test(inner)) return 'range';
+  // Strided / list slices are valid but have no control here — see `custom`.
+  return 'custom';
+};
+const atRowOf = slice => (sliceModeOf(slice) === 'at' ? slice.slice(1, -1) : '');
+const rangePartsOf = slice =>
+  sliceModeOf(slice) === 'range' ? slice.slice(1, -1).split(':') : ['', ''];
+const rangeExpr = (start, end) => (start === '' && end === '' ? '' : `[${start}:${end}]`);
 
 const AGG_LABELS = {
   sum: 'SUM',
@@ -194,6 +220,7 @@ const PillMenu = React.forwardRef(
     {
       state,
       slice = null,
+      slotShape = 'unknown',
       onApply,
       onCustomAggregation,
       onSaveAsMetric,
@@ -292,6 +319,7 @@ const PillMenu = React.forwardRef(
         createPortal(
           <PillMenuPopover
             state={state}
+            slotShape={slotShape}
             draft={draft}
             setDraft={setDraft}
             onApply={handleApply}
@@ -328,6 +356,7 @@ PillMenu.displayName = 'PillMenu';
 
 const PillMenuPopover = ({
   state,
+  slotShape,
   draft,
   setDraft,
   onApply,
@@ -353,7 +382,52 @@ const PillMenuPopover = ({
   const modelName = isColumnBacked ? state?.ref || null : null;
   const modelNames = useMemo(() => (modelName ? [modelName] : []), [modelName]);
   const { columnsByModel, loading: columnsLoading } = useModelColumns(modelNames);
-  const columns = columnsByModel?.[modelName] || [];
+  const columns = useMemo(() => columnsByModel?.[modelName] || [], [columnsByModel, modelName]);
+
+  // An unbound `modelRef` (dropped model, nothing chosen yet) opens with
+  // `draft.column === ''`, which matches NO <option> — so the browser renders
+  // the FIRST column as the visible selection while the draft still says
+  // "nothing chosen". Apply then committed an empty column and the pill came
+  // back unbound, exactly as if the click had done nothing. Adopt whatever the
+  // control is actually showing the moment there is something to show, so the
+  // visible selection and the draft can never disagree.
+  useEffect(() => {
+    if (!columns.length) return;
+    setDraft(d => (d.column ? d : { ...d, column: columns[0] }));
+  }, [columns, setDraft]);
+
+  // The Index row first shipped as All / First / Last only, which dropped
+  // "At row…" and "Rows…" — both of which the standalone SliceMenu offered —
+  // along with the slot-shape policy that greys out the ones a given prop
+  // can't accept (a scalar-only prop has no use for a range). The popover
+  // mounts fresh on every open, so seeding from `draft.slice` here is enough.
+  const slicePolicy = menuPolicyFor(slotShape);
+  const [indexMode, setIndexMode] = useState(() => sliceModeOf(draft.slice));
+  const [atRow, setAtRow] = useState(() => atRowOf(draft.slice));
+  const [[rangeStart, rangeEnd], setRange] = useState(() => rangePartsOf(draft.slice));
+
+  const selectIndexMode = mode => {
+    setIndexMode(mode);
+    // Re-selecting `custom` keeps the authored expression as-is.
+    if (mode === 'custom') return;
+    const next =
+      mode === 'at'
+        ? atRow === ''
+          ? ''
+          : `[${atRow}]`
+        : mode === 'range'
+          ? rangeExpr(rangeStart, rangeEnd)
+          : mode;
+    setDraft(d => ({ ...d, slice: next }));
+  };
+  const setIndexAtRow = value => {
+    setAtRow(value);
+    setDraft(d => ({ ...d, slice: value === '' ? '' : `[${value}]` }));
+  };
+  const setIndexRange = (start, end) => {
+    setRange([start, end]);
+    setDraft(d => ({ ...d, slice: rangeExpr(start, end) }));
+  };
 
   // T4 (pills-buildrail #5): measured-then-flip. `style` is the DOWNWARD
   // guess computed before the popover's actual content (a variable-length
@@ -538,16 +612,66 @@ const PillMenuPopover = ({
       </div>
       <div className="px-3 pb-1.5">
         <select
-          value={draft.slice}
-          onChange={e => setDraft(d => ({ ...d, slice: e.target.value }))}
+          value={indexMode}
+          onChange={e => selectIndexMode(e.target.value)}
           data-testid="pill-menu-index"
           aria-label="Index"
           className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
         >
-          <option value="">All values</option>
-          <option value="[0]">First (0)</option>
-          <option value="[-1]">Last (-1)</option>
+          <option value="" disabled={!slicePolicy.all}>
+            All values
+          </option>
+          <option value="[0]" disabled={!slicePolicy.first}>
+            First (0)
+          </option>
+          <option value="[-1]" disabled={!slicePolicy.last}>
+            Last (-1)
+          </option>
+          <option value="at" disabled={!slicePolicy.atRow}>
+            At row…
+          </option>
+          <option value="range" disabled={!slicePolicy.range}>
+            Rows…
+          </option>
+          {/* An already-authored shape this form can't model (e.g. `[0,2,5]`,
+              a strided `[0:9:2]`) stays selectable rather than being silently
+              rewritten to something else the moment the menu opens. */}
+          {indexMode === 'custom' && <option value="custom">{draft.slice}</option>}
         </select>
+        {indexMode === 'at' && (
+          <input
+            type="number"
+            value={atRow}
+            onChange={e => setIndexAtRow(e.target.value)}
+            placeholder="row index"
+            data-testid="pill-menu-index-at-row"
+            aria-label="Row index"
+            className="mt-1 w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+          />
+        )}
+        {indexMode === 'range' && (
+          <div className="mt-1 flex items-center gap-1.5">
+            <input
+              type="number"
+              value={rangeStart}
+              onChange={e => setIndexRange(e.target.value, rangeEnd)}
+              placeholder="start"
+              data-testid="pill-menu-index-range-start"
+              aria-label="First row"
+              className="w-full min-w-0 rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+            />
+            <span className="flex-shrink-0 text-[11px] text-gray-400">to</span>
+            <input
+              type="number"
+              value={rangeEnd}
+              onChange={e => setIndexRange(rangeStart, e.target.value)}
+              placeholder="end"
+              data-testid="pill-menu-index-range-end"
+              aria-label="Last row"
+              className="w-full min-w-0 rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+            />
+          </div>
+        )}
       </div>
 
       {/* Modifier — trailing SQL, applied INSIDE the `?{ }` so an index can
@@ -580,8 +704,14 @@ const PillMenuPopover = ({
         <button
           type="button"
           onClick={onApply}
+          // A column-backed pill with no column serializes to a dangling ref,
+          // so Apply stays inert until there is one to commit.
+          disabled={isColumnBacked && !draft.column}
+          title={
+            isColumnBacked && !draft.column ? 'Choose a dimension first' : undefined
+          }
           data-testid="pill-menu-apply"
-          className="rounded bg-primary-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-primary-700"
+          className="rounded bg-primary-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed"
         >
           Apply
         </button>

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -25,7 +25,7 @@ const NUMERIC_ONLY_AGGS = new Set(['sum', 'avg', 'median']);
 const RESTRICTED_AGGS = new Set(['min', 'max', 'count', 'count_distinct']);
 
 const KIND_LABEL = {
-  modelRef: 'Model — pick a property',
+  modelRef: 'Model — pick a dimension',
   dimension: 'Dimension',
   aggregate: 'Aggregate',
   metricRef: 'Metric',
@@ -461,13 +461,13 @@ const PillMenuPopover = ({
 
       {isColumnBacked && (
         <>
-          {/* VIS-1241: the property picker — the half of the pill that could
+          {/* VIS-1241: the dimension picker — the half of the pill that could
               never be changed here. The header was static text, so re-pointing
               a pill at a different column meant a drag or a raw-text edit.
               Columns come from the model-schema endpoint, which only started
               answering for uncommitted models in #619. */}
           <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
-            Property
+            Dimension
           </div>
           <div className="px-3 pb-1.5">
             {columns.length ? (
@@ -475,7 +475,7 @@ const PillMenuPopover = ({
                 value={draft.column}
                 onChange={e => setDraft(d => ({ ...d, column: e.target.value }))}
                 data-testid="pill-menu-property"
-                aria-label="Property"
+                aria-label="Dimension"
                 className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
               >
                 {!columns.includes(draft.column) && draft.column && (
@@ -495,7 +495,7 @@ const PillMenuPopover = ({
                 value={draft.column}
                 onChange={e => setDraft(d => ({ ...d, column: e.target.value }))}
                 data-testid="pill-menu-property"
-                aria-label="Property"
+                aria-label="Dimension"
                 className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
               />
             )}
@@ -511,7 +511,7 @@ const PillMenuPopover = ({
             Use as
           </div>
           <MenuRow
-            label="Dimension"
+            label="Value"
             selected={presetIsSelected('dimension')}
             onClick={() => onSelectPreset('dimension')}
             testId="pill-menu-preset-dimension"

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -239,7 +239,9 @@ const PillMenu = React.forwardRef(
   const buildDraft = useCallback(
     () => ({
       useAs: state?.kind === 'aggregate' ? state.agg : 'dimension',
-      column: state?.column ?? '',
+      // The FULL path, not the bare column: an Apply that doesn't touch the
+      // property must round-trip `gdp[0]` unchanged.
+      column: state?.propertyPath ?? state?.column ?? '',
       modifier: state?.modifier ?? '',
       slice: slice ?? '',
     }),

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -180,7 +180,7 @@ function Divider() {
  * small chevron trigger + a `SliceMenu`-shaped portal popover.
  *
  * Phase 3b shipped PRESETS-ONLY (S5 §5 item 6): dimension ↔ preset
- * aggregation toggling, dialect-gated MEDIAN, "Custom aggregation…" (switches
+ * aggregation toggling, dialect-gated MEDIAN, "Manually edit field…" (switches
  * the slot back to raw `RefTextArea` editing — reuses the existing widget,
  * 06 §5), and a preflight warning for the global-name-first ref-collision
  * case. Phase 4 (06 §4) enables "Save as metric…" — for `kind: 'aggregate'`
@@ -198,7 +198,7 @@ function Divider() {
  * @param {(preset: 'dimension'|string) => void} props.onSelectPreset -
  *   called with `'dimension'` or an aggregation key from
  *   `PRESET_AGGREGATIONS`; the caller rebuilds + serializes the new state.
- * @param {() => void} props.onCustomAggregation - switch this slot to raw
+ * @param {() => void} props.onManualEdit - switch this slot to raw
  *   `RefTextArea` editing, pre-filled with the current body.
  * @param {() => void} [props.onSaveAsMetric] - Explore 2.0 Phase 4: promote
  *   this slot's aggregate expression to a named Metric. Enables the action
@@ -222,7 +222,7 @@ const PillMenu = React.forwardRef(
       slice = null,
       slotShape = 'unknown',
       onApply,
-      onCustomAggregation,
+      onManualEdit,
       onSaveAsMetric,
       onRemove,
       disabled = false,
@@ -331,8 +331,8 @@ const PillMenu = React.forwardRef(
             hasCollisionWarning={hasCollisionWarning}
             presetIsSelected={presetIsSelected}
             onSelectPreset={handleSelect}
-            onCustomAggregation={() => {
-              onCustomAggregation?.();
+            onManualEdit={() => {
+              onManualEdit?.();
               setOpen(false);
             }}
             saveAsMetricEnabled={saveAsMetricEnabled}
@@ -368,7 +368,7 @@ const PillMenuPopover = ({
   hasCollisionWarning,
   presetIsSelected,
   onSelectPreset,
-  onCustomAggregation,
+  onManualEdit,
   saveAsMetricEnabled,
   onSaveAsMetric,
   onRemove,
@@ -721,12 +721,12 @@ const PillMenuPopover = ({
       <button
         type="button"
         role="menuitem"
-        onClick={onCustomAggregation}
-        data-testid="pill-menu-custom-aggregation"
+        onClick={onManualEdit}
+        data-testid="pill-menu-manual-edit"
         className="w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-primary-50 text-gray-700"
       >
         <PiTextAa size={13} />
-        Custom aggregation…
+        Manually edit field…
       </button>
       <button
         type="button"

--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -25,6 +25,7 @@ const NUMERIC_ONLY_AGGS = new Set(['sum', 'avg', 'median']);
 const RESTRICTED_AGGS = new Set(['min', 'max', 'count', 'count_distinct']);
 
 const KIND_LABEL = {
+  modelRef: 'Model — pick a property',
   dimension: 'Dimension',
   aggregate: 'Aggregate',
   metricRef: 'Metric',
@@ -228,7 +229,10 @@ const PillMenu = React.forwardRef(
 
   useImperativeHandle(ref, () => ({ open: openMenu }), [openMenu]);
 
-  const isColumnBacked = state?.kind === 'dimension' || state?.kind === 'aggregate';
+  // A modelRef is "column-backed" in the sense that matters here: it has a
+  // model and needs a property picked (VIS-1242).
+  const isColumnBacked =
+    state?.kind === 'dimension' || state?.kind === 'aggregate' || state?.kind === 'modelRef';
   const isNumeric = useColumnIsNumeric(isColumnBacked ? state.ref : null, state?.column);
   const dialect = usePillDialect(state);
   const medianAllowed = isMedianSupported(dialect);

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -467,7 +467,7 @@ describe('PillMenu', () => {
   });
 
   test('metricRef/dimensionRef pills hide the "Use as" preset section entirely', () => {
-    render(<PillMenu state={{ kind: 'metricRef', ref: 'churn_rate' }} />);
+    render(<PillMenu state={{ kind: 'metricRef', ref: 'churn_rate' }} onSaveAsMetric={jest.fn()} />);
     openMenu();
     expect(screen.queryByTestId('pill-menu-preset-dimension')).not.toBeInTheDocument();
     expect(screen.queryByTestId('pill-menu-preset-sum')).not.toBeInTheDocument();
@@ -478,10 +478,30 @@ describe('PillMenu', () => {
   });
 
   describe('"Save as metric…" (Explore 2.0 Phase 4, 06 §4)', () => {
-    test('disabled with no onSaveAsMetric handler, even on an aggregate pill', () => {
+    // Review finding #3: a surface that doesn't wire the handler used to show a
+    // DISABLED item blaming the pill — on an aggregate pill, whose own header
+    // read `Aggregate (AVG)`. Two different facts, treated differently now: a
+    // flow this surface never offers is omitted, rather than shown dead with a
+    // reason that isn't the reason.
+    test('omitted entirely when the surface does not offer the flow', () => {
       render(<PillMenu state={{ kind: 'aggregate', agg: 'sum', ref: 'orders_q', column: 'amount' }} />);
       openMenu();
-      expect(screen.getByTestId('pill-menu-save-as-metric')).toBeDisabled();
+      expect(screen.queryByTestId('pill-menu-save-as-metric')).not.toBeInTheDocument();
+      // ...and no orphaned explanation for an item that isn't there.
+      expect(
+        screen.queryByTestId('pill-menu-save-as-metric-disabled-hint')
+      ).not.toBeInTheDocument();
+    });
+
+    test('an aggregate pill on a surface that DOES offer it is enabled', () => {
+      render(
+        <PillMenu
+          state={{ kind: 'aggregate', agg: 'sum', ref: 'orders_q', column: 'amount' }}
+          onSaveAsMetric={jest.fn()}
+        />
+      );
+      openMenu();
+      expect(screen.getByTestId('pill-menu-save-as-metric')).toBeEnabled();
     });
 
     test('disabled on a dimension pill even WITH a handler — only aggregate/custom qualify', () => {
@@ -524,7 +544,15 @@ describe('PillMenu', () => {
     // on hover — a visible line is required so the reason isn't invisible
     // until the user happens to hover a greyed-out item.
     test('a disabled "Save as metric…" shows a VISIBLE reason, not just a hover title', () => {
-      render(<PillMenu state={{ kind: 'dimension', ref: 'orders_q', column: 'region' }} />);
+      // The reason is only shown where it is TRUE: the surface offers the flow,
+      // and this particular pill isn't an aggregate — which it can become from
+      // this very menu.
+      render(
+        <PillMenu
+          state={{ kind: 'dimension', ref: 'orders_q', column: 'region' }}
+          onSaveAsMetric={jest.fn()}
+        />
+      );
       openMenu();
       expect(screen.getByTestId('pill-menu-save-as-metric-disabled-hint')).toHaveTextContent(
         'Only an aggregate pill'
@@ -1016,7 +1044,25 @@ describe('PillMenu — the Index row covers the whole slice vocabulary', () => {
 describe('PillMenu — an unbound model pill', () => {
   const modelRef = { kind: 'modelRef', ref: 'new-model' };
 
-  test('Apply commits the column the picker is actually showing, even untouched', () => {
+  // Finding #5: this used to seed the first column so the DISPLAY and the draft
+  // agreed — but that made the pill's "choose a dimension" a lie, since a
+  // choice had silently been made. The control now says what is true: nothing
+  // is chosen, and Apply waits.
+  test('an unbound pill shows a placeholder, not a silently-chosen column', () => {
+    useModelColumns.mockReturnValue({
+      columnsByModel: { 'new-model': ['x', 'y'] },
+      loading: false,
+    });
+    render(<PillMenu state={modelRef} onApply={jest.fn()} />);
+    openMenu();
+
+    expect(screen.getByTestId('pill-menu-property')).toHaveValue('');
+    expect(screen.getByRole('option', { name: 'Choose a dimension…' })).toBeInTheDocument();
+    // The original bug this replaces: Apply must never commit an empty column.
+    expect(screen.getByTestId('pill-menu-apply')).toBeDisabled();
+  });
+
+  test('choosing a dimension enables Apply and commits it', () => {
     useModelColumns.mockReturnValue({
       columnsByModel: { 'new-model': ['x', 'y'] },
       loading: false,
@@ -1024,9 +1070,29 @@ describe('PillMenu — an unbound model pill', () => {
     const onApply = jest.fn();
     render(<PillMenu state={modelRef} onApply={onApply} />);
     openMenu();
-    expect(screen.getByTestId('pill-menu-property')).toHaveValue('x');
+
+    fireEvent.change(screen.getByTestId('pill-menu-property'), { target: { value: 'y' } });
+    expect(screen.getByTestId('pill-menu-apply')).toBeEnabled();
     fireEvent.click(screen.getByTestId('pill-menu-apply'));
-    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ column: 'x' }));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ column: 'y' }));
+  });
+
+  test('a CONFIGURED pill still round-trips its column untouched', () => {
+    useModelColumns.mockReturnValue({
+      columnsByModel: { orders_q: ['amount', 'region'] },
+      loading: false,
+    });
+    const onApply = jest.fn();
+    render(
+      <PillMenu
+        state={{ kind: 'dimension', ref: 'orders_q', column: 'region' }}
+        onApply={onApply}
+      />
+    );
+    openMenu();
+    expect(screen.queryByRole('option', { name: 'Choose a dimension…' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ column: 'region' }));
   });
 
   test('Apply stays inert while there is no column to commit', () => {

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -472,7 +472,7 @@ describe('PillMenu', () => {
     expect(screen.queryByTestId('pill-menu-preset-dimension')).not.toBeInTheDocument();
     expect(screen.queryByTestId('pill-menu-preset-sum')).not.toBeInTheDocument();
     // The universal actions still render.
-    expect(screen.getByTestId('pill-menu-custom-aggregation')).toBeInTheDocument();
+    expect(screen.getByTestId('pill-menu-manual-edit')).toBeInTheDocument();
     expect(screen.getByTestId('pill-menu-save-as-metric')).toBeInTheDocument();
     expect(screen.getByTestId('pill-menu-remove')).toBeInTheDocument();
   });
@@ -545,17 +545,17 @@ describe('PillMenu', () => {
     });
   });
 
-  test('"Custom aggregation…" calls onCustomAggregation and closes the menu', () => {
-    const onCustomAggregation = jest.fn();
+  test('"Manually edit field…" calls onManualEdit and closes the menu', () => {
+    const onManualEdit = jest.fn();
     render(
       <PillMenu
         state={{ kind: 'dimension', ref: 'orders_q', column: 'region' }}
-        onCustomAggregation={onCustomAggregation}
+        onManualEdit={onManualEdit}
       />
     );
     openMenu();
-    fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
-    expect(onCustomAggregation).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('pill-menu-manual-edit'));
+    expect(onManualEdit).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
   });
 
@@ -708,7 +708,7 @@ describe('PillMenu', () => {
       render(<PillMenu state={{ kind: 'metricRef', ref: 'churn_rate' }} />);
       openMenu();
       // snowflake supports MEDIAN -> resolved via config.model, not parentModel.
-      expect(screen.getByTestId('pill-menu-custom-aggregation')).toBeInTheDocument();
+      expect(screen.getByTestId('pill-menu-manual-edit')).toBeInTheDocument();
     });
 
     test('dimensionRef resolves against the dimensions list (not metrics)', () => {
@@ -730,7 +730,7 @@ describe('PillMenu', () => {
       // again, "Use as" never renders for a non-column-backed kind, so assert
       // the dialect-gated custom-aggregation control is present and the menu
       // doesn't crash.
-      expect(screen.getByTestId('pill-menu-custom-aggregation')).toBeInTheDocument();
+      expect(screen.getByTestId('pill-menu-manual-edit')).toBeInTheDocument();
     });
 
     test('resolves via model.source (no .config wrapper) when the model has no config.source', () => {
@@ -796,7 +796,7 @@ describe('PillMenu', () => {
       useStore.setState({ metrics: undefined });
       render(<PillMenu state={{ kind: 'metricRef', ref: 'churn_rate' }} />);
       openMenu();
-      expect(screen.getByTestId('pill-menu-custom-aggregation')).toBeInTheDocument();
+      expect(screen.getByTestId('pill-menu-manual-edit')).toBeInTheDocument();
     });
 
     test('a dimension pill with `models` itself undefined fails open, no crash', () => {

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -3,10 +3,16 @@ import React from 'react';
 import { render, screen, fireEvent, renderHook, act } from '@testing-library/react';
 import PillMenu, { usePillDialect } from './PillMenu';
 import useStore from '../../../stores/store';
+import { useModelColumns } from '../workspace/relations/useModelColumns';
+
+jest.mock('../workspace/relations/useModelColumns', () => ({
+  useModelColumns: jest.fn(() => ({ columnsByModel: {}, loading: false })),
+}));
 
 const openMenu = () => fireEvent.click(screen.getByTestId('pill-menu-trigger'));
 
 beforeEach(() => {
+  useModelColumns.mockReturnValue({ columnsByModel: {}, loading: false });
   useStore.setState({
     models: [],
     sources: [],
@@ -932,5 +938,101 @@ describe('PillMenu', () => {
       ref.current.open();
     });
     expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+  });
+});
+
+// VIS-1241 follow-up: the Index row first shipped as All / First / Last only,
+// silently dropping "At row…" and "Rows…" — both of which the standalone
+// SliceMenu had offered — and with them the slot-shape policy.
+describe('PillMenu — the Index row covers the whole slice vocabulary', () => {
+  const dimension = { kind: 'dimension', ref: 'orders_q', column: 'region' };
+
+  test('"At row…" reveals a row input and Apply commits that index', () => {
+    const onApply = jest.fn();
+    render(<PillMenu state={dimension} onApply={onApply} />);
+    openMenu();
+    fireEvent.change(screen.getByTestId('pill-menu-index'), { target: { value: 'at' } });
+    fireEvent.change(screen.getByTestId('pill-menu-index-at-row'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ slice: '[3]' }));
+  });
+
+  test('"Rows…" commits a start:end range', () => {
+    const onApply = jest.fn();
+    render(<PillMenu state={dimension} onApply={onApply} />);
+    openMenu();
+    fireEvent.change(screen.getByTestId('pill-menu-index'), { target: { value: 'range' } });
+    fireEvent.change(screen.getByTestId('pill-menu-index-range-start'), { target: { value: '1' } });
+    fireEvent.change(screen.getByTestId('pill-menu-index-range-end'), { target: { value: '5' } });
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ slice: '[1:5]' }));
+  });
+
+  test('an authored range re-opens in "Rows…" with both bounds filled', () => {
+    render(<PillMenu state={dimension} slice="[1:5]" />);
+    openMenu();
+    expect(screen.getByTestId('pill-menu-index')).toHaveValue('range');
+    expect(screen.getByTestId('pill-menu-index-range-start')).toHaveValue(1);
+    expect(screen.getByTestId('pill-menu-index-range-end')).toHaveValue(5);
+  });
+
+  test('an authored single row re-opens in "At row…"', () => {
+    render(<PillMenu state={dimension} slice="[7]" />);
+    openMenu();
+    expect(screen.getByTestId('pill-menu-index')).toHaveValue('at');
+    expect(screen.getByTestId('pill-menu-index-at-row')).toHaveValue(7);
+  });
+
+  test('a scalar-only slot disables the options that slot cannot accept', () => {
+    render(<PillMenu state={dimension} slotShape="scalar-only" />);
+    openMenu();
+    expect(screen.getByRole('option', { name: 'First (0)' })).toBeEnabled();
+    expect(screen.getByRole('option', { name: 'At row…' })).toBeEnabled();
+    // A prop that takes exactly one value has no use for a range or for "all".
+    expect(screen.getByRole('option', { name: 'Rows…' })).toBeDisabled();
+    expect(screen.getByRole('option', { name: 'All values' })).toBeDisabled();
+  });
+
+  test('an array-only slot disables the single-row options instead', () => {
+    render(<PillMenu state={dimension} slotShape="array-only" />);
+    openMenu();
+    expect(screen.getByRole('option', { name: 'Rows…' })).toBeEnabled();
+    expect(screen.getByRole('option', { name: 'First (0)' })).toBeDisabled();
+  });
+
+  test('a slice this form cannot model survives untouched rather than being rewritten', () => {
+    const onApply = jest.fn();
+    render(<PillMenu state={dimension} slice="[0,2,5]" onApply={onApply} />);
+    openMenu();
+    expect(screen.getByTestId('pill-menu-index')).toHaveValue('custom');
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ slice: '[0,2,5]' }));
+  });
+});
+
+// VIS-1242 follow-up: an unbound model pill opened with `draft.column === ''`,
+// which matches no <option> — so the browser showed the first column while the
+// draft still said "nothing chosen", and Apply committed an empty column.
+describe('PillMenu — an unbound model pill', () => {
+  const modelRef = { kind: 'modelRef', ref: 'new-model' };
+
+  test('Apply commits the column the picker is actually showing, even untouched', () => {
+    useModelColumns.mockReturnValue({
+      columnsByModel: { 'new-model': ['x', 'y'] },
+      loading: false,
+    });
+    const onApply = jest.fn();
+    render(<PillMenu state={modelRef} onApply={onApply} />);
+    openMenu();
+    expect(screen.getByTestId('pill-menu-property')).toHaveValue('x');
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ column: 'x' }));
+  });
+
+  test('Apply stays inert while there is no column to commit', () => {
+    useModelColumns.mockReturnValue({ columnsByModel: {}, loading: true });
+    render(<PillMenu state={modelRef} onApply={jest.fn()} />);
+    openMenu();
+    expect(screen.getByTestId('pill-menu-apply')).toBeDisabled();
   });
 });

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -85,25 +85,28 @@ describe('PillMenu', () => {
     // up, re-opening the menu in the same tick that selecting a preset closed
     // it. The menu then stayed open forever and the next chevron click only
     // appeared to do nothing (it toggled the already-open menu shut).
-    const onSelectPreset = jest.fn();
+    const onApply = jest.fn();
     const reopen = jest.fn();
     render(
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div onClick={reopen} data-testid="pill-body-ancestor">
         <PillMenu
           state={{ kind: 'dimension', ref: 'orders_q', column: 'amount' }}
-          onSelectPreset={onSelectPreset}
+          onApply={onApply}
         />
       </div>
     );
     openMenu();
     expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
 
+    // VIS-1241: a preset click EDITS the draft and leaves the menu open.
     fireEvent.click(screen.getByTestId('pill-menu-preset-sum'));
+    expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
 
-    expect(onSelectPreset).toHaveBeenCalledWith('sum');
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ useAs: 'sum' }));
     expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
-    // The ancestor never saw the in-menu click, so nothing re-opened it.
+    // The ancestor never saw the in-menu clicks, so nothing re-opened it.
     expect(reopen).not.toHaveBeenCalled();
   });
 
@@ -117,31 +120,57 @@ describe('PillMenu', () => {
     expect(screen.getByTestId('pill-menu-preset-count')).toBeInTheDocument();
   });
 
-  test('selecting a preset calls onSelectPreset with the aggregation key and closes the menu', () => {
-    const onSelectPreset = jest.fn();
+  test('a preset selection stays open until Apply, then commits once', () => {
+    const onApply = jest.fn();
     render(
       <PillMenu
         state={{ kind: 'dimension', ref: 'orders_q', column: 'amount' }}
-        onSelectPreset={onSelectPreset}
+        onApply={onApply}
       />
     );
     openMenu();
     fireEvent.click(screen.getByTestId('pill-menu-preset-sum'));
-    expect(onSelectPreset).toHaveBeenCalledWith('sum');
+    // Still open — the user may also want to set an index or a modifier.
+    expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+    expect(onApply).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ useAs: 'sum' }));
     expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
   });
 
-  test('clicking "Dimension" itself calls onSelectPreset(\'dimension\') and closes the menu', () => {
-    const onSelectPreset = jest.fn();
+  test('Cancel discards the draft without committing', () => {
+    const onApply = jest.fn();
+    render(
+      <PillMenu
+        state={{ kind: 'dimension', ref: 'orders_q', column: 'amount' }}
+        onApply={onApply}
+      />
+    );
+    openMenu();
+    fireEvent.click(screen.getByTestId('pill-menu-preset-sum'));
+    fireEvent.click(screen.getByTestId('pill-menu-cancel'));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
+
+    // Re-opening starts from the STORED state, not the abandoned draft.
+    openMenu();
+    expect(screen.getByTestId('pill-menu-preset-dimension')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('clicking "Dimension" drafts a switch back to a plain dimension', () => {
+    const onApply = jest.fn();
     render(
       <PillMenu
         state={{ kind: 'aggregate', agg: 'sum', ref: 'orders_q', column: 'amount' }}
-        onSelectPreset={onSelectPreset}
+        onApply={onApply}
       />
     );
     openMenu();
     fireEvent.click(screen.getByTestId('pill-menu-preset-dimension'));
-    expect(onSelectPreset).toHaveBeenCalledWith('dimension');
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ useAs: 'dimension' }));
     expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
   });
 
@@ -865,18 +894,19 @@ describe('PillMenu', () => {
     });
   });
 
-  test('selecting the "Dimension" row (not an aggregation preset) calls onSelectPreset with "dimension"', () => {
-    const onSelectPreset = jest.fn();
+  test('the "Dimension" row drafts `useAs: dimension` (not an aggregation preset)', () => {
+    const onApply = jest.fn();
     render(
       <PillMenu
         state={{ kind: 'aggregate', agg: 'sum', ref: 'orders_q', column: 'amount' }}
-        onSelectPreset={onSelectPreset}
+        onApply={onApply}
       />
     );
     openMenu();
     fireEvent.click(screen.getByTestId('pill-menu-preset-dimension'));
-    expect(onSelectPreset).toHaveBeenCalledWith('dimension');
-    expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
+    expect(screen.getByTestId('pill-menu-preset-dimension')).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ useAs: 'dimension' }));
   });
 
   test('a keydown inside the popover never bubbles to reach an ancestor handler (same portal-bubbling guard as click)', () => {

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import useStore from '../../../stores/store';
 import { getTypeByValue, DEFAULT_COLORS } from './objectTypeConfigs';
+import { createRefTokenElement } from './refTokenElement';
 import { parseTextWithRefs } from '../../../utils/contextString';
 import { serializeContentEditableToRefString } from '../../../utils/contextString';
 import { formatRefExpression } from '../../../utils/refString';
@@ -47,6 +48,7 @@ const RefTextArea = ({
   hideAddButton = false,
   restrictBrackets = false,
   acceptDrops = false,
+  plainRefs = false,
 }) => {
   const editableRef = useRef(null);
   const containerRef = useRef(null);
@@ -224,6 +226,16 @@ const RefTextArea = ({
     return pill;
   }, [getPillTypeConfig, getInputAccessors]);
 
+  // Plain-text refs (see refTokenElement.js) — the pill/plain decision lives
+  // in this one place rather than at all four insertion sites below.
+  const createRefNode = useCallback(
+    (name, property) =>
+      plainRefs
+        ? createRefTokenElement(name, property, getPillTypeConfig(name, property))
+        : createPillElement(name, property),
+    [plainRefs, getPillTypeConfig, createPillElement]
+  );
+
   const buildDOMFromValue = useCallback((val) => {
     const el = editableRef.current;
     if (!el) return;
@@ -237,18 +249,19 @@ const RefTextArea = ({
     // Use zero-width space (\u200B) for cursor positioning around pills
     const ZWS = '\u200B';
 
-    // Ensure there's a text node before the first pill for cursor placement
-    if (segments.length > 0 && segments[0].type === 'ref') {
+    // Cursor-parking ZWS exists because a chip is `contenteditable=false` and
+    // otherwise has no place to put the caret beside it. A plain token is
+    // editable text, so it needs none — and they would show up as stray
+    // characters mid-expression.
+    if (!plainRefs && segments.length > 0 && segments[0].type === 'ref') {
       el.appendChild(document.createTextNode(ZWS));
     }
 
     segments.forEach((segment, i) => {
       if (segment.type === 'ref') {
-        const pill = createPillElement(segment.name, segment.property);
-        el.appendChild(pill);
-        // Ensure there's a text node after each pill for cursor placement
+        el.appendChild(createRefNode(segment.name, segment.property));
         const next = segments[i + 1];
-        if (!next || next.type === 'ref') {
+        if (!plainRefs && (!next || next.type === 'ref')) {
           el.appendChild(document.createTextNode(ZWS));
         }
       } else {
@@ -256,7 +269,7 @@ const RefTextArea = ({
         el.appendChild(textNode);
       }
     });
-  }, [createPillElement]);
+  }, [createRefNode, plainRefs]);
 
   // Sync DOM from value prop when not focused
   useEffect(() => {
@@ -506,7 +519,7 @@ const RefTextArea = ({
     const segments = parseTextWithRefs(text);
     segments.forEach(segment => {
       if (segment.type === 'ref') {
-        const pill = createPillElement(segment.name, segment.property);
+        const pill = createRefNode(segment.name, segment.property);
         range.insertNode(pill);
         range.setStartAfter(pill);
       } else {
@@ -521,7 +534,7 @@ const RefTextArea = ({
     sel.addRange(range);
 
     serializeAndUpdate();
-  }, [createPillElement, serializeAndUpdate, restrictBrackets]);
+  }, [createRefNode, serializeAndUpdate, restrictBrackets]);
 
   // In restrictBrackets mode the editor is chip-body-only — bracket
   // characters are reserved for the SliceBadge's authored slice suffix.
@@ -677,7 +690,7 @@ const RefTextArea = ({
         const after = text.slice(offset);
 
         // Build pill
-        const pill = createPillElement(item.name, item.property || null);
+        const pill = createRefNode(item.name, item.property || null);
 
         // Replace text node content
         node.textContent = before;
@@ -715,7 +728,7 @@ const RefTextArea = ({
 
     setMentionState({ active: false, query: '', rect: null, selectedIndex: 0 });
     serializeAndUpdate();
-  }, [createPillElement, serializeAndUpdate]);
+  }, [createRefNode, serializeAndUpdate]);
 
   // Keep ref in sync with latest insertMentionItem
   insertMentionItemRef.current = insertMentionItem;
@@ -734,7 +747,7 @@ const RefTextArea = ({
       const refSegment = segments.find(s => s.type === 'ref');
       if (!refSegment) return;
 
-      const pill = createPillElement(refSegment.name, refSegment.property);
+      const pill = createRefNode(refSegment.name, refSegment.property);
       const editable = editableRef.current;
 
       if (savedCursorOffsetRef.current !== null) {
@@ -763,10 +776,16 @@ const RefTextArea = ({
               inserted = true;
             }
             currentOffset += len;
-          } else if (child.nodeType === Node.ELEMENT_NODE && child.hasAttribute('data-ref-name')) {
+          } else if (child.nodeType === Node.ELEMENT_NODE) {
+            // A chip's serialized length comes from its attributes; anything
+            // else (a plain ref token, a wrapper) already reads as its own
+            // text. Counting only chips skipped plain tokens entirely and
+            // landed the insert short of where it was dropped.
             const refName = child.getAttribute('data-ref-name');
             const refProp = child.getAttribute('data-ref-property');
-            const refLen = refProp ? `\${ref(${refName}).${refProp}}`.length : `\${ref(${refName})}`.length;
+            const refLen = refName
+              ? (refProp ? `\${ref(${refName}).${refProp}}` : `\${ref(${refName})}`).length
+              : child.textContent.length;
             if (currentOffset + refLen >= targetOffset) {
               if (child.nextSibling) {
                 editable.insertBefore(pill, child.nextSibling);
@@ -791,7 +810,7 @@ const RefTextArea = ({
 
       serializeAndUpdate();
     },
-    [createPillElement, serializeAndUpdate]
+    [createRefNode, serializeAndUpdate]
   );
 
   useEffect(() => {
@@ -804,7 +823,7 @@ const RefTextArea = ({
 
   // VIS-1243: a RefTextArea was never a drop target — dragging a model onto a
   // dimension/metric expression, a relation condition, or a slot switched to
-  // "Custom aggregation…" simply did nothing. Only `PropertyRow`'s row wrapper
+  // "Manually edit field…" simply did nothing. Only `PropertyRow`'s row wrapper
   // accepted drops, and only in the Build rail (`droppable`). Opt-in so the 8+
   // other surfaces that share this component keep their current behaviour.
   const dropId = useId();

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useMemo, useCallback, useEffect, useId } from 'react';
+import { useDroppable } from '@dnd-kit/core';
 import { createPortal } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import useStore from '../../../stores/store';
@@ -45,6 +46,7 @@ const RefTextArea = ({
   helperText,
   hideAddButton = false,
   restrictBrackets = false,
+  acceptDrops = false,
 }) => {
   const editableRef = useRef(null);
   const containerRef = useRef(null);
@@ -720,12 +722,11 @@ const RefTextArea = ({
 
   // --- DnD Cursor-Aware Insertion ---
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    const handler = (e) => {
-      const { refExpr } = e.detail;
+  // Extracted from the `ref-insert-at-cursor` listener below so a dnd-kit drop
+  // can reuse the identical caret-aware insertion instead of replacing the
+  // whole value (which is what every non-RefTextArea drop target does).
+  const insertRefExpr = useCallback(
+    refExpr => {
       if (!refExpr || !editableRef.current) return;
 
       // Parse the ref expression to get name and property
@@ -789,11 +790,36 @@ const RefTextArea = ({
       }
 
       serializeAndUpdate();
-    };
+    },
+    [createPillElement, serializeAndUpdate]
+  );
 
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = e => insertRefExpr(e.detail?.refExpr);
     el.addEventListener('ref-insert-at-cursor', handler);
     return () => el.removeEventListener('ref-insert-at-cursor', handler);
-  }, [createPillElement, serializeAndUpdate]);
+  }, [insertRefExpr]);
+
+  // VIS-1243: a RefTextArea was never a drop target — dragging a model onto a
+  // dimension/metric expression, a relation condition, or a slot switched to
+  // "Custom aggregation…" simply did nothing. Only `PropertyRow`'s row wrapper
+  // accepted drops, and only in the Build rail (`droppable`). Opt-in so the 8+
+  // other surfaces that share this component keep their current behaviour.
+  const dropId = useId();
+  const { isOver, setNodeRef: setDropRef } = useDroppable({
+    id: `ref-text-${dropId}`,
+    data: { kind: 'ref-text', allowedTypes, onInsertRef: insertRefExpr },
+    disabled: !acceptDrops || disabled,
+  });
+  const setContainerRef = useCallback(
+    node => {
+      containerRef.current = node;
+      if (acceptDrops && !disabled) setDropRef(node);
+    },
+    [acceptDrops, disabled, setDropRef]
+  );
 
   // --- Render ---
 
@@ -894,7 +920,14 @@ const RefTextArea = ({
     : null;
 
   return (
-    <div className="space-y-1" ref={containerRef} data-has-cursor={hasCursor ? 'true' : 'false'}>
+    <div
+      className={`space-y-1 rounded-md transition-shadow ${
+        isOver ? 'ring-2 ring-primary-300 ring-offset-1' : ''
+      }`}
+      ref={setContainerRef}
+      data-has-cursor={hasCursor ? 'true' : 'false'}
+      data-drop-target={acceptDrops ? 'ref-text' : undefined}
+    >
       {/* Label */}
       {label && (
         <div className="flex items-center justify-between h-6">

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -165,6 +165,7 @@ const RefTextArea = ({
   // is detached by the time Apply runs. The index identifies THIS chip rather
   // than the first textually-identical one — the same lesson the accessor
   // dropdown learned.
+  const showWorkspaceToast = useStore(state => state.showWorkspaceToast);
   const [chipMenu, setChipMenu] = useState(null);
   const chipMenuRef = useRef(null);
 
@@ -878,7 +879,21 @@ const RefTextArea = ({
   const dropId = useId();
   const { isOver, setNodeRef: setDropRef } = useDroppable({
     id: `ref-text-${dropId}`,
-    data: { kind: 'ref-text', allowedTypes, onInsertRef: insertRefExpr },
+    data: {
+      kind: 'ref-text',
+      allowedTypes,
+      onInsertRef: insertRefExpr,
+      // A drop this zone won't accept has to SAY so. The property-zone branch
+      // has had a rejection toast since VIS-1242, but that allowlist only runs
+      // on rows that are themselves droppable — so on every other surface an
+      // unacceptable drop was a silent no-op: no pill, no error, no animation,
+      // which `InsightBuildSection` rightly calls the most trust-destroying
+      // moment in the flow. The zone that refuses is the zone that must speak.
+      onReject: type =>
+        showWorkspaceToast?.(
+          type ? `Can't use a ${type} as a reference here.` : "Can't use that here."
+        ),
+    },
     disabled: !acceptDrops || disabled,
   });
   const setContainerRef = useCallback(

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -38,7 +38,13 @@ import { formatRefExpression } from '../../../utils/refString';
 const RefTextArea = ({
   value = '',
   onChange,
-  allowedTypes = ['model', 'dimension', 'metric', 'source'],
+  // VIS-1254: `source` was in this default and nowhere else. A source has no
+  // value to reference from inside an expression — it names a connection, not a
+  // column — so offering it produced a ref that can never resolve. Surfaces
+  // that pass nothing (SQLEditor, RequiredFieldsSection) inherited it silently.
+  // Callers with a declared field type should pass `refKindsFor(...)` instead
+  // of relying on this at all.
+  allowedTypes = ['model', 'dimension', 'metric'],
   label,
   error,
   required = false,

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import useStore from '../../../stores/store';
 import { getTypeByValue, DEFAULT_COLORS } from './objectTypeConfigs';
 import { createRefTokenElement } from './refTokenElement';
+import PillMenu, { CHIP_SECTIONS } from './PillMenu';
 import { parseTextWithRefs } from '../../../utils/contextString';
 import { serializeContentEditableToRefString } from '../../../utils/contextString';
 import { formatRefExpression } from '../../../utils/refString';
@@ -29,12 +30,27 @@ import { formatRefExpression } from '../../../utils/refString';
  * - disabled: Whether the field is disabled
  * - rows: Number of rows (approximate height)
  * - helperText: Helper text shown below the editor
- * - hideAddButton: Whether to hide add-ref affordances
+ * - hideAddButton: legacy no-op. There has never been an add-ref BUTTON in this
+ *   component — references are inserted by typing `@` (the mention dropdown) or
+ *   by dropping one in. Helper copy across the app told users to "use the +
+ *   button", describing a control that does not exist. Kept only so existing
+ *   call sites don't break; it gates nothing.
  * - restrictBrackets: Block typing/pasting `[` and `]`. Only for chip-body
  *   editors where slices are authored separately (SchemaEditor PropertyRow +
  *   SliceBadge); free-form SQL fields must keep brackets (array indexing,
  *   quoted identifiers, json access).
  */
+/**
+ * How a reference actually gets into one of these editors — the same wording
+ * this component's own docs use ("Type @ to insert references"), so the help
+ * text and the feature description can't drift apart. Exported so every surface
+ * says the same true thing instead of each inventing its own copy.
+ *
+ * Notably it does NOT mention a "+ button": several fields told users to use
+ * one, and no such control has ever existed here.
+ */
+export const REF_INSERT_HINT = 'Type @ to insert references, or drag them in from the library.';
+
 const RefTextArea = ({
   value = '',
   onChange,
@@ -55,6 +71,10 @@ const RefTextArea = ({
   restrictBrackets = false,
   acceptDrops = false,
   plainRefs = false,
+  // VIS-1243: make each ref chip configurable in place — click it to re-point
+  // the ref instead of deleting and retyping. Opt-in, since 8+ surfaces share
+  // this component.
+  configurableChips = false,
 }) => {
   const editableRef = useRef(null);
   const containerRef = useRef(null);
@@ -140,6 +160,13 @@ const RefTextArea = ({
   // Accessor dropdown for input pills
   const [accessorDropdown, setAccessorDropdown] = useState(null);
   const accessorAnchorRef = useRef(null);
+  // The chip whose menu is open. Held by INDEX, not by node: opening the menu
+  // re-renders, and the value->DOM sync rebuilds every chip, so a captured node
+  // is detached by the time Apply runs. The index identifies THIS chip rather
+  // than the first textually-identical one — the same lesson the accessor
+  // dropdown learned.
+  const [chipMenu, setChipMenu] = useState(null);
+  const chipMenuRef = useRef(null);
 
   const getInputAccessors = useCallback((refName) => {
     const input = (inputs || []).find(i => i.name === refName);
@@ -578,7 +605,7 @@ const RefTextArea = ({
     e.clipboardData.setData('text/plain', serialized);
   }, []);
 
-  // Handle click for accessor dropdown
+  // Handle click for accessor dropdown / chip menu
   const handleClick = useCallback((e) => {
     const target = e.target;
     const accessorName = target.getAttribute('data-accessor-name');
@@ -588,8 +615,24 @@ const RefTextArea = ({
       const property = target.getAttribute('data-accessor-property');
       const isOpen = accessorDropdown?.name === accessorName;
       setAccessorDropdown(isOpen ? null : { name: accessorName, property });
+      return;
     }
-  }, [accessorDropdown]);
+
+    if (!configurableChips) return;
+    // The click can land on the chip's icon or label span, so walk up to the
+    // chip itself. An input accessor is handled above and keeps its own menu.
+    const chip = target.closest?.('[data-ref-name]');
+    if (chip && editableRef.current?.contains(chip)) {
+      e.stopPropagation();
+      const chips = [...editableRef.current.querySelectorAll('[data-ref-name]')];
+      setChipMenu({
+        index: chips.indexOf(chip),
+        name: chip.getAttribute('data-ref-name'),
+        property: chip.getAttribute('data-ref-property') || null,
+        rect: chip.getBoundingClientRect(),
+      });
+    }
+  }, [accessorDropdown, configurableChips]);
 
   // After any click, if the browser selected a pill as a block or placed the caret
   // at a container-level offset, resolve it to a text node position so the caret is visible.
@@ -846,6 +889,70 @@ const RefTextArea = ({
     [acceptDrops, disabled, setDropRef]
   );
 
+  // Re-point the open chip. Mutating the node's attributes (rather than a
+  // string replace on the value) is what makes this correct when the same ref
+  // appears more than once — the accessor dropdown learned the same lesson.
+  const chipAt = index => {
+    if (index == null || index < 0 || !editableRef.current) return null;
+    return editableRef.current.querySelectorAll('[data-ref-name]')[index] || null;
+  };
+
+  const handleChipApply = useCallback(
+    draft => {
+      const chip = chipAt(chipMenu?.index);
+      setChipMenu(null);
+      if (!chip) return;
+      const nextProperty = (draft?.column || '').trim();
+      if (!nextProperty) return;
+      chip.setAttribute('data-ref-property', nextProperty);
+      const propSpan = chip.querySelector('span:last-child');
+      if (propSpan && propSpan.textContent.startsWith('.')) {
+        propSpan.textContent = `.${nextProperty}`;
+      }
+      serializeAndUpdate();
+    },
+    [chipMenu, serializeAndUpdate]
+  );
+
+  const handleChipRemove = useCallback(() => {
+    const chip = chipAt(chipMenu?.index);
+    setChipMenu(null);
+    if (!chip) return;
+    chip.remove();
+    serializeAndUpdate();
+  }, [chipMenu, serializeAndUpdate]);
+
+  // Auto-open on mount: the anchor is an invisible zero-size span placed over
+  // the chip, so PillMenu's own positioning works unchanged.
+  useEffect(() => {
+    if (chipMenu && chipMenuRef.current) chipMenuRef.current.open();
+  }, [chipMenu]);
+
+  const chipMenuPortal =
+    chipMenu &&
+    createPortal(
+      <span
+        style={{
+          position: 'fixed',
+          top: chipMenu.rect.top,
+          left: chipMenu.rect.right,
+          width: 0,
+          height: chipMenu.rect.height,
+          opacity: 0,
+        }}
+        data-testid="chip-menu-anchor"
+      >
+        <PillMenu
+          ref={chipMenuRef}
+          state={{ kind: 'dimension', ref: chipMenu.name, column: chipMenu.property }}
+          sections={CHIP_SECTIONS}
+          onApply={handleChipApply}
+          onRemove={handleChipRemove}
+        />
+      </span>,
+      document.body
+    );
+
   // --- Render ---
 
   const editorMinHeight = Math.max(40, rows * 20);
@@ -1011,6 +1118,9 @@ const RefTextArea = ({
 
       {/* Accessor dropdown */}
       {accessorDropdownPortal}
+
+      {/* Chip re-point menu (VIS-1243) */}
+      {chipMenuPortal}
 
       {/* @ mention dropdown */}
       {mentionDropdownPortal}

--- a/viewer/src/components/views/common/RefTextArea.test.jsx
+++ b/viewer/src/components/views/common/RefTextArea.test.jsx
@@ -798,3 +798,62 @@ describe('RefTextArea — rendering', () => {
     );
   });
 });
+
+
+// The "Manually edit field…" escape hatch handed the user an expression whose
+// refs were `contenteditable="false"` chips — the one part of the text they
+// could not actually edit. `plainRefs` renders them as editable literal text,
+// while staying on the contentEditable so a bad ref can still be marked up.
+describe('RefTextArea — plainRefs (editable literal refs)', () => {
+  beforeEach(() => {
+    useStore.setState({
+      sources: [],
+      models: [{ name: 'orders' }],
+      dimensions: [],
+      metrics: [],
+      relations: [],
+      inputs: [],
+      explorerModelStates: {},
+    });
+  });
+
+  const editableOf = () => screen.getByRole('textbox');
+
+  test('a ref renders as the literal text, not an uneditable chip', () => {
+    render(<RefTextArea value={`avg(${R('orders', 'amount')})`} onChange={jest.fn()} plainRefs />);
+    const editable = editableOf();
+    expect(editable.textContent).toBe(`avg(${R('orders', 'amount')})`);
+    // No chip: nothing is walled off from the caret.
+    expect(editable.querySelector('[contenteditable="false"]')).toBeNull();
+    expect(editable.querySelector('[data-ref-name]')).toBeNull();
+    expect(editable.querySelector('[data-ref-token="orders"]')).not.toBeNull();
+  });
+
+  test('without plainRefs the same value still renders a chip', () => {
+    render(<RefTextArea value={R('orders', 'amount')} onChange={jest.fn()} />);
+    expect(editableOf().querySelector('[data-ref-name="orders"]')).not.toBeNull();
+  });
+
+  test('a name matching no known object is marked so it can be called out', () => {
+    render(<RefTextArea value={R('no_such_model', 'x')} onChange={jest.fn()} plainRefs />);
+    const token = editableOf().querySelector('[data-ref-token="no_such_model"]');
+    expect(token).not.toBeNull();
+    expect(token.getAttribute('data-ref-unknown')).toBe('true');
+    // ...and a resolvable one is not.
+    expect(token.textContent).toBe(R('no_such_model', 'x'));
+  });
+
+  test('a known ref carries no unknown marker', () => {
+    render(<RefTextArea value={R('orders', 'amount')} onChange={jest.fn()} plainRefs />);
+    const token = editableOf().querySelector('[data-ref-token="orders"]');
+    expect(token.hasAttribute('data-ref-unknown')).toBe(false);
+  });
+
+  test('no zero-width cursor-parking characters leak into the text', () => {
+    // They exist only so a caret can sit beside an uneditable chip; a plain
+    // token is editable text, so they would just be stray characters.
+    render(<RefTextArea value={R('orders')} onChange={jest.fn()} plainRefs />);
+    expect(editableOf().textContent).not.toContain('\u200B');
+    expect(editableOf().textContent).toBe(R('orders'));
+  });
+});

--- a/viewer/src/components/views/common/RefTextArea.test.jsx
+++ b/viewer/src/components/views/common/RefTextArea.test.jsx
@@ -857,3 +857,75 @@ describe('RefTextArea — plainRefs (editable literal refs)', () => {
     expect(editableOf().textContent).toBe(R('orders'));
   });
 });
+
+
+// VIS-1243: a chip was display-only — re-pointing a ref meant deleting it and
+// retyping. Now clicking one opens the same PillMenu a standalone pill uses,
+// scoped to what actually applies inside free text.
+describe('RefTextArea — configurable chips', () => {
+  beforeEach(() => {
+    useStore.setState({
+      sources: [], models: [{ name: 'orders' }], dimensions: [], metrics: [],
+      relations: [], inputs: [], explorerModelStates: {},
+    });
+  });
+
+  const clickChip = () => {
+    const chip = screen.getByRole('textbox').querySelector('[data-ref-name="orders"]');
+    fireEvent.click(chip, { bubbles: true });
+    return chip;
+  };
+
+  test('a chip is inert unless the surface opts in', () => {
+    render(<RefTextArea value={R('orders', 'amount')} onChange={jest.fn()} />);
+    clickChip();
+    expect(screen.queryByTestId('pill-menu')).not.toBeInTheDocument();
+  });
+
+  test('clicking a chip opens its menu', () => {
+    render(<RefTextArea value={R('orders', 'amount')} onChange={jest.fn()} configurableChips />);
+    clickChip();
+    expect(screen.getByTestId('pill-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('pill-menu-property')).toHaveValue('amount');
+  });
+
+  test('the menu offers only what applies to an embedded ref', () => {
+    render(<RefTextArea value={R('orders', 'amount')} onChange={jest.fn()} configurableChips />);
+    clickChip();
+    // Re-pointing the ref applies...
+    expect(screen.getByTestId('pill-menu-property')).toBeInTheDocument();
+    // ...but an aggregation, an index and a modifier are the SURROUNDING SQL
+    // here, not properties of the chip, so offering them would ask the user to
+    // author something this editor can't place.
+    expect(screen.queryByTestId('pill-menu-index')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pill-menu-modifier')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pill-menu-preset-dimension')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pill-menu-manual-edit')).not.toBeInTheDocument();
+  });
+
+  test('applying a new property rewrites the ref and preserves surrounding text', () => {
+    const onChange = jest.fn();
+    render(
+      <RefTextArea
+        value={`sum(${R('orders', 'amount')}) / 100`}
+        onChange={onChange}
+        configurableChips
+      />
+    );
+    clickChip();
+    fireEvent.change(screen.getByTestId('pill-menu-property'), { target: { value: 'revenue' } });
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+    // The free text around the ref is untouched — only the ref moved.
+    expect(onChange).toHaveBeenCalledWith(`sum(${R('orders', 'revenue')}) / 100`);
+  });
+
+  test('removing a chip leaves the rest of the expression intact', () => {
+    const onChange = jest.fn();
+    render(
+      <RefTextArea value={`sum(${R('orders', 'amount')})`} onChange={onChange} configurableChips />
+    );
+    clickChip();
+    fireEvent.click(screen.getByTestId('pill-menu-remove'));
+    expect(onChange).toHaveBeenCalledWith('sum()');
+  });
+});

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -291,13 +291,42 @@ export function PropertyRow({
     () => pillGrammar.parse(body, pillFieldOpts),
     [body, pillFieldOpts]
   );
+
+  // VIS-1240: whether this value CAN render as a pill — a pure function of the
+  // parsed value.
+  const pillEligible =
+    isQueryFormValue && pillState.kind !== 'opaque' && pillState.kind !== 'custom';
+
+  // VIS-1240 (flip #1 — mid-typing). `pillEligible` is re-derived from the LIVE
+  // text on every keystroke, so typing an expression by hand used to swap the
+  // editor out from under the caret the instant a partial string happened to
+  // parse (`${ref(q).gdp}`), then swap back on the next character (` / 100`).
+  // While the raw editor holds focus the representation is frozen: the user is
+  // mid-thought, and re-deciding is what loses their cursor.
+  const [rawEditing, setRawEditing] = useState(false);
+  const handleRawFocus = useCallback(() => setRawEditing(true), []);
+  const handleRawBlur = useCallback(e => {
+    // Focus moving WITHIN the editor (to its "+ add ref" button, the mention
+    // dropdown) still fires focusout — only a real exit ends the edit.
+    if (!e.currentTarget.contains(e.relatedTarget)) setRawEditing(false);
+  }, []);
+
+  // VIS-1240 (flip #2 — async field tables). `pillFieldOpts` is built from
+  // `s.metrics`/`s.dimensions`, which start `[]`, so a bare `?{${ref(name)}}`
+  // parses as `opaque` until those lists arrive — it painted as raw code and
+  // then jumped to a pill (or back, if a refetch emptied them). Hold the last
+  // decision while a fetch is in flight instead of re-deciding on data that is
+  // still moving.
+  const fieldTablesLoading = useStore(s => !!s.metricsLoading || !!s.dimensionsLoading);
+  const lastEligibleRef = useRef(pillEligible);
+  if (!fieldTablesLoading) lastEligibleRef.current = pillEligible;
+  const stablePillEligible = fieldTablesLoading ? lastEligibleRef.current : pillEligible;
+
   const showPill =
-    droppable &&
     currentMode === 'query' &&
-    isQueryFormValue &&
-    pillState.kind !== 'opaque' &&
-    pillState.kind !== 'custom' &&
-    !forceRawEdit;
+    stablePillEligible &&
+    !forceRawEdit &&
+    !rawEditing;
 
   // D3 (e2e-gap-review.md delta pass): "Custom aggregation…" is otherwise a
   // ONE-WAY RATCHET into raw-text mode — `forceRawEdit` is only ever reset
@@ -314,12 +343,7 @@ export function PropertyRow({
   // valid; `onClick` just flips `forceRawEdit` back to `false` so the SAME
   // value renders as a pill instead of text).
   const canReturnToPill =
-    droppable &&
-    currentMode === 'query' &&
-    isQueryFormValue &&
-    forceRawEdit &&
-    pillState.kind !== 'opaque' &&
-    pillState.kind !== 'custom';
+    droppable && currentMode === 'query' && forceRawEdit && pillEligible;
 
   const pillType = pillState.kind === 'aggregate' || pillState.kind === 'metricRef' ? 'metric' : 'dimension';
   const pillLabel =
@@ -404,14 +428,25 @@ export function PropertyRow({
               type="button"
               aria-label="static value"
               aria-pressed={currentMode === 'static'}
-              disabled={disabled}
+              // VIS-1240 (flip #3): this button used to lie. `currentMode` is
+              // `forceQueryMode || isQueryMode`, so with a `?{...}` value
+              // stored, clicking "static" cleared the override but `isQueryMode`
+              // held the row in query mode — the button visibly depressed and
+              // snapped straight back. It CAN'T demote: a `?{...}` string in a
+              // static number input mangles character-by-character. So say why
+              // instead of pretending: an expression must be cleared first.
+              disabled={disabled || isQueryMode}
+              title={
+                isQueryMode
+                  ? 'Clear the expression to use a static value'
+                  : 'Static value'
+              }
               onClick={() => handleModeChange('static')}
               className={`p-1 transition-colors ${
                 currentMode === 'static'
                   ? 'bg-primary-100 text-primary-700'
                   : 'bg-white text-gray-400 hover:text-gray-600 hover:bg-gray-50'
               } disabled:opacity-50 disabled:cursor-not-allowed`}
-              title="Static value"
             >
               <PiSliders size={14} />
             </button>
@@ -517,16 +552,26 @@ export function PropertyRow({
                 />
               ) : (
                 <>
-                  <RefTextArea
-                    value={body}
-                    onChange={handleQueryChange}
-                    label=""
-                    rows={2}
-                    helperText={description}
-                    disabled={disabled}
-                    allowedTypes={['model', 'dimension', 'metric', 'input']}
-                    restrictBrackets
-                  />
+                  {/* VIS-1240: the focus wrapper is what freezes pill-vs-text
+                      while the user is typing. React's onFocus/onBlur are
+                      focusin/focusout, so they catch focus anywhere inside —
+                      no prop changes to RefTextArea, which 8+ surfaces share. */}
+                  <div
+                    onFocus={handleRawFocus}
+                    onBlur={handleRawBlur}
+                    data-testid={`property-${path}-raw-editor`}
+                  >
+                    <RefTextArea
+                      value={body}
+                      onChange={handleQueryChange}
+                      label=""
+                      rows={2}
+                      helperText={description}
+                      disabled={disabled}
+                      allowedTypes={['model', 'dimension', 'metric', 'input']}
+                      restrictBrackets
+                    />
+                  </div>
                   {canReturnToPill && (
                     <button
                       type="button"

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -389,9 +389,9 @@ export function PropertyRow({
     pillState.kind === 'modelRef'
       ? `${pillState.ref} ▸ choose a dimension`
       : pillState.kind === 'aggregate'
-      ? `${(pillState.agg || '').toUpperCase()} · ${pillState.ref} ▸ ${pillState.column}`
+      ? `${(pillState.agg || '').toUpperCase()} · ${pillState.ref} ▸ ${pillState.propertyPath ?? pillState.column}`
       : pillState.kind === 'dimension'
-        ? `${pillState.ref} ▸ ${pillState.column}`
+        ? `${pillState.ref} ▸ ${pillState.propertyPath ?? pillState.column}`
         : pillState.ref;
 
   // The pill claims to BE the expression, so it has to show all of it. The

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -188,7 +188,7 @@ export function PropertyRow({
   const pillFieldOptsRef = useRef(pillFieldOpts);
   pillFieldOptsRef.current = pillFieldOpts;
 
-  // Escape hatch back to raw-text editing ("Custom aggregation…", 06 §4/§5) —
+  // Escape hatch back to raw-text editing ("Manually edit field…", 06 §4/§5) —
   // per-row local state so switching one pill to raw edit never affects its
   // siblings. Resets whenever the row's OWN path changes (a different field
   // entirely) so a stale escape-hatch flag can't leak across fields.
@@ -354,7 +354,7 @@ export function PropertyRow({
     !forceRawEdit &&
     !rawEditing;
 
-  // D3 (e2e-gap-review.md delta pass): "Custom aggregation…" is otherwise a
+  // D3 (e2e-gap-review.md delta pass): "Manually edit field…" is otherwise a
   // ONE-WAY RATCHET into raw-text mode — `forceRawEdit` is only ever reset
   // by the `useEffect` above, keyed on `path` (stable for the row's whole
   // mount), so even retyping the EXACT original recognized shape (e.g.
@@ -372,7 +372,7 @@ export function PropertyRow({
   // The `droppable` gate that used to be here made that escape hatch reachable
   // ONLY in the Build rail. VIS-1240 removed the same gate from `showPill`, so
   // every other surface (the right rail included) renders pills but had no way
-  // back from raw text: "Custom aggregation…" swapped the interactive pill for
+  // back from raw text: "Manually edit field…" swapped the interactive pill for
   // a RefTextArea whose ref chips carry no menu, permanently. Dropping is what
   // `droppable` governs; whether a value can RENDER as a pill is a property of
   // the value, and so is whether it can render as one again.
@@ -622,7 +622,7 @@ export function PropertyRow({
                       // one can't take a single row.
                       slotShape={slotShape}
                       onApply={handlePillApply}
-                      onCustomAggregation={() => setForceRawEdit(true)}
+                      onManualEdit={() => setForceRawEdit(true)}
                       onSaveAsMetric={
                         onSaveAsMetric ? () => onSaveAsMetric(pillState) : undefined
                       }
@@ -653,7 +653,12 @@ export function PropertyRow({
                       // Raw-text mode has no pill to drop onto, and outside the
                       // Build rail the row wrapper isn't a drop target either.
                       acceptDrops
-                      restrictBrackets
+                      // "Manually edit field…" means the WHOLE expression is
+                      // text, refs included — a chip there is the one part the
+                      // manual escape hatch can't edit. An opaque value the
+                      // user never opted into editing keeps its chips.
+                      plainRefs={forceRawEdit}
+                      restrictBrackets={!forceRawEdit}
                     />
                   </div>
                   {canReturnToPill && (

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -377,14 +377,27 @@ export function PropertyRow({
       : pillState.kind === 'aggregate' || pillState.kind === 'metricRef'
         ? 'metric'
         : 'dimension';
-  const pillLabel =
+  const pillBaseLabel =
     pillState.kind === 'modelRef'
-      ? `${pillState.ref} ▸ choose a property`
+      ? `${pillState.ref} ▸ choose a dimension`
       : pillState.kind === 'aggregate'
       ? `${(pillState.agg || '').toUpperCase()} · ${pillState.ref} ▸ ${pillState.column}`
       : pillState.kind === 'dimension'
         ? `${pillState.ref} ▸ ${pillState.column}`
         : pillState.ref;
+
+  // The pill claims to BE the expression, so it has to show all of it. The
+  // modifier and the index are both authored inside the pill's own editor and
+  // then rendered nowhere on it — `sum(gdp) / 100 }[0]` and a bare `sum(gdp)`
+  // were the same green chip. Suffix them in serialization order (modifier
+  // inside the braces, index outside and last) so the label reads like the
+  // string it generates. `slice` already carries its own brackets.
+  // An unbound `modelRef` has neither yet, so it keeps its bare prompt.
+  const pillSuffix =
+    pillState.kind === 'modelRef'
+      ? ''
+      : `${pillState.modifier ? ` ${pillState.modifier}` : ''}${slice || ''}`;
+  const pillLabel = `${pillBaseLabel}${pillSuffix}`;
 
   // T4 (pills-buildrail #4): the whole pill is a drag SOURCE too, so it can
   // move between slots (drag the x pill onto the y slot), not just receive
@@ -450,8 +463,12 @@ export function PropertyRow({
   // next to every pill. An index is now set from inside the pill's own editor,
   // and the badge appears only once there is a real index to show (and to
   // clear).
+  // ...and once the pill itself renders the index, the badge beside it is the
+  // same fact stated twice. Keep the badge only where there is no pill to carry
+  // it (raw-text / opaque values), where it stays the sole way to see and clear
+  // a slice.
   const showSliceBadge =
-    currentMode === 'query' && isQueryFormValue && !!slice && slotShape !== 'unknown';
+    currentMode === 'query' && isQueryFormValue && !!slice && slotShape !== 'unknown' && !showPill;
 
   return (
     <div

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -368,8 +368,15 @@ export function PropertyRow({
   // toggle that never mutates the underlying value (the raw text is already
   // valid; `onClick` just flips `forceRawEdit` back to `false` so the SAME
   // value renders as a pill instead of text).
-  const canReturnToPill =
-    droppable && currentMode === 'query' && forceRawEdit && pillEligible;
+  //
+  // The `droppable` gate that used to be here made that escape hatch reachable
+  // ONLY in the Build rail. VIS-1240 removed the same gate from `showPill`, so
+  // every other surface (the right rail included) renders pills but had no way
+  // back from raw text: "Custom aggregation…" swapped the interactive pill for
+  // a RefTextArea whose ref chips carry no menu, permanently. Dropping is what
+  // `droppable` governs; whether a value can RENDER as a pill is a property of
+  // the value, and so is whether it can render as one again.
+  const canReturnToPill = currentMode === 'query' && forceRawEdit && pillEligible;
 
   const pillType =
     pillState.kind === 'modelRef'
@@ -610,6 +617,10 @@ export function PropertyRow({
                       ref={pillMenuRef}
                       state={pillState}
                       slice={slice}
+                      // Drives which index options the menu offers — a
+                      // scalar-only prop can't take a range, an array-only
+                      // one can't take a single row.
+                      slotShape={slotShape}
                       onApply={handlePillApply}
                       onCustomAggregation={() => setForceRawEdit(true)}
                       onSaveAsMetric={

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -137,6 +137,7 @@ export function PropertyRow({
   // additive, not a replacement.
   const metrics = useStore(s => s.metrics);
   const dimensions = useStore(s => s.dimensions);
+  const models = useStore(s => s.models);
   const explorerModelStates = useStore(s => s.explorerModelStates);
   const pillFieldOpts = useMemo(() => {
     const toField = f => ({
@@ -175,8 +176,17 @@ export function PropertyRow({
         ...(Array.isArray(dimensions) ? dimensions.map(toField) : []),
         ...computedDimensionFields,
       ],
+      // VIS-1242: lets a bare `${ref(model)}` parse as an UNBOUND pill (a model
+      // was dropped, no property chosen yet) instead of opaque. Draft explorer
+      // models count — a scratch query is the common thing to drop.
+      modelNames: [
+        ...(Array.isArray(models) ? models.map(m => m?.name).filter(Boolean) : []),
+        ...Object.keys(explorerModelStates || {}),
+      ],
     };
-  }, [metrics, dimensions, explorerModelStates]);
+  }, [metrics, dimensions, models, explorerModelStates]);
+  const pillFieldOptsRef = useRef(pillFieldOpts);
+  pillFieldOptsRef.current = pillFieldOpts;
 
   // Escape hatch back to raw-text editing ("Custom aggregation…", 06 §4/§5) —
   // per-row local state so switching one pill to raw edit never affects its
@@ -287,6 +297,22 @@ export function PropertyRow({
     }
   }, []);
 
+  // VIS-1242: a dropped model lands as an UNBOUND pill, and the thing the user
+  // must do next is pick a property — so open the editor for them. Keyed on the
+  // value CHANGING into that state, so an insight loaded with an unbound ref
+  // doesn't pop a menu on every mount.
+  const prevValueRef = useRef(value);
+  useEffect(() => {
+    const changed = prevValueRef.current !== value;
+    prevValueRef.current = value;
+    if (!changed) return;
+    const parsedNow = pillGrammar.parse(
+      parseQueryString(value)?.body ?? '',
+      pillFieldOptsRef.current
+    );
+    if (parsedNow.kind === 'modelRef') pillMenuRef.current?.open();
+  }, [value]);
+
   const pillState = useMemo(
     () => pillGrammar.parse(body, pillFieldOpts),
     [body, pillFieldOpts]
@@ -345,9 +371,16 @@ export function PropertyRow({
   const canReturnToPill =
     droppable && currentMode === 'query' && forceRawEdit && pillEligible;
 
-  const pillType = pillState.kind === 'aggregate' || pillState.kind === 'metricRef' ? 'metric' : 'dimension';
+  const pillType =
+    pillState.kind === 'modelRef'
+      ? 'model'
+      : pillState.kind === 'aggregate' || pillState.kind === 'metricRef'
+        ? 'metric'
+        : 'dimension';
   const pillLabel =
-    pillState.kind === 'aggregate'
+    pillState.kind === 'modelRef'
+      ? `${pillState.ref} ▸ choose a property`
+      : pillState.kind === 'aggregate'
       ? `${(pillState.agg || '').toUpperCase()} · ${pillState.ref} ▸ ${pillState.column}`
       : pillState.kind === 'dimension'
         ? `${pillState.ref} ▸ ${pillState.column}`

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -371,15 +371,32 @@ export function PropertyRow({
     disabled: !showPill,
   });
 
-  const handleSelectPreset = useCallback(
-    preset => {
+  // VIS-1241: ONE commit for everything the pill editor changed — property,
+  // aggregation, modifier and index land in a single `onChange`. Previously
+  // each preset click committed on its own and the index was a separate
+  // control, so a two-part edit wrote the value twice.
+  const handlePillApply = useCallback(
+    ({ useAs, column, modifier, slice: nextSlice }) => {
+      const trimmedModifier = (modifier || '').trim();
+      const base =
+        useAs === 'dimension'
+          ? { kind: 'dimension', ref: pillState.ref, column }
+          : { kind: 'aggregate', agg: useAs, ref: pillState.ref, column };
+      // A metric/dimension REF pill has no model/column of its own — keep its
+      // kind and ref, and let the modifier ride along.
       const nextState =
-        preset === 'dimension'
-          ? { kind: 'dimension', ref: pillState.ref, column: pillState.column }
-          : { kind: 'aggregate', agg: preset, ref: pillState.ref, column: pillState.column };
-      handleQueryChange(pillGrammar.serialize(nextState));
+        pillState.kind === 'metricRef' || pillState.kind === 'dimensionRef'
+          ? { kind: pillState.kind, ref: pillState.ref }
+          : base;
+      if (trimmedModifier) nextState.modifier = trimmedModifier;
+      onChange(
+        serializeQueryString({
+          body: pillGrammar.serialize(nextState),
+          slice: nextSlice || null,
+        })
+      );
     },
-    [pillState, handleQueryChange]
+    [pillState, onChange]
   );
 
   const handlePillRemove = useCallback(() => {
@@ -395,11 +412,13 @@ export function PropertyRow({
   //    bare so we don't show a slicing UI for things we don't classify.
   // We also keep the badge visible when a slice is already authored
   // even if the body is empty, so the user can clear it.
+  // VIS-1241: only shown for a NON-DEFAULT index. Every query slot used to
+  // carry an "All values" badge — the default state, restated on every row,
+  // next to every pill. An index is now set from inside the pill's own editor,
+  // and the badge appears only once there is a real index to show (and to
+  // clear).
   const showSliceBadge =
-    currentMode === 'query' &&
-    isQueryFormValue &&
-    (!!body || !!slice) &&
-    slotShape !== 'unknown';
+    currentMode === 'query' && isQueryFormValue && !!slice && slotShape !== 'unknown';
 
   return (
     <div
@@ -540,7 +559,8 @@ export function PropertyRow({
                     <PillMenu
                       ref={pillMenuRef}
                       state={pillState}
-                      onSelectPreset={handleSelectPreset}
+                      slice={slice}
+                      onApply={handlePillApply}
                       onCustomAggregation={() => setForceRawEdit(true)}
                       onSaveAsMetric={
                         onSaveAsMetric ? () => onSaveAsMetric(pillState) : undefined

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -651,9 +651,19 @@ export function PropertyRow({
                       helperText={description}
                       disabled={disabled}
                       allowedTypes={refKindsFor('insight', 'props')}
-                      // Raw-text mode has no pill to drop onto, and outside the
-                      // Build rail the row wrapper isn't a drop target either.
-                      acceptDrops
+                      // ONLY when the row itself isn't a drop target. This
+                      // editor's droppable nests INSIDE the row's
+                      // `property-zone`, and `pointerWithin` resolves to the
+                      // innermost hit — so registering both made the inner one
+                      // shadow the row. That broke column drops in the Build
+                      // rail: `property-zone` builds `${ref(activeModel).col}`
+                      // from the drag payload, while `ref-text` only knows how
+                      // to insert a ref BY NAME, so a column fell outside its
+                      // allowlist and the drop silently did nothing. A model
+                      // drag passed the allowlist, which is why only columns
+                      // broke. Where the row IS droppable it already handles
+                      // this correctly; where it isn't, this is the only target.
+                      acceptDrops={!droppable}
                       // "Manually edit field…" means the WHOLE expression is
                       // text, refs included — a chip there is the one part the
                       // manual escape hatch can't edit. An opaque value the

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -136,6 +136,7 @@ export function PropertyRow({
   // surfaces this phase's gate doesn't cover). `RefTextArea` remains the
   // fallback for opaque/custom expressions on the Build rail too — this is
   // additive, not a replacement.
+  const showWorkspaceToast = useStore(s => s.showWorkspaceToast);
   const metrics = useStore(s => s.metrics);
   const dimensions = useStore(s => s.dimensions);
   const models = useStore(s => s.models);
@@ -512,18 +513,33 @@ export function PropertyRow({
               // snapped straight back. It CAN'T demote: a `?{...}` string in a
               // static number input mangles character-by-character. So say why
               // instead of pretending: an expression must be cleared first.
-              disabled={disabled || isQueryMode}
+              // Review finding #4: the "says why" was a `title` alone — hover
+              // only, and a real `disabled` button swallows the click, so a
+              // user who clicked simply got nothing. Keep it inert and look
+              // inert, but stay REACHABLE (`aria-disabled` rather than
+              // `disabled`) so the click it already invites can answer itself.
+              // Genuine form-level disabling still uses the real attribute.
+              disabled={disabled}
+              aria-disabled={disabled || isQueryMode}
               title={
                 isQueryMode
                   ? 'Clear the expression to use a static value'
                   : 'Static value'
               }
-              onClick={() => handleModeChange('static')}
+              onClick={() => {
+                if (isQueryMode) {
+                  showWorkspaceToast?.(
+                    'Clear the expression to use a static value.'
+                  );
+                  return;
+                }
+                handleModeChange('static');
+              }}
               className={`p-1 transition-colors ${
                 currentMode === 'static'
                   ? 'bg-primary-100 text-primary-700'
                   : 'bg-white text-gray-400 hover:text-gray-600 hover:bg-gray-50'
-              } disabled:opacity-50 disabled:cursor-not-allowed`}
+              } disabled:opacity-50 disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:cursor-not-allowed`}
             >
               <PiSliders size={14} />
             </button>

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -650,6 +650,9 @@ export function PropertyRow({
                       helperText={description}
                       disabled={disabled}
                       allowedTypes={['model', 'dimension', 'metric', 'input']}
+                      // Raw-text mode has no pill to drop onto, and outside the
+                      // Build rail the row wrapper isn't a drop target either.
+                      acceptDrops
                       restrictBrackets
                     />
                   </div>

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -18,6 +18,7 @@ import { getSlotShape, menuPolicyFor } from './utils/slotShape';
 import { getFieldComponent } from './fields/fields';
 import { SliceBadge } from './SliceBadge';
 import { SliceBanner } from './SliceBanner';
+import { refKindsFor } from '../fieldTypes';
 
 /**
  * PropertyRow - A single property in the schema editor with optional query-string toggle
@@ -649,7 +650,7 @@ export function PropertyRow({
                       rows={2}
                       helperText={description}
                       disabled={disabled}
-                      allowedTypes={['model', 'dimension', 'metric', 'input']}
+                      allowedTypes={refKindsFor('insight', 'props')}
                       // Raw-text mode has no pill to drop onto, and outside the
                       // Build rail the row wrapper isn't a drop target either.
                       acceptDrops

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -713,8 +713,35 @@ describe('PropertyRow', () => {
       const staticBtn = screen.getByLabelText('static value');
       // It used to depress and immediately revert, because `currentMode` ORs in
       // `isQueryMode`. A `?{...}` string cannot render in a static number input.
-      expect(staticBtn).toBeDisabled();
+      // Inert and marked inert — but REACHABLE (finding #4): a real `disabled`
+      // swallows the click, so a user who clicked got nothing at all unless
+      // they hovered and waited for the title.
+      expect(staticBtn).toHaveAttribute('aria-disabled', 'true');
       expect(staticBtn).toHaveAttribute('title', 'Clear the expression to use a static value');
+    });
+
+    test('flip #3: clicking the inert static toggle explains itself', () => {
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ showWorkspaceToast });
+      render(<PropertyRow {...queryRowProps({ value: '?{${ref(orders_q).amount}}' })} />);
+
+      fireEvent.click(screen.getByLabelText('static value'));
+
+      expect(showWorkspaceToast).toHaveBeenCalledWith(
+        'Clear the expression to use a static value.'
+      );
+    });
+
+    test('the toggle still demotes when there IS no expression to clear', () => {
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ showWorkspaceToast });
+      render(<PropertyRow {...queryRowProps({ value: 42 })} />);
+
+      const staticBtn = screen.getByLabelText('static value');
+      expect(staticBtn).not.toHaveAttribute('aria-disabled', 'true');
+      fireEvent.click(staticBtn);
+      // Nothing to explain — it just works.
+      expect(showWorkspaceToast).not.toHaveBeenCalled();
     });
 
     // VIS-1240 (flip #3): this used to assert the opposite — the pill was gated
@@ -944,7 +971,7 @@ describe('PropertyRow', () => {
       );
     });
 
-    test('without onSaveAsMetric, PillMenu renders the action disabled even on an aggregate pill', () => {
+    test('without onSaveAsMetric, PillMenu omits the action rather than showing it dead', () => {
       render(
         <PropertyRow
           {...defaultProps}
@@ -956,7 +983,10 @@ describe('PropertyRow', () => {
         />
       );
       fireEvent.click(screen.getByTestId('pill-menu-trigger'));
-      expect(screen.getByTestId('pill-menu-save-as-metric')).toBeDisabled();
+      // Finding #3: it used to render disabled, blaming the pill for not being
+      // an aggregate — on an aggregate pill. A flow this surface never offers
+      // is omitted instead.
+      expect(screen.queryByTestId('pill-menu-save-as-metric')).not.toBeInTheDocument();
     });
 
     test('PillMenu Remove clears the slot value (never the whole property)', () => {

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -862,6 +862,43 @@ describe('PropertyRow', () => {
           droppable
         />
       );
+      // The pill IS the expression, so it shows the index itself — and the
+      // badge beside it would be the same fact twice.
+      expect(screen.getByTestId('property-pill-x')).toHaveTextContent('[0]');
+      expect(screen.queryByTestId('slice-badge')).not.toBeInTheDocument();
+    });
+
+    test('a modifier and an index both show on the pill, in serialized order', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{sum(${ref(orders_q).amount}) / 100}[0]"
+          droppable
+        />
+      );
+      // Modifier inside the braces, index outside and last — the pill reads
+      // like the string it generates.
+      expect(screen.getByTestId('property-pill-x')).toHaveTextContent(
+        'SUM · orders_q ▸ amount / 100[0]'
+      );
+    });
+
+    test('a value with no pill keeps the badge as its only slice affordance', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          // Two refs — deliberately opaque, so no pill renders.
+          value="?{${ref(orders_q).amount} + ${ref(orders_q).tax}}[0]"
+          droppable
+        />
+      );
+      expect(screen.queryByTestId('property-pill-x')).not.toBeInTheDocument();
       expect(screen.getByTestId('slice-badge')).toBeInTheDocument();
     });
 

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -6,9 +6,9 @@ import useStore from '../../../../stores/store';
 
 // Mock the RefTextArea component
 jest.mock('../RefTextArea', () => {
-  return function MockRefTextArea({ value, onChange, helperText, disabled }) {
+  return function MockRefTextArea({ value, onChange, helperText, disabled, acceptDrops }) {
     return (
-      <div data-testid="ref-text-area">
+      <div data-testid="ref-text-area" data-accept-drops={acceptDrops ? 'true' : 'false'}>
         <input
           value={value || ''}
           onChange={e => onChange(e.target.value)}
@@ -1496,4 +1496,35 @@ describe('PropertyRow', () => {
       expect(onChange).toHaveBeenCalledWith('new value');
     });
   });
+
+
+  // The raw editor's droppable nests INSIDE the row's `property-zone`, and
+  // dnd-kit's `pointerWithin` resolves to the innermost hit. Registering both
+  // let the inner one shadow the row, which broke COLUMN drops in the Build
+  // rail: `property-zone` builds `${ref(activeModel).col}` from the payload,
+  // while `ref-text` can only insert a ref by name — so a column fell outside
+  // its allowlist and the drop silently did nothing. A model passed the
+  // allowlist, so only columns broke.
+  describe('the raw editor does not shadow the row as a drop target', () => {
+    const defs = { 'query-string': { type: 'string', pattern: '^\\?\\{.*\\}$' } };
+    const rawProps = {
+      ...defaultProps,
+      path: 'x',
+      schema: { oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] },
+      defs,
+      // Two refs — deliberately opaque, so the raw editor renders.
+      value: '?{${ref(orders_q).amount} + ${ref(orders_q).tax}}',
+    };
+
+    test('a droppable row keeps ownership of drops', () => {
+      render(<PropertyRow {...rawProps} droppable />);
+      expect(screen.getByTestId('ref-text-area')).toHaveAttribute('data-accept-drops', 'false');
+    });
+
+    test('a NON-droppable row lets the editor accept them — the only target there', () => {
+      render(<PropertyRow {...rawProps} />);
+      expect(screen.getByTestId('ref-text-area')).toHaveAttribute('data-accept-drops', 'true');
+    });
+  });
+
 });

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -768,7 +768,101 @@ describe('PropertyRow', () => {
       );
       fireEvent.click(screen.getByTestId('pill-menu-trigger'));
       fireEvent.click(screen.getByTestId('pill-menu-preset-sum'));
+      // VIS-1241: one commit, on Apply — not one per click.
+      expect(onChange).not.toHaveBeenCalled();
+      fireEvent.click(screen.getByTestId('pill-menu-apply'));
+      expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith('?{sum(${ref(orders_q).amount})}');
+    });
+
+    // ── VIS-1241: the pill is a self-contained editor ────────────────────
+    test('the modifier lands INSIDE the braces, so an index can still follow', () => {
+      const onChange = jest.fn();
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{sum(${ref(orders_q).amount})}"
+          droppable
+          onChange={onChange}
+        />
+      );
+      fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+      fireEvent.change(screen.getByTestId('pill-menu-modifier'), { target: { value: '/ 100' } });
+      fireEvent.change(screen.getByTestId('pill-menu-index'), { target: { value: '[0]' } });
+      fireEvent.click(screen.getByTestId('pill-menu-apply'));
+
+      // `?{ ... }[0]`, never `?{ ... }[0] / 100` — the slice must be last.
+      expect(onChange).toHaveBeenCalledWith('?{sum(${ref(orders_q).amount}) / 100}[0]');
+    });
+
+    test('a modified expression re-opens as a pill with its modifier intact', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{sum(${ref(orders_q).amount}) / 100}[0]"
+          droppable
+        />
+      );
+      // Before the grammar learned modifiers this whole value was opaque and
+      // the pill vanished the moment a modifier was applied.
+      expect(screen.getByTestId('property-pill-x')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+      expect(screen.getByTestId('pill-menu-modifier')).toHaveValue('/ 100');
+      expect(screen.getByTestId('pill-menu-index')).toHaveValue('[0]');
+    });
+
+    test('changing the property re-points the pill', () => {
+      const onChange = jest.fn();
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{${ref(orders_q).amount}}"
+          droppable
+          onChange={onChange}
+        />
+      );
+      fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+      // No schema cached in jsdom, so the picker falls back to a text input —
+      // the point is that the property is editable here at all.
+      fireEvent.change(screen.getByTestId('pill-menu-property'), { target: { value: 'region' } });
+      fireEvent.click(screen.getByTestId('pill-menu-apply'));
+      expect(onChange).toHaveBeenCalledWith('?{${ref(orders_q).region}}');
+    });
+
+    test('the index badge is hidden at its default and shown once set', () => {
+      const { rerender } = render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{${ref(orders_q).amount}}"
+          droppable
+        />
+      );
+      // "All values" is the default; it used to be restated on every row.
+      expect(screen.queryByTestId('slice-badge')).not.toBeInTheDocument();
+
+      rerender(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{${ref(orders_q).amount}}[0]"
+          droppable
+        />
+      );
+      expect(screen.getByTestId('slice-badge')).toBeInTheDocument();
     });
 
     test('onSaveAsMetric threads through to PillMenu, called with the parsed pill state (Explore 2.0 Phase 4)', () => {
@@ -1091,7 +1185,7 @@ describe('PropertyRow', () => {
       });
     });
 
-    test('handleSelectPreset("dimension"): switching an AGGREGATE pill back to a plain dimension via the menu', () => {
+    test('Apply after picking "Dimension": switching an AGGREGATE pill back to a plain dimension via the menu', () => {
       const onChange = jest.fn();
       render(
         <PropertyRow
@@ -1106,6 +1200,7 @@ describe('PropertyRow', () => {
       );
       fireEvent.click(screen.getByTestId('pill-menu-trigger'));
       fireEvent.click(screen.getByTestId('pill-menu-preset-dimension'));
+      fireEvent.click(screen.getByTestId('pill-menu-apply'));
       expect(onChange).toHaveBeenCalledWith('?{${ref(orders_q).amount}}');
     });
 

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -868,6 +868,27 @@ describe('PropertyRow', () => {
       expect(screen.queryByTestId('slice-badge')).not.toBeInTheDocument();
     });
 
+    // "Custom aggregation…" was a one-way trip outside the Build rail: the
+    // return affordance was gated on `droppable`, which only that rail sets.
+    test('the way back from "Custom aggregation…" exists on a NON-droppable row', () => {
+      render(
+        <PropertyRow
+          {...defaultProps}
+          path="x"
+          schema={{ oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] }}
+          defs={queryStringDef}
+          value="?{avg(${ref(orders_q).amount})}"
+        />
+      );
+      fireEvent.click(screen.getByTestId('pill-menu-trigger'));
+      fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+      // The pill is gone (raw text now), and the escape hatch is present.
+      expect(screen.queryByTestId('property-pill-x')).not.toBeInTheDocument();
+      expect(screen.getByTestId('property-x-back-to-pill')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('property-x-back-to-pill'));
+      expect(screen.getByTestId('property-pill-x')).toBeInTheDocument();
+    });
+
     test('a modifier and an index both show on the pill, in serialized order', () => {
       render(
         <PropertyRow

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { PropertyRow } from './PropertyRow';
 import useStore from '../../../../stores/store';
 
@@ -651,7 +651,79 @@ describe('PropertyRow', () => {
       expect(screen.getByTestId('property-pill-x')).not.toHaveAttribute('data-warning');
     });
 
-    test('the SAME recognized value falls back to RefTextArea when NOT droppable (fork is gated, not universal)', () => {
+    // ── VIS-1240: the three reasons the editor appeared to change at random ──
+
+    const queryRowProps = extra => ({
+      path: 'x',
+      value: '?{count(distinct ${ref(orders_q).id})}', // opaque -> raw editor
+      onChange: jest.fn(),
+      onRemove: jest.fn(),
+      schema: { oneOf: [{ $ref: '#/$defs/query-string' }, { type: 'number' }] },
+      defs: queryStringDef,
+      droppable: true,
+      ...extra,
+    });
+
+    test('flip #1: typing does not swap the editor out from under the caret', () => {
+      const { rerender } = render(<PropertyRow {...queryRowProps()} />);
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+
+      // The user clicks into the raw editor and starts typing.
+      fireEvent.focus(screen.getByTestId('ref-input'));
+      // Mid-keystroke the text momentarily parses as a clean ref. Before this
+      // fix the pill replaced the editor here and the caret was lost.
+      rerender(<PropertyRow {...queryRowProps({ value: '?{${ref(orders_q).amount}}' })} />);
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+      expect(screen.queryByTestId('property-pill-x')).not.toBeInTheDocument();
+
+      // Once they leave the field, it settles into the pill.
+      fireEvent.blur(screen.getByTestId('property-x-raw-editor'));
+      expect(screen.getByTestId('property-pill-x')).toBeInTheDocument();
+    });
+
+    test('flip #1: focus moving WITHIN the raw editor does not end the edit', () => {
+      const { rerender } = render(<PropertyRow {...queryRowProps()} />);
+      const input = screen.getByTestId('ref-input');
+      fireEvent.focus(input);
+      // focusout fires when focus hops to a sibling control inside the editor
+      // (its "+ add ref" button); `relatedTarget` still inside means keep editing.
+      fireEvent.blur(screen.getByTestId('property-x-raw-editor'), { relatedTarget: input });
+      rerender(<PropertyRow {...queryRowProps({ value: '?{${ref(orders_q).amount}}' })} />);
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+    });
+
+    test('flip #2: the representation is held while the field tables are loading', () => {
+      // A bare `${ref(name)}` only resolves once metrics/dimensions arrive; until
+      // then it parses as opaque. Re-deciding on data still in flight is what
+      // made a value paint as raw code and then jump to a pill.
+      const props = queryRowProps({ value: '?{${ref(revenue)}}' });
+      const { rerender } = render(<PropertyRow {...props} />);
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+
+      act(() => useStore.setState({ metricsLoading: true }));
+      rerender(<PropertyRow {...props} />);
+      // Still the raw editor — not re-decided mid-fetch.
+      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
+
+      act(() => useStore.setState({ metricsLoading: false }));
+    });
+
+    test('flip #3: the static toggle says why it cannot demote instead of snapping back', () => {
+      render(<PropertyRow {...queryRowProps({ value: '?{${ref(orders_q).amount}}' })} />);
+      const staticBtn = screen.getByLabelText('static value');
+      // It used to depress and immediately revert, because `currentMode` ORs in
+      // `isQueryMode`. A `?{...}` string cannot render in a static number input.
+      expect(staticBtn).toBeDisabled();
+      expect(staticBtn).toHaveAttribute('title', 'Clear the expression to use a static value');
+    });
+
+    // VIS-1240 (flip #3): this used to assert the opposite — the pill was gated
+    // on `droppable`, so the SAME stored value rendered as a pill in the Build
+    // rail and as raw text in the right rail. That surface-dependent split was
+    // one of the three reasons the editor appeared to change at random.
+    // DROPPING is still gated on `droppable`; how a value RENDERS is now a
+    // property of the value alone.
+    test('the SAME recognized value renders as a pill even when NOT droppable', () => {
       render(
         <PropertyRow
           {...defaultProps}
@@ -661,8 +733,10 @@ describe('PropertyRow', () => {
           value="?{${ref(orders_q).amount}}"
         />
       );
-      expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
-      expect(screen.queryByTestId('pill-menu-trigger')).not.toBeInTheDocument();
+      expect(screen.getByTestId('property-pill-x')).toBeInTheDocument();
+      expect(screen.getByTestId('pill-menu-trigger')).toBeInTheDocument();
+      // …but the row is not a drop target.
+      expect(screen.queryByTestId('droppable-property-x')).not.toBeInTheDocument();
     });
 
     test('an opaque/unparseable expression always falls back to RefTextArea, even when droppable', () => {

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.test.jsx
@@ -868,9 +868,9 @@ describe('PropertyRow', () => {
       expect(screen.queryByTestId('slice-badge')).not.toBeInTheDocument();
     });
 
-    // "Custom aggregation…" was a one-way trip outside the Build rail: the
+    // "Manually edit field…" was a one-way trip outside the Build rail: the
     // return affordance was gated on `droppable`, which only that rail sets.
-    test('the way back from "Custom aggregation…" exists on a NON-droppable row', () => {
+    test('the way back from "Manually edit field…" exists on a NON-droppable row', () => {
       render(
         <PropertyRow
           {...defaultProps}
@@ -881,7 +881,7 @@ describe('PropertyRow', () => {
         />
       );
       fireEvent.click(screen.getByTestId('pill-menu-trigger'));
-      fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+      fireEvent.click(screen.getByTestId('pill-menu-manual-edit'));
       // The pill is gone (raw text now), and the escape hatch is present.
       expect(screen.queryByTestId('property-pill-x')).not.toBeInTheDocument();
       expect(screen.getByTestId('property-x-back-to-pill')).toBeInTheDocument();
@@ -977,7 +977,7 @@ describe('PropertyRow', () => {
       expect(onChange).toHaveBeenCalledWith('');
     });
 
-    test('"Custom aggregation…" switches the slot back to RefTextArea, pre-filled with the current body', () => {
+    test('"Manually edit field…" switches the slot back to RefTextArea, pre-filled with the current body', () => {
       render(
         <PropertyRow
           {...defaultProps}
@@ -989,18 +989,18 @@ describe('PropertyRow', () => {
         />
       );
       fireEvent.click(screen.getByTestId('pill-menu-trigger'));
-      fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+      fireEvent.click(screen.getByTestId('pill-menu-manual-edit'));
       expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
       expect(screen.getByTestId('ref-input')).toHaveValue('${ref(orders_q).amount}');
     });
 
-    // D3 (e2e-gap-review.md delta pass): the "Custom aggregation…" escape
+    // D3 (e2e-gap-review.md delta pass): the "Manually edit field…" escape
     // hatch used to be a one-way ratchet — no way back to pill rendering
     // short of an unrelated remount, even once the raw text re-parses as a
     // clean, recognized shape. These three tests lock in the "Back to pill"
     // affordance's exact contract.
     describe('"Back to pill" return path (D3)', () => {
-      test('the affordance is ABSENT immediately after "Custom aggregation…" while the raw text is still opaque/custom-shaped', () => {
+      test('the affordance is ABSENT immediately after "Manually edit field…" while the raw text is still opaque/custom-shaped', () => {
         render(
           <PropertyRow
             {...defaultProps}
@@ -1035,7 +1035,7 @@ describe('PropertyRow', () => {
           />
         );
         fireEvent.click(screen.getByTestId('pill-menu-trigger'));
-        fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+        fireEvent.click(screen.getByTestId('pill-menu-manual-edit'));
         // Still the exact original recognized shape — RefTextArea is showing
         // (forceRawEdit is true) but the affordance should already be visible
         // since the raw text re-parses as a clean 'dimension' pill.
@@ -1086,7 +1086,7 @@ describe('PropertyRow', () => {
           />
         );
         fireEvent.click(screen.getByTestId('pill-menu-trigger'));
-        fireEvent.click(screen.getByTestId('pill-menu-custom-aggregation'));
+        fireEvent.click(screen.getByTestId('pill-menu-manual-edit'));
         expect(screen.getByTestId('ref-text-area')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('property-x-back-to-pill'));

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -13,6 +13,7 @@ import { parseRefValue, formatRef } from '../../../utils/refString';
 import RefTextArea from './RefTextArea';
 import Select from '../../common/Select';
 import { refKindsFor } from './fieldTypes';
+import { REF_INSERT_HINT } from './RefTextArea';
 
 /**
  * TableEditForm - Form component for editing/creating tables
@@ -383,7 +384,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
                 label="Columns"
                 items={columns}
                 onChange={setColumns}
-                helperText="Field references for pivot column headers"
+                helperText={`Field references for pivot column headers. ${REF_INSERT_HINT}`}
                 error={errors.columns}
               />
 
@@ -391,7 +392,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
                 label="Rows"
                 items={rows}
                 onChange={setRows}
-                helperText="Field references for pivot row grouping"
+                helperText={`Field references for pivot row grouping. ${REF_INSERT_HINT}`}
                 error={errors.rows}
               />
 
@@ -399,7 +400,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
                 label="Values"
                 items={values}
                 onChange={setValues}
-                helperText="Aggregation expressions, e.g. sum(...)"
+                helperText={`Aggregation expressions, e.g. sum(...). ${REF_INSERT_HINT}`}
                 error={errors.values}
               />
             </div>
@@ -520,7 +521,6 @@ const RefListField = ({ label, items, onChange, helperText, error }) => {
               onChange={value => handleChange(index, value)}
               allowedTypes={refKindsFor('table', 'columns')}
               rows={1}
-              hideAddButton
             />
           </div>
           <button

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -12,6 +12,7 @@ import { getTypeByValue } from './objectTypeConfigs';
 import { parseRefValue, formatRef } from '../../../utils/refString';
 import RefTextArea from './RefTextArea';
 import Select from '../../common/Select';
+import { refKindsFor } from './fieldTypes';
 
 /**
  * TableEditForm - Form component for editing/creating tables
@@ -517,7 +518,7 @@ const RefListField = ({ label, items, onChange, helperText, error }) => {
             <RefTextArea
               value={item}
               onChange={value => handleChange(index, value)}
-              allowedTypes={['model', 'insight', 'dimension', 'metric']}
+              allowedTypes={refKindsFor('table', 'columns')}
               rows={1}
               hideAddButton
             />

--- a/viewer/src/components/views/common/fieldTypes.js
+++ b/viewer/src/components/views/common/fieldTypes.js
@@ -1,0 +1,252 @@
+/**
+ * fieldTypes — the one place that says how each field may be edited.
+ *
+ * WHY THIS EXISTS
+ *
+ * The rules for authoring a field are real and enforced, but they live in three
+ * places the viewer can't read: Pydantic types (`QueryOrStringField` vs plain
+ * `str`), Python validators (`sql_model.py`'s nested-ref prohibition,
+ * `relation.py`'s two-model minimum, `accessor_validator.py`'s input accessors),
+ * and a scatter of hardcoded literals across components. Every surface has been
+ * re-deriving them, differently, and getting them subtly wrong.
+ *
+ * This is the schema's understudy. It is deliberately JavaScript rather than a
+ * `$defs` change: the shape below maps 1:1 onto a future schema annotation, so
+ * once we trust these entries they can move into `visivo/models/` and this file
+ * becomes a thin reader. Until then, changing an authoring rule means changing
+ * Python AND this file — the tests at the bottom of `fieldTypes.test.js` pin the
+ * pairs that are checkable so they can't drift silently.
+ *
+ * TWO INDEPENDENT AXES
+ *
+ * The naive reading is that a field's grammar tells you its editor. It doesn't.
+ * `?{ }` is a type DISCRIMINATOR — it exists only where a field's Pydantic type
+ * is a union of literal-or-SQL, to say which branch a value is on. A field that
+ * can only ever hold SQL (`metric.expression`, `relation.condition`) carries no
+ * wrapper, and that says nothing about how it should be edited. So `editor`
+ * (which control) and `refKinds`/`bareRefs`/`minRefs` (what's legal inside) are
+ * declared separately.
+ */
+
+/**
+ * The control a field is authored through.
+ *
+ * - `object-ref`   one whole-object pointer, `ref(name)`. Not an expression.
+ * - `query-string` `?{ ... }` with an optional trailing `[index]`.
+ * - `context-sql`  raw SQL that may contain `${ref(...)}` context strings.
+ * - `plain-sql`    raw SQL where refs are a hard validation error.
+ */
+export const EDITORS = {
+  OBJECT_REF: 'object-ref',
+  QUERY_STRING: 'query-string',
+  CONTEXT_SQL: 'context-sql',
+  PLAIN_SQL: 'plain-sql',
+};
+
+/**
+ * An input's "property" is not a column — it's one of a fixed set of accessors,
+ * and which are legal depends on the input's type. Mirrors
+ * `visivo/query/patterns.py`'s SINGLE_SELECT_ACCESSORS / MULTI_SELECT_ACCESSORS,
+ * enforced by `accessor_validator.validate_input_accessor`.
+ */
+export const INPUT_ACCESSORS = {
+  'single-select': ['value'],
+  'multi-select': ['values', 'min', 'max', 'first', 'last'],
+};
+
+/** Every accessor, for the "input type unknown yet" case (fail open). */
+export const ALL_INPUT_ACCESSORS = ['value', 'values', 'min', 'max', 'first', 'last'];
+
+// The vocabulary shared by every `?{ }` slot: a model column, a semantic-layer
+// field, or an input's runtime value. Named once so props and interactions
+// can't drift apart — they are the same authoring surface.
+const QUERY_STRING_REF_KINDS = ['model', 'dimension', 'metric', 'input'];
+
+const DEFAULTS = {
+  refKinds: [],
+  bareRefs: false,
+  minRefs: 0,
+  maxRefs: null,
+  slice: false,
+};
+
+/**
+ * Keyed `<objectType>.<field>`. `field` is the schema field name, except for
+ * `props`, which stands for the whole Plotly prop tree — every leaf under it
+ * shares one rule.
+ */
+const FIELD_TYPES = {
+  // ── Whole-object pointers ────────────────────────────────────────────────
+  // Not expressions at all: exactly one object, chosen or dropped, never typed.
+  'item.chart': {
+    editor: EDITORS.OBJECT_REF,
+    refKinds: ['chart', 'table', 'markdown', 'input'],
+    minRefs: 1,
+    maxRefs: 1,
+    why: 'An item holds exactly one leaf object.',
+  },
+  'table.columns': {
+    editor: EDITORS.CONTEXT_SQL,
+    // A table column may render a whole insight, unlike every other expression
+    // surface — the only place `insight` is a legal ref.
+    refKinds: ['model', 'insight', 'dimension', 'metric'],
+    bareRefs: true,
+    why: 'A table column is an expression, or a whole insight rendered in the cell.',
+  },
+  'input.options': {
+    editor: EDITORS.QUERY_STRING,
+    // An input's options come from a model query. It cannot reference another
+    // input (that would be circular) or a metric (an aggregate is not a list).
+    refKinds: ['model'],
+    bareRefs: false,
+    why: 'The option list is a query against a model.',
+  },
+  'model.source': {
+    editor: EDITORS.OBJECT_REF,
+    refKinds: ['source'],
+    minRefs: 1,
+    maxRefs: 1,
+    why: 'A model reads from exactly one source.',
+  },
+
+  // ── Query strings (`?{ }`) ───────────────────────────────────────────────
+  'insight.props': {
+    editor: EDITORS.QUERY_STRING,
+    refKinds: QUERY_STRING_REF_KINDS,
+    bareRefs: true,
+    slice: true,
+    why: 'A Plotly prop may be a literal or SQL; `?{ }` says which, and a trailing [index] slices the result.',
+  },
+  'interaction.filter': {
+    editor: EDITORS.QUERY_STRING,
+    refKinds: QUERY_STRING_REF_KINDS,
+    bareRefs: true,
+    slice: true,
+    why: 'Boolean expression evaluated per row in the viewer.',
+  },
+  'interaction.split': {
+    editor: EDITORS.QUERY_STRING,
+    refKinds: QUERY_STRING_REF_KINDS,
+    bareRefs: true,
+    slice: true,
+    why: 'Column or expression whose distinct values break the insight into series.',
+  },
+  'interaction.sort': {
+    editor: EDITORS.QUERY_STRING,
+    refKinds: QUERY_STRING_REF_KINDS,
+    bareRefs: true,
+    slice: true,
+    why: 'Column or expression to sort rows by.',
+  },
+
+  // ── SQL carrying context strings ─────────────────────────────────────────
+  'relation.condition': {
+    editor: EDITORS.CONTEXT_SQL,
+    // Only models. A dimension or metric ref would resolve to an aggregate or a
+    // derived column, neither of which is a join key. NOTE: `relation.py`
+    // documents "Cannot join on metrics (aggregated values)" in the field
+    // description but does NOT enforce it — this list is the only thing
+    // stopping a user from authoring one.
+    refKinds: ['model'],
+    // A bare `${ref(orders)}` names a table, not a column; it cannot be one
+    // side of an `=`. Every ref here must carry a property.
+    bareRefs: false,
+    // Enforced by `relation.validate_condition_has_models`.
+    minRefs: 2,
+    why: 'A join predicate between two models; every ref names a column on one of them.',
+  },
+  'metric.expression': {
+    editor: EDITORS.CONTEXT_SQL,
+    refKinds: ['model', 'metric', 'dimension'],
+    // Unlike a relation condition, a BARE ref is meaningful and common here:
+    // `${ref(other_metric)}` composes metrics. The field resolver handles it
+    // explicitly ("when field name is none, the name is a metric or dimension").
+    bareRefs: true,
+    why: 'An aggregate expression that may compose other metrics and model columns.',
+  },
+  'dimension.expression': {
+    editor: EDITORS.CONTEXT_SQL,
+    refKinds: ['model', 'dimension'],
+    bareRefs: true,
+    why: 'A row-level expression over model columns and other dimensions.',
+  },
+};
+
+/**
+ * Nested (model-scoped) metrics and dimensions are a DIFFERENT GRAMMAR under the
+ * same field name — the only thing distinguishing them is where they sit in the
+ * YAML. `sql_model.py`'s `set_parent_names_on_nested_objects` raises on any ref:
+ *
+ *   Nested metric '…' cannot use ref() syntax in expression. Nested metrics can
+ *   only reference fields from their parent model directly.
+ *
+ * The Explorer's "computed column" is exactly this case — it promotes to a
+ * metric/dimension with a `parentModel`, which `project_writer._new` nests under
+ * `model.metrics` / `model.dimensions`.
+ */
+const NESTED_OVERRIDES = {
+  'metric.expression': {
+    editor: EDITORS.PLAIN_SQL,
+    refKinds: [],
+    bareRefs: false,
+    maxRefs: 0,
+    why: 'Nested in a model: plain SQL over the parent model’s columns. Refs are a save-time error.',
+  },
+  'dimension.expression': {
+    editor: EDITORS.PLAIN_SQL,
+    refKinds: [],
+    bareRefs: false,
+    maxRefs: 0,
+    why: 'Nested in a model: plain SQL over the parent model’s columns. Refs are a save-time error.',
+  },
+};
+
+/**
+ * Resolve how a field may be edited.
+ *
+ * @param {string} objectType - e.g. 'relation', 'metric', 'insight'
+ * @param {string} field - schema field name; 'props' covers the whole prop tree
+ * @param {object} [opts]
+ * @param {boolean} [opts.nested] - the object is defined UNDER a model
+ *   (embedded/model-scoped), which changes metric/dimension to `plain-sql`
+ * @returns {object|null} the entry, or null when the field has no declared rule
+ */
+export function fieldTypeFor(objectType, field, { nested = false } = {}) {
+  if (!objectType || !field) return null;
+  // A Plotly prop path ('marker.color', 'x') resolves to the shared props rule.
+  const key = objectType === 'insight' && field !== 'props' ? 'insight.props' : `${objectType}.${field}`;
+  const base = FIELD_TYPES[key];
+  if (!base) return null;
+  const override = nested ? NESTED_OVERRIDES[key] : null;
+  return { key, ...DEFAULTS, ...base, ...override };
+}
+
+/**
+ * The library types a field's editor may insert or accept on drop.
+ *
+ * Replaces the per-call-site `allowedTypes` literals. Returns `[]` — no ref
+ * affordances at all — for `plain-sql` fields, which is the point: an editor
+ * should not offer an insertion the backend will reject on save.
+ *
+ * @returns {string[]}
+ */
+export function refKindsFor(objectType, field, opts) {
+  return fieldTypeFor(objectType, field, opts)?.refKinds ?? [];
+}
+
+/**
+ * The accessors legal on an input pill, given the input's type. Falls open to
+ * the full set when the type isn't known yet, matching the project's
+ * fail-open convention for not-yet-loaded metadata.
+ *
+ * @param {string} [inputType] - 'single-select' | 'multi-select'
+ * @returns {string[]}
+ */
+export function accessorsForInput(inputType) {
+  return INPUT_ACCESSORS[inputType] || ALL_INPUT_ACCESSORS;
+}
+
+/** Every declared key, for tests that assert call sites delegate here. */
+export const DECLARED_FIELD_KEYS = Object.keys(FIELD_TYPES);
+
+export default fieldTypeFor;

--- a/viewer/src/components/views/common/fieldTypes.test.js
+++ b/viewer/src/components/views/common/fieldTypes.test.js
@@ -1,0 +1,167 @@
+import {
+  fieldTypeFor,
+  refKindsFor,
+  accessorsForInput,
+  EDITORS,
+  ALL_INPUT_ACCESSORS,
+} from './fieldTypes';
+
+describe('fieldTypeFor — container vs vocabulary are separate axes', () => {
+  test('two fields with the same container can have different vocabularies', () => {
+    const relation = fieldTypeFor('relation', 'condition');
+    const metric = fieldTypeFor('metric', 'expression');
+
+    // Same editor…
+    expect(relation.editor).toBe(EDITORS.CONTEXT_SQL);
+    expect(metric.editor).toBe(EDITORS.CONTEXT_SQL);
+    // …different rules. This is the distinction the old "Grammar" column hid.
+    expect(relation.refKinds).toEqual(['model']);
+    expect(metric.refKinds).toEqual(expect.arrayContaining(['metric']));
+    expect(relation.bareRefs).toBe(false);
+    expect(metric.bareRefs).toBe(true);
+  });
+
+  test('an unknown field has no declared rule rather than a wrong default', () => {
+    expect(fieldTypeFor('relation', 'join_type')).toBeNull();
+    expect(fieldTypeFor('nonsense', 'field')).toBeNull();
+    expect(fieldTypeFor(null, 'x')).toBeNull();
+    expect(fieldTypeFor('metric', null)).toBeNull();
+  });
+
+  test('every entry carries a prose reason, so the next reader need not re-derive it', () => {
+    ['relation.condition', 'metric.expression', 'insight.props', 'model.source'].forEach(key => {
+      const [type, field] = key.split('.');
+      expect(fieldTypeFor(type, field).why).toEqual(expect.any(String));
+    });
+  });
+});
+
+// `relation.validate_condition_has_models` requires two distinct models, and a
+// bare `${ref(orders)}` names a table — it cannot be one side of an `=`.
+describe('relation.condition — the only field with a minimum ref count', () => {
+  const entry = fieldTypeFor('relation', 'condition');
+
+  test('requires at least two refs', () => {
+    expect(entry.minRefs).toBe(2);
+  });
+
+  test('requires a property on every ref', () => {
+    expect(entry.bareRefs).toBe(false);
+  });
+
+  test('offers models only — a metric ref would be an aggregate, not a join key', () => {
+    expect(entry.refKinds).toEqual(['model']);
+  });
+
+  test('no other declared field imposes a minimum', () => {
+    const others = [
+      fieldTypeFor('metric', 'expression'),
+      fieldTypeFor('dimension', 'expression'),
+      fieldTypeFor('insight', 'props'),
+      fieldTypeFor('interaction', 'filter'),
+    ];
+    others.forEach(e => expect(e.minRefs).toBe(0));
+  });
+});
+
+// `sql_model.set_parent_names_on_nested_objects` raises on ANY ref in a nested
+// metric/dimension expression. The registry has to agree, or the editor will
+// offer insertions that fail on save.
+describe('nested metric/dimension — a different grammar under the same field name', () => {
+  test.each(['metric', 'dimension'])('%s.expression nests to plain-sql with no refs', type => {
+    const standalone = fieldTypeFor(type, 'expression');
+    const nested = fieldTypeFor(type, 'expression', { nested: true });
+
+    expect(standalone.editor).toBe(EDITORS.CONTEXT_SQL);
+    expect(standalone.refKinds.length).toBeGreaterThan(0);
+
+    expect(nested.editor).toBe(EDITORS.PLAIN_SQL);
+    expect(nested.refKinds).toEqual([]);
+    expect(nested.bareRefs).toBe(false);
+    // Not merely "none offered" — none are legal at all.
+    expect(nested.maxRefs).toBe(0);
+  });
+
+  test('nesting does not change fields that have no nested form', () => {
+    const plain = fieldTypeFor('relation', 'condition');
+    const asNested = fieldTypeFor('relation', 'condition', { nested: true });
+    expect(asNested).toEqual(plain);
+  });
+});
+
+describe('query strings', () => {
+  test('every Plotly prop path resolves to the one shared props rule', () => {
+    const x = fieldTypeFor('insight', 'x');
+    const nested = fieldTypeFor('insight', 'marker.color');
+    expect(x.key).toBe('insight.props');
+    expect(nested.key).toBe('insight.props');
+    expect(x).toEqual(nested);
+  });
+
+  test('props and interactions share one vocabulary — they are the same surface', () => {
+    const props = fieldTypeFor('insight', 'props').refKinds;
+    ['filter', 'split', 'sort'].forEach(f => {
+      expect(fieldTypeFor('interaction', f).refKinds).toEqual(props);
+    });
+  });
+
+  test('inputs are legal in query strings but not in semantic-layer expressions', () => {
+    // An input is a runtime value; a metric/dimension must resolve statically.
+    expect(fieldTypeFor('insight', 'props').refKinds).toContain('input');
+    expect(fieldTypeFor('metric', 'expression').refKinds).not.toContain('input');
+    expect(fieldTypeFor('dimension', 'expression').refKinds).not.toContain('input');
+    expect(fieldTypeFor('relation', 'condition').refKinds).not.toContain('input');
+  });
+
+  test('only query strings accept a trailing [index]', () => {
+    expect(fieldTypeFor('insight', 'props').slice).toBe(true);
+    expect(fieldTypeFor('relation', 'condition').slice).toBe(false);
+    expect(fieldTypeFor('metric', 'expression').slice).toBe(false);
+  });
+});
+
+describe('refKindsFor', () => {
+  test('delegates to the entry', () => {
+    expect(refKindsFor('relation', 'condition')).toEqual(['model']);
+  });
+
+  test('a plain-sql field offers nothing — the whole point of declaring it', () => {
+    expect(refKindsFor('metric', 'expression', { nested: true })).toEqual([]);
+  });
+
+  test('an undeclared field offers nothing rather than a permissive default', () => {
+    // The old RefTextArea default included `source`, which has no value to
+    // reference from inside an expression — a ref that can never resolve.
+    expect(refKindsFor('relation', 'join_type')).toEqual([]);
+    expect(refKindsFor('relation', 'join_type')).not.toContain('source');
+  });
+
+  test('no declared field offers `source`', () => {
+    ['relation.condition', 'metric.expression', 'dimension.expression', 'insight.props'].forEach(
+      key => {
+        const [type, field] = key.split('.');
+        expect(refKindsFor(type, field)).not.toContain('source');
+      }
+    );
+  });
+});
+
+// An input pill's "property" is an accessor from a fixed set, not a column —
+// and which are legal depends on the input's type
+// (`accessor_validator.validate_input_accessor`).
+describe('accessorsForInput', () => {
+  test('single-select exposes only `value`', () => {
+    expect(accessorsForInput('single-select')).toEqual(['value']);
+  });
+
+  test('multi-select exposes the collection accessors, and not `value`', () => {
+    const accessors = accessorsForInput('multi-select');
+    expect(accessors).toEqual(expect.arrayContaining(['values', 'min', 'max', 'first', 'last']));
+    expect(accessors).not.toContain('value');
+  });
+
+  test('an unknown type fails OPEN, matching the project convention', () => {
+    expect(accessorsForInput(undefined)).toEqual(ALL_INPUT_ACCESSORS);
+    expect(accessorsForInput('not-a-type')).toEqual(ALL_INPUT_ACCESSORS);
+  });
+});

--- a/viewer/src/components/views/common/pillFieldSwap.js
+++ b/viewer/src/components/views/common/pillFieldSwap.js
@@ -43,7 +43,14 @@ const parseQueryBody = value => {
   // slot's syntactic shape (bare column ref vs aggregate-wrapped), which is
   // what both detectors below need, independent of whatever the store's
   // CURRENT metrics/dimensions lists happen to contain right now.
-  return pillGrammar.parse(match[1], {});
+  const state = pillGrammar.parse(match[1], {});
+  // VIS-1241: a slot carrying a MODIFIER (`${ref(m).region} = 'west'`) is now
+  // recognized by the grammar, but it must not be swap-eligible: the swap
+  // rewrites a slot to a bare `?{${ref(name)}}`, which would silently discard
+  // the hand-written modifier. Treat it the way it was treated before the
+  // grammar learned modifiers — as a shape these detectors don't touch.
+  if (state && state.modifier) return null;
+  return state;
 };
 
 /** Every column-ref-shaped (dimension/aggregate) prop + interaction slot

--- a/viewer/src/components/views/common/pillFieldSwap.test.js
+++ b/viewer/src/components/views/common/pillFieldSwap.test.js
@@ -60,9 +60,10 @@ describe('pillFieldSwap', () => {
           interactions: [{ type: 'filter', value: '?{${ref(orders_q).region} = \'west\'}' }],
         },
       };
-      // Not a clean single-ref shape (has a trailing comparison) — this
-      // exercises the "doesn't match, no false positive" path along with a
-      // clean one below.
+      // Carries a MODIFIER (the trailing comparison). The grammar recognizes
+      // that shape since VIS-1241, but it is deliberately NOT swap-eligible:
+      // a swap rewrites the slot to a bare `?{${ref(name)}}`, which would
+      // silently discard the hand-written `= 'west'`.
       expect(findReclassifiedSlots('region', 'dimension', insightStates)).toHaveLength(0);
 
       const cleanInteraction = {
@@ -72,6 +73,33 @@ describe('pillFieldSwap', () => {
       expect(hits).toHaveLength(1);
       expect(hits[0].location).toBe('interaction');
       expect(hits[0].key).toBe(0);
+    });
+  });
+
+  describe('modified expressions are never swap-eligible (VIS-1241)', () => {
+    test('a modifier excludes a slot from BOTH detectors', () => {
+      const modified = {
+        a: {
+          props: { y: "?{sum(${ref(orders_q).amount}) / 100}" },
+          interactions: [],
+        },
+      };
+      // Reclassification (a global `amount` is promoted)…
+      expect(findReclassifiedSlots('amount', 'metric', modified)).toHaveLength(0);
+      // …and the dedup scan, which would otherwise offer to replace the
+      // expression with a bare metric ref and drop the `/ 100`.
+      expect(
+        findMatchingExpressionSlots(
+          {
+            promotedRef: 'orders_q',
+            promotedColumn: 'amount',
+            promotedAgg: 'sum',
+            promotedName: 'revenue',
+            promotedType: 'metric',
+          },
+          modified
+        )
+      ).toHaveLength(0);
     });
   });
 

--- a/viewer/src/components/views/common/pillGrammar.js
+++ b/viewer/src/components/views/common/pillGrammar.js
@@ -176,7 +176,7 @@ const findGlobalField = (name, { metricFields, dimensionFields }) => {
  * @param {Array<{name: string, parentModel?: string}>} [opts.dimensionFields] -
  *   every known Dimension, same shape.
  * @returns {{
- *   kind: 'dimension'|'aggregate'|'metricRef'|'dimensionRef'|'custom'|'opaque',
+ *   kind: 'dimension'|'aggregate'|'metricRef'|'dimensionRef'|'modelRef'|'custom'|'opaque',
  *   ref?: string, column?: string, agg?: string, raw: string,
  *   statedModel?: string, resolvedParent?: string,
  * }}
@@ -190,6 +190,11 @@ export function parse(expr, opts = {}) {
     const name = bare[1].trim();
     const global = findGlobalField(name, opts);
     if (global) return { kind: global.kind, ref: name, raw };
+    // VIS-1242: a bare ref naming a MODEL is an unbound pill — a model was
+    // dropped and no property has been chosen yet. Without this it parsed as
+    // `opaque`, which suppresses the pill entirely, so a dropped model had
+    // nothing to configure.
+    if ((opts.modelNames || []).includes(name)) return { kind: 'modelRef', ref: name, raw };
     return { kind: 'opaque', raw };
   }
 
@@ -311,6 +316,7 @@ export function serialize(state) {
       return withModifier(`${state.agg}(${formatRefExpression(state.ref, state.column)})`);
     case 'metricRef':
     case 'dimensionRef':
+    case 'modelRef':
       return withModifier(formatRefExpression(state.ref));
     case 'custom':
     case 'opaque':

--- a/viewer/src/components/views/common/pillGrammar.js
+++ b/viewer/src/components/views/common/pillGrammar.js
@@ -104,6 +104,56 @@ const BARE_REF = /^\$\{\s*ref\(\s*([^)]+?)\s*\)\s*\}$/;
 // Reuses pivotDraft's exact leading-function-call pattern.
 const AGG_WRAP = /^\s*(\w+)\s*\(([\s\S]*)\)\s*$/;
 
+// VIS-1241 — MODIFIER support. The same two shapes as above, but matching only
+// at the HEAD so a trailing fragment (`/ 100`) can be captured rather than
+// dropping the whole expression to `opaque`. A modifier is plain SQL appended
+// after the reference; it is what lets the pill express `sum(x) / 100` without
+// the user leaving the structured editor.
+const SINGLE_REF_HEAD = /^\$\{\s*ref\(\s*([^)]+?)\s*\)\s*\.\s*([^}\s]+)\s*\}/;
+const BARE_REF_HEAD = /^\$\{\s*ref\(\s*([^)]+?)\s*\)\s*\}/;
+const REF_TOKEN = /\$\{\s*ref\(/;
+
+/**
+ * Split `fn( … )rest` at the paren that actually closes `fn(`, so a modifier
+ * after an aggregation is recoverable. A regex can't do this: `AGG_WRAP`'s
+ * `\)\s*$` anchor means `sum(${ref(m).x}) / 100` matches nothing at all, which
+ * is exactly why every modified expression collapsed to raw text.
+ * Returns null when there is no leading call or the parens don't balance.
+ */
+const splitAggHead = text => {
+  const head = text.match(/^\s*(\w+)\s*\(/);
+  if (!head) return null;
+  const open = head[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < text.length; i += 1) {
+    if (text[i] === '(') depth += 1;
+    else if (text[i] === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          fn: head[1].toLowerCase(),
+          inner: text.slice(open + 1, i),
+          rest: text.slice(i + 1),
+        };
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * A trailing fragment is only a modifier if it holds no SECOND reference — a
+ * pill represents ONE reference, and hiding another inside a text field would
+ * misrepresent the expression (`${ref(a).x} + ${ref(b).y}` is not "a.x with a
+ * modifier"). Those stay opaque, as they were.
+ */
+const toModifier = rest => {
+  const trimmed = (rest || '').trim();
+  if (!trimmed) return { ok: true, modifier: undefined };
+  if (REF_TOKEN.test(trimmed)) return { ok: false };
+  return { ok: true, modifier: trimmed };
+};
+
 const findGlobalField = (name, { metricFields, dimensionFields }) => {
   const metric = (metricFields || []).find(f => f.name === name);
   if (metric) return { kind: 'metricRef', field: metric };
@@ -190,7 +240,55 @@ export function parse(expr, opts = {}) {
     }
   }
 
+  // VIS-1241: nothing matched as a WHOLE expression — retry allowing a trailing
+  // modifier. Ordered after the exact matches so an unmodified expression takes
+  // the original path untouched.
+  const headed = parseWithModifier(raw, opts, buildResult);
+  if (headed) return headed;
+
   return { kind: 'opaque', raw };
+}
+
+/**
+ * Second pass: match the reference at the head and treat whatever follows as a
+ * modifier. Returns null (→ opaque) for anything that isn't exactly one
+ * reference plus trailing SQL.
+ */
+function parseWithModifier(raw, opts, buildResult) {
+  // `fn(<single ref>) <modifier>`
+  const agg = splitAggHead(raw);
+  if (agg) {
+    const inner = agg.inner.trim().match(SINGLE_REF);
+    if (inner) {
+      const { ok, modifier } = toModifier(agg.rest);
+      if (ok && modifier) {
+        const result = buildResult({ statedModel: inner[1].trim(), field: inner[2].trim() }, agg.fn);
+        if (result) return { ...result, modifier };
+      }
+    }
+  }
+
+  // `<single ref> <modifier>` and `<bare ref> <modifier>`
+  const single = raw.match(SINGLE_REF_HEAD);
+  if (single) {
+    const { ok, modifier } = toModifier(raw.slice(single[0].length));
+    if (ok && modifier) {
+      const result = buildResult({ statedModel: single[1].trim(), field: single[2].trim() }, null);
+      if (result) return { ...result, modifier };
+    }
+  }
+
+  const bare = raw.match(BARE_REF_HEAD);
+  if (bare) {
+    const { ok, modifier } = toModifier(raw.slice(bare[0].length));
+    if (ok && modifier) {
+      const name = bare[1].trim();
+      const global = findGlobalField(name, opts);
+      if (global) return { kind: global.kind, ref: name, raw, modifier };
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -202,14 +300,18 @@ export function parse(expr, opts = {}) {
  */
 export function serialize(state) {
   if (!state) return '';
+  // VIS-1241: the modifier is SQL, so it belongs INSIDE the `?{ }` the caller
+  // wraps this in — `?{ sum(x) / 100 }[0]`, never `?{ sum(x) }[0] / 100`
+  // (the slice must be last; see mkdocs/topics/query-and-context-strings.md).
+  const withModifier = core => (state.modifier ? `${core} ${state.modifier}` : core);
   switch (state.kind) {
     case 'dimension':
-      return formatRefExpression(state.ref, state.column);
+      return withModifier(formatRefExpression(state.ref, state.column));
     case 'aggregate':
-      return `${state.agg}(${formatRefExpression(state.ref, state.column)})`;
+      return withModifier(`${state.agg}(${formatRefExpression(state.ref, state.column)})`);
     case 'metricRef':
     case 'dimensionRef':
-      return formatRefExpression(state.ref);
+      return withModifier(formatRefExpression(state.ref));
     case 'custom':
     case 'opaque':
     default:

--- a/viewer/src/components/views/common/pillGrammar.js
+++ b/viewer/src/components/views/common/pillGrammar.js
@@ -99,6 +99,25 @@ export function isMedianSupported(dialect) {
 
 // Reuses pivotDraft's exact anchored single-ref pattern.
 const SINGLE_REF = /^\$\{\s*ref\(\s*([^)]+?)\s*\)\s*\.\s*([^}\s]+)\s*\}$/;
+
+/**
+ * Split a matched property path into its column and its full path.
+ *
+ * The backend's `PROPERTY_PATH_PATTERN` allows dots and brackets after the ref
+ * — `${ref(m).gdp}`, `${ref(m).gdp[0]}`, `${ref(m).list[0].prop}` are all
+ * valid. `SINGLE_REF`'s `([^}\s]+)` captures ALL of that as one blob, and it
+ * was being reported as the column NAME. So a pill on `gdp[0]` claimed its
+ * column was "gdp[0]", and `saveAsMetricFlow` built `sum(gdp[0])` — invalid
+ * SQL, which is the bug this fixes.
+ *
+ * `column` is the bare first segment (what a column picker and a generated
+ * aggregate need); `propertyPath` is the whole thing (what serialization needs
+ * to round-trip the value unchanged).
+ */
+const splitPropertyPath = path => ({
+  column: path.split(/[.[]/)[0],
+  propertyPath: path,
+});
 // New: a bare ref with no `.field` — only ever a metric/dimension-ref pill.
 const BARE_REF = /^\$\{\s*ref\(\s*([^)]+?)\s*\)\s*\}$/;
 // Reuses pivotDraft's exact leading-function-call pattern.
@@ -224,9 +243,9 @@ export function parse(expr, opts = {}) {
     }
     if (agg) {
       if (!PRESET_AGGREGATIONS.includes(agg)) return null;
-      return { kind: 'aggregate', agg, ref: statedModel, column: field, raw };
+      return { kind: 'aggregate', agg, ref: statedModel, ...splitPropertyPath(field), raw };
     }
-    return { kind: 'dimension', ref: statedModel, column: field, raw };
+    return { kind: 'dimension', ref: statedModel, ...splitPropertyPath(field), raw };
   };
 
   const direct = trySingleRef(raw);
@@ -311,9 +330,11 @@ export function serialize(state) {
   const withModifier = core => (state.modifier ? `${core} ${state.modifier}` : core);
   switch (state.kind) {
     case 'dimension':
-      return withModifier(formatRefExpression(state.ref, state.column));
+      return withModifier(formatRefExpression(state.ref, state.propertyPath ?? state.column));
     case 'aggregate':
-      return withModifier(`${state.agg}(${formatRefExpression(state.ref, state.column)})`);
+      return withModifier(
+        `${state.agg}(${formatRefExpression(state.ref, state.propertyPath ?? state.column)})`
+      );
     case 'metricRef':
     case 'dimensionRef':
     case 'modelRef':

--- a/viewer/src/components/views/common/pillGrammar.test.js
+++ b/viewer/src/components/views/common/pillGrammar.test.js
@@ -18,6 +18,7 @@ describe('pillGrammar.parse', () => {
       kind: 'dimension',
       ref: 'orders_q',
       column: 'region',
+      propertyPath: 'region',
       raw: '${ref(orders_q).region}',
     });
   });
@@ -29,6 +30,7 @@ describe('pillGrammar.parse', () => {
       agg: 'sum',
       ref: 'orders_q',
       column: 'amount',
+      propertyPath: 'amount',
       raw: 'sum(${ref(orders_q).amount})',
     });
   });
@@ -237,6 +239,7 @@ describe('pillGrammar — modifiers', () => {
       agg: 'sum',
       ref: 'orders_q',
       column: 'amount',
+      propertyPath: 'amount',
       modifier: '/ 100',
       raw,
     });
@@ -250,6 +253,7 @@ describe('pillGrammar — modifiers', () => {
       kind: 'dimension',
       ref: 'orders_q',
       column: 'region',
+      propertyPath: 'region',
       modifier: "|| '!'",
     });
     expect(serialize(state)).toBe(raw);
@@ -269,6 +273,7 @@ describe('pillGrammar — modifiers', () => {
       agg: 'sum',
       ref: 'orders_q',
       column: 'amount',
+      propertyPath: 'amount',
       modifier: '/ 100',
     });
     expect(`?{ ${body} }[0]`).toBe('?{ sum(${ref(orders_q).amount}) / 100 }[0]');
@@ -318,5 +323,52 @@ describe('pillGrammar — modelRef', () => {
       kind: 'opaque',
       raw: '${ref(nope)}',
     });
+  });
+});
+
+
+// The backend's PROPERTY_PATH_PATTERN allows dots and brackets after a ref, but
+// `SINGLE_REF` captured all of it as one blob and reported it as the COLUMN
+// NAME. Downstream, `saveAsMetricFlow` built `${agg}(${column})` — producing
+// `sum(gdp[0])`, which is not valid SQL. There were zero tests for `[0]` or
+// dotted paths before this.
+describe('pillGrammar — property paths are parsed, not swallowed', () => {
+  const R = (name, prop) => '${ref(' + name + ')' + (prop ? '.' + prop : '') + '}';
+
+  test.each([
+    ['gdp', 'gdp', 'gdp'],
+    ['gdp[0]', 'gdp', 'gdp[0]'],
+    ['gdp[-1]', 'gdp', 'gdp[-1]'],
+    ['list[0].prop', 'list', 'list[0].prop'],
+    ['nested.deep', 'nested', 'nested.deep'],
+  ])('%s -> column %s, path %s', (path, column, propertyPath) => {
+    const state = parse(R('orders', path));
+    expect(state.kind).toBe('dimension');
+    expect(state.column).toBe(column);
+    expect(state.propertyPath).toBe(propertyPath);
+  });
+
+  test('an aggregate over an indexed property keeps a usable column name', () => {
+    const state = parse(`sum(${R('orders', 'gdp[0]')})`);
+    expect(state.kind).toBe('aggregate');
+    expect(state.agg).toBe('sum');
+    // This is the value saveAsMetricFlow interpolates; `gdp[0]` here was the bug.
+    expect(state.column).toBe('gdp');
+    expect(state.propertyPath).toBe('gdp[0]');
+  });
+
+  test('serialization round-trips the FULL path, not the bare column', () => {
+    [R('orders', 'gdp[0]'), R('orders', 'list[0].prop'), `sum(${R('orders', 'gdp[0]')})`].forEach(
+      raw => {
+        expect(serialize(parse(raw))).toBe(raw);
+      }
+    );
+  });
+
+  test('a plain column is unaffected — column and path agree', () => {
+    const state = parse(R('orders', 'amount'));
+    expect(state.column).toBe('amount');
+    expect(state.propertyPath).toBe('amount');
+    expect(serialize(state)).toBe(R('orders', 'amount'));
   });
 });

--- a/viewer/src/components/views/common/pillGrammar.test.js
+++ b/viewer/src/components/views/common/pillGrammar.test.js
@@ -291,3 +291,32 @@ describe('pillGrammar — modifiers', () => {
     expect(parse(raw, OPTS)).toEqual({ kind: 'opaque', raw });
   });
 });
+
+// ── VIS-1242: an unbound model ref (drop-then-configure) ────────────────────
+describe('pillGrammar — modelRef', () => {
+  const WITH_MODELS = { ...OPTS, modelNames: ['orders_q'] };
+
+  test('a bare ref naming a MODEL is an unbound pill, not opaque', () => {
+    // Without this the dropped model parsed as `opaque`, which suppresses the
+    // pill entirely — so there was nothing to configure.
+    expect(parse('${ref(orders_q)}', WITH_MODELS)).toEqual({
+      kind: 'modelRef',
+      ref: 'orders_q',
+      raw: '${ref(orders_q)}',
+    });
+    expect(serialize({ kind: 'modelRef', ref: 'orders_q' })).toBe('${ref(orders_q)}');
+  });
+
+  test('a metric/dimension name still wins over a model of the same name', () => {
+    // Global-name-first, matching the backend's resolve_ref order.
+    const opts = { ...OPTS, modelNames: ['churn_rate'] };
+    expect(parse('${ref(churn_rate)}', opts)).toMatchObject({ kind: 'metricRef' });
+  });
+
+  test('an unknown bare ref is still opaque', () => {
+    expect(parse('${ref(nope)}', WITH_MODELS)).toEqual({
+      kind: 'opaque',
+      raw: '${ref(nope)}',
+    });
+  });
+});

--- a/viewer/src/components/views/common/pillGrammar.test.js
+++ b/viewer/src/components/views/common/pillGrammar.test.js
@@ -223,3 +223,71 @@ describe('MEDIAN dialect gating', () => {
     expect(isMedianSupported('')).toBe(true);
   });
 });
+
+// ── VIS-1241: manual modifiers ────────────────────────────────────────────────
+// A modifier is trailing SQL after the reference (`/ 100`). Before this, ANY
+// trailing fragment dropped the whole expression to `opaque` and the pill
+// disappeared — which is why "add a modifier" meant "leave the editor".
+describe('pillGrammar — modifiers', () => {
+  test('aggregate + modifier parses, and round-trips byte-for-byte', () => {
+    const raw = 'sum(${ref(orders_q).amount}) / 100';
+    const state = parse(raw, OPTS);
+    expect(state).toEqual({
+      kind: 'aggregate',
+      agg: 'sum',
+      ref: 'orders_q',
+      column: 'amount',
+      modifier: '/ 100',
+      raw,
+    });
+    expect(serialize(state)).toBe(raw);
+  });
+
+  test('dimension + modifier parses and round-trips', () => {
+    const raw = '${ref(orders_q).region} || \'!\'';
+    const state = parse(raw, OPTS);
+    expect(state).toMatchObject({
+      kind: 'dimension',
+      ref: 'orders_q',
+      column: 'region',
+      modifier: "|| '!'",
+    });
+    expect(serialize(state)).toBe(raw);
+  });
+
+  test('a metric ref can carry a modifier too', () => {
+    const state = parse('${ref(churn_rate)} * 100', OPTS);
+    expect(state).toMatchObject({ kind: 'metricRef', ref: 'churn_rate', modifier: '* 100' });
+    expect(serialize(state)).toBe('${ref(churn_rate)} * 100');
+  });
+
+  test('the modifier serializes INSIDE the expression, so a slice can follow it', () => {
+    // `?{ sum(x) / 100 }[0]` is valid; `?{ sum(x) }[0] / 100` is not — the
+    // slice must be last. See mkdocs/topics/query-and-context-strings.md.
+    const body = serialize({
+      kind: 'aggregate',
+      agg: 'sum',
+      ref: 'orders_q',
+      column: 'amount',
+      modifier: '/ 100',
+    });
+    expect(`?{ ${body} }[0]`).toBe('?{ sum(${ref(orders_q).amount}) / 100 }[0]');
+  });
+
+  test('an unmodified expression is untouched by the modifier pass', () => {
+    const state = parse('sum(${ref(orders_q).amount})', OPTS);
+    expect(state.modifier).toBeUndefined();
+    expect(serialize(state)).toBe('sum(${ref(orders_q).amount})');
+  });
+
+  // The conservative half: a modifier means ONE reference plus trailing SQL.
+  // Anything else stays opaque rather than being misrepresented as a pill.
+  test.each([
+    ['a second reference is not a modifier', '${ref(a).x} + ${ref(b).y}'],
+    ['the canonical multi-call expression', 'count(distinct ${ref(orders_q).id}) / count(*)'],
+    ['arithmetic INSIDE the aggregate is different SQL', 'sum(${ref(orders_q).amount} / 100)'],
+    ['a non-preset function', 'date_trunc(\'week\', ${ref(orders_q).completed_at}) / 2'],
+  ])('%s -> opaque, raw verbatim', (_label, raw) => {
+    expect(parse(raw, OPTS)).toEqual({ kind: 'opaque', raw });
+  });
+});

--- a/viewer/src/components/views/common/refTokenElement.js
+++ b/viewer/src/components/views/common/refTokenElement.js
@@ -1,0 +1,38 @@
+import { DEFAULT_COLORS } from './objectTypeConfigs';
+
+/**
+ * A `${ref(...)}` rendered as EDITABLE literal text rather than a chip.
+ *
+ * "Manually edit field…" is the escape hatch for expressions the pill can't
+ * model, but `RefTextArea` still rendered every ref as a
+ * `contenteditable="false"` chip — so the ref was the one part of the text the
+ * user could not actually edit. This node's textContent IS the literal
+ * `${ref(name).property}`, so it serializes back through the same plain-text
+ * path a hand-typed ref does: `serializeContentEditableToRefString` only
+ * special-cases elements carrying `data-ref-name`, and this deliberately
+ * carries none, recursing into it as ordinary text instead.
+ *
+ * The span earns its keep as a styling hook. A name that resolves to no known
+ * object is marked `data-ref-unknown` and underlined, so a bad reference can be
+ * called out without taking the text away from the user — the reason to stay on
+ * a contentEditable here rather than drop to a plain <textarea>.
+ *
+ * @param {string} name - the referenced object's name
+ * @param {string|null} property - optional trailing `.property`
+ * @param {object|null} typeConfig - resolved type config, or null when the name
+ *   matches no known object in the project
+ * @returns {HTMLSpanElement}
+ */
+export function createRefTokenElement(name, property, typeConfig) {
+  const known = !!typeConfig;
+  const token = document.createElement('span');
+  token.setAttribute('data-ref-token', name);
+  if (!known) token.setAttribute('data-ref-unknown', 'true');
+  token.className = known
+    ? `${typeConfig.colors?.text || DEFAULT_COLORS.text} font-medium`
+    : 'text-red-600 underline decoration-wavy decoration-red-400';
+  token.textContent = property ? `\${ref(${name}).${property}}` : `\${ref(${name})}`;
+  return token;
+}
+
+export default createRefTokenElement;

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -18,6 +18,7 @@ import { isNumericColumnType } from '../../../utils/columnType';
 import SaveAsMetricPrompt from './SaveAsMetricPrompt';
 import FieldSwapOfferBanner from './FieldSwapOfferBanner';
 import { saveAsMetric, suggestMetricName } from './saveAsMetricFlow';
+import { refKindsFor } from '../common/fieldTypes';
 
 const INSIGHT_COLORS = getTypeColors('insight');
 const InsightTypeIcon = getTypeIcon('insight');
@@ -66,7 +67,7 @@ const InteractionRow = ({ interaction, index, insightName, updateInsightInteract
           }}
           label=""
           rows={1}
-          allowedTypes={['model', 'dimension', 'metric', 'input']}
+          allowedTypes={refKindsFor('interaction', 'filter')}
         />
       </div>
       <button

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -216,8 +216,23 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
         showWorkspaceToast?.("Can't drop a whole table here — drag a column instead.");
         return;
       }
+      // VIS-1242: an explicit allowlist. Anything with a `name` used to fall
+      // into the generic branch below and silently write
+      // `?{${ref(<activeModel>).<objectName>}}` — so dropping a SOURCE or an
+      // INSIGHT produced a dangling ref with no message at all. The canvas has
+      // had a type guard since Phase 3a; property slots never did.
+      const DROPPABLE_ON_PROPERTY = ['metric', 'dimension', 'input', 'model', 'sourceColumn', 'column'];
+      if (dragData.type && !DROPPABLE_ON_PROPERTY.includes(dragData.type)) {
+        showWorkspaceToast?.(`Can't use a ${dragData.type} as a field value.`);
+        return;
+      }
       let body;
-      if (dragData.type === 'metric' || dragData.type === 'dimension') {
+      if (dragData.type === 'model') {
+        // Unbound on purpose: the pill opens its editor so the property (and
+        // aggregation, index, modifier) get picked there — the same editor a
+        // fully-configured pill uses.
+        body = formatRefExpression(dragData.name);
+      } else if (dragData.type === 'metric' || dragData.type === 'dimension') {
         body = dragData.parentModel
           ? formatRefExpression(dragData.parentModel, dragData.name)
           : formatRefExpression(dragData.name);

--- a/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
@@ -259,6 +259,41 @@ describe('InsightBuildSection', () => {
       expect(setInsightProp).toHaveBeenCalledWith('test_insight', 'x', '?{${ref(orders_q).region}}');
     });
 
+    // ── VIS-1242 ────────────────────────────────────────────────────────
+    it('a MODEL drop writes an unbound ref for the pill editor to configure', async () => {
+      const setInsightProp = jest.fn();
+      useStore.setState({ setInsightProp });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      await screen.findByTestId('trace-props-editor-mock');
+
+      mockCaptured.onDropField('x', { source: 'library', type: 'model', name: 'orders_q' });
+
+      // Unbound on purpose — the property gets picked in the pill's editor.
+      expect(setInsightProp).toHaveBeenCalledWith('test_insight', 'x', '?{${ref(orders_q)}}');
+    });
+
+    it('a type that is not a field value is rejected with a message, not written', async () => {
+      const setInsightProp = jest.fn();
+      const showWorkspaceToast = jest.fn();
+      useStore.setState({ setInsightProp, showWorkspaceToast });
+      render(
+        <InsightBuildSection insightName="test_insight" isExpanded={true} onToggleExpand={jest.fn()} />
+      );
+      await screen.findByTestId('trace-props-editor-mock');
+
+      // These used to fall into the generic branch and silently write
+      // `?{${ref(<activeModel>).<objectName>}}` — a dangling ref, no message.
+      ['source', 'insight', 'chart'].forEach(type => {
+        mockCaptured.onDropField('x', { source: 'library', type, name: `some_${type}` });
+      });
+
+      expect(setInsightProp).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalledTimes(3);
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringMatching(/can't use a source/i));
+    });
+
     it('a metric/dimension object drop resolves to its own ref, parentModel-scoped when present', async () => {
       const setInsightProp = jest.fn();
       useStore.setState({ setInsightProp });

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -4,6 +4,7 @@ import useRecordSave from '../../../hooks/useRecordSave';
 import useFormBaseline from '../../../hooks/useFormBaseline';
 import { FormInput, FormFooter, FormLayout, FormAlert } from '../../styled/FormComponents';
 import ExpressionField from '../common/ExpressionField';
+import { REF_INSERT_HINT } from '../common/RefTextArea';
 import { validateName } from '../common/namedModel';
 import { isEmbeddedObject } from '../common/embeddedObjectUtils';
 import { getTypeByValue } from '../common/objectTypeConfigs';
@@ -59,14 +60,14 @@ export const TYPE_CONFIG = {
   dimension: {
     expressionField: 'expression',
     expressionLabel: 'Expression',
-    helperText: 'SQL expression for this dimension. Use the + button to insert references.',
+    helperText: `SQL expression for this dimension. ${REF_INSERT_HINT}`,
     embeddedHelperText: 'Plain SQL expression referencing columns from the parent model.',
     rows: 4,
   },
   metric: {
     expressionField: 'expression',
     expressionLabel: 'Expression',
-    helperText: 'SQL aggregate expression for this metric. Use the + button to insert references.',
+    helperText: `SQL aggregate expression for this metric. ${REF_INSERT_HINT}`,
     embeddedHelperText: 'Plain SQL aggregate expression over the parent model.',
     rows: 4,
   },
@@ -74,7 +75,7 @@ export const TYPE_CONFIG = {
     expressionField: 'condition',
     expressionLabel: 'Condition',
     // eslint-disable-next-line no-template-curly-in-string
-    helperText: 'Join condition using ${ref(model).field} syntax. Must reference at least two models.',
+    helperText: `Join condition between two models — every reference needs a column. ${REF_INSERT_HINT}`,
     rows: 4,
   },
 };
@@ -94,16 +95,33 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   const checkCommitStatus = store.checkCommitStatus;
 
   const isEmbedded = isEmbeddedObject(record);
-  // The model a nested (model-scoped) metric/dimension belongs to. It is a
-  // SIBLING of `config`, not a field inside it — `Metric`/`Dimension` declare
-  // no `model` field and forbid extras, so nesting can only be expressed
-  // positionally in the YAML. The managers surface it as `parentModel` on read,
-  // and both save views pop it back off and call `set_parent_name`.
+  // MODEL-SCOPED is not the same thing as EMBEDDED, and conflating them was a
+  // bug. `isEmbedded` means "edited in place inside its parent's config" — it
+  // reads `record._embedded`. A metric/dimension defined UNDER a model is
+  // loaded from its OWN collection with `_embedded` unset, carrying the parent
+  // as a SIBLING of `config` rather than a field inside it: `Metric`/`Dimension`
+  // declare no `model` field and forbid extras, so nesting can only be
+  // expressed positionally in the YAML.
   //
-  // This form built its save body as `{ ...config, name }`, which drops it. The
-  // object then validated as STANDALONE, and `project_writer` wrote it at the
-  // top level — silently un-nesting a field from its model on an ordinary save.
+  // Exactly two keys mean "scoped to a model", and both are load-bearing:
+  //   - `parentModel`, attached by the managers ONLY when walking
+  //     `model.dimensions` / `model.metrics` (i.e. genuinely nested), and
+  //   - `config.parentModel`, which `saveAsMetricFlow` and `promoteChecklist`
+  //     write to REQUEST nesting; `project_writer._new` then nests it.
+  //
+  // Deliberately NOT `config.model`: `Dimension`/`Metric` can never return one,
+  // so testing for it could only ever produce a false positive — a standalone
+  // field wrongly demoted to plain SQL, losing its ref editor.
+  //
+  // This one value drives two things, and each was a separate bug:
+  //   1. the GRAMMAR — `sql_model.py` rejects any ref() in a nested expression,
+  //      so a model-scoped field must get the plain editor, not the ref one;
+  //   2. the SAVE BODY — built as `{ ...config, name }`, it dropped every
+  //      sibling key, so the object validated as standalone and
+  //      `project_writer` wrote it to the top level, silently un-nesting a
+  //      field from its model on an ordinary save.
   const parentModelName = record?.parentModel || record?.config?.parentModel || null;
+  const isModelScoped = isEmbedded || !!parentModelName;
   const parentName = record?._embedded?.parentName;
   const isEditMode = !!record && !isCreate && !isEmbedded;
   const isNewObject = record?.status === ObjectStatus.NEW;
@@ -294,7 +312,8 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
         <ExpressionField
           objectType={type}
           field={exprField}
-          nested={isEmbedded}
+          nested={isModelScoped}
+          scopedToModel={parentModelName}
           value={value}
           onChange={onChange}
           error={error}
@@ -302,7 +321,7 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
           label={typeConfig.expressionLabel || fieldLabel(getObjectSchemaSync(type), exprField)}
           rows={typeConfig.rows || 4}
           helperText={
-            isEmbedded && typeConfig.embeddedHelperText
+            isModelScoped && typeConfig.embeddedHelperText
               ? typeConfig.embeddedHelperText
               : typeConfig.helperText
           }
@@ -311,7 +330,7 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
     };
     // typeConfig is a stable module-level object per type.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [type, isEmbedded]);
+  }, [type, isModelScoped]);
 
   const typeDef = getTypeByValue(type);
   const singular = typeDef?.singularLabel || type;

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -281,6 +281,10 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
           required
           error={error}
           allowedTypes={isEmbedded ? [] : typeConfig.allowedTypes || []}
+          // VIS-1243: a dimension/metric expression and a relation condition
+          // are authored here and nowhere else, so this is the surface where
+          // "drag a model in" has to work.
+          acceptDrops={!isEmbedded}
           hideAddButton={isEmbedded}
           rows={typeConfig.rows || 4}
           helperText={

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -3,7 +3,7 @@ import useStore, { ObjectStatus } from '../../../stores/store';
 import useRecordSave from '../../../hooks/useRecordSave';
 import useFormBaseline from '../../../hooks/useFormBaseline';
 import { FormInput, FormFooter, FormLayout, FormAlert } from '../../styled/FormComponents';
-import RefTextArea from '../common/RefTextArea';
+import ExpressionField from '../common/ExpressionField';
 import { validateName } from '../common/namedModel';
 import { isEmbeddedObject } from '../common/embeddedObjectUtils';
 import { getTypeByValue } from '../common/objectTypeConfigs';
@@ -44,16 +44,21 @@ import { useFieldParentModel } from './fields/useFieldParentModel';
  */
 
 /**
- * Per-type declarative layer. `expressionField` names the schema field that
- * should render through RefTextArea instead of the generic engine widget;
- * `allowedTypes` scopes its + ref-insert menu; `helperText`/`embeddedHelperText`
- * carry the authoring guidance the schema description doesn't.
+ * Per-type declarative layer — PROSE AND LAYOUT ONLY. `expressionField` names
+ * the schema field that renders through `ExpressionField` instead of the
+ * generic engine widget; `helperText`/`embeddedHelperText`/`rows` carry
+ * guidance and sizing the schema description doesn't.
+ *
+ * The authoring RULES — which editor, which refs are legal, whether a bare ref
+ * or an index is allowed — deliberately do NOT live here any more. They're in
+ * `common/fieldTypes.js`, so the Explorer's computed-column popover and this
+ * form can't disagree about the same field. `allowedTypes` used to sit here and
+ * was one of seven such literals.
  */
 export const TYPE_CONFIG = {
   dimension: {
     expressionField: 'expression',
     expressionLabel: 'Expression',
-    allowedTypes: ['model', 'dimension'],
     helperText: 'SQL expression for this dimension. Use the + button to insert references.',
     embeddedHelperText: 'Plain SQL expression referencing columns from the parent model.',
     rows: 4,
@@ -61,7 +66,6 @@ export const TYPE_CONFIG = {
   metric: {
     expressionField: 'expression',
     expressionLabel: 'Expression',
-    allowedTypes: ['model', 'metric', 'dimension'],
     helperText: 'SQL aggregate expression for this metric. Use the + button to insert references.',
     embeddedHelperText: 'Plain SQL aggregate expression over the parent model.',
     rows: 4,
@@ -69,7 +73,6 @@ export const TYPE_CONFIG = {
   relation: {
     expressionField: 'condition',
     expressionLabel: 'Condition',
-    allowedTypes: ['model'],
     // eslint-disable-next-line no-template-curly-in-string
     helperText: 'Join condition using ${ref(model).field} syntax. Must reference at least two models.',
     rows: 4,
@@ -266,26 +269,26 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
 
   const mergedErrors = { ...fieldErrors, ...localErrors };
 
-  // ---- expression widget override (RefTextArea) ----
+  // ---- expression widget override ----
+  // Which editor this field gets, and which refs it may contain, come from the
+  // field-type registry rather than from `typeConfig` literals. `isEmbedded` is
+  // the nested case: a metric/dimension defined UNDER a model, where
+  // `sql_model.py` rejects any ref — so the registry resolves it to `plain-sql`
+  // and `ExpressionField` renders a bare textarea with no ref affordances.
   const overrides = useMemo(() => {
     const exprField = typeConfig.expressionField;
     if (!exprField) return {};
     return {
       [exprField]: ({ value, onChange, error }) => (
-        <RefTextArea
-          value={value ?? ''}
+        <ExpressionField
+          objectType={type}
+          field={exprField}
+          nested={isEmbedded}
+          value={value}
           onChange={onChange}
-          label={
-            typeConfig.expressionLabel || fieldLabel(getObjectSchemaSync(type), exprField)
-          }
-          required
           error={error}
-          allowedTypes={isEmbedded ? [] : typeConfig.allowedTypes || []}
-          // VIS-1243: a dimension/metric expression and a relation condition
-          // are authored here and nowhere else, so this is the surface where
-          // "drag a model in" has to work.
-          acceptDrops={!isEmbedded}
-          hideAddButton={isEmbedded}
+          required
+          label={typeConfig.expressionLabel || fieldLabel(getObjectSchemaSync(type), exprField)}
           rows={typeConfig.rows || 4}
           helperText={
             isEmbedded && typeConfig.embeddedHelperText

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -284,7 +284,11 @@ export const routeWorkspaceDragEnd = (
         name: dragData.name,
         accepted: isValid,
       });
-    if (!isValid) return 'ref_text_rejected';
+    if (!isValid) {
+      // Tell the user, rather than leaving the drag to evaporate.
+      dropData.onReject?.(dragData.type);
+      return 'ref_text_rejected';
+    }
     // A dimension/metric names its own parent model; everything else (a model,
     // an input) is referenced by name alone and the user narrows it from there.
     const refExpr =

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -274,7 +274,7 @@ export const routeWorkspaceDragEnd = (
   // overwriting would discard whatever the user already wrote. Before this,
   // a RefTextArea was not a drop target at all: dragging a model onto a
   // dimension/metric expression, a relation condition, or a slot switched to
-  // "Custom aggregation…" did nothing whatsoever, with no feedback.
+  // "Manually edit field…" did nothing whatsoever, with no feedback.
   if (dropData.kind === 'ref-text') {
     const allowed = dropData.allowedTypes || [];
     const isValid = allowed.includes(dragData.type);

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -268,6 +268,34 @@ export const routeWorkspaceDragEnd = (
     return 'ref_accepted';
   }
 
+  // ── Branch 2b: any compatible drag → a RefTextArea (VIS-1243) ───────────
+  // The only editor that holds free text AROUND its refs, so unlike every
+  // other zone this INSERTS at the caret rather than replacing the value —
+  // overwriting would discard whatever the user already wrote. Before this,
+  // a RefTextArea was not a drop target at all: dragging a model onto a
+  // dimension/metric expression, a relation condition, or a slot switched to
+  // "Custom aggregation…" did nothing whatsoever, with no feedback.
+  if (dropData.kind === 'ref-text') {
+    const allowed = dropData.allowedTypes || [];
+    const isValid = allowed.includes(dragData.type);
+    emit &&
+      emit('ref_text_drop', {
+        type: dragData.type,
+        name: dragData.name,
+        accepted: isValid,
+      });
+    if (!isValid) return 'ref_text_rejected';
+    // A dimension/metric names its own parent model; everything else (a model,
+    // an input) is referenced by name alone and the user narrows it from there.
+    const refExpr =
+      (dragData.type === 'metric' || dragData.type === 'dimension') && dragData.parentModel
+        ? formatRefExpression(dragData.parentModel, dragData.name)
+        : formatRefExpression(dragData.name);
+    if (typeof dropData.onInsertRef !== 'function') return 'noop';
+    dropData.onInsertRef(refExpr);
+    return 'ref_text_accepted';
+  }
+
   // ── Branch 2a: Library model → Relation ERD canvas (VIS-1006b) ───────────
   // A Library MODEL row dropped on the Relation ERD's canvas droppable (which
   // carries `{ kind: 'erd-canvas', onAddModel }`) adds that model to the ERD so

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -492,6 +492,60 @@ describe('routeWorkspaceDragEnd — pivot field branch (VIS-1008)', () => {
   });
 });
 
+// VIS-1243: a RefTextArea accepted no drops at all — dragging a model onto a
+// dimension/metric expression, a relation condition, or a slot switched to
+// "Custom aggregation…" did nothing, silently.
+describe('routeWorkspaceDragEnd — ref-text branch', () => {
+  const refTextDrop = (dragData, allowedTypes, onInsertRef) =>
+    routeWorkspaceDragEnd(
+      {
+        active: { data: { current: dragData } },
+        over: { data: { current: { kind: 'ref-text', allowedTypes, onInsertRef } } },
+      },
+      { emit: jest.fn() }
+    );
+
+  test('a dragged model inserts a bare ref rather than replacing the value', () => {
+    const onInsertRef = jest.fn();
+    const result = refTextDrop(
+      { source: 'library', type: 'model', name: 'orders' },
+      ['model', 'metric'],
+      onInsertRef
+    );
+    expect(result).toBe('ref_text_accepted');
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(onInsertRef).toHaveBeenCalledWith('${ref(orders)}');
+  });
+
+  test('a dragged metric carries its parent model into the ref', () => {
+    const onInsertRef = jest.fn();
+    refTextDrop(
+      { source: 'library', type: 'metric', name: 'revenue', parentModel: 'orders' },
+      ['metric'],
+      onInsertRef
+    );
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(onInsertRef).toHaveBeenCalledWith('${ref(orders).revenue}');
+  });
+
+  test('a type the field does not allow is rejected without writing anything', () => {
+    const onInsertRef = jest.fn();
+    const result = refTextDrop(
+      { source: 'library', type: 'dashboard', name: 'sales' },
+      ['model'],
+      onInsertRef
+    );
+    expect(result).toBe('ref_text_rejected');
+    expect(onInsertRef).not.toHaveBeenCalled();
+  });
+
+  test('a zone with no insert callback is a noop, not a crash', () => {
+    expect(
+      refTextDrop({ source: 'library', type: 'model', name: 'orders' }, ['model'], undefined)
+    ).toBe('noop');
+  });
+});
+
 describe('routeWorkspaceDragEnd — property-zone branch (Explore 2.0 Phase 3b, S5 §1/D10)', () => {
   test('a Library drag dropped on a property-zone invokes the ROW-OWNED onDropField with the full drag payload', () => {
     const onDropField = jest.fn();

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -494,7 +494,7 @@ describe('routeWorkspaceDragEnd — pivot field branch (VIS-1008)', () => {
 
 // VIS-1243: a RefTextArea accepted no drops at all — dragging a model onto a
 // dimension/metric expression, a relation condition, or a slot switched to
-// "Custom aggregation…" did nothing, silently.
+// "Manually edit field…" did nothing, silently.
 describe('routeWorkspaceDragEnd — ref-text branch', () => {
   const refTextDrop = (dragData, allowedTypes, onInsertRef) =>
     routeWorkspaceDragEnd(

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.test.jsx
@@ -528,6 +528,40 @@ describe('routeWorkspaceDragEnd — ref-text branch', () => {
     expect(onInsertRef).toHaveBeenCalledWith('${ref(orders).revenue}');
   });
 
+  // Review finding #1: the property-zone allowlist toasts on rejection, but it
+  // only runs on rows that are THEMSELVES droppable. Everywhere else an
+  // unacceptable drop was a silent no-op — no pill, no error, no animation —
+  // which is the single most trust-destroying moment in the flow. The zone that
+  // refuses has to be the zone that speaks.
+  test('a rejected drop tells the user, rather than evaporating', () => {
+    const onReject = jest.fn();
+    const result = routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'library', type: 'source', name: 'warehouse' } } },
+        over: { data: { current: { kind: 'ref-text', allowedTypes: ['model'], onReject } } },
+      },
+      { emit: jest.fn() }
+    );
+    expect(result).toBe('ref_text_rejected');
+    expect(onReject).toHaveBeenCalledWith('source');
+  });
+
+  test('an accepted drop stays silent', () => {
+    const onReject = jest.fn();
+    routeWorkspaceDragEnd(
+      {
+        active: { data: { current: { source: 'library', type: 'model', name: 'orders' } } },
+        over: {
+          data: {
+            current: { kind: 'ref-text', allowedTypes: ['model'], onInsertRef: jest.fn(), onReject },
+          },
+        },
+      },
+      { emit: jest.fn() }
+    );
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
   test('a type the field does not allow is rejected without writing anything', () => {
     const onInsertRef = jest.fn();
     const result = refTextDrop(

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -597,6 +597,7 @@ const Library = () => {
             onRowClick={handleRowClick}
             onContextAction={handleContextAction}
             canAddToExploration={canAddToExploration}
+            nestedFieldsByModel={data.nestedFieldsByModel}
           />
         ))}
         {renderedTypes.length === 0 && (

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -200,16 +200,26 @@ describe('Library', () => {
     );
   });
 
-  test('Layout-Items rows expose drag handles; model/relation Data-Layer rows do not', () => {
+  test('Layout-Items rows expose drag handles; relation rows do not', () => {
     renderLibrary();
     fireEvent.mouseEnter(screen.getByTestId('library-row-chart-waterfall'));
     expect(screen.getByTestId('library-row-chart-waterfall-drag-handle')).toBeInTheDocument();
     fireEvent.mouseEnter(screen.getByTestId('library-row-table-revenue_rows'));
     expect(screen.getByTestId('library-row-table-revenue_rows-drag-handle')).toBeInTheDocument();
-    fireEvent.mouseEnter(screen.getByTestId('library-row-model-monthly_revenue'));
+    fireEvent.mouseEnter(screen.getByTestId('library-row-relation-customers_orders'));
     expect(
-      screen.queryByTestId('library-row-model-monthly_revenue-drag-handle')
+      screen.queryByTestId('library-row-relation-customers_orders-drag-handle')
     ).not.toBeInTheDocument();
+  });
+
+  // VIS-1242: model rows became draggable so a model can be dropped on an
+  // insight property slot and configured there. Like the source-row change
+  // below, this is a deliberate capability ADD — models were previously in
+  // neither drag list, so the drag could not start at all.
+  test('model rows expose a drag handle (droppable onto property slots)', () => {
+    renderLibrary();
+    fireEvent.mouseEnter(screen.getByTestId('library-row-model-monthly_revenue'));
+    expect(screen.getByTestId('library-row-model-monthly_revenue-drag-handle')).toBeInTheDocument();
   });
 
   // Explore 2.0 Phase 3a (D9 / 02-architecture.md §4): source rows are now an

--- a/viewer/src/components/views/workspace/library/LibraryModelRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryModelRow.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import LibraryRow, { getTypeDef } from './LibraryRow';
+
+/**
+ * LibraryModelRow — a model row that can expand to show the fields defined
+ * inside it, mirroring the source → table → column drill-down.
+ *
+ * Model-scoped metrics and dimensions used to be listed flat, alongside
+ * standalone ones and indistinguishable from them. That is not a cosmetic
+ * problem: a nested field is plain SQL where `${ref()}` is a hard save-time
+ * error (`sql_model.py`), while a standalone one is authored WITH refs. Two
+ * things that look identical and obey different rules is the worst
+ * combination, and the flat list gave the user nothing to go on.
+ *
+ * Nesting them under their owner makes the relationship structural rather than
+ * something to infer from a badge. It also answers "what does this model
+ * define?" — previously only answerable by opening each field in turn.
+ *
+ * The children come from the SAME `dimensions`/`metrics` collections the flat
+ * lists used, just regrouped, so they inherit the refetch those stores already
+ * do on save. Reading them from `models[].config` instead would have been more
+ * direct and staler — nothing refetches models after a field is saved.
+ */
+export const LibraryModelRow = ({
+  obj,
+  selected,
+  draggable,
+  onClick,
+  onContextAction,
+  canAddToExploration,
+  nestedFields,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const dimensions = nestedFields?.dimension || [];
+  const metrics = nestedFields?.metric || [];
+  const total = dimensions.length + metrics.length;
+
+  return (
+    <>
+      <LibraryRow
+        obj={obj}
+        selected={selected}
+        draggable={draggable}
+        onClick={onClick}
+        onContextAction={onContextAction}
+        canAddToExploration={canAddToExploration}
+        // A model with nothing defined inside it gets no chevron — an expander
+        // that opens onto an empty list is a dead affordance.
+        expandable={total > 0}
+        expanded={expanded}
+        onToggleExpand={e => {
+          e?.stopPropagation?.();
+          setExpanded(v => !v);
+        }}
+      />
+      {expanded && total > 0 && (
+        <ul
+          className="flex flex-col gap-px"
+          data-testid={`library-model-${obj.name}-fields`}
+        >
+          {[...dimensions, ...metrics].map(field => (
+            <li key={field.id} className="relative pl-4">
+              <LibraryRow
+                obj={field}
+                selected={false}
+                // Same drag affordances a top-level field row has — a nested
+                // dimension is still a legal thing to drop into an exploration.
+                draggable={
+                  getTypeDef(field.type).explorationDragSource ||
+                  getTypeDef(field.type).propertyDragSource
+                }
+                onClick={onClick}
+                onContextAction={onContextAction}
+                canAddToExploration={canAddToExploration}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+};
+
+export default LibraryModelRow;

--- a/viewer/src/components/views/workspace/library/LibraryModelRow.test.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryModelRow.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import LibraryModelRow from './LibraryModelRow';
+
+const withDnd = ui => <DndContext>{ui}</DndContext>;
+
+const MODEL = { id: 'model:orders', type: 'model', name: 'orders' };
+const FIELDS = {
+  dimension: [{ id: 'dimension:region', type: 'dimension', name: 'region', parentModel: 'orders' }],
+  metric: [{ id: 'metric:revenue', type: 'metric', name: 'revenue', parentModel: 'orders' }],
+};
+
+// Model-scoped fields used to sit flat alongside standalone ones, identical in
+// every respect while obeying different rules — a nested expression may not
+// contain a ref at all. Nesting them under their owner makes the relationship
+// structural instead of something the user has to infer from a badge.
+describe('LibraryModelRow', () => {
+  test('a model with fields offers an expander', () => {
+    render(withDnd(<LibraryModelRow obj={MODEL} nestedFields={FIELDS} />));
+    expect(screen.getByLabelText('Expand orders')).toBeInTheDocument();
+  });
+
+  test('its fields are hidden until it is expanded', () => {
+    render(withDnd(<LibraryModelRow obj={MODEL} nestedFields={FIELDS} />));
+    expect(screen.queryByTestId('library-model-orders-fields')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Expand orders'));
+    const list = screen.getByTestId('library-model-orders-fields');
+    expect(list).toBeInTheDocument();
+    expect(screen.getByTestId('library-row-dimension-region')).toBeInTheDocument();
+    expect(screen.getByTestId('library-row-metric-revenue')).toBeInTheDocument();
+  });
+
+  test('expanding and collapsing round-trips', () => {
+    render(withDnd(<LibraryModelRow obj={MODEL} nestedFields={FIELDS} />));
+    fireEvent.click(screen.getByLabelText('Expand orders'));
+    expect(screen.getByTestId('library-model-orders-fields')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Collapse orders'));
+    expect(screen.queryByTestId('library-model-orders-fields')).not.toBeInTheDocument();
+  });
+
+  test('a model that defines nothing gets no expander', () => {
+    // An affordance that opens onto an empty list is a dead affordance.
+    render(withDnd(<LibraryModelRow obj={MODEL} nestedFields={{ dimension: [], metric: [] }} />));
+    expect(screen.queryByLabelText('Expand orders')).not.toBeInTheDocument();
+  });
+
+  test('a model with no nested data at all is still a normal row', () => {
+    render(withDnd(<LibraryModelRow obj={MODEL} />));
+    expect(screen.getByTestId('library-row-model-orders')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Expand orders')).not.toBeInTheDocument();
+  });
+
+  test('clicking a nested field selects it, like any other row', () => {
+    const onClick = jest.fn();
+    render(withDnd(<LibraryModelRow obj={MODEL} nestedFields={FIELDS} onClick={onClick} />));
+    fireEvent.click(screen.getByLabelText('Expand orders'));
+    fireEvent.click(screen.getByTestId('library-row-dimension-region'));
+    // Called as (obj, event) — assert the payload, not the arity.
+    expect(onClick.mock.calls[0][0]).toEqual(expect.objectContaining({ name: 'region' }));
+  });
+});

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -62,6 +62,14 @@ export const DROPPABLE_TYPES = ['chart', 'table', 'markdown', 'input'];
 // source is orthogonal to it being a valid DASHBOARD canvas item.
 export const EXPLORATION_DRAG_TYPES = ['source', 'metric', 'dimension', 'insight'];
 
+// VIS-1242: types that can be dragged onto an insight PROPERTY slot. Kept
+// separate from EXPLORATION_DRAG_TYPES on purpose — that set also drives the
+// row's "Add to exploration" action, and a model is not an exploration input.
+// `model` was in neither list before, so `LibrarySubsection` rendered model
+// rows with `draggable={false}` and the drag could not even start. The
+// dashboard canvas still rejects models: that guard checks DROPPABLE_TYPES.
+export const PROPERTY_DRAG_TYPES = ['model'];
+
 // Explore 2.0 Phase 5 (VIS-1067): types a right-click "Explore this" can mint
 // a brand-new, pre-wired exploration from (`explorerStore.js`'s
 // `buildExplorationSeedState`) — broader than `EXPLORATION_DRAG_TYPES`
@@ -105,6 +113,7 @@ export const getTypeDef = type => {
     // Independent of `droppable` (canvas-item eligibility) — see
     // EXPLORATION_DRAG_TYPES's comment above.
     explorationDragSource: EXPLORATION_DRAG_TYPES.includes(type),
+    propertyDragSource: PROPERTY_DRAG_TYPES.includes(type),
   };
 };
 

--- a/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
@@ -3,6 +3,7 @@ import { PiCaretDown } from 'react-icons/pi';
 import LibraryRow from './LibraryRow';
 import { getTypeDef } from './LibraryRow';
 import LibrarySourceRow from './LibrarySourceRow';
+import LibraryModelRow from './LibraryModelRow';
 import useStore from '../../../../stores/store';
 import { isLibrarySubsectionCollapsed } from '../../../../stores/libraryPrefsStore';
 
@@ -37,10 +38,14 @@ const LibrarySubsection = ({
   onRowClick,
   onContextAction,
   canAddToExploration = false,
+  // Model-scoped fields, keyed by owning model — only `model` rows use it.
+  nestedFieldsByModel = null,
 }) => {
   const def = getTypeDef(typeKey);
   const Icon = def.icon;
-  const RowComponent = typeKey === 'source' ? LibrarySourceRow : LibraryRow;
+  // Sources and models both drill down; everything else is a plain row.
+  const RowComponent =
+    typeKey === 'source' ? LibrarySourceRow : typeKey === 'model' ? LibraryModelRow : LibraryRow;
 
   // Subsections default to COLLAPSED (VIS-828): absence of a saved preference
   // reads as collapsed; an explicit `false` keeps a user-expanded subsection
@@ -115,6 +120,7 @@ const LibrarySubsection = ({
                     onClick={onRowClick}
                     onContextAction={onContextAction}
                     canAddToExploration={canAddToExploration}
+                    nestedFields={nestedFieldsByModel?.[obj.name]}
                   />
                 </li>
               ))}

--- a/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
+++ b/viewer/src/components/views/workspace/library/LibrarySubsection.jsx
@@ -111,7 +111,7 @@ const LibrarySubsection = ({
                   <RowComponent
                     obj={obj}
                     selected={selectedRowId === obj.id}
-                    draggable={def.droppable || def.explorationDragSource}
+                    draggable={def.droppable || def.explorationDragSource || def.propertyDragSource}
                     onClick={onRowClick}
                     onContextAction={onContextAction}
                     canAddToExploration={canAddToExploration}

--- a/viewer/src/components/views/workspace/library/useLibraryData.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.js
@@ -176,7 +176,25 @@ export function useLibraryData() {
           }))
       );
 
+    // Model-scoped fields are shown UNDER their model (see LibraryModelRow),
+    // not as top-level entries. Listing them flat put a nested dimension
+    // side-by-side with a standalone one, identical in every respect, when the
+    // two obey different rules — a nested expression may not contain a ref at
+    // all. Grouping by owner makes the relationship structural instead of
+    // something the user has to infer.
+    const allDimensions = withParentModel(dimensions, 'dimension');
+    const allMetrics = withParentModel(metrics, 'metric');
+    const unscoped = list => list.filter(f => !f.parentModel);
+
+    const nestedFieldsByModel = {};
+    [...allDimensions, ...allMetrics].forEach(field => {
+      if (!field.parentModel) return;
+      const bucket = (nestedFieldsByModel[field.parentModel] ||= { dimension: [], metric: [] });
+      bucket[field.type].push(field);
+    });
+
     return {
+      nestedFieldsByModel,
       layoutItems: {
         chart: mapRows(charts, 'chart'),
         table: mapRows(tables, 'table'),
@@ -187,8 +205,8 @@ export function useLibraryData() {
       dataLayer: {
         source: sourceRows,
         model: modelRows,
-        dimension: withParentModel(dimensions, 'dimension'),
-        metric: withParentModel(metrics, 'metric'),
+        dimension: unscoped(allDimensions),
+        metric: unscoped(allMetrics),
         relation: mapRows(relations, 'relation'),
         insight: mapRows(insights, 'insight'),
       },

--- a/viewer/src/components/views/workspace/library/useLibraryData.test.js
+++ b/viewer/src/components/views/workspace/library/useLibraryData.test.js
@@ -121,12 +121,11 @@ describe('useLibraryData', () => {
   // Explore 2.0 Phase 3a — 02-architecture.md §4's DnD "payload gap": a
   // dropped field's ref-scoping and an input's `.value`/`.values` accessor
   // both depend on data the Library row previously didn't carry.
-  test('dimensions/metrics carry parentModel + expression when model-scoped', () => {
+  test('model-scoped fields group under their owner; unscoped stay top-level', () => {
     act(() => {
       useStore.setState({
         dimensions: [
           { name: 'scoped_dim', parentModel: 'orders', config: { expression: 'UPPER(region)' } },
-          { name: 'ref_scoped_dim', config: { model: '${ref(users)}', expression: 'region' } },
           { name: 'unscoped_dim', config: { expression: 'count(*)' } },
         ],
         metrics: [
@@ -135,118 +134,36 @@ describe('useLibraryData', () => {
       });
     });
     const { result } = renderHook(() => useLibraryData());
-    // Alphabetical now, so name them rather than relying on seed order.
-    const byName = Object.fromEntries(
-      result.current.dataLayer.dimension.map(d => [d.name, d])
-    );
-    const { scoped_dim: scoped, ref_scoped_dim: refScoped, unscoped_dim: unscoped } = byName;
-    expect(scoped.parentModel).toBe('orders');
-    expect(scoped.expression).toBe('UPPER(region)');
-    // Falls back to config.model (a ref string) when parentModel isn't set
-    // directly on the record — mirrors useFieldParentModel.js's resolution.
-    expect(refScoped.parentModel).toBe('${ref(users)}');
-    expect(unscoped.parentModel).toBeNull();
 
-    const [scopedMetric] = result.current.dataLayer.metric;
-    expect(scopedMetric.parentModel).toBe('orders');
-    expect(scopedMetric.expression).toBe('sum(amount)');
+    // A nested field is plain SQL where `${ref()}` is a save-time error, while
+    // a standalone one is authored WITH refs. Listing them side by side made
+    // two different things look identical, so scoped ones now live under their
+    // model (LibraryModelRow) and only unscoped ones remain top-level.
+    expect(result.current.dataLayer.dimension.map(d => d.name)).toEqual(['unscoped_dim']);
+    expect(result.current.dataLayer.metric).toEqual([]);
+
+    const owned = result.current.nestedFieldsByModel.orders;
+    expect(owned.dimension.map(d => d.name)).toEqual(['scoped_dim']);
+    expect(owned.metric.map(m => m.name)).toEqual(['scoped_metric']);
+
+    // The DnD payload the drop side needs is still carried (Phase 3a): scoping
+    // decides `${ref(model).name}` vs a bare `${ref(name)}`.
+    expect(owned.dimension[0].parentModel).toBe('orders');
+    expect(owned.dimension[0].expression).toBe('UPPER(region)');
+    expect(result.current.dataLayer.dimension[0].parentModel).toBeNull();
   });
 
-  // Ordering — unpublished first, then by name. Rows previously came back in
-  // whatever order the API returned, which is insertion order: in a project
-  // with 124 models, the one you had just edited was wherever it happened to
-  // land, and a refetch could reorder the list under you.
-  describe('row ordering', () => {
-    const names = rows => rows.map(r => r.name);
-
-    test('rows with unpublished changes sort above published ones', () => {
-      act(() => {
-        useStore.setState({
-          charts: [
-            { name: 'alpha', status: 'published' },
-            { name: 'zulu', status: 'modified' },
-            { name: 'bravo', status: 'published' },
-            { name: 'yankee', status: 'new' },
-          ],
-        });
+  test('a model with no fields of its own gets no entry', () => {
+    act(() => {
+      useStore.setState({
+        dimensions: [{ name: 'unscoped_dim', config: { expression: 'count(*)' } }],
+        metrics: [],
       });
-      const { result } = renderHook(() => useLibraryData());
-      // Both dot states (new AND modified) lead — the rule is "has a dot",
-      // matching StatusDot, so the sort can never disagree with the UI.
-      expect(names(result.current.layoutItems.chart)).toEqual([
-        'yankee',
-        'zulu',
-        'alpha',
-        'bravo',
-      ]);
     });
-
-    test('a missing status counts as published, not as an edit', () => {
-      act(() => {
-        useStore.setState({
-          charts: [{ name: 'zebra' }, { name: 'apple', status: 'modified' }, { name: 'mango' }],
-        });
-      });
-      const { result } = renderHook(() => useLibraryData());
-      expect(names(result.current.layoutItems.chart)).toEqual(['apple', 'mango', 'zebra']);
-    });
-
-    test('names sort naturally, so model_2 precedes model_10', () => {
-      act(() => {
-        useStore.setState({
-          models: [{ name: 'model_10' }, { name: 'model_2' }, { name: 'model_1' }],
-        });
-      });
-      const { result } = renderHook(() => useLibraryData());
-      expect(names(result.current.dataLayer.model)).toEqual(['model_1', 'model_2', 'model_10']);
-    });
-
-    test('casing does not split otherwise-adjacent names', () => {
-      act(() => {
-        useStore.setState({
-          models: [{ name: 'beta' }, { name: 'Alpha' }, { name: 'gamma' }],
-        });
-      });
-      const { result } = renderHook(() => useLibraryData());
-      expect(names(result.current.dataLayer.model)).toEqual(['Alpha', 'beta', 'gamma']);
-    });
-
-    test('every type is ordered, not just the ones sharing a mapper', () => {
-      // sources / models / inputs are built by their own inline mappers, so
-      // they can drift from mapRows if the sort is applied per-mapper.
-      act(() => {
-        useStore.setState({
-          sources: [{ name: 'z_src' }, { name: 'a_src', status: 'modified' }],
-          models: [{ name: 'z_model' }, { name: 'a_model', status: 'modified' }],
-          inputs: [{ name: 'z_in' }, { name: 'a_in', status: 'modified' }],
-          dimensions: [{ name: 'z_dim' }, { name: 'a_dim', status: 'modified' }],
-          tables: [{ name: 'z_tbl' }, { name: 'a_tbl', status: 'modified' }],
-        });
-      });
-      const { result } = renderHook(() => useLibraryData());
-      expect(names(result.current.dataLayer.source)).toEqual(['a_src', 'z_src']);
-      expect(names(result.current.dataLayer.model)).toEqual(['a_model', 'z_model']);
-      expect(names(result.current.layoutItems.input)).toEqual(['a_in', 'z_in']);
-      expect(names(result.current.dataLayer.dimension)).toEqual(['a_dim', 'z_dim']);
-      expect(names(result.current.layoutItems.table)).toEqual(['a_tbl', 'z_tbl']);
-    });
-
-    test('sources, models and inputs keep soft-deleted rows like every other type', () => {
-      // The Library is the one surface that shows tombstones — it is where a
-      // pending deletion is seen and undone. Every type has to agree, or a
-      // deleted source would be unrecoverable while a deleted chart was not.
-      act(() => {
-        useStore.setState({
-          sources: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
-          models: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
-          inputs: [{ name: 'gone', status: 'deleted' }, { name: 'kept' }],
-        });
-      });
-      const { result } = renderHook(() => useLibraryData());
-      expect(names(result.current.dataLayer.source)).toContain('gone');
-      expect(names(result.current.dataLayer.model)).toContain('gone');
-      expect(names(result.current.layoutItems.input)).toContain('gone');
-    });
+    const { result } = renderHook(() => useLibraryData());
+    // LibraryModelRow keys its chevron off this — an expander that opens onto
+    // an empty list is a dead affordance.
+    expect(result.current.nestedFieldsByModel).toEqual({});
   });
 
   test('inputs carry inputType (single-select | multi-select)', () => {

--- a/viewer/src/hooks/useDraftInsightPreview.js
+++ b/viewer/src/hooks/useDraftInsightPreview.js
@@ -17,6 +17,27 @@ import { collectInsightRefNames } from '../utils/refWalk';
  * the original name), since Chart.jsx only ever reads whatever key
  * `chart.insights[].name` names, and the exploration's OWN live-preview
  * chart config is the only place that references this key. */
+/**
+ * The model named by a prop that is still just a dropped placeholder.
+ *
+ * A configured ref carries a property (`${ref(m).col}`); an unconfigured one
+ * does not (`${ref(m)}`). Only the second is a placeholder — and only when the
+ * name is a MODEL, since a bare `${ref(x)}` naming a metric or dimension is a
+ * legitimate, resolvable reference.
+ *
+ * @returns {string|null} the model name, or null when every prop is ready
+ */
+export const unconfiguredModelRef = (props, modelStates) => {
+  const modelNames = new Set(Object.keys(modelStates || {}));
+  if (!modelNames.size) return null;
+  for (const value of Object.values(props || {})) {
+    if (typeof value !== 'string') continue;
+    const match = value.match(/\$\{\s*ref\(\s*([^).]+?)\s*\)\s*\}/);
+    if (match && modelNames.has(match[1])) return match[1];
+  }
+  return null;
+};
+
 export const draftInsightKey = name => `__draft__:${name}`;
 
 // The debounce coalesces rapid edits before hitting the server compile +
@@ -323,6 +344,28 @@ const useDraftInsightPreview = () => {
             error: null,
             blockedReason: 'no_data_props',
             blockedModel: null,
+          });
+          continue;
+        }
+
+        // VIS-1242 follow-up: a model dropped on a slot lands UNCONFIGURED on
+        // purpose — `?{${ref(model)}}`, a bare model ref with no property — so
+        // the pill can open its editor and let the user pick one. That is a
+        // placeholder, not an expression: the backend resolves `${ref(x)}` by
+        // looking for an `expression` on x, and a SqlModel has none, so
+        // compiling it answered 400 with a raw `'SqlModel' object has no
+        // attribute 'expression'` on the headline drop-a-model path.
+        //
+        // Nothing surfaced in the UI, which made it worse — a console error on
+        // the flow's happy path. Wait for the property, the same way an insight
+        // with nothing mapped yet is never compiled.
+        const unconfigured = unconfiguredModelRef(state.props, modelStates);
+        if (unconfigured) {
+          setInsightStatus(name, {
+            isLoading: false,
+            error: null,
+            blockedReason: 'unconfigured_model_ref',
+            blockedModel: unconfigured,
           });
           continue;
         }

--- a/viewer/src/hooks/useDraftInsightPreview.test.js
+++ b/viewer/src/hooks/useDraftInsightPreview.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-template-curly-in-string -- test fixtures use literal Visivo `${ref(...)}` strings */
 import { renderHook, act } from '@testing-library/react';
 import useStore from '../stores/store';
-import useDraftInsightPreview, { draftInsightKey } from './useDraftInsightPreview';
+import useDraftInsightPreview, { draftInsightKey, unconfiguredModelRef } from './useDraftInsightPreview';
 import { useDuckDB } from '../contexts/DuckDBContext';
 import { getConnection } from '../duckdb/duckdb';
 import { runDuckDBQuery } from '../duckdb/queries';
@@ -1362,5 +1362,44 @@ describe('useDraftInsightPreview', () => {
     expect(useStore.getState().insightJobs[draftInsightKey('my_insight')]?.data).toEqual([
       { a: 1 },
     ]);
+  });
+});
+
+
+// Review finding #2: a model dropped on a slot lands UNCONFIGURED on purpose
+// (`?{${ref(model)}}`, no property) so the pill can open its editor. Compiling
+// that placeholder answered 400 with a raw `'SqlModel' object has no attribute
+// 'expression'` — a console error on the headline drop-a-model path.
+describe('unconfiguredModelRef', () => {
+  const modelStates = { orders: {}, users: {} };
+
+  test('a bare MODEL ref is a placeholder', () => {
+    expect(unconfiguredModelRef({ x: '?{${ref(orders)}}' }, modelStates)).toBe('orders');
+  });
+
+  test('a model ref WITH a property is configured', () => {
+    expect(unconfiguredModelRef({ x: '?{${ref(orders).amount}}' }, modelStates)).toBeNull();
+  });
+
+  test('a bare ref to a metric/dimension is legitimate, not a placeholder', () => {
+    // `${ref(revenue)}` resolves — only a MODEL has no expression to resolve.
+    expect(unconfiguredModelRef({ x: '?{${ref(revenue)}}' }, modelStates)).toBeNull();
+  });
+
+  test('finds the placeholder among configured siblings', () => {
+    const props = {
+        x: '?{${ref(orders).amount}}',
+        y: '?{${ref(users)}}',
+    };
+    expect(unconfiguredModelRef(props, modelStates)).toBe('users');
+  });
+
+  test('no models, no verdict', () => {
+    expect(unconfiguredModelRef({ x: '?{${ref(orders)}}' }, {})).toBeNull();
+  });
+
+  test('non-string and empty props are ignored', () => {
+    expect(unconfiguredModelRef({ x: 5, y: null, z: '' }, modelStates)).toBeNull();
+    expect(unconfiguredModelRef(null, modelStates)).toBeNull();
   });
 });

--- a/viewer/src/schemas/plotlyValidator.js
+++ b/viewer/src/schemas/plotlyValidator.js
@@ -50,7 +50,11 @@ const QUERY_STRING_PATTERN_MARKER = '\\?\\{';
 function humanizePatternError(error) {
   const pattern = error.params?.pattern || '';
   if (pattern.includes(QUERY_STRING_PATTERN_MARKER)) {
-    return 'Enter a query expression like ?{ref(model).column}, or drag a column here.';
+    // Deliberately does NOT tell the user to type `?{ }`: the editor wraps the
+    // body for them, so quoting the wrapped form describes a string they never
+    // author and can't produce by typing what the message shows.
+    // eslint-disable-next-line no-template-curly-in-string
+    return 'Drag a column here, or enter an expression like ${ref(model).column} — the ?{ } wrapper is added for you.';
   }
   return "This value doesn't match the format this field expects.";
 }

--- a/viewer/src/schemas/plotlyValidator.test.js
+++ b/viewer/src/schemas/plotlyValidator.test.js
@@ -128,8 +128,14 @@ describe('validateProps - pattern violations never leak the raw regex (T4)', () 
       expect(err.message).not.toMatch(/\^.*\$/);
       expect(err.message.toLowerCase()).not.toContain('pattern "');
     });
-    // The actionable, human copy IS present.
-    expect(xErrors.some(e => e.message.includes('?{ref(model).column}'))).toBe(true);
+    // The actionable, human copy IS present...
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(xErrors.some(e => e.message.includes('${ref(model).column}'))).toBe(true);
+    expect(xErrors.some(e => e.message.includes('Drag a column here'))).toBe(true);
+    // ...and it does NOT instruct the user to type the `?{ }` wrapper, which
+    // the editor adds for them — quoting the wrapped form described a string
+    // they can never produce by typing what the message showed.
+    xErrors.forEach(err => expect(err.message).not.toContain('?{ref('));
   });
 });
 

--- a/viewer/src/stores/modelStore.js
+++ b/viewer/src/stores/modelStore.js
@@ -28,12 +28,32 @@ const createModelSlice = (set, get) => ({
   },
 
   // Save model to cache
+  /**
+   * Refresh the collections a model can change by proxy. Nested metrics and
+   * dimensions have no independent existence: the managers assemble their lists
+   * by walking `model.metrics` / `model.dimensions`, so a model write is also a
+   * write to those. Tolerates their absence — the stores are composed, and a
+   * partial store (tests, embedded hosts) must not break a model save.
+   */
+  refetchModelScopedFields: async () => {
+    await Promise.all([
+      get().fetchDimensions?.(),
+      get().fetchMetrics?.(),
+    ]);
+  },
+
   saveModel: async (name, config) => {
     try {
       const projectId = get().project?.id;
       const result = await modelsApi.saveModel(name, config, projectId);
       // Refresh models list to get updated status
       await get().fetchModels();
+      // A model OWNS its nested metrics/dimensions — `list_all_dimensions` /
+      // `list_all_metrics` walk the models to build their lists — so saving one
+      // can add or remove entries in those collections. Refetching only
+      // `models` left the Library showing fields that no longer exist, and
+      // hiding ones just added, until a full page reload.
+      await get().refetchModelScopedFields?.();
       // Trigger commit status check
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();
@@ -52,6 +72,8 @@ const createModelSlice = (set, get) => ({
       const projectId = get().project?.id;
       await modelsApi.deleteModel(name, projectId);
       await get().fetchModels();
+      // Deleting a model takes its nested fields with it.
+      await get().refetchModelScopedFields?.();
       // Trigger commit status check
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();


### PR DESCRIPTION
Phases 1–3 of **VIS-1238**. Closes **VIS-1240**, **VIS-1241**, **VIS-1242**.

## Phase 1 — Stop the flip-flopping (VIS-1240)

> "I have seen behavior in two ways… I am not sure what causes it to switch back and forth."

It wasn't a mode you were choosing. `showPill` was re-derived on **every render**, so it flipped for three unrelated reasons:

| Cause | What you saw |
|---|---|
| **Mid-typing** | `${ref(q).gdp}` momentarily parses → pill replaces the editor, caret lost; ` / 100` flips it back |
| **Async field tables** | `metrics`/`dimensions` start `[]`, so a bare ref is opaque until they load → raw code, then a pill |
| **Surface** | pills were gated on `droppable`, so the *same value* was a pill in the Build rail and raw text in the right rail |

Fixed by freezing the representation while the raw editor has focus, holding the decision during a fetch, and making rendering a property of the **value** (dropping is still gated on `droppable`).

Also: the static/query toggle **used to lie** — `currentMode` ORs in `isQueryMode`, so on a `?{...}` value the "static" button depressed and snapped straight back. It can't demote (a `?{...}` in a number input mangles), so it now says why.

*Measured, not guessed:* removing the `droppable` gate broke **1 test out of 6866** — the one asserting the split by name.

## Phase 2 — The pill becomes a self-contained editor (VIS-1241)

The menu could only change the **aggregation**; the `ref ▸ column` header was static text, the index lived in a separate badge, and every click committed and closed.

It's now a form — **Property · Use as · Index · Modifier**, with Apply/Cancel, committing once:

```
Property  [ gdp   ▾ ]   →  ?{ sum(${ref(m).gdp}) / 100 }[0]
Use as    [ SUM   ▾ ]            └───┬───┘ └─┬─┘  └┬┘
Index     [ [0]   ▾ ]         aggregation modifier index
Modifier  [ / 100    ]                     (inside)  (last)
```

- **Property picker** from `POST /api/model-schemas/<model>/`, requested inside the popover (which mounts only when open) so a panel of pills doesn't fire a request per row. Stays editable while loading; falls back to free text when a model has no schema.
- **Modifier** — the manual escape valve you asked for, applied *inside* the braces so an index can still follow.

**The modifier forced grammar work planned for Phase 4**, because without it applying a modifier reparsed as `opaque` and the pill vanished on Apply — reintroducing the very flip Phase 1 removed. `parse` gained a head-match pass with a balanced-paren scan (`AGG_WRAP`'s `\)\s*$` anchor is precisely why `sum(x) / 100` matched nothing). It stays conservative: a second `${ref()}`, arithmetic *inside* the aggregate, and non-preset functions all remain opaque, verbatim.

⚠️ **A dangerous consequence, caught and closed:** once modified expressions parse, `pillFieldSwap` would have offered to rewrite `?{${ref(m).region} = 'west'}` to a bare `?{${ref(region)}}` — **silently dropping the `= 'west'`**. Modified slots are now excluded from both swap detectors.

Per your request, the index is **hidden at its default** — every slot used to carry an "All values" badge restating the default; it now appears only when there's a real index to show.

## Phase 3 — Drop a model, then configure it (VIS-1242)

Three blockers, the first fatal:

1. **Models weren't draggable at all** — in neither drag list, so `draggable={false}`. Added a separate `PROPERTY_DRAG_TYPES` rather than extending `EXPLORATION_DRAG_TYPES`, which also drives "Add to exploration" (a test caught that side effect).
2. **The drop had no type guard** — any payload with a `name` silently wrote `?{${ref(<activeModel>).<objectName>}}`, so dropping a source or insight produced a dangling ref with no message. Now an explicit allowlist that says why.
3. **An unbound model ref had no pill** — `${ref(model)}` parsed as `opaque`, suppressing the pill, so a dropped model had nothing to configure. New `modelRef` kind; metric/dimension names still win (backend's global-name-first order), unknown refs still opaque.

A dropped model lands as `<model> ▸ choose a property` and **opens the same editor** a configured pill uses — keyed on the value *changing* into that state, so loading an insight doesn't pop menus.

## Verification

Sandbox, end to end:
- Right rail renders `AVG · local_test_table ▸ y` as a pill while a sibling `CASE WHEN` correctly stays raw text — representation following the value, not the panel
- Property list populated from the real endpoint (`["x","y"]`)
- Menu stays open across three edits, commits once
- Applying `/ 100` + `[0]` leaves a pill that **re-opens with both intact** — the round-trip that matters
- Zero console errors throughout

**6887 tests passing** (359 suites), `yarn lint` clean.

## Not covered
The right-rail form's Save button wasn't exercised in the browser (no `form-footer-save` in that view to click), so the *persisted* string rests on unit tests plus the earlier check of the exact form against the Python `QUERY_STRING_VALUE_PATTERN`. Phase 4 (VIS-1243) — configurable chips in `RefTextArea`, structured property paths — remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
