### PR TITLE
Fix visivo dist: the bundle carried no dashboards list (+ browser smoke test in CI)

### DIFF
--- a/.rwx/test_visivo.yml
+++ b/.rwx/test_visivo.yml
@@ -198,6 +198,70 @@ tasks:
       DEBUG: true
     filter: [test-projects/integration]
 
+  - key: test-dist-command
+    # `visivo dist` exits 0 even when the bundle it wrote cannot render — the
+    # command writes files and never loads them. That gap shipped a real
+    # regression: `/api/project/` stopped carrying the dereferenced project,
+    # resource lists moved to their own endpoints, and dist was never given an
+    # equivalent for the dashboards list, so every static build rendered
+    # "No dashboards found" while the command reported success.
+    #
+    # So this builds a bundle and actually LOADS a dashboard in a browser,
+    # asserting charts render with no failed `/data/*` request and no console
+    # errors. Unit tests cover the file shapes; only this covers "does it work".
+    use: [visivo-install, node-modules]
+    background-processes:
+      - key: dist-server
+        # Build THEN serve in the same process: the bundle doesn't exist until
+        # `visivo dist` runs, so a server started alongside the task would have
+        # nothing to answer with and its ready-check would never pass.
+        #
+        # `serve_dist.py` reproduces the `_redirects` SPA rule dist writes, so
+        # `/<dashboard>` resolves the way it does on a real static host rather
+        # than 404ing.
+        run: |
+          # Build the viewer from THIS commit's source. The committed
+          # `visivo/viewers/dist` bundle is only refreshed at release time, so
+          # on any non-release commit it lags the viewer source — testing it
+          # would assert against the last release, not the change under review.
+          set -e
+          cd viewer && yarn deploy:dist && cd ..
+          # `visivo` is pip-installed, so `DIST_PATH` resolves inside
+          # site-packages and the fresh build has to land THERE — `yarn
+          # deploy:dist` only writes the repo checkout, which the installed CLI
+          # never reads.
+          #
+          # Resolve that path from /tmp, not from here: the workspace root
+          # contains a `visivo/` package directory, and python puts cwd first on
+          # sys.path, so importing from here yields the CHECKOUT's DIST_PATH.
+          # Copying there leaves site-packages stale and `visivo dist` ships the
+          # last release's viewer — which is exactly how the first run of this
+          # task failed, with the browser throwing the pre-fix
+          # "'dashboardsList' is not available in 'dist' environment".
+          VIEWER_BUILD="$PWD/viewer/build"
+          DIST_PATH=$(cd /tmp && python -c "from visivo.utils import DIST_PATH; print(DIST_PATH)")
+          echo "Installing freshly-built viewer into $DIST_PATH"
+          rm -rf "$DIST_PATH"
+          cp -R "$VIEWER_BUILD" "$DIST_PATH"
+          # Fail loudly here rather than as a confusing browser error later.
+          diff -q "$VIEWER_BUILD/index.html" "$DIST_PATH/index.html"
+          cd test-projects/integration
+          visivo run -s local-duckdb
+          visivo dist -s local-duckdb
+          cd ../..
+          python scripts/serve_dist.py test-projects/integration/dist 8899
+        # Asserts the dashboards LIST is present and served — the exact
+        # artifact whose absence caused the regression — before the browser
+        # check starts, so a missing one fails here with a clear cause.
+        ready-check: curl -fsS http://localhost:8899/data/dashboards.json >/dev/null
+    run: |
+      cd viewer
+      yarn playwright install --with-deps chromium
+      node scripts/dist-smoke.mjs http://localhost:8899 simple-dashboard
+    env:
+      STACKTRACE: true
+    filter: [visivo, viewer, test-projects/integration, scripts]
+
   - key: binary-init-smoke
     # Runs the PyInstaller bundle (dist/visivo/visivo) end-to-end against
     # `visivo init` in an empty directory — the exact path that crashed

--- a/scripts/serve_dist.py
+++ b/scripts/serve_dist.py
@@ -1,0 +1,50 @@
+"""Serve a `visivo dist` bundle the way a static host would.
+
+`visivo dist` writes a `_redirects` file (`/*  /index.html  200`) because the
+viewer is a client-routed SPA: a dashboard lives at `/<dashboard-name>`, which
+is not a file on disk. Netlify/S3/Cloudflare honour that rule; a plain static
+server does not, so deep links 404 and the bundle looks broken for reasons that
+have nothing to do with the build.
+
+This reproduces that one rule locally and in CI, so a smoke test exercises the
+same routes a real deployment serves.
+
+Usage:
+    python scripts/serve_dist.py <dist_dir> [port]
+"""
+
+import os
+import sys
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+
+class SPARequestHandler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        path = self.translate_path(self.path.split("?")[0])
+        # Fall back to index.html only for route-shaped requests. A missing
+        # *file* (`/data/dashboards.json`, `/assets/index.js`) must still 404 —
+        # answering 200-with-HTML would turn a missing artifact into a JSON
+        # parse error and hide the very regression this exists to catch.
+        if not os.path.exists(path) and "." not in os.path.basename(path):
+            self.path = "/index.html"
+        return SimpleHTTPRequestHandler.do_GET(self)
+
+    def log_message(self, *args):
+        pass
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        raise SystemExit(2)
+    dist_dir = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8899
+    if not os.path.isdir(dist_dir):
+        raise SystemExit(f"No dist directory at '{dist_dir}'. Run `visivo dist` first.")
+    os.chdir(dist_dir)
+    print(f"Serving {dist_dir} on http://localhost:{port} (SPA fallback enabled)")
+    ThreadingHTTPServer(("127.0.0.1", port), SPARequestHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -91,6 +91,68 @@ def test_dist_creates_dist_folder(setup_project, output_dir, dist_dir):
         assert "source_count" in data
 
 
+def test_dist_writes_a_dashboards_list_with_layout(setup_project, output_dir, dist_dir):
+    """The bundle must carry the dashboards LIST, with each config's layout.
+
+    `/api/project/` stopped shipping the dereferenced project — resource lists
+    moved to their own endpoints — and dist was never given an equivalent. The
+    viewer's `dashboardsList` fetch had nothing to resolve to in dist mode, so
+    every static build rendered "No dashboards found". The per-dashboard files
+    existed but carried only id/name/thumbnail: a name with no layout.
+    """
+    project, working_dir = setup_project
+
+    from visivo.commands.run import run
+
+    assert runner.invoke(run, ["-w", working_dir, "-o", output_dir, "-s", "source"]).exit_code == 0
+    result = runner.invoke(
+        dist,
+        ["-w", working_dir, "-s", "source", "--output-dir", output_dir, "--dist-dir", dist_dir],
+    )
+    assert result.exit_code == 0
+
+    list_path = os.path.join(dist_dir, "data", "dashboards.json")
+    assert os.path.exists(list_path), "dist wrote no dashboards list"
+
+    with open(list_path) as f:
+        payload = json.load(f)
+
+    # Same envelope the server's `/api/dashboards/` returns, so the viewer
+    # reads one shape in both modes.
+    assert "dashboards" in payload
+    names = [d["name"] for d in payload["dashboards"]]
+    assert names == [project.dashboards[0].name]
+
+    entry = payload["dashboards"][0]
+    assert set(["id", "name", "status", "config"]).issubset(entry.keys())
+    assert entry["status"] == "published"
+    # The load-bearing part: rows/items, not just a name.
+    assert entry["config"]["rows"], "dashboard config carries no rows"
+    assert entry["config"]["rows"][0]["items"], "dashboard row carries no items"
+
+    # The per-dashboard detail file stays in sync with its list entry.
+    detail_path = os.path.join(dist_dir, "data", "dashboards", f"{entry['name']}.json")
+    with open(detail_path) as f:
+        assert json.load(f)["config"] == entry["config"]
+
+
+def test_dist_project_created_at_is_a_string(setup_project, output_dir, dist_dir):
+    """A stray trailing comma made `created_at` a 1-tuple, so it serialized as
+    `["<iso>"]` — an array where every consumer expects a timestamp."""
+    project, working_dir = setup_project
+
+    from visivo.commands.run import run
+
+    assert runner.invoke(run, ["-w", working_dir, "-o", output_dir, "-s", "source"]).exit_code == 0
+    runner.invoke(
+        dist,
+        ["-w", working_dir, "-s", "source", "--output-dir", output_dir, "--dist-dir", dist_dir],
+    )
+
+    with open(os.path.join(dist_dir, "data", "project.json")) as f:
+        assert isinstance(json.load(f)["created_at"], str)
+
+
 def test_dist_errors_without_data(setup_project, output_dir, dist_dir):
     project, working_dir = setup_project
 

--- a/viewer/scripts/dist-smoke.mjs
+++ b/viewer/scripts/dist-smoke.mjs
@@ -1,0 +1,96 @@
+/**
+ * Smoke-test a served `visivo dist` bundle by actually loading a dashboard.
+ *
+ * `visivo dist` exits 0 even when the bundle it produced cannot render: the
+ * command's job is to write files, and it has no idea whether the viewer can
+ * read them. That gap let a real regression ship — `/api/project/` stopped
+ * carrying the dereferenced project, resource lists moved to their own
+ * endpoints, and dist was never given an equivalent for the dashboards list.
+ * Every static build rendered "No dashboards found" while `visivo dist`
+ * reported success.
+ *
+ * So this asserts on the rendered page, not on the files:
+ *   - the dashboard route renders charts (not a loading or empty state)
+ *   - no request for a `/data/*` artifact 404s
+ *   - no console errors, including the URL-config throw that caused the above
+ *
+ * Usage: node scripts/dist-smoke.mjs <base-url> <dashboard-name>
+ */
+import { chromium } from 'playwright';
+
+const [baseUrl, dashboardName] = process.argv.slice(2);
+if (!baseUrl || !dashboardName) {
+  console.error('Usage: node scripts/dist-smoke.mjs <base-url> <dashboard-name>');
+  process.exit(2);
+}
+
+const IGNORED = [
+  // A static bundle has no server to talk to; the viewer's socket client
+  // retries and gives up. Not a bundle defect.
+  'socket.io',
+];
+const ignorable = url => IGNORED.some(part => url.includes(part));
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const consoleErrors = [];
+const badResponses = [];
+
+page.on('console', m => {
+  if (m.type() === 'error' && !ignorable(m.text())) consoleErrors.push(m.text());
+});
+page.on('pageerror', e => consoleErrors.push(`Uncaught: ${e.message}`));
+page.on('response', r => {
+  if (r.status() >= 400 && !ignorable(r.url())) badResponses.push(`${r.status()} ${r.url()}`);
+});
+page.on('requestfailed', r => {
+  if (!ignorable(r.url())) badResponses.push(`FAILED ${r.url()}`);
+});
+
+const failures = [];
+try {
+  const url = `${baseUrl.replace(/\/$/, '')}/${dashboardName}`;
+  console.log(`Loading ${url}`);
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+
+  // Charts mount asynchronously (parquet fetch + DuckDB), so wait for the
+  // first one rather than sampling a fixed instant.
+  await page
+    .locator('.js-plotly-plot')
+    .first()
+    .waitFor({ state: 'attached', timeout: 45000 })
+    .catch(() => {});
+
+  const chartCount = await page.locator('.js-plotly-plot').count();
+  const bodyText = (await page.locator('body').innerText()).trim();
+
+  console.log(`Charts rendered: ${chartCount}`);
+
+  if (chartCount === 0) failures.push('No charts rendered on the dashboard route.');
+  // The exact strings the two known failure modes produce.
+  if (/No dashboards found/i.test(bodyText)) {
+    failures.push('Page shows "No dashboards found" — the bundle carries no dashboards list.');
+  }
+  if (/Loading dashboard/i.test(bodyText)) {
+    failures.push('Page stuck on "Loading dashboard..." — the dashboard never resolved.');
+  }
+  if (badResponses.length) {
+    failures.push(`Failed requests:\n    ${[...new Set(badResponses)].join('\n    ')}`);
+  }
+  if (consoleErrors.length) {
+    failures.push(`Console errors:\n    ${[...new Set(consoleErrors)].join('\n    ')}`);
+  }
+
+  if (failures.length) {
+    console.error(`\nDist smoke FAILED (${failures.length}):`);
+    failures.forEach(f => console.error(`  - ${f}`));
+    console.error(`\nPage text (first 300 chars):\n${bodyText.slice(0, 300)}`);
+  } else {
+    console.log('Dist smoke PASSED — dashboard rendered with no failed requests or errors.');
+  }
+} finally {
+  await browser.close();
+}
+
+process.exit(failures.length ? 1 : 0);

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -181,6 +181,7 @@ const URL_PATTERNS = {
     error: '/data/error.json',
     insightJobsQuery: '/data/insights.json',
     inputJobsQuery: '/data/inputs.json',
+    dashboardsList: '/data/dashboards.json',
     dashboardQuery: '/data/dashboards/{name}.json',
     dashboardThumbnail: '/data/dashboards/{name}.png',
 

--- a/viewer/src/config/urls.test.js
+++ b/viewer/src/config/urls.test.js
@@ -60,6 +60,15 @@ describe('URLConfig.getUrl — dist environment', () => {
     );
   });
 
+  // `/api/project/` stopped carrying the dereferenced project ("resource lists
+  // come from their own endpoints"), but dist was never given an equivalent for
+  // the dashboards LIST — so `dashboardStore` threw "not available in 'dist'"
+  // and every static build rendered "No dashboards found".
+  test('serves the dashboards LIST, not just per-dashboard detail', () => {
+    expect(config.isAvailable('dashboardsList')).toBe(true);
+    expect(config.getUrl('dashboardsList')).toBe('/data/dashboards.json');
+  });
+
   test('throws for endpoints that are null in dist', () => {
     expect(() => config.getUrl('commit')).toThrow(
       "URL key 'commit' is not available in 'dist' environment"

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -57,7 +57,7 @@ def dist_phase(
         if os.path.exists(dashboards_dir):
             dist_dashboards_dir = os.path.join(dist_dir, "data", "dashboards")
             shutil.copytree(dashboards_dir, dist_dashboards_dir, dirs_exist_ok=True)
-        created_at = (datetime.datetime.now().isoformat(),)
+        created_at = datetime.datetime.now().isoformat()
         # Same canonical envelope the server serves at /api/project/, so the
         # viewer reads one shape in both modes. ``project_json`` below stays a
         # local variable — it drives the per-dashboard files written further
@@ -190,7 +190,14 @@ def dist_phase(
 
         # Generate dashboard JSON files for dist mode (keyed by clean name —
         # thumbnails on disk are also named <dashboard_name>.png after the
-        # storage refactor)
+        # storage refactor).
+        #
+        # Each entry mirrors the server's `/api/dashboards/` element shape
+        # (`object_manager._serialize_object`): id / name / status / config,
+        # plus the `signed_thumbnail_file_url` sibling the cards page reads.
+        # `config` is the load-bearing key — it carries rows/items, and without
+        # it the viewer has a dashboard's NAME but no layout to render.
+        dashboards_list = []
         if "dashboards" in project_json:
             os.makedirs(f"{dist_dir}/data/dashboards", exist_ok=True)
             for dashboard in project_json["dashboards"]:
@@ -203,6 +210,10 @@ def dist_phase(
                 dashboard_data = {
                     "id": dashboard_name,
                     "name": dashboard_name,
+                    # A dist bundle is a snapshot of committed state — nothing
+                    # in it is a draft, so every dashboard reads as published.
+                    "status": "published",
+                    "config": dashboard,
                     "signed_thumbnail_file_url": (
                         f"{deployment_root}/data/dashboards/{dashboard_name}.png"
                         if thumbnail_exists
@@ -212,6 +223,16 @@ def dist_phase(
 
                 with open(f"{dist_dir}/data/dashboards/{dashboard_name}.json", "w") as f:
                     json.dump(dashboard_data, f)
+                dashboards_list.append(dashboard_data)
+
+        # The LIST endpoint. `/api/project/` stopped carrying the whole
+        # dereferenced project ("Resource lists come from their own
+        # endpoints" — data_views.py), and dist was never given an equivalent:
+        # the viewer's dashboardStore called `dashboardsList`, which resolved
+        # to null in the dist environment, so every static build rendered
+        # "No dashboards found" no matter what the project contained.
+        with open(f"{dist_dir}/data/dashboards.json", "w") as f:
+            json.dump({"dashboards": dashboards_list}, f)
 
         shutil.copytree(DIST_PATH, dist_dir, dirs_exist_ok=True)
 


### PR DESCRIPTION
## The bug

A static build rendered **"No dashboards found"** for every project — while `visivo dist` exited 0 and printed "Created dist folder".

`/api/project/` stopped carrying the whole dereferenced project ("resource lists come from their own endpoints" — `data_views.py`), and `dist` was never given an equivalent. The viewer's `dashboardStore` calls `dashboardsList`, which is `null` in the dist environment, so it threw before rendering anything:

```
dashboardStore: fetch error
Error: URL key 'dashboardsList' is not available in 'dist' environment
```

The per-dashboard files existed, but held only `{id, name, signed_thumbnail_file_url}` — a name with **no layout to render**.

## The fix

- `dist_phase.py` writes `data/dashboards.json` in the same envelope `/api/dashboards/` returns (`id`/`name`/`status`/`config` + the thumbnail sibling), with `config` carrying rows/items. The per-dashboard detail files gain the same `config`.
- `urls.js` maps `dashboardsList` → `/data/dashboards.json`.
- `created_at` was a **1-tuple** from a stray trailing comma, so it serialized as `["<iso>"]` where every consumer expects a timestamp.

## Why it wasn't caught

`visivo dist` exits 0 whether or not the bundle it wrote can render — the command writes files and never loads them. The existing tests asserted the folder and `project.json` shape, both of which were fine.

## The regression test

CI now builds a bundle and **loads a dashboard in a browser**:

| Piece | Does |
|---|---|
| `scripts/serve_dist.py` | Serves a bundle with the SPA fallback `_redirects` asks for, so `/<dashboard>` resolves like it does on a real static host. Missing *files* still 404 — a missing artifact can't hide behind an HTML 200. |
| `viewer/scripts/dist-smoke.mjs` | Asserts charts render, no `/data/*` request fails, console is clean. Names both known failure modes so a failure reads as a cause. |
| `.rwx/test_visivo.yml` → `test-dist-command` | Runs the whole thing. Ready-check curls `data/dashboards.json`, so the missing-list case fails fast. |

**One thing worth reviewing:** the task rebuilds the viewer from the commit under test. The committed `visivo/viewers/dist` bundle is only refreshed at release time (the "Build viewer for Python package" commits), so it lags viewer source on every non-release commit — testing it would assert against the last release rather than the PR. Since `visivo` is pip-installed from a wheel in CI, the fresh build is also copied over `DIST_PATH` in site-packages.

I deliberately did **not** commit the rebuilt bundle, to keep this diff free of release artifacts.

Unit tests cover both layers: the list has rows/items and matches its detail file, `created_at` is a string, and `dashboardsList` resolves in dist.

## Verification

Locally, end-to-end against `test-projects/integration`:

```
Loading http://localhost:8899/simple-dashboard
Charts rendered: 7
Dist smoke PASSED — dashboard rendered with no failed requests or errors.
```

And with `dashboards.json` removed from the bundle, the guard fires with the original symptom:

```
Dist smoke FAILED (4):
  - No charts rendered on the dashboard route.
  - Page shows "No dashboards found" — the bundle carries no dashboards list.
  - Failed requests: 404 /data/dashboards.json?project_id=id
```

**2396 pytest, 6909 viewer tests, black + lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
