### PR TITLE
The scaffold's dashboard example parses (M8)

### DIFF
--- a/tests/commands/test_init_phase.py
+++ b/tests/commands/test_init_phase.py
@@ -29,10 +29,11 @@ def test_basic_init_writes_scaffolded_yaml():
 
     content = yml_path.read_text()
     # Comment markers (the user-facing copy) must be present.
-    assert "# A Source is where your data lives" in content
-    assert "# A Model is a SQL query saved against a Source." in content
-    assert "# An Insight is a chart configured against a Model." in content
-    assert "# A Dashboard arranges Insights into a layout." in content
+    assert "## A Source is where your data lives" in content
+    assert "## A Model is a SQL query saved against a Source." in content
+    assert "## An Insight is a chart configured against a Model." in content
+    assert "## A Chart wraps one or more Insights" in content
+    assert "## A Dashboard arranges Charts into rows of items." in content
     # name should match directory basename
     assert "name: my-scaffold-project" in content
 
@@ -124,3 +125,46 @@ def test_scaffold_template_constants_are_strings():
     assert isinstance(SCAFFOLD_TEMPLATE, str) and len(SCAFFOLD_TEMPLATE) > 0
     assert isinstance(GITIGNORE_CONTENT, str) and "target/" in GITIGNORE_CONTENT
     assert isinstance(ENV_EXAMPLE_CONTENT, str) and ENV_EXAMPLE_CONTENT.startswith("#")
+
+
+def _uncomment_examples(scaffold_text):
+    """Strip prose (##) lines and uncomment example (#) lines.
+
+    The template's own header documents the convention: `##` is guidance,
+    a single `#` marks a runnable example that must parse once uncommented.
+    """
+    lines = []
+    for line in scaffold_text.splitlines():
+        stripped = line.lstrip()
+        indent = line[: len(line) - len(stripped)]
+        if stripped.startswith("##"):
+            continue
+        if stripped.startswith("# "):
+            lines.append(indent + stripped[2:])
+        elif stripped == "#":
+            continue
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def test_scaffold_examples_parse_with_the_real_project_model():
+    """M8: four field testers copied the scaffold's dashboard example and were
+    rejected by the tool's own parser (`insight:` is not a dashboard item —
+    items take chart/table/markdown/input). Uncommenting every example must
+    yield a project the real Project model accepts."""
+    scaffold = SCAFFOLD_TEMPLATE.format(project_name="scaffold_test")
+    uncommented = _uncomment_examples(scaffold)
+    data = yaml.safe_load(uncommented)
+    project = Project(**data)
+    assert project.name == "scaffold_test"
+    assert [d.name for d in project.dashboards] == ["my_dashboard"]
+    assert [c.name for c in project.charts] == ["revenue_chart"]
+
+
+def test_scaffold_teaches_the_chart_wrapper_not_bare_insights_on_items():
+    """The decision of 27 Aug: dashboard items never take a bare insight —
+    the Chart wrapper is the composition boundary. The scaffold must teach
+    exactly that shape."""
+    assert "chart: ${ref(revenue_chart)}" in SCAFFOLD_TEMPLATE.format(project_name="x")
+    assert "insight: ${ref(" not in SCAFFOLD_TEMPLATE.format(project_name="x")

--- a/visivo/commands/init_phase.py
+++ b/visivo/commands/init_phase.py
@@ -46,20 +46,20 @@ def get_env_content_for_example_type(example_type: str) -> str:
 
 
 SCAFFOLD_TEMPLATE = """\
-# Visivo project file. Edit this directly or use `visivo serve` to author in the browser.
+## Visivo project file. Edit this directly or use `visivo serve` to author in the browser.
+## Prose guidance uses `##`; runnable examples use a single `#` — uncomment an
+## example (strip the leading `# `) and it parses as-is.
 name: {project_name}
 
 sources:
-  # A Source is where your data lives - a database or file.
-  # Uncomment and edit, or use the in-browser wizard.
-  #
+  ## A Source is where your data lives - a database or file.
+  ## Uncomment and edit, or use the in-browser wizard.
   # - name: my_db
   #   type: sqlite
   #   database: /path/to/file.db
 
 models:
-  # A Model is a SQL query saved against a Source.
-  #
+  ## A Model is a SQL query saved against a Source.
   # - name: monthly_revenue
   #   source: ${{ref(my_db)}}
   #   sql: |
@@ -69,23 +69,29 @@ models:
   #     GROUP BY 1
 
 insights:
-  # An Insight is a chart configured against a Model.
-  #
+  ## An Insight is a chart configured against a Model.
   # - name: revenue_by_month
   #   props:
   #     type: bar
   #     x: ?{{ ${{ref(monthly_revenue).month}} }}
   #     y: ?{{ ${{ref(monthly_revenue).revenue}} }}
 
+charts:
+  ## A Chart wraps one or more Insights so a dashboard can place them.
+  ## (A dashboard item takes a chart, table, markdown or input - never a
+  ## bare insight.)
+  # - name: revenue_chart
+  #   insights:
+  #     - ${{ref(revenue_by_month)}}
+
 dashboards:
-  # A Dashboard arranges Insights into a layout.
-  #
+  ## A Dashboard arranges Charts into rows of items.
   # - name: my_dashboard
   #   rows:
   #     - height: medium
   #       items:
   #         - width: 1
-  #           insight: ${{ref(revenue_by_month)}}
+  #           chart: ${{ref(revenue_chart)}}
 """
 
 GITIGNORE_CONTENT = """\


### PR DESCRIPTION
## What

Field-test finding **M8**: the `visivo init` scaffold's own dashboard example used `insight:` on a row item — **which the tool's own parser rejects** (`Item` is `extra="forbid"`, items take chart/table/markdown/input). Four of eight testers copied it; it's the first thing a newcomer reads.

Per the decision recorded 27 Aug (**insights stay wrapped in Charts; the Item schema is untouched**), the scaffold now teaches exactly that shape: a `charts:` section wrapping the example insight, and `chart: ${ref(revenue_chart)}` on the dashboard item, with a one-line explanation of *why* the wrapper exists.

Comment convention (from the Docs dossier): `##` = prose guidance, `#` = runnable example — so uncommenting is mechanical, and:

**`test_scaffold_examples_parse_with_the_real_project_model`** uncomments every example line and validates the result with the real `Project` model. This makes the M8 class of bug (valid-looking scaffold YAML the parser rejects) structurally unrepeatable — the test, not a reviewer, catches the next drift.

## Test Strategy
- 2 new tests (full uncomment→parse; wrapper-shape guard). Both **fail against the old template** (verified by stashing).
- Existing scaffold tests updated for the `##` convention · full suite 2430 passed · black clean.

Findings: M8 (Docs, Scaffold & Onboarding Truth — inside Acquisition & Activation Relaunch P4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U