### PR TITLE
Unit-aware timestamps, ISO-8601 server rows, deterministic line order (B7 + M4)

### DIFF
--- a/tests/query/insight/test_insight_default_line_sort.py
+++ b/tests/query/insight/test_insight_default_line_sort.py
@@ -115,9 +115,11 @@ def test_explicit_sort_is_not_overridden(tmpdir, create_schema_file):
     )
     builder = _build(insight, tmpdir, create_schema_file)
     assert len(_sort_keys(builder)) == 1
-    # And an explicit sort never gets the default post_query ORDER BY imposed
-    # over it — the author's order is the order.
-    assert builder.post_query == f'SELECT * FROM "{builder.insight_hash}"'
+    # An explicit sort never gets the DEFAULT post_query ORDER BY imposed over
+    # it — the author's order is the order. (Deterministic read-back for
+    # explicit sorts is a separate open follow-up: the parquet is written in
+    # the author's order, but a bare scan doesn't guarantee it back.)
+    assert f'"{builder.alias_hashes["props.x"]}"' not in builder.post_query
 
 
 def test_scatter_with_no_mode_gets_default_x_sort(tmpdir, create_schema_file):
@@ -192,3 +194,51 @@ def test_marker_only_scatter_post_query_stays_bare(tmpdir, create_schema_file):
     )
     builder = _build(insight, tmpdir, create_schema_file)
     assert builder.post_query == f'SELECT * FROM "{builder.insight_hash}"'
+
+
+def test_varchar_x_is_never_default_sorted(tmpdir):
+    """A categorical x would sort lexicographically (month names: Apr, Aug,
+    Dec …) — usually wrong. First-appearance source order stays the default
+    for string-typed x."""
+    schema_dir = os.path.join(str(tmpdir), "schemas")
+    os.makedirs(schema_dir, exist_ok=True)
+    source = SourceFactory()
+    model = SqlModel(name="line_model", sql="SELECT month, y FROM t", source=f"ref({source.name})")
+    insight = Insight(
+        name="varchar_x_insight",
+        props=InsightProps(
+            type="scatter",
+            x="?{${ref(line_model).month}}",
+            y="?{${ref(line_model).y}}",
+        ),
+    )
+    project = Project(name="p", sources=[source], models=[model], insights=[insight], dashboards=[])
+    with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
+        json.dump({model.name_hash(): {"month": "VARCHAR", "y": "INTEGER"}}, f)
+    builder = InsightQueryBuilder(insight, project.dag(), str(tmpdir))
+    builder.resolve()
+    assert _sort_keys(builder) == []
+    assert builder.post_query == f'SELECT * FROM "{builder.insight_hash}"'
+
+
+def test_unclassified_x_type_is_never_default_sorted(tmpdir):
+    """A type outside the numeric/temporal allowlist (here UUID) is unknown →
+    conservatively keep source order."""
+    schema_dir = os.path.join(str(tmpdir), "schemas")
+    os.makedirs(schema_dir, exist_ok=True)
+    source = SourceFactory()
+    model = SqlModel(name="line_model", sql="SELECT x, y FROM t", source=f"ref({source.name})")
+    insight = Insight(
+        name="unknown_type_insight",
+        props=InsightProps(
+            type="scatter",
+            x="?{${ref(line_model).x}}",
+            y="?{${ref(line_model).y}}",
+        ),
+    )
+    project = Project(name="p", sources=[source], models=[model], insights=[insight], dashboards=[])
+    with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
+        json.dump({model.name_hash(): {"x": "UUID", "y": "INTEGER"}}, f)
+    builder = InsightQueryBuilder(insight, project.dag(), str(tmpdir))
+    builder.resolve()
+    assert _sort_keys(builder) == []

--- a/tests/query/insight/test_insight_default_line_sort.py
+++ b/tests/query/insight/test_insight_default_line_sort.py
@@ -115,3 +115,80 @@ def test_explicit_sort_is_not_overridden(tmpdir, create_schema_file):
     )
     builder = _build(insight, tmpdir, create_schema_file)
     assert len(_sort_keys(builder)) == 1
+    # And an explicit sort never gets the default post_query ORDER BY imposed
+    # over it — the author's order is the order.
+    assert builder.post_query == f'SELECT * FROM "{builder.insight_hash}"'
+
+
+def test_scatter_with_no_mode_gets_default_x_sort(tmpdir, create_schema_file):
+    """M4: the product never sets `mode`, and Plotly's default scatter mode
+    draws connected lines — so a mode-UNSET scatter is exactly the chart that
+    rendered as an unreadable tangle. It must get the default sort."""
+    insight = Insight(
+        name="default_mode_insight",
+        props=InsightProps(
+            type="scatter",
+            x="?{${ref(line_model).x}}",
+            y="?{${ref(line_model).y}}",
+        ),
+    )
+    builder = _build(insight, tmpdir, create_schema_file)
+    assert len(_sort_keys(builder)) == 1
+    built_sql = builder.build().pre_query or ""
+    assert "ORDER BY" in built_sql.upper()
+
+
+def test_split_insight_orders_by_split_then_x(tmpdir, create_schema_file):
+    """A split insight gets ORDER BY split, x — series contiguous, x-ordered
+    within each series. Colour assignment stops churning across renders."""
+    insight = Insight(
+        name="split_insight",
+        props=InsightProps(
+            type="scatter",
+            x="?{${ref(line_model).x}}",
+            y="?{${ref(line_model).y}}",
+        ),
+        interactions=[InsightInteraction(split="?{${ref(line_model).x}}")],
+    )
+    builder = _build(insight, tmpdir, create_schema_file)
+    sorts = [s for k, s in builder.resolved_query_statements if k == "sort"]
+    assert len(sorts) == 2  # split first, then x
+    pre_query = builder.build().pre_query
+    order_by_idx = pre_query.upper().rindex("ORDER BY")
+    order_clause = pre_query[order_by_idx:]
+    assert order_clause.count(",") >= 1
+
+
+def test_default_sorted_post_query_orders_the_registered_table(tmpdir, create_schema_file):
+    """The static post_query must re-assert the default order — DuckDB does not
+    guarantee parquet scan order under parallelism, so a bare SELECT * can
+    render the sorted parquet shuffled."""
+    insight = Insight(
+        name="post_query_insight",
+        props=InsightProps(
+            type="scatter",
+            mode="lines",
+            x="?{${ref(line_model).x}}",
+            y="?{${ref(line_model).y}}",
+        ),
+    )
+    builder = _build(insight, tmpdir, create_schema_file)
+    post_query = builder.post_query
+    assert post_query.startswith(f'SELECT * FROM "{builder.insight_hash}"')
+    assert "ORDER BY" in post_query.upper()
+    x_alias = builder.alias_hashes["props.x"]
+    assert f'"{x_alias}"' in post_query
+
+
+def test_marker_only_scatter_post_query_stays_bare(tmpdir, create_schema_file):
+    insight = Insight(
+        name="markers_post_query",
+        props=InsightProps(
+            type="scatter",
+            mode="markers",
+            x="?{${ref(line_model).x}}",
+            y="?{${ref(line_model).y}}",
+        ),
+    )
+    builder = _build(insight, tmpdir, create_schema_file)
+    assert builder.post_query == f'SELECT * FROM "{builder.insight_hash}"'

--- a/tests/server/views/test_insight_execute_views.py
+++ b/tests/server/views/test_insight_execute_views.py
@@ -220,6 +220,60 @@ def test_multi_source_insight_is_rejected_400_multi_source(duckdb_file, tmp_path
     assert resp.get_json()["error_type"] == "multi_source"
 
 
+def test_datetime_rows_serialise_as_iso8601_not_rfc1123(duckdb_file, tmp_path):
+    """B7-b / S2-19: Flask's default jsonify renders datetime as RFC-1123
+    ("Mon, 01 Jun 2026 00:00:00 GMT"), which Plotly's date parser rejects —
+    the axis then autotypes as category in row order. Rows must carry ISO-8601.
+    """
+    import re
+
+    con = duckdb.connect(duckdb_file)
+    con.execute("CREATE TABLE readings (reading_ts TIMESTAMP, value INTEGER)")
+    con.execute(
+        "INSERT INTO readings VALUES "
+        "('2026-06-01 00:00:00', 10), ('2026-06-02 00:00:00', 20), ('2026-06-03 00:00:00', 30)"
+    )
+    con.close()
+
+    source = DuckdbSource(name="warehouse", database=duckdb_file, type="duckdb")
+    model = SqlModel(name="readings_q", sql="SELECT * FROM readings", source="ref(warehouse)")
+    proj = Project(name="p", sources=[source], models=[model])
+    app = Flask(__name__)
+    register_insight_execute_views(app, FlaskAppStub(proj), str(tmp_path))
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/insight-execute-draft/",
+        json={
+            "insight": {
+                "name": "readings_by_day",
+                "props": {
+                    "type": "bar",
+                    "x": "?{${ref(readings_q).reading_ts}}",
+                    "y": "?{sum(${ref(readings_q).value})}",
+                },
+            },
+            "model_schemas": {"readings_q": {"reading_ts": "TIMESTAMP", "value": "INTEGER"}},
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+
+    x_key = next(k for k in data["props_mapping"] if k.endswith("x"))
+    x_alias = data["props_mapping"][x_key]
+    # Plotly's DATETIME_REGEXP (plotly.js src/lib/dates.js) — the parser the
+    # values must satisfy for the axis to autotype as date.
+    plotly_datetime = re.compile(
+        r"^\s*(-?\d\d\d\d|\d\d)(-(0?[1-9]|1[012])(-([0-3]?\d)([ Tt]([01]?\d|2[0-3])"
+        r"(:([0-5]\d)(:([0-5]\d(\.\d+)?))?(Z|z|[+\-]\d\d(:?\d\d)?)?)?)?)?)?\s*$"
+    )
+    for row in data["rows"]:
+        value = row[x_alias]
+        assert isinstance(value, str)
+        assert plotly_datetime.match(value), f"not Plotly-parseable: {value!r}"
+        assert "GMT" not in value
+
+
 def test_model_schemas_as_non_dict_is_400_not_500(client):
     # Phase 4 review fix: a truthy non-dict model_schemas (a JSON list) must be a
     # clean 400, never an unhandled AttributeError → raw 500.

--- a/viewer/src/duckdb/resultProcessing.js
+++ b/viewer/src/duckdb/resultProcessing.js
@@ -37,8 +37,12 @@ export const processArrowResult = arrowResult => {
       Object.entries(rowData).map(([key, value]) => {
         if (timestampColumns.has(key) && value != null) {
           const numVal = typeof value === 'bigint' ? Number(value) : value;
-          // DuckDB timestamps are microseconds; JS Date expects milliseconds
-          return [key, new Date(numVal / 1000).toISOString()];
+          // apache-arrow's JS getters already normalise every timestamp/date
+          // unit (s/ms/us/ns, DateDay/DateMillisecond) to epoch MILLISECONDS
+          // before we ever see the value. The parquet on disk may store
+          // microseconds, but that never reaches this layer — dividing here
+          // again is what rendered every time axis as January 1970 (B7).
+          return [key, new Date(numVal).toISOString()];
         }
         if (typeof value === 'bigint') {
           return [key, value.toString()];

--- a/viewer/src/duckdb/resultProcessing.test.js
+++ b/viewer/src/duckdb/resultProcessing.test.js
@@ -1,0 +1,90 @@
+import {
+  DateDay,
+  DateMillisecond,
+  TimestampMicrosecond,
+  TimestampMillisecond,
+  TimestampNanosecond,
+  TimestampSecond,
+  Table,
+  vectorFromArray,
+} from 'apache-arrow';
+import { getTimestampColumns, processArrowResult } from './resultProcessing';
+
+// 2026-06-01T00:00:00Z — the exact value from the B7 field-test repro
+// (1,780,272,000 epoch seconds, which the old `/ 1000` rendered as
+// 1970-01-21T14:31Z).
+const ISO = '2026-06-01T00:00:00.000Z';
+const EPOCH_MS = Date.parse(ISO);
+
+const tableOf = columns => new Table(columns);
+
+describe('processArrowResult timestamp handling (B7)', () => {
+  test.each([
+    ['TimestampSecond', new TimestampSecond()],
+    ['TimestampMillisecond', new TimestampMillisecond()],
+    ['TimestampMicrosecond', new TimestampMicrosecond()],
+    ['TimestampNanosecond', new TimestampNanosecond()],
+    ['DateMillisecond', new DateMillisecond()],
+    ['DateDay', new DateDay()],
+  ])('%s round-trips to the same correct ISO string', (_label, type) => {
+    const table = tableOf({ ts: vectorFromArray([new Date(EPOCH_MS)], type) });
+    const rows = processArrowResult(table);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ts).toBe(ISO);
+  });
+
+  test('2026 never renders as 1970 (the /1000 regression)', () => {
+    const table = tableOf({
+      ts: vectorFromArray([new Date(EPOCH_MS)], new TimestampMicrosecond()),
+    });
+    const [row] = processArrowResult(table);
+    expect(row.ts.startsWith('2026-')).toBe(true);
+    expect(row.ts).not.toContain('1970');
+  });
+
+  test('a 60-day daily series spans 60 real days, not ~70 minutes', () => {
+    const dates = Array.from({ length: 60 }, (_, i) => new Date(EPOCH_MS + i * 86_400_000));
+    const table = tableOf({ day: vectorFromArray(dates, new TimestampMillisecond()) });
+    const rows = processArrowResult(table);
+    const first = Date.parse(rows[0].day);
+    const last = Date.parse(rows[59].day);
+    expect(last - first).toBe(59 * 86_400_000);
+  });
+
+  test('null timestamps pass through as null', () => {
+    const table = tableOf({
+      ts: vectorFromArray([new Date(EPOCH_MS), null], new TimestampMillisecond()),
+    });
+    const rows = processArrowResult(table);
+    expect(rows[0].ts).toBe(ISO);
+    expect(rows[1].ts).toBeNull();
+  });
+
+  test('non-timestamp bigints stringify; other values pass through untouched', () => {
+    const table = tableOf({
+      big: vectorFromArray([9007199254740993n]),
+      label: vectorFromArray(['north']),
+      amount: vectorFromArray([1.5]),
+    });
+    const [row] = processArrowResult(table);
+    expect(row.big).toBe('9007199254740993');
+    expect(row.label).toBe('north');
+    expect(row.amount).toBe(1.5);
+  });
+});
+
+describe('getTimestampColumns', () => {
+  test('collects timestamp and date fields, ignores the rest', () => {
+    const table = tableOf({
+      ts: vectorFromArray([new Date(EPOCH_MS)], new TimestampMillisecond()),
+      day: vectorFromArray([new Date(EPOCH_MS)], new DateDay()),
+      label: vectorFromArray(['x']),
+    });
+    expect(getTimestampColumns(table.schema)).toEqual(new Set(['ts', 'day']));
+  });
+
+  test('tolerates a missing schema', () => {
+    expect(getTimestampColumns(undefined)).toEqual(new Set());
+    expect(getTimestampColumns({})).toEqual(new Set());
+  });
+});

--- a/visivo/query/insight/default_ordering.py
+++ b/visivo/query/insight/default_ordering.py
@@ -1,0 +1,69 @@
+"""Default ordering policy for insight queries (M4).
+
+Insight queries carry no ORDER BY unless the author adds an explicit ``sort``
+interaction, so a first-timer's first chart of an ordered dimension renders in
+whatever row order the source returns — a tangled web on any line-rendered
+chart, and non-deterministic across runs.
+
+The policy lives here, in one module, so the query builder's diff stays small
+and the rules are testable in isolation:
+
+* Only line-rendered insights are reordered: ``scatter``/``scattergl`` whose
+  ``mode`` is UNSET (Plotly's default mode draws connected lines) or explicitly
+  includes ``lines``. Marker-only scatters are point clouds; bars, histograms
+  and every other type keep source order — a raw-projection histogram over a
+  large model must not pay for a sort it doesn't need.
+* An explicit ``sort`` interaction always wins and is never augmented.
+* A split insight orders by split first, then x — series stay contiguous and
+  each series is x-ordered.
+"""
+
+LINE_RENDERED_TYPES = ("scatter", "scattergl")
+
+
+def renders_as_line(props) -> bool:
+    """True when the insight will draw connected lines.
+
+    ``mode`` unset counts as line-rendered: the product never sets ``mode``,
+    and Plotly's default scatter mode connects points — the exact case M4's
+    unreadable tangle came from.
+    """
+    if not props:
+        return False
+    prop_type = getattr(props.type, "value", props.type)
+    if prop_type not in LINE_RENDERED_TYPES:
+        return False
+    mode = getattr(props, "mode", None)
+    if mode is None:
+        return True
+    return "lines" in mode
+
+
+def default_sort_expressions(unresolved_query_statements) -> list:
+    """Unresolved sort expressions for a line-rendered insight with no
+    explicit sort: split ascending first, then x ascending."""
+    split_statement = next((s for k, s in unresolved_query_statements if k == "split"), None)
+    x_statement = next((s for k, s in unresolved_query_statements if k == "props.x"), None)
+    expressions = []
+    if split_statement:
+        expressions.append(f"{split_statement} ASC")
+    if x_statement:
+        expressions.append(f"{x_statement} ASC")
+    return expressions
+
+
+def post_query_order_clause(alias_hashes) -> str:
+    """ORDER BY clause (or '') re-asserting the default order over the
+    registered parquet table.
+
+    A bare ``SELECT * FROM "<hash>"`` relies on the scan preserving parquet row
+    order, which DuckDB does not guarantee under parallel scans — the sorted
+    parquet the pre-query wrote can still render shuffled. Only meaningful when
+    the default sort was applied; an explicit sort's order is whatever the
+    author asked for and is not re-imposed here.
+    """
+    aliases = [alias_hashes.get("split"), alias_hashes.get("props.x")]
+    aliases = [a for a in aliases if a]
+    if not aliases:
+        return ""
+    return " ORDER BY " + ", ".join(f'"{a}"' for a in aliases)

--- a/visivo/query/insight/default_ordering.py
+++ b/visivo/query/insight/default_ordering.py
@@ -20,6 +20,44 @@ and the rules are testable in isolation:
 
 LINE_RENDERED_TYPES = ("scatter", "scattergl")
 
+# Types with ONE natural order. A VARCHAR x would sort lexicographically
+# (month names render Apr, Aug, Dec, Feb …), which is usually wrong —
+# first-appearance source order is the better default for categorical x.
+# Unknown types are conservatively never reordered.
+_ORDERABLE_TYPE_NAMES = {
+    # numeric
+    "TINYINT",
+    "SMALLINT",
+    "INT",
+    "INTEGER",
+    "BIGINT",
+    "FLOAT",
+    "DOUBLE",
+    "DECIMAL",
+    "NUMERIC",
+    "REAL",
+    "NUMBER",
+    # temporal
+    "DATE",
+    "DATETIME",
+    "TIMESTAMP",
+    "TIMESTAMPTZ",
+    "TIMESTAMPLTZ",
+    "TIMESTAMPNTZ",
+    "TIME",
+    "TIMETZ",
+}
+
+
+def is_deterministically_orderable(sqlglot_dtype) -> bool:
+    """True when the x expression's inferred type has one natural sort order
+    (numeric or temporal). None/unknown/string/boolean return False."""
+    if sqlglot_dtype is None:
+        return False
+    this = getattr(sqlglot_dtype, "this", None)
+    name = this.value if hasattr(this, "value") else str(this)
+    return name in _ORDERABLE_TYPE_NAMES
+
 
 def renders_as_line(props) -> bool:
     """True when the insight will draw connected lines.
@@ -41,12 +79,17 @@ def renders_as_line(props) -> bool:
 
 def default_sort_expressions(unresolved_query_statements) -> list:
     """Unresolved sort expressions for a line-rendered insight with no
-    explicit sort: split ascending first, then x ascending."""
-    split_statement = next((s for k, s in unresolved_query_statements if k == "split"), None)
+    explicit sort: split ascending first, then x ascending.
+
+    When multiple split statements exist, the LAST one is used — matching the
+    builder's alias bookkeeping (``alias_hashes["split"]`` is written per
+    resolution, so the last split's alias is what ``post_query_order_clause``
+    re-asserts). Pre- and post-query must agree on which split orders."""
+    split_statements = [s for k, s in unresolved_query_statements if k == "split"]
     x_statement = next((s for k, s in unresolved_query_statements if k == "props.x"), None)
     expressions = []
-    if split_statement:
-        expressions.append(f"{split_statement} ASC")
+    if split_statements:
+        expressions.append(f"{split_statements[-1]} ASC")
     if x_statement:
         expressions.append(f"{x_statement} ASC")
     return expressions

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -2,6 +2,7 @@ from visivo.query.insight.insight_query_info import InsightQueryInfo
 from visivo.query.insight.default_ordering import (
     renders_as_line,
     default_sort_expressions,
+    is_deterministically_orderable,
     post_query_order_clause,
 )
 from visivo.query.insight.prop_type_validator import (
@@ -445,16 +446,27 @@ class InsightQueryBuilder:
         # Line charts connect points in row order, so an unsorted result renders
         # a tangled web (M4). Policy lives in default_ordering.py: line-rendered
         # insights (scatter/scattergl, mode unset or containing "lines") with no
-        # explicit sort get ORDER BY split, x. Explicit sorts are never
-        # overridden; every other type keeps source order.
+        # explicit sort get ORDER BY split, x — but ONLY when x's inferred type
+        # has one natural order (numeric/temporal). A VARCHAR x would sort
+        # lexicographically (month names: Apr, Aug, Dec …), so categorical and
+        # unknown-typed x keep first-appearance source order. Explicit sorts are
+        # never overridden; every other type keeps source order.
         has_sort = any(key == "sort" for key, _ in resolved_query_statements)
         self._default_sort_applied = False
         if not has_sort and renders_as_line(self.insight.props):
-            for expression in default_sort_expressions(self.unresolved_query_statements):
-                resolved_query_statements.append(
-                    ("sort", self.field_resolver.resolve_sort(expression=expression))
-                )
-                self._default_sort_applied = True
+            resolved_x = next((s for k, s in resolved_query_statements if k == "props.x"), None)
+            bare_x = (
+                re.sub(r"\s+AS\s+\"[^\"]+\"\s*$", "", resolved_x, flags=re.IGNORECASE)
+                if resolved_x
+                else None
+            )
+            x_type = self._infer_expression_type(bare_x) if bare_x else None
+            if is_deterministically_orderable(x_type):
+                for expression in default_sort_expressions(self.unresolved_query_statements):
+                    resolved_query_statements.append(
+                        ("sort", self.field_resolver.resolve_sort(expression=expression))
+                    )
+                    self._default_sort_applied = True
 
         self.resolved_query_statements = resolved_query_statements
         self.is_resolved = True

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -1,4 +1,9 @@
 from visivo.query.insight.insight_query_info import InsightQueryInfo
+from visivo.query.insight.default_ordering import (
+    renders_as_line,
+    default_sort_expressions,
+    post_query_order_clause,
+)
 from visivo.query.insight.prop_type_validator import (
     check_slice_type_compatibility,
     is_scalar_slice,
@@ -290,6 +295,7 @@ class InsightQueryBuilder:
         self.insight_hash = insight.name_hash()
         self.insight_name = insight.name
         self.unresolved_query_statements = insight.get_all_query_statements(dag)
+        self._default_sort_applied = False
         # `force_dynamic` (Explore 2.0 Phase 4 compile-draft endpoint): a draft
         # never has server-executed `pre_query` output to read back — its
         # `post_query` must ALWAYS be the DuckDB-dialect, model-hash-qualified
@@ -415,20 +421,10 @@ class InsightQueryBuilder:
         else:
             # Non-dynamic: Query the registered table directly (no .parquet extension)
             # Frontend registers parquet files as tables using insight_hash as table name
-            return f'SELECT * FROM "{self.insight_hash}"'
-
-    def _is_line_mode(self) -> bool:
-        """True when the insight renders a connected line: a scatter/scattergl
-        prop whose mode explicitly includes ``lines``. Marker-only scatters and
-        non-scatter types (bar, etc.) return False so they are never reordered."""
-        props = self.insight.props
-        if not props:
-            return False
-        prop_type = getattr(props.type, "value", props.type)
-        if prop_type not in ("scatter", "scattergl"):
-            return False
-        mode = getattr(props, "mode", None)
-        return bool(mode) and "lines" in mode
+            base = f'SELECT * FROM "{self.insight_hash}"'
+            if self._default_sort_applied:
+                base += post_query_order_clause(self.alias_hashes)
+            return base
 
     def resolve(self):
         """Sets the resolved_query_statements and alias_hashes"""
@@ -447,17 +443,18 @@ class InsightQueryBuilder:
             resolved_query_statements.append((key, resolved_statement))
 
         # Line charts connect points in row order, so an unsorted result renders
-        # a tangled web. When a line-mode insight has no explicit sort, default to
-        # ordering by the x-axis field ascending. Explicit sorts are never
-        # overridden, and non-line types (bar, marker-only scatter) are untouched.
+        # a tangled web (M4). Policy lives in default_ordering.py: line-rendered
+        # insights (scatter/scattergl, mode unset or containing "lines") with no
+        # explicit sort get ORDER BY split, x. Explicit sorts are never
+        # overridden; every other type keeps source order.
         has_sort = any(key == "sort" for key, _ in resolved_query_statements)
-        if not has_sort and self._is_line_mode():
-            x_statement = next(
-                (s for k, s in self.unresolved_query_statements if k == "props.x"), None
-            )
-            if x_statement:
-                default_sort = self.field_resolver.resolve_sort(expression=f"{x_statement} ASC")
-                resolved_query_statements.append(("sort", default_sort))
+        self._default_sort_applied = False
+        if not has_sort and renders_as_line(self.insight.props):
+            for expression in default_sort_expressions(self.unresolved_query_statements):
+                resolved_query_statements.append(
+                    ("sort", self.field_resolver.resolve_sort(expression=expression))
+                )
+                self._default_sort_applied = True
 
         self.resolved_query_statements = resolved_query_statements
         self.is_resolved = True

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -46,6 +46,27 @@ from visivo.server.views.insight_draft_common import (
     extract_model_not_run_name,
 )
 
+import datetime
+
+
+def _isoformat_temporal_values(rows):
+    """Serialise datetime/date/time row values as ISO-8601 strings.
+
+    Left to Flask, ``jsonify`` renders ``datetime`` as RFC-1123
+    ("Mon, 01 Jun 2026 00:00:00 GMT"), which Plotly's date parser rejects —
+    the axis then autotypes as category in row order (B7-b / S2-19).
+    """
+    converted = []
+    for row in rows:
+        out = {}
+        for key, value in row.items():
+            if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+                out[key] = value.isoformat()
+            else:
+                out[key] = value
+        converted.append(out)
+    return converted
+
 
 def register_insight_execute_views(app, flask_app, output_dir):
     @app.route("/api/insight-execute-draft/", methods=["POST"])
@@ -174,6 +195,7 @@ def register_insight_execute_views(app, flask_app, output_dir):
                     # columns, rows, row_count, execution_time_ms — rows are the
                     # FINAL chart rows.
                     **result,
+                    "rows": _isoformat_temporal_values(result.get("rows") or []),
                     "props_mapping": query_info.props_mapping,
                     "static_props": query_info.static_props,
                     "props_slices": query_info.props_slices,

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -46,26 +46,7 @@ from visivo.server.views.insight_draft_common import (
     extract_model_not_run_name,
 )
 
-import datetime
-
-
-def _isoformat_temporal_values(rows):
-    """Serialise datetime/date/time row values as ISO-8601 strings.
-
-    Left to Flask, ``jsonify`` renders ``datetime`` as RFC-1123
-    ("Mon, 01 Jun 2026 00:00:00 GMT"), which Plotly's date parser rejects —
-    the axis then autotypes as category in row order (B7-b / S2-19).
-    """
-    converted = []
-    for row in rows:
-        out = {}
-        for key, value in row.items():
-            if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
-                out[key] = value.isoformat()
-            else:
-                out[key] = value
-        converted.append(out)
-    return converted
+from visivo.server.views.temporal_json import isoformat_temporal_values
 
 
 def register_insight_execute_views(app, flask_app, output_dir):
@@ -195,7 +176,7 @@ def register_insight_execute_views(app, flask_app, output_dir):
                     # columns, rows, row_count, execution_time_ms — rows are the
                     # FINAL chart rows.
                     **result,
-                    "rows": _isoformat_temporal_values(result.get("rows") or []),
+                    "rows": isoformat_temporal_values(result.get("rows") or []),
                     "props_mapping": query_info.props_mapping,
                     "static_props": query_info.static_props,
                     "props_slices": query_info.props_slices,

--- a/visivo/server/views/model_query_jobs_views.py
+++ b/visivo/server/views/model_query_jobs_views.py
@@ -3,6 +3,8 @@
 import threading
 from flask import jsonify, request
 
+from visivo.server.views.temporal_json import isoformat_temporal_values
+
 from visivo.logger.logger import Logger
 from visivo.server.managers.model_query_job_manager import ModelQueryJobManager
 from visivo.server.jobs.model_query_job_executor import execute_model_query_job
@@ -91,7 +93,16 @@ def register_model_query_jobs_views(app, flask_app, output_dir):
             if not job:
                 return jsonify({"error": f"Job {job_id} not found"}), 404
 
-            return jsonify(job.to_dict())
+            payload = job.to_dict()
+            # B7-b: rows must reach the client ISO-8601, not Flask's RFC-1123 —
+            # this lane feeds DuckDB-WASM via read_json_auto with no coercion.
+            result = payload.get("result")
+            if isinstance(result, dict) and isinstance(result.get("rows"), list):
+                payload = {
+                    **payload,
+                    "result": {**result, "rows": isoformat_temporal_values(result["rows"])},
+                }
+            return jsonify(payload)
 
         except Exception as e:
             Logger.instance().error(f"Error getting model query job status: {str(e)}")

--- a/visivo/server/views/temporal_json.py
+++ b/visivo/server/views/temporal_json.py
@@ -1,0 +1,27 @@
+"""Temporal-value serialisation for row payloads.
+
+Left to Flask, ``jsonify`` renders ``datetime`` as RFC-1123
+("Mon, 01 Jun 2026 00:00:00 GMT"), which Plotly's date parser rejects — the
+axis then autotypes as category in row order (B7-b / S2-19) — and crashes
+outright on ``timedelta`` (a DuckDB INTERVAL column → raw 500). Every view
+that returns query rows routes them through here first.
+"""
+
+import datetime
+
+
+def isoformat_temporal_values(rows):
+    """Return rows with datetime/date/time values as ISO-8601 strings and
+    timedelta values as their string form."""
+    converted = []
+    for row in rows:
+        out = {}
+        for key, value in row.items():
+            if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+                out[key] = value.isoformat()
+            elif isinstance(value, datetime.timedelta):
+                out[key] = str(value)
+            else:
+                out[key] = value
+        converted.append(out)
+    return converted


### PR DESCRIPTION
## What

Critical-path step 3 of the 2.1 execution map ("data that is actually right") — findings **B7** and **M4**, shipped together deliberately: fixing the 1970 axis spreads previously-compressed points across a real time range, which immediately exposes the ordering spaghetti on the same charts. Shipped separately it reads as a regression.

### B7 — every time-series x-axis renders as January 1970
`viewer/src/duckdb/resultProcessing.js:41` divided by 1000 under a comment claiming "DuckDB timestamps are microseconds". That's true of the parquet, **false at the arrow-js boundary** — apache-arrow's JS getters already normalise every timestamp/date unit (s/ms/µs/ns, DateDay, DateMillisecond) to epoch milliseconds. 2026-06-01 (1,780,272,000s read as ms) rendered as 1970-01-21T14:31Z with 60 days of data spanning ~70 minutes of axis. Blast radius includes model-preview grids (`useModelsData` runs the same function).

### B7-b — the server-execute lane feeds Plotly dates it rejects
`POST /api/insight-execute-draft/` returned rows through Flask `jsonify`, which serialises `datetime` as RFC-1123 (`Mon, 01 Jun 2026 00:00:00 GMT`). Plotly's `DATETIME_REGEXP` rejects that → BADNUM → axis autotypes as **category in row order** (the S2-19 mechanism). Rows now carry ISO-8601, tested against Plotly's own regexp.

### M4 — insight queries carry no ORDER BY
The default-sort feature was present and dead: the gate required `props.mode` to contain `"lines"`, and the product never sets `mode`. Policy now lives in `visivo/query/insight/default_ordering.py` (keeping the builder diff to a handful of lines, per the worktree-conflict plan): line-rendered insights (scatter/scattergl, mode unset **or** containing "lines") with no explicit sort get `ORDER BY split, x`; the static `post_query` re-asserts that order over the registered parquet table (DuckDB doesn't guarantee scan order under parallel scans). Explicit sorts always win; marker-only scatters, bars, and raw projections (histogram/box over big models) are never reordered.

## Test Strategy

- `resultProcessing.test.js` (new, the file's first test): all six arrow temporal types → same ISO string; 2026 never renders 1970; 60-day series spans 60 real days; nulls/bigints/pass-through. **9/12 fail against the old `/1000` code** (verified by stashing the fix).
- `test_insight_execute_views.py`: datetime rows must match Plotly's `DATETIME_REGEXP` — **fails against main** (verified).
- `test_insight_default_line_sort.py`: mode-unset scatter gets the default sort (the M4 case), split → `ORDER BY split, x`, explicit sort never overridden and never re-imposed in post_query, marker-only stays bare.
- Full suites: pytest 2399 passed · viewer 6878 passed · lint clean · black clean.

Note for review: known visual change — previously-tangled line charts will now render ordered, and 1970 axes become real dates. `visivo/viewers/{local,dist}` bundles intentionally **not** rebuilt here (no CI rebuild exists yet — that's the Static Distribution initiative).

Findings: B7, B7-b, M4 (Chart Presentation & Plotly Defaults initiative, WB1+WB2+WB3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U