### PR TITLE
Docs: the dashboard-building path and the visivo dist capability matrix

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
   - Tutorials:
       - Overview: how_tos.md
       - Use Cases: use_cases.md
+      - Build a Dashboard: topics/dashboards.md
       - Sources: topics/sources.md
       - Source Types: topics/source-types.md
       - Semantic Layer: topics/semantic-layer.md
@@ -125,6 +126,7 @@ nav:
       - Annotations & Shapes: topics/annotations.md
       - CI/CD for BI: topics/ci-cd.md
       - Deployment: topics/deployments.md
+      - Static Distribution: topics/static-distribution.md
       - Telemetry: topics/telemetry.md
   - Concepts:
       - Overview: concepts/index.md

--- a/mkdocs/topics/dashboards.md
+++ b/mkdocs/topics/dashboards.md
@@ -30,12 +30,13 @@ A [Source](../concepts/source.md) is where your data lives — a database or fil
 ```yaml
 sources:
   - name: my_db
-    type: sqlite
-    database: /path/to/file.db
+    type: duckdb
+    database: target/example.duckdb
 ```
 
-See [Source Types](source-types.md) for PostgreSQL, Snowflake, BigQuery, DuckDB, CSV,
-and the rest.
+This guide uses DuckDB from here to the end: it is a single file, so there is nothing to
+start and every step below runs as written. See [Source Types](source-types.md) for
+PostgreSQL, Snowflake, BigQuery, SQLite, CSV, and the rest.
 
 ## Step 2 — a Model
 
@@ -46,11 +47,24 @@ models:
   - name: monthly_revenue
     source: ${ref(my_db)}
     sql: |
-      SELECT date_trunc('month', order_date) AS month,
+      SELECT date_trunc('month', order_date::DATE) AS month,
              SUM(amount) AS revenue
       FROM orders
       GROUP BY 1
 ```
+
+!!! note "Write the SQL in the source's own dialect"
+
+    Visivo hands `sql` to the source unchanged — it does not translate between
+    databases. `date_trunc` and the `::DATE` cast above are DuckDB (and PostgreSQL)
+    syntax; against a `type: sqlite` source the same rollup is
+    `strftime('%Y-%m', order_date)`, and `date_trunc` fails outright with
+    `no such function: DATE_TRUNC`. Change a source's `type` and its models' SQL has to
+    move with it.
+
+    The `::DATE` cast is here because this walkthrough's `orders` table arrives as CSV
+    text (see the complete project at the end of Step 5). Drop it when `order_date` is
+    already a `DATE` column.
 
 ## Step 3 — an Insight
 
@@ -63,7 +77,7 @@ insights:
     props:
       type: bar
       x: ?{ ${ref(monthly_revenue).month} }
-      y: ?{ ${ref(monthly_revenue).revenue} }
+      y: ?{ sum(${ref(monthly_revenue).revenue}) }
 ```
 
 An insight knows what to draw and which data feeds it — but it does not know *where* it
@@ -130,9 +144,9 @@ dashboards:
             chart: ${ref(revenue_chart)}
 ```
 
-That is the whole path. Here it is end to end, as one runnable project — the source
-seeds its own data, so you can paste this into a `project.visivo.yml` and run
-`visivo serve`:
+That is the whole path. Here it is end to end, as one runnable project — every object is
+the one you just built, and the source seeds its own `orders` table, so you can paste
+this into a `project.visivo.yml` and run `visivo serve`:
 
 ```yaml
 name: revenue-example
@@ -146,15 +160,20 @@ sources:
         args:
           - echo
           - |-
-            month,revenue
-            2025-01-01,100
-            2025-02-01,150
-            2025-03-01,200
+            order_date,amount
+            2025-01-05,100
+            2025-01-20,50
+            2025-02-11,150
+            2025-03-02,200
 
 models:
   - name: monthly_revenue
     source: ${ref(my_db)}
-    sql: SELECT month, SUM(revenue) AS revenue FROM orders GROUP BY 1
+    sql: |
+      SELECT date_trunc('month', order_date::DATE) AS month,
+             SUM(amount) AS revenue
+      FROM orders
+      GROUP BY 1
 
 insights:
   - name: revenue_by_month

--- a/mkdocs/topics/dashboards.md
+++ b/mkdocs/topics/dashboards.md
@@ -1,0 +1,342 @@
+# Build a Dashboard
+
+A dashboard is the page your team opens — but it is the **last** object in a chain. Every
+dashboard in Visivo is assembled from the same five pieces, connected with
+[`${ref()}`](query-and-context-strings.md):
+
+```
+Source  →  Model  →  Insight  →  Chart  →  Dashboard
+(where     (a SQL     (data +     (wraps      (rows of
+data       query)     plotly      insights)   items)
+lives)                props)
+```
+
+This guide walks the whole path once, then covers the layout system — rows, items,
+widths, heights, and markdown — in depth.
+
+There are two ways to author everything on this page:
+
+- **YAML** — edit `project.visivo.yml` directly in your editor. Save, and
+  `visivo serve` hot-reloads the browser.
+- **The in-browser workspace** — run `visivo serve` and build visually: create sources
+  with the wizard, explore models, and drag objects onto the dashboard canvas. The
+  workspace writes the same YAML back to your project, so the two routes are always
+  interchangeable.
+
+## Step 1 — a Source
+
+A [Source](../concepts/source.md) is where your data lives — a database or file:
+
+```yaml
+sources:
+  - name: my_db
+    type: sqlite
+    database: /path/to/file.db
+```
+
+See [Source Types](source-types.md) for PostgreSQL, Snowflake, BigQuery, DuckDB, CSV,
+and the rest.
+
+## Step 2 — a Model
+
+A [Model](../concepts/model.md) is a SQL query saved against a Source:
+
+```yaml
+models:
+  - name: monthly_revenue
+    source: ${ref(my_db)}
+    sql: |
+      SELECT date_trunc('month', order_date) AS month,
+             SUM(amount) AS revenue
+      FROM orders
+      GROUP BY 1
+```
+
+## Step 3 — an Insight
+
+An [Insight](../concepts/insight.md) binds a Model's columns to plotly props with
+[query strings](query-and-context-strings.md):
+
+```yaml
+insights:
+  - name: revenue_by_month
+    props:
+      type: bar
+      x: ?{ ${ref(monthly_revenue).month} }
+      y: ?{ ${ref(monthly_revenue).revenue} }
+```
+
+An insight knows what to draw and which data feeds it — but it does not know *where* it
+belongs on a page. That is the next step's job.
+
+## Step 4 — wrap it in a Chart
+
+A [Chart](../reference/configuration/Chart/index.md) wraps one or more Insights and
+carries the presentation-level layout (title, axes, legend):
+
+```yaml
+charts:
+  - name: revenue_chart
+    insights:
+      - ${ref(revenue_by_month)}
+    layout:
+      title:
+        text: Monthly Revenue
+```
+
+!!! warning "The Chart is the composition boundary"
+
+    A dashboard item never takes a bare insight. Items place **charts** (or tables,
+    markdown, and inputs) — so every insight must be wrapped in a chart before it can
+    appear on a dashboard. `chart: ${ref(revenue_by_month)}` will not validate;
+    `chart: ${ref(revenue_chart)}` will.
+
+    In the in-browser workspace this happens for you: dropping an insight onto the
+    canvas auto-wraps it in a new chart.
+
+Why the extra layer? Two things an insight alone cannot do:
+
+- **Combine** — a chart can render several insights on shared axes: a bar series plus a
+  line on a second y-axis, or an indicator layered over a trend. See the
+  [dual-axis example](../reference/configuration/Chart/index.md#dual-axis).
+- **Reuse** — the same insight can appear in many charts, each with its own title,
+  axis labels, and styling. The underlying query still runs once.
+
+```yaml
+charts:
+  - name: revenue_dual_axis
+    insights:
+      - ${ref(revenue_by_month)}      # bar, left axis
+      - ${ref(orders_by_month)}       # line, yaxis: 'y2'
+    layout:
+      title:
+        text: Revenue vs Orders
+      yaxis2:
+        overlaying: 'y'
+        side: right
+```
+
+## Step 5 — place it on a Dashboard
+
+A [Dashboard](../concepts/dashboard.md) arranges charts into **rows** of **items**:
+
+```yaml
+dashboards:
+  - name: my_dashboard
+    rows:
+      - height: medium
+        items:
+          - width: 1
+            chart: ${ref(revenue_chart)}
+```
+
+That is the whole path. Here it is end to end, as one runnable project — the source
+seeds its own data, so you can paste this into a `project.visivo.yml` and run
+`visivo serve`:
+
+```yaml
+name: revenue-example
+
+sources:
+  - name: my_db
+    type: duckdb
+    database: target/example.duckdb
+    seeds:
+      - table_name: orders
+        args:
+          - echo
+          - |-
+            month,revenue
+            2025-01-01,100
+            2025-02-01,150
+            2025-03-01,200
+
+models:
+  - name: monthly_revenue
+    source: ${ref(my_db)}
+    sql: SELECT month, SUM(revenue) AS revenue FROM orders GROUP BY 1
+
+insights:
+  - name: revenue_by_month
+    props:
+      type: bar
+      x: ?{ ${ref(monthly_revenue).month} }
+      y: ?{ sum(${ref(monthly_revenue).revenue}) }
+
+charts:
+  - name: revenue_chart
+    insights:
+      - ${ref(revenue_by_month)}
+    layout:
+      title:
+        text: Monthly Revenue
+
+dashboards:
+  - name: my_dashboard
+    rows:
+      - height: medium
+        items:
+          - width: 1
+            chart: ${ref(revenue_chart)}
+```
+
+## The layout system
+
+A dashboard is a vertical stack of rows; each row is a horizontal band of items. Items
+are placed left to right in the order they are listed.
+
+### Items
+
+An [Item](../reference/configuration/Dashboards/Dashboard/Row/Item/index.md) holds
+exactly one of:
+
+| Field | Places |
+|-------|--------|
+| `chart` | A chart (which wraps your insights) |
+| `table` | A [table](../reference/configuration/Table/index.md), defined inline or by reference |
+| `markdown` | Formatted text — see [Markdown items](#markdown-items) |
+| `input` | An [input widget](inputs.md) that drives interactivity |
+| `rows` | A nested stack of rows — see [Nested rows](#nested-rows) |
+
+An item may also be empty (none of the five set) to reserve intentional whitespace in a
+row, sized by its `width`.
+
+### Relative widths
+
+Each item has an integer `width` (default `1`). Widths are **relative, not absolute**:
+within a row, each item gets `width ÷ (sum of all widths in the row)` of the horizontal
+space. There is no fixed column count — the row's total is whatever its widths sum to.
+
+```yaml
+rows:
+  - height: medium
+    items:
+      - width: 1              # 1/4 of the row
+        markdown:
+          content: "**Q1** commentary"
+      - width: 1              # 1/4 of the row
+        table:
+          name: revenue_table
+          data: ${ref(monthly_revenue)}
+      - width: 2              # 2/4 = half the row
+        chart: ${ref(revenue_chart)}
+```
+
+So `1 / 1 / 2` renders the same as `2 / 2 / 4` or `25 / 25 / 50` — only the ratios
+matter, and only within that row. Rows do not need to agree with each other: one row can
+split `1 / 1` while the next splits `5 / 3 / 4`.
+
+### Row heights
+
+Each row has a `height` — either a named token or a positive integer pixel value:
+
+| Height | Pixels |
+|--------|--------|
+| `compact` | wraps to content |
+| `xsmall` | 128 |
+| `small` | 256 |
+| `medium` | 396 *(default)* |
+| `large` | 512 |
+| `xlarge` | 768 |
+| `xxlarge` | 1024 |
+| `<int>` | that many pixels exactly |
+
+`compact` is the natural fit for rows holding only markdown or inputs — the row shrinks
+to its content instead of reserving chart-sized space:
+
+```yaml
+rows:
+  - height: compact
+    items:
+      - input: ${ref(region_filter)}
+  - height: 450
+    items:
+      - chart: ${ref(revenue_chart)}
+```
+
+### Markdown items
+
+Markdown adds titles, commentary, and section breaks between your charts. Inline it
+directly on an item:
+
+```yaml
+rows:
+  - height: compact
+    items:
+      - markdown:
+          content: |
+            ## Revenue
+            All figures in **USD**, updated nightly.
+```
+
+Or define a named markdown object once and reference it from any dashboard —
+`align` controls horizontal alignment and `justify` controls vertical distribution:
+
+```yaml
+markdowns:
+  - name: welcome_note
+    content: |
+      # Welcome to Visivo
+      This is **formatted** text.
+    align: center
+    justify: start
+
+dashboards:
+  - name: my_dashboard
+    rows:
+      - height: compact
+        items:
+          - markdown: ${ref(welcome_note)}
+```
+
+Markdown content supports [CommonMark](https://commonmark.org/help/) and
+[GitHub Flavored Markdown](https://github.github.com/gfm/), including raw HTML.
+
+### Nested rows
+
+An item can hold `rows` instead of a leaf object, turning it into a **row-container**:
+the nested rows render as a vertical stack inside the slot the parent row reserved. Use
+this for layouts like "one big chart beside a stack of three small ones":
+
+```yaml
+rows:
+  - height: large
+    items:
+      - width: 2
+        chart: ${ref(big_chart)}
+      - width: 1
+        rows:
+          - height: small
+            items: [{ chart: "${ref(small_a)}" }]
+          - height: small
+            items: [{ chart: "${ref(small_b)}" }]
+          - height: small
+            items: [{ chart: "${ref(small_c)}" }]
+```
+
+Inside a row-container, nested row heights act as *relative weights* within the parent
+slot rather than absolute pixel heights.
+
+## Iterating on a layout
+
+Run `visivo serve` and keep it open while you work:
+
+- **In YAML** — edit heights and widths, save, and the browser hot-reloads. Because the
+  layout is plain YAML, layout changes show up in pull requests like any other code.
+- **In the workspace** — drag items between rows, resize them on the canvas, and drop
+  project objects (insights included — they auto-wrap in charts) straight onto the page.
+  Saving from the workspace commits the same YAML back to your project files.
+
+## Next steps
+
+- [Interactivity](interactivity.md) — wire inputs to insight interactions so viewers can
+  filter, sort, and split.
+- [Testing](testing.md) — assert on your data before a dashboard ships.
+- [Deployment](deployments.md) — share it via Visivo Cloud, or as a
+  [static bundle](static-distribution.md) with `visivo dist`.
+- Reference:
+  [Dashboard](../reference/configuration/Dashboards/Dashboard/index.md) ·
+  [Row](../reference/configuration/Dashboards/Dashboard/Row/index.md) ·
+  [Item](../reference/configuration/Dashboards/Dashboard/Row/Item/index.md) ·
+  [Chart](../reference/configuration/Chart/index.md) ·
+  [Markdown](../reference/configuration/Markdown/index.md)

--- a/mkdocs/topics/deployments.md
+++ b/mkdocs/topics/deployments.md
@@ -505,3 +505,5 @@ jobs:
 ## Static
 
 You can also manage and host the dashboard internally if you wish to manage it entirely within your systems.  To create a self-contained build all you need to do is run the `visivo dist` command.  This will create a folder that you can use to host in any manner that suits your needs.
+
+See [Static Distribution](static-distribution.md) for what a static bundle can and cannot do — and for an important note about the data it contains.

--- a/mkdocs/topics/static-distribution.md
+++ b/mkdocs/topics/static-distribution.md
@@ -4,19 +4,55 @@
 HTML, JavaScript, JSON, and data files that renders your dashboards with no Visivo
 server behind it. You can host the folder anywhere static files can live: S3, GitHub
 Pages, Netlify, Cloudflare Pages, an nginx directory, or an internal file share.
+"Self-contained" means no server of yours has to run — not that the page never talks to
+the network; see [what the bundle fetches](#external-requests).
 
 ```bash
 visivo run    # execute the project's queries and materialize the data
 visivo dist   # package the viewer + that data into ./dist
 ```
 
-`visivo dist` packages the output of the **last `visivo run`** — run first, or `dist`
-fails with a message telling you to. Options:
+`visivo dist` packages the output of the **last `visivo run`** — always run first. It
+does not execute a single query of its own; it copies what the run left in `target/`.
+Options:
 
 | Option | Does |
 |--------|------|
 | `--dist-dir` | Where to write the bundle (default `dist`) |
 | `--deployment-root` | Path prefix when hosting under a sub-path, e.g. `--deployment-root /reports` for `example.com/reports` |
+
+!!! danger "`visivo dist` reports success even when there is nothing to package"
+
+    Run `visivo dist` before `visivo run` and the command prints an error **and then
+    reports success anyway**:
+
+    ```
+    Creating distribution for project in folder...
+    Error creating dist. Try running `visivo run` to ensure your project is up to date.
+    Message: No run output found at '<project>/target/main'. Run `visivo run` before `visivo dist`., set STACKTRACE=true to see full error
+    Created dist folder: <project>/dist
+    ```
+
+    It **exits `0`**. What it leaves behind is not a working bundle:
+
+    - **First time** — `dist/` holds an empty `data/` directory and nothing else: no
+      `index.html`, no viewer, no data.
+    - **Any later time** — a bundle from an earlier run is left **completely
+      untouched**, and the success line is printed over it. The command has no way to
+      tell you that you just "rebuilt" a stale bundle.
+
+    This bites hardest in [CI/CD](ci-cd.md), where a failed or skipped `visivo run`
+    will not stop the `dist` step from claiming success and the deploy step from
+    publishing yesterday's numbers. Until the command exits non-zero, gate it yourself:
+
+    ```bash
+    visivo run
+    visivo dist
+    test -s dist/index.html || { echo "dist bundle is empty — did visivo run succeed?"; exit 1; }
+    ```
+
+    (Known bug: the `dist` phase catches this error, logs it, and returns normally
+    instead of failing the command.)
 
 The result is a folder shaped like this:
 
@@ -34,6 +70,9 @@ dist/
     └── files/<name>.parquet  # the materialized query results
 ```
 
+(Plus a few small bookkeeping files the viewer reads: `error.json`,
+`project_history.json`, and an empty `traces.json` left over from 1.x.)
+
 ## What works
 
 A static bundle is not a screenshot — it is the real viewer running on pre-computed
@@ -44,8 +83,10 @@ data:
 - **Interactivity works.** [Inputs](inputs.md) and insight
   [interactions](interactivity.md) — filter, sort, split — execute **in the browser**,
   in DuckDB-WASM, against the parquet files in the bundle. Changing a dropdown re-runs
-  the insight's client-side query with no network request beyond the data files already
-  fetched.
+  the insight's client-side query and never touches your database. It does not touch
+  your host either, once the data files and the DuckDB parquet extension have loaded —
+  and that extension comes from the public internet, not the bundle
+  ([details](#external-requests)).
 - **Any static host.** No runtime, no database driver, no environment variables. The
   `--deployment-root` flag rewrites every asset and data URL so the bundle works from a
   sub-path.
@@ -66,6 +107,11 @@ data:
   the equivalent rewrite yourself (for nginx:
   `try_files $uri /index.html;`) — otherwise only the root URL loads and dashboard
   links 404 on refresh.
+- **"Self-contained" is about servers, not about the network.** The bundle needs no
+  server of yours, but the browser rendering it still reaches the public internet — for
+  the DuckDB parquet extension on every dashboard, and for basemap assets on geo
+  charts. See [what the bundle fetches](#external-requests) before planning an
+  air-gapped deployment.
 
 ## What is impossible
 
@@ -110,6 +156,31 @@ Bundle size follows the same rule: the folder grows with the rows your run
 materializes. Aggregating in your models — pushing `GROUP BY`s into the SQL instead of
 shipping raw rows — keeps bundles small *and* limits what a bundle can expose.
 
+## What the bundle fetches from the internet { #external-requests }
+
+A dist bundle is self-contained in the sense that matters for hosting: no server, no
+database driver, no runtime. It is **not** free of outbound requests. Load one with the
+browser's network panel open and three things come from outside your origin:
+
+| Fetched from | When | If it cannot be reached |
+|--------------|------|-------------------------|
+| `extensions.duckdb.org` — `<version>/wasm_eh/parquet.duckdb_extension.wasm` | **Every dashboard**, the first time DuckDB-WASM reads a parquet file | Charts draw their frame, axes, and title with **no data in them** |
+| `cdn.plot.ly` — TopoJSON (e.g. `un/world_110m.json`) | Dashboards with `scattergeo` or `choropleth` insights | No country/coastline outlines |
+| `basemaps.cartocdn.com` — style JSON, sprites, glyphs, vector tiles | Dashboards with `scattermap`, `densitymap`, or `choroplethmap` insights | Points plot over a blank background |
+
+The first row is the one to plan around, because it applies to **every** bundle, not
+just map-shaped ones: DuckDB-WASM ships in the bundle, but its parquet extension does
+not — it is downloaded on demand. Blocking that host and reloading a plain bar-chart
+dashboard renders an empty plot: the title and axes are there and every series is gone.
+There is no configuration today that points the viewer at a different extension
+repository, so an air-gapped or egress-filtered network needs `extensions.duckdb.org`
+reachable — through an allowlist entry, a caching proxy, or a mirror that answers for
+it — before a bundle will show data.
+
+Everything else is same-origin: the viewer JS/CSS, the DuckDB-WASM binaries and their
+workers, the JSON manifests, and the parquet files all come from the bundle. No webfont
+CDN is contacted; the UI uses fonts that ship with it or are already on the machine.
+
 ## Trying it locally
 
 Any static file server can preview a bundle:
@@ -129,4 +200,4 @@ which `http.server` does not provide — navigate from the root page.)
 | Local development with hot reload and editing | `visivo serve` |
 | Hosted dashboards with auth, stages, and sharing | [`visivo deploy`](deployments.md) → Visivo Cloud |
 | Dashboards inside your own infrastructure, no server to operate | `visivo dist` → any static host |
-| Dashboards in an air-gapped or locked-down environment | `visivo dist` — the bundle makes no external requests |
+| Dashboards in an air-gapped or locked-down environment | `visivo dist` — but the browser still fetches the DuckDB parquet extension, so read [what the bundle fetches](#external-requests) first |

--- a/mkdocs/topics/static-distribution.md
+++ b/mkdocs/topics/static-distribution.md
@@ -1,0 +1,132 @@
+# Static Distribution
+
+`visivo dist` builds your project into a **self-contained static bundle** — a folder of
+HTML, JavaScript, JSON, and data files that renders your dashboards with no Visivo
+server behind it. You can host the folder anywhere static files can live: S3, GitHub
+Pages, Netlify, Cloudflare Pages, an nginx directory, or an internal file share.
+
+```bash
+visivo run    # execute the project's queries and materialize the data
+visivo dist   # package the viewer + that data into ./dist
+```
+
+`visivo dist` packages the output of the **last `visivo run`** — run first, or `dist`
+fails with a message telling you to. Options:
+
+| Option | Does |
+|--------|------|
+| `--dist-dir` | Where to write the bundle (default `dist`) |
+| `--deployment-root` | Path prefix when hosting under a sub-path, e.g. `--deployment-root /reports` for `example.com/reports` |
+
+The result is a folder shaped like this:
+
+```
+dist/
+├── index.html            # the viewer application
+├── assets/               # viewer JS/CSS, including DuckDB-WASM
+├── _redirects            # SPA fallback rule (Netlify-style)
+└── data/
+    ├── project.json          # project envelope
+    ├── dashboards.json       # every dashboard, with its full layout config
+    ├── dashboards/<name>.json
+    ├── insights.json         # per-insight metadata + client-side query
+    ├── inputs.json
+    └── files/<name>.parquet  # the materialized query results
+```
+
+## What works
+
+A static bundle is not a screenshot — it is the real viewer running on pre-computed
+data:
+
+- **Dashboards render fully.** Charts, tables, and markdown all work, laid out exactly
+  as they do under `visivo serve`.
+- **Interactivity works.** [Inputs](inputs.md) and insight
+  [interactions](interactivity.md) — filter, sort, split — execute **in the browser**,
+  in DuckDB-WASM, against the parquet files in the bundle. Changing a dropdown re-runs
+  the insight's client-side query with no network request beyond the data files already
+  fetched.
+- **Any static host.** No runtime, no database driver, no environment variables. The
+  `--deployment-root` flag rewrites every asset and data URL so the bundle works from a
+  sub-path.
+- **Deep links.** The bundle ships a `_redirects` file with the single-page-app
+  fallback rule (`/* → /index.html 200`), so `example.com/my-dashboard` resolves
+  directly on hosts that honor it (Netlify, Cloudflare Pages).
+
+## What degrades
+
+- **Data is frozen at `visivo run` time.** The bundle is a snapshot. Nothing in it ever
+  queries your sources again — to refresh the numbers you re-run
+  `visivo run && visivo dist` and re-upload the folder (typically on a schedule in
+  [CI/CD](ci-cd.md)).
+- **Interactivity is bounded by the shipped data.** Filters, sorts, and splits
+  recompute over the parquet in the bundle; an input can never pull rows that the run
+  didn't materialize.
+- **Deep links depend on the host.** On hosts that don't read `_redirects`, configure
+  the equivalent rewrite yourself (for nginx:
+  `try_files $uri /index.html;`) — otherwise only the root URL loads and dashboard
+  links 404 on refresh.
+
+## What is impossible
+
+- **Live queries.** There is no path from the bundle to your database at view time —
+  by design. Viewers see the snapshot, nothing else.
+- **Editing.** The in-browser workspace, the Explorer, and every authoring surface
+  require the `visivo serve` server. A dist bundle is strictly view-only.
+- **Alerts.** [Alerts](../reference/configuration/Alert/index.md) fire during
+  `visivo run`, not from the bundle.
+- **Access control.** The bundle has no login and no permissions — protecting it is
+  entirely up to the host (see the warning below).
+- **Cloud features.** Stages, deployment history, teams, and sharing controls belong to
+  [`visivo deploy` and Visivo Cloud](deployments.md), not to static bundles.
+
+## Your data ships in the bundle { #data-exposure }
+
+!!! danger "A dist bundle contains the query results themselves"
+
+    `visivo dist` ships the **results** of your queries as static files. Everything
+    under `dist/data/files/` is a parquet file holding the full result set of a model,
+    insight, or input query — every row, **including columns no chart displays**. The
+    JSON manifests also carry your dashboard configurations and models' SQL text.
+
+    **Anyone who can fetch the files can read the data.** There is no login in front of
+    a static bundle, and "nobody knows the URL" is not protection. Before publishing
+    one, either be comfortable treating every row of the underlying result sets as
+    public to its audience, or put the files behind access control you provide —
+    a VPN, reverse-proxy authentication, or your host's protected-site feature.
+
+    What the bundle does **not** contain: credentials for sources defined at the top
+    level of your project — the normal pattern. A model's `source: ${ref(my_db)}` ships
+    as that unresolved string, and `${ env_var(...) }` templates ship unresolved too;
+    connection details are only used while `visivo run` executes the queries. One
+    caveat: a source defined **inline inside a model** is embedded in the bundle's JSON
+    along with the model — so define sources at the top level and keep secrets in
+    environment variables, and nothing sensitive ships.
+
+    If you need authenticated hosting with the serving handled for you, that is what
+    [Visivo Cloud](../cloud/index.md) is for.
+
+Bundle size follows the same rule: the folder grows with the rows your run
+materializes. Aggregating in your models — pushing `GROUP BY`s into the SQL instead of
+shipping raw rows — keeps bundles small *and* limits what a bundle can expose.
+
+## Trying it locally
+
+Any static file server can preview a bundle:
+
+```bash
+cd dist
+python -m http.server 8000
+```
+
+Then open `http://localhost:8000`. (Deep links into dashboards need the SPA fallback,
+which `http.server` does not provide — navigate from the root page.)
+
+## When to reach for `dist`
+
+| You want | Use |
+|----------|-----|
+| Local development with hot reload and editing | `visivo serve` |
+| Hosted dashboards with auth, stages, and sharing | [`visivo deploy`](deployments.md) → Visivo Cloud |
+| Dashboards inside your own infrastructure, no server to operate | `visivo dist` → any static host |
+| Dashboards in an air-gapped or locked-down environment | `visivo dist` — the bundle makes no external requests |


### PR DESCRIPTION
## The problem

Two P1/P2 docs gaps from the audit:

1. **No dashboard-building guide.** `mkdocs/topics/` had 14 topics and not one taught the thing the product exists for — assembling a dashboard. The blocker (is an insight a dashboard item?) was settled by the 08-27 ruling: insights are **not** first-class items; the Chart wrapper stays.
2. **`visivo dist` was one sentence** at the bottom of `deployments.md`, with no statement of what a static bundle can and cannot do — and no warning anywhere that a bundle ships the query **results** as static files.

## The fix

**`mkdocs/topics/dashboards.md` — "Build a Dashboard"**
- The full path `source → model → insight → chart → dashboard`, with the Chart taught as the **composition boundary**: an item never takes a bare insight; a chart wraps one or more insights (dual-axis combination, reuse across charts).
- The layout system in depth: rows/items, **sum-normalized relative widths** (`1/1/2` ≡ `25/25/50`; ratios only, per row), row heights (token table + integer pixels), markdown items (inline, named + `${ref()}`, align/justify), nested row-containers, empty items.
- Both authoring routes: YAML and the in-browser workspace (including the #632/#637 auto-wrap behavior when dropping an insight on the canvas).

**`mkdocs/topics/static-distribution.md` — "Static Distribution"**
- What **works** (full rendering; inputs + filter/sort/split run client-side in DuckDB-WASM over the shipped parquet; any static host; `--deployment-root` sub-paths; `_redirects` deep links), what **degrades** (data frozen at `visivo run` time; interactivity bounded by shipped data; SPA fallback is host-dependent), what is **impossible** (live queries, editing/workspace/Explorer, alerts, access control, cloud stages).
- The **data-exposure warning**: `dist/data/files/*.parquet` holds every row of every materialized result — including columns no chart displays — plus dashboard configs and model SQL text in the JSON manifests. Anyone who can fetch the files sees the data.

Both pages registered in the `mkdocs.yml` nav (Tutorials); `deployments.md`'s Static section now links the new page. No Python source changes. No new `known_words.txt` entries were needed (spellcheck is clean).

## Ground-truthing (every claim tested against the current code)

Built probe projects and ran `visivo run && visivo dist` on the current `dist_phase.py` (post-#633):

- `data/files/*.parquet` contains the full result rows, including the undisplayed `region` column → the "every row, including columns no chart displays" wording.
- `data/insights/<name>.json` carries the client-side query + props mapping.
- A model referenced by a table ships its **SQL text** inside `dashboards.json`, but its `source: ${ref(probe_db)}` stays an **unresolved string** — top-level source credentials do not ship.
- Edge case probed: a source defined **inline inside a model** IS embedded in the bundle JSON, while `${ env_var('X') }` templates ship **unresolved** → the doc's precise credentials caveat.

## Falsification evidence

Every YAML fence is validated against the live Pydantic schema (validator script extracts fences and runs `Project`/`Dashboard`/`Row`/`Chart`/… `model_validate`). All 12 fences in `dashboards.md` pass. With the doc's central rule deliberately broken (`chart: ${ref(revenue_chart)}` → `insight: ${ref(revenue_by_month)}` — the exact mistake the page warns about), validation fails as the doc promises:

```
FENCE 5: dashboards[0] FAILED: 1 validation error for Dashboard
rows.0.items.0.insight
  Extra inputs are not permitted [type=extra_forbidden, input_value='${ref(revenue_by_month)}', ...]
EXIT: 1
```

The complete "runnable" example was also extracted verbatim from the page and executed: `visivo run` → `Updated data for insight revenue_by_month ... [SUCCESS]`.

## Test results

- `mkdocs build` from the worktree (fresh arm64 venv, `pip install -e .` + the pyproject docs deps, after `write_mkdocs_markdown_files.py` exactly as docs CI does): **build succeeds, zero warnings on the two new pages, zero spellcheck warnings**; `validate_mkdocs_build.sh` passes.
- `pytest tests/docs/test_docs_parity.py`: 4 passed, 1 failed — `test_committed_schema_is_fresh`, which fails **identically with this branch's changes stashed** (clean origin/main; the same pre-existing failure PR #640's body notes). Not regenerated here: this is a docs-only lane and the stale schema comes from a model change owned elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
