### PR TITLE
Post-promote always offers a destination — "New dashboard…" for the zero-dashboard first run (W6)

### DIFF
--- a/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
@@ -20,8 +20,11 @@
  *
  * Also covers W6 (Dashboard Building v1 — "Post-promote always offers a
  * destination, including a brand-new dashboard"): the ZERO-dashboard
- * first-run case, manufactured in-test by soft-deleting every dashboard
- * before the app loads (afterEach's commit/discard restores them).
+ * first-run case, manufactured in-test by HIDING the project's existing
+ * dashboards from the viewer's list fetch (`page.route`) before the app
+ * loads — never by deleting them, so this file's blast radius on the shared
+ * sandbox stays "one appended row" rather than "the whole dashboard
+ * collection, restored only if afterEach gets to run".
  *
  * Precondition: sandbox running (integration project — has ≥1 real
  * dashboard), e.g.
@@ -254,18 +257,48 @@ test.describe('Post-promote fallback dashboard offer, reached through the ordina
   test('ZERO dashboards: promote offers "New dashboard…", creates one, and fills its born slot with the chart', async ({
     page,
   }) => {
-    // Manufacture the first-run state BEFORE the app loads, so the viewer's
-    // dashboard fetch really returns nothing: soft-delete every dashboard
-    // (tombstoned — afterEach's commit/discard restores them all).
+    // Manufacture the first-run state BEFORE the app loads — WITHOUT mutating
+    // the shared project. An earlier version of this test soft-deleted every
+    // dashboard in the sandbox and leaned on afterEach's best-effort
+    // `commit/discard` to put them back: that escalated this file's blast
+    // radius from "appends one row to a shared dashboard" to "tombstones the
+    // whole dashboard collection", and a worker crash, a timeout before
+    // afterEach, or a 500 on the discard would leave every later spec in the
+    // serial `exploration-mutations` project (and this file's own first test,
+    // on retry) running against a dashboard-less project.
+    //
+    // Hiding them from the VIEWER's list fetch produces exactly the state
+    // under test — `dashboards` is empty in the store, which is all
+    // `ExplorationPromoteModal` reads — while leaving the backend untouched.
     const listRes = await page.request.get(`${apiBase}/api/dashboards/`);
     expect(listRes.ok()).toBe(true);
-    const { dashboards: preexisting } = await listRes.json();
-    for (const d of preexisting) {
-      await page.request.delete(`${apiBase}/api/dashboards/${encodeURIComponent(d.name)}/`);
-    }
-    const emptyRes = await page.request.get(`${apiBase}/api/dashboards/`);
-    expect(emptyRes.ok()).toBe(true);
-    expect((await emptyRes.json()).dashboards).toHaveLength(0);
+    const preexisting = new Set((await listRes.json()).dashboards.map(d => d.name));
+    // The created dashboard is named by `generateUniqueName('new-dashboard',
+    // <the names the VIEWER can see>)`, so a hidden real dashboard called
+    // `new-dashboard*` could be overwritten by the create. Fail loudly here
+    // rather than silently clobbering a fixture.
+    expect(
+      [...preexisting].filter(name => name.startsWith('new-dashboard')),
+      'no fixture dashboard may share the created dashboard\'s name prefix'
+    ).toEqual([]);
+    // Matches the LIST endpoint only (with or without a `?project_id=` query);
+    // the per-dashboard save/delete routes live under
+    // `/api/dashboards/<name>/` and are deliberately left alone.
+    await page.route(
+      url => url.pathname === '/api/dashboards/',
+      async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const response = await route.fetch();
+        const body = await response.json();
+        await route.fulfill({
+          response,
+          json: {
+            ...body,
+            dashboards: (body.dashboards || []).filter(d => !preexisting.has(d.name)),
+          },
+        });
+      }
+    );
 
     // The same ordinary flow as the test above — Explorer home, source tile,
     // query, chart, Save to project. No dashboard exists anywhere.
@@ -301,14 +334,17 @@ test.describe('Post-promote fallback dashboard offer, reached through the ordina
     await page.getByTestId('exploration-promote-fallback-place').click();
 
     // A dashboard now exists that didn't a moment ago; register it for
-    // cleanup and confirm its tab opened.
+    // cleanup and confirm its tab opened. Identified as "not one of the
+    // dashboards that existed before this test", which holds whether or not
+    // the route filter above applies to `page.request`.
     let createdDashboardName;
     await expect(async () => {
       const res = await page.request.get(`${apiBase}/api/dashboards/`);
       expect(res.ok()).toBe(true);
       const { dashboards } = await res.json();
-      expect(dashboards).toHaveLength(1);
-      createdDashboardName = dashboards[0].name;
+      const created = dashboards.filter(d => !preexisting.has(d.name));
+      expect(created).toHaveLength(1);
+      createdDashboardName = created[0].name;
     }).toPass({ timeout: 20000 });
     createdObjects.push({ segment: 'dashboards', name: createdDashboardName });
     await expect(page.getByTestId(`dashboard_${createdDashboardName}`)).toBeVisible({

--- a/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
+++ b/viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs
@@ -18,6 +18,11 @@
  * reuses the same `placeChartInDashboardSlot` plumbing the return_to-driven
  * offer does.
  *
+ * Also covers W6 (Dashboard Building v1 — "Post-promote always offers a
+ * destination, including a brand-new dashboard"): the ZERO-dashboard
+ * first-run case, manufactured in-test by soft-deleting every dashboard
+ * before the app loads (afterEach's commit/discard restores them).
+ *
  * Precondition: sandbox running (integration project — has ≥1 real
  * dashboard), e.g.
  *   VISIVO_SANDBOX_NAME=fallbackOffer VISIVO_SANDBOX_BACKEND_PORT=8055 \
@@ -133,6 +138,16 @@ async function bindXSlotToNumericColumn(page) {
   await expect(xSlot.getByTestId('pill-menu-trigger')).toBeVisible({ timeout: 10000 });
 }
 
+/** Rename the draft chart via its name input (select-all + type + blur). */
+async function nameChart(page, chartName) {
+  const nameInput = page.getByTestId('chart-name-input');
+  await nameInput.click();
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await page.keyboard.press(`${modifier}+a`);
+  await page.keyboard.type(chartName, { delay: 5 });
+  await nameInput.blur();
+}
+
 async function fetchDashboard(page, name) {
   const res = await page.request.get(`${apiBase}/api/dashboards/${encodeURIComponent(name)}/`);
   expect(res.ok()).toBe(true);
@@ -186,12 +201,7 @@ test.describe('Post-promote fallback dashboard offer, reached through the ordina
 
     await bindXSlotToNumericColumn(page);
     const chartName = `e2e_fallback_offer_chart_${Date.now()}`;
-    const nameInput = page.getByTestId('chart-name-input');
-    await nameInput.click();
-    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
-    await page.keyboard.press(`${modifier}+a`);
-    await page.keyboard.type(chartName, { delay: 5 });
-    await nameInput.blur();
+    await nameChart(page, chartName);
 
     const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
     const insightName = await page.evaluate(
@@ -230,6 +240,90 @@ test.describe('Post-promote fallback dashboard offer, reached through the ordina
       const dashboard = await fetchDashboard(page, dashboardName);
       expect(dashboardReferencesChart(dashboard, chartName)).toBe(true);
     }).toPass({ timeout: 20000 });
+  });
+
+  // W6 (Dashboard Building v1 — "Post-promote always offers a destination,
+  // including a brand-new dashboard"): the FIRST-RUN case. A project with
+  // ZERO dashboards used to auto-close the modal on a clean chart promote
+  // (`showFallbackDashboardOffer` required `dashboards.length > 0`), so the
+  // one working exit ramp from Explorer to a dashboard never fired for
+  // exactly the user who needs it most — every field-test tester. Now the
+  // offer renders with a "New dashboard…" default; accepting creates a
+  // dashboard through the standard inline-create path and FILLS the born
+  // row's existing empty slot (#621) — never appends a second row.
+  test('ZERO dashboards: promote offers "New dashboard…", creates one, and fills its born slot with the chart', async ({
+    page,
+  }) => {
+    // Manufacture the first-run state BEFORE the app loads, so the viewer's
+    // dashboard fetch really returns nothing: soft-delete every dashboard
+    // (tombstoned — afterEach's commit/discard restores them all).
+    const listRes = await page.request.get(`${apiBase}/api/dashboards/`);
+    expect(listRes.ok()).toBe(true);
+    const { dashboards: preexisting } = await listRes.json();
+    for (const d of preexisting) {
+      await page.request.delete(`${apiBase}/api/dashboards/${encodeURIComponent(d.name)}/`);
+    }
+    const emptyRes = await page.request.get(`${apiBase}/api/dashboards/`);
+    expect(emptyRes.ok()).toBe(true);
+    expect((await emptyRes.json()).dashboards).toHaveLength(0);
+
+    // The same ordinary flow as the test above — Explorer home, source tile,
+    // query, chart, Save to project. No dashboard exists anywhere.
+    await gotoExplorerHome(page);
+    await startFromSourceTile(page);
+    await bindXSlotToNumericColumn(page);
+    const chartName = `e2e_zero_dash_chart_${Date.now()}`;
+    await nameChart(page, chartName);
+
+    const queryName = await page.evaluate(() => window.useStore.getState().explorerActiveModelName);
+    const insightName = await page.evaluate(
+      () => window.useStore.getState().explorerChartInsightNames[0]
+    );
+
+    await page.getByTestId('explorer-save-button').click();
+    await expect(page.getByTestId('exploration-promote-modal')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('exploration-promote-submit').click();
+    await expect(page.getByTestId('exploration-promote-success')).toBeVisible({ timeout: 20000 });
+    createdObjects.push(
+      { segment: 'models', name: queryName },
+      { segment: 'insights', name: insightName },
+      { segment: 'charts', name: chartName }
+    );
+
+    // The modal did NOT auto-close as a "clean success with nothing to act
+    // on" — the offer renders, and with zero dashboards its select defaults
+    // to the "New dashboard…" sentinel (no picking needed).
+    const fallbackOffer = page.getByTestId('exploration-promote-fallback-dashboard-offer');
+    await expect(fallbackOffer).toBeVisible({ timeout: 10000 });
+    await expect(fallbackOffer).toContainText(chartName);
+    await expect(fallbackOffer).toContainText('New dashboard…');
+
+    await page.getByTestId('exploration-promote-fallback-place').click();
+
+    // A dashboard now exists that didn't a moment ago; register it for
+    // cleanup and confirm its tab opened.
+    let createdDashboardName;
+    await expect(async () => {
+      const res = await page.request.get(`${apiBase}/api/dashboards/`);
+      expect(res.ok()).toBe(true);
+      const { dashboards } = await res.json();
+      expect(dashboards).toHaveLength(1);
+      createdDashboardName = dashboards[0].name;
+    }).toPass({ timeout: 20000 });
+    createdObjects.push({ segment: 'dashboards', name: createdDashboardName });
+    await expect(page.getByTestId(`dashboard_${createdDashboardName}`)).toBeVisible({
+      timeout: 20000,
+    });
+
+    // Backend-asserted (feedback_backend_diffing.md): the chart FILLED the
+    // born row's existing empty slot — exactly one row holding exactly one
+    // item, and that item IS the chart. Never a second row appended below an
+    // empty placeholder row.
+    const dashboard = await fetchDashboard(page, createdDashboardName);
+    const rows = dashboard?.config?.rows || [];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].items).toHaveLength(1);
+    expect(rows[0].items[0].chart || '').toContain(chartName);
   });
 
   test('the fallback offer never appears when nothing was promoted this run', async ({ page }) => {

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PiCheckCircle, PiXCircle, PiCircleNotch, PiPencilSimple } from 'react-icons/pi';
 import useStore from '../../../stores/store';
 import { useGuardedAsync } from '../../../hooks/useGuardedAsync';
@@ -15,10 +15,25 @@ const TIER_ORDER = ['model', 'field', 'insight', 'chart'];
 
 const rowKey = row => `${row.type}:${row.name}`;
 
-// W6 (Dashboard Building v1) — the sentinel value for the fallback dashboard
-// offer's "New dashboard…" choice. Not a valid object name (names are
-// validated identifiers), so it can never collide with a real dashboard.
+// W6 (Dashboard Building v1) — the BASE sentinel value for the fallback
+// dashboard offer's "New dashboard…" choice.
+//
+// It is NOT safe to assume this can never be a real dashboard name: the
+// viewer's `NAME_PATTERN` (namedModel.js) forbids a leading underscore only
+// for names typed into VIEWER forms — the backend's `NamedModel.name` is a
+// plain `Optional[str]` with no validator, so a hand-authored .visivo.yml may
+// legitimately declare `dashboards: [{ name: __new__, … }]`. Two options
+// sharing one value would make `Select`'s `flatOptions.find(o => o.value ===
+// value)` match the sentinel first: the real dashboard would RENDER as "New
+// dashboard…", and picking it would silently create a different dashboard
+// instead. `resolveNewDashboardValue` escapes the sentinel until it collides
+// with nothing, so the two choices are always distinguishable.
 const NEW_DASHBOARD_VALUE = '__new__';
+export const resolveNewDashboardValue = takenNames => {
+  let sentinel = NEW_DASHBOARD_VALUE;
+  while (takenNames.has(sentinel)) sentinel = `_${sentinel}_`;
+  return sentinel;
+};
 
 // D11 (specs/plan/explorer-workspace-unification/08-ux-overhaul.md) — the ONE
 // user-facing verb for this whole chain is "Save to project"; "promote"
@@ -411,23 +426,54 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   // inline-create path and fills its born row's empty slot (#621) via
   // `placeChartInNewDashboard`.
   const showFallbackDashboardOffer = !!promotedChart && !returnTo?.dashboard;
-  // The user's explicit pick, or `null` until they choose one. The effective
-  // name is derived SYNCHRONOUSLY (default = first dashboard) rather than seeded
-  // via an effect: an effect costs an extra render, and the guarded placement
-  // below (whose fn is swapped in post-commit by useGuardedAsync) could capture
-  // the pre-effect empty value if the click lands in that window — which is
-  // exactly the flake a render-timing change surfaced (VIS-1226 review).
-  //
-  // Zero dashboards defaults to "New dashboard…" (the only choice there is);
-  // with dashboards present the default stays the first one, and a malformed
-  // nameless first dashboard still degrades to '' (Add disabled) as before.
+  // The offer's destination options, plus the collision-free sentinel value
+  // standing for "New dashboard…" (see `resolveNewDashboardValue` above).
+  const fallbackDashboardOptions = useMemo(() => {
+    const existing = dashboards.map(d => ({ value: d.name, label: d.name }));
+    const newDashboardValue = resolveNewDashboardValue(new Set(existing.map(o => o.value)));
+    return {
+      newDashboardValue,
+      // W6: "New dashboard…" is offered ALWAYS — as the only (and default)
+      // choice in a zero-dashboard project, closing the first-run dead end,
+      // and alongside the existing dashboards in every other project.
+      options: [{ value: newDashboardValue, label: 'New dashboard…' }, ...existing],
+    };
+  }, [dashboards]);
+  // The user's explicit pick as a TAGGED choice (`{ isNew: true }` or
+  // `{ name }`) — never a bare string, so no dashboard name can ever be
+  // mistaken for the "New dashboard…" option — or `null` until they choose.
   const [fallbackDashboardChoice, setFallbackDashboardChoice] = useState(null);
-  const fallbackDashboardName =
-    fallbackDashboardChoice != null
-      ? fallbackDashboardChoice
-      : dashboards.length > 0
-        ? dashboards[0]?.name || ''
-        : NEW_DASHBOARD_VALUE;
+  // The default is FROZEN the first time the offer renders, and derived
+  // SYNCHRONOUSLY (never seeded via an effect: an effect costs an extra
+  // render, and the guarded placement below — whose fn is swapped in
+  // post-commit by useGuardedAsync — could capture the pre-effect empty value
+  // if the click lands in that window, exactly the flake a render-timing
+  // change surfaced in the VIS-1226 review).
+  //
+  // Freezing is what keeps the destination HONEST. `placeChartInNewDashboard`
+  // creates the dashboard before it places the chart, and that create refetches
+  // `dashboards` — so a create-succeeded/placement-failed run turns a
+  // zero-dashboard project into a one-dashboard project while this offer is
+  // still on screen. Re-deriving the default there silently flipped the
+  // untouched select from "New dashboard…" to the orphan the failed attempt had
+  // just created, and the user's retry click then routed to
+  // `placeChartInDashboardSlot` with no slot — appending a SECOND row below the
+  // still-empty born one, the exact layout #621 and this offer exist to avoid.
+  const defaultFallbackChoiceRef = useRef(null);
+  if (showFallbackDashboardOffer && !defaultFallbackChoiceRef.current) {
+    // Zero dashboards defaults to "New dashboard…" (the only choice there is);
+    // with dashboards present the default stays the first one, and a malformed
+    // nameless first dashboard still degrades to '' (Add disabled) as before.
+    defaultFallbackChoiceRef.current =
+      dashboards.length > 0 ? { name: dashboards[0]?.name || '' } : { isNew: true };
+  }
+  const fallbackChoice =
+    fallbackDashboardChoice || defaultFallbackChoiceRef.current || { isNew: true };
+  const placingIntoNewDashboard = !!fallbackChoice.isNew;
+  const fallbackDashboardName = placingIntoNewDashboard ? '' : fallbackChoice.name || '';
+  const fallbackSelectValue = placingIntoNewDashboard
+    ? fallbackDashboardOptions.newDashboardValue
+    : fallbackDashboardName;
   const [fallbackPlaceError, setFallbackPlaceError] = useState(null);
 
   // The double-click guard + `pending` flag for these placement actions lives
@@ -443,15 +489,16 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     // fills its born row's empty slot; an existing pick places into that
     // dashboard exactly as before. Either way the placed-into dashboard's
     // tab opens so the user lands looking at the chart.
-    const placingIntoNew = fallbackDashboardName === NEW_DASHBOARD_VALUE;
-    const placeResult = placingIntoNew
+    const placeResult = placingIntoNewDashboard
       ? await placeChartInNewDashboard(promotedChart.name)
       : await placeChartInDashboardSlot(fallbackDashboardName, promotedChart.name);
     if (!placeResult?.success) {
       setFallbackPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
       return;
     }
-    const placedDashboardName = placingIntoNew ? placeResult.dashboardName : fallbackDashboardName;
+    const placedDashboardName = placingIntoNewDashboard
+      ? placeResult.dashboardName
+      : fallbackDashboardName;
     openWorkspaceTab?.({
       id: `dashboard:${placedDashboardName}`,
       type: 'dashboard',
@@ -460,13 +507,13 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     onClose?.();
   });
   const handleFallbackPlace = () => {
-    if (!promotedChart || !fallbackDashboardName) return;
+    if (!promotedChart) return;
+    if (!placingIntoNewDashboard && !fallbackDashboardName) return;
     // Preconditions stay OUTSIDE the guarded run (a no-op click never flips
     // `pending`): each choice needs its own store action to exist.
-    const placeAction =
-      fallbackDashboardName === NEW_DASHBOARD_VALUE
-        ? placeChartInNewDashboard
-        : placeChartInDashboardSlot;
+    const placeAction = placingIntoNewDashboard
+      ? placeChartInNewDashboard
+      : placeChartInDashboardSlot;
     if (!placeAction) return;
     runFallbackPlace();
   };
@@ -826,18 +873,18 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
               Add <span className="font-medium">{promotedChart.name}</span> to
               <Select
                 data-testid="exploration-promote-fallback-dashboard-select"
-                value={fallbackDashboardName}
-                onChange={setFallbackDashboardChoice}
+                value={fallbackSelectValue}
+                onChange={value =>
+                  setFallbackDashboardChoice(
+                    value === fallbackDashboardOptions.newDashboardValue
+                      ? { isNew: true }
+                      : { name: value }
+                  )
+                }
                 disabled={fallbackPlacing}
                 size="sm"
                 isSearchable={false}
-                options={[
-                  // W6: always offered — in a zero-dashboard project it is
-                  // the only (and default) choice, closing the first-run
-                  // dead end where promote had no destination at all.
-                  { value: NEW_DASHBOARD_VALUE, label: 'New dashboard…' },
-                  ...dashboards.map(d => ({ value: d.name, label: d.name })),
-                ]}
+                options={fallbackDashboardOptions.options}
                 className="min-w-[7rem]"
               />
               ?
@@ -846,7 +893,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
               type="button"
               data-testid="exploration-promote-fallback-place"
               onClick={handleFallbackPlace}
-              disabled={fallbackPlacing || !fallbackDashboardName}
+              disabled={fallbackPlacing || (!placingIntoNewDashboard && !fallbackDashboardName)}
               className="shrink-0 rounded-md bg-primary px-2 py-1 text-xs font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {fallbackPlacing ? 'Adding…' : 'Add'}

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.jsx
@@ -15,6 +15,11 @@ const TIER_ORDER = ['model', 'field', 'insight', 'chart'];
 
 const rowKey = row => `${row.type}:${row.name}`;
 
+// W6 (Dashboard Building v1) — the sentinel value for the fallback dashboard
+// offer's "New dashboard…" choice. Not a valid object name (names are
+// validated identifiers), so it can never collide with a real dashboard.
+const NEW_DASHBOARD_VALUE = '__new__';
+
 // D11 (specs/plan/explorer-workspace-unification/08-ux-overhaul.md) — the ONE
 // user-facing verb for this whole chain is "Save to project"; "promote"
 // stays as internal-only vocabulary (store/API names, test ids). A row can
@@ -106,6 +111,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   const dashboards = useStore(s => s.dashboards || EMPTY_DASHBOARDS);
   const openWorkspaceTab = useStore(s => s.openWorkspaceTab);
   const placeChartInDashboardSlot = useStore(s => s.placeChartInDashboardSlot);
+  const placeChartInNewDashboard = useStore(s => s.placeChartInNewDashboard);
   const consumeExplorationReturnTo = useStore(s => s.consumeExplorationReturnTo);
   // VIS-1069 — Semantic Layer reciprocal: "View in Semantic Layer" after
   // promoting a metric/dimension.
@@ -308,10 +314,12 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
       succeeded.find(r => r.type === 'metric' || r.type === 'dimension') ||
       succeeded.find(r => r.type === 'model') ||
       null;
+    // W6: a promoted chart ALWAYS has a placement offer now — return_to when
+    // armed, otherwise the fallback offer, whose "New dashboard…" option
+    // exists even in a project with zero dashboards (the first-run case that
+    // used to dead-end right here by auto-closing with no next step).
     const hasOffer =
-      (result.reclassificationOffers?.length || 0) > 0 ||
-      (!!promotedChart && (!!returnTo?.dashboard || dashboards.length > 0)) ||
-      !!promotedField;
+      (result.reclassificationOffers?.length || 0) > 0 || !!promotedChart || !!promotedField;
 
     setPromoting(false);
 
@@ -337,7 +345,7 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
     if (result.reclassificationOffers?.length > 0) {
       setReclassificationOffers(result.reclassificationOffers);
     }
-  }, [selected, promoteExploration, explorationId, returnTo, dashboards, onClose]);
+  }, [selected, promoteExploration, explorationId, onClose]);
 
   const dismissOffer = useCallback(index => {
     setReclassificationOffers(prev => prev.filter((_, i) => i !== index));
@@ -394,16 +402,32 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   // plumbing for the common case: a chart was promoted this run, there's no
   // `return_to` intent already offering placement, and at least one
   // dashboard exists to place it in.
-  const showFallbackDashboardOffer = !!promotedChart && !returnTo?.dashboard && dashboards.length > 0;
+  //
+  // W6 (Dashboard Building v1): the `dashboards.length > 0` term is GONE — a
+  // first-run user has ZERO dashboards, so the one working exit ramp from
+  // Explorer to a dashboard never fired for exactly the user who needs it
+  // most. The offer's select now always carries a "New dashboard…" option
+  // (`NEW_DASHBOARD_VALUE`), which creates one through the standard
+  // inline-create path and fills its born row's empty slot (#621) via
+  // `placeChartInNewDashboard`.
+  const showFallbackDashboardOffer = !!promotedChart && !returnTo?.dashboard;
   // The user's explicit pick, or `null` until they choose one. The effective
   // name is derived SYNCHRONOUSLY (default = first dashboard) rather than seeded
   // via an effect: an effect costs an extra render, and the guarded placement
   // below (whose fn is swapped in post-commit by useGuardedAsync) could capture
   // the pre-effect empty value if the click lands in that window — which is
   // exactly the flake a render-timing change surfaced (VIS-1226 review).
+  //
+  // Zero dashboards defaults to "New dashboard…" (the only choice there is);
+  // with dashboards present the default stays the first one, and a malformed
+  // nameless first dashboard still degrades to '' (Add disabled) as before.
   const [fallbackDashboardChoice, setFallbackDashboardChoice] = useState(null);
   const fallbackDashboardName =
-    fallbackDashboardChoice != null ? fallbackDashboardChoice : dashboards[0]?.name || '';
+    fallbackDashboardChoice != null
+      ? fallbackDashboardChoice
+      : dashboards.length > 0
+        ? dashboards[0]?.name || ''
+        : NEW_DASHBOARD_VALUE;
   const [fallbackPlaceError, setFallbackPlaceError] = useState(null);
 
   // The double-click guard + `pending` flag for these placement actions lives
@@ -415,20 +439,35 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
   // no-op click never flips `pending` — a clean no-op, as before.
   const [runFallbackPlace, fallbackPlacing] = useGuardedAsync(async () => {
     setFallbackPlaceError(null);
-    const placeResult = await placeChartInDashboardSlot(fallbackDashboardName, promotedChart.name);
+    // W6: "New dashboard…" creates one (standard inline-create path) and
+    // fills its born row's empty slot; an existing pick places into that
+    // dashboard exactly as before. Either way the placed-into dashboard's
+    // tab opens so the user lands looking at the chart.
+    const placingIntoNew = fallbackDashboardName === NEW_DASHBOARD_VALUE;
+    const placeResult = placingIntoNew
+      ? await placeChartInNewDashboard(promotedChart.name)
+      : await placeChartInDashboardSlot(fallbackDashboardName, promotedChart.name);
     if (!placeResult?.success) {
       setFallbackPlaceError(placeResult?.error || 'Could not place the chart in the dashboard');
       return;
     }
+    const placedDashboardName = placingIntoNew ? placeResult.dashboardName : fallbackDashboardName;
     openWorkspaceTab?.({
-      id: `dashboard:${fallbackDashboardName}`,
+      id: `dashboard:${placedDashboardName}`,
       type: 'dashboard',
-      name: fallbackDashboardName,
+      name: placedDashboardName,
     });
     onClose?.();
   });
   const handleFallbackPlace = () => {
-    if (!promotedChart || !fallbackDashboardName || !placeChartInDashboardSlot) return;
+    if (!promotedChart || !fallbackDashboardName) return;
+    // Preconditions stay OUTSIDE the guarded run (a no-op click never flips
+    // `pending`): each choice needs its own store action to exist.
+    const placeAction =
+      fallbackDashboardName === NEW_DASHBOARD_VALUE
+        ? placeChartInNewDashboard
+        : placeChartInDashboardSlot;
+    if (!placeAction) return;
     runFallbackPlace();
   };
 
@@ -792,7 +831,13 @@ const ExplorationPromoteModal = ({ explorationId, onClose }) => {
                 disabled={fallbackPlacing}
                 size="sm"
                 isSearchable={false}
-                options={dashboards.map(d => ({ value: d.name, label: d.name }))}
+                options={[
+                  // W6: always offered — in a zero-dashboard project it is
+                  // the only (and default) choice, closing the first-run
+                  // dead end where promote had no destination at all.
+                  { value: NEW_DASHBOARD_VALUE, label: 'New dashboard…' },
+                  ...dashboards.map(d => ({ value: d.name, label: d.name })),
+                ]}
                 className="min-w-[7rem]"
               />
               ?

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import ExplorationPromoteModal from './ExplorationPromoteModal';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
+import selectEvent from 'react-select-event';
+import ExplorationPromoteModal, { resolveNewDashboardValue } from './ExplorationPromoteModal';
 import useStore from '../../../stores/store';
 import { buildPromoteChecklist } from '../../../stores/promoteChecklist';
 
@@ -31,6 +32,24 @@ beforeEach(() => {
     renameInsight: jest.fn(),
     setChartName: jest.fn(),
     explorerModelStates: {},
+  });
+});
+
+// The "New dashboard…" option's value shares a namespace with real dashboard
+// names (react-select matches options BY VALUE), and `NamedModel.name` is an
+// unvalidated `Optional[str]` on the backend — so the sentinel has to escape
+// itself out of the way of whatever names the project actually has.
+describe('resolveNewDashboardValue (W6 sentinel collision escape)', () => {
+  test('uses the plain sentinel when no dashboard claims it', () => {
+    expect(resolveNewDashboardValue(new Set(['sales', 'ops']))).toBe('__new__');
+  });
+
+  test('escapes past a colliding dashboard name', () => {
+    expect(resolveNewDashboardValue(new Set(['__new__']))).toBe('___new___');
+  });
+
+  test('keeps escaping until the value is genuinely free', () => {
+    expect(resolveNewDashboardValue(new Set(['__new__', '___new___']))).toBe('____new____');
   });
 });
 
@@ -647,6 +666,137 @@ describe('ExplorationPromoteModal', () => {
         )
       );
       expect(useStore.getState().placeChartInNewDashboard).not.toHaveBeenCalled();
+    });
+
+    // The assertion above reads the CLOSED react-select control, which renders
+    // only the selected label — it pins the default and says nothing about
+    // what else is on the menu. Deleting the "New dashboard…" option for every
+    // project that already has a dashboard (the majority case, and half of
+    // this feature) left the whole suite green. This opens the menu and reads
+    // the real option list, then drives the sentinel end-to-end.
+    test('with existing dashboards the OPEN menu really lists "New dashboard…" alongside them, and picking it creates one (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [{ name: 'sales' }, { name: 'ops' }],
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: true, dashboardName: 'new-dashboard' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      const combobox = within(
+        screen.getByTestId('exploration-promote-fallback-dashboard-select')
+      ).getByRole('combobox');
+      selectEvent.openMenu(combobox);
+      const optionLabels = (await screen.findAllByRole('option')).map(o => o.textContent);
+      // The escape hatch is on the menu WITH the existing dashboards, not
+      // instead of them.
+      expect(optionLabels).toEqual(['New dashboard…', 'sales', 'ops']);
+
+      await selectEvent.select(combobox, 'New dashboard…', { container: document.body });
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInNewDashboard).toHaveBeenCalledWith('churn_chart')
+      );
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'dashboard:new-dashboard',
+          type: 'dashboard',
+          name: 'new-dashboard',
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    // The "New dashboard…" sentinel shares a value space with real dashboard
+    // names, and `NamedModel.name` is an unvalidated `Optional[str]` on the
+    // backend — a hand-authored .visivo.yml really can declare a dashboard
+    // named `__new__`. With a colliding value, `Select` matches the sentinel
+    // first: the real dashboard rendered as "New dashboard…" and picking it
+    // created a different dashboard instead of placing into it.
+    test('a real dashboard named like the sentinel is still a distinct, selectable destination (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [{ name: '__new__' }, { name: 'sales' }],
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: true, dashboardName: 'new-dashboard' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+      // The default is the first REAL dashboard, and it reads as itself —
+      // never mislabelled as the "New dashboard…" option.
+      expect(offer).toHaveTextContent('__new__');
+      expect(offer).not.toHaveTextContent('New dashboard…');
+
+      const combobox = within(
+        screen.getByTestId('exploration-promote-fallback-dashboard-select')
+      ).getByRole('combobox');
+      await selectEvent.select(combobox, '__new__', { container: document.body });
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      // Picking the real dashboard PLACES INTO it; it never creates one.
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInDashboardSlot).toHaveBeenCalledWith(
+          '__new__',
+          'churn_chart'
+        )
+      );
+      expect(useStore.getState().placeChartInNewDashboard).not.toHaveBeenCalled();
+    });
+
+    // `placeChartInNewDashboard` creates the dashboard before it places the
+    // chart, and the create refetches `dashboards` — so a create-succeeded/
+    // placement-failed run turns a zero-dashboard project into a
+    // one-dashboard project with this offer still on screen. The destination
+    // the user is looking at must NOT silently flip to that dashboard: the
+    // retry would then route to `placeChartInDashboardSlot` with no slot,
+    // appending a second row below the still-empty born one.
+    test('ZERO dashboards: a failed create-and-place does NOT flip the destination — the retry still creates (W6)', async () => {
+      const placeChartInNewDashboard = jest.fn(async () => {
+        // The create half succeeded and its refetch landed the born (empty)
+        // dashboard in the store before the placement save failed.
+        act(() => {
+          useStore.setState({ dashboards: [{ name: 'new-dashboard', config: { rows: [] } }] });
+        });
+        return { success: false, error: 'validation refused it' };
+      });
+      seedReturnTo(null, { dashboards: [], placeChartInNewDashboard });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+      await waitFor(() =>
+        expect(screen.getByTestId('exploration-promote-fallback-place-error')).toHaveTextContent(
+          'validation refused it'
+        )
+      );
+
+      // The untouched select still reads "New dashboard…" — not the orphan
+      // the failed attempt just created.
+      expect(offer).toHaveTextContent('New dashboard…');
+      expect(offer).not.toHaveTextContent('Add churn_chart to new-dashboard');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() => expect(placeChartInNewDashboard).toHaveBeenCalledTimes(2));
+      // Never the existing-dashboard path — that one, with no slot, appends a
+      // SECOND row below the born empty one.
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
     });
 
     test('no fallback offer when no chart was promoted this run (even with no return_to)', async () => {

--- a/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPromoteModal.test.jsx
@@ -42,7 +42,7 @@ describe('ExplorationPromoteModal', () => {
     expect(screen.queryByTestId('exploration-promote-return-to-offer')).not.toBeInTheDocument();
   });
 
-  test('fails safe (no crash) when the dashboards collection is undefined, and closes the clean success', async () => {
+  test('fails safe (no crash) when the dashboards collection is undefined — the fallback offer still renders, defaulting to "New dashboard…" (W6)', async () => {
     buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
     useStore.setState({
       dashboards: undefined,
@@ -56,12 +56,12 @@ describe('ExplorationPromoteModal', () => {
     render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
     await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
     fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-    // dashboards undefined must not throw; with no dashboards and no field this
-    // is a clean success, so the modal closes rather than linger (VIS-1226).
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-    expect(
-      screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
-    ).not.toBeInTheDocument();
+    // dashboards undefined must not throw — and no longer auto-closes: W6
+    // dropped the dashboards.length gate, so a promoted chart ALWAYS gets a
+    // destination offer, "New dashboard…" being the zero-dashboard default.
+    const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+    expect(offer).toHaveTextContent('New dashboard…');
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   test('fails safe when promoteExploration resolves with no `results` array at all', async () => {
@@ -500,7 +500,13 @@ describe('ExplorationPromoteModal', () => {
       expect(fallback).toHaveTextContent('churn_chart');
     });
 
-    test('closes on a clean success when a chart is promoted but no dashboards exist to place it in (VIS-1226)', async () => {
+    // W6 (Dashboard Building v1) — REVERSES the old "closes on a clean
+    // success when no dashboards exist" behavior. A first-run user has ZERO
+    // dashboards, so the auto-close made promote a dead end in exactly the
+    // exit-gate scenario: the chart was saved, the modal vanished, and no
+    // path toward a dashboard was ever offered. The offer now always renders
+    // for a promoted chart, defaulting to "New dashboard…".
+    test('ZERO dashboards: the fallback offer still renders, defaulting to "New dashboard…" — never a dead-end auto-close (W6)', async () => {
       seedReturnTo(null, { dashboards: [] });
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
       useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
@@ -508,12 +514,139 @@ describe('ExplorationPromoteModal', () => {
       render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      // No dashboards to offer and no field to jump to -> nothing to act on, so
-      // the modal closes instead of lingering on a bare "Saved" receipt.
-      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+      expect(offer).toHaveTextContent('churn_chart');
+      expect(offer).toHaveTextContent('New dashboard…');
+      expect(onClose).not.toHaveBeenCalled();
+      // The Add button is live — "New dashboard…" is a real destination, not
+      // a disabled placeholder.
+      expect(screen.getByTestId('exploration-promote-fallback-place')).toBeEnabled();
+    });
+
+    test('ZERO dashboards: accepting "New dashboard…" creates + places via placeChartInNewDashboard, opens the NEW dashboard tab, and closes (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [],
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: true, dashboardName: 'new-dashboard' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInNewDashboard).toHaveBeenCalledWith('churn_chart')
+      );
+      // Never the existing-dashboard placement path — there is no dashboard.
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
+      // Opens the tab of the dashboard the store action just created (its
+      // REAL name comes from the action's result, never guessed here).
+      await waitFor(() =>
+        expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'dashboard:new-dashboard',
+          type: 'dashboard',
+          name: 'new-dashboard',
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('ZERO dashboards: a failed create-and-place shows the inline error and does not close (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [],
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: false, error: 'could not create a new dashboard' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('exploration-promote-fallback-place-error')).toHaveTextContent(
+          'could not create a new dashboard'
+        )
+      );
+      expect(useStore.getState().openWorkspaceTab).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test('ZERO dashboards: a failed create-and-place with no `error` field falls back to the generic message (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [],
+        placeChartInNewDashboard: jest.fn().mockResolvedValue({ success: false }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
       expect(
-        screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
+        await screen.findByTestId('exploration-promote-fallback-place-error')
+      ).toHaveTextContent('Could not place the chart in the dashboard');
+    });
+
+    test('ZERO dashboards: clicking Add when placeChartInNewDashboard is missing from the store is a safe no-op (W6)', async () => {
+      seedReturnTo(null, { dashboards: [], placeChartInNewDashboard: undefined });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      const onClose = jest.fn();
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      // No crash, no error banner, no navigation, no close — and the
+      // existing-dashboard path was never wrongly invoked as a stand-in.
+      expect(
+        screen.queryByTestId('exploration-promote-fallback-place-error')
       ).not.toBeInTheDocument();
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
+      expect(useStore.getState().openWorkspaceTab).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test('with existing dashboards the "New dashboard…" option is offered ALONGSIDE them, and the default stays the first dashboard (W6)', async () => {
+      seedReturnTo(null, {
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: true, dashboardName: 'new-dashboard' }),
+      });
+      buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
+      useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
+      render(<ExplorationPromoteModal explorationId="exp_1" onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
+      fireEvent.click(screen.getByTestId('exploration-promote-submit'));
+      const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+      // Default is unchanged: the FIRST existing dashboard, not the new-
+      // dashboard sentinel.
+      expect(offer).toHaveTextContent('sales');
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInDashboardSlot).toHaveBeenCalledWith(
+          'sales',
+          'churn_chart'
+        )
+      );
+      expect(useStore.getState().placeChartInNewDashboard).not.toHaveBeenCalled();
     });
 
     test('no fallback offer when no chart was promoted this run (even with no return_to)', async () => {
@@ -1368,20 +1501,42 @@ describe('ExplorationPromoteModal', () => {
       expect(fallback).toHaveTextContent('churn_chart');
     });
 
-    test('closes on a clean success when a chart is promoted but no dashboards exist to place it in (VIS-1226)', async () => {
-      seedReturnTo(null, { dashboards: [] });
+    // W6 — the coverage-push twin of the primary describe's zero-dashboard
+    // suite: pins that the old auto-close (VIS-1226's "nothing to act on")
+    // no longer swallows the first-run case, and that the sentinel routes to
+    // placeChartInNewDashboard rather than the existing-dashboard action.
+    test('ZERO dashboards: the offer renders with "New dashboard…" and accepting routes through placeChartInNewDashboard (W6)', async () => {
+      seedReturnTo(null, {
+        dashboards: [],
+        placeChartInNewDashboard: jest
+          .fn()
+          .mockResolvedValue({ success: true, dashboardName: 'new-dashboard' }),
+      });
       buildPromoteChecklist.mockResolvedValue([row({ tier: 'chart', type: 'chart', name: 'churn_chart' })]);
       useStore.setState({ promoteExploration: jest.fn().mockResolvedValue(promoteChartResult()) });
       const onClose = jest.fn();
       render(<ExplorationPromoteModal explorationId="exp_1" onClose={onClose} />);
       await waitFor(() => expect(screen.getByTestId('exploration-promote-submit')).toBeEnabled());
       fireEvent.click(screen.getByTestId('exploration-promote-submit'));
-      // No dashboards to offer and no field to jump to -> nothing to act on, so
-      // the modal closes instead of lingering on a bare "Saved" receipt.
-      await waitFor(() => expect(onClose).toHaveBeenCalled());
-      expect(
-        screen.queryByTestId('exploration-promote-fallback-dashboard-offer')
-      ).not.toBeInTheDocument();
+
+      const offer = await screen.findByTestId('exploration-promote-fallback-dashboard-offer');
+      expect(offer).toHaveTextContent('New dashboard…');
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('exploration-promote-fallback-place'));
+
+      await waitFor(() =>
+        expect(useStore.getState().placeChartInNewDashboard).toHaveBeenCalledWith('churn_chart')
+      );
+      expect(useStore.getState().placeChartInDashboardSlot).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(useStore.getState().openWorkspaceTab).toHaveBeenCalledWith({
+          id: 'dashboard:new-dashboard',
+          type: 'dashboard',
+          name: 'new-dashboard',
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
     });
 
     test('no fallback offer when no chart was promoted this run (even with no return_to)', async () => {

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -178,6 +178,11 @@ const createDashboardSlice = (set, get) => ({
    * post-save refetch resets baselines — any subsequent canvas editing
    * session starts its explicit-save working copy clean on server truth.
    *
+   * The create and the placement are two saves, so a placement failure is
+   * ROLLED BACK (the just-created empty dashboard is deleted) rather than
+   * left as an orphan in the project's pending changes — see the rollback
+   * block below.
+   *
    * Returns `{ success, dashboardName, … }` so the caller can open the new
    * dashboard's tab; `{ success: false, error }` otherwise.
    */
@@ -237,7 +242,30 @@ const createDashboardSlice = (set, get) => ({
       });
     }
     const saved = await get().saveDashboard(dashboardName, nextConfig);
-    return saved?.success ? { ...saved, dashboardName } : saved;
+    if (saved?.success) {
+      return { ...saved, dashboardName };
+    }
+    // ROLLBACK. The create succeeded and the placement did not, so without
+    // this the project is left carrying an EMPTY orphan dashboard: it rides
+    // along in pending changes into the user's .visivo.yml, the inline error
+    // never mentions it exists, and every retry mints another one
+    // (`new-dashboard-1`, `-2`, …) because `generateUniqueName` dedupes
+    // against the one already there. Undoing the create is safe here in a way
+    // a general delete is not — the dashboard was created microseconds ago by
+    // this action, is empty, and nothing references it — and it leaves no
+    // staged change behind: `mark_for_deletion` DROPS a never-published
+    // object outright rather than tombstoning it (object_manager.py).
+    const rollback = await get().deleteDashboard?.(dashboardName);
+    const placeError = saved?.error || 'Could not place the chart in the dashboard';
+    if (!rollback?.success) {
+      // The orphan really is still there — say so, rather than reporting a
+      // clean failure the project state contradicts.
+      return {
+        success: false,
+        error: `${placeError}. An empty dashboard "${dashboardName}" was created and could not be removed — delete it from the Library.`,
+      };
+    }
+    return { success: false, error: placeError };
   },
 
   // Mark dashboard for deletion

--- a/viewer/src/stores/dashboardStore.js
+++ b/viewer/src/stores/dashboardStore.js
@@ -2,6 +2,11 @@ import * as dashboardsApi from '../api/dashboards';
 import { recordOnboardingAction } from '../components/onboarding/onboardingState';
 import { getEffectiveLevels } from '../utils/effectiveLevels';
 import { insertItemAtTarget } from '../components/views/project/canvas/canvasReorder';
+import {
+  createRow,
+  setItemLeaf,
+  LEAF_REF_FIELDS,
+} from '../components/views/workspace/itemMutations';
 
 /**
  * Translate a J-1 / J-2 `slot` descriptor into the `insertItemAtTarget` target
@@ -154,6 +159,85 @@ const createDashboardSlice = (set, get) => ({
       return { success: false, error: 'Could not place the chart in the requested slot' };
     }
     return get().saveDashboard(dashboardName, nextConfig);
+  },
+
+  /**
+   * W6 (Dashboard Building v1) — the promote modal's "New dashboard…" exit
+   * ramp, for the first-run project with ZERO dashboards: create a brand-new
+   * dashboard through the STANDARD inline-create path (`createDashboard` →
+   * `createWorkspaceObject('dashboard')`, so the naming + template rules
+   * stay in one place), then place `chartName` into the born row's existing
+   * empty slot. #621 makes every new dashboard start with one row holding
+   * one empty slot — the chart FILLS that slot (`setItemLeaf`), never
+   * appends a second row, so the new dashboard opens showing the chart
+   * rather than an empty placeholder row above it.
+   *
+   * Persistence goes through `saveDashboard`, exactly like
+   * `placeChartInDashboardSlot` above: the dashboard was created this
+   * instant, so there is no #46/#617 working copy to clobber, and the
+   * post-save refetch resets baselines — any subsequent canvas editing
+   * session starts its explicit-save working copy clean on server truth.
+   *
+   * Returns `{ success, dashboardName, … }` so the caller can open the new
+   * dashboard's tab; `{ success: false, error }` otherwise.
+   */
+  placeChartInNewDashboard: async chartName => {
+    if (!chartName) {
+      return { success: false, error: 'chart name is required' };
+    }
+    const created = await get().createDashboard();
+    if (!created?.success) {
+      return { success: false, error: created?.error || 'Could not create a new dashboard' };
+    }
+    const dashboardName = created.name;
+    // `saveDashboard` refetches before resolving, so the born config is in
+    // the list; fall back to the template's own shape defensively so the
+    // placement never silently drops the chart.
+    const config =
+      (get().dashboards || []).find(d => d.name === dashboardName)?.config || {
+        rows: [createRow()],
+      };
+    const rows = Array.isArray(config.rows) ? config.rows : [];
+    // An empty slot is an item with no leaf ref and no nested rows (a bare
+    // `{ width }` — itemMutations' own definition); a nullish item is
+    // fillable too (`setItemLeaf` normalizes it to a valid slot).
+    const isEmptySlot = item =>
+      !item || (!Array.isArray(item.rows) && !LEAF_REF_FIELDS.some(field => item[field]));
+    let target = null;
+    rows.some((rowConfig, rowIdx) => {
+      const items = Array.isArray(rowConfig?.items) ? rowConfig.items : [];
+      const itemIdx = items.findIndex(isEmptySlot);
+      if (itemIdx === -1) return false;
+      target = { rowIdx, itemIdx };
+      return true;
+    });
+    let nextConfig;
+    if (target) {
+      nextConfig = {
+        ...config,
+        rows: rows.map((rowConfig, rowIdx) =>
+          rowIdx !== target.rowIdx
+            ? rowConfig
+            : {
+                ...rowConfig,
+                items: rowConfig.items.map((item, itemIdx) =>
+                  itemIdx !== target.itemIdx ? item : setItemLeaf(item, 'chart', chartName)
+                ),
+              }
+        ),
+      };
+    } else {
+      // Defensive: the born template always has an empty slot (#621), but if
+      // that ever changes the chart still lands — appended through the same
+      // never-drop fallback the slot-descriptor path uses.
+      const baseConfig = { ...config, rows };
+      nextConfig = insertItemAtTarget(baseConfig, slotToInsertTarget(baseConfig, 'new'), {
+        width: 1,
+        chart: `ref(${chartName})`,
+      });
+    }
+    const saved = await get().saveDashboard(dashboardName, nextConfig);
+    return saved?.success ? { ...saved, dashboardName } : saved;
   },
 
   // Mark dashboard for deletion

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -56,6 +56,146 @@ describe('dashboardStore createDashboard (Project Editor "+ New Dashboard")', ()
   });
 });
 
+// W6 (Dashboard Building v1) — the promote modal's "New dashboard…" exit ramp
+// for a project with ZERO dashboards: create through the standard
+// inline-create path, then FILL the born row's empty slot (#621) — never
+// append a second row.
+describe('dashboardStore placeChartInNewDashboard (W6 zero-dashboard promote)', () => {
+  /**
+   * Stub `saveDashboard` to also simulate its refetch: the saved config
+   * lands in `state.dashboards`, which is where `placeChartInNewDashboard`
+   * reads the born config back from after the create.
+   */
+  const seedWithRefetchingSave = (dashboards = []) => {
+    const saveDashboard = jest.fn(async (name, config) => {
+      const current = useStore.getState().dashboards || [];
+      useStore.setState({
+        dashboards: current.filter(d => d.name !== name).concat([{ name, config }]),
+      });
+      return { success: true };
+    });
+    seed(dashboards, saveDashboard);
+    return saveDashboard;
+  };
+
+  test('creates a dashboard via the standard path and FILLS the born row\'s empty slot — one row, one item, never a second row', async () => {
+    const saveDashboard = seedWithRefetchingSave([]);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result).toMatchObject({ success: true, dashboardName: 'new-dashboard' });
+    // Two saves: the born template (create), then the filled slot (place).
+    expect(saveDashboard).toHaveBeenCalledTimes(2);
+    expect(saveDashboard.mock.calls[0]).toEqual([
+      'new-dashboard',
+      { rows: [{ height: 'medium', items: [{ width: 1 }] }] },
+    ]);
+    const [placedName, placedConfig] = saveDashboard.mock.calls[1];
+    expect(placedName).toBe('new-dashboard');
+    // The #621 born slot is FILLED in place (itemMutations' context-string
+    // ref form) — the config still has exactly one row with one item, so the
+    // new dashboard opens showing the chart, not an empty placeholder row.
+    expect(placedConfig.rows).toHaveLength(1);
+    expect(placedConfig.rows[0].items).toHaveLength(1);
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(placedConfig.rows[0].items[0]).toEqual({ width: 1, chart: '${ref(churn_chart)}' });
+  });
+
+  test('deduplicates the new dashboard name and reports the REAL created name back', async () => {
+    const saveDashboard = seedWithRefetchingSave([{ name: 'new-dashboard', config: {} }]);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result.success).toBe(true);
+    expect(result.dashboardName).not.toBe('new-dashboard');
+    // Both saves address the deduplicated name.
+    expect(saveDashboard.mock.calls[0][0]).toBe(result.dashboardName);
+    expect(saveDashboard.mock.calls[1][0]).toBe(result.dashboardName);
+  });
+
+  test('requires a chart name — no dashboard is created without one', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seed([], saveDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('');
+
+    expect(result.success).toBe(false);
+    expect(saveDashboard).not.toHaveBeenCalled();
+  });
+
+  test('propagates a failed create and never attempts a placement save', async () => {
+    const saveDashboard = jest.fn(async () => ({ success: false, error: 'disk full' }));
+    seed([], saveDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result).toEqual({ success: false, error: 'disk full' });
+    expect(saveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  test('propagates a failed placement save (create succeeded)', async () => {
+    const saveDashboard = jest
+      .fn()
+      .mockImplementationOnce(async (name, config) => {
+        useStore.setState({
+          dashboards: (useStore.getState().dashboards || []).concat([{ name, config }]),
+        });
+        return { success: true };
+      })
+      .mockImplementationOnce(async () => ({ success: false, error: 'validation refused it' }));
+    seed([], saveDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('validation refused it');
+  });
+
+  test('defensive: a born config with NO empty slot still lands the chart (appended, never dropped)', async () => {
+    // Simulate a server that normalizes the created dashboard into a config
+    // whose only slot is already occupied — the #621 template guarantees an
+    // empty slot, but the placement must never silently drop the chart if
+    // that guarantee ever changes.
+    const saveDashboard = jest.fn(async (name, config) => {
+      const occupied = {
+        // eslint-disable-next-line no-template-curly-in-string
+        rows: [{ height: 'medium', items: [{ width: 1, chart: '${ref(already_there)}' }] }],
+      };
+      const stored = saveDashboard.mock.calls.length === 1 ? occupied : config;
+      const current = useStore.getState().dashboards || [];
+      useStore.setState({
+        dashboards: current.filter(d => d.name !== name).concat([{ name, config: stored }]),
+      });
+      return { success: true };
+    });
+    seed([], saveDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result.success).toBe(true);
+    const [, placedConfig] = saveDashboard.mock.calls[1];
+    const allItems = placedConfig.rows.flatMap(r => r.items || []);
+    expect(allItems.some(item => (item.chart || '').includes('churn_chart'))).toBe(true);
+    // The occupied slot was not overwritten.
+    expect(allItems.some(item => (item.chart || '').includes('already_there'))).toBe(true);
+  });
+
+  test('defensive: when the refetch misses the new dashboard, the born template shape is assumed and the slot still fills', async () => {
+    // saveDashboard succeeds but never lands the dashboard in the list (a
+    // refetch race) — the placement falls back to the template's own shape.
+    const saveDashboard = jest.fn(async () => ({ success: true }));
+    seed([], saveDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result).toMatchObject({ success: true, dashboardName: 'new-dashboard' });
+    const [, placedConfig] = saveDashboard.mock.calls[1];
+    expect(placedConfig.rows).toHaveLength(1);
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(placedConfig.rows[0].items[0]).toEqual({ width: 1, chart: '${ref(churn_chart)}' });
+  });
+});
+
 describe('dashboardStore reassignDashboardLevel', () => {
   test('saves the dashboard config with the new level', async () => {
     const saveDashboard = jest.fn(async () => ({ success: true }));

--- a/viewer/src/stores/dashboardStore.test.js
+++ b/viewer/src/stores/dashboardStore.test.js
@@ -133,7 +133,11 @@ describe('dashboardStore placeChartInNewDashboard (W6 zero-dashboard promote)', 
     expect(saveDashboard).toHaveBeenCalledTimes(1);
   });
 
-  test('propagates a failed placement save (create succeeded)', async () => {
+  /**
+   * The create succeeds (the born dashboard is already in the draft cache and
+   * in `state.dashboards`) and the placement save then fails.
+   */
+  const seedCreateOkPlaceFailing = (deleteDashboard) => {
     const saveDashboard = jest
       .fn()
       .mockImplementationOnce(async (name, config) => {
@@ -144,11 +148,91 @@ describe('dashboardStore placeChartInNewDashboard (W6 zero-dashboard promote)', 
       })
       .mockImplementationOnce(async () => ({ success: false, error: 'validation refused it' }));
     seed([], saveDashboard);
+    useStore.setState({ deleteDashboard });
+    return saveDashboard;
+  };
+
+  test('propagates a failed placement save (create succeeded)', async () => {
+    const deleteDashboard = jest.fn(async () => ({ success: true }));
+    seedCreateOkPlaceFailing(deleteDashboard);
 
     const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('validation refused it');
+  });
+
+  // The create and the placement are two separate saves. A placement failure
+  // used to leave the dashboard the create had just made sitting in the
+  // project as an EMPTY orphan — invisible in the inline error, shipped in the
+  // next commit, and multiplied by every retry (`new-dashboard-1`, `-2`, …).
+  test('ROLLS BACK the just-created dashboard when the placement save fails — no empty orphan is left behind', async () => {
+    const deleteDashboard = jest.fn(async name => {
+      useStore.setState({
+        dashboards: (useStore.getState().dashboards || []).filter(d => d.name !== name),
+      });
+      return { success: true };
+    });
+    seedCreateOkPlaceFailing(deleteDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result).toEqual({ success: false, error: 'validation refused it' });
+    expect(deleteDashboard).toHaveBeenCalledWith('new-dashboard');
+    // The project is back to where it started — nothing to ride along into
+    // the user's .visivo.yml, and a retry creates `new-dashboard` again
+    // rather than piling up `new-dashboard-1`.
+    expect(useStore.getState().dashboards).toEqual([]);
+  });
+
+  test('retrying after a rolled-back failure creates the SAME name again, never a second orphan', async () => {
+    const saveDashboard = jest
+      .fn()
+      // Attempt 1: create ok, placement fails.
+      .mockImplementationOnce(async (name, config) => {
+        useStore.setState({
+          dashboards: (useStore.getState().dashboards || []).concat([{ name, config }]),
+        });
+        return { success: true };
+      })
+      .mockImplementationOnce(async () => ({ success: false, error: 'validation refused it' }))
+      // Attempt 2: both saves succeed.
+      .mockImplementation(async (name, config) => {
+        const current = useStore.getState().dashboards || [];
+        useStore.setState({
+          dashboards: current.filter(d => d.name !== name).concat([{ name, config }]),
+        });
+        return { success: true };
+      });
+    seed([], saveDashboard);
+    useStore.setState({
+      deleteDashboard: jest.fn(async name => {
+        useStore.setState({
+          dashboards: (useStore.getState().dashboards || []).filter(d => d.name !== name),
+        });
+        return { success: true };
+      }),
+    });
+
+    await useStore.getState().placeChartInNewDashboard('churn_chart');
+    const retry = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(retry).toMatchObject({ success: true, dashboardName: 'new-dashboard' });
+    // Exactly one dashboard exists at the end — the successful retry's.
+    expect(useStore.getState().dashboards.map(d => d.name)).toEqual(['new-dashboard']);
+  });
+
+  test('a rollback that itself fails is DISCLOSED — the error names the dashboard left behind', async () => {
+    const deleteDashboard = jest.fn(async () => ({ success: false, error: 'delete refused' }));
+    seedCreateOkPlaceFailing(deleteDashboard);
+
+    const result = await useStore.getState().placeChartInNewDashboard('churn_chart');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('validation refused it');
+    expect(result.error).toContain('new-dashboard');
+    // The orphan is real, so the message must not pretend otherwise.
+    expect(useStore.getState().dashboards.map(d => d.name)).toEqual(['new-dashboard']);
   });
 
   test('defensive: a born config with NO empty slot still lands the chart (appended, never dropped)', async () => {


### PR DESCRIPTION
## Problem

`ExplorationPromoteModal`'s fallback dashboard offer (`showFallbackDashboardOffer`, and the matching `hasOffer` term in `handlePromote`) required `dashboards.length > 0`. A first-run user has ZERO dashboards, so on a clean chart promote the modal auto-closed as "nothing to act on" — the one working exit ramp from Explorer to a dashboard never fired in exactly the exit-gate scenario (Dashboard Building v1 dossier W6, finding B2; every field-test tester hits this).

## Fix

- **Gate dropped**: a promoted chart always gets a destination offer — `return_to` when armed, otherwise the fallback offer.
- **"New dashboard…" option** (sentinel `__new__`) is prepended to the offer's select and is the default when no dashboards exist. With existing dashboards nothing changes: the default stays the first dashboard.
- **New store action `placeChartInNewDashboard(chartName)`** (`dashboardStore.js`): creates via the standard inline-create path (`createDashboard` → `createWorkspaceObject('dashboard')`), then **fills the born row's existing empty slot** — #621 makes every new dashboard start with one row holding one empty slot, and the chart lands in that slot via `itemMutations.setItemLeaf` (canonical `${ref(name)}` form), never as an appended second row. Then the new dashboard's tab opens.
- **#617 semantics respected**: persistence goes through `saveDashboard` exactly like the sibling `placeChartInDashboardSlot` — the dashboard was created this instant so there is no working copy to clobber, and the post-save refetch resets `dashboardBaselines`, so the explicit-save working copy starts clean on server truth.
- **Defensive paths** (never drop the chart): a born config with no empty slot appends through the existing `slotToInsertTarget`/`insertItemAtTarget` fallback; a refetch that misses the new dashboard assumes the template's own shape.

## Falsification evidence

With the tests kept and both implementation files stashed (`ExplorationPromoteModal.jsx`, `dashboardStore.js`):

```
Tests:       14 failed, 126 passed, 140 total
  ● dashboardStore placeChartInNewDashboard … › creates a dashboard via the standard path and FILLS the born row's empty slot …
  ● … (all 7 new store tests fail — the action does not exist pre-fix)
  ● ExplorationPromoteModal › … ZERO dashboards: the fallback offer still renders … — never a dead-end auto-close (W6)
  ● … ZERO dashboards: accepting "New dashboard…" creates + places via placeChartInNewDashboard …
  ● … (6 more modal tests fail — pre-fix the modal auto-closes with no offer)
```

`git stash pop` restores the fix; all 140 pass. (The one new test green pre-fix is the deliberate behavior-preservation pin: with existing dashboards the default stays the first dashboard.)

## Tests

- 7 new `dashboardStore` tests: slot filled in place (exactly one row, one item, `${ref(chart)}`), name dedupe reports the real created name, failure propagation for both the create and the placement save, both defensive paths.
- 7 new/updated `ExplorationPromoteModal` tests, including rewrites of the three tests that pinned the old auto-close (`dashboards` undefined + the two "closes on a clean success when no dashboards exist" copies).
- E2E story: `viewer/e2e/stories/exploration-promote-fallback-dashboard-offer.spec.mjs` gains the zero-dashboard walkthrough — soft-deletes every dashboard before the app loads, runs the ordinary source-tile → query → chart → Save-to-project flow, accepts "New dashboard…", and backend-asserts the created dashboard has exactly one row with one item referencing the chart (restored by the existing `commit/discard` cleanup). Written but **not run here** — it needs the shared sandbox ports and runs in the serial `exploration-mutations` project (file already double-registered in `playwright.config.mjs`).
- Full suite `yarn test --watchAll=false`: **7024 passed, 365 suites**; `yarn lint`: clean.

Note: branched off main independently of #643 (same file, different regions — the two diffs don't overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U