### PR TITLE
Wire "Wrap in Chart…" — the silent no-op becomes the real affordance (B2)

### DIFF
--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -13,6 +13,7 @@ import { emitWorkspaceEvent } from '../telemetry';
 import ViewSwitcher from '../ViewSwitcher';
 import { useConfirm } from '../../../common/ConfirmDialog';
 import { ObjectStatus } from '../../../../stores/store';
+import { generateUniqueName } from '../../../../utils/uniqueName';
 
 // Row Delete -> the per-type store action. Every one has the same shape (API
 // call, refetch, checkCommitStatus) and returns `{ success, error }`, so the
@@ -116,6 +117,8 @@ const Library = () => {
   const createExploration = useStore(s => s.createExploration);
   const buildExplorationSeedState = useStore(s => s.buildExplorationSeedState);
   const addObjectToActiveExploration = useStore(s => s.addObjectToActiveExploration);
+  const saveChart = useStore(s => s.saveChart);
+  const charts = useStore(s => s.charts);
   // VIS-1067: "Add to exploration" is only offered while an exploration tab
   // is the ACTIVE one — that's the exploration whose live legacy working
   // state `addObjectToActiveExploration` actually mutates.
@@ -337,10 +340,22 @@ const Library = () => {
         name: obj.name,
         action,
       });
-      // VIS-811 / O-2: the open actions are live; `wrapInChart`/`delete` stay
-      // telemetry-only until their tracks wire them. VIS-1067 wires
-      // `exploreThis`/`addToExploration`; `showLineage` is wired below.
       const type = routeType(obj);
+      if (action === 'wrapInChart' && saveChart) {
+        // B2: the advertised affordance existed and was a silent no-op. A
+        // wrap creates a chart whose only content is this insight — the
+        // hyphenated cascade name (#615) with -2 disambiguation (#620).
+        const existingChartNames = (charts || []).map(chart => chart.name);
+        const chartName = generateUniqueName(`${obj.name}-chart`, existingChartNames, {
+          separator: '-',
+        });
+        saveChart(chartName, { insights: [`ref(${obj.name})`] }).then(result => {
+          if (result?.success && openWorkspaceTab) {
+            openWorkspaceTab({ id: `chart:${chartName}`, type: 'chart', name: chartName });
+          }
+        });
+        return;
+      }
       if (action === 'edit' && openWorkspaceTab) {
         openWorkspaceTab({ id: `${type}:${obj.name}`, type, name: obj.name });
       } else if (action === 'openInNewTab' && openWorkspaceTabBackground) {
@@ -387,6 +402,8 @@ const Library = () => {
       createExploration,
       buildExplorationSeedState,
       addObjectToActiveExploration,
+      saveChart,
+      charts,
       handleDelete,
       handleRestore,
     ]

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -278,6 +278,64 @@ describe('Library', () => {
     );
   });
 
+  test('Wrap in Chart creates a chart wrapping the insight and opens its tab (B2)', async () => {
+    // The menu item existed and was a silent telemetry-only no-op — the
+    // advertised affordance for the headline insight→dashboard path.
+    const openWorkspaceTab = jest.fn();
+    const saveChart = jest.fn().mockResolvedValue({ success: true });
+    seedStore({ openWorkspaceTab, saveChart });
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+    fireEvent.click(screen.getByText('Wrap in Chart…'));
+    expect(saveChart).toHaveBeenCalledWith('revenue_growth-chart', {
+      insights: ['ref(revenue_growth)'],
+    });
+    await waitFor(() =>
+      expect(openWorkspaceTab).toHaveBeenCalledWith({
+        id: 'chart:revenue_growth-chart',
+        type: 'chart',
+        name: 'revenue_growth-chart',
+      })
+    );
+  });
+
+  test('Wrap in Chart disambiguates against an existing chart name with -2', () => {
+    const saveChart = jest.fn().mockResolvedValue({ success: true });
+    seedStore({
+      saveChart,
+      charts: [{ name: 'revenue_growth-chart' }],
+    });
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+    fireEvent.click(screen.getByText('Wrap in Chart…'));
+    expect(saveChart).toHaveBeenCalledWith('revenue_growth-chart-2', {
+      insights: ['ref(revenue_growth)'],
+    });
+  });
+
+  test('a failed wrap save opens no tab', async () => {
+    const openWorkspaceTab = jest.fn();
+    const saveChart = jest.fn().mockResolvedValue({ success: false, error: 'boom' });
+    seedStore({ openWorkspaceTab, saveChart });
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+    fireEvent.click(screen.getByText('Wrap in Chart…'));
+    await waitFor(() => expect(saveChart).toHaveBeenCalled());
+    expect(openWorkspaceTab).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'chart' })
+    );
+  });
+
+  test('the Wrap in Chart item advertises no unbound keyboard accelerator', () => {
+    seedStore();
+    renderLibrary();
+    fireEvent.contextMenu(screen.getByTestId('library-row-insight-revenue_growth'));
+    // No ⌘⇧W hint anywhere in the open menu — the accelerator was never
+    // bound, so advertising it fails a user who tries it.
+    expect(screen.getByText('Wrap in Chart…')).toBeInTheDocument();
+    expect(screen.queryByText(/⌘/)).not.toBeInTheDocument();
+  });
+
   test('a source row reaches the same context actions as any other row', () => {
     // `onContextAction` was already being passed to the source row by
     // LibrarySubsection — the old component just never accepted it, so the

--- a/viewer/src/components/views/workspace/library/LibraryRow.jsx
+++ b/viewer/src/components/views/workspace/library/LibraryRow.jsx
@@ -205,7 +205,6 @@ const ContextMenu = ({ obj, onAction, onDismiss, canAddToExploration = false }) 
             <ContextMenuItem
               icon={getTypeDef('chart').icon}
               label="Wrap in Chart…"
-              hint="⌘⇧W"
               onClick={handle('wrapInChart')}
             />
           </li>


### PR DESCRIPTION
## What

Field-test finding **B2** (one of three remaining sub-issues after #621): the insight kebab's "Wrap in Chart… ⌘⇧W" fired a telemetry event and returned — `Library.handleContextAction` had no `wrapInChart` branch, and the accelerator was never bound anywhere. The affordance for the headline insight→dashboard path *existed and was broken*, which reads worse than missing.

- `wrapInChart` now creates `{ insights: ['ref(<insight>)'] }` named `<insight>-chart` (hyphenated cascade per #615, `-2` disambiguation per #620, via the shared `generateUniqueName`), saves through the real `saveChart` store action (so refetch/commit-status fire), and opens the new chart's tab.
- The fictional `⌘⇧W` hint is **removed** rather than bound (dossier W2 allows either; an unbound advertised accelerator fails acceptance) — binding it properly needs selection-context design that belongs with the workspace keyboard-shortcut work.

Remaining B2 sub-issues (separate PRs, gated on the **Item.insight decision**): insights as a canvas drop type, click-to-pick on empty slots, and the zero-dashboards promote offer.

## Test Strategy
- 4 new Library integration tests (real context menu → real click): wrap creates + opens tab; `-2` collision; failed save opens no tab; no unbound accelerator advertised.
- Falsification: 2/4 fail with the Library change stashed.
- Full viewer suite: 6890 passed · lint clean.

Findings: B2 (Dashboard Building v1 / Dashboard Authoring dossier W2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U