### PR TITLE
Ask the same-source question that was already written (M19 / T1+T2)

### DIFF
--- a/tests/jobs/test_run_insight_job_cross_source.py
+++ b/tests/jobs/test_run_insight_job_cross_source.py
@@ -1,21 +1,31 @@
 """The runtime half: what happens to a cross-source insight that got past compile.
 
-``CrossSourceValidator`` refuses to let such a project exist, so everything here
-reaches the invalid state the way the code paths that skip project validation do
-— an in-memory overlay, a project assembled in code, a mutation after
-construction. The point of the guard is that those paths fail with the SAME
-sentence rather than executing a query whose CTEs name tables the chosen source
-has never heard of.
+Two lanes, two opposite answers, and both of them are the point:
+
+* **Static** — ``CrossSourceValidator`` refuses to let such a project exist, so
+  the tests below reach the invalid state the way the code paths that skip
+  project validation do (an in-memory overlay, a project assembled in code, a
+  mutation after construction). Those paths must fail with the SAME sentence
+  rather than executing a query whose CTEs name tables the chosen source has
+  never heard of.
+* **Dynamic** — ``TestTheDynamicLane`` runs the real jobs against two real
+  DuckDB files and asserts the insight SUCCEEDS, because there the join is
+  DuckDB's over each model's own parquet. Nothing about this test is a mock:
+  if the guard ever fires on the dynamic lane again, the assertion that the
+  post_query joins both model hashes and returns the joined row fails.
 """
 
 import json
 
+import duckdb
 import pytest
 
 from tests.factories.model_factories import (
     DuckdbSourceFactory,
+    InputFactory,
     InsightFactory,
     ProjectFactory,
+    RelationFactory,
     SqlModelFactory,
 )
 from visivo.jobs.run_insight_job import action
@@ -157,3 +167,136 @@ class TestRunInsightJob:
 
         assert result.success is False
         assert result.error_details["error_type"] == "missing_relation"
+
+
+class TestTheDynamicLane:
+    """Two real DuckDB files, two real models, the real jobs — and it works.
+
+    This is the shape ``mkdocs/topics/sources.md`` sells: "you can bring data
+    together in a single chart with insights whose models originate from
+    different sources". It works because a dynamic insight has NO ``pre_query``:
+    ``run_sql_model_job`` materialises each model against ITS OWN source into
+    ``models/<name>.parquet``, and the DuckDB-dialect ``post_query`` joins those
+    parquet files. Guarding it would turn a working project into one that does
+    not load at all.
+    """
+
+    @staticmethod
+    def _two_databases(tmp_path):
+        a_db = str(tmp_path / "a.duckdb")
+        b_db = str(tmp_path / "b.duckdb")
+        connection = duckdb.connect(a_db)
+        connection.execute(
+            "CREATE TABLE orders AS SELECT * FROM "
+            "(VALUES (1, 10, 'east'), (2, 20, 'west')) t(id, amount, region)"
+        )
+        connection.close()
+        connection = duckdb.connect(b_db)
+        connection.execute(
+            "CREATE TABLE users AS SELECT * FROM (VALUES (1, 30), (2, 40)) t(id, age)"
+        )
+        connection.close()
+        return a_db, b_db
+
+    @staticmethod
+    def _project(a_db, b_db):
+        insight = InsightFactory(
+            name="cross_dynamic",
+            props=InsightProps(
+                type="scatter",
+                x="?{ ${ ref(orders).amount } }",
+                y="?{ ${ ref(users).age } }",
+            ),
+            interactions=[{"filter": "?{ ${ref(orders).region} = ${ref(region_pick).value} }"}],
+        )
+        project = ProjectFactory(
+            sources=[
+                DuckdbSourceFactory(name="source_a", database=a_db),
+                DuckdbSourceFactory(name="source_b", database=b_db),
+            ],
+            models=[
+                SqlModelFactory(name="orders", sql="SELECT * FROM orders", source="ref(source_a)"),
+                SqlModelFactory(name="users", sql="SELECT * FROM users", source="ref(source_b)"),
+            ],
+            relations=[
+                RelationFactory(
+                    name="orders_to_users", condition="${ref(orders).id} = ${ref(users).id}"
+                )
+            ],
+            inputs=[InputFactory(name="region_pick", label="Region", options=["east", "west"])],
+            insights=[insight],
+            dashboards=[],
+        )
+        return project, insight
+
+    def test_the_project_loads_and_the_insight_job_succeeds_across_two_sources(self, tmp_path):
+        from visivo.jobs.run_input_job import action as run_input
+        from visivo.jobs.run_source_schema_job import action as run_source_schema
+        from visivo.jobs.run_sql_model_job import model_query_and_schema_action
+
+        a_db, b_db = self._two_databases(tmp_path)
+        # Constructed through the ordinary constructor: CrossSourceValidator runs
+        # here, and this project must survive it.
+        project, insight = self._project(a_db, b_db)
+        dag = project.dag()
+        assert insight.is_dynamic(dag) is True
+
+        output_dir = str(tmp_path / "target")
+        # The real pipeline, in the real order: introspect each source, then
+        # materialise each model AGAINST ITS OWN SOURCE, then the inputs.
+        for source in project.sources:
+            assert run_source_schema(source, output_dir=output_dir, run_id="main").success
+        for model in project.models:
+            assert model_query_and_schema_action(model, dag, output_dir, run_id="main").success
+        for input_obj in project.inputs:
+            assert run_input(input_obj, dag, output_dir, run_id="main").success
+
+        result = action(insight, dag, output_dir, run_id="main")
+        assert result.success is True, result.message
+
+        with open(f"{output_dir}/main/insights/cross_dynamic.json") as file:
+            insight_data = json.load(file)
+
+        # Both models' OWN parquet, each written against its own database.
+        hashes = {model.name: model.name_hash() for model in project.models}
+        assert {file_entry["name_hash"] for file_entry in insight_data["files"]} == set(
+            hashes.values()
+        )
+        # No pre_query result was written; the join is in the post_query.
+        query = insight_data["query"]
+        assert hashes["orders"] in query and hashes["users"] in query
+        assert "JOIN" in query.upper()
+
+        # And it is not just well-formed text: register both parquet files and
+        # run it. Filtering region='east' leaves order 1 (amount 10) joined to
+        # user 1 (age 30).
+        connection = duckdb.connect()
+        for file_entry in insight_data["files"]:
+            connection.execute(
+                f'CREATE VIEW "{file_entry["name_hash"]}" AS '
+                f"SELECT * FROM read_parquet('{file_entry['signed_data_file_url']}')"
+            )
+        rows = connection.execute(query.replace("${region_pick.value}", "east")).fetchall()
+        connection.close()
+        assert rows == [(10, 30)]
+
+    def test_the_builder_also_lets_a_forced_dynamic_draft_across_sources_through(self, tmp_path):
+        """``force_dynamic=True`` is how /api/insight-compile-draft/ builds every
+        draft — the DuckDB-over-parquet form. A draft that introduces a second
+        source must not 400 there either."""
+        a_db, b_db = self._two_databases(tmp_path)
+        project, insight = self._project(a_db, b_db)
+        dag = project.dag()
+        output_dir = str(tmp_path / "target")
+
+        from visivo.jobs.run_source_schema_job import action as run_source_schema
+        from visivo.jobs.run_sql_model_job import model_query_and_schema_action
+
+        for source in project.sources:
+            assert run_source_schema(source, output_dir=output_dir, run_id="main").success
+        for model in project.models:
+            assert model_query_and_schema_action(model, dag, output_dir, run_id="main").success
+
+        builder = InsightQueryBuilder(insight, dag, f"{output_dir}/main", force_dynamic=True)
+        assert builder.is_dynamic is True
+        assert {model.name for model in builder.models} == {"orders", "users"}

--- a/tests/jobs/test_run_insight_job_cross_source.py
+++ b/tests/jobs/test_run_insight_job_cross_source.py
@@ -1,0 +1,159 @@
+"""The runtime half: what happens to a cross-source insight that got past compile.
+
+``CrossSourceValidator`` refuses to let such a project exist, so everything here
+reaches the invalid state the way the code paths that skip project validation do
+— an in-memory overlay, a project assembled in code, a mutation after
+construction. The point of the guard is that those paths fail with the SAME
+sentence rather than executing a query whose CTEs name tables the chosen source
+has never heard of.
+"""
+
+import json
+
+import pytest
+
+from tests.factories.model_factories import (
+    DuckdbSourceFactory,
+    InsightFactory,
+    ProjectFactory,
+    SqlModelFactory,
+)
+from visivo.jobs.run_insight_job import action
+from visivo.models.props.insight_props import InsightProps
+from visivo.query.insight.insight_query_builder import InsightQueryBuilder
+from visivo.query.source_scope import CrossSourceError
+
+
+def _write_schema(schema_base, model, columns):
+    """Mirror the on-disk schema layout the FieldResolver reads from."""
+    schema_base.join(f"{model.name}.json").write(json.dumps({model.name_hash(): columns}))
+
+
+def _project(cross_source: bool):
+    """orders + users + an insight over both. ``cross_source`` moves users onto
+    a second source AFTER validation, which is the only way to get one now."""
+    insight = InsightFactory(
+        name="cross",
+        props=InsightProps(
+            type="scatter",
+            x="?{ ${ ref(orders).amount } }",
+            y="?{ ${ ref(users).age } }",
+        ),
+    )
+    project = ProjectFactory(
+        sources=[
+            DuckdbSourceFactory(name="source_a", database="a.duckdb"),
+            DuckdbSourceFactory(name="source_b", database="b.duckdb"),
+        ],
+        models=[
+            SqlModelFactory(name="orders", sql="SELECT * FROM orders", source="ref(source_a)"),
+            SqlModelFactory(name="users", sql="SELECT * FROM users", source="ref(source_a)"),
+        ],
+        insights=[insight],
+        dashboards=[],
+    )
+    if cross_source:
+        for model in project.models:
+            if model.name == "users":
+                model.source = "ref(source_b)"
+        project.invalidate_dag_cache()
+    return project, insight
+
+
+def _seed_schemas(tmpdir, project, run_id="main"):
+    run_dir = tmpdir.mkdir(run_id)
+    schema_base = run_dir.mkdir("schemas")
+    for model in project.models:
+        _write_schema(schema_base, model, {"amount": "INTEGER", "age": "INTEGER"})
+
+
+class TestInsightQueryBuilder:
+    def test_it_refuses_to_build_across_sources(self, tmpdir):
+        project, insight = _project(cross_source=True)
+        _seed_schemas(tmpdir, project)
+
+        with pytest.raises(CrossSourceError) as excinfo:
+            InsightQueryBuilder(insight, project.dag(), f"{tmpdir}/main")
+
+        assert str(excinfo.value) == (
+            "Insight 'cross' references models from more than one source: "
+            "source_a, source_b.\n"
+            "\n"
+            "  Model 'orders' uses source: source_a\n"
+            "  Model 'users' uses source: source_b\n"
+            "\n"
+            "Cross-source insights are not currently supported. "
+            "Every model an insight references must use the same source."
+        )
+
+    def test_a_single_source_insight_still_builds(self, tmpdir):
+        project, insight = _project(cross_source=False)
+        _seed_schemas(tmpdir, project)
+
+        builder = InsightQueryBuilder(insight, project.dag(), f"{tmpdir}/main")
+        assert {model.name for model in builder.models} == {"orders", "users"}
+        assert builder.source_dialect == "duckdb"
+
+    def test_a_file_source_without_db_schema_does_not_raise_attribute_error(self, tmpdir):
+        """A CSVFileSource is a DuckDB source over a file and carries neither
+        ``db_schema`` nor ``database``; the plain attribute reads used to blow
+        up on the way to a query that never needed either value."""
+        from visivo.models.sources.csv_source import CSVFileSource
+
+        insight = InsightFactory(
+            name="from_csv",
+            props=InsightProps(
+                type="scatter",
+                x="?{ ${ ref(products).amount } }",
+                y="?{ ${ ref(products).age } }",
+            ),
+        )
+        project = ProjectFactory(
+            sources=[CSVFileSource(name="products_csv", type="csv", file="products.csv")],
+            models=[
+                SqlModelFactory(
+                    name="products", sql="SELECT * FROM products", source="ref(products_csv)"
+                )
+            ],
+            insights=[insight],
+            dashboards=[],
+        )
+        _seed_schemas(tmpdir, project)
+
+        builder = InsightQueryBuilder(insight, project.dag(), f"{tmpdir}/main")
+        assert builder.default_schema is None
+        assert builder.default_database is None
+
+
+class TestRunInsightJob:
+    def test_the_job_fails_with_the_message_and_typed_details(self, tmpdir):
+        project, insight = _project(cross_source=True)
+        _seed_schemas(tmpdir, project)
+
+        result = action(insight, project.dag(), str(tmpdir), run_id="main")
+
+        assert result.success is False
+        # e.message, not repr(e) — the run output shows the sentence, not a
+        # quoted exception with escaped newlines.
+        assert "references models from more than one source: source_a, source_b" in result.message
+        assert "ValueError(" not in result.message
+
+        assert result.error_details["error_type"] == "multi_source"
+        assert result.error_details["error_models"] == ["orders", "users"]
+        assert result.error_details["error_sources"] == ["source_a", "source_b"]
+        diagnostic = result.error_details["diagnostic"]
+        assert diagnostic["code"] == "cross_source"
+        assert diagnostic["phase"] == "run"
+        assert diagnostic["object"] == {"type": "insight", "name": "cross"}
+
+    def test_a_single_source_insight_keeps_its_ordinary_failure_shape(self, tmpdir):
+        """The guard must not swallow every other failure into a cross-source
+        one: this insight has no relation between its two models, so it still
+        fails as ``missing_relation`` with no cross-source details."""
+        project, insight = _project(cross_source=False)
+        _seed_schemas(tmpdir, project)
+
+        result = action(insight, project.dag(), str(tmpdir), run_id="main")
+
+        assert result.success is False
+        assert result.error_details["error_type"] == "missing_relation"

--- a/tests/models/test_diagnostic.py
+++ b/tests/models/test_diagnostic.py
@@ -129,3 +129,30 @@ def test_from_exception_never_raises_on_an_unregistered_code():
     assert diagnostic.code == "unexpected_error"
     assert diagnostic.message == "the real failure"
     assert "typo_code" in diagnostic.detail
+
+
+def test_the_viewer_mirror_lists_exactly_the_same_codes():
+    """This module's docstring calls ``viewer/src/types/diagnostic.js`` the
+    mirror and says "keep the two in sync — the shape is the contract", and the
+    JS file repeats the claim. Nothing enforced it, so a code added on one side
+    only silently broke the contract: a viewer that later branches on membership
+    would drop every diagnostic carrying the missing code, with no failing test
+    anywhere to say why. Enforce the parity that both files already promise.
+    """
+    import re
+    from pathlib import Path
+
+    mirror = Path(__file__).resolve().parents[2] / "viewer" / "src" / "types" / "diagnostic.js"
+    assert mirror.exists(), f"the declared mirror is missing: {mirror}"
+
+    source = mirror.read_text()
+    match = re.search(r"export const DIAGNOSTIC_CODES = \[(.*?)\];", source, re.DOTALL)
+    assert match, "DIAGNOSTIC_CODES array not found in the viewer mirror"
+    js_codes = set(re.findall(r"'([^']+)'", match.group(1)))
+
+    assert js_codes, "the viewer mirror parsed to an empty set — the parse, not the file, is wrong"
+    assert js_codes == set(DIAGNOSTIC_CODES), (
+        "DIAGNOSTIC_CODES has drifted. "
+        f"Python only: {sorted(set(DIAGNOSTIC_CODES) - js_codes)}; "
+        f"viewer only: {sorted(js_codes - set(DIAGNOSTIC_CODES))}"
+    )

--- a/tests/models/test_relation_validation.py
+++ b/tests/models/test_relation_validation.py
@@ -319,6 +319,29 @@ class TestRelationGetReferencedModels:
         assert models == {"my-orders", "my-users"}
 
 
+def _cross_source_project(sources, models, relations, cross):
+    """Build a project whose models span sources.
+
+    ``CrossSourceValidator`` now runs inside ``Project``'s ``mode="after"``
+    validator, so such a project can no longer be constructed — which is the
+    fix. To keep exercising ``validate_same_source`` directly, build the legal
+    version and move one model afterwards (nothing re-validates on assignment)
+    and drop the cached DAG. ``cross`` maps ``{model_name: source_ref}``.
+    """
+    project = Project(
+        name="test_project",
+        sources=sources,
+        models=models,
+        relations=relations,
+        dashboards=[],
+    )
+    for model in project.models:
+        if model.name in cross:
+            model.source = cross[model.name]
+    project.invalidate_dag_cache()
+    return project
+
+
 class TestRelationCrossSourceValidation:
     """Test cross-source relation validation."""
 
@@ -355,19 +378,18 @@ class TestRelationCrossSourceValidation:
         source_b = DuckdbSource(name="source_b", database="db_b.duckdb", type="duckdb")
 
         model_a = SqlModel(name="orders", sql="SELECT * FROM orders", source="ref(source_a)")
-        model_b = SqlModel(name="users", sql="SELECT * FROM users", source="ref(source_b)")
+        model_b = SqlModel(name="users", sql="SELECT * FROM users", source="ref(source_a)")
 
         relation = Relation(
             name="cross_source",
             condition="${ref(orders).user_id} = ${ref(users).id}",
         )
 
-        project = Project(
-            name="test_project",
+        project = _cross_source_project(
             sources=[source_a, source_b],
             models=[model_a, model_b],
             relations=[relation],
-            dashboards=[],
+            cross={"users": "ref(source_b)"},
         )
         dag = project.dag()
 
@@ -397,7 +419,7 @@ class TestRelationCrossSourceValidation:
             name="sales_orders", sql="SELECT * FROM orders", source="ref(production_warehouse)"
         )
         model_metrics = SqlModel(
-            name="user_metrics", sql="SELECT * FROM metrics", source="ref(analytics_db)"
+            name="user_metrics", sql="SELECT * FROM metrics", source="ref(production_warehouse)"
         )
 
         relation = Relation(
@@ -405,12 +427,11 @@ class TestRelationCrossSourceValidation:
             condition="${ref(sales_orders).user_id} = ${ref(user_metrics).user_id}",
         )
 
-        project = Project(
-            name="test_project",
+        project = _cross_source_project(
             sources=[source_warehouse, source_analytics],
             models=[model_orders, model_metrics],
             relations=[relation],
-            dashboards=[],
+            cross={"user_metrics": "ref(analytics_db)"},
         )
         dag = project.dag()
 

--- a/tests/models/validators/test_cross_source_validator.py
+++ b/tests/models/validators/test_cross_source_validator.py
@@ -1,9 +1,17 @@
-"""The cross-source rule is actually asked, at compile, before anything runs.
+"""The cross-source rule is actually asked, at compile, before anything runs —
+and asked ONLY of the lane it is true for.
 
 Everything below builds a real project through the ordinary constructor —
 ``Project``'s ``mode="after"`` validator runs ``ProjectValidator``, so a project
-that spans sources cannot be brought into existence at all. Before this the same
-project parsed clean and died much later inside a driver.
+whose STATIC insight spans sources cannot be brought into existence at all.
+Before this the same project parsed clean and died much later inside a driver.
+
+The other half of the contract matters just as much: a DYNAMIC insight (one with
+an ``Input`` descendant) has no ``pre_query``. Its models are materialised
+against their own sources and its DuckDB ``post_query`` joins the parquet files
+client-side, which is the multi-source chart ``mkdocs/topics/sources.md``
+advertises. Those projects must still construct, and so must a relation that no
+static insight ever compiles.
 """
 
 import pytest
@@ -12,6 +20,7 @@ from pydantic import ValidationError
 from tests.factories.model_factories import (
     DimensionFactory,
     DuckdbSourceFactory,
+    InputFactory,
     InsightFactory,
     MetricFactory,
     ProjectFactory,
@@ -51,6 +60,32 @@ def _joining_insight(name="revenue_by_user"):
     )
 
 
+def _dynamic_joining_insight(name="revenue_by_user"):
+    """The same join, but reading an Input — so ``is_dynamic`` is True, there is
+    no ``pre_query``, and the join happens in DuckDB over the two models' own
+    parquet files instead of inside one database."""
+    return InsightFactory(
+        name=name,
+        props=InsightProps(
+            type="scatter",
+            x="?{ ${ ref(orders).amount } }",
+            y="?{ ${ ref(users).age } }",
+        ),
+        interactions=[{"filter": "?{ ${ref(orders).region} = ${ref(region_pick).value} }"}],
+    )
+
+
+def _region_input():
+    return InputFactory(name="region_pick", label="Region", options=["east", "west"])
+
+
+def _orders_to_users():
+    return RelationFactory(
+        name="orders_to_users",
+        condition="${ref(orders).user_id} = ${ref(users).id}",
+    )
+
+
 class TestItIsRegistered:
     def test_it_runs_last(self):
         """After the reference and single-source validators: a broken ref or a
@@ -62,15 +97,14 @@ class TestItIsRegistered:
 
 
 class TestRelations:
-    def test_a_cross_source_relation_fails_the_project(self):
+    def test_a_cross_source_relation_a_static_insight_compiles_fails_the_project(self):
+        """The relation is reported, not the insight: a static insight over both
+        models compiles this JOIN into one statement, and the join the author
+        wrote is the more local thing to name."""
         with pytest.raises(ValidationError) as excinfo:
             _project(
-                relations=[
-                    RelationFactory(
-                        name="orders_to_users",
-                        condition="${ref(orders).user_id} = ${ref(users).id}",
-                    )
-                ],
+                relations=[_orders_to_users()],
+                insights=[_joining_insight()],
                 dashboards=[],
             )
 
@@ -85,11 +119,54 @@ class TestRelations:
     def test_a_same_source_relation_is_untouched(self):
         project = _project(
             users_source="ref(source_a)",
-            relations=[
-                RelationFactory(
-                    name="orders_to_users",
-                    condition="${ref(orders).user_id} = ${ref(users).id}",
-                )
+            relations=[_orders_to_users()],
+            insights=[_joining_insight()],
+            dashboards=[],
+        )
+        assert [relation.name for relation in project.relations] == ["orders_to_users"]
+
+    def test_a_relation_no_static_insight_compiles_is_left_alone(self):
+        """A relation is a join CONDITION, not an executable thing. Nothing
+        compiles this one — which is the state every relation is in while it is
+        being authored — so there is no wrong query to refuse yet."""
+        project = _project(relations=[_orders_to_users()], dashboards=[])
+        assert [relation.name for relation in project.relations] == ["orders_to_users"]
+
+    def test_a_relation_only_a_dynamic_insight_uses_is_left_alone(self):
+        """The dynamic lane joins the two models' parquet files in DuckDB, so
+        this relation IS compiled — into a query where two sources is correct.
+        Refusing it here would break a chart that runs today."""
+        project = _project(
+            relations=[_orders_to_users()],
+            inputs=[_region_input()],
+            insights=[_dynamic_joining_insight()],
+            dashboards=[],
+        )
+        assert [relation.name for relation in project.relations] == ["orders_to_users"]
+
+    def test_a_relation_whose_models_never_share_a_static_insight_is_left_alone(self):
+        """orders and users each appear in a static insight, but never in the
+        SAME one, so neither statement ever contains this JOIN. A union of the
+        two model sets would wrongly fire here."""
+        project = _project(
+            relations=[_orders_to_users()],
+            insights=[
+                InsightFactory(
+                    name="orders_only",
+                    props=InsightProps(
+                        type="scatter",
+                        x="?{ ${ ref(orders).amount } }",
+                        y="?{ ${ ref(orders).total } }",
+                    ),
+                ),
+                InsightFactory(
+                    name="users_only",
+                    props=InsightProps(
+                        type="scatter",
+                        x="?{ ${ ref(users).age } }",
+                        y="?{ ${ ref(users).id } }",
+                    ),
+                ),
             ],
             dashboards=[],
         )
@@ -115,6 +192,32 @@ class TestInsights:
             users_source="ref(source_a)", insights=[_joining_insight()], dashboards=[]
         )
         assert [insight.name for insight in project.insights] == ["revenue_by_user"]
+
+    def test_a_dynamic_cross_source_insight_is_allowed(self):
+        """The regression this validator must never cause. The SAME two models
+        on the SAME two sources, but the insight reads an Input, so
+        ``is_dynamic`` is True and there is no ``pre_query``: run_sql_model_job
+        materialises each model against its own source and the DuckDB
+        ``post_query`` joins the parquet files. mkdocs/topics/sources.md sells
+        exactly this ("bring data together in a single chart with insights whose
+        models originate from different sources"), and refusing it inside
+        Project's mode="after" validator would stop the WHOLE project loading —
+        every other dashboard in it included."""
+        insight = _dynamic_joining_insight()
+        project = _project(
+            inputs=[_region_input()],
+            insights=[insight],
+            dashboards=[],
+        )
+        assert [i.name for i in project.insights] == ["revenue_by_user"]
+        # Not vacuous: the insight really is on the dynamic lane, and it really
+        # does depend on models across both sources.
+        dag = project.dag()
+        assert insight.is_dynamic(dag) is True
+        assert {model.name for model in insight.get_all_dependent_models(dag)} == {
+            "orders",
+            "users",
+        }
 
     def test_a_single_model_insight_is_untouched_even_with_two_sources_present(self):
         """Two sources in a project is normal. Only an object that spans them is

--- a/tests/models/validators/test_cross_source_validator.py
+++ b/tests/models/validators/test_cross_source_validator.py
@@ -1,0 +1,168 @@
+"""The cross-source rule is actually asked, at compile, before anything runs.
+
+Everything below builds a real project through the ordinary constructor —
+``Project``'s ``mode="after"`` validator runs ``ProjectValidator``, so a project
+that spans sources cannot be brought into existence at all. Before this the same
+project parsed clean and died much later inside a driver.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from tests.factories.model_factories import (
+    DimensionFactory,
+    DuckdbSourceFactory,
+    InsightFactory,
+    MetricFactory,
+    ProjectFactory,
+    RelationFactory,
+    SqlModelFactory,
+)
+from visivo.models.props.insight_props import InsightProps
+from visivo.models.validators import CrossSourceValidator, ProjectValidator
+
+
+def _sources():
+    return [
+        DuckdbSourceFactory(name="source_a", database="a.duckdb"),
+        DuckdbSourceFactory(name="source_b", database="b.duckdb"),
+    ]
+
+
+def _models(users_source):
+    return [
+        SqlModelFactory(name="orders", sql="SELECT * FROM orders", source="ref(source_a)"),
+        SqlModelFactory(name="users", sql="SELECT * FROM users", source=users_source),
+    ]
+
+
+def _project(users_source="ref(source_b)", **kwargs):
+    return ProjectFactory(sources=_sources(), models=_models(users_source), **kwargs)
+
+
+def _joining_insight(name="revenue_by_user"):
+    return InsightFactory(
+        name=name,
+        props=InsightProps(
+            type="scatter",
+            x="?{ ${ ref(orders).amount } }",
+            y="?{ ${ ref(users).age } }",
+        ),
+    )
+
+
+class TestItIsRegistered:
+    def test_it_runs_last(self):
+        """After the reference and single-source validators: a broken ref or a
+        metric that already spans sources is the more local mistake and should
+        be the sentence the author reads first."""
+        names = [validator.__class__.__name__ for validator in ProjectValidator().validators]
+        assert names[-1] == "CrossSourceValidator"
+        assert names.index("SingleSourceValidator") < names.index("CrossSourceValidator")
+
+
+class TestRelations:
+    def test_a_cross_source_relation_fails_the_project(self):
+        with pytest.raises(ValidationError) as excinfo:
+            _project(
+                relations=[
+                    RelationFactory(
+                        name="orders_to_users",
+                        condition="${ref(orders).user_id} = ${ref(users).id}",
+                    )
+                ],
+                dashboards=[],
+            )
+
+        message = str(excinfo.value)
+        # Names the relation, both models, and both sources — not "a table does
+        # not exist" from whichever driver happened to be asked.
+        assert "Relation 'orders_to_users' connects models from different sources." in message
+        assert "Model 'orders' uses source: source_a" in message
+        assert "Model 'users' uses source: source_b" in message
+        assert "Cross-source relations are not currently supported." in message
+
+    def test_a_same_source_relation_is_untouched(self):
+        project = _project(
+            users_source="ref(source_a)",
+            relations=[
+                RelationFactory(
+                    name="orders_to_users",
+                    condition="${ref(orders).user_id} = ${ref(users).id}",
+                )
+            ],
+            dashboards=[],
+        )
+        assert [relation.name for relation in project.relations] == ["orders_to_users"]
+
+
+class TestInsights:
+    def test_a_cross_source_insight_fails_the_project(self):
+        with pytest.raises(ValidationError) as excinfo:
+            _project(insights=[_joining_insight()], dashboards=[])
+
+        message = str(excinfo.value)
+        assert (
+            "Insight 'revenue_by_user' references models from more than one source: "
+            "source_a, source_b." in message
+        )
+        assert "Model 'orders' uses source: source_a" in message
+        assert "Model 'users' uses source: source_b" in message
+        assert "Cross-source insights are not currently supported." in message
+
+    def test_a_same_source_insight_is_untouched(self):
+        project = _project(
+            users_source="ref(source_a)", insights=[_joining_insight()], dashboards=[]
+        )
+        assert [insight.name for insight in project.insights] == ["revenue_by_user"]
+
+    def test_a_single_model_insight_is_untouched_even_with_two_sources_present(self):
+        """Two sources in a project is normal. Only an object that spans them is
+        the problem, so the rule must not fire on a project that merely has
+        more than one source declared."""
+        project = _project(
+            insights=[
+                InsightFactory(
+                    name="orders_only",
+                    props=InsightProps(
+                        type="scatter",
+                        x="?{ ${ ref(orders).amount } }",
+                        y="?{ ${ ref(orders).total } }",
+                    ),
+                )
+            ],
+            dashboards=[],
+        )
+        assert [insight.name for insight in project.insights] == ["orders_only"]
+
+
+class TestItDefersToMoreLocalRules:
+    def test_a_metric_spanning_sources_is_still_reported_as_a_metric(self):
+        """SingleSourceValidator runs first and owns this wording — the author
+        gets told about the metric they wrote, not about the insight that used
+        it."""
+        with pytest.raises(ValidationError) as excinfo:
+            _project(
+                metrics=[
+                    MetricFactory(
+                        name="mixed",
+                        expression="sum(${ref(orders).amount}) + sum(${ref(users).age})",
+                    )
+                ],
+                dashboards=[],
+            )
+        assert "ties back to multiple sources" in str(excinfo.value)
+
+    def test_a_dimension_inside_one_source_still_passes(self):
+        project = _project(
+            users_source="ref(source_a)",
+            dimensions=[DimensionFactory(name="region", expression="${ref(orders).region}")],
+            dashboards=[],
+        )
+        assert [dimension.name for dimension in project.dimensions] == ["region"]
+
+
+class TestTheValidatorInIsolation:
+    def test_it_returns_the_project_when_there_is_nothing_to_say(self):
+        project = _project(users_source="ref(source_a)", dashboards=[])
+        assert CrossSourceValidator().validate(project) is project

--- a/tests/query/test_source_scope.py
+++ b/tests/query/test_source_scope.py
@@ -1,0 +1,283 @@
+"""The single-source rule, and the fact that its message never moves.
+
+``Relation.validate_same_source`` was written, worded well, fully tested — and
+called by nothing but its own tests. These tests cover the pure rule now that it
+lives in one place; ``tests/models/validators/test_cross_source_validator.py``
+covers it actually being asked at compile, and
+``tests/jobs/test_run_insight_job_cross_source.py`` covers the runtime guard.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from tests.factories.model_factories import (
+    DuckdbSourceFactory,
+    InsightFactory,
+    ProjectFactory,
+    RelationFactory,
+    SqlModelFactory,
+)
+from visivo.models.props.insight_props import InsightProps
+from visivo.models.diagnostic import DIAGNOSTIC_CODES, DiagnosticPhase
+from visivo.query.source_scope import (
+    CrossSourceError,
+    cross_source_insight_error,
+    cross_source_relation_error,
+    resolve_insight_source,
+    source_names_by_model,
+)
+
+
+def two_source_project(**kwargs):
+    """orders on source_a, users on source_b — built by going AROUND the gate.
+
+    Now that ``CrossSourceValidator`` is wired, a cross-source project cannot be
+    constructed: ``Project``'s ``mode="after"`` validator rejects it outright.
+    That is the whole point of T1, and it means every test of the downstream
+    guards has to reach the invalid state the way real code paths do — by
+    mutating a valid project after construction (nothing re-validates on
+    assignment) and dropping the cached DAG.
+    """
+    project = ProjectFactory(
+        sources=[
+            DuckdbSourceFactory(name="source_a", database="a.duckdb"),
+            DuckdbSourceFactory(name="source_b", database="b.duckdb"),
+        ],
+        models=[
+            SqlModelFactory(name="orders", sql="SELECT * FROM orders", source="ref(source_a)"),
+            SqlModelFactory(name="users", sql="SELECT * FROM users", source="ref(source_a)"),
+        ],
+        dashboards=[],
+        **kwargs,
+    )
+    for model in project.models:
+        if model.name == "users":
+            model.source = "ref(source_b)"
+    project.invalidate_dag_cache()
+    return project
+
+
+def one_source_project(**kwargs):
+    return ProjectFactory(
+        sources=[DuckdbSourceFactory(name="source_a", database="a.duckdb")],
+        models=[
+            SqlModelFactory(name="orders", sql="SELECT * FROM orders", source="ref(source_a)"),
+            SqlModelFactory(name="users", sql="SELECT * FROM users", source="ref(source_a)"),
+        ],
+        dashboards=[],
+        **kwargs,
+    )
+
+
+def joining_insight(name="cross"):
+    return InsightFactory(
+        name=name,
+        props=InsightProps(
+            type="scatter",
+            x="?{ ${ ref(orders).amount } }",
+            y="?{ ${ ref(users).age } }",
+        ),
+    )
+
+
+class TestSourceNamesByModel:
+    def test_resolves_every_model_to_its_source_name(self):
+        project = two_source_project()
+        dag = project.dag()
+        models = [dag.get_descendant_by_name(n) for n in ("orders", "users")]
+        assert source_names_by_model(models, dag) == {"orders": "source_a", "users": "source_b"}
+
+    def test_a_model_with_no_resolvable_source_is_omitted_not_guessed(self):
+        """ModelsHaveSourcesValidator owns "no source"; guessing here would turn
+        a missing source into a bogus cross-source complaint."""
+        project = one_source_project()
+        dag = project.dag()
+        orders = dag.get_descendant_by_name("orders")
+        assert source_names_by_model([orders, None], dag) == {"orders": "source_a"}
+
+
+class TestRelationRule:
+    def test_a_relation_across_two_sources_names_both_models_and_both_sources(self):
+        relation = RelationFactory(
+            name="orders_to_users",
+            condition="${ref(orders).user_id} = ${ref(users).id}",
+        )
+        project = two_source_project(relations=[relation])
+        error = cross_source_relation_error(relation, project.dag())
+
+        assert isinstance(error, CrossSourceError)
+        assert str(error) == (
+            "Relation 'orders_to_users' connects models from different sources.\n"
+            "\n"
+            "  Model 'orders' uses source: source_a\n"
+            "  Model 'users' uses source: source_b\n"
+            "\n"
+            "Cross-source relations are not currently supported. "
+            "Both models must use the same source."
+        )
+
+    def test_a_relation_inside_one_source_is_not_an_error(self):
+        relation = RelationFactory(
+            name="orders_to_users",
+            condition="${ref(orders).user_id} = ${ref(users).id}",
+        )
+        project = one_source_project(relations=[relation])
+        assert cross_source_relation_error(relation, project.dag()) is None
+
+    def test_a_relation_naming_a_model_that_does_not_exist_defers(self):
+        """RelationReferencesValidator reports the broken ref; this rule must
+        not crash trying to resolve it first."""
+        relation = RelationFactory(name="ghost", condition="${ref(orders).id} = ${ref(nope).id}")
+        project = one_source_project()
+        assert cross_source_relation_error(relation, project.dag()) is None
+
+    def test_the_model_shim_still_raises_and_still_takes_an_output_dir(self, tmpdir):
+        relation = RelationFactory(
+            name="orders_to_users",
+            condition="${ref(orders).user_id} = ${ref(users).id}",
+        )
+        project = two_source_project(relations=[relation])
+        with pytest.raises(ValueError, match="different sources"):
+            relation.validate_same_source(project.dag(), str(tmpdir))
+
+
+class TestInsightRule:
+    def test_an_insight_across_two_sources_names_both_models_and_both_sources(self):
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        error = cross_source_insight_error(insight.name, insight.get_all_dependent_models(dag), dag)
+
+        assert str(error) == (
+            "Insight 'cross' references models from more than one source: "
+            "source_a, source_b.\n"
+            "\n"
+            "  Model 'orders' uses source: source_a\n"
+            "  Model 'users' uses source: source_b\n"
+            "\n"
+            "Cross-source insights are not currently supported. "
+            "Every model an insight references must use the same source."
+        )
+
+    def test_an_insight_inside_one_source_is_not_an_error(self):
+        insight = joining_insight()
+        project = one_source_project(insights=[insight])
+        dag = project.dag()
+        assert (
+            cross_source_insight_error(insight.name, insight.get_all_dependent_models(dag), dag)
+            is None
+        )
+
+
+class TestResolveInsightSource:
+    def test_returns_the_one_shared_source(self):
+        insight = joining_insight()
+        project = one_source_project(insights=[insight])
+        dag = project.dag()
+        source = resolve_insight_source(insight.name, insight.get_all_dependent_models(dag), dag)
+        assert source.name == "source_a"
+
+    def test_raises_rather_than_picking_a_winner(self):
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        with pytest.raises(CrossSourceError) as excinfo:
+            resolve_insight_source(insight.name, insight.get_all_dependent_models(dag), dag)
+        assert excinfo.value.source_names == ["source_a", "source_b"]
+
+    def test_no_models_is_a_sentence_not_an_index_error(self):
+        project = one_source_project()
+        with pytest.raises(ValueError, match="has no dependent models"):
+            resolve_insight_source("empty", set(), project.dag())
+
+
+class TestDiagnostic:
+    def test_the_code_is_registered(self):
+        assert "cross_source" in DIAGNOSTIC_CODES
+
+    def test_it_carries_the_object_the_sources_and_a_stable_id(self):
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        error = cross_source_insight_error(insight.name, insight.get_all_dependent_models(dag), dag)
+
+        diagnostic = error.diagnostic(DiagnosticPhase.RUN)
+        assert diagnostic.code == "cross_source"
+        assert diagnostic.phase == DiagnosticPhase.RUN
+        assert diagnostic.object.type == "insight"
+        assert diagnostic.object.name == "cross"
+        assert diagnostic.id == "run:cross_source:insight:cross"
+        # One headline sentence, never the multi-line body.
+        assert "\n" not in diagnostic.message
+        assert diagnostic.detail == error.message
+        assert [related.object.name for related in diagnostic.related] == ["orders", "users"]
+        assert error.error_details() == {
+            "error_type": "multi_source",
+            "error_models": ["orders", "users"],
+            "error_sources": ["source_a", "source_b"],
+        }
+
+    def test_the_same_error_at_a_different_phase_gets_a_different_id(self):
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        error = cross_source_insight_error(insight.name, insight.get_all_dependent_models(dag), dag)
+        assert error.diagnostic(DiagnosticPhase.SERVE).id == "serve:cross_source:insight:cross"
+
+
+# The message is built from a *set* of model names, and Python randomises str
+# hashes per process — so before this the same broken project blamed either half
+# of the join depending on the run, which is exactly what makes a cross-source
+# failure feel like a flake rather than a fact. Running the build under several
+# PYTHONHASHSEEDs is the only honest way to prove the sort holds.
+_DETERMINISM_SCRIPT = textwrap.dedent("""
+    from visivo.models.project import Project
+    from visivo.models.relation import Relation
+    from visivo.models.models.sql_model import SqlModel
+    from visivo.models.sources.duckdb_source import DuckdbSource
+    from visivo.query.source_scope import cross_source_relation_error
+
+    relation = Relation(
+        name="orders_to_users",
+        condition="${ref(zebra).user_id} = ${ref(apple).id}",
+    )
+    project = Project(
+        name="p",
+        sources=[
+            DuckdbSource(name="s_zebra", database="z.duckdb", type="duckdb"),
+            DuckdbSource(name="s_apple", database="a.duckdb", type="duckdb"),
+        ],
+        models=[
+            SqlModel(name="zebra", sql="SELECT 1", source="ref(s_zebra)"),
+            SqlModel(name="apple", sql="SELECT 1", source="ref(s_zebra)"),
+        ],
+        relations=[relation],
+        dashboards=[],
+    )
+    for model in project.models:
+        if model.name == "apple":
+            model.source = "ref(s_apple)"
+    project.invalidate_dag_cache()
+    print(repr(str(cross_source_relation_error(relation, project.dag()))))
+    """)
+
+
+def test_the_message_is_identical_under_every_hash_seed():
+    messages = set()
+    for seed in ("0", "1", "42", "12345"):
+        completed = subprocess.run(
+            [sys.executable, "-c", _DETERMINISM_SCRIPT],
+            capture_output=True,
+            text=True,
+            env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"},
+        )
+        assert completed.returncode == 0, completed.stderr
+        messages.add(completed.stdout.strip())
+
+    assert len(messages) == 1, f"message varies with hash seed: {messages}"
+    # And it is sorted by model name, not by whatever the set handed back.
+    only = messages.pop()
+    assert only.index("Model 'apple'") < only.index("Model 'zebra'")

--- a/tests/query/test_source_scope.py
+++ b/tests/query/test_source_scope.py
@@ -10,6 +10,7 @@ covers it actually being asked at compile, and
 import subprocess
 import sys
 import textwrap
+from functools import lru_cache
 
 import pytest
 
@@ -20,6 +21,8 @@ from tests.factories.model_factories import (
     RelationFactory,
     SqlModelFactory,
 )
+from visivo.jobs.utils import get_source_for_model
+from visivo.models.models.sql_model import SqlModel
 from visivo.models.props.insight_props import InsightProps
 from visivo.models.diagnostic import DIAGNOSTIC_CODES, DiagnosticPhase
 from visivo.query.source_scope import (
@@ -92,11 +95,43 @@ class TestSourceNamesByModel:
 
     def test_a_model_with_no_resolvable_source_is_omitted_not_guessed(self):
         """ModelsHaveSourcesValidator owns "no source"; guessing here would turn
-        a missing source into a bogus cross-source complaint."""
+        a missing source into a bogus cross-source complaint.
+
+        A REAL model whose source does not resolve — ``source`` unset and
+        nothing tying it to a Source in the dag, the shape a draft-overlay model
+        arrives in — not a ``None`` placeholder, which would only exercise the
+        loop's other guard."""
+        project = one_source_project()
+        dag = project.dag()
+        orders = dag.get_descendant_by_name("orders")
+        unattached = SqlModel(name="unattached", sql="SELECT 1")
+        assert get_source_for_model(unattached, dag, "") is None
+
+        resolved = source_names_by_model([orders, unattached], dag)
+
+        # Omitted entirely: not a placeholder name, not the only other source in
+        # the project. One model left means len(resolved) < 2, so no rule fires.
+        assert resolved == {"orders": "source_a"}
+
+    def test_a_none_placeholder_is_skipped_before_it_is_dereferenced(self):
+        """The other guard in the same loop: ``None`` never reaches
+        ``model.name``."""
         project = one_source_project()
         dag = project.dag()
         orders = dag.get_descendant_by_name("orders")
         assert source_names_by_model([orders, None], dag) == {"orders": "source_a"}
+
+    def test_an_unresolvable_model_cannot_manufacture_a_cross_source_error(self):
+        """The consequence the omission exists for. If the unresolved model were
+        given any stand-in name, this single-source project would be refused
+        with a message naming a source that does not exist."""
+        insight = joining_insight()
+        project = one_source_project(insights=[insight])
+        dag = project.dag()
+        models = list(insight.get_all_dependent_models(dag)) + [
+            SqlModel(name="unattached", sql="SELECT 1")
+        ]
+        assert cross_source_insight_error(insight.name, models, dag) is None
 
 
 class TestRelationRule:
@@ -171,6 +206,30 @@ class TestInsightRule:
             is None
         )
 
+    def test_the_dynamic_lane_is_not_an_error(self):
+        """``is_dynamic`` means there is no ``pre_query`` to be wrong: each model
+        was materialised against its own source and the DuckDB ``post_query``
+        joins the parquet files. Same models, same two sources, no failure."""
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        models = insight.get_all_dependent_models(dag)
+
+        # Falsifiable against itself: strict is the default, so the ONLY
+        # difference between these two lines is the lane.
+        assert cross_source_insight_error(insight.name, models, dag) is not None
+        assert cross_source_insight_error(insight.name, models, dag, is_dynamic=True) is None
+
+    def test_the_flag_is_keyword_only_so_it_cannot_be_passed_by_accident(self):
+        """A positional fourth argument is ``output_dir``. If ``is_dynamic``
+        could be passed positionally, every caller that threads an output_dir
+        would silently disable the rule."""
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        models = insight.get_all_dependent_models(dag)
+        assert cross_source_insight_error(insight.name, models, dag, "/tmp/anything") is not None
+
 
 class TestResolveInsightSource:
     def test_returns_the_one_shared_source(self):
@@ -187,6 +246,21 @@ class TestResolveInsightSource:
         with pytest.raises(CrossSourceError) as excinfo:
             resolve_insight_source(insight.name, insight.get_all_dependent_models(dag), dag)
         assert excinfo.value.source_names == ["source_a", "source_b"]
+
+    def test_the_dynamic_lane_gets_a_deterministic_source_instead_of_a_refusal(self):
+        """The dynamic builder still reads a dialect off A source, it just never
+        executes against it. The pick must not be the old ``list(a_set)[0]``:
+        models are walked in NAME order, so 'orders' (source_a) wins every run
+        regardless of how the set was iterated."""
+        insight = joining_insight()
+        project = two_source_project(insights=[insight])
+        dag = project.dag()
+        models = insight.get_all_dependent_models(dag)
+
+        source = resolve_insight_source(insight.name, models, dag, is_dynamic=True)
+        assert source.name == "source_a"
+        # In-process this only proves the name-order rule; the seeded subprocess
+        # run below proves it does not move between processes either.
 
     def test_no_models_is_a_sentence_not_an_index_error(self):
         project = one_source_project()
@@ -228,46 +302,95 @@ class TestDiagnostic:
         assert error.diagnostic(DiagnosticPhase.SERVE).id == "serve:cross_source:insight:cross"
 
 
-# The message is built from a *set* of model names, and Python randomises str
-# hashes per process — so before this the same broken project blamed either half
-# of the join depending on the run, which is exactly what makes a cross-source
-# failure feel like a flake rather than a fact. Running the build under several
-# PYTHONHASHSEEDs is the only honest way to prove the sort holds.
+# Both messages are built from *sets* — the models come out of
+# `get_all_dependent_models`, and the insight headline comma-joins a set of
+# SOURCE names on top of that. Python randomises str hashes per process, so
+# before the sorts the same broken project blamed either half of the join
+# depending on the run, which is exactly what makes a cross-source failure feel
+# like a flake rather than a fact. Running the build under several
+# PYTHONHASHSEEDs is the only honest way to prove the sorts hold.
+#
+# Every set-derived string the module emits has to be in here. The relation
+# message alone is not enough: `sorted(set(resolved.values()))` in
+# `cross_source_insight_error` is the ONLY place a set of source names is
+# joined into a headline, and it appears in no relation message — so with only
+# the relation covered, dropping that sort still passes roughly one run in six.
+# The dynamic lane's source pick is here for the same reason: nothing raises on
+# that path, so a `list(a_set)[0]` regression would be invisible otherwise.
+#
+# THREE models on THREE sources, not two, and deliberately so: with two names a
+# random order is right half the time, so an unsorted build can still come out
+# identical across a handful of seeds by luck. With three there are six
+# permutations, and "every seed agrees AND agrees on the alphabetical one" stops
+# being something chance produces.
 _DETERMINISM_SCRIPT = textwrap.dedent("""
     from visivo.models.project import Project
     from visivo.models.relation import Relation
+    from visivo.models.insight import Insight
     from visivo.models.models.sql_model import SqlModel
+    from visivo.models.props.insight_props import InsightProps
     from visivo.models.sources.duckdb_source import DuckdbSource
-    from visivo.query.source_scope import cross_source_relation_error
+    from visivo.query.source_scope import (
+        cross_source_insight_error,
+        cross_source_relation_error,
+        resolve_insight_source,
+    )
 
     relation = Relation(
         name="orders_to_users",
         condition="${ref(zebra).user_id} = ${ref(apple).id}",
+    )
+    insight = Insight(
+        name="cross",
+        props=InsightProps(
+            type="scatter",
+            x="?{ ${ ref(zebra).amount } }",
+            y="?{ ${ ref(apple).age } }",
+        ),
+        interactions=[{"filter": "?{ ${ref(cherry).flag} = 1 }"}],
     )
     project = Project(
         name="p",
         sources=[
             DuckdbSource(name="s_zebra", database="z.duckdb", type="duckdb"),
             DuckdbSource(name="s_apple", database="a.duckdb", type="duckdb"),
+            DuckdbSource(name="s_cherry", database="c.duckdb", type="duckdb"),
         ],
         models=[
             SqlModel(name="zebra", sql="SELECT 1", source="ref(s_zebra)"),
             SqlModel(name="apple", sql="SELECT 1", source="ref(s_zebra)"),
+            SqlModel(name="cherry", sql="SELECT 1", source="ref(s_zebra)"),
         ],
         relations=[relation],
+        insights=[insight],
         dashboards=[],
     )
+    # Spread them AFTER construction — CrossSourceValidator would (correctly)
+    # refuse this static insight otherwise.
     for model in project.models:
         if model.name == "apple":
             model.source = "ref(s_apple)"
+        if model.name == "cherry":
+            model.source = "ref(s_cherry)"
     project.invalidate_dag_cache()
-    print(repr(str(cross_source_relation_error(relation, project.dag()))))
+    dag = project.dag()
+    models = insight.get_all_dependent_models(dag)
+    print(repr(str(cross_source_relation_error(relation, dag))))
+    print(repr(str(cross_source_insight_error(insight.name, models, dag))))
+    print(repr(resolve_insight_source(insight.name, models, dag, is_dynamic=True).name))
     """)
 
+_SEEDS = ("0", "1", "42", "12345", "31337", "808")
 
-def test_the_message_is_identical_under_every_hash_seed():
-    messages = set()
-    for seed in ("0", "1", "42", "12345"):
+
+@lru_cache(maxsize=1)
+def _under_every_hash_seed():
+    """stdout of the script, once per seed, asserted identical.
+
+    Cached: six interpreter starts is the price of the proof, and the three
+    assertions below are three different reads of the SAME six runs."""
+    outputs = set()
+    for seed in _SEEDS:
         completed = subprocess.run(
             [sys.executable, "-c", _DETERMINISM_SCRIPT],
             capture_output=True,
@@ -275,9 +398,31 @@ def test_the_message_is_identical_under_every_hash_seed():
             env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"},
         )
         assert completed.returncode == 0, completed.stderr
-        messages.add(completed.stdout.strip())
+        outputs.add(completed.stdout)
 
-    assert len(messages) == 1, f"message varies with hash seed: {messages}"
-    # And it is sorted by model name, not by whatever the set handed back.
-    only = messages.pop()
-    assert only.index("Model 'apple'") < only.index("Model 'zebra'")
+    assert len(outputs) == 1, f"output varies with hash seed: {outputs}"
+    return outputs.pop().strip().splitlines()
+
+
+def test_the_relation_message_is_identical_under_every_hash_seed():
+    relation_message, _, _ = _under_every_hash_seed()
+    # Sorted by model name, not by whatever the set handed back.
+    assert relation_message.index("Model 'apple'") < relation_message.index("Model 'zebra'")
+
+
+def test_the_insight_message_is_identical_under_every_hash_seed():
+    _, insight_message, _ = _under_every_hash_seed()
+    # The headline joins a set of SOURCE names — the one string in the module
+    # whose order no relation message can vouch for.
+    assert "more than one source: s_apple, s_cherry, s_zebra." in insight_message
+    assert (
+        insight_message.index("Model 'apple'")
+        < insight_message.index("Model 'cherry'")
+        < insight_message.index("Model 'zebra'")
+    )
+
+
+def test_the_dynamic_lane_source_pick_is_identical_under_every_hash_seed():
+    _, _, picked_source = _under_every_hash_seed()
+    # 'apple' sorts before 'zebra', so its source answers — every process.
+    assert picked_source == "'s_apple'"

--- a/tests/server/views/test_insight_execute_views.py
+++ b/tests/server/views/test_insight_execute_views.py
@@ -183,7 +183,7 @@ def test_multi_source_insight_is_rejected_400_multi_source(duckdb_file, tmp_path
     source1 = DuckdbSource(name="warehouse", database=duckdb_file, type="duckdb")
     source2 = DuckdbSource(name="warehouse2", database=db2, type="duckdb")
     model_a = SqlModel(name="orders_q", sql="SELECT * FROM orders", source="ref(warehouse)")
-    model_b = SqlModel(name="users_q", sql="SELECT * FROM users", source="ref(warehouse2)")
+    model_b = SqlModel(name="users_q", sql="SELECT * FROM users", source="ref(warehouse)")
     insight = Insight(
         name="cross",
         props=InsightProps(
@@ -195,6 +195,11 @@ def test_multi_source_insight_is_rejected_400_multi_source(duckdb_file, tmp_path
     proj = Project(
         name="p", sources=[source1, source2], models=[model_a, model_b], insights=[insight]
     )
+    # CrossSourceValidator now refuses to construct a project that spans
+    # sources, so move the second model afterwards — the endpoint's job is to
+    # catch exactly the drafts that never went through project validation.
+    model_b.source = "ref(warehouse2)"
+    proj.invalidate_dag_cache()
     app = Flask(__name__)
     register_insight_execute_views(app, FlaskAppStub(proj), str(tmp_path))
     client = app.test_client()
@@ -217,7 +222,13 @@ def test_multi_source_insight_is_rejected_400_multi_source(duckdb_file, tmp_path
         },
     )
     assert resp.status_code == 400
-    assert resp.get_json()["error_type"] == "multi_source"
+    body = resp.get_json()
+    assert body["error_type"] == "multi_source"
+    # One wording across compile, run and preview — see visivo/query/source_scope.py.
+    assert "references models from more than one source: warehouse, warehouse2" in body["error"]
+    assert body["error_models"] == ["orders_q", "users_q"]
+    assert body["diagnostic"]["code"] == "cross_source"
+    assert body["diagnostic"]["phase"] == "serve"
 
 
 def test_datetime_rows_serialise_as_iso8601_not_rfc1123(duckdb_file, tmp_path):

--- a/tests/server/views/test_insight_execute_views.py
+++ b/tests/server/views/test_insight_execute_views.py
@@ -18,6 +18,7 @@ from visivo.models.props.insight_props import InsightProps
 from visivo.models.interaction import InsightInteraction
 from visivo.models.inputs.types.multi_select import MultiSelectInput
 from visivo.models.models.sql_model import SqlModel
+from visivo.models.relation import Relation
 from visivo.models.sources.duckdb_source import DuckdbSource
 from visivo.server.views.insight_execute_views import register_insight_execute_views
 
@@ -229,6 +230,87 @@ def test_multi_source_insight_is_rejected_400_multi_source(duckdb_file, tmp_path
     assert body["error_models"] == ["orders_q", "users_q"]
     assert body["diagnostic"]["code"] == "cross_source"
     assert body["diagnostic"]["phase"] == "serve"
+
+
+def test_multi_source_DYNAMIC_insight_is_409_client_lane_not_400(duckdb_file, tmp_path):
+    """The mirror image of the test above, and the one that keeps the guard
+    honest.
+
+    Identical two-source setup, except the insight reads an Input, so it is
+    dynamic: there is no ``pre_query`` for this endpoint to bake, and the client
+    runs it in DuckDB over each model's OWN parquet — the lane on which
+    cross-source is the documented feature, not a failure. 400-ing it here would
+    dead-end a chart that works, so it has to fall through to the ordinary
+    ``requires_client_lane`` handoff.
+    """
+    db2 = str(tmp_path / "warehouse2.duckdb")
+    con = duckdb.connect(db2)
+    con.execute("CREATE TABLE users (id INTEGER)")
+    con.execute("INSERT INTO users VALUES (1), (2)")
+    con.close()
+
+    source1 = DuckdbSource(name="warehouse", database=duckdb_file, type="duckdb")
+    source2 = DuckdbSource(name="warehouse2", database=db2, type="duckdb")
+    model_a = SqlModel(name="orders_q", sql="SELECT * FROM orders", source="ref(warehouse)")
+    model_b = SqlModel(name="users_q", sql="SELECT * FROM users", source="ref(warehouse2)")
+    an_input = MultiSelectInput(name="region_filter", label="Region", options=["west", "east"])
+    insight = Insight(
+        name="cross_dynamic",
+        props=InsightProps(
+            type="scatter",
+            x="?{${ref(orders_q).amount}}",
+            y="?{${ref(users_q).id}}",
+        ),
+        interactions=[
+            InsightInteraction(
+                filter="?{${ref(orders_q).region} IN (${ref(region_filter).values})}"
+            )
+        ],
+    )
+    # A relation so the two models have a join path at all. Nothing executes on
+    # this lane, so joining amount to id is only shape, not semantics.
+    relation = Relation(
+        name="orders_to_users", condition="${ref(orders_q).amount} = ${ref(users_q).id}"
+    )
+    # No post-construction mutation needed: this project is VALID, two sources,
+    # a cross-source relation and all. CrossSourceValidator lets the dynamic
+    # lane — and the relation only that lane compiles — through.
+    proj = Project(
+        name="p",
+        sources=[source1, source2],
+        models=[model_a, model_b],
+        relations=[relation],
+        inputs=[an_input],
+        insights=[insight],
+    )
+    app = Flask(__name__)
+    register_insight_execute_views(app, FlaskAppStub(proj), str(tmp_path))
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/insight-execute-draft/",
+        json={
+            "insight": {
+                "name": "cross_dynamic",
+                "props": {
+                    "type": "scatter",
+                    "x": "?{${ref(orders_q).amount}}",
+                    "y": "?{${ref(users_q).id}}",
+                },
+                "interactions": [
+                    {"filter": "?{${ref(orders_q).region} IN (${ref(region_filter).values})}"}
+                ],
+            },
+            "model_schemas": {
+                "orders_q": {"amount": "INTEGER", "region": "VARCHAR"},
+                "users_q": {"id": "INTEGER"},
+            },
+        },
+    )
+    body = resp.get_json()
+    assert resp.status_code == 409, body
+    assert body["error_type"] == "requires_client_lane"
+    assert "multi_source" not in json.dumps(body)
 
 
 def test_datetime_rows_serialise_as_iso8601_not_rfc1123(duckdb_file, tmp_path):

--- a/viewer/src/components/views/common/InsightPreview.jsx
+++ b/viewer/src/components/views/common/InsightPreview.jsx
@@ -110,7 +110,14 @@ const InsightPreview = ({ insightConfig, projectId, layoutValues = {} }) => {
         data-testid="preview-error"
       >
         <h3 className="text-lg font-medium text-red-600 mb-2">Preview Failed</h3>
-        <p className="text-sm text-gray-700 max-w-sm font-mono bg-red-50 p-3 rounded">
+        {/* whitespace-pre-line, because several backend errors are deliberately
+            multi-line — the cross-source refusal is a headline, one indented
+            line per model, then the closing sentence. HTML collapses those
+            newlines, so without this the whole thing renders as one run-on
+            sentence, strictly less readable than the shape the server sent.
+            text-left for the same reason: centring a per-model list scatters
+            it. Matches how ChartPreview renders its technical details. */}
+        <p className="text-sm text-gray-700 max-w-sm font-mono bg-red-50 p-3 rounded whitespace-pre-line break-words text-left">
           {errorMessage}
         </p>
       </div>

--- a/viewer/src/components/views/common/InsightPreview.test.jsx
+++ b/viewer/src/components/views/common/InsightPreview.test.jsx
@@ -171,6 +171,36 @@ describe('InsightPreview', () => {
       expect(screen.queryByTestId('missing-relation-card')).not.toBeInTheDocument();
       expect(screen.queryByTestId('ambiguous-relation-card')).not.toBeInTheDocument();
     });
+
+    it('preserves the newlines of a deliberately multi-line backend error', () => {
+      // The cross-source refusal (visivo/query/source_scope.py) is a headline,
+      // one indented line per model, then a closing sentence — and errorType
+      // 'multi_source' matches neither typed card, so it lands in this block.
+      // HTML collapses newlines, so without whitespace-pre-line the whole
+      // thing renders as one run-on sentence.
+      const multiLine =
+        "Insight 'cross' references models from more than one source: source_a, source_b.\n" +
+        '\n' +
+        "  Model 'orders' uses source: source_a\n" +
+        "  Model 'users' uses source: source_b\n" +
+        '\n' +
+        'Cross-source insights are not currently supported. Every model an insight references must use the same source.';
+      setResolver({
+        error: multiLine,
+        errorDetails: { error_type: 'multi_source', error_models: ['orders', 'users'] },
+      });
+      render(<InsightPreview insightConfig={defaultInsightConfig} projectId="proj-1" />);
+
+      expect(screen.getByTestId('preview-error')).toBeInTheDocument();
+      // Identity normalizer: the default one collapses whitespace, which is
+      // precisely the thing under test.
+      const paragraph = screen.getByText(multiLine, { normalizer: value => value });
+      expect(paragraph.tagName).toBe('P');
+      expect(paragraph.textContent).toBe(multiLine);
+      // The class is the whole fix: it is what makes those \n characters render
+      // as line breaks instead of collapsing into one run-on sentence.
+      expect(paragraph).toHaveClass('whitespace-pre-line');
+    });
   });
 
   describe('Typed relation errors (VIS-1007)', () => {

--- a/viewer/src/types/diagnostic.js
+++ b/viewer/src/types/diagnostic.js
@@ -52,6 +52,7 @@ export const DIAGNOSTIC_CODES = [
   'dependency_failed',
   'missing_relation',
   'ambiguous_relation',
+  'cross_source',
   'query_execution_failed',
   'schema_build_failed',
   'not_built',

--- a/visivo/jobs/run_insight_job.py
+++ b/visivo/jobs/run_insight_job.py
@@ -35,15 +35,26 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
     insight_query_info = None
 
     try:
-        # Which source runs this insight is not a free choice: the built
-        # pre_query embeds EVERY dependent model as a CTE, so a two-source
-        # insight has half its tables missing wherever it executes. The old
-        # `[0]` pick made that an arbitrary — and, off a set, run-to-run
+        # Which source runs this insight is not a free choice WHEN there is a
+        # pre_query: it embeds EVERY dependent model as a CTE, so a two-source
+        # static insight has half its tables missing wherever it executes. The
+        # old `[0]` pick made that an arbitrary — and, off a set, run-to-run
         # unstable — bet, and the user got the losing source's driver error
         # about a table it had never heard of. Refuse, in the same words the
         # compile-time validator uses.
+        #
+        # A DYNAMIC insight has no pre_query and never touches `source` below:
+        # its models were each materialised against their own source by
+        # run_sql_model_job and the DuckDB post_query joins those parquet files
+        # in the browser. Refusing it here would break the multi-source charts
+        # mkdocs/topics/sources.md documents, so pass the lane through and keep
+        # only the deterministic pick.
         source = resolve_insight_source(
-            insight.name, insight.get_all_dependent_models(dag), dag, run_output_dir
+            insight.name,
+            insight.get_all_dependent_models(dag),
+            dag,
+            run_output_dir,
+            is_dynamic=insight.is_dynamic(dag),
         )
 
         insight_query_info = insight.get_query_info(dag, run_output_dir)

--- a/visivo/jobs/run_insight_job.py
+++ b/visivo/jobs/run_insight_job.py
@@ -11,6 +11,8 @@ from visivo.jobs.job import (
 from visivo.logger.query_error_logger import log_failed_query, extract_error_location
 from time import time
 from visivo.jobs.utils import get_source_for_model
+from visivo.models.diagnostic import DiagnosticPhase
+from visivo.query.source_scope import CrossSourceError, resolve_insight_source
 from visivo.constants import DEFAULT_RUN_ID
 import json
 import os
@@ -33,8 +35,16 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
     insight_query_info = None
 
     try:
-        model = all_descendants_of_type(type=Model, dag=dag, from_node=insight)[0]
-        source = get_source_for_model(model, dag, run_output_dir)
+        # Which source runs this insight is not a free choice: the built
+        # pre_query embeds EVERY dependent model as a CTE, so a two-source
+        # insight has half its tables missing wherever it executes. The old
+        # `[0]` pick made that an arbitrary — and, off a set, run-to-run
+        # unstable — bet, and the user got the losing source's driver error
+        # about a table it had never heard of. Refuse, in the same words the
+        # compile-time validator uses.
+        source = resolve_insight_source(
+            insight.name, insight.get_all_dependent_models(dag), dag, run_output_dir
+        )
 
         insight_query_info = insight.get_query_info(dag, run_output_dir)
 
@@ -135,6 +145,14 @@ def action(insight: Insight, dag: ProjectDag, output_dir, run_id=DEFAULT_RUN_ID)
         error_details = None
         if isinstance(e, JoinPathError):
             error_details = join_error_to_structured_fields(e)
+        elif isinstance(e, CrossSourceError):
+            # Same shape the join failures use (error_type + the models the
+            # failure is about), plus the Diagnostic so a consumer that speaks
+            # the contract does not have to re-derive it from the message.
+            error_details = e.error_details()
+            error_details["diagnostic"] = e.diagnostic(DiagnosticPhase.RUN).model_dump(
+                mode="json", exclude_none=True
+            )
 
         # Log failed query to file for debugging
         query_file = None

--- a/visivo/models/diagnostic.py
+++ b/visivo/models/diagnostic.py
@@ -67,6 +67,7 @@ DIAGNOSTIC_CODES = {
     "dependency_failed": "The job was skipped because something it depends on failed.",
     "missing_relation": "An insight joins models with no relation declared between them.",
     "ambiguous_relation": "More than one relation path exists between the joined models.",
+    "cross_source": "A relation or insight spans models that resolve to more than one source.",
     "query_execution_failed": "The source raised an error executing the job's query.",
     "schema_build_failed": "Schema inference for a model failed.",
     "not_built": "The artifact has never been produced (empty state, not an error).",

--- a/visivo/models/relation.py
+++ b/visivo/models/relation.py
@@ -105,12 +105,21 @@ class Relation(NamedModel, ParentModel):
         return children
 
     def validate_same_source(self, dag, output_dir: str = "") -> None:
-        """Validate that all models in this relation use the same source.
+        """Raise if the two models in this relation use different sources.
 
-        Relations between models from different sources are not supported because
-        SQL joins require all tables to be accessible from a single database connection.
+        A cross-source join cannot be expressed in the SQL a single database
+        connection executes — which is why it is refused wherever a relation is
+        compiled into one ``pre_query``.
 
-        The rule itself now lives in ``visivo.query.source_scope`` so the
+        CAVEAT, and the reason ``CrossSourceValidator`` does not call this for
+        every relation in a project: it is unconditional. A relation reached
+        only by DYNAMIC insights is joined by DuckDB over each model's own
+        parquet, where two sources is the documented feature — so asking this
+        question about such a relation gets a "failure" that is not one. Ask it
+        only about a relation you know a static insight compiles. See
+        ``visivo.query.source_scope``'s module docstring for the two lanes.
+
+        The rule itself lives in ``visivo.query.source_scope`` so the
         compile-time validator (``CrossSourceValidator``), the insight query
         builder and the run job all read one wording; this stays as the entry
         point for callers that already hold a dag. ``output_dir`` is optional

--- a/visivo/models/relation.py
+++ b/visivo/models/relation.py
@@ -104,41 +104,27 @@ class Relation(NamedModel, ParentModel):
 
         return children
 
-    def validate_same_source(self, dag, output_dir: str) -> None:
+    def validate_same_source(self, dag, output_dir: str = "") -> None:
         """Validate that all models in this relation use the same source.
 
         Relations between models from different sources are not supported because
         SQL joins require all tables to be accessible from a single database connection.
 
+        The rule itself now lives in ``visivo.query.source_scope`` so the
+        compile-time validator (``CrossSourceValidator``), the insight query
+        builder and the run job all read one wording; this stays as the entry
+        point for callers that already hold a dag. ``output_dir`` is optional
+        because ``get_source_for_model`` has never read it.
+
         Args:
             dag: The project DAG
-            output_dir: Output directory for model schemas
+            output_dir: Unused; kept for callers that already pass one
 
         Raises:
-            ValueError: If models use different sources
+            CrossSourceError (a ValueError): If models use different sources
         """
-        from visivo.jobs.utils import get_source_for_model
+        from visivo.query.source_scope import cross_source_relation_error
 
-        model_names = list(self.get_referenced_models())
-        if len(model_names) != 2:
-            return  # Other validation handles this case
-
-        model_a = dag.get_descendant_by_name(model_names[0])
-        model_b = dag.get_descendant_by_name(model_names[1])
-
-        source_a = get_source_for_model(model_a, dag, output_dir)
-        source_b = get_source_for_model(model_b, dag, output_dir)
-
-        if source_a is None or source_b is None:
-            # If sources can't be determined, skip validation
-            # Other validation will catch missing source errors
-            return
-
-        if source_a.name != source_b.name:
-            raise ValueError(
-                f"Relation '{self.name}' connects models from different sources.\n\n"
-                f"  Model '{model_a.name}' uses source: {source_a.name}\n"
-                f"  Model '{model_b.name}' uses source: {source_b.name}\n\n"
-                f"Cross-source relations are not currently supported. "
-                f"Both models must use the same source."
-            )
+        error = cross_source_relation_error(self, dag, output_dir)
+        if error:
+            raise error

--- a/visivo/models/validators/__init__.py
+++ b/visivo/models/validators/__init__.py
@@ -15,6 +15,7 @@ from visivo.models.validators.standalone_field_refs_validator import (
     StandaloneFieldRefsValidator,
     standalone_field_ref_error,
 )
+from visivo.models.validators.cross_source_validator import CrossSourceValidator
 from visivo.models.validators.project_validator import ProjectValidator
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "SingleSourceValidator",
     "StandaloneFieldRefsValidator",
     "standalone_field_ref_error",
+    "CrossSourceValidator",
     "ProjectValidator",
 ]

--- a/visivo/models/validators/cross_source_validator.py
+++ b/visivo/models/validators/cross_source_validator.py
@@ -1,4 +1,4 @@
-"""A relation joins, and an insight queries, inside ONE source."""
+"""A STATIC insight queries, and the joins it compiles run, inside ONE source."""
 
 from visivo.models.validators.base_validator import BaseProjectValidator
 from visivo.models.dag import all_descendants_of_type
@@ -15,22 +15,33 @@ if TYPE_CHECKING:
 
 
 class CrossSourceValidator(BaseProjectValidator):
-    """Reject at compile what can only be built wrong at run.
+    """Reject at compile what can only be built wrong at run — and nothing else.
 
     ``SingleSourceValidator`` already holds each *metric* and *dimension* to one
-    source, but nothing held the two objects that actually generate a join:
+    source, but nothing held the object that actually compiles a join into one
+    statement: a **static insight** embeds every dependent model as a CTE in one
+    query and hands it to a single ``source.read_sql``. It failed late and badly
+    instead — the driver for whichever source got picked complained about a
+    table belonging to the other one, and *which* source got picked came out of
+    set iteration order, so the same project could blame either half on
+    different runs.
 
-    * a **relation** produces a SQL ``JOIN`` between two models, and two
-      databases cannot be joined in one statement;
-    * an **insight** embeds every dependent model as a CTE in one query and
-      hands it to a single ``source.read_sql``.
+    What this validator deliberately does NOT reject:
 
-    Both failed late and badly instead — the driver for whichever source got
-    picked complained about a table belonging to the other one, and *which*
-    source got picked came out of set iteration order, so the same project could
-    blame either half on different runs. The rule to prevent it
-    (``Relation.validate_same_source``) was written and tested a long time ago
-    and never wired to anything.
+    * a **dynamic insight** (one with an ``Input`` descendant). It has no
+      ``pre_query``; each model is materialised against its own source and the
+      DuckDB ``post_query`` joins the parquet files client-side. Spanning
+      sources there works today and is the documented feature — see
+      ``visivo/query/source_scope``'s module docstring.
+    * a **relation** in isolation. A relation is a join condition, not an
+      executable thing; it is only wrong when a static insight compiles it into
+      a single-source statement. A relation reached only by dynamic insights (or
+      by no insight at all, which is every relation mid-authoring) is fine, so
+      the relation rule is asked only for relations whose two models both land
+      inside one static insight's model set — the same scoping
+      ``RelationGraph(relevant_models=...)`` uses when it decides which
+      relations to resolve. It is asked FIRST so the author reads about the join
+      they wrote rather than about the insight that consumed it.
 
     Runs last, after the reference and single-source validators: a broken
     ``${ref()}`` or a metric that already spans sources is the more local,
@@ -40,12 +51,28 @@ class CrossSourceValidator(BaseProjectValidator):
     def validate(self, project: "Project") -> "Project":
         dag = project.dag()
 
+        static_insights = [
+            insight
+            for insight in all_descendants_of_type(type=Insight, dag=dag)
+            if not insight.is_dynamic(dag)
+        ]
+        # Per insight, NOT unioned: model A in one insight and model B in
+        # another never meet in a single statement, so a relation between them
+        # is never compiled by either.
+        static_model_name_sets = [
+            {model.name for model in insight.get_all_dependent_models(dag) if model is not None}
+            for insight in static_insights
+        ]
+
         for relation in all_descendants_of_type(type=Relation, dag=dag):
+            referenced = set(relation.get_referenced_models())
+            if not any(referenced <= names for names in static_model_name_sets):
+                continue
             error = cross_source_relation_error(relation, dag)
             if error:
                 raise error
 
-        for insight in all_descendants_of_type(type=Insight, dag=dag):
+        for insight in static_insights:
             error = cross_source_insight_error(
                 insight.name, insight.get_all_dependent_models(dag), dag
             )

--- a/visivo/models/validators/cross_source_validator.py
+++ b/visivo/models/validators/cross_source_validator.py
@@ -1,0 +1,55 @@
+"""A relation joins, and an insight queries, inside ONE source."""
+
+from visivo.models.validators.base_validator import BaseProjectValidator
+from visivo.models.dag import all_descendants_of_type
+from visivo.models.insight import Insight
+from visivo.models.relation import Relation
+from visivo.query.source_scope import (
+    cross_source_insight_error,
+    cross_source_relation_error,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from visivo.models.project import Project
+
+
+class CrossSourceValidator(BaseProjectValidator):
+    """Reject at compile what can only be built wrong at run.
+
+    ``SingleSourceValidator`` already holds each *metric* and *dimension* to one
+    source, but nothing held the two objects that actually generate a join:
+
+    * a **relation** produces a SQL ``JOIN`` between two models, and two
+      databases cannot be joined in one statement;
+    * an **insight** embeds every dependent model as a CTE in one query and
+      hands it to a single ``source.read_sql``.
+
+    Both failed late and badly instead — the driver for whichever source got
+    picked complained about a table belonging to the other one, and *which*
+    source got picked came out of set iteration order, so the same project could
+    blame either half on different runs. The rule to prevent it
+    (``Relation.validate_same_source``) was written and tested a long time ago
+    and never wired to anything.
+
+    Runs last, after the reference and single-source validators: a broken
+    ``${ref()}`` or a metric that already spans sources is the more local,
+    more actionable mistake and should be the one the author reads first.
+    """
+
+    def validate(self, project: "Project") -> "Project":
+        dag = project.dag()
+
+        for relation in all_descendants_of_type(type=Relation, dag=dag):
+            error = cross_source_relation_error(relation, dag)
+            if error:
+                raise error
+
+        for insight in all_descendants_of_type(type=Insight, dag=dag):
+            error = cross_source_insight_error(
+                insight.name, insight.get_all_dependent_models(dag), dag
+            )
+            if error:
+                raise error
+
+        return project

--- a/visivo/models/validators/project_validator.py
+++ b/visivo/models/validators/project_validator.py
@@ -14,6 +14,7 @@ from visivo.models.validators.single_source_validator import SingleSourceValidat
 from visivo.models.validators.standalone_field_refs_validator import (
     StandaloneFieldRefsValidator,
 )
+from visivo.models.validators.cross_source_validator import CrossSourceValidator
 from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:
@@ -47,6 +48,11 @@ class ProjectValidator:
             # mistake it is rather than as a whole-project failure.
             StandaloneFieldRefsValidator(),
             SingleSourceValidator(),
+            # Last: a relation or insight that spans sources is a structural
+            # failure of the whole join, so every more local mistake that could
+            # explain it (a broken ref, a metric already spanning sources) gets
+            # to be reported first.
+            CrossSourceValidator(),
         ]
 
     def validate(self, project: "Project") -> "Project":

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -23,7 +23,7 @@ from visivo.query.sqlglot_utils import (
     normalize_identifier_for_dialect,
 )
 from visivo.query.schema_aggregator import SchemaAggregator
-from visivo.query.source_scope import cross_source_insight_error
+from visivo.query.source_scope import resolve_insight_source
 from visivo.query.patterns import (
     INPUT_ACCESSOR_PATTERN,
     extract_input_accessors,
@@ -307,17 +307,24 @@ class InsightQueryBuilder:
         # DuckDB/post_query-only build path regardless of is_dynamic()".
         self.is_dynamic = force_dynamic or insight.is_dynamic(dag)
         self.models = insight.get_all_dependent_models(dag)
-        # Anything that reaches here with models on two sources got past
-        # CrossSourceValidator — a draft assembled by the server, a project
-        # built in code, a Project.validate() that was never called. There is no
-        # correct query to build from it: the CTEs would name tables from both
-        # databases and execute against one. Fail with the same sentence the
-        # compile-time validator uses rather than let get_dependent_source pick
-        # an arbitrary winner and hand the user the other source's driver error.
-        cross_source = cross_source_insight_error(self.insight_name, self.models, dag, output_dir)
-        if cross_source:
-            raise cross_source
-        source = insight.get_dependent_source(dag, output_dir)
+        # One call, two jobs, and both of them depend on the lane:
+        #
+        # * NOT dynamic — the CTEs are compiled into one `pre_query` that runs
+        #   against one `source.read_sql`, so models on two sources have no
+        #   correct query at all. Refuse in the same sentence the compile-time
+        #   validator uses rather than let an arbitrary winner be picked and
+        #   hand the user the other source's "table does not exist".
+        # * dynamic (or `force_dynamic`) — `pre_query` is None. Each model was
+        #   already materialised against ITS OWN source and the DuckDB
+        #   `post_query` joins the parquet files, so two sources is the
+        #   documented feature, not a failure. The source is still resolved
+        #   because `get_sqlglot_dialect` is read below, but nothing is executed
+        #   against it; `resolve_insight_source` walks models in NAME order so
+        #   the pick (and any "no source found" message) is stable run to run,
+        #   which `insight.get_dependent_source`'s `list(a_set)[0]` was not.
+        source = resolve_insight_source(
+            self.insight_name, self.models, dag, output_dir, is_dynamic=self.is_dynamic
+        )
         # getattr, not attribute access: a CSVFileSource/ExcelFileSource is a
         # DuckDB source over a file and carries neither field, so the plain
         # reads raised AttributeError on the way to a query that never needed

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -23,6 +23,7 @@ from visivo.query.sqlglot_utils import (
     normalize_identifier_for_dialect,
 )
 from visivo.query.schema_aggregator import SchemaAggregator
+from visivo.query.source_scope import cross_source_insight_error
 from visivo.query.patterns import (
     INPUT_ACCESSOR_PATTERN,
     extract_input_accessors,
@@ -306,9 +307,23 @@ class InsightQueryBuilder:
         # DuckDB/post_query-only build path regardless of is_dynamic()".
         self.is_dynamic = force_dynamic or insight.is_dynamic(dag)
         self.models = insight.get_all_dependent_models(dag)
+        # Anything that reaches here with models on two sources got past
+        # CrossSourceValidator — a draft assembled by the server, a project
+        # built in code, a Project.validate() that was never called. There is no
+        # correct query to build from it: the CTEs would name tables from both
+        # databases and execute against one. Fail with the same sentence the
+        # compile-time validator uses rather than let get_dependent_source pick
+        # an arbitrary winner and hand the user the other source's driver error.
+        cross_source = cross_source_insight_error(self.insight_name, self.models, dag, output_dir)
+        if cross_source:
+            raise cross_source
         source = insight.get_dependent_source(dag, output_dir)
-        self.default_schema = source.db_schema
-        self.default_database = source.database
+        # getattr, not attribute access: a CSVFileSource/ExcelFileSource is a
+        # DuckDB source over a file and carries neither field, so the plain
+        # reads raised AttributeError on the way to a query that never needed
+        # either value (both are only consumed by the non-dynamic CTE qualify).
+        self.default_schema = getattr(source, "db_schema", None)
+        self.default_database = getattr(source, "database", None)
         self.source_dialect = source.get_sqlglot_dialect()
         self.native_dialect = "duckdb" if self.is_dynamic else self.source_dialect
         field_resolver = FieldResolver(

--- a/visivo/query/source_scope.py
+++ b/visivo/query/source_scope.py
@@ -1,0 +1,233 @@
+"""Does this thing live in exactly ONE source?
+
+A relation joins two models with a SQL ``JOIN``; an insight embeds every model
+it touches as a CTE in one statement and hands that statement to a single
+``source.read_sql``. Both are single-source constructs by construction — when
+the objects they name resolve to two different databases there is no correct
+query to build, only a wrong one.
+
+The rule already existed and was never asked. ``Relation.validate_same_source``
+was written, worded well and fully tested, and called by nothing outside its own
+tests, so a cross-source relation compiled clean and failed much later as a raw
+driver error ("table X does not exist") against whichever source an arbitrary
+``list(models)[0]`` pick landed on. That pick is from a *set*, so which half of
+the join the user was told about could change between runs of the same project.
+
+Everything here is a pure function over the DAG, with one wording shared by the
+compile-time validator, ``InsightQueryBuilder``, ``run_insight_job`` and the
+draft-preview endpoint — an author who slips past one gate meets the same
+sentence at the next. Names are sorted before they are reported: the message is
+part of the contract and must not depend on set iteration order.
+
+``output_dir`` is threaded through only because callers already hold one;
+``get_source_for_model`` has never read it.
+"""
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from visivo.models.diagnostic import (
+    Diagnostic,
+    DiagnosticObjectRef,
+    DiagnosticPhase,
+    DiagnosticRelated,
+    DiagnosticSeverity,
+)
+
+# The wire ``error_type`` a cross-source failure carries. Matches the value the
+# draft-preview endpoint has always returned so the viewer keeps one branch.
+CROSS_SOURCE_ERROR_TYPE = "multi_source"
+
+
+class CrossSourceError(ValueError):
+    """A relation or insight spans more than one source.
+
+    A ``ValueError`` so every existing ``except ValueError`` around project
+    validation keeps working, with three additions:
+
+    * ``message`` — the plain multi-line text. ``run_insight_job``'s error path
+      prefers ``e.message`` over ``repr(e)``, so the user reads the sentence
+      instead of a quoted exception repr with escaped newlines.
+    * ``diagnostic()`` — the structured ``Diagnostic`` for consumers that speak
+      the contract.
+    * ``error_details()`` — the ``JobResult.error_details`` dict, shaped like
+      the join-path failures the preview run status already carries.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        object_type: str,
+        object_name: str,
+        pairs: Iterable[Tuple[str, str]],
+    ):
+        super().__init__(message)
+        self.message = message
+        self.object_type = object_type
+        self.object_name = object_name
+        # (model_name, source_name), sorted by model name by the builder.
+        self.pairs: List[Tuple[str, str]] = list(pairs)
+        self.model_names = [model for model, _ in self.pairs]
+        self.source_names = sorted({source for _, source in self.pairs})
+
+    def diagnostic(self, phase: DiagnosticPhase = DiagnosticPhase.RUN) -> Diagnostic:
+        return Diagnostic(
+            id=f"{phase.value}:cross_source:{self.object_type}:{self.object_name}",
+            severity=DiagnosticSeverity.ERROR,
+            phase=phase,
+            code="cross_source",
+            message=self.message.splitlines()[0],
+            object=DiagnosticObjectRef(type=self.object_type, name=self.object_name),
+            detail=self.message,
+            hint=(
+                f"Point every model this {self.object_type} reaches at one source, "
+                "or split the work into one object per source."
+            ),
+            related=[
+                DiagnosticRelated(
+                    message=f"Model '{model}' uses source: {source}",
+                    object=DiagnosticObjectRef(type="model", name=model),
+                )
+                for model, source in self.pairs
+            ],
+        )
+
+    def error_details(self) -> dict:
+        return {
+            "error_type": CROSS_SOURCE_ERROR_TYPE,
+            "error_models": self.model_names,
+            "error_sources": self.source_names,
+        }
+
+
+def source_names_by_model(models, dag, output_dir: str = "") -> Dict[str, str]:
+    """``{model_name: source_name}`` for every model whose source resolves.
+
+    Models whose source cannot be resolved are omitted rather than reported —
+    ``ModelsHaveSourcesValidator`` owns that failure, and guessing here would
+    turn a missing source into a bogus cross-source complaint.
+    """
+    from visivo.jobs.utils import get_source_for_model
+
+    resolved: Dict[str, str] = {}
+    for model in models:
+        if model is None:
+            continue
+        source = get_source_for_model(model, dag, output_dir)
+        if source is not None and getattr(source, "name", None):
+            resolved[model.name] = source.name
+    return resolved
+
+
+def _build(
+    *,
+    headline: str,
+    closing: str,
+    object_type: str,
+    object_name: str,
+    pairs: List[Tuple[str, str]],
+) -> CrossSourceError:
+    detail_lines = "\n".join(f"  Model '{model}' uses source: {source}" for model, source in pairs)
+    return CrossSourceError(
+        f"{headline}\n\n{detail_lines}\n\n{closing}",
+        object_type=object_type,
+        object_name=object_name,
+        pairs=pairs,
+    )
+
+
+def cross_source_relation_error(relation, dag, output_dir: str = "") -> Optional[CrossSourceError]:
+    """The failure for a relation joining two sources, or ``None``.
+
+    Returns rather than raises so the caller decides: the project validator
+    raises it; an advisory pass could report it instead once cross-source
+    execution exists. Only the two-model form is checked — ``RelationGraph``
+    silently skips any other arity, so complaining about it here would be the
+    wrong place to start that argument.
+    """
+    model_names = sorted(relation.get_referenced_models())
+    if len(model_names) != 2:
+        return None  # Other validation handles this case.
+
+    models = []
+    for name in model_names:
+        try:
+            models.append(dag.get_descendant_by_name(name))
+        except Exception:
+            return None  # A broken ref is RelationReferencesValidator's to report.
+
+    resolved = source_names_by_model(models, dag, output_dir)
+    if len(resolved) != 2:
+        return None
+    pairs = sorted(resolved.items())
+    if len({source for _, source in pairs}) == 1:
+        return None
+
+    return _build(
+        headline=f"Relation '{relation.name}' connects models from different sources.",
+        closing=(
+            "Cross-source relations are not currently supported. "
+            "Both models must use the same source."
+        ),
+        object_type="relation",
+        object_name=relation.name,
+        pairs=pairs,
+    )
+
+
+def cross_source_insight_error(
+    insight_name: str, models, dag, output_dir: str = ""
+) -> Optional[CrossSourceError]:
+    """The failure for an insight whose models span sources, or ``None``.
+
+    The built ``pre_query`` embeds every dependent model's CTE but executes
+    against exactly one source, so two sources means one of them is absent at
+    execution time — historically surfacing as the *other* source's driver
+    complaining about a table it has never heard of.
+    """
+    resolved = source_names_by_model(models, dag, output_dir)
+    source_names = sorted(set(resolved.values()))
+    if len(source_names) < 2:
+        return None
+
+    pairs = sorted(resolved.items())
+    return _build(
+        headline=(
+            f"Insight '{insight_name}' references models from more than one source: "
+            f"{', '.join(source_names)}."
+        ),
+        closing=(
+            "Cross-source insights are not currently supported. "
+            "Every model an insight references must use the same source."
+        ),
+        object_type="insight",
+        object_name=insight_name,
+        pairs=pairs,
+    )
+
+
+def resolve_insight_source(insight_name: str, models, dag, output_dir: str = ""):
+    """The one source every model of an insight resolves to.
+
+    Raises ``CrossSourceError`` when they disagree, so no caller is ever handed
+    an arbitrary winner. When they agree the pick walks models in name order
+    rather than ``list(a_set)[0]``: the source that comes back is the same
+    either way once they agree, but the *model* named by any downstream
+    "no source found" message stops changing between runs.
+    """
+    from visivo.jobs.utils import get_source_for_model
+
+    ordered = sorted((m for m in models if m is not None), key=lambda m: m.name)
+    if not ordered:
+        raise ValueError(f"Insight '{insight_name}' has no dependent models")
+
+    error = cross_source_insight_error(insight_name, ordered, dag, output_dir)
+    if error:
+        raise error
+
+    for model in ordered:
+        source = get_source_for_model(model, dag, output_dir)
+        if source is not None:
+            return source
+
+    raise ValueError(f"No source found for model '{ordered[0].name}' in insight '{insight_name}'")

--- a/visivo/query/source_scope.py
+++ b/visivo/query/source_scope.py
@@ -1,13 +1,35 @@
-"""Does this thing live in exactly ONE source?
+"""Does this ONE STATEMENT live in exactly ONE source?
 
-A relation joins two models with a SQL ``JOIN``; an insight embeds every model
-it touches as a CTE in one statement and hands that statement to a single
-``source.read_sql``. Both are single-source constructs by construction — when
-the objects they name resolve to two different databases there is no correct
-query to build, only a wrong one.
+The rule is about a *lane*, not about an object. Visivo executes an insight two
+different ways, and only one of them can be wrong across sources:
 
-The rule already existed and was never asked. ``Relation.validate_same_source``
-was written, worded well and fully tested, and called by nothing outside its own
+* **Static lane** (``pre_query``) — the builder embeds every dependent model as
+  a CTE in one statement and hands that statement to a single
+  ``source.read_sql``. Two sources means half the CTEs name tables the executing
+  database has never heard of. There is no correct query to build, only a wrong
+  one.
+* **Dynamic lane** (``post_query``, an insight with an ``Input`` descendant, or
+  a ``force_dynamic`` draft) — ``pre_query`` is ``None``. ``run_sql_model_job``
+  has already materialised EACH model against ITS OWN source into
+  ``models/<name>.parquet``, and the DuckDB-dialect ``post_query`` joins those
+  parquet files client-side. Cross-source is not a mistake here, it is the
+  documented feature (``mkdocs/topics/sources.md``: "you can bring data together
+  in a single chart with insights whose models originate from different
+  sources"). Refusing it would break projects that run correctly today.
+
+So ``cross_source_insight_error`` takes ``is_dynamic`` and answers ``None`` for
+the dynamic lane. The flag is keyword-only and defaults to ``False`` — the
+strict single-statement reading — so a caller that has not thought about the
+lane gets the conservative answer rather than a silent hole.
+
+A **relation** is a join condition, not an executable thing: whether it can be
+compiled depends entirely on which insight consumes it, so the caller
+(``CrossSourceValidator``) decides whether a relation is reachable from the
+static lane before asking. ``cross_source_relation_error`` stays a pure
+predicate over two models.
+
+The rule existed and was never asked. ``Relation.validate_same_source`` was
+written, worded well and fully tested, and called by nothing outside its own
 tests, so a cross-source relation compiled clean and failed much later as a raw
 driver error ("table X does not exist") against whichever source an arbitrary
 ``list(models)[0]`` pick landed on. That pick is from a *set*, so which half of
@@ -176,15 +198,26 @@ def cross_source_relation_error(relation, dag, output_dir: str = "") -> Optional
 
 
 def cross_source_insight_error(
-    insight_name: str, models, dag, output_dir: str = ""
+    insight_name: str, models, dag, output_dir: str = "", *, is_dynamic: bool = False
 ) -> Optional[CrossSourceError]:
-    """The failure for an insight whose models span sources, or ``None``.
+    """The failure for a STATIC insight whose models span sources, or ``None``.
 
     The built ``pre_query`` embeds every dependent model's CTE but executes
     against exactly one source, so two sources means one of them is absent at
     execution time — historically surfacing as the *other* source's driver
     complaining about a table it has never heard of.
+
+    ``is_dynamic=True`` (the insight has an ``Input`` descendant, or the caller
+    forced the dynamic build) short-circuits to ``None``: that lane has no
+    ``pre_query`` at all. Each model was materialised against its own source
+    into ``models/<name>.parquet`` and the DuckDB ``post_query`` joins the
+    parquet files, so spanning sources there is the documented feature rather
+    than a mistake. Keyword-only and defaulted off so the strict, single
+    statement reading is what a caller gets by accident.
     """
+    if is_dynamic:
+        return None
+
     resolved = source_names_by_model(models, dag, output_dir)
     source_names = sorted(set(resolved.values()))
     if len(source_names) < 2:
@@ -206,14 +239,22 @@ def cross_source_insight_error(
     )
 
 
-def resolve_insight_source(insight_name: str, models, dag, output_dir: str = ""):
-    """The one source every model of an insight resolves to.
+def resolve_insight_source(
+    insight_name: str, models, dag, output_dir: str = "", *, is_dynamic: bool = False
+):
+    """The one source a STATIC insight's models resolve to.
 
     Raises ``CrossSourceError`` when they disagree, so no caller is ever handed
     an arbitrary winner. When they agree the pick walks models in name order
     rather than ``list(a_set)[0]``: the source that comes back is the same
     either way once they agree, but the *model* named by any downstream
     "no source found" message stops changing between runs.
+
+    ``is_dynamic=True`` keeps the deterministic walk and drops the refusal. The
+    dynamic lane still wants A source — the builder reads a dialect off it —
+    but it never executes ``pre_query`` against it, so which of two legitimately
+    different sources answers is immaterial as long as it is the same one every
+    run.
     """
     from visivo.jobs.utils import get_source_for_model
 
@@ -221,7 +262,9 @@ def resolve_insight_source(insight_name: str, models, dag, output_dir: str = "")
     if not ordered:
         raise ValueError(f"Insight '{insight_name}' has no dependent models")
 
-    error = cross_source_insight_error(insight_name, ordered, dag, output_dir)
+    error = cross_source_insight_error(
+        insight_name, ordered, dag, output_dir, is_dynamic=is_dynamic
+    )
     if error:
         raise error
 

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -80,19 +80,31 @@ def register_insight_execute_views(app, flask_app, output_dir):
         run_output_dir = f"{output_dir}/{DEFAULT_RUN_ID}"
 
         # Reject a genuinely MULTI-SOURCE insight up front (before the query
-        # build). A relation-join insight spans >1 model and the built pre_query
-        # embeds every model's CTE, so all dependent models must resolve to ONE
+        # build) — but only on THIS endpoint's lane. Here `force_dynamic=False`,
+        # so a relation-join insight spans >1 model and the built pre_query
+        # embeds every model's CTE: all dependent models must resolve to ONE
         # source for a single source.read_sql to be correct. get_dependent_source
         # picks an ARBITRARY model's source rather than enforcing this, so a
         # two-source insight would otherwise execute against one source and
         # surface a raw "table does not exist" driver error for the other's
         # tables. The wording comes from visivo.query.source_scope so a draft
         # rejected here reads exactly like the same project rejected at compile
-        # or at run. `dependent_models` is reused for the response payload below.
+        # or at run.
+        #
+        # A DYNAMIC draft has no pre_query to bake, so it is not this endpoint's
+        # to refuse: it belongs in the 409 `requires_client_lane` branch below,
+        # where the client runs it in DuckDB over the models' own parquet — the
+        # lane on which cross-source is the documented feature. 400-ing it here
+        # would dead-end a chart that works. `dependent_models` is reused for
+        # the response payload below.
         try:
             dependent_models = insight.get_all_dependent_models(dag)
             cross_source = cross_source_insight_error(
-                insight.name, dependent_models, dag, run_output_dir
+                insight.name,
+                dependent_models,
+                dag,
+                run_output_dir,
+                is_dynamic=insight.is_dynamic(dag),
             )
         except Exception as e:
             return jsonify({"error": str(e)}), 400

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -37,7 +37,8 @@ from flask import request, jsonify
 from visivo.constants import DEFAULT_RUN_ID
 from visivo.logger.logger import Logger
 from visivo.jobs.run_model_data_job import execute_and_get_result
-from visivo.jobs.utils import get_source_for_model
+from visivo.models.diagnostic import DiagnosticPhase
+from visivo.query.source_scope import cross_source_insight_error
 from visivo.query.insight.draft_overlay import build_draft_overlay, DraftOverlayError
 from visivo.server.views.insight_draft_common import (
     parse_draft_request,
@@ -85,26 +86,25 @@ def register_insight_execute_views(app, flask_app, output_dir):
         # picks an ARBITRARY model's source rather than enforcing this, so a
         # two-source insight would otherwise execute against one source and
         # surface a raw "table does not exist" driver error for the other's
-        # tables. `dependent_models` is reused for the response payload below.
+        # tables. The wording comes from visivo.query.source_scope so a draft
+        # rejected here reads exactly like the same project rejected at compile
+        # or at run. `dependent_models` is reused for the response payload below.
         try:
             dependent_models = insight.get_all_dependent_models(dag)
-            source_names = {
-                src.name
-                for src in (get_source_for_model(m, dag, run_output_dir) for m in dependent_models)
-                if src
-            }
+            cross_source = cross_source_insight_error(
+                insight.name, dependent_models, dag, run_output_dir
+            )
         except Exception as e:
             return jsonify({"error": str(e)}), 400
-        if len(source_names) > 1:
+        if cross_source:
             return (
                 jsonify(
                     {
-                        "error": (
-                            f"Insight '{insight.name}' references models from more than one "
-                            f"source ({', '.join(sorted(source_names))}) and cannot be "
-                            "previewed server-side."
+                        "error": cross_source.message,
+                        **cross_source.error_details(),
+                        "diagnostic": cross_source.diagnostic(DiagnosticPhase.SERVE).model_dump(
+                            mode="json", exclude_none=True
                         ),
-                        "error_type": "multi_source",
                     }
                 ),
                 400,


### PR DESCRIPTION
## Problem

`Relation.validate_same_source` has been in the tree for a long time: complete, well-worded, fully tested — and called by nothing but its own tests. `ProjectValidator` registered eleven validators and none of them for this, and `SingleSourceValidator` only covers metrics and dimensions.

So an insight or relation whose objects span two sources compiles clean, and then:

* `Insight.get_dependent_source` picks `list(models)[0]` off a **set** and builds a query whose CTEs name tables from both databases;
* `run_insight_job.action` independently picks `all_descendants_of_type(...)[0]`;
* the query executes against one of them and the user gets that driver's "table does not exist" about the *other* source's tables.

Because both picks come off sets of objects and strings, *which* half of the join got blamed changed between runs of the same project — the failure read like a flake instead of a fact. Only the draft-preview endpoint had a guard, so `visivo run` had none.

## Fix

**New `visivo/query/source_scope.py`** — the rule as pure functions over the DAG, with one wording used by every gate, and `CrossSourceError` (a `ValueError`) carrying `message`, a `Diagnostic`, and the `error_details` dict the preview run status already speaks.

**T1 — compile time.** `CrossSourceValidator` registered last in `ProjectValidator.__init__` (following #640's `StandaloneFieldRefsValidator` pattern), covering both **relations** and **insights**. It runs after the reference and single-source validators on purpose: a broken `${ref()}`, or a metric that already spans sources, is the more local mistake and should be the sentence the author reads first. `Relation.validate_same_source` stays as a delegating shim (its `output_dir` is now optional — `get_source_for_model` has never read it).

The message names the object, both models and both sources:

```
Insight 'revenue_by_user' references models from more than one source: analytics_db, warehouse.

  Model 'orders' uses source: warehouse
  Model 'users' uses source: analytics_db

Cross-source insights are not currently supported. Every model an insight references
must use the same source.
```

**T2 — runtime guards, same sentence.** `InsightQueryBuilder.__init__` refuses before it resolves a source; `run_insight_job.action` resolves through `resolve_insight_source` instead of `[0]` and attaches `{error_type: "multi_source", error_models, error_sources, diagnostic}` to the `JobResult`; `insight_execute_views` now renders the shared message instead of its own bespoke one (it keeps `error_type: multi_source`, and gains `error_models` + `diagnostic`).

**Determinism.** Every name is sorted before it is reported. Proven, not asserted — see falsification E.

**Diagnostic.** `cross_source` appended to `DIAGNOSTIC_CODES` (append-only respected: nothing renamed or removed), emitted at `run` from the job and at `serve` from the endpoint.

**B3 (subsumed per the dossier).** `getattr(source, "db_schema"/"database", None)` — a `CSVFileSource` is a DuckDB source over a file and carries neither field, so the plain reads raised `AttributeError` on the way to a query that never needed either value (both are only consumed by the non-dynamic CTE `qualify`). This is the getattr half of VIS-1289; that issue's larger "delete csv/xls behind SourceTypeDeprecation" scope is untouched.

### What I deliberately did not do

* **The lazy half of T2** (resolve the source only when `not is_dynamic`). It is not required for the guard — the guard runs *before* the resolution and subsumes the arbitrary pick entirely. It is a T9 enabling step (a dynamic multi-source insight would no longer need a source at all), and on its own today it would only change behaviour for drafts whose source does not resolve. Independent scope; left for T9.
* **The `JoinOperatorPopover` source-mismatch band.** Viewer surface, needs its own e2e/screenshot acceptance. Still open under VIS-1294.
* `run_insight_job.job()`'s `_get_source` still uses the `[0]` pick. Raising there would abort the whole run with a traceback instead of failing one insight into a `JobResult` — the guard belongs in `action`.

## Falsification evidence

Each guard was removed with the tests left in place; every one failed, and the restore is green (`57 passed, 3 xfailed`). Script: `scratchpad/lanes2/falsify.sh`.

**A — unregister `CrossSourceValidator`:**
```
FAILED ...TestItIsRegistered::test_it_runs_last - assert 'SingleSourceValidator' == 'CrossSourceValidator'
FAILED ...TestRelations::test_a_cross_source_relation_fails_the_project - Failed: DID NOT RAISE ValidationError
FAILED ...TestInsights::test_a_cross_source_insight_fails_the_project - Failed: DID NOT RAISE ValidationError
3 failed, 6 passed
```

**B — remove the `InsightQueryBuilder` guard:**
```
FAILED ...::test_it_refuses_to_build_across_sources - Failed: DID NOT RAISE CrossSourceError
```

**C — restore the getattr-free attribute reads:**
```
E  AttributeError: 'CSVFileSource' object has no attribute 'db_schema'. Did you mean: 'get_schema'?
FAILED ...::test_a_file_source_without_db_schema_does_not_raise_attribute_error
```

**D — restore `run_insight_job`'s arbitrary `[0]` pick:**
```
>   assert result.error_details["error_type"] == "multi_source"
E   TypeError: 'NoneType' object is not subscriptable
FAILED ...TestRunInsightJob::test_the_job_fails_with_the_message_and_typed_details
```

**E — unsort the message.** This is the non-determinism, reproduced: the same broken project blames a different half of the join depending on `PYTHONHASHSEED`.
```
E  AssertionError: message varies with hash seed: {
     "...\n  Model 'apple' uses source: s_apple\n  Model 'zebra' uses source: s_zebra\n...",
     "...\n  Model 'zebra' uses source: s_zebra\n  Model 'apple' uses source: s_apple\n..."
   }
E  assert 2 == 1
FAILED tests/query/test_source_scope.py::test_the_message_is_identical_under_every_hash_seed
```

**F — restore the endpoint's bespoke wording:**
```
E  assert 'references models from more than one source: warehouse, warehouse2' in
     "Insight 'cross' references models from more than one source and cannot be previewed server-side."
```

## Tests

`2494 passed, 2 skipped, 5 xfailed, 1 xpassed` — full suite, zero failures. `black --check --target-version py312 .` clean (548 files).

New: `tests/query/test_source_scope.py` (15), `tests/models/validators/test_cross_source_validator.py` (9), `tests/jobs/test_run_insight_job_cross_source.py` (5). All use factory-boy factories.

Three existing tests are updated, all for the same reason worth knowing about: **a cross-source project can no longer be constructed at all.** `Project`'s `mode="after"` validator runs `ProjectValidator`, so `Project(...)` with models on two sources now raises `ValidationError` — which is the fix, but it means any test that wants the invalid state has to reach it the way the real bypass paths do: build the legal project, move one model's source afterwards (nothing re-validates on assignment), `invalidate_dag_cache()`. That is also exactly how the runtime-guard tests prove the guards fire on input the validator never saw.

## Schema

`python -m visivo.generate_project_schema_json` produces **no diff** — `Diagnostic` is not reachable from `Project`, so `visivo/src/visivo_project_schema.json` is unchanged and this PR does **not** overlap #642's regeneration of that file.

Linear: VIS-1294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
