### PR TITLE
Dropping an insight on the canvas auto-wraps it in a chart (B2)

### DIFF
--- a/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
@@ -38,6 +38,7 @@ import {
   buildLibraryItem,
 } from '../project/canvas/canvasReorder';
 import useStore from '../../../stores/store';
+import { generateUniqueName } from '../../../utils/uniqueName';
 
 const clone = value => JSON.parse(JSON.stringify(value));
 
@@ -262,6 +263,18 @@ describe('router → REAL commit integration (drag-end payloads commit to the wo
     moveLevel: jest.fn(),
     commitCanvasConfig,
     emit: jest.fn(),
+    // Mirrors the component's wrapInsight dep (auto-wrap on insight drop):
+    // fresh store reads, same naming + save path as Library "Wrap in Chart…".
+    wrapInsight: {
+      mintChartName: insightName => {
+        const existing = (useStore.getState().charts || []).map(c => c.name);
+        return generateUniqueName(`${insightName}-chart`, existing, { separator: '-' });
+      },
+      createChart: (chartName, insightName) => {
+        const save = useStore.getState().saveChart;
+        if (save) save(chartName, { insights: [`ref(${insightName})`] });
+      },
+    },
   });
 
   const RouterProbe = ({ event }) => {
@@ -329,6 +342,103 @@ describe('router → REAL commit integration (drag-end payloads commit to the wo
     expect(committed).toHaveBeenCalledTimes(1);
     const persisted = committed.mock.calls[0][1];
     expect(persisted.rows[1].items[2].chart).toBe('ref(indicator-chart)');
+  });
+
+  test('an insight drop AUTO-WRAPS: mints a chart, saves it, places chart: ref(...) (B2)', () => {
+    // Decision 27 Aug: items never take a bare insight — the drop mints a
+    // wrapper chart and places THAT. Same naming/save path as Library
+    // "Wrap in Chart…" (#632).
+    const config = clone(API_SHAPED_CONFIG);
+    const saveChart = jest.fn().mockResolvedValue({ success: true });
+    useStore.setState({ charts: [], saveChart });
+    const committed = driveRouter({
+      active: { data: { current: { source: 'library', type: 'insight', name: 'rev-insight' } } },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'end-of-row', rowPath: 'row.1' },
+          },
+        },
+      },
+    });
+    expect(committed).toHaveBeenCalledTimes(1);
+    const persisted = committed.mock.calls[0][1];
+    expect(persisted.rows[1].items[2].chart).toBe('ref(rev-insight-chart)');
+    expect(persisted.rows[1].items[2].insight).toBeUndefined();
+    expect(saveChart).toHaveBeenCalledWith('rev-insight-chart', {
+      insights: ['ref(rev-insight)'],
+    });
+  });
+
+  test('an insight drop disambiguates the wrapper name against existing charts', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveChart = jest.fn().mockResolvedValue({ success: true });
+    useStore.setState({ charts: [{ name: 'rev-insight-chart' }], saveChart });
+    const committed = driveRouter({
+      active: { data: { current: { source: 'library', type: 'insight', name: 'rev-insight' } } },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'end-of-row', rowPath: 'row.1' },
+          },
+        },
+      },
+    });
+    const persisted = committed.mock.calls[0][1];
+    expect(persisted.rows[1].items[2].chart).toBe('ref(rev-insight-chart-2)');
+    expect(saveChart).toHaveBeenCalledWith('rev-insight-chart-2', {
+      insights: ['ref(rev-insight)'],
+    });
+  });
+
+  test('a rejected insight drop mints NO chart (no orphan drafts)', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveChart = jest.fn();
+    useStore.setState({ charts: [], saveChart });
+    const committed = driveRouter({
+      active: { data: { current: { source: 'library', type: 'insight', name: 'rev-insight' } } },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            // A malformed target path → insertItemAtTarget returns the SAME
+            // config reference, which the router treats as a rejected drop.
+            target: { kind: 'on-item', rowPath: 'not-a-row-path' },
+          },
+        },
+      },
+    });
+    expect(committed).not.toHaveBeenCalled();
+    expect(saveChart).not.toHaveBeenCalled();
+  });
+
+  test('non-insight exploration drag types (metric) still never insert on the canvas', () => {
+    const config = clone(API_SHAPED_CONFIG);
+    const saveChart = jest.fn();
+    useStore.setState({ charts: [], saveChart });
+    const committed = driveRouter({
+      active: { data: { current: { source: 'library', type: 'metric', name: 'churn_rate' } } },
+      over: {
+        data: {
+          current: {
+            kind: 'canvas-drop',
+            dashboardName: 'simple-dashboard',
+            config,
+            target: { kind: 'end-of-row', rowPath: 'row.1' },
+          },
+        },
+      },
+    });
+    expect(committed).not.toHaveBeenCalled();
+    expect(saveChart).not.toHaveBeenCalled();
   });
 
   test('a real drag-end cross-row item move routes through and commits', () => {

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -17,6 +17,7 @@ import { DROPPABLE_TYPES } from './library/LibraryRow';
 import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
 import { emitWorkspaceEvent } from './telemetry';
 import { formatRefExpression } from '../../../utils/refString';
+import { generateUniqueName } from '../../../utils/uniqueName';
 import {
   reorderItemsInRow,
   moveItemBetweenRows,
@@ -206,6 +207,7 @@ export const routeWorkspaceDragEnd = (
     commitCanvasConfig,
     emit,
     exploration,
+    wrapInsight,
   }
 ) => {
   const { active, over } = event || {};
@@ -498,7 +500,37 @@ export const routeWorkspaceDragEnd = (
       // targets below) would let a dashboard-canvas drop build a bogus item
       // like `{ metric: '${ref(churn_rate)}' }` — a shape the canvas schema
       // has no rendering for.
-      if (!DROPPABLE_TYPES.includes(dragData.type)) return 'noop';
+      if (!DROPPABLE_TYPES.includes(dragData.type)) {
+        // Insights are placeable via AUTO-WRAP (decision 27 Aug: items never
+        // take a bare insight — the Chart wrapper is the composition
+        // boundary, and the schema stays untouched). Dropping an insight
+        // mints a wrapper chart named `<insight>-chart` and places THAT.
+        // Ordering matters: validate the placement first, and only mint the
+        // chart once the item actually landed — a rejected drop must not
+        // leave an orphan draft chart behind. If the async chart save fails,
+        // the placed ref renders as a BrokenRefCard with its Fix… flow — a
+        // visible, recoverable state rather than a silent drop (B2).
+        if (dragData.type === 'insight' && wrapInsight) {
+          const chartName = wrapInsight.mintChartName(dragData.name);
+          if (!chartName) return 'noop';
+          const wrappedItem = buildLibraryItem('chart', chartName);
+          const next = insertItemAtTarget(config, target, wrappedItem);
+          if (next === config) return 'noop';
+          wrapInsight.createChart(chartName, dragData.name);
+          commitCanvasConfig(dashboardName, next, { kind: 'library_insert' });
+          emit &&
+            emit('canvas_action', {
+              kind: 'add_item',
+              source: 'library',
+              type: 'insight',
+              name: dragData.name,
+              wrapped_chart: chartName,
+              target: target.kind,
+            });
+          return 'canvas_library_insert';
+        }
+        return 'noop';
+      }
       const newItem = buildLibraryItem(dragData.type, dragData.name);
       const next = insertItemAtTarget(config, target, newItem);
       if (next === config) return 'noop';
@@ -897,6 +929,22 @@ const WorkspaceDndContext = ({ children }) => {
         moveLevel,
         commitCanvasConfig,
         emit: emitWorkspaceEvent,
+        // AUTO-WRAP (27 Aug decision): dropping an insight on the canvas mints
+        // a wrapper chart — same naming + save path as the Library's
+        // "Wrap in Chart…" (#632). Store reads are deliberately getState()
+        // (fresh at drop time), keeping the handler's dep list unchanged.
+        wrapInsight: {
+          mintChartName: insightName => {
+            const existingCharts = (useStore.getState().charts || []).map(chart => chart.name);
+            return generateUniqueName(`${insightName}-chart`, existingCharts, {
+              separator: '-',
+            });
+          },
+          createChart: (chartName, insightName) => {
+            const save = useStore.getState().saveChart;
+            if (save) save(chartName, { insights: [`ref(${insightName})`] });
+          },
+        },
         exploration: {
           activeModelName: explorerActiveModelName,
           updateInsightInteraction,


### PR DESCRIPTION
## What

The second of B2's three remaining sub-issues: insights were **draggable** (the exploration surface needs them) but `routeWorkspaceDragEnd`'s canvas branch rejected them with a silent `'noop'` — dragging an insight onto a dashboard did nothing, no toast, no feedback.

Per the decision recorded 27 Aug (**items never take a bare insight; the Chart wrapper is the composition boundary; Item schema untouched**), the drop now **auto-wraps**:

- Mints `<insight>-chart` via the shared `generateUniqueName` (hyphen cascade, `-2` disambiguation), saves `{ insights: ['ref(<insight>)'] }` through the real `saveChart` store action — byte-identical naming/save path to Library's "Wrap in Chart…" (#632) — and places `chart: ref(<name>)` at the drop target.
- **Ordering guarantee:** placement is validated first; the chart is only minted once the item actually lands, so a rejected drop leaves no orphan draft chart. A failed async save renders the placed ref as `BrokenRefCard` with its existing Fix… flow — visible and recoverable, never silent.
- Metric/dimension/source drags still never insert on the canvas (guarded + tested).

Telemetry: `canvas_action{kind: add_item, type: insight, wrapped_chart}` so wrap-adoption is measurable.

## Test Strategy
- 4 new router→commit integration tests: wrap+place+save; `-2` collision; rejected drop mints nothing; metric still noops. **2/4 fail with the router change stashed.**
- Full viewer suite green · lint clean.

Remaining B2 sub-issue after this: click-to-pick on empty slots (ReferencePicker promotion, insights listed with the same auto-wrap) — next PR.

Findings: B2 (Dashboard Building v1; supersedes the dossier's Option A per the Item.insight decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U