### PR TITLE
A failed run's error_json carries the diagnostics, and the viewer renders them (M16 W4)

### DIFF
--- a/tests/server/test_run_views.py
+++ b/tests/server/test_run_views.py
@@ -194,6 +194,120 @@ class TestRunOnSave:
         assert runs[0]["dag_filter"] == "+a+,+b+"
 
 
+class TestRunFailureDiagnostics:
+    """W4: a failed run's error_json carries the failed jobs' Diagnostics —
+    killing the bare ``{"phase": "run"}`` payload the viewer used to render
+    verbatim."""
+
+    def _wait_terminal(self, integration_app):
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            runs = integration_app.run_manager.list()
+            if runs and runs[0]["state"] in ("succeeded", "failed"):
+                return runs[0]
+            time.sleep(0.05)
+        raise AssertionError("run never reached a terminal state")
+
+    def _failed_result(self, diagnostic=None):
+        from tests.factories.model_factories import SqlModelFactory
+        from visivo.jobs.job import JobResult
+
+        return JobResult(
+            item=SqlModelFactory(name="orders"),
+            success=False,
+            message="Failed query \033[31m[FAILURE]\033[0m",
+            diagnostic=diagnostic,
+        )
+
+    def test_error_json_is_the_exact_diagnostics_envelope(self, integration_app):
+        from visivo.models.diagnostic import Diagnostic, DiagnosticObjectRef, DiagnosticPhase
+
+        diagnostic = Diagnostic(
+            phase=DiagnosticPhase.RUN,
+            code="query_execution_failed",
+            message="no such table: orders",
+            object=DiagnosticObjectRef(type="model", name="orders"),
+        )
+        with patch.object(save_run_executor, "FilteredRunner") as MockRunner:
+            inst = MockRunner.return_value
+            inst.failed_job_results = [self._failed_result(diagnostic)]
+            inst.successful_job_results = []
+
+            save_run_executor.request_run(integration_app, ["orders"])
+            run = self._wait_terminal(integration_app)
+
+        assert run["state"] == "failed"
+        assert run["error_json"] == {
+            "phase": "run",
+            "diagnostics": [
+                {
+                    "severity": "error",
+                    "phase": "run",
+                    "code": "query_execution_failed",
+                    "message": "no such table: orders",
+                    "object": {"type": "model", "name": "orders"},
+                    "related": [],
+                }
+            ],
+        }
+
+    def test_a_result_without_a_diagnostic_gets_an_ansi_free_fallback(self, integration_app):
+        import json
+
+        with patch.object(save_run_executor, "FilteredRunner") as MockRunner:
+            inst = MockRunner.return_value
+            inst.failed_job_results = [self._failed_result(diagnostic=None)]
+            inst.successful_job_results = []
+
+            save_run_executor.request_run(integration_app, ["orders"])
+            run = self._wait_terminal(integration_app)
+
+        diagnostics = run["error_json"]["diagnostics"]
+        assert len(diagnostics) == 1
+        assert diagnostics[0]["code"] == "unexpected_error"
+        assert "orders" in diagnostics[0]["message"]
+        assert diagnostics[0]["object"] == {"type": "model", "name": "orders"}
+        # Never the dot-padded ANSI terminal message.
+        assert "\033" not in json.dumps(run["error_json"])
+
+    def test_diagnostics_are_capped_at_fifty(self, integration_app):
+        from visivo.models.diagnostic import Diagnostic, DiagnosticPhase
+
+        results = [
+            self._failed_result(
+                Diagnostic(
+                    phase=DiagnosticPhase.RUN,
+                    code="query_execution_failed",
+                    message=f"failure {i}",
+                )
+            )
+            for i in range(55)
+        ]
+        with patch.object(save_run_executor, "FilteredRunner") as MockRunner:
+            inst = MockRunner.return_value
+            inst.failed_job_results = results
+            inst.successful_job_results = []
+
+            save_run_executor.request_run(integration_app, ["orders"])
+            run = self._wait_terminal(integration_app)
+
+        assert len(run["error_json"]["diagnostics"]) == 50
+
+    def test_the_exception_path_reports_a_diagnostic_too(self, integration_app):
+        with patch.object(save_run_executor, "FilteredRunner") as MockRunner:
+            MockRunner.return_value.run.side_effect = RuntimeError("compile exploded")
+
+            save_run_executor.request_run(integration_app, ["orders"])
+            run = self._wait_terminal(integration_app)
+
+        assert run["state"] == "failed"
+        # `error` stays for older consumers; diagnostics carries the same failure.
+        assert run["error_json"]["phase"] == "run"
+        assert run["error_json"]["error"] == "compile exploded"
+        assert run["error_json"]["diagnostics"][0]["code"] == "unexpected_error"
+        assert run["error_json"]["diagnostics"][0]["message"] == "compile exploded"
+
+
 class TestExplorationRunIsolation:
     """Explorations are workbench drafts, never DAG/YAML config — saving or
     deleting one must never schedule a run (02-architecture.md §2, 07 S3

--- a/viewer/src/components/RunsView.jsx
+++ b/viewer/src/components/RunsView.jsx
@@ -5,6 +5,7 @@ import { fetchRuns, fetchRunLog, cancelRun } from '../api/runs';
 import AnsiText from './common/AnsiText';
 import useProjectChangeListener from './views/workspace/useProjectChangeListener';
 import { getTypeColors, getTypeIcon } from './views/common/objectTypeConfigs';
+import { diagnosticsFrom } from '../types/diagnostic';
 
 // queued/running are the only non-terminal states — while active a run is still
 // building, so the detail panel tail-polls the log.
@@ -240,6 +241,7 @@ function CancelRunButton({ run }) {
 
 function RunDetail({ run }) {
   const err = run.error_json;
+  const diagnostics = diagnosticsFrom(err);
   const active = isActiveRun(run);
   // The captured build log, tail-polled while the run is active, then the final
   // static log once terminal. RunDetail only mounts while the row is open, so
@@ -278,6 +280,29 @@ function RunDetail({ run }) {
         <div className={`font-medium mb-1 ${err ? 'text-highlight-700' : 'text-gray-500'}`}>
           {err ? `Error${err.phase ? ` — ${err.phase}` : ''}` : 'Logs'}
         </div>
+        {/* W4: the structured failures, when the payload carries them — one
+            entry per failed/skipped job: what failed, and what to do. The raw
+            log below stays the full-detail channel. */}
+        {diagnostics.length > 0 && (
+          <ul data-testid="run-detail-diagnostics" className="mb-2 space-y-1.5">
+            {diagnostics.map((diagnostic, index) => (
+              <li
+                key={diagnostic.id || index}
+                className="rounded border border-highlight/30 bg-highlight-50 px-3 py-2"
+              >
+                <p className="font-medium text-highlight-700">
+                  {diagnostic.object?.name
+                    ? `${diagnostic.object.type ? `${diagnostic.object.type} ` : ''}'${diagnostic.object.name}' — `
+                    : ''}
+                  {diagnostic.message}
+                </p>
+                {diagnostic.hint && (
+                  <p className="mt-0.5 text-highlight-600">{diagnostic.hint}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
         <pre className="bg-gray-900 text-gray-100 rounded p-3 overflow-auto max-h-80 whitespace-pre-wrap">
           <AnsiText text={consoleText} />
         </pre>

--- a/viewer/src/components/RunsView.test.jsx
+++ b/viewer/src/components/RunsView.test.jsx
@@ -125,6 +125,58 @@ describe('RunsView is self-contained (6c-T2 dark-on-dark hardening)', () => {
   });
 });
 
+describe('RunsView — RunDetail diagnostics (W4)', () => {
+  const diagnosticsErrorJson = {
+    phase: 'run',
+    diagnostics: [
+      {
+        severity: 'error',
+        phase: 'run',
+        code: 'query_execution_failed',
+        message: 'no such table: orders',
+        object: { type: 'model', name: 'orders' },
+        hint: 'Check the model SQL, then run again.',
+        related: [],
+      },
+      {
+        severity: 'error',
+        phase: 'run',
+        code: 'dependency_failed',
+        message: "Skipped insight 'revenue' because its dependency 'orders' failed.",
+        object: { type: 'insight', name: 'revenue' },
+        related: [],
+      },
+    ],
+  };
+
+  test('a diagnostics-carrying failure renders one entry per failed job, with object and hint', () => {
+    mockQueries({
+      runs: [run({ state: 'failed', error_json: diagnosticsErrorJson })],
+      log: { state: 'failed', logs: 'boom', error_json: diagnosticsErrorJson },
+    });
+    render(<RunsView />);
+    fireEvent.click(screen.getByRole('button', { name: /failed/i }));
+
+    const list = screen.getByTestId('run-detail-diagnostics');
+    expect(list).toHaveTextContent("model 'orders' — no such table: orders");
+    expect(list).toHaveTextContent('Check the model SQL, then run again.');
+    expect(list).toHaveTextContent(
+      "insight 'revenue' — Skipped insight 'revenue' because its dependency 'orders' failed."
+    );
+  });
+
+  test('a legacy payload without diagnostics renders no diagnostics list', () => {
+    mockQueries({
+      runs: [run({ state: 'failed', error_json: { phase: 'run' } })],
+      log: { state: 'failed', logs: 'boom', error_json: { phase: 'run' } },
+    });
+    render(<RunsView />);
+    fireEvent.click(screen.getByRole('button', { name: /failed/i }));
+
+    expect(screen.queryByTestId('run-detail-diagnostics')).not.toBeInTheDocument();
+  });
+});
+
 describe('RunsView — RunDetail meta + console-text fallback chain', () => {
   test('a queued run with no dag_filter shows "not set yet" in its OWN detail meta row (distinct from the list Scope column)', () => {
     mockQueries({ runs: [run({ state: 'queued', dag_filter: '' })] });

--- a/viewer/src/components/views/workspace/RecordRunStatus.jsx
+++ b/viewer/src/components/views/workspace/RecordRunStatus.jsx
@@ -32,6 +32,17 @@ const RecordRunStatus = ({ name, showRunsLink = false }) => {
 
   if (!failure) return null;
 
+  // W4: diagnostics-carrying payloads name the failed object and say what to
+  // do; older payloads keep the extracted one-liner. When the failure is
+  // about a DIFFERENT object (this record was skipped because an upstream
+  // failed), say which one.
+  const diagnosticObject = failure.diagnostic?.object;
+  const objectLabel =
+    diagnosticObject?.name && diagnosticObject.name !== name
+      ? `${diagnosticObject.type ? `${diagnosticObject.type} ` : ''}'${diagnosticObject.name}': `
+      : '';
+  const hint = failure.diagnostic?.hint;
+
   return (
     <div
       data-testid="record-run-status"
@@ -45,8 +56,18 @@ const RecordRunStatus = ({ name, showRunsLink = false }) => {
       <div className="min-w-0 flex-1">
         <p className="text-[11.5px] font-semibold text-highlight">Last run failed</p>
         <p className="truncate text-[11px] text-highlight-600" title={failure.error}>
+          {objectLabel}
           {failure.error}
         </p>
+        {hint && (
+          <p
+            data-testid="record-run-status-hint"
+            className="truncate text-[11px] text-highlight-500"
+            title={hint}
+          >
+            {hint}
+          </p>
+        )}
       </div>
       {showRunsLink && (
         <Link

--- a/viewer/src/components/views/workspace/RecordRunStatus.test.jsx
+++ b/viewer/src/components/views/workspace/RecordRunStatus.test.jsx
@@ -90,3 +90,90 @@ describe('RecordRunStatus', () => {
     expect(link).toHaveAttribute('href', '/runs');
   });
 });
+
+describe('RecordRunStatus with diagnostics payloads (W4)', () => {
+  const diagnosticsRun = diagnostics => ({
+    id: 'run-11',
+    state: 'failed',
+    dag_filter: '+revenue_insight+,+warehouse+',
+    error_json: { phase: 'run', diagnostics },
+    is_superseded: false,
+    created_at: '2026-07-01T12:00:00Z',
+  });
+
+  it('renders the diagnostic message and hint for the record', () => {
+    setRuns([
+      diagnosticsRun([
+        {
+          severity: 'error',
+          phase: 'run',
+          code: 'query_execution_failed',
+          message: 'no such table: orders',
+          object: { type: 'insight', name: 'revenue_insight' },
+          hint: 'Check the model SQL, then run again.',
+          related: [],
+        },
+      ]),
+    ]);
+    render(<RecordRunStatus name="revenue_insight" />);
+    const banner = screen.getByTestId('record-run-status');
+    expect(banner).toHaveTextContent('Last run failed');
+    expect(banner).toHaveTextContent('no such table: orders');
+    expect(screen.getByTestId('record-run-status-hint')).toHaveTextContent(
+      'Check the model SQL, then run again.'
+    );
+  });
+
+  it('names the upstream object when the failure is about a different record', () => {
+    setRuns([
+      diagnosticsRun([
+        {
+          severity: 'error',
+          phase: 'run',
+          code: 'source_locked',
+          message: 'database file is held by another connection',
+          object: { type: 'source', name: 'warehouse' },
+          related: [],
+        },
+      ]),
+    ]);
+    render(<RecordRunStatus name="revenue_insight" />);
+    const banner = screen.getByTestId('record-run-status');
+    expect(banner).toHaveTextContent("source 'warehouse':");
+    expect(banner).toHaveTextContent('database file is held by another connection');
+  });
+
+  it('never renders the raw {"phase":"run"} envelope for legacy payloads', () => {
+    setRuns([
+      {
+        id: 'run-12',
+        state: 'failed',
+        dag_filter: '+revenue_insight+',
+        error_json: { phase: 'run' },
+        is_superseded: false,
+        created_at: '2026-07-01T12:00:00Z',
+      },
+    ]);
+    render(<RecordRunStatus name="revenue_insight" />);
+    const banner = screen.getByTestId('record-run-status');
+    expect(banner).not.toHaveTextContent('{"phase":"run"}');
+    expect(banner).toHaveTextContent('Run failed');
+  });
+
+  it('omits the hint row when the diagnostic has none', () => {
+    setRuns([
+      diagnosticsRun([
+        {
+          severity: 'error',
+          phase: 'run',
+          code: 'query_execution_failed',
+          message: 'boom',
+          object: { type: 'insight', name: 'revenue_insight' },
+          related: [],
+        },
+      ]),
+    ]);
+    render(<RecordRunStatus name="revenue_insight" />);
+    expect(screen.queryByTestId('record-run-status-hint')).not.toBeInTheDocument();
+  });
+});

--- a/viewer/src/stores/runFailures.js
+++ b/viewer/src/stores/runFailures.js
@@ -21,9 +21,28 @@
  * select `s.runs` and memoize `findLatestRunFailureFor` instead, as
  * RecordRunStatus does. The factory suits imperative reads
  * (`selectLatestRunFailureFor(name)(useStore.getState())`).
+ *
+ * W4 (Error Legibility): `error_json` now carries `diagnostics` (the shared
+ * Diagnostic contract). The failure result prefers the diagnostic matching the
+ * record — message/hint/object come from it — with the dag_filter matching and
+ * `extractRunError` kept as the fallback for payloads that predate the
+ * contract (older local serves, cloud).
  */
+import { diagnosticsFrom } from '../types/diagnostic';
 
 const FALLBACK_ERROR = 'Run failed';
+
+/**
+ * The diagnostic to show ON a given record: the one about the record itself
+ * when present, else the first — a run that failed upstream of this record
+ * reports the upstream failure rather than nothing.
+ * @param {import('../types/diagnostic').Diagnostic[]} diagnostics
+ * @param {string} name
+ */
+export const pickDiagnosticFor = (diagnostics, name) => {
+  if (!Array.isArray(diagnostics) || diagnostics.length === 0) return null;
+  return diagnostics.find(d => d?.object?.name === name) ?? diagnostics[0];
+};
 
 /**
  * "+revenue_insight+,+orders_model+" → ['revenue_insight', 'orders_model'].
@@ -49,6 +68,11 @@ export const extractRunError = errorJson => {
   if (typeof errorJson === 'object') {
     const message = errorJson.message || errorJson.error || errorJson.detail;
     if (typeof message === 'string' && message) return message;
+    // A run envelope with nothing readable — the bare {"phase":"run"} payload
+    // pre-diagnostics servers emit. Rendering its JSON verbatim was the M16
+    // bug; a generic message beats the raw envelope. (Diagnostics-carrying
+    // payloads never reach this: callers read them via diagnosticsFrom first.)
+    if ('phase' in errorJson || Array.isArray(errorJson.diagnostics)) return FALLBACK_ERROR;
     try {
       return JSON.stringify(errorJson);
     } catch (e) {
@@ -77,9 +101,13 @@ const runTime = run => {
 /**
  * The failure currently applying to `name`, per the module semantics above.
  *
+ * `diagnostic` is the structured failure to render for this record (message +
+ * hint + object), null for payloads that predate the contract; `error` is the
+ * one-line message either way.
+ *
  * @param {Array|undefined} runs the cloud runs list (state.runs)
  * @param {string} name the record name to match against dag_filter
- * @returns {{runId: string, error: string, createdAt: string|null} | null}
+ * @returns {{runId: string, error: string, diagnostic: Object|null, createdAt: string|null} | null}
  */
 export const findLatestRunFailureFor = (runs, name) => {
   if (!Array.isArray(runs) || runs.length === 0 || !name) return null;
@@ -96,9 +124,11 @@ export const findLatestRunFailureFor = (runs, name) => {
   for (const { run } of relevant) {
     if (run.state === 'succeeded') return null; // a newer success clears it
     if (run.state === 'failed') {
+      const diagnostic = pickDiagnosticFor(diagnosticsFrom(run.error_json), name);
       return {
         runId: run.id,
-        error: extractRunError(run.error_json),
+        error: diagnostic ? diagnostic.message : extractRunError(run.error_json),
+        diagnostic,
         createdAt: run.created_at ?? null,
       };
     }

--- a/viewer/src/stores/runFailures.test.js
+++ b/viewer/src/stores/runFailures.test.js
@@ -10,6 +10,7 @@ import {
   parseDagFilterNames,
   extractRunError,
   findLatestRunFailureFor,
+  pickDiagnosticFor,
   selectLatestRunFailureFor,
 } from './runFailures';
 
@@ -52,6 +53,12 @@ describe('extractRunError', () => {
 
   it('stringifies objects without a known message key', () => {
     expect(extractRunError({ code: 500 })).toBe('{"code":500}');
+  });
+
+  it('never renders the bare {"phase":"run"} envelope (M16)', () => {
+    expect(extractRunError({ phase: 'run' })).toBe('Run failed');
+    expect(extractRunError('{"phase":"run"}')).toBe('Run failed');
+    expect(extractRunError({ phase: 'run', diagnostics: [] })).toBe('Run failed');
   });
 
   it('parses a JSON-encoded string payload', () => {
@@ -116,6 +123,7 @@ describe('findLatestRunFailureFor', () => {
     expect(findLatestRunFailureFor([failed()], 'revenue_insight')).toEqual({
       runId: 'run-failed',
       error: 'query exploded',
+      diagnostic: null,
       createdAt: '2026-07-01T12:00:00Z',
     });
     // Also matches the OTHER name in the same dag_filter.
@@ -189,5 +197,90 @@ describe('findLatestRunFailureFor', () => {
     expect(selector({ runs: [] })).toBeNull();
     expect(selector({})).toBeNull();
     expect(selector(undefined)).toBeNull();
+  });
+});
+
+describe('diagnostics payloads (W4)', () => {
+  const insightDiagnostic = {
+    severity: 'error',
+    phase: 'run',
+    code: 'query_execution_failed',
+    message: 'no such table: orders',
+    object: { type: 'insight', name: 'revenue_insight' },
+    hint: 'Check the model SQL.',
+    related: [],
+  };
+  const sourceDiagnostic = {
+    severity: 'error',
+    phase: 'run',
+    code: 'source_locked',
+    message: "Database file for 'warehouse' is held by another connection",
+    object: { type: 'source', name: 'warehouse' },
+    related: [],
+  };
+  const failedWithDiagnostics = (diagnostics, over = {}) => ({
+    id: 'run-diag',
+    state: 'failed',
+    dag_filter: '+revenue_insight+,+warehouse+',
+    error_json: { phase: 'run', diagnostics },
+    is_superseded: false,
+    created_at: '2026-07-01T12:00:00Z',
+    ...over,
+  });
+
+  describe('pickDiagnosticFor', () => {
+    it('prefers the diagnostic about the record itself', () => {
+      expect(pickDiagnosticFor([sourceDiagnostic, insightDiagnostic], 'revenue_insight')).toBe(
+        insightDiagnostic
+      );
+    });
+
+    it('falls back to the first diagnostic when none matches', () => {
+      expect(pickDiagnosticFor([sourceDiagnostic], 'revenue_insight')).toBe(sourceDiagnostic);
+    });
+
+    it('returns null for empty / missing lists', () => {
+      expect(pickDiagnosticFor([], 'x')).toBeNull();
+      expect(pickDiagnosticFor(undefined, 'x')).toBeNull();
+    });
+  });
+
+  it('the failure carries the matching diagnostic and its message', () => {
+    const runs = [failedWithDiagnostics([sourceDiagnostic, insightDiagnostic])];
+    expect(findLatestRunFailureFor(runs, 'revenue_insight')).toEqual({
+      runId: 'run-diag',
+      error: 'no such table: orders',
+      diagnostic: insightDiagnostic,
+      createdAt: '2026-07-01T12:00:00Z',
+    });
+  });
+
+  it('a record failed upstream reports the upstream diagnostic', () => {
+    const runs = [failedWithDiagnostics([sourceDiagnostic])];
+    expect(findLatestRunFailureFor(runs, 'revenue_insight')).toMatchObject({
+      error: "Database file for 'warehouse' is held by another connection",
+      diagnostic: sourceDiagnostic,
+    });
+  });
+
+  it('tolerates a JSON-encoded diagnostics payload', () => {
+    const runs = [
+      failedWithDiagnostics([], {
+        error_json: JSON.stringify({ phase: 'run', diagnostics: [insightDiagnostic] }),
+      }),
+    ];
+    expect(findLatestRunFailureFor(runs, 'revenue_insight')).toMatchObject({
+      error: 'no such table: orders',
+    });
+  });
+
+  it('a legacy bare {"phase":"run"} payload degrades to the generic message, never raw JSON', () => {
+    const runs = [failedWithDiagnostics([], { error_json: { phase: 'run' } })];
+    expect(findLatestRunFailureFor(runs, 'revenue_insight')).toEqual({
+      runId: 'run-diag',
+      error: 'Run failed',
+      diagnostic: null,
+      createdAt: '2026-07-01T12:00:00Z',
+    });
   });
 });

--- a/visivo/server/jobs/save_run_executor.py
+++ b/visivo/server/jobs/save_run_executor.py
@@ -13,12 +13,18 @@ from copy import deepcopy
 
 from visivo.constants import DEFAULT_RUN_ID
 from visivo.jobs.filtered_runner import FilteredRunner
+from visivo.jobs.job import diagnostic_object_ref
 from visivo.logger.logger import Logger
+from visivo.models.diagnostic import Diagnostic, DiagnosticPhase
 from visivo.server.jobs.project_injection import inject_cached_objects
 from visivo.server.managers.run_manager import RunState
 
 # Coalesce rapid saves (e.g. one editor action touching several rows) into one run.
 _DEBOUNCE_SECONDS = 0.5
+
+# error_json is a polled status payload, not the log channel — cap it. The
+# full text stays on GET /api/runs/<run_id>/logs/.
+_MAX_DIAGNOSTICS = 50
 
 _pending_names = set()
 _pending_lock = threading.Lock()
@@ -119,7 +125,9 @@ def _execute(flask_app, run_id, dag_filter):
 
         logs = _format_logs(runner)
         if runner.failed_job_results:
-            run_manager.set_state(run_id, RunState.FAILED, logs=logs, error_json={"phase": "run"})
+            run_manager.set_state(
+                run_id, RunState.FAILED, logs=logs, error_json=_error_json_from(runner)
+            )
         else:
             # Record what this run built, so the staged list drops exactly the
             # items it covered. A failure deliberately leaves them staged — the
@@ -132,8 +140,51 @@ def _execute(flask_app, run_id, dag_filter):
             run_id,
             RunState.FAILED,
             logs=str(exc),
-            error_json={"phase": "run", "error": str(exc)},
+            # `error` stays for older viewers (extractRunError renders it);
+            # `diagnostics` is the same failure in the shared contract shape.
+            error_json={
+                "phase": "run",
+                "error": str(exc),
+                "diagnostics": [
+                    Diagnostic.from_exception(exc, phase=DiagnosticPhase.RUN).model_dump(
+                        mode="json", exclude_none=True
+                    )
+                ],
+            },
         )
+
+
+def _error_json_from(runner):
+    """The structured payload for a failed run (W4, Error Legibility).
+
+    ``{'phase': 'run'}`` used to be the ENTIRE payload — the runner's
+    failed_job_results were discarded one line after being formatted into the
+    logs, so the viewer's per-record failure banner rendered the literal JSON
+    envelope. ``diagnostics`` now carries each failed job's Diagnostic
+    (additive: ``phase`` stays for consumers that predate the contract).
+    """
+    diagnostics = []
+    for result in runner.failed_job_results:
+        if len(diagnostics) >= _MAX_DIAGNOSTICS:
+            break
+        if result.diagnostic is not None:
+            diagnostics.append(result.diagnostic.model_dump(mode="json", exclude_none=True))
+        else:
+            # Every W3 failure site populates a diagnostic; this belt covers
+            # any producer that predates the contract. Never the dot-padded,
+            # ANSI-coloured terminal message — point at the logs instead.
+            diagnostics.append(
+                Diagnostic(
+                    phase=DiagnosticPhase.RUN,
+                    code="unexpected_error",
+                    message=(
+                        f"Job for '{getattr(result.item, 'name', 'unknown')}' failed — "
+                        f"see the run logs for details."
+                    ),
+                    object=diagnostic_object_ref(result.item),
+                ).model_dump(mode="json", exclude_none=True)
+            )
+    return {"phase": "run", "diagnostics": diagnostics}
 
 
 def mark_staged_built(flask_app, dag_filter):


### PR DESCRIPTION
> **Stacked on #650** (`error-legibility-w3-jobresult-diagnostic`). This PR targets that branch, not `main` — review #650 first, and the diff here will shrink to just this change once #650 merges.

## The problem

This is the bug you can see. A failed run's `error_json` was, in its entirety:

```json
{"phase": "run"}
```

`save_run_executor` formatted the runner's `failed_job_results` into the logs and then dropped them one line later. So the viewer's per-record failure banner had nothing to render — and `extractRunError`, finding no `message`/`error`/`detail` key, fell through to `JSON.stringify` and printed the envelope back at the user:

```
Last run failed
{"phase":"run"}
```

W3 (#650) gave every failed job a structured `Diagnostic`. This PR carries them to the viewer and renders them.

## Server

`save_run_executor` now emits `{'phase': 'run', 'diagnostics': [...]}`, built from the failed job results:

- **Capped at 50.** `error_json` is a polled status payload, not the log channel — the full text stays on `GET /api/runs/<run_id>/logs/`.
- **A result with no diagnostic** gets a synthesized `unexpected_error` naming the object and pointing at the logs. Never the dot-padded, ANSI-coloured terminal `message` — a test asserts no `\033` survives into the payload.
- **The compile/exception path** gains a diagnostic too, and keeps its `error` key so consumers that predate the contract still render.

`phase` stays put throughout; the change is purely additive on the wire.

## Viewer

All three consumers read through W0's existing `diagnosticsFrom` helper in `types/diagnostic.js`:

- **`runFailures.js`** — `findLatestRunFailureFor` returns the diagnostic matching the record alongside `error`. New `pickDiagnosticFor` prefers the diagnostic *about* the record, falling back to the first: a record skipped because an upstream failed reports **the upstream failure** rather than nothing. `extractRunError` stops stringifying a bare run envelope.
- **`RecordRunStatus.jsx`** — renders message + hint, and prefixes the object name when the failure is about a *different* record (`source 'warehouse': database file is held by another connection`).
- **`RunsView.jsx`** — `RunDetail` lists one entry per failed/skipped job above the raw log, each with object name, message, and hint.

## Legacy payloads

Every consumer degrades to the previous behaviour when `diagnostics` is absent — older local serves, cloud. `diagnosticsFrom` also tolerates a JSON-encoded string payload, which `error_json` is documented to arrive as on some older run rows. **Both shapes are covered by tests**, including the specific assertion that a bare `{"phase":"run"}` renders `Run failed` and never the raw JSON.

## Falsification

Implementation reverted to the W3 parent, tests kept.

Server — **4 fail**, each showing the bare envelope:

```
E  assert {'phase': 'run'} == {'phase': 'run', 'diagnostics': [...]}
E    {
E        'phase': 'run',
E  -     'diagnostics': [
E  -         {'severity': 'error', 'code': 'query_execution_failed',
E  -          'message': 'no such table: orders', ...},
E  -     ],
E    }
FAILED test_a_result_without_a_diagnostic_gets_an_ansi_free_fallback - KeyError: 'diagnostics'
FAILED test_diagnostics_are_capped_at_fifty - KeyError: 'diagnostics'
FAILED test_the_exception_path_reports_a_diagnostic_too - KeyError: 'diagnostics'
```

Viewer — **13 fail** across the three consumers:

```
● extractRunError › never renders the bare {"phase":"run"} envelope (M16)
● diagnostics payloads (W4) › pickDiagnosticFor › prefers the diagnostic about the record itself
● diagnostics payloads (W4) › a record failed upstream reports the upstream diagnostic
● diagnostics payloads (W4) › a legacy bare {"phase":"run"} payload degrades to the generic message, never raw JSON
● RecordRunStatus with diagnostics payloads (W4) › renders the diagnostic message and hint for the record
● RecordRunStatus with diagnostics payloads (W4) › names the upstream object when the failure is about a different record
● RecordRunStatus with diagnostics payloads (W4) › never renders the raw {"phase":"run"} envelope for legacy payloads
● RunsView — RunDetail diagnostics (W4) › a diagnostics-carrying failure renders one entry per failed job, with object and hint
... Tests: 13 failed, 66 passed, 79 total
```

## Tests

- `.venv/bin/pytest tests/ -q` — **2486 passed**, 2 skipped, 5 xfailed, 1 xpassed
- `.venv/bin/black --check --target-version py312 .` — 544 files unchanged
- `yarn test --watchAll=false` — **366 suites, 7051 tests, all passing**
- `yarn lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
