### PR TITLE
Every failed job carries a Diagnostic; skipped jobs are recorded (M16 W3)

### DIFF
--- a/tests/jobs/test_job_diagnostics.py
+++ b/tests/jobs/test_job_diagnostics.py
@@ -1,0 +1,288 @@
+"""W3 (Error Legibility): every failed JobResult carries a Diagnostic, and jobs
+skipped for a failed dependency are recorded instead of silently dropped.
+
+The three load-bearing failure sites (source failure, SQL error,
+skipped-dependency) are covered against real projects — the same construction
+pattern as tests/jobs/test_run_insight_job_join_errors.py — plus the B9 guard:
+a model-less insight must fail its own job with a legible diagnostic rather
+than IndexError-ing the runner's scheduling loop (which killed the whole run,
+and the process under `visivo run`).
+"""
+
+import io
+import sys
+
+import pytest
+
+from tests.factories.model_factories import (
+    InsightFactory,
+    ProjectFactory,
+    SingleSelectInputFactory,
+    SourceFactory,
+    SqlModelFactory,
+)
+from tests.support.utils import temp_folder
+from visivo.commands.utils import create_file_database
+from visivo.jobs.filtered_runner import FilteredRunner
+from visivo.jobs.run_input_job import action as input_action
+from visivo.jobs.run_insight_job import action as insight_action
+from visivo.jobs.run_insight_job import job as insight_job
+from visivo.jobs.run_source_schema_job import action as source_schema_action
+from visivo.jobs.run_sql_model_job import (
+    model_query_and_schema_action,
+    schema_only_action,
+)
+from visivo.models.insight import Insight
+from visivo.models.props.insight_props import InsightProps
+from visivo.models.project import Project
+
+
+def _model_less_insight_project():
+    insight = Insight(name="lonely", props=InsightProps(type="scatter", x="?{ 1 }"))
+    project = Project(name="p", insights=[insight], dashboards=[])
+    return project, insight
+
+
+class TestMissingModelGuard:
+    """B9: an insight that references no model."""
+
+    def test_job_creation_does_not_raise(self):
+        # On main this IndexErrors inside the DAG runner's scheduling loop.
+        project, insight = _model_less_insight_project()
+        created = insight_job(project.dag(), temp_folder(), insight)
+        assert created is not None
+
+    def test_the_created_job_reports_a_missing_model_diagnostic(self):
+        project, insight = _model_less_insight_project()
+        created = insight_job(project.dag(), temp_folder(), insight)
+
+        result = created.action(**created.kwargs)
+
+        assert result.success is False
+        assert result.diagnostic is not None
+        assert result.diagnostic.code == "missing_model"
+        assert result.diagnostic.object.type == "insight"
+        assert result.diagnostic.object.name == "lonely"
+        assert "does not reference a model" in result.diagnostic.message
+        assert result.diagnostic.hint
+
+    def test_direct_action_call_is_guarded_too(self):
+        project, insight = _model_less_insight_project()
+        result = insight_action(insight, project.dag(), temp_folder())
+        assert result.success is False
+        assert result.diagnostic.code == "missing_model"
+
+    def test_a_full_run_survives_a_model_less_insight(self):
+        """The whole point of the guard: the runner finishes and records the
+        failure instead of crashing serve/run."""
+        project, insight = _model_less_insight_project()
+        runner = FilteredRunner(project=project, output_dir=temp_folder(), soft_failure=True)
+        runner.run()
+
+        assert [d.code for d in runner.diagnostics] == ["missing_model"]
+        assert runner.diagnostics[0].object.name == "lonely"
+
+
+def _failing_source_project():
+    """A project whose source-schema job fails: sqlite cannot open a database
+    file inside a directory that does not exist."""
+    source = SourceFactory(name="bad_source", database="/nonexistent_dir_w3/nope.sqlite")
+    model = SqlModelFactory(name="model1", source="ref(bad_source)")
+    insight = InsightFactory(name="insight1", model=model)
+    return ProjectFactory(sources=[source], models=[model], insights=[insight], dashboards=[])
+
+
+class TestSourceFailureDiagnostic:
+    def test_unreachable_source_fails_with_a_source_diagnostic(self):
+        project = _failing_source_project()
+        source = project.sources[0]
+
+        result = source_schema_action(source_to_build=source, output_dir=temp_folder())
+
+        assert result.success is False
+        assert result.diagnostic is not None
+        assert result.diagnostic.code in ("schema_build_failed", "source_connection_failed")
+        assert result.diagnostic.object.type == "source"
+        assert result.diagnostic.object.name == "bad_source"
+        assert result.diagnostic.message
+
+    def test_a_source_locked_tag_is_lifted_to_the_typed_code(self, monkeypatch):
+        """PR #629 tags lock conflicts `[source_locked]` precisely so W3 can
+        lift them into the Diagnostic without rewording."""
+        source = SourceFactory(name="held", database=":memory:")
+        monkeypatch.setattr(
+            type(source),
+            "get_schema",
+            lambda self, table_names=None: (_ for _ in ()).throw(
+                Exception("Cannot open 'x.duckdb' [source_locked]: held by another process")
+            ),
+        )
+
+        result = source_schema_action(source_to_build=source, output_dir=temp_folder())
+
+        assert result.success is False
+        assert result.diagnostic.code == "source_locked"
+
+    def test_a_plain_connection_failure_keeps_the_connection_code(self, monkeypatch):
+        source = SourceFactory(name="refused", database=":memory:")
+        monkeypatch.setattr(
+            type(source),
+            "get_schema",
+            lambda self, table_names=None: (_ for _ in ()).throw(Exception("connection refused")),
+        )
+
+        result = source_schema_action(source_to_build=source, output_dir=temp_folder())
+
+        assert result.success is False
+        assert result.diagnostic.code == "source_connection_failed"
+        assert result.diagnostic.message == "connection refused"
+
+
+class TestSqlErrorDiagnostic:
+    def _working_source_project(self, sql):
+        output_dir = temp_folder()
+        source = SourceFactory(name="src", database=f"{output_dir}/test.sqlite")
+        model = SqlModelFactory(name="orders", source="ref(src)", sql=sql)
+        project = ProjectFactory(sources=[source], models=[model], dashboards=[])
+        create_file_database(url=source.url(), output_dir=output_dir)
+        return output_dir, project, model
+
+    def test_query_failure_carries_a_query_execution_diagnostic(self):
+        output_dir, project, model = self._working_source_project(
+            "SELECT * FROM table_that_does_not_exist"
+        )
+
+        result = model_query_and_schema_action(model, project.dag(), output_dir)
+
+        assert result.success is False
+        assert result.diagnostic is not None
+        assert result.diagnostic.code == "query_execution_failed"
+        assert result.diagnostic.object.type == "model"
+        assert result.diagnostic.object.name == "orders"
+        assert result.diagnostic.message
+
+    def test_schema_only_failure_carries_a_schema_build_diagnostic(self, mocker):
+        output_dir, project, model = self._working_source_project("SELECT 1 AS id")
+        mocker.patch(
+            "visivo.jobs.run_sql_model_job._build_and_write_schema",
+            side_effect=RuntimeError("schema build blew up"),
+        )
+
+        result = schema_only_action(model, project.dag(), output_dir)
+
+        assert result.success is False
+        assert result.diagnostic.code == "schema_build_failed"
+        assert result.diagnostic.object.name == "orders"
+        assert result.diagnostic.message == "schema build blew up"
+
+
+class TestInputFailureDiagnostic:
+    def test_misconfigured_input_is_invalid_value(self):
+        # 0-row options query -> the module's own ValueError vocabulary.
+        source = SourceFactory(name="source")
+        model = SqlModelFactory(
+            name="empty_model", sql="SELECT 'x' AS col WHERE 1=0", source="ref(source)"
+        )
+        input_obj = SingleSelectInputFactory(
+            name="empty_input", options="?{ SELECT col FROM ${ref(empty_model)} }"
+        )
+        project = ProjectFactory(sources=[source], models=[model], inputs=[input_obj])
+
+        result = input_action(input_obj, project.dag(), temp_folder())
+
+        assert result.success is False
+        assert result.diagnostic is not None
+        assert result.diagnostic.code == "invalid_value"
+        assert result.diagnostic.object.type == "input"
+        assert result.diagnostic.object.name == "empty_input"
+
+    def test_source_refusal_is_query_execution_failed(self, mocker):
+        source = SourceFactory(name="source")
+        model = SqlModelFactory(name="m", sql="SELECT 'x' AS col", source="ref(source)")
+        input_obj = SingleSelectInputFactory(
+            name="query_input", options="?{ SELECT col FROM ${ref(m)} }"
+        )
+        project = ProjectFactory(sources=[source], models=[model], inputs=[input_obj])
+        mocker.patch(
+            "visivo.jobs.run_input_job._execute_query_for_options",
+            side_effect=RuntimeError("no such table: m"),
+        )
+
+        result = input_action(input_obj, project.dag(), temp_folder())
+
+        assert result.success is False
+        assert result.diagnostic.code == "query_execution_failed"
+
+
+class TestSkippedDependencyDiagnostics:
+    """M16-1: a failed source-schema job must leave dependency_failed records
+    on every runnable job above it — on main the skip is only a log line."""
+
+    def _run(self):
+        project = _failing_source_project()
+        runner = FilteredRunner(project=project, output_dir=temp_folder(), soft_failure=True)
+        runner.run()
+        return runner
+
+    def test_the_skipped_insight_gets_a_dependency_failed_diagnostic(self):
+        runner = self._run()
+
+        by_name = {d.object.name: d for d in runner.diagnostics}
+        insight_diagnostic = by_name["insight1"]
+        assert insight_diagnostic.code == "dependency_failed"
+        assert insight_diagnostic.object.type == "insight"
+        # related[] names the job that actually failed — the source.
+        related_names = [r.object.name for r in insight_diagnostic.related if r.object]
+        assert related_names == ["bad_source"]
+
+    def test_the_skipped_model_is_recorded_too(self):
+        runner = self._run()
+
+        by_name = {d.object.name: d for d in runner.diagnostics}
+        model_diagnostic = by_name["model1"]
+        assert model_diagnostic.code == "dependency_failed"
+        assert model_diagnostic.object.type == "model"
+        assert [r.object.name for r in model_diagnostic.related if r.object] == ["bad_source"]
+
+    def test_the_failed_source_keeps_its_own_diagnostic(self):
+        runner = self._run()
+
+        by_name = {d.object.name: d for d in runner.diagnostics}
+        assert by_name["bad_source"].code in (
+            "schema_build_failed",
+            "source_connection_failed",
+        )
+
+    def test_presentation_nodes_are_not_recorded(self):
+        """Charts/dashboards above a failure are not jobs — recording them
+        would bury the real failure in derived noise."""
+        output_dir = temp_folder()
+        project = ProjectFactory()  # full factory chain: dashboard -> ... -> source
+        project.sources[0].database = "/nonexistent_dir_w3/nope.sqlite"
+
+        runner = FilteredRunner(project=project, output_dir=output_dir, soft_failure=True)
+        runner.run()
+
+        types = {d.object.type for d in runner.diagnostics}
+        assert types <= {"source", "model", "insight", "input"}
+
+    def test_summary_line_separates_errors_from_skips(self):
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self._run()
+        finally:
+            sys.stdout = sys.__stdout__
+
+        assert "with 1 query error(s) (2 dependent job(s) skipped)" in captured.getvalue()
+
+    def test_skipped_results_render_a_skipped_status_not_a_failure(self):
+        runner = self._run()
+        skipped = [
+            r
+            for r in runner.failed_job_results
+            if r.diagnostic and r.diagnostic.code == "dependency_failed"
+        ]
+        assert len(skipped) == 2
+        for result in skipped:
+            assert "SKIPPED" in result.message

--- a/tests/jobs/test_run_insight_job_join_errors.py
+++ b/tests/jobs/test_run_insight_job_join_errors.py
@@ -70,6 +70,12 @@ def test_two_unjoined_model_insight_run_yields_missing_relation(tmpdir):
     assert result.error_details is not None
     assert result.error_details["error_type"] == "missing_relation"
     assert set(result.error_details["error_models"]) == {"orders", "users"}
+    # W3: the same failure lifted into the Diagnostic contract without renaming.
+    assert result.diagnostic is not None
+    assert result.diagnostic.code == "missing_relation"
+    assert result.diagnostic.object.type == "insight"
+    assert result.diagnostic.object.name == "cross_model_insight"
+    assert {r.object.name for r in result.diagnostic.related if r.object} == {"orders", "users"}
 
 
 def test_non_join_failure_has_no_structured_error_details(tmpdir):
@@ -95,3 +101,9 @@ def test_non_join_failure_has_no_structured_error_details(tmpdir):
 
     assert result.success is False
     assert result.error_details is None
+    # W3: ordinary failures still carry a diagnostic — just the generic
+    # query-execution one, with no join-fix related[] models.
+    assert result.diagnostic is not None
+    assert result.diagnostic.code == "query_execution_failed"
+    assert result.diagnostic.object.name == "single_model_insight"
+    assert result.diagnostic.related == []

--- a/viewer/src/types/diagnostic.js
+++ b/viewer/src/types/diagnostic.js
@@ -50,6 +50,7 @@ export const DIAGNOSTIC_CODES = [
   'source_locked',
   'source_connection_failed',
   'dependency_failed',
+  'missing_model',
   'missing_relation',
   'ambiguous_relation',
   'query_execution_failed',

--- a/visivo/jobs/dag_runner.py
+++ b/visivo/jobs/dag_runner.py
@@ -12,7 +12,8 @@ import queue
 import sys
 from visivo.models.sources.source import Source
 from visivo.models.inputs.input import Input
-from visivo.jobs.job import JobResult
+from visivo.jobs.job import JobResult, diagnostic_object_ref, format_message_skipped
+from visivo.models.diagnostic import Diagnostic, DiagnosticPhase, DiagnosticRelated
 
 from visivo.jobs.run_insight_job import job as insight_job
 from visivo.jobs.run_source_schema_job import job as source_schema_job
@@ -23,6 +24,12 @@ from visivo.query.source_schema_cache import SourceSchemaCache
 from threading import Lock
 
 warnings.filterwarnings("ignore")
+
+# The node types create_jobs_from_item turns into jobs. Only these get a
+# synthesized "skipped" JobResult — presentation nodes (charts, dashboards,
+# rows...) sit above failed dependencies too, but they are not jobs and
+# recording them would bury the real failure in derived noise.
+_RUNNABLE_TYPES = (Insight, Input, SqlModel, Source)
 
 
 class DagRunner:
@@ -75,10 +82,17 @@ class DagRunner:
                     job.future.add_done_callback(self.job_callback)
 
         if len(self.failed_job_results) > 0:
+            skipped_count = sum(
+                1
+                for result in self.failed_job_results
+                if result.diagnostic is not None and result.diagnostic.code == "dependency_failed"
+            )
+            error_count = len(self.failed_job_results) - skipped_count
+            skipped_suffix = f" ({skipped_count} dependent job(s) skipped)" if skipped_count else ""
             Logger.instance().info("")
             Logger.instance().info("")
             Logger.instance().error(
-                f"\n\nRun failed in {round(time()-start_time, 2)}s with {len(self.failed_job_results)} query error(s)."
+                f"\n\nRun failed in {round(time()-start_time, 2)}s with {error_count} query error(s){skipped_suffix}."
             )
             for result in self.failed_job_results:
                 Logger.instance().error(str(result.message))
@@ -121,6 +135,12 @@ class DagRunner:
                     Logger.instance().info(
                         f"Skipping job for '{terminal_node.name}' because it has a failed dependency"
                     )
+                    failed_upstreams = [
+                        descendant
+                        for descendant in descendants
+                        if job_tracker.is_job_name_failed(descendant.name)
+                    ]
+                    self.record_skipped_job(terminal_node, failed_upstreams)
                     self.job_tracking_dag.remove_node(terminal_node)
                     continue
 
@@ -132,6 +152,55 @@ class DagRunner:
                     job_tracker.track_job(job)
 
             return len(self.job_tracking_dag.nodes()) == 1
+
+    def record_skipped_job(self, item, failed_upstreams):
+        """Synthesize a failed JobResult for a runnable node skipped because an
+        upstream failed (M16). Before this, the skip was only a log line: no
+        JobResult, no failed_job_results entry — so the viewer saw an insight
+        silently produce nothing while only the upstream's failure surfaced.
+        """
+        if not isinstance(item, _RUNNABLE_TYPES):
+            return
+        object_ref = diagnostic_object_ref(item)
+        upstream_refs = [diagnostic_object_ref(upstream) for upstream in failed_upstreams]
+        upstream_names = ", ".join(f"'{ref.name}'" for ref in upstream_refs) or "a dependency"
+        message = (
+            f"Skipped {object_ref.type} '{object_ref.name}' because "
+            f"{'its dependency' if len(upstream_refs) == 1 else 'its dependencies'} "
+            f"{upstream_names} failed."
+        )
+        diagnostic = Diagnostic(
+            phase=DiagnosticPhase.RUN,
+            code="dependency_failed",
+            message=message,
+            object=object_ref,
+            hint="Fix the failed dependency and run again — this job never ran.",
+            related=[
+                DiagnosticRelated(
+                    message=f"{ref.type} '{ref.name}' failed",
+                    object=ref,
+                )
+                for ref in upstream_refs
+            ],
+        )
+        self.failed_job_results.append(
+            JobResult(
+                item=item,
+                success=False,
+                message=format_message_skipped(
+                    details=f"Skipped job for {object_ref.type} \033[4m{object_ref.name}\033[0m",
+                    error_msg=f"upstream {upstream_names} failed",
+                ),
+                diagnostic=diagnostic,
+            )
+        )
+
+    @property
+    def diagnostics(self):
+        """The structured failures of this run, in job-completion order."""
+        return [
+            result.diagnostic for result in self.failed_job_results if result.diagnostic is not None
+        ]
 
     def create_jobs_from_item(self, item: ParentModel):
         if isinstance(item, Insight):

--- a/visivo/jobs/filtered_runner.py
+++ b/visivo/jobs/filtered_runner.py
@@ -30,6 +30,14 @@ class FilteredRunner:
         self.failed_job_results = []
         self.successful_job_results = []
 
+    @property
+    def diagnostics(self):
+        """The structured failures across every filtered DAG iteration,
+        including dependency_failed entries synthesized for skipped jobs."""
+        return [
+            result.diagnostic for result in self.failed_job_results if result.diagnostic is not None
+        ]
+
     def run(self):
         for job_dag in self.project_dag.filter_dag(self.dag_filter):
             dag_runner = DagRunner(

--- a/visivo/jobs/job.py
+++ b/visivo/jobs/job.py
@@ -1,5 +1,7 @@
 from concurrent.futures import Future
+from typing import Optional
 from visivo.models.base.named_model import NamedModel
+from visivo.models.diagnostic import Diagnostic, DiagnosticObjectRef
 from visivo.models.sources.source import Source
 import os
 import re
@@ -16,6 +18,7 @@ class JobResult:
         message: str,
         warnings: list = None,
         error_details: dict = None,
+        diagnostic: Optional[Diagnostic] = None,
     ):
         self.item = item
         self.success = success
@@ -25,6 +28,34 @@ class JobResult:
         # (e.g. VIS-1007's missing-relation inline fix). None for ordinary
         # failures, which keep flowing through the human-readable ``message``.
         self.error_details = error_details
+        # The structured description of the failure (W3, Error Legibility).
+        # ``message`` stays the terminal renderer (ANSI dot-padding and all);
+        # ``diagnostic`` is what reaches the viewer via error_json, so every
+        # ``success=False`` construction site should populate it.
+        self.diagnostic = diagnostic
+
+
+def diagnostic_object_ref(item) -> DiagnosticObjectRef:
+    """Best-effort ``{type, name}`` ref for the project object a job is about."""
+    # Function-level imports: job.py is imported by every job module, and the
+    # concrete model classes pull in far more than this module needs at import
+    # time.
+    from visivo.models.insight import Insight
+    from visivo.models.inputs.input import Input
+    from visivo.models.models.model import Model
+
+    if isinstance(item, Insight):
+        object_type = "insight"
+    elif isinstance(item, Input):
+        object_type = "input"
+    elif isinstance(item, Model):
+        object_type = "model"
+    elif isinstance(item, Source):
+        object_type = "source"
+    else:
+        object_type = type(item).__name__.lower()
+    name = getattr(item, "name", None) or type(item).__name__
+    return DiagnosticObjectRef(type=object_type, name=name)
 
 
 class CachedFuture:
@@ -139,3 +170,10 @@ def format_message_warning(details, start_time, full_path, warning_msg):
     return _format_message(
         details=details, status=status, full_path=full_path, error_msg=warning_msg
     )
+
+
+def format_message_skipped(details, error_msg=None):
+    """A job that never ran because an upstream failed — not a failure of its
+    own, so no duration and a yellow SKIPPED status."""
+    status = colored("SKIPPED", "yellow")
+    return _format_message(details=details, status=status, full_path=None, error_msg=error_msg)

--- a/visivo/jobs/run_input_job.py
+++ b/visivo/jobs/run_input_job.py
@@ -20,7 +20,14 @@ import polars as pl
 from sqlglot import parse_one
 from sqlglot.optimizer import qualify
 
-from visivo.jobs.job import Job, JobResult, format_message_failure, format_message_success
+from visivo.jobs.job import (
+    Job,
+    JobResult,
+    diagnostic_object_ref,
+    format_message_failure,
+    format_message_success,
+)
+from visivo.models.diagnostic import Diagnostic, DiagnosticPhase
 from visivo.jobs.utils import get_source_for_model
 from visivo.models.base.query_string import QueryString
 from visivo.models.inputs.types.single_select import SingleSelectInput
@@ -566,7 +573,20 @@ def action(
             full_path=None,
             error_msg=message,
         )
-        return JobResult(item=input_obj, success=False, message=failure_msg)
+        # ValueError is this module's own vocabulary for a misconfigured input
+        # (wrong ref count, empty result, too many options); anything else is
+        # the source refusing the options query.
+        return JobResult(
+            item=input_obj,
+            success=False,
+            message=failure_msg,
+            diagnostic=Diagnostic.from_exception(
+                e,
+                phase=DiagnosticPhase.RUN,
+                code="invalid_value" if isinstance(e, ValueError) else "query_execution_failed",
+                object=diagnostic_object_ref(input_obj),
+            ),
+        )
 
 
 def job(

--- a/visivo/jobs/run_insight_job.py
+++ b/visivo/jobs/run_insight_job.py
@@ -5,9 +5,11 @@ from visivo.models.insight import Insight
 from visivo.jobs.job import (
     Job,
     JobResult,
+    diagnostic_object_ref,
     format_message_failure,
     format_message_success,
 )
+from visivo.models.diagnostic import Diagnostic, DiagnosticPhase, DiagnosticRelated
 from visivo.logger.query_error_logger import log_failed_query, extract_error_location
 from time import time
 from visivo.jobs.utils import get_source_for_model
@@ -33,7 +35,12 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
     insight_query_info = None
 
     try:
-        model = all_descendants_of_type(type=Model, dag=dag, from_node=insight)[0]
+        models = all_descendants_of_type(type=Model, dag=dag, from_node=insight)
+        if not models:
+            # B9 guard: a model-less insight must fail ITS job with a legible
+            # diagnostic, not IndexError into the generic except below.
+            return _missing_model_result(insight, start_time)
+        model = models[0]
         source = get_source_for_model(model, dag, run_output_dir)
 
         insight_query_info = insight.get_query_info(dag, run_output_dir)
@@ -163,18 +170,70 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
             full_path=None,
             error_msg=error_display,
         )
+        # error_details' error_type values are registered diagnostic codes by
+        # design (missing_relation / ambiguous_relation) — everything else is a
+        # query that the source refused.
+        diagnostic = Diagnostic.from_exception(
+            e,
+            phase=DiagnosticPhase.RUN,
+            code=error_details["error_type"] if error_details else "query_execution_failed",
+            object=diagnostic_object_ref(insight),
+            related=[
+                DiagnosticRelated(
+                    message=f"Join endpoint model '{model_name}'",
+                    object={"type": "model", "name": model_name},
+                )
+                for model_name in (error_details or {}).get("error_models", [])
+            ],
+        )
         return JobResult(
             item=insight,
             success=False,
             message=failure_message,
             error_details=error_details,
+            diagnostic=diagnostic,
         )
 
 
+def _missing_model_result(insight: Insight, start_time) -> JobResult:
+    """The failed JobResult for an insight that references no model (B9)."""
+    message = f"Insight '{insight.name}' does not reference a model, so it has no data to run."
+    failure_message = format_message_failure(
+        details=f"Failed job for insight \033[4m{insight.name}\033[0m",
+        start_time=start_time,
+        full_path=None,
+        error_msg=message,
+    )
+    return JobResult(
+        item=insight,
+        success=False,
+        message=failure_message,
+        diagnostic=Diagnostic(
+            phase=DiagnosticPhase.RUN,
+            code="missing_model",
+            message=message,
+            object=diagnostic_object_ref(insight),
+            hint=(
+                "Reference a model column in the insight's props, "
+                "e.g. x: ?{ ${ref(my_model).my_column} }."
+            ),
+        ),
+    )
+
+
+def missing_model_action(insight: Insight) -> JobResult:
+    """Job action for a model-less insight: report the failure through the
+    normal JobResult channel instead of crashing the runner (B9)."""
+    return _missing_model_result(insight, time())
+
+
 def _get_source(insight, dag, output_dir):
-    """Get the appropriate source for an insight"""
-    model = all_descendants_of_type(type=Model, dag=dag, from_node=insight)[0]
-    return get_source_for_model(model, dag, output_dir)
+    """Get the appropriate source for an insight, or None when the insight
+    references no model."""
+    models = all_descendants_of_type(type=Model, dag=dag, from_node=insight)
+    if not models:
+        return None
+    return get_source_for_model(models[0], dag, output_dir)
 
 
 def job(dag, output_dir: str, insight: Insight, run_id: str = None):
@@ -187,6 +246,12 @@ def job(dag, output_dir: str, insight: Insight, run_id: str = None):
         run_id: Optional run ID for preview runs (passed to action for custom file naming)
     """
     run_output_dir = f"{output_dir}/{run_id}" if run_id is not None else f"{output_dir}/main"
+    if not all_descendants_of_type(type=Model, dag=dag, from_node=insight):
+        # B9: this used to IndexError right here — at job-creation time, inside
+        # the DAG runner's scheduling loop — killing the whole run (and, from
+        # `visivo run`, the process) instead of failing the one insight. Hand
+        # back a job whose action reports the failure like any other.
+        return Job(item=insight, source=None, action=missing_model_action, insight=insight)
     source = _get_source(insight, dag, run_output_dir)
     kwargs = {
         "insight": insight,

--- a/visivo/jobs/run_source_schema_job.py
+++ b/visivo/jobs/run_source_schema_job.py
@@ -8,11 +8,13 @@ from visivo.models.sources.source import Source
 from visivo.jobs.job import (
     Job,
     JobResult,
+    diagnostic_object_ref,
     format_message_failure,
     format_message_success,
     format_message_warning,
     start_message,
 )
+from visivo.models.diagnostic import Diagnostic, DiagnosticPhase
 from visivo.query.schema_aggregator import SchemaAggregator
 from time import time
 from typing import List, Optional
@@ -119,14 +121,27 @@ def action(
 
         # Check if schema building was successful
         if "error" in schema_data.get("metadata", {}):
-            error_msg = schema_data["metadata"]["error"]
+            error_msg = str(schema_data["metadata"]["error"])
             failure_message = format_message_failure(
                 details=f"Failed to build schema for source \033[4m{source_to_build.name}\033[0m",
                 start_time=start_time,
                 error_msg=f"Schema building error: {error_msg}",
                 full_path=None,
             )
-            return JobResult(item=source_to_build, success=False, message=failure_message)
+            first_line = error_msg.splitlines()[0] if error_msg.strip() else "Schema build failed"
+            return JobResult(
+                item=source_to_build,
+                success=False,
+                message=failure_message,
+                diagnostic=Diagnostic(
+                    phase=DiagnosticPhase.RUN,
+                    code="schema_build_failed",
+                    message=f"Could not read the schema for source '{source_to_build.name}': {first_line}",
+                    detail=error_msg if error_msg != first_line else None,
+                    object=diagnostic_object_ref(source_to_build),
+                    hint="Check the source's connection settings and that its account can read table metadata.",
+                ),
+            )
 
         SchemaAggregator.aggregate_source_schema(
             source_name=source_to_build.name,
@@ -196,6 +211,17 @@ def action(
                     ),
                     full_path=None,
                 ),
+                diagnostic=Diagnostic(
+                    phase=DiagnosticPhase.RUN,
+                    code="schema_build_failed",
+                    message=(
+                        f"Source '{source_to_build.name}' connected but resolved no tables — "
+                        f"downstream queries cannot run without a schema."
+                    ),
+                    detail="\n".join(str(warning) for warning in warnings),
+                    object=diagnostic_object_ref(source_to_build),
+                    hint="Check that the source's account can read table metadata (catalog grants).",
+                ),
             )
 
         if warnings:
@@ -233,7 +259,22 @@ def action(
             error_msg=f"Schema building error: {source_to_build.description()}. {str(repr(e))}",
             full_path=None,
         )
-        return JobResult(item=source_to_build, success=False, message=failure_message)
+        # A held DuckDB file announces itself with the [source_locked] tag (see
+        # DuckdbSource's lock classification) — lift it to the typed code so the
+        # viewer can branch; anything else here is the source refusing us.
+        code = "source_locked" if "source_locked" in str(e) else "source_connection_failed"
+        return JobResult(
+            item=source_to_build,
+            success=False,
+            message=failure_message,
+            diagnostic=Diagnostic.from_exception(
+                e,
+                phase=DiagnosticPhase.RUN,
+                code=code,
+                object=diagnostic_object_ref(source_to_build),
+                hint="Check the source's connection settings, then run again.",
+            ),
+        )
 
 
 def job(

--- a/visivo/jobs/run_sql_model_job.py
+++ b/visivo/jobs/run_sql_model_job.py
@@ -7,9 +7,11 @@ from sqlglot import exp
 from visivo.jobs.job import (
     Job,
     JobResult,
+    diagnostic_object_ref,
     format_message_failure,
     format_message_success,
 )
+from visivo.models.diagnostic import Diagnostic, DiagnosticLocation, DiagnosticPhase
 from visivo.jobs.run_model_data_job import write_query_to_parquet
 from visivo.jobs.utils import get_source_for_model
 from visivo.models.base.project_dag import ProjectDag
@@ -157,6 +159,10 @@ def _get_error_message(e: Exception) -> str:
     return repr(e)
 
 
+def _model_location(sql_model: SqlModel):
+    return DiagnosticLocation(file=sql_model.file_path) if sql_model.file_path else None
+
+
 def model_query_and_schema_action(
     sql_model: SqlModel,
     dag: ProjectDag,
@@ -205,7 +211,18 @@ def model_query_and_schema_action(
             full_path=sql_model.file_path,
             error_msg=_get_error_message(e),
         )
-        return JobResult(item=sql_model, success=False, message=failure_message)
+        return JobResult(
+            item=sql_model,
+            success=False,
+            message=failure_message,
+            diagnostic=Diagnostic.from_exception(
+                e,
+                phase=DiagnosticPhase.RUN,
+                code="query_execution_failed",
+                object=diagnostic_object_ref(sql_model),
+                location=_model_location(sql_model),
+            ),
+        )
 
 
 def schema_only_action(
@@ -252,7 +269,18 @@ def schema_only_action(
             full_path=sql_model.file_path,
             error_msg=_get_error_message(e),
         )
-        return JobResult(item=sql_model, success=False, message=failure_message)
+        return JobResult(
+            item=sql_model,
+            success=False,
+            message=failure_message,
+            diagnostic=Diagnostic.from_exception(
+                e,
+                phase=DiagnosticPhase.RUN,
+                code="schema_build_failed",
+                object=diagnostic_object_ref(sql_model),
+                location=_model_location(sql_model),
+            ),
+        )
 
 
 def job(

--- a/visivo/models/diagnostic.py
+++ b/visivo/models/diagnostic.py
@@ -65,6 +65,7 @@ DIAGNOSTIC_CODES = {
     "source_connection_failed": "The source is unreachable or refused the connection.",
     # Jobs / runs
     "dependency_failed": "The job was skipped because something it depends on failed.",
+    "missing_model": "The object references no model, so there is nothing to run it against.",
     "missing_relation": "An insight joins models with no relation declared between them.",
     "ambiguous_relation": "More than one relation path exists between the joined models.",
     "query_execution_failed": "The source raised an error executing the job's query.",
@@ -154,6 +155,8 @@ class Diagnostic(BaseModel):
         code: str = "unexpected_error",
         object: Optional[DiagnosticObjectRef] = None,
         hint: Optional[str] = None,
+        location: Optional[DiagnosticLocation] = None,
+        related: Optional[List[DiagnosticRelated]] = None,
     ) -> "Diagnostic":
         """Wrap an exception without leaking a traceback into the headline.
 
@@ -173,6 +176,8 @@ class Diagnostic(BaseModel):
                 detail=f"(unregistered diagnostic code '{code}')\n{text}",
                 object=object,
                 hint=hint,
+                location=location,
+                related=related or [],
             )
         return cls(
             phase=phase,
@@ -181,4 +186,6 @@ class Diagnostic(BaseModel):
             detail=text if text != first_line else None,
             object=object,
             hint=hint,
+            location=location,
+            related=related or [],
         )


### PR DESCRIPTION
## The problem

A failed job knew what went wrong; nothing structured survived the trip. `JobResult` carried `message` — a dot-padded, ANSI-coloured string built for a terminal — and that was the whole story. The viewer had no typed failure to render.

Worse, a job **skipped** because an upstream failed produced *nothing at all*. The DAG runner logged one line and dropped the node:

```
Skipping job for 'revenue_insight' because it has a failed dependency
```

No `JobResult`, no `failed_job_results` entry. An insight sitting above a broken source silently produced no data, and only the source's failure surfaced anywhere.

## What this does

**`JobResult` grows an optional `diagnostic`** (the W0 contract from `visivo/models/diagnostic.py`). `message` is untouched and stays the terminal renderer; `diagnostic` is what will reach the viewer in W4.

Every failure construction site in `visivo/jobs/` now populates it — enumerated from the code, not assumed:

| Site | Code |
|---|---|
| `run_insight_job` query failure | `missing_relation` / `ambiguous_relation` / `query_execution_failed` |
| `run_insight_job` model-less insight (**new**, B9) | `missing_model` |
| `run_sql_model_job` query | `query_execution_failed` |
| `run_sql_model_job` schema-only | `schema_build_failed` |
| `run_source_schema_job` aggregation error | `schema_build_failed` |
| `run_source_schema_job` connected-but-no-tables | `schema_build_failed` |
| `run_source_schema_job` connection error | `source_locked` / `source_connection_failed` |
| `run_input_job` | `invalid_value` / `query_execution_failed` |
| `dag_runner` skipped job (**new**) | `dependency_failed` |

**Skipped jobs are now recorded.** A runnable node dropped for a failed dependency synthesizes a `dependency_failed` diagnostic naming the skipped object, with `related[]` pointing at the failed upstream(s), and a `SKIPPED` (yellow) terminal line that is visibly not a failure of its own. Presentation nodes — charts, dashboards, rows — stay unrecorded on purpose: they sit above failed dependencies too, and recording them would bury the real failure under derived noise.

The run summary now separates the two:

```
Run failed in 0.4s with 1 query error(s) (2 dependent job(s) skipped).
```

`FilteredRunner` / `DagRunner` expose `.diagnostics` for W4's `error_json` emitter to consume.

## Folded in: B9

`run_insight_job` indexed `all_descendants_of_type(...)[0]` bare. For an insight referencing no model that raised `IndexError` **at job-creation time, inside the runner's scheduling loop** — killing the entire run (and, from `visivo run`, the process) rather than failing the one insight. Both the job-creation path and the action path now return a failed `JobResult` with a `missing_model` diagnostic.

`DIAGNOSTIC_CODES` is append-only: `missing_model` is added, nothing renamed, and the viewer's mirror in `types/diagnostic.js` is updated to match.

## Falsification

Implementation reverted to `main`, tests kept — **19 fail**:

```
FAILED TestMissingModelGuard::test_job_creation_does_not_raise - IndexError: list index out of range
FAILED TestMissingModelGuard::test_a_full_run_survives_a_model_less_insight - IndexError: list index out of range
FAILED TestSourceFailureDiagnostic::test_a_source_locked_tag_is_lifted_to_the_typed_code
    - AttributeError: 'JobResult' object has no attribute 'diagnostic'
FAILED TestSkippedDependencyDiagnostics::test_the_skipped_insight_gets_a_dependency_failed_diagnostic
    - AttributeError: 'FilteredRunner' object has no attribute 'diagnostics'
FAILED TestSkippedDependencyDiagnostics::test_summary_line_separates_errors_from_skips
    - assert 'with 1 query error(s) (2 dependent job(s) skipped)' in "...[FAILURE 0.0s]..."
... 19 failed in 1.61s
```

The three failure modes map to the three claims: B9 crashes the run, `JobResult` has no diagnostic, and skipped jobs are invisible.

## Tests

- `.venv/bin/pytest tests/ -q` — **2482 passed**, 2 skipped, 5 xfailed, 1 xpassed
- `.venv/bin/black --check --target-version py312 .` — 544 files unchanged
- `yarn test --testPathPattern="types/diagnostic"` — 5 passed
- `yarn lint` — clean

Rebased onto current `main`; the schema regen this branch originally carried is already there via #640, so no schema diff remains.

## Stacked

**W4 (PR-B) builds on this branch** — it turns these diagnostics into the run's `error_json` and renders them in the viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
