### PR TITLE
Deploy keeps nesting: a model-scoped field is not its own record (VIS-1259)

### DIFF
--- a/tests/parsers/test_serializer.py
+++ b/tests/parsers/test_serializer.py
@@ -182,8 +182,13 @@ def test_collect_deploy_resources_emits_all_deploy_types():
 
     assert {s["name"] for s in layer["sources"]} >= {"source"}
     assert {m["name"] for m in layer["models"]} >= {"m1", "m2"}
-    assert {d["name"] for d in layer["dimensions"]} >= {"d1"}
-    assert {m["name"] for m in layer["metrics"]} >= {"mt1"}
+    # VIS-1259: d1/mt1 are authored INSIDE m1, so they are not standalone
+    # records — they travel in the model's own dump.
+    assert layer["dimensions"] == []
+    assert layer["metrics"] == []
+    m1 = next(m for m in layer["models"] if m["name"] == "m1")
+    assert {d["name"] for d in m1["dimensions"]} == {"d1"}
+    assert {m["name"] for m in m1["metrics"]} == {"mt1"}
     assert {r["name"] for r in layer["relations"]} == {"r1"}
 
     # The SqlModel subtype bucket must not leak csv-script / local-merge models.
@@ -204,8 +209,9 @@ def test_collect_deploy_resources_finds_objects_nested_in_other_objects():
       * ``top_source``        — declared top-level
       * ``nested_source``     — inlined inside a model (``model.source``)
       * ``nested_dim`` /
-        ``nested_metric``     — defined inside a model (``model.dimensions`` /
-                                 ``model.metrics``)
+        ``nested_metric``     — defined inside a model; these must NOT be
+                                 collected standalone (VIS-1259), they ride
+                                 inside the model's own dump
       * ``nested_chart``      — inlined inside a dashboard item
       * ``nested_insight``    — inlined inside that chart
 
@@ -240,7 +246,48 @@ def test_collect_deploy_resources_finds_objects_nested_in_other_objects():
     # Top-level and nested objects are both collected.
     assert {s["name"] for s in layer["sources"]} == {"top_source", "nested_source"}
     assert {m["name"] for m in layer["models"]} == {"top_model"}
-    assert {d["name"] for d in layer["dimensions"]} == {"nested_dim"}
-    assert {m["name"] for m in layer["metrics"]} == {"nested_metric"}
+    # VIS-1259: a model-scoped field is NOT its own deploy record. Emitting it
+    # here was lossy — `_parent_name` is a PrivateAttr, so the dump carried no
+    # owner and the cloud could not tell it from a project-level field — and it
+    # shipped the same field twice, once standalone and once inside its model.
+    assert layer["dimensions"] == []
+    assert layer["metrics"] == []
+    # It travels with its model instead, which is what records the nesting.
+    (deployed_model,) = layer["models"]
+    assert {d["name"] for d in deployed_model["dimensions"]} == {"nested_dim"}
+    assert {m["name"] for m in deployed_model["metrics"]} == {"nested_metric"}
     assert {c["name"] for c in layer["charts"]} == {"nested_chart"}
     assert {i["name"] for i in layer["insights"]} == {"nested_insight"}
+
+
+def test_collect_deploy_resources_still_emits_project_level_fields():
+    """The other half of VIS-1259: a PROJECT-LEVEL metric/dimension is its own
+    object and must still deploy as its own record.
+
+    Nesting is the only thing that distinguishes the two — neither type has a
+    `model` or `parentModel` field, and both forbid extras — so the filter has
+    to key off `_parent_name`, not off the type."""
+    model = SqlModelFactory(
+        name="scoped_model",
+        dimensions=[DimensionFactory(name="nested_dim")],
+    )
+    # A project-level field must tie back to a source through a model
+    # (single_source_validator), so these reference the model explicitly.
+    project = ProjectFactory(
+        models=[model],
+        dimensions=[DimensionFactory(name="global_dim", expression="${ref(scoped_model).x}")],
+        metrics=[MetricFactory(name="global_metric", expression="sum(${ref(scoped_model).x})")],
+        insights=[],
+        charts=[],
+        dashboards=[],
+    )
+    project.invalidate_dag_cache()
+
+    layer = Serializer(project=project).collect_deploy_resources()
+
+    assert {d["name"] for d in layer["dimensions"]} == {"global_dim"}
+    assert {m["name"] for m in layer["metrics"]} == {"global_metric"}
+    # ...and the nested one is still absent from the flat list, present in the model.
+    assert "nested_dim" not in {d["name"] for d in layer["dimensions"]}
+    (deployed_model,) = layer["models"]
+    assert {d["name"] for d in deployed_model["dimensions"]} == {"nested_dim"}

--- a/visivo/parsers/serializer.py
+++ b/visivo/parsers/serializer.py
@@ -165,18 +165,31 @@ class Serializer:
         managers serve in ``visivo serve`` for the local editor (they read this
         same DAG).
 
-        Dimensions and metrics are
-        surfaced even when authored inside a model, since they are their own
-        named nodes in the DAG. Charts/insights/tables/markdowns/inputs are
+        Dimensions and metrics are emitted ONLY when project-level. A
+        model-scoped one stays inside its model's config, which is the only
+        thing that records the nesting — neither type has a `model` or
+        `parentModel` field, and both forbid extras. They remain their own DAG
+        nodes (validators and bare-`${ref()}` resolution depend on that); this
+        is about the wire, not the graph. Charts/insights/tables/markdowns/inputs are
         emitted in source (ref) form — distinct from the baked, inlined copies
         carried on the dashboards for rendering.
         """
         dag = self._get_dag()
 
-        def collect(node_type):
+        def collect(node_type, standalone_only=False):
             collected = []
             seen = set()
             for node in all_descendants_of_type(type=node_type, dag=dag):
+                # VIS-1259: a metric/dimension authored INSIDE a model is not
+                # its own object — it belongs to the model and rides along in
+                # the model's own dump. Emitting it here as a separate record
+                # was lossy: `_parent_name` is a PrivateAttr, so `model_dump()`
+                # produced `{name, expression}` with NO owner at all, and the
+                # cloud could not tell a nested field from a project-level one.
+                # Worse, it shipped the same field twice — once standalone,
+                # once inside its model.
+                if standalone_only and getattr(node, "_parent_name", None):
+                    continue
                 name = getattr(node, "name", None)
                 if name and name not in seen:
                     seen.add(name)
@@ -186,8 +199,8 @@ class Serializer:
         return {
             "sources": collect(Source),
             "models": collect(SqlModel),
-            "dimensions": collect(Dimension),
-            "metrics": collect(Metric),
+            "dimensions": collect(Dimension, standalone_only=True),
+            "metrics": collect(Metric, standalone_only=True),
             "relations": collect(Relation),
             "charts": collect(Chart),
             "insights": collect(Insight),


### PR DESCRIPTION
First code change for **VIS-1259**. Pairs with **core#381** — merge that one first (see below).

## The bug

`collect_deploy_resources` walked the DAG and emitted **every** `Dimension` and `Metric` as its own top-level deploy record — including ones authored *inside* a model. That was lossy in a way nothing downstream could recover from: `_parent_name` is a `PrivateAttr`, so `model_dump()` produced `{name, expression}` with **no owner at all**. The cloud received a nested field and a project-level field looking identical.

It also shipped the same field **twice** — once standalone, once inside its model's own dump — so the two could disagree after any edit.

Nesting is the *only* thing that records the distinction: neither `Metric` nor `Dimension` has a `model` or `parentModel` field, and both set `extra="forbid"`. So the fix is to stop emitting the nested ones and let them travel in their model, where the nesting *is* the fact.

The filter keys off `_parent_name`, **not off the type** — a project-level metric is still its own object and still deploys as its own record.

## What this deliberately does not change

This is about the **wire**, not the graph. Nested fields remain their own DAG nodes, because the validators and bare-`${ref(x)}` resolution both depend on it — `field_resolver.py:504-517` recovers the owner from the **DAG edge**, not from `_parent_name`. `Project.child_items()` is untouched on purpose; "cleaning it up" would break bare refs to nested metrics.

## Verified on a real project

`test-projects/integration`:

```
standalone dimensions deployed: []
standalone metrics deployed:    ['composite_metric']

  model local_test_table          dimensions=['x_rounded']      metrics=['x_sum']
  model daily_metrics             dimensions=['formatted_date'] metrics=['total_value','avg_value']
  model another_local_test_table  dimensions=['new_x_rounded']  metrics=['new_y_sum']
```

All three nested dimensions now ride inside their models, while `composite_metric` — the one genuinely project-level metric — still deploys standalone. Before this change the flat lists held all seven, owner-less.

## Merge order

**core#381 first.** It teaches the backend to see nested fields when answering "does this name exist?". Without it, a deployed project whose insight references a nested dimension reads that ref as **dangling** and is **blocked from committing** in cloud.

## Tests

`test_collect_deploy_resources_finds_objects_nested_in_other_objects` asserted the old behaviour and is inverted — it now checks the field is absent from the flat list and present in the model. A new test pins the other half: a project-level field is unaffected. That one needed real refs (`${ref(scoped_model).x}`) because `single_source_validator` requires a project-level field to tie back to a source through a model.

**2442 pytest, black clean.**

## Still ahead on VIS-1259

The local editor half — the API list endpoints stop returning nested fields, and the viewer derives them from models instead of the flat lists. That's ~25 viewer call sites and needs to land as one piece, since Phase 1's API change would otherwise break the Library and the edit panel. Tracked on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
