### PR TITLE
"+ New" tells you what the project is missing, and never invents a column

### DIFF
--- a/viewer/src/components/views/common/PillMenu.jsx
+++ b/viewer/src/components/views/common/PillMenu.jsx
@@ -76,6 +76,19 @@ const KIND_LABEL = {
 };
 
 /**
+ * Which store collection a pill's BASE name may be re-pointed within, and what
+ * to call it in the picker. A pill referencing a model can only ever move to
+ * another model — swapping in a metric would change the pill's whole grammar.
+ */
+const REF_SOURCE = {
+  modelRef: { collection: 'models', label: 'Model' },
+  dimension: { collection: 'models', label: 'Model' },
+  aggregate: { collection: 'models', label: 'Model' },
+  metricRef: { collection: 'metrics', label: 'Metric' },
+  dimensionRef: { collection: 'dimensions', label: 'Dimension' },
+};
+
+/**
  * Best-effort "is this pill's bound column numeric" check (06 §3's drop-time
  * heuristic, reused here to TYPE-RESTRICT the preset list per 06 §4). Reuses
  * the exact row-value inference `CenterPanel`'s results grid already runs
@@ -262,6 +275,10 @@ const PillMenu = React.forwardRef(
   const buildDraft = useCallback(
     () => ({
       useAs: state?.kind === 'aggregate' ? state.agg : 'dimension',
+      // The object being referenced. Editable for the same reason the property
+      // is: `+ New` has to pick SOME model to scaffold against, and re-pointing
+      // the reference otherwise meant deleting the pill and dragging another.
+      ref: state?.ref ?? '',
       // The FULL path, not the bare column: an Apply that doesn't touch the
       // property must round-trip `gdp[0]` unchanged.
       column: state?.propertyPath ?? state?.column ?? '',
@@ -420,10 +437,26 @@ const PillMenuPopover = ({
   // parent because this component is mounted only while the menu is open — a
   // property panel full of pills would otherwise fire one schema request per
   // row on every render.
-  const modelName = isColumnBacked ? state?.ref || null : null;
+  // The DRAFT's model, not the pill's committed one: re-pointing the reference
+  // has to re-ask for that model's columns, or the property picker would keep
+  // offering the old model's.
+  const modelName = isColumnBacked ? draft.ref || state?.ref || null : null;
   const modelNames = useMemo(() => (modelName ? [modelName] : []), [modelName]);
   const { columnsByModel, loading: columnsLoading } = useModelColumns(modelNames);
   const columns = useMemo(() => columnsByModel?.[modelName] || [], [columnsByModel, modelName]);
+
+  // The names this pill may be re-pointed at — every OTHER object of the same
+  // type, plus its own so the select has something selected.
+  const refSource = REF_SOURCE[state?.kind] || null;
+  const refCandidates = useStore(s => (refSource ? s[refSource.collection] : null));
+  const refNames = useMemo(() => {
+    const names = (refCandidates || []).map(o => o?.name).filter(Boolean);
+    // A pill can reference something not (yet) in the collection — a draft, or
+    // a name the user typed. Keep it selectable rather than silently dropping
+    // the current value out of its own picker.
+    if (draft.ref && !names.includes(draft.ref)) names.unshift(draft.ref);
+    return names;
+  }, [refCandidates, draft.ref]);
 
 
   // The Index row first shipped as All / First / Last only, which dropped
@@ -561,6 +594,44 @@ const PillMenuPopover = ({
             &apos;s data.
           </span>
         </div>
+      )}
+
+      {/* The BASE name. `+ New` has to scaffold against SOME model, so the
+          reference it picks is a starting point — this is where it gets
+          re-pointed, without deleting the pill and dragging another in.
+          Only names of the same type are offered: a model pill swapped for a
+          metric would be a different grammar, not an edited reference. */}
+      {refSource && refNames.length > 1 && (
+        <>
+          <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+            {refSource.label}
+          </div>
+          <div className="px-3 pb-1.5">
+            <select
+              value={draft.ref}
+              onChange={e =>
+                setDraft(d => ({
+                  ...d,
+                  ref: e.target.value,
+                  // A column belongs to the model it came from. Carrying it
+                  // across would leave the pill pointing at a column the new
+                  // model may not have — the exact class of bug the `+ New`
+                  // scaffold used to ship. Clear it and make the user pick.
+                  column: e.target.value === state?.ref ? d.column : '',
+                }))
+              }
+              data-testid="pill-menu-ref"
+              aria-label={refSource.label}
+              className="w-full rounded border border-gray-300 px-1.5 py-1 text-xs text-gray-800 focus:border-primary-500 focus:outline-none"
+            >
+              {refNames.map(name => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
 
       {isColumnBacked && (

--- a/viewer/src/components/views/common/PillMenu.test.jsx
+++ b/viewer/src/components/views/common/PillMenu.test.jsx
@@ -1038,6 +1038,74 @@ describe('PillMenu — the Index row covers the whole slice vocabulary', () => {
   });
 });
 
+// The pill's BASE name used to be the one part of it that could never be
+// changed here — you deleted the pill and dragged another in. `+ New` has to
+// scaffold against SOME model, so re-pointing is the normal follow-up move.
+describe('PillMenu — re-pointing the reference', () => {
+  const modelPill = { kind: 'dimension', ref: 'orders', column: 'amount' };
+
+  beforeEach(() => {
+    useModelColumns.mockReturnValue({
+      columnsByModel: { orders: ['amount', 'id'], users: ['email', 'signed_up'] },
+      loading: false,
+    });
+  });
+
+  test('offers the project\'s other models, and commits the one picked', () => {
+    useStore.setState({ models: [{ name: 'orders' }, { name: 'users' }] });
+    const onApply = jest.fn();
+    render(<PillMenu state={modelPill} onApply={onApply} />);
+    openMenu();
+
+    const picker = screen.getByTestId('pill-menu-ref');
+    expect(picker).toHaveValue('orders');
+    expect(screen.getByRole('option', { name: 'users' })).toBeInTheDocument();
+
+    fireEvent.change(picker, { target: { value: 'users' } });
+    fireEvent.change(screen.getByTestId('pill-menu-property'), {
+      target: { value: 'email' },
+    });
+    fireEvent.click(screen.getByTestId('pill-menu-apply'));
+
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ ref: 'users', column: 'email' }));
+  });
+
+  test('changing the model clears the column — it belonged to the old one', () => {
+    useStore.setState({ models: [{ name: 'orders' }, { name: 'users' }] });
+    render(<PillMenu state={modelPill} onApply={jest.fn()} />);
+    openMenu();
+
+    expect(screen.getByTestId('pill-menu-property')).toHaveValue('amount');
+    fireEvent.change(screen.getByTestId('pill-menu-ref'), { target: { value: 'users' } });
+
+    // `users` has no `amount`; carrying it over is the bug the `+ New` scaffold
+    // used to ship (a hardcoded `.id` against models that had none).
+    expect(screen.getByTestId('pill-menu-property')).toHaveValue('');
+    expect(screen.getByTestId('pill-menu-apply')).toBeDisabled();
+  });
+
+  test('a metric pill is re-pointed within METRICS, not models', () => {
+    useStore.setState({
+      models: [{ name: 'orders' }],
+      metrics: [{ name: 'revenue' }, { name: 'margin' }],
+    });
+    render(<PillMenu state={{ kind: 'metricRef', ref: 'revenue' }} onApply={jest.fn()} />);
+    openMenu();
+
+    expect(screen.getByTestId('pill-menu-ref')).toHaveValue('revenue');
+    expect(screen.getByRole('option', { name: 'margin' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'orders' })).not.toBeInTheDocument();
+  });
+
+  test('no picker when there is nothing else to point at', () => {
+    useStore.setState({ models: [{ name: 'orders' }] });
+    render(<PillMenu state={modelPill} onApply={jest.fn()} />);
+    openMenu();
+
+    expect(screen.queryByTestId('pill-menu-ref')).not.toBeInTheDocument();
+  });
+});
+
 // VIS-1242 follow-up: an unbound model pill opened with `draft.column === ''`,
 // which matches no <option> — so the browser showed the first column while the
 // draft still said "nothing chosen", and Apply committed an empty column.

--- a/viewer/src/components/views/common/RefTextArea.jsx
+++ b/viewer/src/components/views/common/RefTextArea.jsx
@@ -919,14 +919,14 @@ const RefTextArea = ({
       if (!chip) return;
       const nextProperty = (draft?.column || '').trim();
       if (!nextProperty) return;
-      chip.setAttribute('data-ref-property', nextProperty);
-      const propSpan = chip.querySelector('span:last-child');
-      if (propSpan && propSpan.textContent.startsWith('.')) {
-        propSpan.textContent = `.${nextProperty}`;
-      }
+      const nextName = (draft?.ref || '').trim() || chip.getAttribute('data-ref-name');
+      // REBUILT, not patched: the menu can now re-point the reference itself,
+      // and a different object may be a different type — so the icon and
+      // colours have to be re-derived, not just the trailing `.property`.
+      chip.replaceWith(createRefNode(nextName, nextProperty));
       serializeAndUpdate();
     },
-    [chipMenu, serializeAndUpdate]
+    [chipMenu, createRefNode, serializeAndUpdate]
   );
 
   const handleChipRemove = useCallback(() => {

--- a/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
+++ b/viewer/src/components/views/common/SchemaEditor/PropertyRow.jsx
@@ -431,17 +431,22 @@ export function PropertyRow({
   // each preset click committed on its own and the index was a separate
   // control, so a two-part edit wrote the value twice.
   const handlePillApply = useCallback(
-    ({ useAs, column, modifier, slice: nextSlice }) => {
+    ({ useAs, ref, column, modifier, slice: nextSlice }) => {
       const trimmedModifier = (modifier || '').trim();
+      // The referenced object is part of the draft now (the menu offers other
+      // names of the same type), so an Apply that re-points the pill has to
+      // carry the new name through. Falls back to the committed one for a
+      // caller that doesn't send it.
+      const nextRef = ref || pillState.ref;
       const base =
         useAs === 'dimension'
-          ? { kind: 'dimension', ref: pillState.ref, column }
-          : { kind: 'aggregate', agg: useAs, ref: pillState.ref, column };
+          ? { kind: 'dimension', ref: nextRef, column }
+          : { kind: 'aggregate', agg: useAs, ref: nextRef, column };
       // A metric/dimension REF pill has no model/column of its own — keep its
-      // kind and ref, and let the modifier ride along.
+      // kind, and let the modifier ride along.
       const nextState =
         pillState.kind === 'metricRef' || pillState.kind === 'dimensionRef'
-          ? { kind: pillState.kind, ref: pillState.ref }
+          ? { kind: pillState.kind, ref: nextRef }
           : base;
       if (trimmedModifier) nextState.modifier = trimmedModifier;
       onChange(

--- a/viewer/src/components/views/workspace/library/Library.jsx
+++ b/viewer/src/components/views/workspace/library/Library.jsx
@@ -6,6 +6,7 @@ import LibrarySubsection from './LibrarySubsection';
 import useLibraryData from './useLibraryData';
 import useLibraryFilter from './useLibraryFilter';
 import { LAYOUT_TYPES, DATA_TYPES, getTypeDef } from './LibraryRow';
+import { createBlockedReason } from '../../../../stores/inlineCreateStore';
 import useStore from '../../../../stores/store';
 import { isLibrarySubsectionCollapsed } from '../../../../stores/libraryPrefsStore';
 import { useWorkspaceScope } from '../useWorkspaceScope';
@@ -193,6 +194,28 @@ const Library = () => {
   // Data Layer first, then Layout Items (VIS thread: data elements before
   // layout items).
   const allTypes = useMemo(() => [...DATA_TYPES, ...LAYOUT_TYPES], []);
+
+  // Which "+ New" items can't be drafted yet, and why. A metric or dimension
+  // needs a model to reference (at project level that reference IS its tie to a
+  // source); a relation needs two to join. Asking the same predicate
+  // `createWorkspaceObject` enforces means the menu can never disagree with
+  // what the click would do.
+  //
+  // Keyed on the model list because that is what every predicate reads today;
+  // `createBlockedReason` takes the whole state, so a future predicate reading
+  // something else needs that value added here too.
+  const models = useStore(s => s.models);
+  const blockedCreateReasons = useMemo(() => {
+    const state = useStore.getState();
+    return allTypes.reduce((acc, type) => {
+      const reason = createBlockedReason(state, type);
+      if (reason) acc[type] = reason;
+      return acc;
+    }, {});
+    // `models` is not read directly (createBlockedReason takes the whole
+    // state) but it IS what the predicates look at — recompute when it changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allTypes, models]);
   const allRows = useMemo(
     () => allTypes.flatMap(t => rowsByType[t] || []),
     [allTypes, rowsByType]
@@ -470,11 +493,18 @@ const Library = () => {
   // project's first two models, and the ERD stays the way to author one
   // visually rather than the only way.
   const handleNewPick = useCallback(
-    typeKey => {
+    (typeKey, blockedReason) => {
       setNewMenuOpen(false);
+      // Clicking a blocked item is a natural "why not?" gesture — answer it
+      // with the same sentence the tooltip carries, in case the pointer never
+      // rested long enough for the tooltip to appear (or there is no pointer).
+      if (blockedReason) {
+        if (showWorkspaceToast) showWorkspaceToast(blockedReason);
+        return;
+      }
       handleCreate(typeKey, 'library-menu');
     },
-    [handleCreate]
+    [handleCreate, showWorkspaceToast]
   );
 
   return (
@@ -528,13 +558,26 @@ const Library = () => {
                     {group.types.map(typeKey => {
                       const def = getTypeDef(typeKey);
                       const Icon = def.icon;
+                      const blockedReason = blockedCreateReasons[typeKey] || null;
                       return (
                         <button
                           key={typeKey}
                           type="button"
                           data-testid={`library-new-object-${typeKey}`}
-                          onClick={() => handleNewPick(typeKey)}
-                          className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12.5px] text-gray-800 hover:bg-gray-50"
+                          // NOT the `disabled` attribute: a disabled button
+                          // fires no mouse events, so the browser never shows
+                          // its `title` — the hover explanation would be
+                          // exactly what you couldn't read. `aria-disabled`
+                          // tells assistive tech the same thing while leaving
+                          // the element hoverable and focusable.
+                          aria-disabled={blockedReason ? true : undefined}
+                          title={blockedReason || undefined}
+                          onClick={() => handleNewPick(typeKey, blockedReason)}
+                          className={
+                            blockedReason
+                              ? 'flex w-full cursor-not-allowed items-center gap-2 px-3 py-1.5 text-left text-[12.5px] text-gray-400'
+                              : 'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12.5px] text-gray-800 hover:bg-gray-50'
+                          }
                         >
                           {Icon && <Icon style={{ fontSize: 14 }} className="shrink-0" />}
                           {def.label}

--- a/viewer/src/components/views/workspace/library/Library.test.jsx
+++ b/viewer/src/components/views/workspace/library/Library.test.jsx
@@ -733,6 +733,69 @@ describe('Library', () => {
     }
   });
 
+  // A "+ New" item whose precondition isn't met stays VISIBLE and says why on
+  // hover. Hiding it would make the type look unsupported; letting it look live
+  // and then fail teaches nothing about what the project is missing.
+  describe('create items whose preconditions are not met', () => {
+    const showWorkspaceToast = jest.fn();
+
+    test('a relation needs two models — one is not enough', () => {
+      seedStore({ models: [{ name: 'orders' }], showWorkspaceToast });
+      renderLibrary();
+      openNewMenu();
+
+      const item = screen.getByTestId('library-new-object-relation');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).toHaveAttribute('title', expect.stringMatching(/two models/i));
+    });
+
+    test.each(['metric', 'dimension'])('a %s needs a model to reference', type => {
+      seedStore({ models: [], showWorkspaceToast });
+      renderLibrary();
+      openNewMenu();
+
+      const item = screen.getByTestId(`library-new-object-${type}`);
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).toHaveAttribute('title', expect.stringMatching(/model/i));
+    });
+
+    test('a blocked item does not draft, and answers the click with the reason', () => {
+      const createWorkspaceObject = jest.fn();
+      seedStore({ models: [{ name: 'orders' }], createWorkspaceObject, showWorkspaceToast });
+      renderLibrary();
+      openNewMenu();
+
+      fireEvent.click(screen.getByTestId('library-new-object-relation'));
+
+      expect(createWorkspaceObject).not.toHaveBeenCalled();
+      expect(showWorkspaceToast).toHaveBeenCalledWith(expect.stringMatching(/two models/i));
+    });
+
+    test('the same items are live once the models exist', () => {
+      seedStore({ models: [{ name: 'orders' }, { name: 'users' }], showWorkspaceToast });
+      renderLibrary();
+      openNewMenu();
+
+      ['relation', 'metric', 'dimension'].forEach(type => {
+        expect(screen.getByTestId(`library-new-object-${type}`)).not.toHaveAttribute(
+          'aria-disabled'
+        );
+      });
+    });
+
+    test('types with no model precondition are never blocked', () => {
+      seedStore({ models: [], showWorkspaceToast });
+      renderLibrary();
+      openNewMenu();
+
+      ['chart', 'dashboard', 'markdown', 'source'].forEach(type => {
+        expect(screen.getByTestId(`library-new-object-${type}`)).not.toHaveAttribute(
+          'aria-disabled'
+        );
+      });
+    });
+  });
+
   // VIS-1237: Relation used to be special-cased into opening the Semantic
   // Layer, which read as "+ New does nothing". It now drafts like every other
   // type and opens in the edit panel.
@@ -743,7 +806,13 @@ describe('Library', () => {
       type: 'relation',
     }));
     const openWorkspaceTab = jest.fn();
-    seedStore({ createWorkspaceObject, openWorkspaceTab });
+    // Two models: a relation joins two, so with fewer the menu item is
+    // deliberately inert (see the guard tests below).
+    seedStore({
+      createWorkspaceObject,
+      openWorkspaceTab,
+      models: [{ name: 'orders' }, { name: 'users' }],
+    });
     renderLibrary();
     openNewMenu();
     fireEvent.click(screen.getByTestId('library-new-object-relation'));

--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -1,3 +1,4 @@
+import { fetchModelColumnNames } from '../api/modelSchema';
 import { generateUniqueName } from '../utils/uniqueName';
 import { createRow } from '../components/views/workspace/itemMutations';
 
@@ -42,15 +43,42 @@ const firstTwoModelNames = state => {
  * expression — nesting it inside a model is the other way, and that is a
  * different object. So a scaffold like `count(*)` is not "a draft to fill in",
  * it is a field that can never resolve: the project stops parsing on commit and
- * every metric and dimension disappears from the editor. Same precedent as
- * `relation` below — the model reference is real (which is what validation
- * requires), the column is a guess the user re-points.
+ * every metric and dimension disappears from the editor.
  */
 const firstModelName = state =>
   (state.models || []).map(m => m?.name).find(Boolean) || null;
 
-const NEEDS_A_MODEL =
-  'A project-level metric or dimension has to reference a model. Create a model first.';
+/** Why a project-level metric/dimension can't be drafted with no models yet. */
+const needsAModel = kind =>
+  `A ${kind} references a model, and this project has none yet. Create a model first.`;
+
+/**
+ * A real column on `modelName`, inferred server-side (SQLGlot against the
+ * source's cached schema — no query, no run required).
+ *
+ * The scaffolds used to hardcode `id`. Most models don't have one, so "+ New
+ * Metric" produced `count(${ref(orders).id})` against a column that isn't
+ * there: valid to the parser, broken the moment it runs, and the user had no
+ * reason to suspect the column rather than their own edit. Guess the model —
+ * that is a starting point with a name attached — but never the column.
+ *
+ * @returns {Promise<string|null>} null when the columns can't be determined,
+ *   which the caller turns into a refusal rather than a fabricated reference.
+ */
+const firstColumnOf = async (state, modelName) => {
+  if (!modelName) return null;
+  try {
+    const columns = await fetchModelColumnNames(modelName, { projectId: state.project?.id });
+    return columns?.[0] || null;
+  } catch {
+    return null;
+  }
+};
+
+/** Why a draft can't be built when a model's columns are unknown. */
+const unknownColumns = modelName =>
+  `Could not read any columns from model '${modelName}', so there is nothing to reference yet. ` +
+  `Check the model's SQL and its source connection.`;
 
 export const CREATE_TEMPLATES = {
   dashboard: {
@@ -113,40 +141,77 @@ export const CREATE_TEMPLATES = {
     // Declared, not inferred: the backend rejects a dash in a dimension name,
     // and a user-named dimension (`region`) carries no separator to infer from.
     nameSeparator: '_',
-    requires: state => (firstModelName(state) ? null : NEEDS_A_MODEL),
-    // eslint-disable-next-line no-template-curly-in-string
-    config: state => ({ expression: `\${ref(${firstModelName(state)}).id}` }),
+    requires: state => (firstModelName(state) ? null : needsAModel('dimension')),
+    config: async state => {
+      const model = firstModelName(state);
+      const column = await firstColumnOf(state, model);
+      if (!column) throw new Error(unknownColumns(model));
+      // eslint-disable-next-line no-template-curly-in-string
+      return { expression: `\${ref(${model}).${column}}` };
+    },
   },
   metric: {
     namePrefix: 'new_metric',
     collectionKey: 'metrics',
     saveKey: 'saveMetric',
     nameSeparator: '_',
-    requires: state => (firstModelName(state) ? null : NEEDS_A_MODEL),
-    // eslint-disable-next-line no-template-curly-in-string
-    config: state => ({ expression: `count(\${ref(${firstModelName(state)}).id})` }),
+    requires: state => (firstModelName(state) ? null : needsAModel('metric')),
+    config: async state => {
+      const model = firstModelName(state);
+      const column = await firstColumnOf(state, model);
+      if (!column) throw new Error(unknownColumns(model));
+      // eslint-disable-next-line no-template-curly-in-string
+      return { expression: `count(\${ref(${model}).${column}})` };
+    },
   },
   relation: {
     namePrefix: 'new_relation',
     collectionKey: 'relations',
     saveKey: 'saveRelation',
-    // Seeded with the project's first two models joined on `id` — a starting
-    // point the user re-points in the edit panel, exactly like every other
-    // "+ New" draft. The join keys are a guess; the MODEL references are real,
-    // which is what the backend validator requires.
+    // Seeded with the project's first two models joined on a REAL column from
+    // each — a starting point the user re-points in the edit panel, exactly
+    // like every other "+ New" draft. Which columns to join on is a guess; that
+    // the columns and models EXIST is not.
     requires: state =>
       firstTwoModelNames(state)
         ? null
-        : 'A relation joins two models. Create at least two models first.',
-    config: state => {
+        : 'A relation joins two models, and this project has fewer than two. Create another model first.',
+    config: async state => {
       const [left, right] = firstTwoModelNames(state);
+      const [leftColumn, rightColumn] = await Promise.all([
+        firstColumnOf(state, left),
+        firstColumnOf(state, right),
+      ]);
+      if (!leftColumn) throw new Error(unknownColumns(left));
+      if (!rightColumn) throw new Error(unknownColumns(right));
       return {
         join_type: 'inner',
         // eslint-disable-next-line no-template-curly-in-string
-        condition: `\${ref(${left}).id} = \${ref(${right}).id}`,
+        condition: `\${ref(${left}).${leftColumn}} = \${ref(${right}).${rightColumn}}`,
       };
     },
   },
+};
+
+/**
+ * Why `type` cannot be drafted right now, or null when it can.
+ *
+ * The same predicate `createWorkspaceObject` enforces, exposed so the UI can
+ * ask BEFORE the click. A "+ New" item that looks live and then fails is a
+ * worse answer than one that shows, disabled, with the reason on hover — the
+ * user learns what the project is missing instead of what the backend rejected.
+ *
+ * Pure and synchronous, so a component can call it during render.
+ *
+ * @param {object} state the store state (`useStore.getState()`, or the value
+ *   a `useStore(s => …)` selector is given)
+ * @param {string} type one of CREATE_TEMPLATES' keys
+ * @returns {string|null}
+ */
+export const createBlockedReason = (state, type) => {
+  const template = CREATE_TEMPLATES[type];
+  if (!template || !template.requires) return null;
+  return template.requires(state) || null;
 };
 
 const createInlineCreateSlice = (set, get) => ({
@@ -169,7 +234,7 @@ const createInlineCreateSlice = (set, get) => ({
     // A type whose draft depends on other objects existing (relation → two
     // models) reports WHY it can't be drafted, rather than posting a config
     // the backend will reject with a validator message.
-    const blocked = template.requires ? template.requires(get()) : null;
+    const blocked = createBlockedReason(get(), type);
     if (blocked) {
       return { success: false, error: blocked };
     }
@@ -177,7 +242,17 @@ const createInlineCreateSlice = (set, get) => ({
     const name = generateUniqueName(template.namePrefix, existing, {
       separator: template.nameSeparator,
     });
-    const result = await save(name, template.config(get()));
+    // A template that cannot build a valid draft THROWS with the reason (a
+    // model whose columns can't be read). Report it the same way an unmet
+    // precondition is reported, rather than letting it escape as an unhandled
+    // rejection and look like the button did nothing.
+    let config;
+    try {
+      config = await template.config(get());
+    } catch (error) {
+      return { success: false, error: error?.message || `Could not draft a new ${type}` };
+    }
+    const result = await save(name, config);
     return result?.success ? { ...result, name, type } : result;
   },
 });

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -6,6 +6,18 @@
  */
 import useStore from './store';
 import { CREATE_TEMPLATES } from './inlineCreateStore';
+import { fetchModelColumnNames } from '../api/modelSchema';
+
+// The metric/dimension/relation scaffolds ask the server which columns a model
+// actually has, rather than hardcoding `id` (which most models don't have).
+jest.mock('../api/modelSchema', () => ({
+  fetchModelColumnNames: jest.fn(async () => ['order_id', 'amount']),
+}));
+
+beforeEach(() => {
+  fetchModelColumnNames.mockClear();
+  fetchModelColumnNames.mockResolvedValue(['order_id', 'amount']);
+});
 
 describe('createWorkspaceObject', () => {
   test.each(Object.keys(CREATE_TEMPLATES))('drafts a %s through its save action', async type => {
@@ -18,7 +30,7 @@ describe('createWorkspaceObject', () => {
       [template.collectionKey]: [],
       [template.saveKey]: save,
     });
-    const expectedConfig = template.config(useStore.getState());
+    const expectedConfig = await template.config(useStore.getState());
 
     const result = await useStore.getState().createWorkspaceObject(type);
 
@@ -114,10 +126,11 @@ describe('createWorkspaceObject', () => {
       expect(result).toMatchObject({ success: true, type: 'relation' });
       const [, config] = save.mock.calls[0];
       expect(config.join_type).toBe('inner');
-      // Real model refs — what the backend's validator requires. The join keys
-      // are a starting point the user re-points in the edit panel.
+      // Real model refs — what the backend's validator requires — joined on
+      // REAL columns. Which columns is a starting point the user re-points in
+      // the edit panel; that they exist is not negotiable.
       // eslint-disable-next-line no-template-curly-in-string
-      expect(config.condition).toBe('${ref(orders).id} = ${ref(users).id}');
+      expect(config.condition).toBe('${ref(orders).order_id} = ${ref(users).order_id}');
     });
 
     test('says WHY it cannot draft one when the project has fewer than two models', async () => {
@@ -155,15 +168,43 @@ describe('createWorkspaceObject', () => {
       return save.mock.calls[0][1];
     };
 
-    test('a metric counts a column of the first model', async () => {
+    test('a metric counts a REAL column of the first model', async () => {
       // eslint-disable-next-line no-template-curly-in-string
-      expect((await draftConfig('metric')).expression).toBe('count(${ref(orders).id})');
+      expect((await draftConfig('metric')).expression).toBe('count(${ref(orders).order_id})');
+      expect(fetchModelColumnNames).toHaveBeenCalledWith('orders', expect.anything());
     });
 
-    test('a dimension selects a column of the first model', async () => {
+    test('a dimension selects a REAL column of the first model', async () => {
       // eslint-disable-next-line no-template-curly-in-string
-      expect((await draftConfig('dimension')).expression).toBe('${ref(orders).id}');
+      expect((await draftConfig('dimension')).expression).toBe('${ref(orders).order_id}');
     });
+
+    // The scaffolds used to hardcode `id`. Most models don't have one, so the
+    // draft saved and then broke at run time against a column that was never
+    // there — with nothing pointing at the column as the cause.
+    test.each(['metric', 'dimension'])('a %s never invents a column name', async type => {
+      const config = await draftConfig(type);
+      expect(config.expression).not.toContain('.id}');
+    });
+
+    test.each(['metric', 'dimension'])(
+      'a %s refuses to draft when the columns cannot be read',
+      async type => {
+        fetchModelColumnNames.mockResolvedValue([]);
+        const save = jest.fn(async () => ({ success: true }));
+        useStore.setState({
+          models: [{ name: 'orders' }],
+          [CREATE_TEMPLATES[type].collectionKey]: [],
+          [CREATE_TEMPLATES[type].saveKey]: save,
+        });
+
+        const result = await useStore.getState().createWorkspaceObject(type);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/columns/i);
+        expect(save).not.toHaveBeenCalled();
+      }
+    );
 
     test.each(['metric', 'dimension'])(
       'a %s says WHY it cannot draft one with no models, rather than posting a doomed config',


### PR DESCRIPTION
> #640 has merged; this is rebased onto `main` and stands alone.

Three related ways the create flow lied about what it could do.

## 1. A menu item that looked live and wasn't

"+ New" → Relation with one model drafted, failed, and toasted. The precondition was already declared (`template.requires`) and already enforced at create time — it just wasn't readable *before* the click.

Now a blocked item **stays visible**, greys out, and carries the reason on hover.

`aria-disabled`, deliberately **not** `disabled`: a disabled button fires no mouse events, so the browser never shows its `title` — the hover explanation would be exactly the thing you couldn't read. Clicking one still answers via the toast, for when the pointer never rested long enough (or there is no pointer).

The preconditions, confirmed against the validators:

| type | needs | why |
|---|---|---|
| metric, dimension | **1 model** | at project level the `${ref()}` IS the tie to a source (`StandaloneFieldRefsValidator`) — with no models there is nothing to reference |
| relation | **2 models** | `relation.validate_condition_has_models` requires two model refs in the condition |

## 2. A column that didn't exist

The scaffolds hardcoded `id`. Most models don't have one, so "+ New Metric" produced `count(${ref(orders).id})` against a column that was never there — valid to the parser, broken the moment it ran, and nothing pointed at the column as the cause.

They now ask the server which columns the model actually has (`fetchModelColumnNames` → SQLGlot against the source's cached schema; no query, no run required) and use a real one. If the columns can't be read, the create is **refused** with that as the reason rather than fabricating a reference.

Which column is still a guess. That it exists no longer is.

## 3. A reference you couldn't re-point

Since "+ New" has to scaffold against *some* model, changing it is the natural next move — and the pill's base name was the one part of it the menu could not edit.

It now offers the other objects of the **same type**: a model pill moves among models, a metric pill among metrics. Swapping kinds would be a different grammar, not an edited reference. Changing the model **clears the column**, because a column belongs to the model it came from — carrying it across would recreate the bug above.

Both apply paths honour it: `PropertyRow` rebuilds the pill state with the new ref, and `RefTextArea` **rebuilds** the chip node rather than patching its property span, so a reference pointed at a different type re-derives its icon and colours.

## Verification

Sandbox (`:3001`, integration project):
- "+ New Metric" scaffolds `count(${ref(another_local_test_table).new_x})` — a real column, no `.id`
- the chip's menu shows a **Model** picker listing the project's models, defaulted to the current one

`yarn test` — 366 suites, **7045 passed** (+14 new). `yarn lint` clean.

New tests cover: each type's precondition and its hover reason, that a blocked click drafts nothing, that unrelated types are never blocked, that the scaffold never emits `.id`, that an unreadable model refuses instead of fabricating, and the picker's scope / column-clearing / absence when there is nothing else to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3
