### PR TITLE
The editor's overlay keeps nesting too: a model-scoped field is not project-level (B12)

### DIFF
--- a/tests/query/insight/test_draft_overlay.py
+++ b/tests/query/insight/test_draft_overlay.py
@@ -280,6 +280,66 @@ class TestBuildDraftOverlayModelScopedDraftFields:
         assert matching[0].expression == "avg(amount)"
 
 
+class TestBuildDraftOverlayModelScopedCachedFields:
+    """The other way a model-scoped field reaches this overlay: not on the wire
+    as a draft, but SAVED into the editor's cached tier and not yet committed —
+    a computed column the user promoted, then went on using.
+
+    Those arrive through ``inject_cached_objects``, which can only append them
+    to the flat top-level list. Left there, the very reference the Explorer
+    emits for them — ``${ref(model).field}`` — no longer finds them, and the
+    same "computed metric behaves like a dimension" symptom comes back on a
+    field that was, from the user's side, already promoted."""
+
+    def _bar_insight(self):
+        return {
+            "name": "draft_insight",
+            "props": {
+                "type": "bar",
+                "x": "?{${ref(orders_q).region}}",
+                "y": "?{${ref(orders_q).avg_total}}",
+            },
+        }
+
+    def _flask_app_with_cached_metric(self, project):
+        from types import SimpleNamespace
+
+        cached = Metric(name="avg_total", expression="avg(amount)")
+        cached.set_parent_name("orders_q")
+        app = FlaskAppStub(project)
+        app.metric_manager = SimpleNamespace(cached_objects={"avg_total": cached})
+        return app
+
+    def test_a_cached_model_scoped_metric_lands_on_its_model(self, project_with_model):
+        app = self._flask_app_with_cached_metric(project_with_model)
+
+        project, dag, _ = build_draft_overlay(app, self._bar_insight())
+
+        model_node = dag.get_descendant_by_name("orders_q")
+        assert [m.name for m in model_node.metrics or []] == ["avg_total"]
+        assert all(m.name != "avg_total" for m in (project.metrics or []))
+
+    def test_a_cached_model_scoped_metric_compiles_as_an_aggregate(
+        self, project_with_model, tmp_path
+    ):
+        app = self._flask_app_with_cached_metric(project_with_model)
+
+        _, dag, insight = build_draft_overlay(app, self._bar_insight())
+        model_node = dag.get_descendant_by_name("orders_q")
+        query_info = insight.get_query_info(
+            dag,
+            str(tmp_path),
+            schema_overrides={
+                "orders_q": {model_node.name_hash(): {"region": "VARCHAR", "amount": "DOUBLE"}}
+            },
+            force_dynamic=True,
+        )
+
+        post_query = (query_info.post_query or "").lower()
+        assert "avg(" in post_query
+        assert "group by" in post_query
+
+
 class TestBuildDraftOverlayNameShadowing:
     def test_a_draft_model_reusing_a_real_published_name_shadows_it_in_the_ephemeral_copy_only(
         self, flask_app, project_with_model

--- a/tests/query/insight/test_draft_overlay.py
+++ b/tests/query/insight/test_draft_overlay.py
@@ -131,6 +131,31 @@ class TestBuildDraftOverlayValidation:
                 draft_models=[{"name": "missing_sql_field"}],
             )
 
+    def test_a_draft_model_that_fails_pydantic_raises_draft_overlay_error(self, flask_app):
+        # The module's stated contract: a Pydantic ValidationError never escapes
+        # uncaught to the view. `sql` is Optional (post-#533), so the gate above
+        # catches a MISSING one — this covers a dict that fails validation
+        # outright, which is a different branch.
+        with pytest.raises(DraftOverlayError, match="Invalid draft models"):
+            build_draft_overlay(
+                flask_app,
+                insight_config(),
+                draft_models=[{"name": "orders_q", "sql": "select 1", "not_a_field": True}],
+            )
+
+    @pytest.mark.parametrize("field", ["draft_metrics", "draft_dimensions"])
+    def test_a_malformed_model_scoped_draft_field_raises_draft_overlay_error(
+        self, flask_app, field
+    ):
+        # Same contract on the model-scoped branch, which validates each config
+        # separately after popping its `model` key.
+        with pytest.raises(DraftOverlayError, match="Invalid draft"):
+            build_draft_overlay(
+                flask_app,
+                insight_config(),
+                **{field: [{"name": "avg_total", "model": "orders_q"}]},
+            )
+
     @pytest.mark.parametrize("blank_sql", ["", "   ", "\n\t"])
     def test_a_blank_or_whitespace_only_sql_is_gated_like_missing_sql(self, flask_app, blank_sql):
         # Phase 4 review fix: the gate must treat "" / "   " the same as
@@ -253,7 +278,10 @@ class TestBuildDraftOverlayModelScopedDraftFields:
     def test_a_draft_field_naming_an_unknown_model_falls_back_to_project_level(self, flask_app):
         # A metric whose `model` names no known model must not silently vanish —
         # it falls back to the project-level list so a later resolution failure
-        # is a clean, surfaced error rather than a silent drop.
+        # is a clean, surfaced error rather than a silent drop. This is also the
+        # guard on the FINAL re-nest pass `build_draft_overlay` runs after the
+        # wire drafts land: that fallback deliberately leaves `_parent_name`
+        # unset, so the pass must leave the field exactly where it is.
         project, _, _ = build_draft_overlay(
             flask_app,
             self._bar_insight(),
@@ -280,6 +308,25 @@ class TestBuildDraftOverlayModelScopedDraftFields:
         assert matching[0].expression == "avg(amount)"
 
 
+# The wire shape the Explorer ACTUALLY sends: `useDraftInsightPreview.js`
+# builds a `draft_models` entry for EVERY entry in `modelStates` that has
+# `sql` + `sourceName` — published models included, since
+# `buildModelStateFromObject` fills both from the published config. It carries
+# only {name, sql, source}; it never carries `metrics`/`dimensions`. Every
+# test below that exercises the cached/published field path is parameterised
+# over "client sends it" vs "it is absent", because merging this dict by name
+# is a REPLACEMENT and that is where a nested field gets deleted.
+_CLIENT_DRAFT_MODEL = {
+    "name": "orders_q",
+    "sql": "select * from orders",
+    "source": "${ref(warehouse)}",
+}
+_WIRE_SHAPES = pytest.mark.parametrize(
+    "draft_models",
+    [pytest.param(None, id="no_draft_models"), pytest.param([_CLIENT_DRAFT_MODEL], id="client")],
+)
+
+
 class TestBuildDraftOverlayModelScopedCachedFields:
     """The other way a model-scoped field reaches this overlay: not on the wire
     as a draft, but SAVED into the editor's cached tier and not yet committed —
@@ -289,7 +336,13 @@ class TestBuildDraftOverlayModelScopedCachedFields:
     to the flat top-level list. Left there, the very reference the Explorer
     emits for them — ``${ref(model).field}`` — no longer finds them, and the
     same "computed metric behaves like a dimension" symptom comes back on a
-    field that was, from the user's side, already promoted."""
+    field that was, from the user's side, already promoted.
+
+    Every case runs BOTH wire shapes. The overlay re-nests the field and then
+    injects the wire drafts, so a ``draft_models`` entry naming the same model
+    used to replace the model wholesale and take the just-nested field with it
+    — the field ended up in neither ``model.metrics`` nor ``project.metrics``.
+    ``draft_models=None`` alone cannot see that."""
 
     def _bar_insight(self):
         return {
@@ -310,34 +363,232 @@ class TestBuildDraftOverlayModelScopedCachedFields:
         app.metric_manager = SimpleNamespace(cached_objects={"avg_total": cached})
         return app
 
-    def test_a_cached_model_scoped_metric_lands_on_its_model(self, project_with_model):
+    def _compile(self, app, dag, insight, tmp_path):
+        model_node = dag.get_descendant_by_name("orders_q")
+        return insight.get_query_info(
+            dag,
+            str(tmp_path),
+            schema_overrides={
+                "orders_q": {
+                    model_node.name_hash(): {
+                        "region": "VARCHAR",
+                        "amount": "DOUBLE",
+                        # The client's `modelSchemas` still lists a computed
+                        # column among the RAW columns (see the comment at
+                        # useDraftInsightPreview.js). That is what makes a lost
+                        # metric silent rather than loud: the raw column answers
+                        # the ref, the aggregate is dropped, and the metric
+                        # reads as a plain dimension.
+                        "avg_total": "DOUBLE",
+                    }
+                }
+            },
+            force_dynamic=True,
+        )
+
+    @_WIRE_SHAPES
+    def test_a_cached_model_scoped_metric_lands_on_its_model(
+        self, project_with_model, draft_models
+    ):
         app = self._flask_app_with_cached_metric(project_with_model)
 
-        project, dag, _ = build_draft_overlay(app, self._bar_insight())
+        project, dag, _ = build_draft_overlay(app, self._bar_insight(), draft_models=draft_models)
 
         model_node = dag.get_descendant_by_name("orders_q")
         assert [m.name for m in model_node.metrics or []] == ["avg_total"]
         assert all(m.name != "avg_total" for m in (project.metrics or []))
 
+    @_WIRE_SHAPES
     def test_a_cached_model_scoped_metric_compiles_as_an_aggregate(
-        self, project_with_model, tmp_path
+        self, project_with_model, tmp_path, draft_models
     ):
         app = self._flask_app_with_cached_metric(project_with_model)
 
-        _, dag, insight = build_draft_overlay(app, self._bar_insight())
-        model_node = dag.get_descendant_by_name("orders_q")
-        query_info = insight.get_query_info(
-            dag,
-            str(tmp_path),
-            schema_overrides={
-                "orders_q": {model_node.name_hash(): {"region": "VARCHAR", "amount": "DOUBLE"}}
-            },
-            force_dynamic=True,
-        )
+        _, dag, insight = build_draft_overlay(app, self._bar_insight(), draft_models=draft_models)
+        query_info = self._compile(app, dag, insight, tmp_path)
 
         post_query = (query_info.post_query or "").lower()
         assert "avg(" in post_query
         assert "group by" in post_query
+
+    @_WIRE_SHAPES
+    def test_a_cached_model_scoped_metric_still_answers_a_bare_ref(
+        self, project_with_model, tmp_path, draft_models
+    ):
+        # A model-scoped field remains a DAG node addressable WITHOUT its model
+        # qualifier (`Metric.child_items` emits `ref(<parent>)`, the edge #639
+        # relies on). Deleting the field from the overlay does not degrade this
+        # one quietly — `project.dag()` refuses to build at all, so the
+        # compile-draft view answers 400 for an insight that used to render.
+        app = self._flask_app_with_cached_metric(project_with_model)
+        bare = self._bar_insight()
+        bare["props"]["y"] = "?{${ref(avg_total)}}"
+
+        _, dag, insight = build_draft_overlay(app, bare, draft_models=draft_models)
+        query_info = self._compile(app, dag, insight, tmp_path)
+
+        assert "avg(" in (query_info.post_query or "").lower()
+
+
+class TestBuildDraftOverlayDraftModelPreservesNestedFields:
+    """A ``draft_models`` entry is a partial override — the SQL and source of
+    the model the user is editing. It is not a redeclaration of everything that
+    model owns, so merging it by name must not evict the model's metrics and
+    dimensions."""
+
+    def _insight(self, field="avg_total"):
+        return {
+            "name": "draft_insight",
+            "props": {
+                "type": "bar",
+                "x": "?{${ref(orders_q).region}}",
+                "y": f"?{{${{ref(orders_q).{field}}}}}",
+            },
+        }
+
+    def test_a_published_nested_metric_survives_the_client_draft_model(
+        self, flask_app, project_with_model, tmp_path
+    ):
+        # Committed to YAML, not cached: the model in the project already owns
+        # `avg_total`. The client still sends a draft_models entry for it on
+        # every preview, and that must not take the metric with it.
+        project_with_model.models[0].metrics = [Metric(name="avg_total", expression="avg(amount)")]
+
+        project, dag, insight = build_draft_overlay(
+            flask_app, self._insight(), draft_models=[_CLIENT_DRAFT_MODEL]
+        )
+
+        model_node = dag.get_descendant_by_name("orders_q")
+        assert [m.name for m in model_node.metrics or []] == ["avg_total"]
+        query_info = insight.get_query_info(
+            dag,
+            str(tmp_path),
+            schema_overrides={
+                "orders_q": {
+                    model_node.name_hash(): {
+                        "region": "VARCHAR",
+                        "amount": "DOUBLE",
+                        "avg_total": "DOUBLE",
+                    }
+                }
+            },
+            force_dynamic=True,
+        )
+        assert "avg(" in (query_info.post_query or "").lower()
+
+    def test_a_published_nested_dimension_survives_the_client_draft_model(
+        self, flask_app, project_with_model
+    ):
+        from visivo.models.dimension import Dimension
+
+        project_with_model.models[0].dimensions = [
+            Dimension(name="loud_region", expression="upper(region)")
+        ]
+
+        _, dag, _ = build_draft_overlay(
+            flask_app, self._insight(field="loud_region"), draft_models=[_CLIENT_DRAFT_MODEL]
+        )
+
+        model_node = dag.get_descendant_by_name("orders_q")
+        assert [d.name for d in model_node.dimensions or []] == ["loud_region"]
+
+    def test_a_carried_forward_field_keeps_its_scope_on_the_replacement_model(
+        self, flask_app, project_with_model
+    ):
+        # Carrying the object over is not enough on its own: the replacement is
+        # built post-construction, so SqlModel's after-validator never runs and
+        # the scope has to be re-asserted explicitly (the same contract
+        # `_inject_model_scoped_fields` uses).
+        project_with_model.models[0].metrics = [Metric(name="avg_total", expression="avg(amount)")]
+
+        project, _, _ = build_draft_overlay(
+            flask_app, self._insight(), draft_models=[_CLIENT_DRAFT_MODEL]
+        )
+
+        model = next(m for m in project.models if m.name == "orders_q")
+        assert model.metrics[0]._parent_name == "orders_q"
+
+    def test_a_draft_model_that_declares_its_own_metrics_overrides_them(
+        self, flask_app, project_with_model
+    ):
+        # Only keys the draft dict actually carries override. A dict that DOES
+        # declare `metrics` is authoritative — inheritance must not resurrect
+        # the published set behind it.
+        project_with_model.models[0].metrics = [Metric(name="avg_total", expression="avg(amount)")]
+
+        project, _, _ = build_draft_overlay(
+            flask_app,
+            self._insight(field="max_total"),
+            draft_models=[
+                dict(
+                    _CLIENT_DRAFT_MODEL,
+                    metrics=[{"name": "max_total", "expression": "max(amount)"}],
+                )
+            ],
+        )
+
+        model = next(m for m in project.models if m.name == "orders_q")
+        assert [m.name for m in model.metrics] == ["max_total"]
+
+    def test_a_scratch_model_does_not_inherit_another_models_fields(
+        self, flask_app, project_with_model
+    ):
+        # Inheritance is keyed on the name being REPLACED. A brand-new scratch
+        # model shadows nothing, so it must come through empty rather than
+        # picking up whatever the other model in the project happens to own.
+        project_with_model.models[0].metrics = [Metric(name="avg_total", expression="avg(amount)")]
+
+        project, _, _ = build_draft_overlay(
+            flask_app,
+            insight_config(model_name="cohort_q"),
+            draft_models=[
+                {"name": "cohort_q", "sql": "select * from cohorts", "source": "${ref(warehouse)}"}
+            ],
+        )
+
+        scratch = next(m for m in project.models if m.name == "cohort_q")
+        assert scratch.metrics == []
+        assert scratch.dimensions == []
+        # …and the model it did NOT shadow keeps its own.
+        published = next(m for m in project.models if m.name == "orders_q")
+        assert [m.name for m in published.metrics] == ["avg_total"]
+
+
+class TestBuildDraftOverlayCachedFieldOnAWireOnlyModel:
+    """A cached field whose owner reaches the overlay only as a wire draft.
+
+    ``inject_cached_objects`` re-nests against the models it can see, and the
+    scratch model is not one of them yet — it arrives in the NEXT step. The
+    rule therefore has to be re-applied once the whole overlay is assembled,
+    or the field stays a project-level orphan and its qualified reference,
+    ``${ref(cohort_q).avg_total}``, cannot find it."""
+
+    def test_the_field_is_nested_once_its_model_arrives_on_the_wire(self, project_with_model):
+        from types import SimpleNamespace
+
+        cached = Metric(name="avg_total", expression="avg(amount)")
+        cached.set_parent_name("cohort_q")
+        app = FlaskAppStub(project_with_model)
+        app.metric_manager = SimpleNamespace(cached_objects={"avg_total": cached})
+
+        project, dag, _ = build_draft_overlay(
+            app,
+            {
+                "name": "draft_insight",
+                "props": {
+                    "type": "bar",
+                    "x": "?{${ref(cohort_q).region}}",
+                    "y": "?{${ref(cohort_q).avg_total}}",
+                },
+            },
+            draft_models=[
+                {"name": "cohort_q", "sql": "select * from cohorts", "source": "${ref(warehouse)}"}
+            ],
+        )
+
+        model_node = dag.get_descendant_by_name("cohort_q")
+        assert [m.name for m in model_node.metrics or []] == ["avg_total"]
+        assert all(m.name != "avg_total" for m in (project.metrics or []))
 
 
 class TestBuildDraftOverlayNameShadowing:

--- a/tests/server/jobs/test_project_injection.py
+++ b/tests/server/jobs/test_project_injection.py
@@ -1,0 +1,241 @@
+"""The cached-object overlay has to reproduce the project's SHAPE, not just its
+contents.
+
+A model-scoped metric/dimension is scoped by being nested inside its model —
+that nesting is the only record of the scope, because ``_parent_name`` is a
+PrivateAttr and neither ``Metric`` nor ``Dimension`` has a ``model`` field to
+carry one (both are ``extra="forbid"``). VIS-1259 reached that conclusion for
+the deploy wire; these tests hold the same line for the local editor's overlay,
+which every ``visivo serve`` run, draft preview and commit gate is built on.
+"""
+
+import json
+import os
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from tests.factories.model_factories import (
+    DimensionFactory,
+    MetricFactory,
+    ProjectFactory,
+    SqlModelFactory,
+)
+from visivo.query.resolvers.field_resolver import FieldResolver
+from visivo.server.jobs.project_injection import (
+    inject_cached_objects,
+    renest_model_scoped_fields,
+)
+
+
+def _flask_app(project, **cached):
+    """A minimal stand-in: ``inject_cached_objects`` reads ``.cached_objects``
+    off each manager and skips any manager that is missing."""
+    managers = {
+        f"{kind}_manager": SimpleNamespace(cached_objects=objects)
+        for kind, objects in cached.items()
+    }
+    return SimpleNamespace(project=project, **managers)
+
+
+def _project(**kwargs):
+    kwargs.setdefault("models", [SqlModelFactory(name="orders")])
+    return ProjectFactory(insights=[], charts=[], dashboards=[], **kwargs)
+
+
+def _overlay(flask_app):
+    project = deepcopy(flask_app.project)
+    inject_cached_objects(flask_app, project)
+    project.invalidate_dag_cache()
+    return project
+
+
+@pytest.fixture
+def schema_dir(tmp_path):
+    """A schema file for ``orders``, so the raw-column ("implicit dimension")
+    branch of ``FieldResolver`` is reachable — that branch is where a flattened
+    field's reference wrongly ends up."""
+
+    def _write(model, columns):
+        os.makedirs(tmp_path / "schemas", exist_ok=True)
+        with open(tmp_path / "schemas" / f"{model.name}.json", "w") as fp:
+            json.dump({model.name_hash(): columns}, fp)
+        return str(tmp_path)
+
+    return _write
+
+
+class TestModelScopedFieldsSurviveTheOverlay:
+    def test_a_model_scoped_metric_comes_back_nested_under_its_model(self):
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(_flask_app(_project(), metric={"avg_amount": draft}))
+
+        (model,) = project.models
+        assert [m.name for m in model.metrics or []] == ["avg_amount"]
+        assert [m.name for m in project.metrics or []] == []
+
+    def test_a_model_scoped_dimension_comes_back_nested_under_its_model(self):
+        draft = DimensionFactory(name="loud_region", expression="upper(region)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(_flask_app(_project(), dimension={"loud_region": draft}))
+
+        (model,) = project.models
+        assert [d.name for d in model.dimensions or []] == ["loud_region"]
+        assert [d.name for d in project.dimensions or []] == []
+
+    def test_the_nested_field_keeps_its_parent_and_is_not_addressable_project_level(self):
+        """Identity, both halves: it still knows its owner, and it is no longer
+        reachable as a project-level field of the same name."""
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(_flask_app(_project(), metric={"avg_amount": draft}))
+
+        (nested,) = project.models[0].metrics
+        assert nested._parent_name == "orders"
+        assert nested.child_items() == ["ref(orders)"]
+        assert "avg_amount" not in {m.name for m in project.metrics or []}
+
+    def test_a_project_level_field_is_left_alone(self):
+        """The pass keys off ``_parent_name``, not off the type — a genuinely
+        project-level metric is its own object and stays where it is."""
+        draft = MetricFactory(name="global_total", expression="sum(${ref(orders).amount})")
+
+        project = _overlay(_flask_app(_project(), metric={"global_total": draft}))
+
+        assert [m.name for m in project.metrics or []] == ["global_total"]
+        assert project.models[0].metrics in (None, [])
+
+    def test_a_field_scoped_to_a_missing_model_stays_top_level(self):
+        """Dropping it would hide the mistake; leaving it lets the normal
+        validators name it."""
+        orphan = MetricFactory(name="orphan", expression="count(*)")
+        orphan.set_parent_name("deleted_model")
+
+        project = _overlay(_flask_app(_project(), metric={"orphan": orphan}))
+
+        assert [m.name for m in project.metrics or []] == ["orphan"]
+
+    def test_the_cached_field_replaces_the_published_one_of_the_same_name(self):
+        """Editing an already-nested field must overwrite it, not double it."""
+        published = MetricFactory(name="avg_amount", expression="avg(old)")
+        model = SqlModelFactory(name="orders", metrics=[published])
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(_flask_app(_project(models=[model]), metric={"avg_amount": draft}))
+
+        assert [(m.name, m.expression) for m in project.models[0].metrics] == [
+            ("avg_amount", "avg(amount)")
+        ]
+
+    def test_it_re_nests_onto_the_cached_model_not_the_published_one(self):
+        """Models are overlaid before the re-nesting pass runs, so a field lands
+        on the model the user is actually editing."""
+        model = SqlModelFactory(name="orders", sql="select * from published")
+        edited = SqlModelFactory(name="orders", sql="select * from edited")
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(
+            _flask_app(
+                _project(models=[model]),
+                model={"orders": edited},
+                metric={"avg_amount": draft},
+            )
+        )
+
+        (owner,) = project.models
+        assert owner.sql == "select * from edited"
+        assert [m.name for m in owner.metrics or []] == ["avg_amount"]
+
+
+class TestTheReferenceTheExplorerActuallyEmits:
+    """``${ref(model).field}`` is how a model-scoped field is addressed. Whether
+    it resolves is the whole point of keeping the nesting."""
+
+    def test_a_model_scoped_metric_resolves_through_its_qualified_reference(self, schema_dir):
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+        flask_app = _flask_app(_project(), metric={"avg_amount": draft})
+        output_dir = schema_dir(flask_app.project.models[0], {"amount": "DOUBLE"})
+
+        project = _overlay(flask_app)
+        resolver = FieldResolver(dag=project.dag(), output_dir=output_dir, native_dialect="duckdb")
+
+        assert "AVG(" in resolver.resolve("${ref(orders).avg_amount}", alias=False).upper()
+
+    def test_a_computed_field_is_not_silently_replaced_by_a_column_it_shadows(self, schema_dir):
+        """The quiet half of the bug. When the alias matches a real column, a
+        flattened field does not error — the raw column answers instead, so a
+        computed field reads as a plain dimension and the numbers are wrong with
+        nothing to see."""
+        draft = DimensionFactory(name="region", expression="upper(region)")
+        draft.set_parent_name("orders")
+        flask_app = _flask_app(_project(), dimension={"region": draft})
+        output_dir = schema_dir(flask_app.project.models[0], {"region": "VARCHAR"})
+
+        project = _overlay(flask_app)
+        resolver = FieldResolver(dag=project.dag(), output_dir=output_dir, native_dialect="duckdb")
+
+        resolved = resolver.resolve("${ref(orders).region}", alias=False)
+        assert "UPPER(" in resolved.upper()
+
+
+class TestTheShapeSurvivesTheRoundTripTheCommitGateMakes:
+    def test_nesting_survives_model_dump_where_the_private_attr_does_not(self):
+        """Why nesting is the fix and a ``_parent_name`` fallback is not: the
+        commit gate re-constructs the project from ``model_dump()``, and a
+        PrivateAttr does not survive that. Nested, the scope is in the data."""
+        from visivo.models.project import Project
+
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+
+        project = _overlay(_flask_app(_project(), metric={"avg_amount": draft}))
+        rebuilt = Project(**project.model_dump(exclude_none=True))
+
+        (nested,) = rebuilt.models[0].metrics
+        assert nested.name == "avg_amount"
+        assert nested._parent_name == "orders"
+        assert rebuilt.metrics in (None, [])
+
+    def test_a_flat_dump_of_the_same_field_carries_no_owner_at_all(self):
+        """The counterfactual, stated as data: flattened, the dump is
+        ``{name, expression}`` — there is no field on ``Metric`` that could
+        record the model, so the scope is simply gone."""
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+        project = _project()
+        project.metrics = [draft]
+
+        dumped = project.model_dump(exclude_none=True)["metrics"][0]
+
+        assert set(dumped) & {"model", "parentModel", "parent_name"} == set()
+
+
+class TestRenestIsSafeToRunOnItsOwn:
+    def test_it_is_idempotent(self):
+        draft = MetricFactory(name="avg_amount", expression="avg(amount)")
+        draft.set_parent_name("orders")
+        project = _overlay(_flask_app(_project(), metric={"avg_amount": draft}))
+
+        renest_model_scoped_fields(project)
+
+        assert [m.name for m in project.models[0].metrics] == ["avg_amount"]
+        assert project.metrics == []
+
+    def test_a_project_with_no_models_does_not_blow_up(self):
+        orphan = MetricFactory(name="orphan", expression="count(*)")
+        orphan.set_parent_name("gone")
+        project = _project()
+        project.models = []
+        project.metrics = [orphan]
+
+        renest_model_scoped_fields(project)
+
+        assert [m.name for m in project.metrics] == ["orphan"]

--- a/tests/server/views/test_commit_views.py
+++ b/tests/server/views/test_commit_views.py
@@ -503,9 +503,10 @@ class TestPendingProjectValidation:
         assert "must reference at least one model" in error
 
     def test_a_MODEL_SCOPED_draft_is_re_nested_and_allowed(self):
-        """`inject_cached_objects` appends every cached object to the matching
-        TOP-LEVEL list, so a model-scoped draft arrives looking standalone. Left
-        that way it trips the project-level rule and refuses a good commit."""
+        """A model-scoped draft must not be judged by the project-level rule.
+        The overlay itself puts it back under its model — see
+        `tests/server/jobs/test_project_injection.py` for the re-nesting rule;
+        this holds the gate's end of it."""
         from tests.factories.model_factories import MetricFactory
         from visivo.server.views.commit_views import _validate_pending_project
 
@@ -515,9 +516,12 @@ class TestPendingProjectValidation:
 
         assert _validate_pending_project(flask_app) is None
 
-    def test_re_nesting_moves_the_field_under_its_model(self):
+    def test_the_gate_validates_the_nested_shape_that_would_land_on_disk(self):
+        """`project_writer` nests by parent model when it writes, so what the
+        gate validates has to be nested too — otherwise it passes a project on a
+        shape the next parse never sees."""
         from tests.factories.model_factories import DimensionFactory, MetricFactory
-        from visivo.server.views.commit_views import _renest_model_scoped_fields
+        from visivo.server.jobs.project_injection import inject_cached_objects
 
         metric = MetricFactory(name="nested_metric", expression="count(*)")
         metric.set_parent_name("orders")
@@ -525,32 +529,19 @@ class TestPendingProjectValidation:
         dimension.set_parent_name("orders")
         standalone = MetricFactory(name="standalone", expression="sum(${ref(orders).amount})")
 
-        project = self._project(metrics=[standalone], dimensions=[])
-        project.metrics = [standalone, metric]
-        project.dimensions = [dimension]
-
-        _renest_model_scoped_fields(project)
+        project = self._project()
+        flask_app = self._flask_app(
+            project,
+            metric={"standalone": standalone, "nested_metric": metric},
+            dimension={"nested_dim": dimension},
+        )
+        inject_cached_objects(flask_app, project)
 
         (model,) = project.models
         assert [m.name for m in project.metrics] == ["standalone"]
         assert project.dimensions == []
         assert [m.name for m in model.metrics] == ["nested_metric"]
         assert [d.name for d in model.dimensions] == ["nested_dim"]
-
-    def test_a_field_scoped_to_a_model_that_does_not_exist_stays_top_level(self):
-        """Dropping it would hide the mistake; leaving it lets the normal
-        validators name it."""
-        from tests.factories.model_factories import MetricFactory
-        from visivo.server.views.commit_views import _renest_model_scoped_fields
-
-        orphan = MetricFactory(name="orphan", expression="count(*)")
-        orphan.set_parent_name("deleted_model")
-        project = self._project()
-        project.metrics = [orphan]
-
-        _renest_model_scoped_fields(project)
-
-        assert [m.name for m in project.metrics] == ["orphan"]
 
     def test_the_gate_fails_OPEN_on_an_unexpected_error(self):
         """It exists to catch a known-invalid project — it must never become a

--- a/visivo/query/insight/draft_overlay.py
+++ b/visivo/query/insight/draft_overlay.py
@@ -26,6 +26,7 @@ from visivo.models.insight import Insight
 from visivo.server.jobs.project_injection import (
     inject_cached_objects,
     merge_objects_into_list,
+    renest_model_scoped_fields,
 )
 
 # Mirrors the pre-#507 ``preview_job_executor.py``'s ``CONTEXT_OBJECT_TYPES``
@@ -125,6 +126,47 @@ def _inject_model_scoped_fields(project, field_name, configs):
         setattr(project, field_name, merge_objects_into_list(existing, project_level))
 
 
+def _carry_forward_nested_fields(existing, replacement, config):
+    """A draft model dict is a partial override of the model the user is
+    editing — its SQL and source — NOT a fresh declaration of everything that
+    model owns.
+
+    The Explorer sends a ``draft_models`` entry for EVERY open model on every
+    preview (``useDraftInsightPreview.js``: every ``modelStates`` entry with
+    ``sql`` + ``sourceName``, published models included), and that wire dict
+    carries only ``{name, sql, source}``. Merging it by name is a REPLACEMENT
+    (``merge_objects_into_list`` does ``by_name[name] = obj``), so without this
+    the freshly validated ``SqlModel`` — ``metrics=[]``, ``dimensions=[]`` —
+    evicts every model-scoped field the overlay had just put on that model:
+    the ones re-nested out of the manager cache moments earlier, and the ones
+    already committed to YAML. The field is then in NEITHER
+    ``model.metrics`` nor ``project.metrics``, which is worse than the
+    flattening this module set out to fix — ``${ref(model).field}`` falls
+    through to the raw column (B12's headline symptom, silently), and a bare
+    ``${ref(field)}`` stops resolving at all because the node is simply gone.
+
+    Only keys the draft dict actually carries override. An explicit
+    ``"metrics": []`` still means "this model declares none"; an absent key
+    means "unchanged", which is what the client is really saying.
+    """
+    if existing is None:
+        return
+    cfg = config if isinstance(config, dict) else {}
+    for field_attr in _MODEL_SCOPED_FIELDS:
+        if cfg.get(field_attr) is not None:
+            continue
+        inherited = list(getattr(existing, field_attr, None) or [])
+        if not inherited:
+            continue
+        for field in inherited:
+            # Post-construction assignment bypasses SqlModel's after-validator,
+            # so re-assert the scope the same way `_inject_model_scoped_fields`
+            # does. (The name is unchanged — this is a same-name replacement —
+            # but stating it keeps the contract in one shape.)
+            field.set_parent_name(replacement.name)
+        setattr(replacement, field_attr, inherited)
+
+
 def _inject_draft_objects(project, draft_objects):
     """``draft_objects``: ``{"models": [...], "metrics": [...], "dimensions": [...]}``
     of wire-shaped config dicts -> validated Pydantic instances, merged by
@@ -144,6 +186,7 @@ def _inject_draft_objects(project, draft_objects):
             validated = [adapter.validate_python(c) for c in configs]
         except ValidationError as e:
             raise DraftOverlayError(f"Invalid draft {field_name}: {e}") from e
+        obj_list = list(getattr(project, field_name, None) or [])
         # A DRAFT model exists solely to be compiled + executed for this
         # insight preview, so it MUST carry executable SQL. Before #533,
         # ``ModelField`` was a discriminated union whose discriminator returned
@@ -157,7 +200,11 @@ def _inject_draft_objects(project, draft_objects):
         # "model not run" marker (a 422) instead of the intended clean 400.
         # Re-assert the gate explicitly for the draft flow only.
         if field_name == "models":
-            for obj in validated:
+            # The models this draft is about to REPLACE by name — captured
+            # before the merge so `_carry_forward_nested_fields` can keep what
+            # each one owns (see its docstring).
+            shadowed = {getattr(m, "name", None): m for m in obj_list}
+            for config, obj in zip(configs, validated):
                 # Blank / whitespace-only sql is as unexecutable as sql=None —
                 # gate both here so they produce the same clean 400 rather than
                 # letting an empty string slip through to a confusing downstream
@@ -167,7 +214,7 @@ def _inject_draft_objects(project, draft_objects):
                         f"Invalid draft models: model '{obj.name}' defines no `sql` — "
                         "a draft model must carry an executable SQL query."
                     )
-        obj_list = list(getattr(project, field_name, None) or [])
+                _carry_forward_nested_fields(shadowed.get(obj.name), obj, config)
         new_objects = [(obj.name, obj) for obj in validated]
         setattr(project, field_name, merge_objects_into_list(obj_list, new_objects))
 
@@ -205,6 +252,16 @@ def build_draft_overlay(
             "dimensions": draft_dimensions,
         },
     )
+    # The rule has to hold on the FINAL overlay, not on an intermediate one.
+    # `inject_cached_objects` re-nests against the models it knows about, but
+    # `draft_models` can introduce the owner AFTER it runs — a scratch model
+    # that lives only in the Explorer's local `modelStates` while a field
+    # scoped to it was already saved into the manager cache. Re-nesting last
+    # lets that field find its model instead of staying a project-level orphan.
+    # Idempotent: a field already nested is no longer in `project.metrics`, and
+    # the project-level fallback in `_inject_model_scoped_fields` deliberately
+    # leaves `_parent_name` unset, so this pass never claws those back.
+    renest_model_scoped_fields(project)
 
     try:
         insight = Insight.model_validate(insight_config)

--- a/visivo/server/jobs/project_injection.py
+++ b/visivo/server/jobs/project_injection.py
@@ -3,7 +3,12 @@
 The editor saves resource edits into each manager's cached tier (not YAML) until
 commit. To rebuild what the user is actually looking at, a run must overlay those
 cached objects onto the published project before running. Shared by the on-save
-run executor (and previously the preview executor)."""
+run executor (and previously the preview executor).
+
+Reproducing the project means reproducing its SHAPE, not just its contents: a
+model-scoped metric/dimension has to come back nested under its model, because
+nesting is the only thing that records that scope (VIS-1259). See
+``renest_model_scoped_fields``."""
 
 from copy import deepcopy
 
@@ -32,10 +37,67 @@ def merge_objects_into_list(obj_list, new_objects):
     return list(by_name.values()) + unnamed
 
 
+def renest_model_scoped_fields(project):
+    """Put model-scoped metrics/dimensions back under the model they belong to.
+
+    Each manager caches its objects in one flat namespace, so the overlay above
+    can only append them to the matching TOP-LEVEL project list — a model-scoped
+    field lands in ``project.metrics`` rather than under its model. Nothing
+    downstream can recover the scope from there: ``_parent_name`` is a
+    PrivateAttr, so the field dumps as ``{name, expression}`` with no owner at
+    all, and neither ``Metric`` nor ``Dimension`` has a ``model`` field to put
+    one in (both are ``extra="forbid"``). Nesting is the fact — the same
+    conclusion VIS-1259 reached for the deploy wire.
+
+    Left flattened, the overlay is wrong in three ways:
+
+    * ``${ref(model).field}`` — the address the Explorer emits for a
+      model-scoped field — no longer finds it. ``FieldResolver._find_model_scoped_field``
+      searches the model's OWN ``metrics``/``dimensions``, so the reference
+      falls through to the raw-column path: "Column 'x' not found on model 'y'"
+      for a computed metric the user is looking at, or, when the field's alias
+      shadows a real column, the raw column *silently* — the computed
+      expression is dropped and a metric reads as a plain dimension.
+    * Project-level rules judge it as a project-level field, which is a
+      different rule: nesting ties a field to a source, so a nested
+      ``count(*)`` is legal where a project-level one is not.
+    * ``project_writer`` nests by parent model when it writes, so the validated
+      shape did not match the shape that would land on disk.
+
+    A field scoped to a model that is not in the project stays top-level:
+    dropping it would hide the mistake, leaving it lets the normal validators
+    name it.
+    """
+    for field_attr in ("metrics", "dimensions"):
+        remaining = []
+        for field in getattr(project, field_attr, None) or []:
+            parent_name = getattr(field, "_parent_name", None)
+            if not parent_name:
+                remaining.append(field)
+                continue
+            owner = next(
+                (m for m in project.models or [] if getattr(m, "name", None) == parent_name), None
+            )
+            if owner is None:
+                remaining.append(field)
+                continue
+            owned = list(getattr(owner, field_attr, None) or [])
+            owned = [o for o in owned if getattr(o, "name", None) != field.name] + [field]
+            setattr(owner, field_attr, owned)
+        setattr(project, field_attr, remaining)
+
+
 def inject_cached_objects(flask_app, project):
     """Overlay every manager's cached objects onto ``project`` so refs to
     objects that exist only in the cached tier (created/modified in the editor,
-    not yet written to YAML) resolve during the run."""
+    not yet written to YAML) resolve during the run.
+
+    ``project`` is mutated in place, so every caller hands in a copy.
+
+    The re-nesting pass runs last, once the cached models are themselves in
+    place, so a model-scoped field is re-nested onto the model the user is
+    actually editing rather than its published version.
+    """
     for manager_attr, project_field in MANAGER_TO_PROJECT_FIELD:
         manager = getattr(flask_app, manager_attr, None)
         if not manager:
@@ -46,3 +108,4 @@ def inject_cached_objects(flask_app, project):
         obj_list = list(getattr(project, project_field, None) or [])
         new_objects = [(name, deepcopy(obj)) for name, obj in cached.items() if obj is not None]
         setattr(project, project_field, merge_objects_into_list(obj_list, new_objects))
+    renest_model_scoped_fields(project)

--- a/visivo/server/views/commit_views.py
+++ b/visivo/server/views/commit_views.py
@@ -627,41 +627,6 @@ def register_commit_views(app, flask_app, output_dir):
             return jsonify({"error": str(e)}), 500
 
 
-def _renest_model_scoped_fields(project):
-    """Put draft metrics/dimensions back under the model they belong to.
-
-    ``inject_cached_objects`` overlays every manager's cached objects onto the
-    project by appending to the matching TOP-LEVEL list — so a draft field that
-    is model-scoped lands in ``project.metrics`` rather than under its model.
-    For a run that is harmless; for validation it is not, because "is this
-    field nested?" is exactly the question the project-level rules ask. Without
-    this, a perfectly good nested draft is reported as a project-level field
-    that references nothing, and the commit is refused.
-
-    ``project_writer`` nests by ``parent_model`` when it writes, so this makes
-    the validated shape match the shape that would land on disk.
-    """
-    for field_attr, model_attr in (("metrics", "metrics"), ("dimensions", "dimensions")):
-        remaining = []
-        for field in getattr(project, field_attr, None) or []:
-            parent_name = getattr(field, "_parent_name", None)
-            if not parent_name:
-                remaining.append(field)
-                continue
-            owner = next(
-                (m for m in project.models if getattr(m, "name", None) == parent_name), None
-            )
-            if owner is None:
-                # Orphaned scope — leave it top-level so the normal validators
-                # report it rather than silently dropping the field.
-                remaining.append(field)
-                continue
-            owned = list(getattr(owner, model_attr, None) or [])
-            owned = [o for o in owned if getattr(o, "name", None) != field.name] + [field]
-            setattr(owner, model_attr, owned)
-        setattr(project, field_attr, remaining)
-
-
 def _validate_pending_project(flask_app):
     """The validation error a commit would produce, or None.
 
@@ -671,6 +636,12 @@ def _validate_pending_project(flask_app):
     validator chain. Re-constructing is the point: ``inject_cached_objects``
     mutates via ``setattr``, which does not re-validate, so only a fresh
     ``Project(**dump)`` exercises the project-level rules.
+
+    The overlay puts model-scoped fields back under their model itself
+    (``renest_model_scoped_fields``), so what is validated here has the shape
+    ``project_writer`` would land on disk. That matters both ways: a nested
+    ``count(*)`` must not be judged by the project-level rule, and a
+    project-level field must not escape it.
 
     Fails OPEN on an unexpected error: this gate exists to catch a *known*
     invalid project, and must not become a new way for a commit to fail.
@@ -683,7 +654,6 @@ def _validate_pending_project(flask_app):
     try:
         pending = deepcopy(flask_app.project)
         inject_cached_objects(flask_app, pending)
-        _renest_model_scoped_fields(pending)
         Project(**pending.model_dump(exclude_none=True))
     except ValueError as error:
         message = str(error)


### PR DESCRIPTION
> **Update (`fdfa011f`) — review fix.** The re-nesting was being undone one line later: `_inject_draft_objects` replaces a model by name, and the wire dict the Explorer sends for *every* open model carries no `metrics`/`dimensions`, so the just-nested field was deleted outright — B12's headline symptom unchanged on the real request, and a bare `${ref(field)}` regressed to a 400. Fixed by making a draft model a partial override (`_carry_forward_nested_fields`) and re-nesting once more after the wire drafts land. The two draft-overlay tests are now parameterised over the client's actual wire shape. Full write-up in the PR comment; gates now `2492 passed`, black clean, `draft_overlay.py` 98% / `project_injection.py` 100%.

## The problem

VIS-1259 settled this for the deploy wire in #639: a metric or dimension authored inside a model is **not its own record**, and nesting is the only thing that says so — neither `Metric` nor `Dimension` has a `model` field to carry an owner, and both are `extra="forbid"`. The **local editor's overlay still flattened it**, which is finding B12 (VIS-1304).

Each manager caches its objects in one flat namespace, so `inject_cached_objects` can only append a cached field to the matching TOP-LEVEL project list. `_parent_name` rides along on the instance, which makes it look survivable, but nothing downstream can act on it: `FieldResolver._find_model_scoped_field` searches the model's **own** `metrics`/`dimensions`, so `${ref(model).field}` — the address the Explorer emits for every computed column — stops finding it.

Two ways that lands, both reproduced against `main` @ 7d31ea69:

```
FLATTENED  ${ref(orders).avg_amount} -> Exception: Column 'avg_amount' not found on model 'orders'
FLATTENED  ${ref(orders).region}     -> "mvhrzfrsckpdxwftwvpdmhaoqjbea"."region"
NESTED     ${ref(orders).region}     -> UPPER("mvhrzfrsckpdxwftwvpdmhaoqjbea"."region")
```

The second is the quiet one and it is B12's headline symptom. When a computed field's alias matches a real column, the reference does not error — the raw column answers instead, the computed expression is dropped, and **a metric reads as a plain dimension** with numbers that are merely wrong.

## Why nesting, and not the fallback the initiative first sketched

VIS-1304 asked for a decision between two strategies. It is decided by Tim's own merges plus one fact that settles it outright.

The alternative was a `_parent_name` fallback inside `_find_model_scoped_field` — teach the reader to accept a project-level-listed field whose `_parent_name` matches the model. It does not survive contact with the commit gate, which re-constructs the project from `model_dump()`:

```
A. dumped project-level metric dict: [{'name': 'avg_amount', 'expression': 'avg(amount)', ...}]
A. Project(**dump) -> ValidationError: Project-level metric 'avg_amount' must reference
                      at least one model ... (StandaloneFieldRefsValidator, #640)

B. dumped model.metrics: ['avg_amount']
B. round-trip nested _parent_name = orders
B. project-level metrics = []
```

`_parent_name` is a PrivateAttr. Flattened, the field dumps with **no owner at all** — the same loss #639 found on the wire — so a fallback keyed on it evaporates at exactly the moment the gate needs it, and #640's `StandaloneFieldRefsValidator` then rejects the field outright. Nesting is in the data and survives. A fallback would also have to be repeated in every reader (resolver, validators, writer, ERD, lineage), which is the two-shapes-for-one-meaning problem #639 rejected.

So: consistent with Tim's model, `_parent_name`-keyed, nesting is the fact.

## The fix

Three call sites share the overlay — the on-save run executor, the Explorer's draft-preview builder (`build_draft_overlay`), and #640's commit gate — so this is fixed **once, in the overlay**, rather than three times in its readers.

- #640's `_renest_model_scoped_fields` moves out of `commit_views.py` into `project_injection.py` as `renest_model_scoped_fields` and runs at the end of `inject_cached_objects`, **after** the cached models are in place, so a field re-nests onto the model the user is actually editing rather than its published version.
- The gate's separate call becomes redundant and goes; the rule now has one home.
- The filter keys off `_parent_name`, not off the type — a genuinely project-level metric stays its own object.
- A field scoped to a model that is not in the project stays top-level, so the normal validators name the mistake instead of it being silently dropped (Tim's behaviour, preserved and re-tested).

Nothing in `visivo/models/` changed, so no schema regeneration — no overlap with #642.

## Falsification

Impl removed (`renest_model_scoped_fields(project)` call deleted), tests kept — **12 fail**:

```
tests/server/jobs/test_project_injection.py
  …metric_comes_back_nested_under_its_model              AssertionError: assert [] == ['avg_amount']
  …dimension_comes_back_nested_under_its_model           AssertionError: assert [] == ['loud_region']
  …keeps_its_parent_and_is_not_addressable_project_level ValueError: not enough values to unpack
  …cached_field_replaces_the_published_one_of_the_same_name
                                                         assert [('avg_amount','avg(old)')] == …
  …re_nests_onto_the_cached_model_not_the_published_one  AssertionError: assert [] == ['avg_amount']
  …resolves_through_its_qualified_reference              Exception: Column 'avg_amount' not found
                                                                    on model 'orders'.
  …not_silently_replaced_by_a_column_it_shadows          assert 'UPPER(' in '"MVHRZ…"."REGION"'
  …nesting_survives_model_dump_where_the_private_attr_does_not
                                                         ValidationError: 1 validation error for Project
tests/query/insight/test_draft_overlay.py
  …cached_model_scoped_metric_lands_on_its_model         AssertionError: assert [] == ['avg_total']
  …cached_model_scoped_metric_compiles_as_an_aggregate   Exception: Column 'avg_total' not found
                                                                    on model 'orders_q'.
tests/server/views/test_commit_views.py
  …MODEL_SCOPED_draft_is_re_nested_and_allowed           (Tim's own test regresses)
  …gate_validates_the_nested_shape_that_would_land_on_disk
```

The three that correctly stay green with the impl removed are the negative-space guards: a project-level field is left alone, an orphaned scope stays top-level, a project with no models does not blow up.

## Tests

- `poetry run pytest tests/` → **2479 passed**, 2 skipped, 5 xfailed, 1 xpassed
- `black --check --target-version py312 .` → clean, 544 files
- Coverage on touched files: `visivo/server/jobs/project_injection.py` **100%**; `visivo/server/views/commit_views.py` 97% (the 8 uncovered lines are pre-existing and untouched here)

New: `tests/server/jobs/test_project_injection.py` (13 tests, factory-boy throughout) plus two on the Explorer's draft-preview path in `tests/query/insight/test_draft_overlay.py` covering the *cached* (saved-but-uncommitted) field, which that file previously only covered for *wire* drafts.

## Scope note

VIS-1304 lists three silent-degradation routes. This PR closes the flattening one. The other two — the client-schema fall-through that returns 200 for an unrunnable query, and the silent project-level demotion of a `draft_dimensions` entry naming an unknown model — are untouched and should build on the merged `Diagnostic` contract from #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U

