### PR TITLE
Local sources bootstrap their own database file (M10)

### DIFF
--- a/tests/models/sources/test_source_bootstrap_database.py
+++ b/tests/models/sources/test_source_bootstrap_database.py
@@ -1,0 +1,78 @@
+"""M10: a local file-backed source must be able to create its own database.
+
+`seeds:` on a fresh DuckDB source died with `[Errno 2] No such file or
+directory: ''` — `os.path.dirname("bike.duckdb")` is `''` and `makedirs('')`
+raises. Creating the identical file by hand outside Visivo made the project
+work, which is exactly the escape hatch six of eight field testers used.
+"""
+
+import os
+
+import duckdb
+import polars as pl
+import pytest
+from sqlalchemy import text
+
+from visivo.jobs.run_source_schema_job import run_seeds
+from visivo.models.sources.duckdb_source import DuckdbSource
+from visivo.models.sources.seed import Seed
+from visivo.models.sources.sqlite_source import SqliteSource
+
+
+def test_duckdb_bare_filename_creates_the_database_on_first_write(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source = DuckdbSource(name="bike_db", database="bike.duckdb", type="duckdb")
+    source.write_dataframe("rides", pl.DataFrame({"id": [1, 2]}))
+    assert os.path.exists("bike.duckdb")
+    con = duckdb.connect("bike.duckdb")
+    try:
+        assert con.execute("SELECT COUNT(*) FROM rides").fetchone()[0] == 2
+    finally:
+        con.close()
+
+
+def test_duckdb_nested_path_creates_parent_directories(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source = DuckdbSource(name="bike_db", database="nested/dir/bike.duckdb", type="duckdb")
+    source.write_dataframe("rides", pl.DataFrame({"id": [1]}))
+    assert os.path.exists("nested/dir/bike.duckdb")
+
+
+def test_duckdb_create_empty_database_accepts_a_bare_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    DuckdbSource.create_empty_database("bare.duckdb")
+    assert os.path.exists("bare.duckdb")
+
+
+def test_sqlite_nested_path_creates_parent_directories(tmp_path):
+    db_path = str(tmp_path / "nested" / "dir" / "local.db")
+    source = SqliteSource(name="local_db", database=db_path, type="sqlite")
+    engine = source.get_engine()
+    with engine.connect() as connection:
+        connection.execute(text("CREATE TABLE t (x INTEGER)"))
+        connection.commit()
+    assert os.path.exists(db_path)
+
+
+def test_seed_on_a_fresh_duckdb_source_creates_the_database_and_loads_the_table(
+    tmp_path, monkeypatch
+):
+    """The full M10 repro: a four-line duckdb source whose only content is a
+    seed, against a database file that does not exist yet."""
+    monkeypatch.chdir(tmp_path)
+    csv_path = tmp_path / "teams.csv"
+    csv_path.write_text("team,wins\nnorth,10\nsouth,7\n")
+
+    source = DuckdbSource(
+        name="seeded_db",
+        database="seeded.duckdb",
+        type="duckdb",
+        seeds=[Seed(table_name="teams", args=["cat", str(csv_path)])],
+    )
+    loaded = run_seeds(source, working_dir=str(tmp_path))
+    assert loaded == 1
+    con = duckdb.connect("seeded.duckdb")
+    try:
+        assert con.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 2
+    finally:
+        con.close()

--- a/visivo/models/sources/duckdb_source.py
+++ b/visivo/models/sources/duckdb_source.py
@@ -88,7 +88,11 @@ class DuckdbSource(ServerSource, BaseDuckdbSource):
                 Logger.instance().debug(
                     f"Database file {database_path} does not exist, creating it"
                 )
-                os.makedirs(os.path.dirname(database_path), exist_ok=True)
+                # `or "."` — a bare filename like `bike.duckdb` makes dirname()
+                # return '' and makedirs('') raises FileNotFoundError('' ),
+                # which surfaced as "[Errno 2] No such file or directory: ''"
+                # on the first seed run (M10).
+                os.makedirs(os.path.dirname(database_path) or ".", exist_ok=True)
                 # Create the database file
                 temp_conn = duckdb.connect(database_path)
                 temp_conn.close()
@@ -168,8 +172,9 @@ class DuckdbSource(ServerSource, BaseDuckdbSource):
         import duckdb
         import os
 
-        # Ensure directory exists
-        os.makedirs(os.path.dirname(database_path), exist_ok=True)
+        # Ensure directory exists (`or "."`: bare filenames make dirname()
+        # return '' and makedirs('') raises — M10)
+        os.makedirs(os.path.dirname(database_path) or ".", exist_ok=True)
 
         # Remove file if it exists (in case it's an invalid empty file)
         if os.path.exists(database_path):

--- a/visivo/models/sources/sqlite_source.py
+++ b/visivo/models/sources/sqlite_source.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Literal, Optional, Any
 from visivo.models.base.base_model import BaseModel
 from visivo.models.sources.sqlalchemy_source import SqlalchemySource
@@ -65,6 +66,16 @@ class SqliteSource(ServerSource, SqlalchemySource):
         None,
         description="List of other local SQLite database sources to attach in the connection that will be available in the base SQL query.",
     )
+
+    def get_engine(self):
+        # SQLite creates a missing database file on connect, but NOT missing
+        # parent directories — `database: nested/dir/local.db` fails with a raw
+        # "unable to open database file" (M10). Create the parents first; an
+        # existing file/dir is untouched.
+        parent = os.path.dirname(str(self.database))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        return super().get_engine()
 
     def get_connection_dialect(self):
         return "sqlite+pysqlite"


### PR DESCRIPTION
## What

Data On-Ramp dossier project 1 (**M10**): "A DuckDB source's own `seeds:` cannot create its database file — fails with `[Errno 2] No such file or directory: ''`. Creating the empty file by hand *outside* Visivo makes the identical project work perfectly." Six of eight field testers escaped through exactly that hatch.

- `duckdb_source.py` `get_connection` and `create_empty_database`: `os.path.dirname("bike.duckdb")` is `''`, and `makedirs('')` raises — both sites now guard with `or "."`.
- `SqliteSource.get_engine`: SQLite creates a missing database **file** on connect but not missing parent **directories** (`database: nested/dir/local.db` → raw "unable to open database file") — parents are created first; existing files untouched.

Per the recorded review decision, non-file ServerSources (Postgres etc.) do **not** self-create — their write failures already raise naming the source and table. Two dossier items deliberately deferred to follow-ups: making `database:` optional on DuckdbSource (defaulting to `target/<name>.duckdb`) — it interacts with `objects_equal`/serialization (a validator-filled default would make every zero-config source read as permanently MODIFIED, the M12 class) and needs the Project State Integrity `exclude` fix first; and the typed run_seeds error for unreachable server sources.

## Test Strategy
- New `test_source_bootstrap_database.py`: bare-filename DuckDB write, nested-path DuckDB, `create_empty_database` bare filename, nested-path SQLite, and the full M10 repro (fresh duckdb source + one `cat` seed → database created, table loaded via `run_seeds`).
- Falsification: 4/5 fail against main.
- Full suite: 2399 passed · black clean.

Heads-up: touches `duckdb_source.py` in a different hunk than #629 (`source_locked` errors) — they merge cleanly in either order.

Findings: M10 (Data On-Ramp initiative, dossier P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U