### PR TITLE
Click-to-pick: every empty slot opens the ReferencePicker (B2)

### DIFF
--- a/viewer/e2e/stories/canvas-click-to-pick.spec.mjs
+++ b/viewer/e2e/stories/canvas-click-to-pick.spec.mjs
@@ -17,6 +17,20 @@
  * path). The story never presses the dashboard Save, so the layout is not
  * persisted; the draft wrapper chart is uniquely named per run.
  *
+ * Because that draft SURVIVES the run, the auto-wrap assertion must never be
+ * a prefix probe: it reads the wrapper's name back out of the slot and asserts
+ * THAT EXACT chart exists exactly once, so a leftover `<insight>-chart` from an
+ * earlier run (or an earlier retry attempt — retries: 2) cannot satisfy it.
+ *
+ * ISOLATION: this file is deliberately NOT registered in the 'state-mutating'
+ * project despite drafting a chart into the backend cache. That project exists
+ * to serialise specs that share the DEFAULT :3001 sandbox; this story, like
+ * every other dedicated-port canvas story (canvas-keyboard-nav,
+ * canvas-wrap-container, canvas-nested-dnd, broken-ref-fix…), runs against its
+ * own sandbox via VIS_PICK_BASE and is environmentally unrunnable on :3001.
+ * Listing it there would be misleading AND (via that project's
+ * `dependencies: ['parallel']`) would mean it never executes at all.
+ *
  * Precondition: an isolated sandbox running the integration project.
  *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
  *   VISIVO_SANDBOX_NAME=pick bash scripts/sandbox.sh start
@@ -61,6 +75,14 @@ const appendEmptySlotRow = async page =>
     },
     { dashboard: DASHBOARD }
   );
+
+// `${ref(name)}` / `ref(name)` → `name`.
+const parseRefName = value => {
+  const match = String(value || '').match(/^\$?\{?\s*ref\(\s*([^)]+?)\s*\)\s*\}?$/);
+  return match ? match[1] : String(value || '');
+};
+
+const escapeRe = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 // Read the item config at a composite canvas path from the live working copy.
 const readItemAtPath = async (page, itemPath) =>
@@ -184,21 +206,35 @@ test.describe('Canvas click-to-pick (W5 / Track L)', () => {
     const item = await readItemAtPath(page, itemPath);
     expect(item.insight).toBeUndefined();
 
-    // The wrapper chart exists as a draft in the chart store, holding exactly
-    // the wrapped insight (same shape as Library "Wrap in Chart…", #632).
+    // Read the wrapper's name back OUT of the slot and assert THAT EXACT chart
+    // exists. A `startsWith(<insight>-chart)` probe is satisfied by a draft
+    // this story left behind on an earlier run (or on an earlier retry
+    // attempt — playwright.config.mjs sets retries: 2), so the auto-wrap half
+    // of the #637 check would silently stop biting: a collision just bumps the
+    // NEW mint to `-2` while the stale `-chart` keeps the assertion green.
+    // Naming the exact chart the slot points at is the only honest check.
+    const placedName = parseRefName(item.chart);
+    expect(placedName).toMatch(new RegExp(`^${escapeRe(insightName)}-chart(-\\d+)?$`));
+
+    // That chart exists as a draft holding exactly the wrapped insight (same
+    // shape as Library "Wrap in Chart…", #632) — and exists exactly once.
     await expect
       .poll(
         async () =>
           page.evaluate(
-            name =>
-              (window.useStore.getState().charts || []).some(c =>
-                c.name.startsWith(`${name}-chart`)
-              ),
-            insightName
+            name => {
+              const matches = (window.useStore.getState().charts || []).filter(
+                c => c.name === name
+              );
+              if (matches.length !== 1) return { count: matches.length };
+              const cfg = matches[0].config || matches[0];
+              return { count: 1, insights: cfg.insights };
+            },
+            placedName
           ),
         { timeout: WAIT }
       )
-      .toBe(true);
+      .toEqual({ count: 1, insights: [`ref(${insightName})`] });
 
     await page.screenshot({ path: `${SCREENS}/pick-03-insight-wrapped.png`, fullPage: true });
   });
@@ -245,9 +281,22 @@ test.describe('Canvas click-to-pick (W5 / Track L)', () => {
     const itemPath = await appendEmptySlotRow(page);
 
     // Focus the slot button directly (it is in the tab order) and open with Enter.
-    await page.getByTestId('canvas-empty-slot').last().focus();
+    const slot = page.getByTestId('canvas-empty-slot').last();
+    await slot.focus();
     await page.keyboard.press('Enter');
     const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+
+    // Escaping HANDS FOCUS BACK to the slot. Without that the keyboard user
+    // lands on <body> and has to Tab from the top of the document to reach the
+    // slot they were filling — a modal that is "keyboard-completable" only in
+    // the forward direction is not keyboard-completable.
+    await page.keyboard.press('Escape');
+    await expect(picker).not.toBeVisible();
+    await expect(slot).toBeFocused();
+
+    // Re-open and complete the pick from the keyboard.
+    await page.keyboard.press('Enter');
     await expect(picker).toBeVisible({ timeout: WAIT });
 
     // Search auto-focuses; Tab moves into the list; Enter picks the row.

--- a/viewer/e2e/stories/canvas-click-to-pick.spec.mjs
+++ b/viewer/e2e/stories/canvas-click-to-pick.spec.mjs
@@ -1,0 +1,272 @@
+/**
+ * Story: Click-to-pick — empty slots stop being drag-only (W5 / Track L, B2).
+ *
+ * Every empty canvas slot is clickable: clicking opens the <ReferencePicker>
+ * scoped to CHARTS and INSIGHTS (typed sections, objectTypeConfigs palette).
+ * Picking a chart places `chart: ref(name)` into that slot's working copy
+ * (#617 explicit save — nothing persists until the dashboard Save). Picking an
+ * INSIGHT auto-wraps it (#637): a unique `<insight>-chart` wrapper chart is
+ * minted through the same saveChart path Library "Wrap in Chart…" (#632) uses,
+ * and the slot points at the wrapper. The same picker opens from the right
+ * rail's "Choose…" on an empty item's edit panel. Zero drags anywhere in this
+ * story, and both paths are keyboard-completable (the slot is a real button,
+ * the picker rows are buttons).
+ *
+ * NOTE: an insight pick saves a DRAFT wrapper chart immediately (the placement
+ * itself stays in the un-saved working copy — same semantics as the #637 drop
+ * path). The story never presses the dashboard Save, so the layout is not
+ * persisted; the draft wrapper chart is uniquely named per run.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8050 VISIVO_SANDBOX_FRONTEND_PORT=3050 \
+ *   VISIVO_SANDBOX_NAME=pick bash scripts/sandbox.sh start
+ *   # then: VIS_PICK_BASE=http://localhost:3050 npx playwright test canvas-click-to-pick
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_PICK_BASE || 'http://localhost:3050';
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+test.use({ viewport: { width: 1600, height: 1400 } });
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  await expect(page.getByTestId(`dashboard_${DASHBOARD}`)).toBeVisible({ timeout: WAIT });
+  await page.waitForTimeout(600);
+};
+
+// APPEND a fresh row holding ONE empty slot, so the story always knows which
+// empty slot it is exercising (the LAST canvas-empty-slot on the canvas) and
+// never mutates the fixture's real items. The write is optimistic-only (#617
+// working copy) — the story never presses Save, so nothing persists.
+const appendEmptySlotRow = async page =>
+  page.evaluate(
+    ({ dashboard }) => {
+      const s = window.useStore.getState();
+      const entry = (s.dashboards || []).find(d => d.name === dashboard);
+      const cfg = entry?.config || entry;
+      const next = JSON.parse(JSON.stringify(cfg));
+      next.rows = Array.isArray(next.rows) ? next.rows : [];
+      next.rows.push({ height: 'small', items: [{ width: 1 }] });
+      if (s.updateDashboardConfigOptimistic) {
+        s.updateDashboardConfigOptimistic(dashboard, next);
+      }
+      // The new slot's canvas path: last row, first item.
+      return `row.${next.rows.length - 1}.item.0`;
+    },
+    { dashboard: DASHBOARD }
+  );
+
+// Read the item config at a composite canvas path from the live working copy.
+const readItemAtPath = async (page, itemPath) =>
+  page.evaluate(
+    ({ dashboard, path }) => {
+      const s = window.useStore.getState();
+      const entry = (s.dashboards || []).find(d => d.name === dashboard);
+      const cfg = entry?.config || entry;
+      const tokens = path.split('.');
+      let node = cfg;
+      for (let i = 0; i < tokens.length; i += 2) {
+        const axis = tokens[i];
+        const index = Number(tokens[i + 1]);
+        node = axis === 'row' ? node.rows?.[index] : node.items?.[index];
+        if (!node) return null;
+      }
+      return node;
+    },
+    { dashboard: DASHBOARD, path: itemPath }
+  );
+
+test.describe('Canvas click-to-pick (W5 / Track L)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('an empty slot is a clickable button that opens the ReferencePicker', async () => {
+    await openCanvas(page);
+    await appendEmptySlotRow(page);
+
+    const slot = page.getByTestId('canvas-empty-slot').last();
+    await expect(slot).toBeVisible({ timeout: WAIT });
+    // A real <button> — focusable, so the path is keyboard-completable.
+    expect(await slot.evaluate(el => el.tagName)).toBe('BUTTON');
+
+    await slot.click();
+    const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('reference-picker-title')).toHaveText('Pick a chart or insight');
+
+    // Typed sections — charts AND insights, objectTypeConfigs headers.
+    await expect(page.getByTestId('reference-picker-section-chart')).toBeVisible();
+    await expect(page.getByTestId('reference-picker-section-insight')).toBeVisible();
+    expect(
+      await picker.locator('[data-picker-type="chart"]').count()
+    ).toBeGreaterThan(0);
+    expect(
+      await picker.locator('[data-picker-type="insight"]').count()
+    ).toBeGreaterThan(0);
+
+    await page.screenshot({ path: `${SCREENS}/pick-01-picker-open.png`, fullPage: true });
+
+    // Escape closes without touching the slot.
+    await page.keyboard.press('Escape');
+    await expect(picker).not.toBeVisible();
+  });
+
+  test('picking a CHART fills the slot with chart: ref(name) in the working copy', async () => {
+    await openCanvas(page);
+    const itemPath = await appendEmptySlotRow(page);
+
+    await page.getByTestId('canvas-empty-slot').last().click();
+    const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+
+    const chartRow = picker.locator('[data-picker-type="chart"]').first();
+    const chartName = (
+      await chartRow.locator('.text-sm').first().textContent()
+    ).trim();
+    await chartRow.click();
+
+    // Picker closed, placement landed in the #617 working copy.
+    await expect(picker).not.toBeVisible();
+    await expect
+      .poll(async () => {
+        const item = await readItemAtPath(page, itemPath);
+        return item?.chart || null;
+      }, { timeout: WAIT })
+      .toContain(chartName);
+
+    // The slot now renders content (the empty placeholder is gone from that row).
+    await page.screenshot({ path: `${SCREENS}/pick-02-chart-placed.png`, fullPage: true });
+  });
+
+  test('picking an INSIGHT auto-wraps: mints <insight>-chart and places the wrapper (#637)', async () => {
+    await openCanvas(page);
+    const itemPath = await appendEmptySlotRow(page);
+
+    await page.getByTestId('canvas-empty-slot').last().click();
+    const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+
+    const insightRow = picker.locator('[data-picker-type="insight"]').first();
+    const insightName = (
+      await insightRow.locator('.text-sm').first().textContent()
+    ).trim();
+    await insightRow.click();
+    await expect(picker).not.toBeVisible();
+
+    // The slot points at the minted wrapper chart — never a bare insight.
+    await expect
+      .poll(async () => {
+        const item = await readItemAtPath(page, itemPath);
+        return item?.chart || null;
+      }, { timeout: WAIT })
+      .toContain(`${insightName}-chart`);
+    const item = await readItemAtPath(page, itemPath);
+    expect(item.insight).toBeUndefined();
+
+    // The wrapper chart exists as a draft in the chart store, holding exactly
+    // the wrapped insight (same shape as Library "Wrap in Chart…", #632).
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            name =>
+              (window.useStore.getState().charts || []).some(c =>
+                c.name.startsWith(`${name}-chart`)
+              ),
+            insightName
+          ),
+        { timeout: WAIT }
+      )
+      .toBe(true);
+
+    await page.screenshot({ path: `${SCREENS}/pick-03-insight-wrapped.png`, fullPage: true });
+  });
+
+  test('the right rail "Choose…" on an empty item opens the same picker', async () => {
+    await openCanvas(page);
+    const itemPath = await appendEmptySlotRow(page);
+
+    // Select the empty item so the right rail routes to its ItemEditForm.
+    await page.evaluate(path => {
+      const s = window.useStore.getState();
+      if (s.setWorkspaceSelection) s.setWorkspaceSelection(undefined, path);
+    }, itemPath);
+
+    const chooseButton = page.getByTestId(/^item-.*-choose$/);
+    await expect(chooseButton).toBeVisible({ timeout: WAIT });
+    await page.screenshot({ path: `${SCREENS}/pick-04-rail-choose.png`, fullPage: true });
+
+    await chooseButton.click();
+    const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+    await expect(page.getByTestId('reference-picker-title')).toHaveText('Pick a chart or insight');
+
+    // Pick a chart from the rail path too — the item leaf fills the same way.
+    const chartRow = picker.locator('[data-picker-type="chart"]').first();
+    const chartName = (
+      await chartRow.locator('.text-sm').first().textContent()
+    ).trim();
+    await chartRow.click();
+    await expect(picker).not.toBeVisible();
+
+    await expect
+      .poll(async () => {
+        const item = await readItemAtPath(page, itemPath);
+        return item?.chart || null;
+      }, { timeout: WAIT })
+      .toContain(chartName);
+
+    await page.screenshot({ path: `${SCREENS}/pick-05-rail-placed.png`, fullPage: true });
+  });
+
+  test('keyboard: Tab reaches the picker rows and Enter picks (no pointer)', async () => {
+    await openCanvas(page);
+    const itemPath = await appendEmptySlotRow(page);
+
+    // Focus the slot button directly (it is in the tab order) and open with Enter.
+    await page.getByTestId('canvas-empty-slot').last().focus();
+    await page.keyboard.press('Enter');
+    const picker = page.getByTestId('reference-picker');
+    await expect(picker).toBeVisible({ timeout: WAIT });
+
+    // Search auto-focuses; Tab moves into the list; Enter picks the row.
+    await expect(page.getByTestId('reference-picker-search')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await expect(picker).not.toBeVisible();
+    await expect
+      .poll(async () => {
+        const item = await readItemAtPath(page, itemPath);
+        return item ? Object.keys(item).some(k => k === 'chart') : false;
+      }, { timeout: WAIT })
+      .toBe(true);
+  });
+
+  test('no console errors across the click-to-pick flows', async () => {
+    const real = page._consoleErrors.filter(
+      e => !e.includes('favicon') && !e.includes('ResizeObserver')
+    );
+    expect(real).toEqual([]);
+  });
+});

--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -12,6 +12,33 @@ import { useVisibleRows } from '../../hooks/useVisibleRows';
 import { parseRefValue, extractRefNamesFromStrings } from '../../utils/refString';
 
 /**
+ * The empty canvas slot's VISIBLE label. Shared with the slot's accessible
+ * name so the two can never diverge (WCAG 2.5.3, Label in Name).
+ */
+export const EMPTY_SLOT_LABEL = 'Empty slot — click to choose';
+
+/**
+ * Turn a composite canvas path (`row.0.item.2`, or a nested
+ * `row.0.item.1.row.0.item.0`) into a 1-indexed human location —
+ * `"row 1, item 3"` — so identical empty slots announce distinguishably to a
+ * screen reader instead of all reading the same generic name.
+ *
+ * Returns '' for an absent/unparseable path (the caller then falls back to the
+ * button's own text).
+ */
+export const describeSlotPath = itemPath => {
+  const tokens = String(itemPath || '').split('.');
+  const parts = [];
+  for (let i = 0; i + 1 < tokens.length; i += 2) {
+    const axis = tokens[i];
+    const index = Number(tokens[i + 1]);
+    if ((axis !== 'row' && axis !== 'item') || !Number.isInteger(index)) return '';
+    parts.push(`${axis} ${index + 1}`);
+  }
+  return parts.join(', ');
+};
+
+/**
  * Normalize a chart/table `insights` array so Chart/Table always receive
  * `[{ name: 'insight-name' }]` objects rather than raw context-string refs
  * (`"${ref(insight-name)}"`).
@@ -628,17 +655,25 @@ const Dashboard = ({
     // way to fill an empty slot.
     if (canvasMode) {
       if (typeof onEmptySlotClick === 'function') {
+        // Accessible name = the VISIBLE label plus this slot's location. Two
+        // rules ride on that shape: WCAG 2.5.3 (Label in Name) needs the
+        // visible string to be contained in the accessible name, or speaking
+        // the on-screen label doesn't activate the control; and a row template
+        // paints several identical slots at once, so the name has to say WHICH
+        // one it is. `undefined` (not a bare label) when there is no path, so
+        // the button falls back to its own text rather than a duplicate name.
+        const slotLocation = describeSlotPath(itemPath);
         return (
           <button
             key={key}
             type="button"
             data-testid="canvas-empty-slot"
-            aria-label="Empty slot — choose content"
+            aria-label={slotLocation ? `${EMPTY_SLOT_LABEL} (${slotLocation})` : undefined}
             onClick={() => onEmptySlotClick({ itemPath })}
             className="flex h-full w-full cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50/40 text-[11px] font-medium text-gray-400 transition-colors hover:border-primary-300 hover:bg-primary-50/40 hover:text-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
             style={{ minHeight: 48 }}
           >
-            Empty slot — click to choose
+            {EMPTY_SLOT_LABEL}
           </button>
         );
       }

--- a/viewer/src/components/project/Dashboard.jsx
+++ b/viewer/src/components/project/Dashboard.jsx
@@ -223,6 +223,12 @@ const Dashboard = ({
   // renderer falls back to the legacy "<Type> not found: <name>" placeholder so
   // static viewing stays at parity.
   renderBrokenRef = null,
+  // Optional click handler for an EMPTY canvas slot (W5 click-to-pick). When
+  // provided (canvas build surface), the empty-slot placeholder renders as a
+  // real <button> and clicking it calls `({ itemPath })` so the canvas can open
+  // the <ReferencePicker> for that slot. When absent, the placeholder stays the
+  // inert VIS-901 #3 div (and View mode still renders nothing at all).
+  onEmptySlotClick = null,
 }) => {
   // Dashboard store (fetched by Project container)
   const dashboards = useStore(state => state.dashboards);
@@ -616,7 +622,26 @@ const Dashboard = ({
     // renders nothing (parity preserved); on the canvas build surface we paint a
     // visible dashed placeholder so the slot is discoverable + a drop target
     // (VIS-901 #3). Backend persistence of a truly-empty item lands with VIS-900.
+    // W5 (click-to-pick): when the canvas supplies `onEmptySlotClick`, the
+    // placeholder is a real button — clicking (or keyboard-activating) it opens
+    // the ReferencePicker for this slot, so drag-and-drop stops being the only
+    // way to fill an empty slot.
     if (canvasMode) {
+      if (typeof onEmptySlotClick === 'function') {
+        return (
+          <button
+            key={key}
+            type="button"
+            data-testid="canvas-empty-slot"
+            aria-label="Empty slot — choose content"
+            onClick={() => onEmptySlotClick({ itemPath })}
+            className="flex h-full w-full cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50/40 text-[11px] font-medium text-gray-400 transition-colors hover:border-primary-300 hover:bg-primary-50/40 hover:text-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            style={{ minHeight: 48 }}
+          >
+            Empty slot — click to choose
+          </button>
+        );
+      }
       return (
         <div
           key={key}

--- a/viewer/src/components/project/Dashboard.test.jsx
+++ b/viewer/src/components/project/Dashboard.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { futureFlags } from '../../router-config';
-import Dashboard from './Dashboard';
+import Dashboard, { EMPTY_SLOT_LABEL, describeSlotPath } from './Dashboard';
 import useStore from '../../stores/store';
 import { useModelsData } from '../../hooks/useModelsData';
 import { useInsightsData } from '../../hooks/useInsightsData';
@@ -314,6 +314,82 @@ describe('Dashboard', () => {
     it('keeps the inert placeholder div when onEmptySlotClick is absent', () => {
       renderEmptySlot({ canvasMode: true });
       expect(screen.getByTestId('canvas-empty-slot').tagName).toBe('DIV');
+    });
+
+    // WCAG 2.5.3 (Label in Name): speaking the visible label must activate the
+    // control, so the accessible name has to CONTAIN the visible string — an
+    // aria-label that replaces it ("Empty slot — choose content") breaks voice
+    // control. The location suffix is what keeps several identical slots
+    // distinguishable.
+    it('gives the slot an accessible name containing its visible label', () => {
+      renderEmptySlot({ canvasMode: true, onEmptySlotClick: jest.fn() });
+      const slot = screen.getByTestId('canvas-empty-slot');
+      expect(slot).toHaveTextContent(EMPTY_SLOT_LABEL);
+      expect(slot).toHaveAccessibleName(expect.stringContaining(EMPTY_SLOT_LABEL));
+      expect(slot).toHaveAccessibleName('Empty slot — click to choose (row 1, item 1)');
+    });
+  });
+
+  // ---------- W5: several empty slots must not all announce identically -----
+  describe('empty-slot accessible names disambiguate (W5)', () => {
+    const kpiRowDashboard = {
+      name: 'kpi-row',
+      rows: [{ height: 'medium', items: [{ width: 1 }, { width: 1 }, { width: 1 }] }],
+    };
+
+    it('names each slot by its own location', () => {
+      useStore.mockImplementation(selector =>
+        selector({
+          project: mockProject,
+          dashboards: [kpiRowDashboard],
+          fetchDashboards: jest.fn(),
+          fetchCharts: jest.fn(),
+          fetchTables: jest.fn(),
+          fetchMarkdowns: jest.fn(),
+          fetchInputs: jest.fn(),
+          fetchModels: jest.fn(),
+          models: [],
+          getChartByName: jest.fn(() => null),
+          getTableByName: jest.fn(() => null),
+          getMarkdownByName: jest.fn(() => null),
+          getInputByName: jest.fn(() => null),
+        })
+      );
+      render(
+        <BrowserRouter future={futureFlags}>
+          <Dashboard
+            project={mockProject}
+            dashboardName="kpi-row"
+            canvasMode
+            onEmptySlotClick={jest.fn()}
+          />
+        </BrowserRouter>
+      );
+      const names = screen
+        .getAllByTestId('canvas-empty-slot')
+        .map(el => el.getAttribute('aria-label'));
+      expect(names).toEqual([
+        'Empty slot — click to choose (row 1, item 1)',
+        'Empty slot — click to choose (row 1, item 2)',
+        'Empty slot — click to choose (row 1, item 3)',
+      ]);
+      expect(new Set(names).size).toBe(names.length);
+    });
+  });
+
+  describe('describeSlotPath', () => {
+    it('reads a composite canvas path as a 1-indexed human location', () => {
+      expect(describeSlotPath('row.0.item.2')).toBe('row 1, item 3');
+      expect(describeSlotPath('row.1.item.0.row.0.item.1')).toBe(
+        'row 2, item 1, row 1, item 2'
+      );
+    });
+
+    it('returns empty string for an absent or unparseable path', () => {
+      expect(describeSlotPath('')).toBe('');
+      expect(describeSlotPath(undefined)).toBe('');
+      expect(describeSlotPath('row.x.item.0')).toBe('');
+      expect(describeSlotPath('column.0')).toBe('');
     });
   });
 

--- a/viewer/src/components/project/Dashboard.test.jsx
+++ b/viewer/src/components/project/Dashboard.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { futureFlags } from '../../router-config';
 import Dashboard from './Dashboard';
@@ -297,6 +297,23 @@ describe('Dashboard', () => {
     it('renders nothing for an empty slot in View mode (parity preserved)', () => {
       renderEmptySlot();
       expect(screen.queryByTestId('canvas-empty-slot')).not.toBeInTheDocument();
+    });
+
+    // ---------- W5 click-to-pick: the empty slot becomes clickable ----------
+    it('renders the empty slot as a real button when onEmptySlotClick is provided', () => {
+      const onEmptySlotClick = jest.fn();
+      renderEmptySlot({ canvasMode: true, onEmptySlotClick });
+      const slot = screen.getByTestId('canvas-empty-slot');
+      // A BUTTON — focusable, so the picker path is keyboard-completable.
+      expect(slot.tagName).toBe('BUTTON');
+      fireEvent.click(slot);
+      expect(onEmptySlotClick).toHaveBeenCalledTimes(1);
+      expect(onEmptySlotClick).toHaveBeenCalledWith({ itemPath: 'row.0.item.0' });
+    });
+
+    it('keeps the inert placeholder div when onEmptySlotClick is absent', () => {
+      renderEmptySlot({ canvasMode: true });
+      expect(screen.getByTestId('canvas-empty-slot').tagName).toBe('DIV');
     });
   });
 

--- a/viewer/src/components/views/common/ItemEditForm.jsx
+++ b/viewer/src/components/views/common/ItemEditForm.jsx
@@ -3,6 +3,7 @@ import RefDropZone from './RefDropZone';
 import ReferencePicker from '../project/canvas/ReferencePicker';
 import useStore from '../../../stores/store';
 import { emitWorkspaceEvent } from '../workspace/telemetry';
+import { isReadOnly } from '../../../stores/branchingStore';
 import { mintWrapperChartName, buildWrapperChartConfig } from '../../../utils/insightWrap';
 import { parseRefValue } from '../../../utils/refString';
 import {
@@ -55,6 +56,28 @@ export const getItemLeafRef = item => {
 
 /** True when the item is acting as a row-container (`Item.rows` is set). */
 export const isContainerItem = item => Array.isArray(item?.rows);
+
+/**
+ * Place `name` into the item's `type` leaf and PROVE the slot now points at
+ * exactly that name.
+ *
+ * The truthiness check this replaced (`!next[type]`) could not fail for any
+ * name the picker emits, so the "#637 rejected placement → mint nothing"
+ * ordering had no teeth on this path. `setItemLeaf` NORMALISES the name — it
+ * trims it, and drops it entirely when the trim leaves nothing — so what the
+ * slot ends up referencing is not always the name the caller holds. Reading
+ * the placed ref back is the postcondition that actually enforces the
+ * invariant: the insight branch must never `saveChart` under a name the slot
+ * does not point at, which is precisely an orphan draft chart plus a broken
+ * ref in the slot.
+ *
+ * @returns the next item when the slot references `name` exactly, else null.
+ */
+const placeLeafRef = (item, type, name) => {
+  const next = applyLeafRef(item, { type, name });
+  if (!next || parseRefValue(next[type]) !== name) return null;
+  return next;
+};
 
 /**
  * ItemEditForm — VIS-787 / Track F F-2.
@@ -111,20 +134,32 @@ export const isContainerItem = item => Array.isArray(item?.rows);
  * only then save the wrapper chart — a rejected placement must never leave an
  * orphan draft chart. The item change flows through `onChange` into the
  * dashboard working copy (#617 — the explicit Save footer persists it).
+ *
+ * READ-ONLY (VIS-1025): `saveChart` is the ONE external side effect this form
+ * fires outside `onChange`, so it is the one write the rail's `persistConfig`
+ * hold cannot cover — on a read-only stage `persistConfig` discards the
+ * placement AFTER the wrapper chart has already been POSTed, which is exactly
+ * the orphan draft chart #637 forbids. The affordance is therefore disabled
+ * (and the select handler held) whenever the stage is read-only.
  */
 const LeafChooseControl = ({ item, itemId, onChange }) => {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const readOnly = useStore(isReadOnly);
 
   const handlePickerSelect = (pickedName, pickedType) => {
     setPickerOpen(false);
     if (!pickedName || !pickedType) return;
+    // Belt-and-braces for a stage that flips read-only while the picker is
+    // open: the trigger disables on the next render, but the mounted picker's
+    // rows are still live, and a pick here would mint against a held write.
+    if (readOnly) return;
 
     if (pickedType === 'insight') {
       const state = useStore.getState();
       const existingCharts = (state.charts || []).map(chart => chart.name);
       const chartName = mintWrapperChartName(pickedName, existingCharts);
-      const next = applyLeafRef(item, { type: 'chart', name: chartName });
-      if (!next || !next.chart) return; // rejected placement → mint nothing
+      const next = placeLeafRef(item, 'chart', chartName);
+      if (!next) return; // rejected placement → mint nothing
       if (typeof state.saveChart === 'function') {
         state.saveChart(chartName, buildWrapperChartConfig(pickedName));
       }
@@ -140,8 +175,8 @@ const LeafChooseControl = ({ item, itemId, onChange }) => {
       return;
     }
 
-    const next = applyLeafRef(item, { type: pickedType, name: pickedName });
-    if (!next || !next[pickedType]) return;
+    const next = placeLeafRef(item, pickedType, pickedName);
+    if (!next) return;
     onChange(next);
     emitWorkspaceEvent('canvas_action', {
       kind: 'add_item',
@@ -152,13 +187,29 @@ const LeafChooseControl = ({ item, itemId, onChange }) => {
     });
   };
 
+  // Create-new from the picker's empty state / footer. Without it a project
+  // with no charts AND no insights opens a dead-end modal whose own copy
+  // ("Create a chart to fill this slot") promises an action it cannot perform
+  // — the canvas path passes one, so the two "same picker" surfaces must too.
+  const handleCreateNew = typeKey => {
+    setPickerOpen(false);
+    if (readOnly) return;
+    emitWorkspaceEvent('inline_create_used', { source: 'picker', kind: typeKey });
+    const openCreateChartModal = useStore.getState().openCreateChartModal;
+    if (typeKey === 'chart' && typeof openCreateChartModal === 'function') {
+      openCreateChartModal();
+    }
+  };
+
   return (
     <>
       <button
         type="button"
         data-testid={`item-${itemId}-choose`}
         onClick={() => setPickerOpen(true)}
-        className="inline-flex items-center gap-1 text-xs font-medium text-primary-600 transition-colors hover:text-primary-700"
+        disabled={readOnly}
+        title={readOnly ? 'Read-only — create a draft to edit' : undefined}
+        className="inline-flex items-center gap-1 text-xs font-medium text-primary-600 transition-colors hover:text-primary-700 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:text-gray-400"
       >
         Choose…
       </button>
@@ -167,6 +218,7 @@ const LeafChooseControl = ({ item, itemId, onChange }) => {
           types={['chart', 'insight']}
           onSelect={handlePickerSelect}
           onClose={() => setPickerOpen(false)}
+          onCreateNew={handleCreateNew}
         />
       )}
     </>

--- a/viewer/src/components/views/common/ItemEditForm.jsx
+++ b/viewer/src/components/views/common/ItemEditForm.jsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import RefDropZone from './RefDropZone';
+import ReferencePicker from '../project/canvas/ReferencePicker';
+import useStore from '../../../stores/store';
+import { emitWorkspaceEvent } from '../workspace/telemetry';
+import { mintWrapperChartName, buildWrapperChartConfig } from '../../../utils/insightWrap';
 import { parseRefValue } from '../../../utils/refString';
 import {
   LEAF_REF_FIELDS,
@@ -92,6 +96,83 @@ export const isContainerItem = item => Array.isArray(item?.rows);
  *                                `row-<rowId>-item-<idx>` id so existing
  *                                bundled behavior stays byte-identical.
  */
+/**
+ * LeafChooseControl — the W5 click-to-pick affordance for an EMPTY leaf slot:
+ * a "Choose…" button that opens the same <ReferencePicker> the canvas
+ * empty-slot click uses (charts + insights), so drag-and-drop is never the
+ * only way to fill a slot from the right rail.
+ *
+ * A separate component (mounted only for empty leaves) so <ItemEditForm>
+ * itself stays hook-free — its picker state lives here.
+ *
+ * A pick lands the SAME way a canvas pick does. A chart pick sets the item's
+ * `chart` leaf. An insight pick AUTO-WRAPS (#637 pattern): mint the unique
+ * `<insight>-chart` name (pure), validate the placement transform FIRST, and
+ * only then save the wrapper chart — a rejected placement must never leave an
+ * orphan draft chart. The item change flows through `onChange` into the
+ * dashboard working copy (#617 — the explicit Save footer persists it).
+ */
+const LeafChooseControl = ({ item, itemId, onChange }) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const handlePickerSelect = (pickedName, pickedType) => {
+    setPickerOpen(false);
+    if (!pickedName || !pickedType) return;
+
+    if (pickedType === 'insight') {
+      const state = useStore.getState();
+      const existingCharts = (state.charts || []).map(chart => chart.name);
+      const chartName = mintWrapperChartName(pickedName, existingCharts);
+      const next = applyLeafRef(item, { type: 'chart', name: chartName });
+      if (!next || !next.chart) return; // rejected placement → mint nothing
+      if (typeof state.saveChart === 'function') {
+        state.saveChart(chartName, buildWrapperChartConfig(pickedName));
+      }
+      onChange(next);
+      emitWorkspaceEvent('canvas_action', {
+        kind: 'add_item',
+        source: 'picker',
+        type: 'insight',
+        name: pickedName,
+        wrapped_chart: chartName,
+        itemId,
+      });
+      return;
+    }
+
+    const next = applyLeafRef(item, { type: pickedType, name: pickedName });
+    if (!next || !next[pickedType]) return;
+    onChange(next);
+    emitWorkspaceEvent('canvas_action', {
+      kind: 'add_item',
+      source: 'picker',
+      type: pickedType,
+      name: pickedName,
+      itemId,
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid={`item-${itemId}-choose`}
+        onClick={() => setPickerOpen(true)}
+        className="inline-flex items-center gap-1 text-xs font-medium text-primary-600 transition-colors hover:text-primary-700"
+      >
+        Choose…
+      </button>
+      {pickerOpen && (
+        <ReferencePicker
+          types={['chart', 'insight']}
+          onSelect={handlePickerSelect}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
 const ItemEditForm = ({
   item,
   itemId,
@@ -287,15 +368,20 @@ const ItemEditForm = ({
           </button>
         </div>
       ) : (
-        <RefDropZone
-          id={resolvedLeafDropZoneId}
-          allowedTypes={ALLOWED_LEAF_TYPES}
-          value={leafRef}
-          onClear={() => handleLeafRefChange(null)}
-          onChange={ref => handleLeafRefChange(ref)}
-          onSelectRef={onSelectRef}
-          hint="Drop a chart, table, markdown, or input"
-        />
+        <div className="space-y-1.5">
+          <RefDropZone
+            id={resolvedLeafDropZoneId}
+            allowedTypes={ALLOWED_LEAF_TYPES}
+            value={leafRef}
+            onClear={() => handleLeafRefChange(null)}
+            onChange={ref => handleLeafRefChange(ref)}
+            onSelectRef={onSelectRef}
+            hint="Drop a chart, table, markdown, or input"
+          />
+          {/* W5 click-to-pick: click alternative to the drop zone, empty leaf
+              only (a filled slot shows its pill; clear it first to re-pick). */}
+          {!leafRef && <LeafChooseControl item={item} itemId={itemId} onChange={onChange} />}
+        </div>
       )}
     </div>
   );

--- a/viewer/src/components/views/common/ItemEditForm.test.jsx
+++ b/viewer/src/components/views/common/ItemEditForm.test.jsx
@@ -9,6 +9,8 @@ import ItemEditForm, {
   ALLOWED_LEAF_TYPES,
 } from './ItemEditForm';
 import RowEditForm from './RowEditForm';
+import useStore from '../../../stores/store';
+import { setWorkspaceTelemetryListener } from '../workspace/telemetry';
 
 const leafItem = { width: 2, chart: 'ref(rev_chart)', table: '', markdown: '', selector: '', input: '' };
 const emptyItem = { width: 1, chart: '', table: '', markdown: '', selector: '', input: '' };
@@ -374,5 +376,116 @@ describe('ItemEditForm — render-safe with no DndContext ancestor', () => {
       )
     ).not.toThrow();
     expect(screen.getByText('rev_chart')).toBeInTheDocument();
+  });
+});
+
+describe('ItemEditForm — right-rail "Choose…" click-to-pick (W5)', () => {
+  let events;
+
+  beforeEach(() => {
+    events = [];
+    setWorkspaceTelemetryListener(e => events.push(e));
+    useStore.setState({
+      charts: [{ name: 'revenue_chart' }],
+      tables: [],
+      markdowns: [],
+      inputs: [],
+      insights: [{ name: 'rev-insight' }],
+      saveChart: jest.fn().mockResolvedValue({ success: true }),
+    });
+  });
+
+  afterEach(() => {
+    setWorkspaceTelemetryListener(null);
+  });
+
+  const openPicker = () => {
+    fireEvent.click(screen.getByTestId('item-row-0-item-0-choose'));
+    return screen.getByTestId('reference-picker');
+  };
+
+  test('an EMPTY leaf renders the Choose… affordance; a filled leaf does not', () => {
+    renderItem({ item: emptyItem });
+    expect(screen.getByTestId('item-row-0-item-0-choose')).toBeInTheDocument();
+
+    cleanup();
+    renderItem({ item: leafItem });
+    expect(screen.queryByTestId('item-row-0-item-0-choose')).not.toBeInTheDocument();
+  });
+
+  test('Choose… opens the ReferencePicker listing charts AND insights', () => {
+    renderItem({ item: emptyItem });
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+    openPicker();
+    expect(screen.getByTestId('reference-picker-title')).toHaveTextContent(
+      'Pick a chart or insight'
+    );
+    expect(screen.getByTestId('reference-picker-row-revenue_chart')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-row-rev-insight')).toBeInTheDocument();
+  });
+
+  test('picking a CHART reports the item with the chart leaf set (working copy, #617)', () => {
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-revenue_chart'));
+
+    // Born-valid item: exactly one leaf key, serialized ${ref()} form.
+    expect(onChange).toHaveBeenCalledWith({ width: 1, chart: '${ref(revenue_chart)}' });
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+
+    const evt = events.find(e => e.eventName === 'canvas_action');
+    expect(evt.payload).toMatchObject({
+      kind: 'add_item',
+      source: 'picker',
+      type: 'chart',
+      name: 'revenue_chart',
+    });
+    expect(evt.payload.wrapped_chart).toBeUndefined();
+  });
+
+  test('picking an INSIGHT auto-wraps: saves <insight>-chart and points the item at it (#637)', () => {
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+    expect(useStore.getState().saveChart).toHaveBeenCalledWith('rev-insight-chart', {
+      insights: ['ref(rev-insight)'],
+    });
+    expect(onChange).toHaveBeenCalledWith({ width: 1, chart: '${ref(rev-insight-chart)}' });
+
+    const evt = events.find(e => e.eventName === 'canvas_action');
+    expect(evt.payload).toMatchObject({
+      kind: 'add_item',
+      source: 'picker',
+      type: 'insight',
+      name: 'rev-insight',
+      wrapped_chart: 'rev-insight-chart',
+    });
+  });
+
+  test('the minted wrapper name disambiguates with -2 against existing charts', () => {
+    useStore.setState({ charts: [{ name: 'revenue_chart' }, { name: 'rev-insight-chart' }] });
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+    expect(useStore.getState().saveChart).toHaveBeenCalledWith('rev-insight-chart-2', {
+      insights: ['ref(rev-insight)'],
+    });
+    expect(onChange).toHaveBeenCalledWith({ width: 1, chart: '${ref(rev-insight-chart-2)}' });
+  });
+
+  test('closing the picker changes nothing and mints nothing', () => {
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-close'));
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
   });
 });

--- a/viewer/src/components/views/common/ItemEditForm.test.jsx
+++ b/viewer/src/components/views/common/ItemEditForm.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string -- assertions use literal Visivo `${ref(...)}` strings */
 import React from 'react';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 import { DndContext } from '@dnd-kit/core';
 import ItemEditForm, {
@@ -392,6 +392,10 @@ describe('ItemEditForm — right-rail "Choose…" click-to-pick (W5)', () => {
       inputs: [],
       insights: [{ name: 'rev-insight' }],
       saveChart: jest.fn().mockResolvedValue({ success: true }),
+      openCreateChartModal: jest.fn(),
+      // VIS-1025: null = local serve (always editable). Set explicitly so a
+      // read-only case can't leak into the neighbouring tests.
+      capabilities: null,
     });
   });
 
@@ -487,5 +491,102 @@ describe('ItemEditForm — right-rail "Choose…" click-to-pick (W5)', () => {
     expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
     expect(onChange).not.toHaveBeenCalled();
     expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+  });
+
+  // ── #637: a REJECTED placement must mint NOTHING ──────────────────────────
+  // `setItemLeaf` normalises the picked name (it trims it, and drops a name
+  // that trims to nothing), so the slot does not always end up referencing the
+  // name the handler holds. Wherever it doesn't, saving a wrapper chart under
+  // that name would leave an orphan draft chart pointed at by nothing — the
+  // exact failure the #637 ordering exists to prevent.
+  test('an insight whose wrapper name the transform rewrites mints NOTHING', () => {
+    // `' rev'` → wrapper name `' rev-chart'`, which `setItemLeaf` TRIMS to
+    // `rev-chart`: the slot would reference a DIFFERENT chart than the one
+    // saveChart creates — an orphan draft plus a broken ref.
+    useStore.setState({ insights: [{ name: ' rev' }] });
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'rev' }));
+
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(events.filter(e => e.eventName === 'canvas_action')).toHaveLength(0);
+  });
+
+  test('a chart whose name the transform drops places NOTHING', () => {
+    useStore.setState({ charts: [{ name: ' orphan' }], insights: [] });
+    const onChange = jest.fn();
+    renderItem({ item: emptyItem, onChange });
+    openPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'orphan' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(events.filter(e => e.eventName === 'canvas_action')).toHaveLength(0);
+  });
+
+  // ── VIS-1025: read-only holds the ONE write that bypasses persistConfig ────
+  // `saveChart` is fired straight at the store, so the rail's persistConfig
+  // read-only hold cannot cover it: without this gate a read-only stage POSTs
+  // a wrapper chart and THEN discards the placement — an orphan draft chart on
+  // a project the user is not allowed to edit.
+  describe('read-only stage (capabilities.can_edit === false)', () => {
+    beforeEach(() => {
+      useStore.setState({ capabilities: { can_edit: false, edit_action: 'Create a draft to edit' } });
+    });
+
+    test('the Choose… trigger is disabled and cannot open the picker', () => {
+      renderItem({ item: emptyItem });
+      const choose = screen.getByTestId('item-row-0-item-0-choose');
+      expect(choose).toBeDisabled();
+      fireEvent.click(choose);
+      expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+      expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+    });
+
+    test('a stage that flips read-only while the picker is OPEN holds the pick', () => {
+      useStore.setState({ capabilities: null });
+      const onChange = jest.fn();
+      renderItem({ item: emptyItem, onChange });
+      openPicker();
+
+      // Capabilities flip mid-flow (e.g. the draft was published from another
+      // tab). The mounted picker's rows are still live.
+      act(() => {
+        useStore.setState({ capabilities: { can_edit: false } });
+      });
+      fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+      expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(events.filter(e => e.eventName === 'canvas_action')).toHaveLength(0);
+    });
+  });
+
+  // ── The rail and the canvas mount the SAME picker ─────────────────────────
+  // ProjectCanvas passes `onCreateNew`; without it the picker's own empty
+  // state renders "Create a chart to fill this slot" with nothing to click,
+  // so an empty project's Choose… is a dead-end modal.
+  test('an EMPTY project offers create-new from the picker (parity with the canvas)', () => {
+    useStore.setState({ charts: [], insights: [] });
+    renderItem({ item: emptyItem });
+    openPicker();
+
+    expect(screen.getByTestId('reference-picker-empty')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('reference-picker-empty-create'));
+
+    expect(useStore.getState().openCreateChartModal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+    expect(events.find(e => e.eventName === 'inline_create_used').payload).toEqual({
+      source: 'picker',
+      kind: 'chart',
+    });
+  });
+
+  test('the picker footer create link is available whenever objects exist', () => {
+    renderItem({ item: emptyItem });
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-create'));
+    expect(useStore.getState().openCreateChartModal).toHaveBeenCalledTimes(1);
   });
 });

--- a/viewer/src/components/views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/views/project/canvas/ProjectCanvas.jsx
@@ -1,10 +1,12 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Dashboard from '../../../project/Dashboard';
 import useStore from '../../../../stores/store';
 import { useWorkspaceCommit } from '../../workspace/WorkspaceDndContext';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { mintWrapperChartName, buildWrapperChartConfig } from '../../../../utils/insightWrap';
 import { setItemRef, removeItemAtPath } from './canvasReorder';
 import BrokenRefCard from './BrokenRefCard';
+import ReferencePicker from './ReferencePicker';
 import CanvasSelectionOverlay from './CanvasSelectionOverlay';
 import CanvasDndLayer from './CanvasDndLayer';
 import CanvasResizeLayer from './CanvasResizeLayer';
@@ -66,8 +68,8 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
   }, [dashboards, dashboardName]);
 
   const handleCreateNew = useCallback(
-    typeKey => {
-      emitWorkspaceEvent('inline_create_used', { source: 'broken_ref', kind: typeKey });
+    (typeKey, source = 'broken_ref') => {
+      emitWorkspaceEvent('inline_create_used', { source, kind: typeKey });
       switch (typeKey) {
         case 'chart':
           if (openCreateChartModal) openCreateChartModal();
@@ -86,6 +88,75 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
       }
     },
     [openCreateChartModal, openCreateTableModal, openCreateMarkdownModal, openCreateInputModal]
+  );
+
+  // ── Click-to-pick (W5 / Track L) ──────────────────────────────────────────
+  // Clicking an EMPTY canvas slot opens the ReferencePicker for that slot
+  // (charts + insights). Picking a chart places `chart: ref(name)`; picking an
+  // insight AUTO-WRAPS it (#637 pattern): the placement is validated FIRST,
+  // and only when the slot actually re-points does the minted wrapper chart get
+  // saved — a rejected placement must never leave an orphan draft chart. The
+  // placement commits into the dashboard's #617 working copy (explicit Save
+  // persists it), exactly like every other canvas mutation.
+  const [pickerItemPath, setPickerItemPath] = useState(null);
+
+  const handleEmptySlotClick = useCallback(({ itemPath }) => {
+    if (itemPath) setPickerItemPath(itemPath);
+  }, []);
+
+  const handlePickerSelect = useCallback(
+    (pickedName, pickedType) => {
+      const itemPath = pickerItemPath;
+      setPickerItemPath(null);
+      if (!itemPath || !pickedName || !dashboardConfig) return;
+      if (typeof commitCanvasConfig !== 'function') return;
+
+      if (pickedType === 'insight') {
+        // Auto-wrap: same naming + save path as Library "Wrap in Chart…"
+        // (#632) and the canvas insight drop (#637). Minting the NAME is pure;
+        // the chart is only SAVED after the placement transform succeeds.
+        const state = useStore.getState();
+        const existingCharts = (state.charts || []).map(chart => chart.name);
+        const chartName = mintWrapperChartName(pickedName, existingCharts);
+        const next = setItemRef(dashboardConfig, itemPath, 'chart', chartName);
+        if (next === dashboardConfig) return; // rejected placement → mint nothing
+        if (typeof state.saveChart === 'function') {
+          state.saveChart(chartName, buildWrapperChartConfig(pickedName));
+        }
+        commitCanvasConfig(dashboardName, next, { kind: 'picker_insert' });
+        emitWorkspaceEvent('canvas_action', {
+          kind: 'add_item',
+          source: 'picker',
+          type: 'insight',
+          name: pickedName,
+          wrapped_chart: chartName,
+          dashboardName,
+          path: itemPath,
+        });
+        return;
+      }
+
+      const next = setItemRef(dashboardConfig, itemPath, pickedType, pickedName);
+      if (next === dashboardConfig) return;
+      commitCanvasConfig(dashboardName, next, { kind: 'picker_insert' });
+      emitWorkspaceEvent('canvas_action', {
+        kind: 'add_item',
+        source: 'picker',
+        type: pickedType,
+        name: pickedName,
+        dashboardName,
+        path: itemPath,
+      });
+    },
+    [pickerItemPath, dashboardConfig, commitCanvasConfig, dashboardName]
+  );
+
+  const handlePickerCreateNew = useCallback(
+    typeKey => {
+      setPickerItemPath(null);
+      handleCreateNew(typeKey, 'picker');
+    },
+    [handleCreateNew]
   );
 
   const renderBrokenRef = useCallback(
@@ -136,7 +207,18 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
         hideEmptyPlaceholder
         canvasMode
         renderBrokenRef={renderBrokenRef}
+        onEmptySlotClick={handleEmptySlotClick}
       />
+      {/* W5 click-to-pick: the ReferencePicker for the clicked empty slot.
+          Charts place directly; insights auto-wrap (#637). */}
+      {pickerItemPath && (
+        <ReferencePicker
+          types={['chart', 'insight']}
+          onSelect={handlePickerSelect}
+          onClose={() => setPickerItemPath(null)}
+          onCreateNew={handlePickerCreateNew}
+        />
+      )}
       <CanvasSelectionOverlay rootRef={rootRef} />
       {/* VIS-771 / D-3: drag-and-drop affordance layer (drag handles + drop
           zones). A SIBLING over the render, wired to the shell's shared

--- a/viewer/src/components/views/project/canvas/ProjectCanvas.test.jsx
+++ b/viewer/src/components/views/project/canvas/ProjectCanvas.test.jsx
@@ -28,9 +28,13 @@ const renderWithRouter = ui =>
 // prop with these args — exactly what the real renderer does for a leaf whose
 // ref doesn't resolve (VIS-792 / L-1).
 let mockBrokenRefArgs = null;
+// When set, the Dashboard mock renders a stand-in empty slot whose click calls
+// the canvas's `onEmptySlotClick` with this itemPath — exactly what the real
+// renderer's empty-slot button does (W5 click-to-pick).
+let mockEmptySlotPath = null;
 
 jest.mock('../../../project/Dashboard', () => {
-  const Mock = ({ projectId, dashboardName, renderBrokenRef }) => (
+  const Mock = ({ projectId, dashboardName, renderBrokenRef, onEmptySlotClick }) => (
     <div
       data-testid="dashboard-new-mock"
       data-project-id={projectId}
@@ -39,6 +43,12 @@ jest.mock('../../../project/Dashboard', () => {
       {mockBrokenRefArgs && typeof renderBrokenRef === 'function'
         ? renderBrokenRef(mockBrokenRefArgs)
         : null}
+      {mockEmptySlotPath && typeof onEmptySlotClick === 'function' ? (
+        <button
+          data-testid="mock-empty-slot"
+          onClick={() => onEmptySlotClick({ itemPath: mockEmptySlotPath })}
+        />
+      ) : null}
     </div>
   );
   Mock.displayName = 'MockDashboard';
@@ -250,5 +260,178 @@ describe('ProjectCanvas — broken-ref repair wiring (VIS-792 / L-1)', () => {
     fireEvent.click(screen.getByTestId('mock-create-chart'));
     // No crash; the intent is still recorded.
     expect(events.find(e => e.eventName === 'inline_create_used')).toBeTruthy();
+  });
+});
+
+describe('ProjectCanvas — empty-slot click-to-pick (W5 / Track L)', () => {
+  // A dashboard whose row.0 carries a genuinely EMPTY third slot.
+  const SALES_WITH_EMPTY = {
+    name: 'sales',
+    config: {
+      rows: [
+        {
+          height: 'medium',
+          items: [
+            { width: 6, chart: 'ref(existing-chart)' },
+            { width: 5, table: 'ref(t)' },
+            { width: 1 }, // empty slot
+          ],
+        },
+      ],
+    },
+  };
+
+  let commit;
+  let events;
+
+  const renderCanvas = (dashboardName = 'sales') =>
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <WorkspaceCommitProvider value={commit}>
+          <ProjectCanvas projectId="proj-1" dashboardName={dashboardName} />
+        </WorkspaceCommitProvider>
+      </MemoryRouter>
+    );
+
+  const openPicker = () => {
+    fireEvent.click(screen.getByTestId('mock-empty-slot'));
+    return screen.getByTestId('reference-picker');
+  };
+
+  beforeEach(() => {
+    commit = jest.fn();
+    events = [];
+    setWorkspaceTelemetryListener(e => events.push(e));
+    mockEmptySlotPath = 'row.0.item.2';
+    useStore.setState({
+      dashboards: [SALES_WITH_EMPTY],
+      charts: [{ name: 'existing-chart' }],
+      tables: [],
+      markdowns: [],
+      inputs: [],
+      insights: [{ name: 'rev-insight' }],
+      saveChart: jest.fn().mockResolvedValue({ success: true }),
+      openCreateChartModal: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    mockEmptySlotPath = null;
+    setWorkspaceTelemetryListener(null);
+  });
+
+  test('clicking an empty slot opens the ReferencePicker listing charts AND insights', () => {
+    renderCanvas();
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+    openPicker();
+    expect(screen.getByTestId('reference-picker-title')).toHaveTextContent(
+      'Pick a chart or insight'
+    );
+    expect(screen.getByTestId('reference-picker-section-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-section-insight')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-row-existing-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-row-rev-insight')).toBeInTheDocument();
+  });
+
+  test('picking a CHART places chart: ref(name) into the slot via the working copy', () => {
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-existing-chart'));
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    const [name, nextConfig, meta] = commit.mock.calls[0];
+    expect(name).toBe('sales');
+    expect(meta).toEqual({ kind: 'picker_insert' });
+    expect(nextConfig.rows[0].items[2]).toEqual({ width: 1, chart: 'ref(existing-chart)' });
+    // Sibling slots untouched; no chart was minted for a plain chart pick.
+    expect(nextConfig.rows[0].items[0]).toEqual({ width: 6, chart: 'ref(existing-chart)' });
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+    // The picker closed on pick.
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+
+    const evt = events.find(e => e.eventName === 'canvas_action');
+    expect(evt.payload).toMatchObject({
+      kind: 'add_item',
+      source: 'picker',
+      type: 'chart',
+      name: 'existing-chart',
+      dashboardName: 'sales',
+      path: 'row.0.item.2',
+    });
+    expect(evt.payload.wrapped_chart).toBeUndefined();
+  });
+
+  test('picking an INSIGHT auto-wraps: mints <insight>-chart, saves it, places the wrapper (#637)', () => {
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    const [, nextConfig, meta] = commit.mock.calls[0];
+    expect(meta).toEqual({ kind: 'picker_insert' });
+    expect(nextConfig.rows[0].items[2]).toEqual({ width: 1, chart: 'ref(rev-insight-chart)' });
+    expect(nextConfig.rows[0].items[2].insight).toBeUndefined();
+    expect(useStore.getState().saveChart).toHaveBeenCalledWith('rev-insight-chart', {
+      insights: ['ref(rev-insight)'],
+    });
+
+    const evt = events.find(e => e.eventName === 'canvas_action');
+    expect(evt.payload).toMatchObject({
+      kind: 'add_item',
+      source: 'picker',
+      type: 'insight',
+      name: 'rev-insight',
+      wrapped_chart: 'rev-insight-chart',
+      dashboardName: 'sales',
+      path: 'row.0.item.2',
+    });
+  });
+
+  test('the minted wrapper name disambiguates with -2 against existing charts', () => {
+    useStore.setState({
+      charts: [{ name: 'existing-chart' }, { name: 'rev-insight-chart' }],
+    });
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+    const [, nextConfig] = commit.mock.calls[0];
+    expect(nextConfig.rows[0].items[2].chart).toBe('ref(rev-insight-chart-2)');
+    expect(useStore.getState().saveChart).toHaveBeenCalledWith('rev-insight-chart-2', {
+      insights: ['ref(rev-insight)'],
+    });
+  });
+
+  test('a REJECTED placement (invalid slot path) mints NOTHING — no commit, no orphan chart', () => {
+    mockEmptySlotPath = 'row.9.item.9';
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+
+    expect(commit).not.toHaveBeenCalled();
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+    expect(events.find(e => e.eventName === 'canvas_action')).toBeUndefined();
+  });
+
+  test('closing the picker commits nothing', () => {
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-close'));
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
+    expect(commit).not.toHaveBeenCalled();
+    expect(useStore.getState().saveChart).not.toHaveBeenCalled();
+  });
+
+  test('Create-new from the picker routes to the chart create modal with source picker', () => {
+    renderCanvas();
+    openPicker();
+    fireEvent.click(screen.getByTestId('reference-picker-create'));
+    expect(useStore.getState().openCreateChartModal).toHaveBeenCalledTimes(1);
+    expect(events.find(e => e.eventName === 'inline_create_used')?.payload).toEqual({
+      source: 'picker',
+      kind: 'chart',
+    });
+    // The picker closed so the create modal isn't stacked under it.
+    expect(screen.queryByTestId('reference-picker')).not.toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/project/canvas/ReferencePicker.jsx
+++ b/viewer/src/components/views/project/canvas/ReferencePicker.jsx
@@ -5,35 +5,47 @@ import useStore from '../../../../stores/store';
 import { getTypeIcon, getTypeColors, getTypeByValue } from '../../common/objectTypeConfigs';
 
 /**
- * ReferencePicker — VIS-792 / Track L L-2.
+ * ReferencePicker — VIS-792 / Track L L-2, promoted by W5 (click-to-pick).
  *
- * Modal that lets a user pick a replacement reference for a broken canvas slot
- * (a slot whose chart/table/markdown/input ref no longer resolves). Triggered by
- * the <BrokenRefCard> "Fix..." button.
+ * Modal that lets a user pick an object reference for a canvas slot. Two
+ * consumers:
+ *
+ *   - <BrokenRefCard>'s "Fix…" (the original L-2 flow) — single `type` mode:
+ *     the picker is scoped to the broken leaf's type (chart/table/markdown/
+ *     input) and picking re-points the leaf.
+ *   - Click-to-pick (W5): an EMPTY canvas slot click, or the right rail's
+ *     "Choose…" on an empty item — multi-`types` mode (charts + insights in
+ *     typed sections). Picking a chart places it; picking an insight
+ *     auto-wraps it in a minted chart (#637 pattern) at the call site.
  *
  * Per the L-2 brief (`specs/.../06-phase-5-polish.md`):
  *   - Centered modal (~480×640, responsive).
- *   - Header "Pick a chart" (matching the broken field type) + close (X).
- *   - Search input filters the list of available objects of the expected type.
+ *   - Header "Pick a chart" (matching the field type(s)) + close (X).
+ *   - Search input filters the list of available objects.
  *   - Scrollable object list — each row: type icon (objectTypeConfigs), name,
  *     small description (e.g. a chart's underlying insight), click-to-select.
  *   - "Create new…" link → the existing <CreateButton> flow (via `onCreateNew`).
- *   - Empty state — no objects of the type exist → prominent create CTA.
+ *   - Empty state — no objects of the type(s) exist → prominent create CTA.
  *
  * Click-to-select is the single selection affordance (no separate "Use this"
  * button), per the acceptance checklist's "pick one and stick with it".
+ * `onSelect(name, type)` — the second argument tells multi-type consumers
+ * WHICH section the pick came from; single-type consumers may ignore it.
  *
  * The store object lists are the single source for available objects; type
  * icons + colours come from the shared objectTypeConfigs palette.
  */
 
-// Map a leaf field (chart/table/markdown/input) to the store list + getter that
-// supply that type's available objects. The picker is leaf-type-scoped.
+// Map a pickable type to the store list that supplies that type's available
+// objects. `insight` joins the leaf types for the click-to-pick multi mode
+// (an insight pick is auto-wrapped in a chart by the consumer — items never
+// take a bare insight).
 const TYPE_SLICES = {
   chart: { listKey: 'charts', singular: 'chart' },
   table: { listKey: 'tables', singular: 'table' },
   markdown: { listKey: 'markdowns', singular: 'markdown' },
   input: { listKey: 'inputs', singular: 'input' },
+  insight: { listKey: 'insights', singular: 'insight' },
 };
 
 // A short, type-appropriate description line for an object row.
@@ -60,7 +72,8 @@ const ObjectRow = ({ type, obj, onSelect }) => {
     <button
       type="button"
       data-testid={`reference-picker-row-${obj.name}`}
-      onClick={() => onSelect(obj.name)}
+      data-picker-type={type}
+      onClick={() => onSelect(obj.name, type)}
       className="flex w-full items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left transition-colors hover:border-primary-200 hover:bg-primary-50 focus:border-primary-300 focus:bg-primary-50 focus:outline-none"
     >
       <span
@@ -82,6 +95,25 @@ const ObjectRow = ({ type, obj, onSelect }) => {
   );
 };
 
+// Typed section header for the multi-type mode — objectTypeConfigs colours +
+// icon, so a "Charts" band and an "Insights" band read in each type's palette.
+const SectionHeader = ({ type }) => {
+  const Icon = getTypeIcon(type);
+  const colors = getTypeColors(type);
+  const meta = getTypeByValue(type);
+  return (
+    <div
+      className="flex items-center gap-1.5 px-3 pb-1 pt-2"
+      data-testid={`reference-picker-section-${type}`}
+    >
+      <Icon style={{ fontSize: 14 }} className={colors.text} aria-hidden="true" />
+      <span className={`text-[11px] font-semibold uppercase tracking-wide ${colors.text}`}>
+        {meta?.label || type}
+      </span>
+    </div>
+  );
+};
+
 const ListSkeleton = () => (
   <div className="space-y-2" data-testid="reference-picker-skeleton" aria-hidden="true">
     {[0, 1, 2, 3, 4].map(i => (
@@ -96,12 +128,45 @@ const ListSkeleton = () => (
   </div>
 );
 
-const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false }) => {
-  const slice = TYPE_SLICES[type] || TYPE_SLICES.chart;
-  const rawObjects = useStore(s => s[slice.listKey]);
-  const objects = useMemo(() => rawObjects || [], [rawObjects]);
-  const typeMeta = getTypeByValue(type);
-  const singularLabel = typeMeta?.singularLabel || slice.singular;
+const ReferencePicker = ({ type, types, onSelect, onClose, onCreateNew, loading = false }) => {
+  // Normalise to an ordered list of pickable types: `types` (multi mode) wins,
+  // else the single `type` (BrokenRefCard's original contract), else chart.
+  const typeList = useMemo(() => {
+    const requested = Array.isArray(types) && types.length > 0 ? types : [type || 'chart'];
+    const valid = requested.filter(t => TYPE_SLICES[t]);
+    return valid.length > 0 ? valid : ['chart'];
+  }, [type, types]);
+  const isMulti = typeList.length > 1;
+
+  // Hook-order-stable store reads: every slice is subscribed unconditionally,
+  // then `typeList` picks the ones this mount actually lists.
+  const charts = useStore(s => s.charts);
+  const tables = useStore(s => s.tables);
+  const markdowns = useStore(s => s.markdowns);
+  const inputs = useStore(s => s.inputs);
+  const insights = useStore(s => s.insights);
+  const listsByType = useMemo(
+    () => ({
+      chart: charts || [],
+      table: tables || [],
+      markdown: markdowns || [],
+      input: inputs || [],
+      insight: insights || [],
+    }),
+    [charts, tables, markdowns, inputs, insights]
+  );
+
+  const singularLabels = typeList.map(
+    t => getTypeByValue(t)?.singularLabel?.toLowerCase() || TYPE_SLICES[t].singular
+  );
+  const listKeys = typeList.map(t => TYPE_SLICES[t].listKey);
+  const titleLabel = singularLabels.join(' or ');
+  const listLabel = listKeys.join(isMulti ? ' and ' : '');
+  // Create-new targets the primary (first) type — for click-to-pick that is
+  // the chart, whose create flow exists everywhere the picker mounts.
+  const createType = typeList[0];
+  const createLabel =
+    getTypeByValue(createType)?.singularLabel?.toLowerCase() || TYPE_SLICES[createType].singular;
 
   const [query, setQuery] = useState('');
   const dialogRef = useRef(null);
@@ -120,15 +185,20 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  const filtered = useMemo(() => {
+  // Per-type sections: total (unfiltered) + the query-filtered rows.
+  const sections = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const list = objects.filter(o => o && o.name);
-    if (!q) return list;
-    return list.filter(o => o.name.toLowerCase().includes(q));
-  }, [objects, query]);
+    return typeList.map(t => {
+      const list = (listsByType[t] || []).filter(o => o && o.name);
+      const filtered = q ? list.filter(o => o.name.toLowerCase().includes(q)) : list;
+      return { type: t, total: list.length, objects: filtered };
+    });
+  }, [typeList, listsByType, query]);
 
-  const isEmpty = !loading && objects.length === 0;
-  const noMatches = !loading && objects.length > 0 && filtered.length === 0;
+  const totalCount = sections.reduce((sum, s) => sum + s.total, 0);
+  const filteredCount = sections.reduce((sum, s) => sum + s.objects.length, 0);
+  const isEmpty = !loading && totalCount === 0;
+  const noMatches = !loading && totalCount > 0 && filteredCount === 0;
 
   return createPortal(
     <div
@@ -143,7 +213,7 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label={`Pick a ${singularLabel.toLowerCase()}`}
+        aria-label={`Pick a ${titleLabel}`}
         data-testid="reference-picker"
         className="flex max-h-[640px] w-full max-w-[480px] flex-col overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-gray-200"
         style={{ height: 'min(640px, 90vh)' }}
@@ -154,7 +224,7 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
             data-testid="reference-picker-title"
             className="flex-1 text-base font-semibold text-gray-900"
           >
-            Pick a {singularLabel.toLowerCase()}
+            Pick a {titleLabel}
           </h2>
           <button
             type="button"
@@ -176,9 +246,9 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
               type="text"
               value={query}
               onChange={e => setQuery(e.target.value)}
-              placeholder={`Search ${slice.listKey}…`}
+              placeholder={`Search ${listLabel}…`}
               spellCheck={false}
-              aria-label={`Search available ${slice.listKey}`}
+              aria-label={`Search available ${listLabel}`}
               data-testid="reference-picker-search"
               className="min-w-0 flex-1 bg-transparent text-sm text-gray-800 placeholder-gray-400 outline-none"
             />
@@ -200,30 +270,30 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
               <span
                 className={[
                   'mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full border',
-                  getTypeColors(type).node,
-                  getTypeColors(type).text,
+                  getTypeColors(createType).node,
+                  getTypeColors(createType).text,
                 ].join(' ')}
               >
                 {(() => {
-                  const Icon = getTypeIcon(type);
+                  const Icon = getTypeIcon(createType);
                   return <Icon style={{ fontSize: 24 }} />;
                 })()}
               </span>
               <p className="text-sm font-medium text-gray-900">
-                No {slice.listKey} available
+                No {listLabel} available
               </p>
               <p className="mt-1 max-w-xs text-xs text-gray-500">
-                Create a {singularLabel.toLowerCase()} to fix this slot.
+                Create a {createLabel} to fill this slot.
               </p>
               {onCreateNew && (
                 <button
                   type="button"
-                  onClick={() => onCreateNew(type)}
+                  onClick={() => onCreateNew(createType)}
                   data-testid="reference-picker-empty-create"
                   className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-600"
                 >
                   <PiPlus className="h-4 w-4" />
-                  Create new {singularLabel.toLowerCase()}
+                  Create new {createLabel}
                 </button>
               )}
             </div>
@@ -232,13 +302,25 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
               className="px-3 py-8 text-center text-sm text-gray-500"
               data-testid="reference-picker-no-matches"
             >
-              No {slice.listKey} match “{query}”.
+              No {listLabel} match “{query}”.
             </p>
           ) : (
             <div className="space-y-1">
-              {filtered.map(obj => (
-                <ObjectRow key={obj.name} type={type} obj={obj} onSelect={onSelect} />
-              ))}
+              {sections.map(section =>
+                section.objects.length === 0 ? null : (
+                  <React.Fragment key={section.type}>
+                    {isMulti && <SectionHeader type={section.type} />}
+                    {section.objects.map(obj => (
+                      <ObjectRow
+                        key={`${section.type}-${obj.name}`}
+                        type={section.type}
+                        obj={obj}
+                        onSelect={onSelect}
+                      />
+                    ))}
+                  </React.Fragment>
+                )
+              )}
             </div>
           )}
         </div>
@@ -248,12 +330,12 @@ const ReferencePicker = ({ type, onSelect, onClose, onCreateNew, loading = false
           <footer className="shrink-0 border-t border-gray-100 px-4 py-3">
             <button
               type="button"
-              onClick={() => onCreateNew(type)}
+              onClick={() => onCreateNew(createType)}
               data-testid="reference-picker-create"
               className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-700"
             >
               <PiPlus className="h-4 w-4" />
-              Create new {singularLabel.toLowerCase()}…
+              Create new {createLabel}…
             </button>
           </footer>
         )}

--- a/viewer/src/components/views/project/canvas/ReferencePicker.jsx
+++ b/viewer/src/components/views/project/canvas/ReferencePicker.jsx
@@ -48,6 +48,18 @@ const TYPE_SLICES = {
   insight: { listKey: 'insights', singular: 'insight' },
 };
 
+// Tab-order members of the dialog, for the focus trap. Deliberately does NOT
+// filter on visibility (jsdom reports every element as unrendered), so the
+// trap behaves identically in tests and the browser.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
 // A short, type-appropriate description line for an object row.
 const describeObject = (type, obj) => {
   if (!obj) return null;
@@ -171,15 +183,60 @@ const ReferencePicker = ({ type, types, onSelect, onClose, onCreateNew, loading 
   const [query, setQuery] = useState('');
   const dialogRef = useRef(null);
   const searchRef = useRef(null);
+  const returnFocusRef = useRef(null);
 
   useEffect(() => {
-    // Focus the search box on open so keyboard users can filter immediately.
+    // Remember what opened us, focus the search box so keyboard users can
+    // filter immediately, and hand focus BACK on close. Without the restore,
+    // closing (Escape / X / backdrop) drops `document.activeElement` to
+    // <body>, and the next Tab restarts at the top of the document — the
+    // click-to-pick path is sold as keyboard-completable, so stranding the
+    // user away from the slot they were filling is not acceptable. When the
+    // opener is gone (a successful pick unmounts the slot button it filled)
+    // there is nothing to return to, so we leave focus alone rather than
+    // throwing at a detached node.
+    returnFocusRef.current = typeof document !== 'undefined' ? document.activeElement : null;
     if (searchRef.current) searchRef.current.focus();
+    return () => {
+      const opener = returnFocusRef.current;
+      if (opener && opener.isConnected && typeof opener.focus === 'function') {
+        opener.focus();
+      }
+    };
   }, []);
 
   useEffect(() => {
     const onKey = e => {
-      if (e.key === 'Escape') onClose && onClose();
+      if (e.key === 'Escape') {
+        onClose && onClose();
+        return;
+      }
+      // Focus TRAP. `aria-modal="true"` promises assistive tech that nothing
+      // outside this dialog is reachable; without a trap that promise is a
+      // lie — Shift+Tab from the search box walks straight out into the page
+      // behind the backdrop. Cycle within the dialog instead, and pull focus
+      // back in if it ever escapes.
+      if (e.key !== 'Tab') return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(dialog.querySelectorAll(FOCUSABLE_SELECTOR));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (!dialog.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);

--- a/viewer/src/components/views/project/canvas/ReferencePicker.test.jsx
+++ b/viewer/src/components/views/project/canvas/ReferencePicker.test.jsx
@@ -187,3 +187,107 @@ describe('ReferencePicker — multi-type mode (W5 click-to-pick)', () => {
     expect(screen.queryByTestId('reference-picker-section-chart')).not.toBeInTheDocument();
   });
 });
+
+// ── Modal focus management (W5) ─────────────────────────────────────────────
+// Click-to-pick promotes this dialog from a failure-state repair tool to the
+// PRIMARY affordance for filling an empty slot, and the flow is sold as
+// keyboard-completable. `aria-modal="true"` promises assistive tech that focus
+// is contained here and that closing returns it where it came from; both have
+// to actually be true.
+describe('ReferencePicker — focus management', () => {
+  const renderWithTrigger = (props = {}) => {
+    const utils = render(
+      <>
+        <button type="button" data-testid="opener">
+          Empty slot
+        </button>
+        <ReferencePicker type="chart" onSelect={jest.fn()} onClose={jest.fn()} {...props} />
+      </>
+    );
+    return utils;
+  };
+
+  test('focuses the search box on open', () => {
+    render(<ReferencePicker type="chart" onSelect={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByTestId('reference-picker-search')).toHaveFocus();
+  });
+
+  test('returns focus to the opener when the picker closes', () => {
+    // Mount the trigger first and focus it, exactly as a real slot click does.
+    const { rerender } = render(
+      <button type="button" data-testid="opener">
+        Empty slot
+      </button>
+    );
+    screen.getByTestId('opener').focus();
+    expect(screen.getByTestId('opener')).toHaveFocus();
+
+    rerender(
+      <>
+        <button type="button" data-testid="opener">
+          Empty slot
+        </button>
+        <ReferencePicker type="chart" onSelect={jest.fn()} onClose={jest.fn()} />
+      </>
+    );
+    expect(screen.getByTestId('reference-picker-search')).toHaveFocus();
+
+    // Close (Escape / X / backdrop all unmount the picker).
+    rerender(
+      <button type="button" data-testid="opener">
+        Empty slot
+      </button>
+    );
+    expect(screen.getByTestId('opener')).toHaveFocus();
+  });
+
+  test('leaves focus alone when the opener is gone (a filled slot unmounts it)', () => {
+    const { rerender } = render(
+      <button type="button" data-testid="opener">
+        Empty slot
+      </button>
+    );
+    screen.getByTestId('opener').focus();
+    rerender(
+      <>
+        <button type="button" data-testid="opener">
+          Empty slot
+        </button>
+        <ReferencePicker type="chart" onSelect={jest.fn()} onClose={jest.fn()} />
+      </>
+    );
+    // A successful pick replaces the slot button with real content.
+    expect(() => rerender(<div data-testid="filled" />)).not.toThrow();
+    expect(screen.queryByTestId('opener')).not.toBeInTheDocument();
+  });
+
+  // DOM order inside the dialog: close (X) → search → object rows → footer
+  // create link (absent here — no onCreateNew). So the trap's endpoints are
+  // the close button and the LAST object row.
+  const firstFocusable = () => screen.getByTestId('reference-picker-close');
+  const lastFocusable = () => screen.getByTestId('reference-picker-row-orders_chart');
+
+  test('Tab from the last focusable wraps to the first (focus trap)', () => {
+    renderWithTrigger();
+    lastFocusable().focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(firstFocusable()).toHaveFocus();
+  });
+
+  test('Shift+Tab from the first focusable wraps to the last, never out of the dialog', () => {
+    renderWithTrigger();
+    firstFocusable().focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(lastFocusable()).toHaveFocus();
+    // aria-modal="true" claims nothing behind the backdrop is reachable.
+    expect(screen.getByTestId('opener')).not.toHaveFocus();
+  });
+
+  test('Tab from outside the dialog is pulled back in', () => {
+    renderWithTrigger();
+    screen.getByTestId('opener').focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(firstFocusable()).toHaveFocus();
+    expect(screen.getByTestId('opener')).not.toHaveFocus();
+  });
+});

--- a/viewer/src/components/views/project/canvas/ReferencePicker.test.jsx
+++ b/viewer/src/components/views/project/canvas/ReferencePicker.test.jsx
@@ -20,6 +20,7 @@ const seedCharts = () => {
     tables: [],
     markdowns: [],
     inputs: [],
+    insights: [],
   });
 };
 
@@ -57,11 +58,11 @@ describe('ReferencePicker (VIS-792)', () => {
     expect(screen.getByTestId('reference-picker-no-matches')).toBeInTheDocument();
   });
 
-  test('click-to-select calls onSelect with the chosen name', () => {
+  test('click-to-select calls onSelect with the chosen name AND its type', () => {
     const onSelect = jest.fn();
     render(<ReferencePicker type="chart" onSelect={onSelect} onClose={jest.fn()} />);
     fireEvent.click(screen.getByTestId('reference-picker-row-cost_chart'));
-    expect(onSelect).toHaveBeenCalledWith('cost_chart');
+    expect(onSelect).toHaveBeenCalledWith('cost_chart', 'chart');
   });
 
   test('close button + Escape both call onClose', () => {
@@ -100,5 +101,89 @@ describe('ReferencePicker (VIS-792)', () => {
     );
     fireEvent.click(screen.getByTestId('reference-picker-create'));
     expect(onCreateNew).toHaveBeenCalledWith('table');
+  });
+});
+
+describe('ReferencePicker — multi-type mode (W5 click-to-pick)', () => {
+  const seedChartsAndInsights = () => {
+    seedCharts();
+    useStore.setState({
+      insights: [{ name: 'rev-insight' }, { name: 'churn-insight' }],
+    });
+  };
+
+  const renderMulti = (props = {}) =>
+    render(
+      <ReferencePicker
+        types={['chart', 'insight']}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+        {...props}
+      />
+    );
+
+  beforeEach(seedChartsAndInsights);
+
+  test('lists charts AND insights in typed sections with headers', () => {
+    renderMulti();
+    expect(screen.getByTestId('reference-picker-title')).toHaveTextContent(
+      'Pick a chart or insight'
+    );
+    // Typed section headers (objectTypeConfigs labels).
+    expect(screen.getByTestId('reference-picker-section-chart')).toHaveTextContent('Charts');
+    expect(screen.getByTestId('reference-picker-section-insight')).toHaveTextContent('Insights');
+    // Rows of both types, each tagged with its section type.
+    expect(screen.getByTestId('reference-picker-row-revenue_chart')).toHaveAttribute(
+      'data-picker-type',
+      'chart'
+    );
+    expect(screen.getByTestId('reference-picker-row-rev-insight')).toHaveAttribute(
+      'data-picker-type',
+      'insight'
+    );
+  });
+
+  test('single-type mode renders NO section headers (BrokenRefCard parity)', () => {
+    render(<ReferencePicker type="chart" onSelect={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.queryByTestId('reference-picker-section-chart')).not.toBeInTheDocument();
+  });
+
+  test('search filters across both sections and hides emptied sections', () => {
+    renderMulti();
+    fireEvent.change(screen.getByTestId('reference-picker-search'), {
+      target: { value: 'insight' },
+    });
+    // Only insight rows match; the chart section disappears entirely.
+    expect(screen.getByTestId('reference-picker-row-rev-insight')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-row-churn-insight')).toBeInTheDocument();
+    expect(screen.queryByTestId('reference-picker-section-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('reference-picker-row-revenue_chart')).not.toBeInTheDocument();
+  });
+
+  test('picking an insight reports the insight type to onSelect', () => {
+    const onSelect = jest.fn();
+    renderMulti({ onSelect });
+    fireEvent.click(screen.getByTestId('reference-picker-row-rev-insight'));
+    expect(onSelect).toHaveBeenCalledWith('rev-insight', 'insight');
+  });
+
+  test('empty state spans both types and the create CTA targets the primary type', () => {
+    useStore.setState({ charts: [], insights: [] });
+    const onCreateNew = jest.fn();
+    renderMulti({ onCreateNew });
+    expect(screen.getByTestId('reference-picker-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-empty')).toHaveTextContent(
+      'No charts and insights available'
+    );
+    fireEvent.click(screen.getByTestId('reference-picker-empty-create'));
+    expect(onCreateNew).toHaveBeenCalledWith('chart');
+  });
+
+  test('one populated type keeps the list mode (no empty state) even when the other is empty', () => {
+    useStore.setState({ charts: [] });
+    renderMulti();
+    expect(screen.queryByTestId('reference-picker-empty')).not.toBeInTheDocument();
+    expect(screen.getByTestId('reference-picker-row-rev-insight')).toBeInTheDocument();
+    expect(screen.queryByTestId('reference-picker-section-chart')).not.toBeInTheDocument();
   });
 });

--- a/viewer/src/components/views/workspace/RightRailEditPanel.jsx
+++ b/viewer/src/components/views/workspace/RightRailEditPanel.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 import { PiArrowCounterClockwise, PiPencil, PiPlus, PiTrash } from 'react-icons/pi';
 import useStore, { ObjectStatus } from '../../../stores/store';
+import { isReadOnly } from '../../../stores/branchingStore';
 import useWorkspaceScope from './useWorkspaceScope';
 import { FormFooter, FormAlert } from '../../styled/FormComponents';
 import SelectionChip from './SelectionChip';
@@ -185,9 +186,11 @@ const RightRailEditPanel = () => {
   const closeWorkspaceTab = useStore(s => s.closeWorkspaceTab);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   // VIS-1025: null = local serve (always editable); a cloud capability object
-  // with can_edit:false makes every rail write a no-op.
+  // with can_edit:false makes every rail write a no-op. The predicate lives in
+  // branchingStore so every write path (this panel, useRecordSave, and the
+  // item form's click-to-pick) reads read-only the same way.
   const capabilities = useStore(s => s.capabilities);
-  const readOnly = !!(capabilities && capabilities.can_edit === false);
+  const readOnly = useStore(isReadOnly);
   const { dashboardName } = useWorkspaceScope();
 
   const type = activeObject?.type || null;
@@ -725,7 +728,7 @@ const LeafObjectForm = ({ type, name, onSelectRef }) => {
   // behind the Read-only notice. The write path is independently held by
   // useRecordSave's short-circuit; this is the UX affordance layer.
   const capabilities = useStore(s => s.capabilities);
-  const readOnly = !!(capabilities && capabilities.can_edit === false);
+  const readOnly = useStore(isReadOnly);
   const record = useMemo(
     () => (Array.isArray(collection) ? collection.find(o => o.name === name) || null : null),
     [collection, name]

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.jsx
@@ -17,7 +17,7 @@ import { DROPPABLE_TYPES } from './library/LibraryRow';
 import { groupDashboardsByLevel } from '../project/editor/useProjectEditorData';
 import { emitWorkspaceEvent } from './telemetry';
 import { formatRefExpression } from '../../../utils/refString';
-import { generateUniqueName } from '../../../utils/uniqueName';
+import { mintWrapperChartName, buildWrapperChartConfig } from '../../../utils/insightWrap';
 import {
   reorderItemsInRow,
   moveItemBetweenRows,
@@ -968,13 +968,11 @@ const WorkspaceDndContext = ({ children }) => {
         wrapInsight: {
           mintChartName: insightName => {
             const existingCharts = (useStore.getState().charts || []).map(chart => chart.name);
-            return generateUniqueName(`${insightName}-chart`, existingCharts, {
-              separator: '-',
-            });
+            return mintWrapperChartName(insightName, existingCharts);
           },
           createChart: (chartName, insightName) => {
             const save = useStore.getState().saveChart;
-            if (save) save(chartName, { insights: [`ref(${insightName})`] });
+            if (save) save(chartName, buildWrapperChartConfig(insightName));
           },
         },
         exploration: {

--- a/viewer/src/hooks/useRecordSave.js
+++ b/viewer/src/hooks/useRecordSave.js
@@ -8,16 +8,9 @@ import {
 } from '../components/views/workspace/validateAgainstSchema';
 import { checkRefTargets } from '../components/views/workspace/refPreflight';
 import { checkExpressions } from '../components/views/workspace/expressionPreflight';
-
-/**
- * Cloud read-only probe (VIS-1025). `capabilities` is null/undefined under
- * local serve (always editable); in cloud it's the stage's capability object
- * and `can_edit === false` holds every write.
- */
-const isReadOnly = state => {
-  const caps = state.capabilities;
-  return !!(caps && caps.can_edit === false);
-};
+// VIS-1025 read-only probe — defined next to the `capabilities` state it reads
+// (branchingStore) so every write path shares ONE predicate.
+import { isReadOnly } from '../stores/branchingStore';
 
 /**
  * useRecordSave(type, name, opts) — the unified optimistic + debounced save

--- a/viewer/src/stores/branchingStore.js
+++ b/viewer/src/stores/branchingStore.js
@@ -1,6 +1,26 @@
 import * as branchingApi from '../api/branching';
 
 /**
+ * Cloud read-only probe (VIS-1025) — the ONE predicate every write path holds
+ * behind. `capabilities` is null/undefined under local serve (always editable);
+ * in cloud it is the stage's capability object and `can_edit === false` marks
+ * the stage read-only.
+ *
+ * Usable as a zustand selector (`useStore(isReadOnly)`) or against a snapshot
+ * (`isReadOnly(useStore.getState())`), so a surface that fires a store write
+ * OUTSIDE `useRecordSave`/`persistConfig` — e.g. the right rail's
+ * click-to-pick "Choose…", which calls `saveChart` directly — cannot drift
+ * from the hook's own reading of read-only.
+ *
+ * Lives here (next to the `capabilities` state it reads) rather than in a
+ * consumer so the predicate is never re-derived by hand.
+ */
+export const isReadOnly = state => {
+  const caps = state?.capabilities;
+  return !!(caps && caps.can_edit === false);
+};
+
+/**
  * Branching slice — backend-agnostic.
  *
  * The viewer always probes capabilities and creates a draft/branch through the

--- a/viewer/src/utils/insightWrap.js
+++ b/viewer/src/utils/insightWrap.js
@@ -1,0 +1,40 @@
+import { generateUniqueName } from './uniqueName';
+
+/**
+ * insightWrap — the ONE naming + config recipe for auto-wrapping an insight in
+ * a chart (decision 27 Aug: dashboard items never take a bare insight — the
+ * Chart wrapper is the composition boundary, and the Item schema stays
+ * untouched).
+ *
+ * Three surfaces mint wrapper charts and they must never drift:
+ *   - Library "Wrap in Chart…" (#632, Library.jsx),
+ *   - dropping an insight on the canvas (#637, WorkspaceDndContext.jsx),
+ *   - picking an insight from the ReferencePicker (click-to-pick: the canvas
+ *     empty slot + the right rail's "Choose…").
+ *
+ * The name is the hyphenated cascade `<insight>-chart` (#615) with `-2`
+ * disambiguation (#620) — `separator: '-'` is forced so a collision on an
+ * underscored insight name still suffixes in the house style the base
+ * `<insight>-chart` already committed to.
+ */
+
+/**
+ * Mint the unique wrapper-chart name for `insightName`.
+ *
+ * @param {string} insightName - the wrapped insight's name.
+ * @param {Array|Set|Object} existingChartNames - chart names already in use.
+ * @returns {string} `<insight>-chart`, suffixed `-2`, `-3`, … on collision.
+ */
+export const mintWrapperChartName = (insightName, existingChartNames) =>
+  generateUniqueName(`${insightName}-chart`, existingChartNames, { separator: '-' });
+
+/**
+ * The wrapper chart's config: a chart whose only content is the insight.
+ * Matches Library "Wrap in Chart…" (#632) byte-for-byte.
+ *
+ * @param {string} insightName - the wrapped insight's name.
+ * @returns {{insights: string[]}}
+ */
+export const buildWrapperChartConfig = insightName => ({
+  insights: [`ref(${insightName})`],
+});

--- a/viewer/src/utils/insightWrap.test.js
+++ b/viewer/src/utils/insightWrap.test.js
@@ -3,6 +3,24 @@
  * consumed by the canvas insight drop AND the click-to-pick picker paths).
  */
 import { mintWrapperChartName, buildWrapperChartConfig } from './insightWrap';
+import { generateUniqueName } from './uniqueName';
+
+// The forced `separator: '-'` cannot be falsified through mintWrapperChartName's
+// RESULT: the base is always `<insight>-chart`, which already contains a hyphen,
+// so `suffixSeparatorFor` infers '-' for every reachable input and the option
+// can never change the output. Spying on the call is the only way to prove the
+// option is actually passed — without this, deleting it leaves the suite green
+// while a future change to `suffixSeparatorFor`'s inference (e.g. preferring the
+// FIRST separator in the base, which picks '_' for `rev_insight-chart`) would
+// silently start minting `rev_insight-chart_2`.
+jest.mock('./uniqueName', () => {
+  const actual = jest.requireActual('./uniqueName');
+  return { ...actual, generateUniqueName: jest.fn(actual.generateUniqueName) };
+});
+
+beforeEach(() => {
+  generateUniqueName.mockClear();
+});
 
 describe('mintWrapperChartName', () => {
   test('mints <insight>-chart when the name is free', () => {
@@ -19,8 +37,24 @@ describe('mintWrapperChartName', () => {
     ).toBe('rev-insight-chart-3');
   });
 
-  test('an underscored insight name still suffixes with a hyphen (forced separator)', () => {
+  test('an underscored insight name still suffixes with a hyphen', () => {
     expect(mintWrapperChartName('rev_insight', ['rev_insight-chart'])).toBe('rev_insight-chart-2');
+  });
+
+  test('FORCES the hyphen separator rather than letting the base infer it', () => {
+    mintWrapperChartName('rev_insight', ['rev_insight-chart']);
+    expect(generateUniqueName).toHaveBeenCalledWith('rev_insight-chart', ['rev_insight-chart'], {
+      separator: '-',
+    });
+  });
+
+  test('the forced separator wins even when the inferred one would differ', () => {
+    // Prove the option is load-bearing by driving the real generator with an
+    // inference that would otherwise pick '_' for this base.
+    const { suffixSeparatorFor, generateUniqueName: real } = jest.requireActual('./uniqueName');
+    expect(suffixSeparatorFor('rev_insight')).toBe('_');
+    expect(real('rev_insight', ['rev_insight'])).toBe('rev_insight_2');
+    expect(real('rev_insight', ['rev_insight'], { separator: '-' })).toBe('rev_insight-2');
   });
 });
 

--- a/viewer/src/utils/insightWrap.test.js
+++ b/viewer/src/utils/insightWrap.test.js
@@ -1,0 +1,31 @@
+/**
+ * insightWrap — the shared auto-wrap naming/config recipe (#632/#637 pattern,
+ * consumed by the canvas insight drop AND the click-to-pick picker paths).
+ */
+import { mintWrapperChartName, buildWrapperChartConfig } from './insightWrap';
+
+describe('mintWrapperChartName', () => {
+  test('mints <insight>-chart when the name is free', () => {
+    expect(mintWrapperChartName('rev-insight', [])).toBe('rev-insight-chart');
+  });
+
+  test('disambiguates with -2 on collision (hyphen separator, #620)', () => {
+    expect(mintWrapperChartName('rev-insight', ['rev-insight-chart'])).toBe('rev-insight-chart-2');
+  });
+
+  test('keeps counting past taken suffixes', () => {
+    expect(
+      mintWrapperChartName('rev-insight', ['rev-insight-chart', 'rev-insight-chart-2'])
+    ).toBe('rev-insight-chart-3');
+  });
+
+  test('an underscored insight name still suffixes with a hyphen (forced separator)', () => {
+    expect(mintWrapperChartName('rev_insight', ['rev_insight-chart'])).toBe('rev_insight-chart-2');
+  });
+});
+
+describe('buildWrapperChartConfig', () => {
+  test('the wrapper chart holds exactly the wrapped insight (matches #632)', () => {
+    expect(buildWrapperChartConfig('rev-insight')).toEqual({ insights: ['ref(rev-insight)'] });
+  });
+});


### PR DESCRIPTION
## Problem

The ReferencePicker (VIS-792 / Track L L-2 — search, type-scoped list, click-to-select, create-new CTA) was fully built but reachable from exactly ONE place: BrokenRefCard's **Fix…** flow, a failure state. Every healthy empty slot on the canvas was an inert "Empty slot" div, and the right rail's empty item panel offered only a drop zone — filling a slot required a drag, full stop (W5, the last B2 sub-issue).

## Fix

**1. Empty canvas slots are clickable.** `Dashboard.jsx`'s canvas-mode empty-slot placeholder becomes a real `<button>` when the canvas supplies the new `onEmptySlotClick` prop (View mode + prop-less canvas render are byte-identical to before). Clicking — or focusing and pressing Enter — opens the picker for that slot.

**2. Right-rail "Choose…".** An empty item's edit panel (`ItemEditForm`, used standalone and inside Row/Dashboard forms) gains a **Choose…** button that opens the same picker. State lives in a child component mounted only for empty leaves, so `ItemEditForm` stays hook-free.

**3. The picker lists CHARTS and INSIGHTS.** `ReferencePicker` gains a multi-`types` mode: typed sections with objectTypeConfigs-coloured headers/icons, cross-section search, a shared empty state. `onSelect` now reports `(name, type)`; the single-`type` BrokenRefCard contract is unchanged.

**4. Insight picks auto-wrap (#637 pattern).** Picking a chart places `chart: ref(name)`. Picking an insight mints a unique `<insight>-chart` name (`generateUniqueName(..., {separator: '-'})`, -2 disambiguation), saves the wrapper via the same `saveChart` path as Library "Wrap in Chart…" (#632), and places the wrapper — never a bare insight. Ordering matches #637: the placement transform is validated FIRST; a rejected placement mints nothing, so no orphan draft charts. The #632/#637/picker recipe now lives in one shared module (`utils/insightWrap.js`) — `WorkspaceDndContext`'s drop path consumes it too, so the three surfaces can't drift.

**5. #617 semantics respected.** Placements land in the dashboard working copy (`commitCanvasConfig` on the canvas, `onChange` in the rail); the explicit Save footer persists them.

**6. Telemetry.** `canvas_action { kind: 'add_item', source: 'picker', type, name, wrapped_chart? }` matching #637's event shape; picker create-new emits `inline_create_used` with `source: 'picker'`.

## Falsification

Implementation stashed (tests kept): **20 tests fail**, all of them the new coverage — Dashboard's clickable slot, ItemEditForm's Choose… flow (incl. -2 collision + close-mints-nothing), ProjectCanvas's pick/wrap/rejected-placement/telemetry, ReferencePicker's multi-type mode. Sample:

```
● Dashboard › empty-slot placeholder (VIS-901 #3) › renders the empty slot as a real button when onEmptySlotClick is provided
  Expected: "BUTTON"
  Received: "DIV"
    > 308 |       expect(slot.tagName).toBe('BUTTON');
```

```
Test Suites: 4 failed, 1 passed, 5 total
Tests:       20 failed, 109 passed, 129 total
```

Stash popped; all green again.

## Test results

- Full viewer suite: `yarn test --watchAll=false` → **366 suites, 7038 tests, all passing**
- `yarn lint` → clean (exit 0)
- New Playwright story (written, not run — needs a sandbox): `viewer/e2e/stories/canvas-click-to-pick.spec.mjs` — slot click → picker sections → chart pick → working-copy assert; insight pick → wrapper minted + placed; right-rail Choose…; keyboard-only completion; console-error sweep.

New unit coverage: `utils/insightWrap.test.js` (mint recipe incl. -2/-3 and forced hyphen), `ReferencePicker.test.jsx` (+6 multi-type), `Dashboard.test.jsx` (+2 clickable/inert slot), `ProjectCanvas.test.jsx` (+7 pick wiring incl. rejected-placement-mints-nothing), `ItemEditForm.test.jsx` (+6 Choose… flow incl. -2 collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U