### PR TITLE
The parse-error banner stops swallowing toolbar clicks (M15)

### DIFF
--- a/viewer/src/components/styled/Error.jsx
+++ b/viewer/src/components/styled/Error.jsx
@@ -1,6 +1,10 @@
 const Error = ({ children }) => {
+  // In-flow and BELOW the top nav's z-50 — never `fixed` at the same z-index.
+  // The old fixed overlay painted over Commit / Deploy / New object / the tab
+  // strip and swallowed their clicks on every parse error, locking the user
+  // out of the exact controls they needed to recover (M15).
   return (
-    <div className="fixed top-1 left-1 right-1 z-50 flex justify-center items-center p-4 bg-highlight-100 rounded-lg shadow-md">
+    <div role="alert" className="sticky top-0 z-40 mx-1 mt-1 flex justify-center items-center p-4 bg-highlight-100 rounded-lg shadow-md max-h-48 overflow-y-auto">
       <p className="text-highlight-600 font-semibold text-center">{children}</p>
     </div>
   );

--- a/viewer/src/components/styled/Error.test.jsx
+++ b/viewer/src/components/styled/Error.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import Error from './Error';
+
+// M15: a parse error used to render as a `fixed` overlay at the same z-50 as
+// TopNav but later in the DOM, so paint order made the opaque banner win —
+// sitting exactly over Commit / Deploy / New object / the tab strip and
+// swallowing their clicks. The banner must stay in flow, below the nav's
+// stacking level, with a bounded height.
+describe('Error banner (M15 click interception)', () => {
+  test('renders its message', () => {
+    render(<Error>1 validation error in Project</Error>);
+    expect(screen.getByText('1 validation error in Project')).toBeInTheDocument();
+  });
+
+  test('is never a fixed overlay at the nav z-level', () => {
+    render(<Error>boom</Error>);
+    const banner = screen.getByRole('alert');
+    expect(banner.className).not.toContain('fixed');
+    expect(banner.className).not.toContain('z-50');
+    expect(banner.className).toContain('sticky');
+    expect(banner.className).toContain('z-40');
+  });
+
+  test('has a bounded, scrollable height (a 470px traceback must not grow unbounded)', () => {
+    render(<Error>{'long\n'.repeat(200)}</Error>);
+    const banner = screen.getByRole('alert');
+    expect(banner.className).toContain('max-h-48');
+    expect(banner.className).toContain('overflow-y-auto');
+  });
+});


### PR DESCRIPTION
## What

Field-test finding **M15** (click-interception half): a validation error painted a `fixed top-1 z-50` banner over the top nav — later in the DOM than TopNav's `sticky top-0 z-50`, so paint order made the opaque, pointer-event-receiving banner win. Commit, Deploy, New object and the tab bar all became unreachable on every parse error, including the Commit button you'd use to recover. Verifier-confirmed via `elementFromPoint`.

One-component fix (Dashboard Authoring dossier W8, scoped to interception only): in-flow `sticky top-0 z-40 mx-1 mt-1`, `role="alert"`, and a bounded scrollable height (`max-h-48 overflow-y-auto`) so the ~470px raw-pydantic traceback can't take the screen. Banner *content* quality (raw traceback → CLI-grade formatting) and the DiagnosticsPanel replacement are Error Legibility W6/W7, built on the #628 Diagnostic contract — this unblocks users today without prejudging that design.

## Test Strategy
- New `Error.test.jsx`: renders message; never `fixed`/`z-50`, is `sticky`/`z-40`; bounded height classes.
- Full viewer tests on the component + Home suites pass · lint clean.

Findings: M15 (interim; Error Legibility owns the full fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U