### PR TITLE
Fail the build when a positional axis resolves to a STRUCT (WB9 / S5-14)

### DIFF
--- a/tests/models/test_diagnostic.py
+++ b/tests/models/test_diagnostic.py
@@ -129,3 +129,15 @@ def test_from_exception_never_raises_on_an_unregistered_code():
     assert diagnostic.code == "unexpected_error"
     assert diagnostic.message == "the real failure"
     assert "typo_code" in diagnostic.detail
+
+
+def test_non_plottable_axis_type_code_is_registered():
+    """WB9's code joins the append-only vocabulary; consumers branch on it."""
+    assert "non_plottable_axis_type" in DIAGNOSTIC_CODES
+    diagnostic = Diagnostic(
+        phase=DiagnosticPhase.COMPILE,
+        code="non_plottable_axis_type",
+        message="positional axis prop 'props.x' resolves to a STRUCT",
+        field="props.x",
+    )
+    assert diagnostic.code == "non_plottable_axis_type"

--- a/tests/models/test_diagnostic.py
+++ b/tests/models/test_diagnostic.py
@@ -1,3 +1,6 @@
+import re
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -141,3 +144,58 @@ def test_non_plottable_axis_type_code_is_registered():
         field="props.x",
     )
     assert diagnostic.code == "non_plottable_axis_type"
+
+
+# ---------------------------------------------------------------------------
+# The Python <-> viewer mirror
+# ---------------------------------------------------------------------------
+
+VIEWER_DIAGNOSTIC_JS = (
+    Path(__file__).resolve().parents[2] / "viewer" / "src" / "types" / "diagnostic.js"
+)
+
+
+def _js_string_array(source: str, name: str):
+    """The string literals of a top-level ``export const <name> = [...]``.
+
+    Deliberately a tiny reader over a flat literal array rather than a JS
+    parser: the arrays are hand-maintained flat lists of quoted strings, and
+    the whole point of this guard is that it stays cheap enough to keep.
+    """
+    match = re.search(rf"export const {name} = \[(.*?)\];", source, re.DOTALL)
+    assert match, f"{name} not found in {VIEWER_DIAGNOSTIC_JS}"
+    return [m.group(1) for m in re.finditer(r"'([^']+)'", match.group(1))]
+
+
+@pytest.mark.skipif(
+    not VIEWER_DIAGNOSTIC_JS.exists(),
+    reason="viewer sources are not present (packaged install)",
+)
+def test_viewer_mirror_lists_every_diagnostic_code():
+    """``visivo/models/diagnostic.py`` states: "The mirror typedef for viewer
+    code lives at viewer/src/types/diagnostic.js. Keep the two in sync — the
+    shape is the contract." Nothing enforced it, and WB9's
+    ``non_plottable_axis_type`` shipped on the Python side only.
+
+    A code missing from the viewer list is not inert: viewer surfaces branch on
+    the vocabulary (join-fix cards, not-built empty states), so an unlisted code
+    falls through to the generic path with no card — the same silent failure
+    class the code was added to close.
+    """
+    source = VIEWER_DIAGNOSTIC_JS.read_text()
+    assert _js_string_array(source, "DIAGNOSTIC_CODES") == list(DIAGNOSTIC_CODES), (
+        "DIAGNOSTIC_CODES drifted between visivo/models/diagnostic.py and "
+        f"{VIEWER_DIAGNOSTIC_JS}"
+    )
+
+
+@pytest.mark.skipif(
+    not VIEWER_DIAGNOSTIC_JS.exists(),
+    reason="viewer sources are not present (packaged install)",
+)
+def test_viewer_mirror_lists_every_phase_and_severity():
+    source = VIEWER_DIAGNOSTIC_JS.read_text()
+    assert _js_string_array(source, "DIAGNOSTIC_PHASES") == [p.value for p in DiagnosticPhase]
+    assert _js_string_array(source, "DIAGNOSTIC_SEVERITIES") == [
+        s.value for s in DiagnosticSeverity
+    ]

--- a/tests/query/insight/test_positional_axis_type_gate.py
+++ b/tests/query/insight/test_positional_axis_type_gate.py
@@ -1,0 +1,360 @@
+"""WB9 / S5-14: the build-time gate on positional-axis prop types.
+
+The failure this closes: an insight whose ``x`` (or any other coordinate)
+resolves to a record-shaped SQL type builds "successfully" and renders a BLANK
+chart with a SUCCESS job. The canonical producer is a doubled query string
+``?{?{col}}`` — SQLGlot parses the residual ``?{col}`` as a DuckDB struct
+literal, which round-trips through parquet as ``STRUCT(VARCHAR)``.
+
+Three properties are pinned here, each falsifiable on its own:
+1. a STRUCT on a positional axis FAILS the build, with the insight, prop,
+   column and type in the message;
+2. a STRUCT on a NON-positional prop is untouched (the gate is scoped);
+3. every type an axis can render is still accepted (no over-rejection).
+"""
+
+import json
+import os
+
+import pytest
+from sqlglot import exp
+
+from visivo.models.diagnostic import (
+    DIAGNOSTIC_CODES,
+    Diagnostic,
+    DiagnosticPhase,
+    DiagnosticSeverity,
+)
+from visivo.models.insight import Insight
+from visivo.models.models.sql_model import SqlModel
+from visivo.models.project import Project
+from visivo.models.props.insight_props import InsightProps
+from visivo.query.insight.insight_query_builder import InsightQueryBuilder
+from visivo.query.insight.prop_type_validator import (
+    NON_PLOTTABLE_AXIS_TYPES,
+    PLOTTABLE_AXIS_TYPES,
+    POSITIONAL_AXIS_PROP_NAMES,
+    PositionalAxisTypeError,
+    axis_plottability,
+    check_positional_axis_plottability,
+    is_positional_axis_prop,
+)
+from tests.factories.model_factories import SourceFactory
+
+# ---------------------------------------------------------------------------
+# Build harness: a real InsightQueryBuilder over a one-model project.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def build_insight(tmpdir):
+    def _build(insight, schema=None, force_dynamic=False):
+        source = SourceFactory()
+        model = SqlModel(name="m", sql="SELECT * FROM t", source=f"ref({source.name})")
+        project = Project(
+            name="p", sources=[source], models=[model], insights=[insight], dashboards=[]
+        )
+        dag = project.dag()
+        schema_dir = os.path.join(str(tmpdir), "schemas")
+        os.makedirs(schema_dir, exist_ok=True)
+        with open(os.path.join(schema_dir, f"{model.name}.json"), "w") as f:
+            json.dump(
+                {model.name_hash(): schema or {"site": "VARCHAR", "amt": "DOUBLE"}},
+                f,
+            )
+        builder = InsightQueryBuilder(insight, dag, str(tmpdir), force_dynamic=force_dynamic)
+        builder.resolve()
+        return builder.build()
+
+    return _build
+
+
+# ---------------------------------------------------------------------------
+# 1. STRUCT on a positional axis is REJECTED (the S5-14 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_struct_on_x_fails_the_build_naming_insight_prop_column_and_type(build_insight):
+    """The exact S5-14 shape: ``x: ?{?{col}}``. Today it builds and renders
+    blank; the gate must abort the build."""
+    insight = Insight(
+        name="site_totals",
+        props=InsightProps(
+            type="bar",
+            x="?{?{${ref(m).site}}}",
+            y="?{count(${ref(m).amt})}",
+        ),
+    )
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight)
+
+    message = str(excinfo.value)
+    assert "site_totals" in message, message  # the insight
+    assert "props.x" in message, message  # the prop
+    assert "'site'" in message, message  # the column
+    assert "STRUCT" in message, message  # the type
+    # Actionable: points at the doubled query string that produced it.
+    assert "?{?{" in message, message
+
+
+def test_struct_on_x_carries_a_structured_diagnostic(build_insight):
+    insight = Insight(
+        name="site_totals",
+        props=InsightProps(type="bar", x="?{?{${ref(m).site}}}", y="?{count(${ref(m).amt})}"),
+    )
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight)
+
+    diagnostic = excinfo.value.diagnostic
+    assert isinstance(diagnostic, Diagnostic)
+    assert diagnostic.code == "non_plottable_axis_type"
+    assert diagnostic.code in DIAGNOSTIC_CODES
+    assert diagnostic.phase == DiagnosticPhase.COMPILE
+    assert diagnostic.severity == DiagnosticSeverity.ERROR
+    assert diagnostic.object.type == "insight"
+    assert diagnostic.object.name == "site_totals"
+    assert diagnostic.field == "props.x"
+    assert "STRUCT" in (diagnostic.detail or "")
+    assert diagnostic.hint
+    # Stable across polls — derived from phase/code/object/field, not random.
+    assert diagnostic.id == "compile:non_plottable_axis_type:site_totals:props.x"
+
+
+def test_struct_on_y_also_fails(build_insight):
+    insight = Insight(
+        name="i",
+        props=InsightProps(type="bar", x="?{${ref(m).site}}", y="?{?{${ref(m).amt}}}"),
+    )
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight)
+    assert "props.y" in str(excinfo.value)
+
+
+def test_struct_on_the_dynamic_preview_path_also_fails(build_insight):
+    """The Explorer preview (force_dynamic) build must gate too — that is the
+    surface where the blank chart is actually seen."""
+    insight = Insight(
+        name="i",
+        props=InsightProps(type="bar", x="?{?{${ref(m).site}}}", y="?{count(${ref(m).amt})}"),
+    )
+    with pytest.raises(PositionalAxisTypeError):
+        build_insight(insight, force_dynamic=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. The gate is SCOPED — non-positional props are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_struct_on_a_non_positional_prop_is_unaffected(build_insight):
+    """``customdata`` legitimately carries arbitrary nested values in Plotly;
+    a record there must NOT fail the build."""
+    insight = Insight(
+        name="i",
+        props=InsightProps(
+            type="bar",
+            x="?{${ref(m).site}}",
+            y="?{count(${ref(m).amt})}",
+            customdata="?{?{${ref(m).site}}}",
+        ),
+    )
+    query_info = build_insight(insight)
+    assert "props.customdata" in query_info.props_mapping
+
+
+def test_struct_on_a_nested_prop_named_like_an_axis_is_unaffected(build_insight):
+    """``props.marker.color`` — and any other leaf that happens to share a
+    name with an axis — is not a coordinate. Matching is anchored to the
+    top-level ``props.<name>`` path."""
+    assert is_positional_axis_prop("props.x") is True
+    assert is_positional_axis_prop("props.domain.x") is False
+    assert is_positional_axis_prop("props.error_x.array") is False
+    assert is_positional_axis_prop("props.marker.colorscale[0]") is False
+    assert is_positional_axis_prop("props.ids") is False
+    assert is_positional_axis_prop("props.customdata") is False
+    assert is_positional_axis_prop("") is False
+    assert is_positional_axis_prop("split") is False
+
+
+def test_every_declared_positional_name_is_recognised():
+    for name in POSITIONAL_AXIS_PROP_NAMES:
+        assert is_positional_axis_prop(f"props.{name}") is True, name
+
+
+def test_check_returns_none_for_a_non_positional_prop():
+    assert (
+        check_positional_axis_plottability(
+            insight_name="i",
+            prop_path="props.customdata",
+            sqlglot_dtype=_dtype("STRUCT"),
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. NO over-rejection — every plottable type still builds
+# ---------------------------------------------------------------------------
+
+
+def _dtype(type_name):
+    """Build a bare ``exp.DataType`` from a sqlglot type NAME.
+
+    ``exp.DataType.build`` goes through the SQL parser and cannot round-trip
+    every member of ``DataType.Type`` (UBIGINT, TIMESTAMP_S, LOWCARDINALITY,
+    ...), so the enum member is used directly — exactly the shape
+    ``annotate_types`` hands the gate at runtime.
+    """
+    return exp.DataType(this=exp.DataType.Type[type_name])
+
+
+@pytest.mark.parametrize("type_name", sorted(PLOTTABLE_AXIS_TYPES))
+def test_every_plottable_type_is_accepted_on_a_positional_axis(type_name):
+    """Guard against the gate widening into a false positive: a type an axis
+    CAN render must never produce a diagnostic."""
+    dtype = _dtype(type_name)
+    assert axis_plottability(dtype) == "plottable", type_name
+    assert (
+        check_positional_axis_plottability(
+            insight_name="i", prop_path="props.x", sqlglot_dtype=dtype
+        )
+        is None
+    ), type_name
+
+
+def test_unrecognised_types_pass_through_rather_than_failing():
+    """A type in neither list classes as 'unknown' and the gate does nothing —
+    a build that used to work must not start failing because sqlglot grew a
+    type name we have not triaged."""
+    for type_name in ("GEOMETRY", "GEOGRAPHY", "POINT", "VECTOR", "HLLSKETCH", "BLOB"):
+        dtype = _dtype(type_name)
+        assert axis_plottability(dtype) == "unknown", type_name
+        assert (
+            check_positional_axis_plottability(
+                insight_name="i", prop_path="props.x", sqlglot_dtype=dtype
+            )
+            is None
+        ), type_name
+
+
+def test_unknown_type_inference_passes():
+    assert axis_plottability(None) == "unknown"
+    assert (
+        check_positional_axis_plottability(
+            insight_name="i", prop_path="props.x", sqlglot_dtype=None
+        )
+        is None
+    )
+
+
+def test_array_types_are_deliberately_not_rejected():
+    """A positional prop with a scalar slice (``x: ?{...}[0]``) binds ONE
+    row's value, so an array column is a perfectly plottable array. Rejecting
+    ARRAY/LIST would be a real false positive."""
+    for type_name in ("ARRAY", "LIST"):
+        dtype = _dtype(type_name)
+        assert axis_plottability(dtype) != "non_plottable", type_name
+
+
+def test_ordinary_insight_still_builds(build_insight):
+    insight = Insight(
+        name="i",
+        props=InsightProps(type="bar", x="?{${ref(m).site}}", y="?{count(${ref(m).amt})}"),
+    )
+    query_info = build_insight(insight)
+    assert query_info.props_mapping["props.x"]
+    assert query_info.props_mapping["props.y"]
+
+
+@pytest.mark.parametrize(
+    "column_type",
+    ["VARCHAR", "DOUBLE", "BIGINT", "DATE", "TIMESTAMP", "BOOLEAN", "DECIMAL(10,2)"],
+)
+def test_real_columns_of_every_common_type_still_build(build_insight, column_type):
+    """End-to-end over the real builder, not just the classifier: the
+    ordinary column types every project uses must keep building."""
+    insight = Insight(
+        name="i",
+        props=InsightProps(type="scatter", x="?{${ref(m).col}}", y="?{count(${ref(m).amt})}"),
+    )
+    query_info = build_insight(insight, schema={"col": column_type, "amt": "DOUBLE"})
+    assert query_info.props_mapping["props.x"]
+
+
+# ---------------------------------------------------------------------------
+# Classifier internals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("type_name", sorted(NON_PLOTTABLE_AXIS_TYPES))
+def test_every_non_plottable_type_is_rejected(type_name):
+    dtype = _dtype(type_name)
+    assert axis_plottability(dtype) == "non_plottable", type_name
+    diagnostic = check_positional_axis_plottability(
+        insight_name="i", prop_path="props.y", sqlglot_dtype=dtype
+    )
+    assert diagnostic is not None, type_name
+    assert diagnostic.code == "non_plottable_axis_type"
+
+
+def test_every_listed_type_name_is_a_real_sqlglot_type():
+    """Both lists are keyed on ``exp.DataType.Type`` MEMBER names — what
+    ``annotate_types`` puts in ``DataType.this``. A SQL spelling that is not a
+    member (``INTEGER``, ``REAL``, ``STRING``) would be a dead entry that
+    silently never matches, so pin it."""
+    members = {t.name for t in exp.DataType.Type}
+    assert PLOTTABLE_AXIS_TYPES <= members, sorted(PLOTTABLE_AXIS_TYPES - members)
+    assert NON_PLOTTABLE_AXIS_TYPES <= members, sorted(NON_PLOTTABLE_AXIS_TYPES - members)
+
+
+def test_plottable_and_non_plottable_sets_are_disjoint():
+    assert not (PLOTTABLE_AXIS_TYPES & NON_PLOTTABLE_AXIS_TYPES)
+
+
+def test_all_record_shaped_sqlglot_types_are_covered():
+    """sqlglot's own record-type set must be fully claimed by the denylist —
+    if it grows a record type we do not list, this test says so."""
+    record_type_names = {t.value for t in exp.DataType.STRUCT_TYPES}
+    assert record_type_names <= NON_PLOTTABLE_AXIS_TYPES
+
+
+@pytest.mark.parametrize("resolved_sql", [None, "", "1 + 1"])
+def test_message_omits_the_column_clause_when_there_is_no_column(resolved_sql):
+    """No resolvable source column (or no expression at all) must still
+    produce a complete, non-garbled message."""
+    diagnostic = check_positional_axis_plottability(
+        insight_name="i",
+        prop_path="props.x",
+        sqlglot_dtype=_dtype("STRUCT"),
+        resolved_sql=resolved_sql,
+        dialect="duckdb",
+    )
+    assert diagnostic is not None
+    assert "built from column" not in diagnostic.message
+    assert "props.x" in diagnostic.message
+    assert "STRUCT" in diagnostic.message
+
+
+def test_message_names_multiple_source_columns():
+    diagnostic = check_positional_axis_plottability(
+        insight_name="i",
+        prop_path="props.x",
+        sqlglot_dtype=_dtype("STRUCT"),
+        resolved_sql='{\'_0\': "t"."site", \'_1\': "t"."region"}',
+        dialect="duckdb",
+    )
+    assert diagnostic is not None
+    assert "'site'" in diagnostic.message
+    assert "'region'" in diagnostic.message
+
+
+def test_positional_axis_error_message_includes_the_hint():
+    diagnostic = check_positional_axis_plottability(
+        insight_name="i",
+        prop_path="props.x",
+        sqlglot_dtype=_dtype("STRUCT"),
+    )
+    error = PositionalAxisTypeError(diagnostic)
+    assert diagnostic.message in str(error)
+    assert diagnostic.hint in str(error)
+    assert isinstance(error, ValueError)

--- a/tests/query/insight/test_positional_axis_type_gate.py
+++ b/tests/query/insight/test_positional_axis_type_gate.py
@@ -6,11 +6,30 @@ chart with a SUCCESS job. The canonical producer is a doubled query string
 ``?{?{col}}`` — SQLGlot parses the residual ``?{col}`` as a DuckDB struct
 literal, which round-trips through parquet as ``STRUCT(VARCHAR)``.
 
-Three properties are pinned here, each falsifiable on its own:
+Properties pinned here, each falsifiable on its own:
 1. a STRUCT on a positional axis FAILS the build, with the insight, prop,
    column and type in the message;
 2. a STRUCT on a NON-positional prop is untouched (the gate is scoped);
-3. every type an axis can render is still accepted (no over-rejection).
+3. every type an axis can render is still accepted (no over-rejection);
+4. the semi-structured family (OBJECT/VARIANT/ARRAY/SUPER/JSON) classifies
+   CONSISTENTLY — those columns arrive as JSON text and plot as categories, so
+   rejecting one of them while accepting its siblings is the over-rejection
+   that shipped once already;
+5. a prop that references an INPUT is gated too — its ``${input.accessor}``
+   placeholder makes the resolved SQL unparseable, which used to drop the gate
+   open on exactly the dynamic lane where the blank chart is seen;
+6. ``props.value`` — the indicator datum — is a coordinate like any other.
+
+Note on what counts as coverage here: the parametrisations over
+``PLOTTABLE_AXIS_TYPES`` / ``NON_PLOTTABLE_AXIS_TYPES`` feed the classifier its
+OWN member names, so they pin the classifier contract but cannot fail
+independently of ``test_plottable_and_non_plottable_sets_are_disjoint``. The
+real over-rejection guards are the ones that run the actual
+``InsightQueryBuilder`` over a real schema —
+``test_real_columns_of_every_common_type_still_build``,
+``test_semi_structured_columns_still_build``,
+``test_an_unsliced_array_column_still_builds`` and
+``test_the_input_column_picker_itself_still_builds``.
 """
 
 import json
@@ -47,12 +66,17 @@ from tests.factories.model_factories import SourceFactory
 
 
 @pytest.fixture
-def build_insight(tmpdir):
-    def _build(insight, schema=None, force_dynamic=False):
+def make_builder(tmpdir):
+    def _make(insight, schema=None, force_dynamic=False, inputs=None, resolve=True):
         source = SourceFactory()
         model = SqlModel(name="m", sql="SELECT * FROM t", source=f"ref({source.name})")
         project = Project(
-            name="p", sources=[source], models=[model], insights=[insight], dashboards=[]
+            name="p",
+            sources=[source],
+            models=[model],
+            insights=[insight],
+            inputs=inputs or [],
+            dashboards=[],
         )
         dag = project.dag()
         schema_dir = os.path.join(str(tmpdir), "schemas")
@@ -63,8 +87,19 @@ def build_insight(tmpdir):
                 f,
             )
         builder = InsightQueryBuilder(insight, dag, str(tmpdir), force_dynamic=force_dynamic)
-        builder.resolve()
-        return builder.build()
+        if resolve:
+            builder.resolve()
+        return builder
+
+    return _make
+
+
+@pytest.fixture
+def build_insight(make_builder):
+    def _build(insight, schema=None, force_dynamic=False, inputs=None):
+        return make_builder(
+            insight, schema=schema, force_dynamic=force_dynamic, inputs=inputs
+        ).build()
 
     return _build
 
@@ -248,12 +283,72 @@ def test_unknown_type_inference_passes():
 
 
 def test_array_types_are_deliberately_not_rejected():
-    """A positional prop with a scalar slice (``x: ?{...}[0]``) binds ONE
-    row's value, so an array column is a perfectly plottable array. Rejecting
-    ARRAY/LIST would be a real false positive."""
+    """ARRAY/LIST stay fail-open in BOTH authoring forms.
+
+    Sliced (``x: ?{...}[0]``) the prop binds ONE row's value, so an array
+    column is a plottable array of scalars. Unsliced it binds an array of
+    arrays, which a linear axis really does draw as nothing — but sqlglot
+    spells DuckDB's genuinely-nested LIST and Snowflake's ARRAY (a VARIANT
+    constrained to arrays, delivered as JSON *text* and perfectly plottable)
+    with the SAME ``DataType.Type.ARRAY``. Rejecting the unsliced case would
+    hard-fail every Snowflake ARRAY column on an axis, so the ambiguity is
+    resolved in favour of the false negative — the same call made for OBJECT,
+    in the opposite direction.
+    """
     for type_name in ("ARRAY", "LIST"):
         dtype = _dtype(type_name)
         assert axis_plottability(dtype) != "non_plottable", type_name
+
+
+def test_an_unsliced_array_column_still_builds(build_insight):
+    """The unsliced form specifically — end to end, not just the classifier.
+    Pinned so that adding ARRAY to the denylist (which would break every
+    Snowflake ARRAY column) cannot happen silently."""
+    insight = Insight(
+        name="i",
+        props=InsightProps(
+            type="bar",
+            x="?{array_agg(${ref(m).site})}",
+            y="?{count(${ref(m).amt})}",
+        ),
+    )
+    query_info = build_insight(insight)
+    assert query_info.props_mapping["props.x"]
+
+
+# ---------------------------------------------------------------------------
+# 3b. Semi-structured columns are NOT records on the wire
+# ---------------------------------------------------------------------------
+
+
+SEMI_STRUCTURED_COLUMN_TYPES = ["OBJECT", "VARIANT", "ARRAY", "SUPER", "JSON", "JSONB"]
+
+
+@pytest.mark.parametrize("column_type", SEMI_STRUCTURED_COLUMN_TYPES)
+def test_semi_structured_columns_still_build(build_insight, column_type):
+    """Snowflake's OBJECT/VARIANT/ARRAY, Redshift's SUPER and JSON/JSONB all
+    arrive as JSON *text* after the connector + parquet round trip, and plot as
+    categories. Every one of them must keep building.
+
+    OBJECT is the one that regressed: it is a member of sqlglot's
+    ``DataType.STRUCT_TYPES``, so classifying by that grouping denylisted it
+    while its identically-shaped sibling VARIANT stayed allowlisted — a hard
+    build failure on a project that renders today.
+    """
+    insight = Insight(
+        name="obj",
+        props=InsightProps(type="bar", x="?{${ref(m).payload}}", y="?{count(${ref(m).id})}"),
+    )
+    query_info = build_insight(insight, schema={"payload": column_type, "id": "BIGINT"})
+    assert query_info.props_mapping["props.x"]
+
+
+def test_semi_structured_types_are_classified_consistently():
+    """The whole family classifies the SAME way. The bug was one member of it
+    classifying differently from the rest on reasoning that applied to all."""
+    classifications = {t: axis_plottability(_dtype(t)) for t in SEMI_STRUCTURED_COLUMN_TYPES}
+    assert classifications["OBJECT"] == classifications["VARIANT"], classifications
+    assert {c for t, c in classifications.items() if t != "ARRAY"} == {"plottable"}, classifications
 
 
 def test_ordinary_insight_still_builds(build_insight):
@@ -268,7 +363,39 @@ def test_ordinary_insight_still_builds(build_insight):
 
 @pytest.mark.parametrize(
     "column_type",
-    ["VARCHAR", "DOUBLE", "BIGINT", "DATE", "TIMESTAMP", "BOOLEAN", "DECIMAL(10,2)"],
+    [
+        # SQL SPELLINGS, as a model's schema JSON actually records them — not
+        # ``DataType.Type`` member names. That gap is where a dead allowlist
+        # entry hides: a schema saying "INTEGER"/"REAL"/"DOUBLE PRECISION"
+        # reaches the classifier as INT/FLOAT/DOUBLE, so listing the spelling
+        # instead of the member would silently never match. Only a real build
+        # closes that loop; the parametrisation over the allowlist itself
+        # cannot, because it feeds the classifier its own member names.
+        "VARCHAR",
+        "TEXT",
+        "CHAR(3)",
+        "NVARCHAR(50)",
+        "STRING",
+        "INTEGER",
+        "BIGINT",
+        "SMALLINT",
+        "REAL",
+        "DOUBLE",
+        "DOUBLE PRECISION",
+        "FLOAT",
+        "NUMERIC(10,2)",
+        "DECIMAL(10,2)",
+        "MONEY",
+        "DATE",
+        "TIMESTAMP",
+        "TIMESTAMP WITH TIME ZONE",
+        "DATETIME",
+        "TIME",
+        "INTERVAL",
+        "BOOLEAN",
+        "UUID",
+        "INET",
+    ],
 )
 def test_real_columns_of_every_common_type_still_build(build_insight, column_type):
     """End-to-end over the real builder, not just the classifier: the
@@ -311,11 +438,34 @@ def test_plottable_and_non_plottable_sets_are_disjoint():
     assert not (PLOTTABLE_AXIS_TYPES & NON_PLOTTABLE_AXIS_TYPES)
 
 
+# The ONE member of sqlglot's ``STRUCT_TYPES`` the denylist deliberately does
+# not claim, and why. Keeping it as data (rather than a subtraction inlined in
+# the assertion) means the next person to widen the exclusion has to write down
+# a reason next to the name.
+SQL_RECORD_TYPES_EXCLUDED_ON_PURPOSE = {
+    "OBJECT": (
+        "Snowflake's OBJECT — a VARIANT constrained to objects. Same wire "
+        "shape as VARIANT (JSON text), and VARIANT is allowlisted, so "
+        "denylisting OBJECT would hard-fail a project that renders today."
+    )
+}
+
+
 def test_all_record_shaped_sqlglot_types_are_covered():
-    """sqlglot's own record-type set must be fully claimed by the denylist —
-    if it grows a record type we do not list, this test says so."""
+    """sqlglot's own record-type set must be fully claimed by the denylist,
+    EXCEPT the members excluded on purpose — if sqlglot grows a record type we
+    have neither denylisted nor written a reason for, this test says so."""
     record_type_names = {t.value for t in exp.DataType.STRUCT_TYPES}
-    assert record_type_names <= NON_PLOTTABLE_AXIS_TYPES
+    unclaimed = record_type_names - NON_PLOTTABLE_AXIS_TYPES
+    assert unclaimed == set(SQL_RECORD_TYPES_EXCLUDED_ON_PURPOSE), sorted(unclaimed)
+
+
+def test_the_excluded_record_types_are_allowlisted_not_merely_dropped():
+    """An intentional exclusion belongs on the PLOTTABLE list, where the
+    "did we just start rejecting something?" question is answerable by reading
+    one list — not silently in the unknown middle."""
+    for type_name in SQL_RECORD_TYPES_EXCLUDED_ON_PURPOSE:
+        assert type_name in PLOTTABLE_AXIS_TYPES, type_name
 
 
 @pytest.mark.parametrize("resolved_sql", [None, "", "1 + 1"])
@@ -346,6 +496,191 @@ def test_message_names_multiple_source_columns():
     assert diagnostic is not None
     assert "'site'" in diagnostic.message
     assert "'region'" in diagnostic.message
+
+
+@pytest.mark.parametrize("type_name", sorted(NON_PLOTTABLE_AXIS_TYPES))
+def test_the_message_uses_the_right_indefinite_article(type_name):
+    """ "a OBJECT" shipped once already. The article is derived, not hardcoded
+    to the current denylist, so a later vowel-initial addition cannot
+    reintroduce it."""
+    diagnostic = check_positional_axis_plottability(
+        insight_name="i", prop_path="props.x", sqlglot_dtype=_dtype(type_name)
+    )
+    article = "an" if type_name[0] in "AEIOU" else "a"
+    wrong = "a" if article == "an" else "an"
+    assert f"resolves to {article} {type_name}" in diagnostic.message, diagnostic.message
+    assert f"cannot plot {article} {type_name}" in diagnostic.message, diagnostic.message
+    assert f"{wrong} {type_name}" not in diagnostic.message, diagnostic.message
+
+
+# ---------------------------------------------------------------------------
+# 4. `props.value` — the indicator datum this module was written about
+# ---------------------------------------------------------------------------
+
+
+def test_value_is_a_positional_prop():
+    """``value`` is the number an ``indicator`` displays and the 4th dimension
+    of ``isosurface``/``volume`` — the datum itself, so a record there is the
+    same silent blank an axis coordinate would be. It is also the example this
+    module's own docstring opens with."""
+    assert is_positional_axis_prop("props.value") is True
+    # Still anchored to the top level: a nested leaf named `value` is not it.
+    assert is_positional_axis_prop("props.link.value") is False
+
+
+def test_value_is_the_only_top_level_value_prop_in_the_trace_schemas():
+    """Claiming ``props.value`` is only safe because every trace schema that
+    has a top-level ``value`` uses it as a numeric datum. If a new schema adds
+    a ``value`` that legitimately carries a record, this test says so first."""
+    import glob
+
+    from visivo.query.insight.prop_type_validator import _load_trace_schema
+
+    schemas_with_value = []
+    for path in sorted(glob.glob("visivo/schema/*.schema.json")):
+        trace_type = os.path.basename(path).replace(".schema.json", "")
+        schema = _load_trace_schema(trace_type)
+        if schema and "value" in (schema.get("properties") or {}):
+            schemas_with_value.append(trace_type)
+    assert schemas_with_value == ["indicator", "isosurface", "volume"], schemas_with_value
+
+
+def test_struct_on_an_indicator_value_fails_the_build(build_insight):
+    """The S5-14 shape on the one trace type this file was originally about."""
+    insight = Insight(
+        name="total",
+        props=InsightProps(type="indicator", value="?{?{${ref(m).amt}}}"),
+    )
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight)
+    assert "props.value" in str(excinfo.value)
+
+
+def test_an_ordinary_indicator_value_still_builds(build_insight):
+    insight = Insight(
+        name="total",
+        props=InsightProps(type="indicator", value="?{sum(${ref(m).amt})}"),
+    )
+    query_info = build_insight(insight)
+    assert query_info.props_mapping["props.value"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Props that reference an INPUT — the dynamic lane the blank chart is on
+# ---------------------------------------------------------------------------
+
+
+def _column_picker(name, y_expression):
+    from visivo.models.inputs.types.single_select import SingleSelectInput
+
+    ycol = SingleSelectInput(name="ycol", label="Y", options=["site", "amt"])
+    insight = Insight(
+        name=name,
+        props=InsightProps(type="scatter", x="?{${ref(m).site}}", y=y_expression),
+    )
+    return insight, [ycol]
+
+
+def test_doubled_query_string_referencing_an_input_fails_the_build(build_insight):
+    """A prop that references an input keeps its ``${ycol.value}`` placeholder
+    in the resolved SQL, which SQLGlot cannot parse — so type inference used to
+    return None and the gate fell open. That is the WORST place to fall open:
+    an input-bearing insight is dynamic, so ``pre_query`` is None, ``build()``
+    skips ``validate_query``, and NOTHING else looks at the post_query. The
+    residual ``?{...}`` then reached DuckDB WASM and parsed as a struct exactly
+    as it does server-side — blank chart, SUCCESS job.
+    """
+    insight, inputs = _column_picker("picker2", "?{?{${ref(ycol).value}}}")
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight, inputs=inputs)
+    assert "props.y" in str(excinfo.value)
+    assert "STRUCT" in str(excinfo.value)
+
+
+def test_the_input_column_picker_itself_still_builds(build_insight):
+    """The other direction, and the reason the fix substitutes sample values
+    only inside this gate: an ordinary input-driven column picker is a real,
+    supported pattern and must keep building."""
+    insight, inputs = _column_picker("picker1", "?{${ref(ycol).value}}")
+    query_info = build_insight(insight, inputs=inputs)
+    assert "${ycol.value}" in query_info.post_query
+
+
+def test_other_input_shapes_on_a_positional_axis_still_build(build_insight):
+    """The false-positive surface of the sample-value fallback. A multi-select
+    ``.values`` substitutes to a COMMA-SEPARATED list (``'west', 'east'``),
+    which turns the wrapper SELECT into two projections — the gate must read
+    the first and classify it as the scalar it is, not choke or reject. An
+    input wrapped in an expression must survive too."""
+    from visivo.models.inputs.types.multi_select import MultiSelectInput
+    from visivo.models.inputs.types.single_select import SingleSelectInput
+
+    regions = MultiSelectInput(name="regions", label="R", options=["west", "east"])
+    values_on_x = Insight(
+        name="a",
+        props=InsightProps(type="bar", x="?{${ref(regions).values}}", y="?{count(${ref(m).amt})}"),
+    )
+    assert build_insight(values_on_x, inputs=[regions]).props_mapping["props.x"]
+
+    ycol = SingleSelectInput(name="ycol", label="Y", options=["site", "amt"])
+    wrapped = Insight(
+        name="b",
+        props=InsightProps(
+            type="bar", x="?{upper(${ref(ycol).value})}", y="?{count(${ref(m).amt})}"
+        ),
+    )
+    assert build_insight(wrapped, inputs=[ycol]).props_mapping["props.x"]
+
+
+def test_sample_substitution_does_not_leak_into_the_authored_message(build_insight):
+    """The diagnostic must quote what the USER wrote, not the sample value the
+    gate parsed with."""
+    insight, inputs = _column_picker("picker2", "?{?{${ref(ycol).value}}}")
+    with pytest.raises(PositionalAxisTypeError) as excinfo:
+        build_insight(insight, inputs=inputs)
+    detail = excinfo.value.diagnostic.detail
+    assert "${ycol.value}" in detail, detail
+    assert "__VISIVO_INPUT" not in detail, detail
+
+
+def test_sample_substitution_is_not_applied_to_the_slice_class_check(make_builder):
+    """``_infer_expression_type`` itself must stay placeholder-blind. A sample
+    value carries the SAMPLE's type, not the runtime column's, so letting it
+    leak into the slice-class check or the default-ordering decision would
+    change two unrelated behaviours on a guess."""
+    insight, inputs = _column_picker("picker1", "?{${ref(ycol).value}}")
+    builder = make_builder(insight, inputs=inputs)
+    resolved_y = dict(builder.resolved_query_statements)["props.y"]
+    assert "${ycol.value}" in resolved_y
+    assert builder._infer_expression_type(resolved_y) is None
+
+
+def test_the_type_inference_schema_is_built_once_per_builder(make_builder, mocker):
+    """The gate calls ``_infer_expression_type`` once per bound coordinate on
+    EVERY build (before WB9 the slice check returned early and it essentially
+    never ran), so the sqlglot ``MappingSchema`` — rebuilt from every dependent
+    model's columns — must not be reconstructed per call. Both of its inputs
+    (``self.models``, ``self.native_dialect``) are fixed for the builder's
+    lifetime, so once is correct.
+    """
+    import sqlglot.schema
+
+    spy = mocker.patch(
+        "sqlglot.schema.MappingSchema", wraps=sqlglot.schema.MappingSchema, autospec=True
+    )
+    insight = Insight(
+        name="i",
+        props=InsightProps(type="scatter", x="?{${ref(m).site}}", y="?{count(${ref(m).amt})}"),
+    )
+    builder = make_builder(insight, resolve=False)
+    builder.resolve()
+    builder.build()
+    # Three inferences over this insight (the default-sort probe on x, then
+    # props.x and props.y through the gate) — one MappingSchema.
+    assert spy.call_count == 1, spy.call_count
+    first = builder._type_inference_schema()
+    assert builder._type_inference_schema() is first
+    assert spy.call_count == 1, spy.call_count
 
 
 def test_positional_axis_error_message_includes_the_hint():

--- a/tests/server/views/test_insight_compile_views.py
+++ b/tests/server/views/test_insight_compile_views.py
@@ -255,7 +255,13 @@ class TestCompileDraftPositionalAxisTypeGate:
             tmp_path, "orders_q", alpha_hash("orders_q"), {"region": "VARCHAR", "amount": "DOUBLE"}
         )
         resp = client.post("/api/insight-compile-draft/", json=self._struct_payload())
-        diagnostic = resp.get_json()["diagnostic"]
+        body = resp.get_json()
+        # PLURAL key, LIST value — the shape `diagnosticsFrom` in
+        # viewer/src/types/diagnostic.js reads. A singular object would be
+        # invisible to every existing client.
+        assert isinstance(body["diagnostics"], list)
+        assert len(body["diagnostics"]) == 1
+        diagnostic = body["diagnostics"][0]
         assert diagnostic["code"] == "non_plottable_axis_type"
         assert diagnostic["phase"] == "compile"
         assert diagnostic["severity"] == "error"
@@ -271,4 +277,4 @@ class TestCompileDraftPositionalAxisTypeGate:
             json=insight_payload(model_name="totally_made_up_model"),
         )
         assert resp.status_code == 400
-        assert "diagnostic" not in resp.get_json()
+        assert "diagnostics" not in resp.get_json()

--- a/tests/server/views/test_insight_compile_views.py
+++ b/tests/server/views/test_insight_compile_views.py
@@ -214,3 +214,61 @@ class TestCompileDraftValidation:
 # mounted on the SAME Flask app (via the shared `integration_app`/
 # `integration_client` fixtures), which this file's minimal stub app
 # deliberately doesn't carry.
+
+
+class TestCompileDraftPositionalAxisTypeGate:
+    """WB9 / S5-14: a draft whose x resolves to a STRUCT must come back as a
+    400 that both READS well (``error``) and PARSES (``diagnostic``), instead
+    of a 200 the Explorer renders as an empty chart."""
+
+    def _struct_payload(self):
+        return {
+            "insight": {
+                "name": "blank_chart",
+                "props": {
+                    "type": "scatter",
+                    # The S5-14 double-wrap: the inner ?{...} survives into the
+                    # resolved SQL and SQLGlot reads it as a struct literal.
+                    "x": "?{?{${ref(orders_q).region}}}",
+                    "y": "?{sum(${ref(orders_q).amount})}",
+                },
+            }
+        }
+
+    def test_struct_bound_to_x_is_a_400_not_a_blank_200(self, client, tmp_path):
+        from visivo.models.base.named_model import alpha_hash
+
+        write_schema(
+            tmp_path, "orders_q", alpha_hash("orders_q"), {"region": "VARCHAR", "amount": "DOUBLE"}
+        )
+        resp = client.post("/api/insight-compile-draft/", json=self._struct_payload())
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "blank_chart" in body["error"]
+        assert "props.x" in body["error"]
+        assert "STRUCT" in body["error"]
+
+    def test_the_400_carries_the_structured_diagnostic(self, client, tmp_path):
+        from visivo.models.base.named_model import alpha_hash
+
+        write_schema(
+            tmp_path, "orders_q", alpha_hash("orders_q"), {"region": "VARCHAR", "amount": "DOUBLE"}
+        )
+        resp = client.post("/api/insight-compile-draft/", json=self._struct_payload())
+        diagnostic = resp.get_json()["diagnostic"]
+        assert diagnostic["code"] == "non_plottable_axis_type"
+        assert diagnostic["phase"] == "compile"
+        assert diagnostic["severity"] == "error"
+        assert diagnostic["field"] == "props.x"
+        assert diagnostic["object"] == {"type": "insight", "name": "blank_chart"}
+        assert diagnostic["hint"]
+
+    def test_an_ordinary_build_failure_carries_no_diagnostic_key(self, client):
+        """`diagnostic` is additive — a 400 from a failure that produced none
+        must not grow a null/empty key."""
+        resp = client.post(
+            "/api/insight-compile-draft/",
+            json=insight_payload(model_name="totally_made_up_model"),
+        )
+        assert resp.status_code == 400
+        assert "diagnostic" not in resp.get_json()

--- a/tests/server/views/test_insight_draft_common.py
+++ b/tests/server/views/test_insight_draft_common.py
@@ -8,6 +8,7 @@ from flask import Flask
 from visivo.server.views.insight_draft_common import (
     parse_draft_request,
     build_schema_overrides,
+    diagnostic_fields,
     is_model_not_run_error,
     extract_model_not_run_name,
 )
@@ -103,3 +104,34 @@ def test_model_not_run_markers_and_name_extraction():
     assert extract_model_not_run_name(ast_msg) == "orders_q"
     assert extract_model_not_run_name(dyn_msg) == "cohort_q"
     assert extract_model_not_run_name("no name here") is None
+
+
+class TestDiagnosticFields:
+    """WB9: build failures that carry a Diagnostic surface it on the 400 body;
+    every other failure leaves the body byte-identical to before."""
+
+    def test_returns_the_serialised_diagnostic_when_the_error_carries_one(self):
+        from visivo.models.diagnostic import Diagnostic, DiagnosticPhase
+        from visivo.query.insight.prop_type_validator import PositionalAxisTypeError
+
+        diagnostic = Diagnostic(
+            phase=DiagnosticPhase.COMPILE,
+            code="non_plottable_axis_type",
+            message="positional axis prop 'props.x' resolves to a STRUCT",
+            field="props.x",
+        )
+        fields = diagnostic_fields(PositionalAxisTypeError(diagnostic))
+        assert fields["diagnostic"]["code"] == "non_plottable_axis_type"
+        assert fields["diagnostic"]["phase"] == "compile"
+        assert fields["diagnostic"]["field"] == "props.x"
+        # exclude_none: absent optionals must not become explicit nulls.
+        assert "location" not in fields["diagnostic"]
+
+    def test_returns_nothing_for_an_ordinary_exception(self):
+        assert diagnostic_fields(ValueError("boom")) == {}
+
+    def test_returns_nothing_when_the_attribute_is_not_a_diagnostic(self):
+        class Weird(Exception):
+            diagnostic = "not a model"
+
+        assert diagnostic_fields(Weird()) == {}

--- a/tests/server/views/test_insight_draft_common.py
+++ b/tests/server/views/test_insight_draft_common.py
@@ -121,11 +121,19 @@ class TestDiagnosticFields:
             field="props.x",
         )
         fields = diagnostic_fields(PositionalAxisTypeError(diagnostic))
-        assert fields["diagnostic"]["code"] == "non_plottable_axis_type"
-        assert fields["diagnostic"]["phase"] == "compile"
-        assert fields["diagnostic"]["field"] == "props.x"
+        # The contract shape is PLURAL + LIST: visivo/models/diagnostic.py
+        # documents payloads as growing a `diagnostics` key, and the viewer's
+        # only reader (`diagnosticsFrom`) returns [] for anything that is not
+        # `Array.isArray(payload.diagnostics)`. This helper is the first
+        # producer on the wire, so it sets the precedent.
+        assert list(fields) == ["diagnostics"]
+        assert isinstance(fields["diagnostics"], list)
+        assert len(fields["diagnostics"]) == 1
+        assert fields["diagnostics"][0]["code"] == "non_plottable_axis_type"
+        assert fields["diagnostics"][0]["phase"] == "compile"
+        assert fields["diagnostics"][0]["field"] == "props.x"
         # exclude_none: absent optionals must not become explicit nulls.
-        assert "location" not in fields["diagnostic"]
+        assert "location" not in fields["diagnostics"][0]
 
     def test_returns_nothing_for_an_ordinary_exception(self):
         assert diagnostic_fields(ValueError("boom")) == {}

--- a/tests/server/views/test_insight_execute_views.py
+++ b/tests/server/views/test_insight_execute_views.py
@@ -289,3 +289,62 @@ def test_malformed_body_is_400(client):
     assert (
         client.post("/api/insight-execute-draft/", json={"insight": {}}).status_code == 400
     )  # no name
+
+
+class TestExecuteDraftPositionalAxisTypeGate:
+    """WB9 / S5-14: the execute-draft path is the one the Explorer's preview
+    lane actually calls, so its 400 must carry the structured diagnostics too.
+
+    The compile view got dedicated endpoint tests for this; this view's
+    identical wiring shipped with none — falsified by reverting the view's
+    `**diagnostic_fields(e)` to a bare `{"error": message}` and watching the
+    whole suite stay green.
+    """
+
+    def _struct_payload(self):
+        return {
+            "insight": {
+                "name": "blank_chart",
+                "props": {
+                    "type": "bar",
+                    # The S5-14 double-wrap: the inner ?{...} survives into the
+                    # resolved SQL and SQLGlot reads it as a struct literal.
+                    "x": "?{?{${ref(orders_q).region}}}",
+                    "y": "?{sum(${ref(orders_q).amount})}",
+                },
+            },
+            "model_schemas": MODEL_SCHEMAS,
+        }
+
+    def test_struct_bound_to_x_is_a_400_not_a_blank_200(self, client):
+        resp = client.post("/api/insight-execute-draft/", json=self._struct_payload())
+        assert resp.status_code == 400, resp.get_json()
+        error = resp.get_json()["error"]
+        assert "blank_chart" in error
+        assert "props.x" in error
+        assert "STRUCT" in error
+
+    def test_the_400_carries_the_structured_diagnostics(self, client):
+        resp = client.post("/api/insight-execute-draft/", json=self._struct_payload())
+        body = resp.get_json()
+        # PLURAL key, LIST value — the shape `diagnosticsFrom` in
+        # viewer/src/types/diagnostic.js reads.
+        assert isinstance(body["diagnostics"], list)
+        assert len(body["diagnostics"]) == 1
+        diagnostic = body["diagnostics"][0]
+        assert diagnostic["code"] == "non_plottable_axis_type"
+        assert diagnostic["phase"] == "compile"
+        assert diagnostic["severity"] == "error"
+        assert diagnostic["field"] == "props.x"
+        assert diagnostic["object"] == {"type": "insight", "name": "blank_chart"}
+        assert diagnostic["hint"]
+
+    def test_an_ordinary_build_failure_carries_no_diagnostics_key(self, client):
+        """`diagnostics` is additive — a 400 from a failure that produced none
+        must not grow an empty/null key."""
+        resp = client.post(
+            "/api/insight-execute-draft/",
+            json={**self._struct_payload(), "model_schemas": [1, 2]},
+        )
+        assert resp.status_code == 400
+        assert "diagnostics" not in resp.get_json()

--- a/viewer/src/types/diagnostic.js
+++ b/viewer/src/types/diagnostic.js
@@ -46,6 +46,7 @@ export const DIAGNOSTIC_CODES = [
   'invalid_value',
   'broken_reference',
   'expression_parse_failed',
+  'non_plottable_axis_type',
   'yaml_parse_failed',
   'source_locked',
   'source_connection_failed',

--- a/viewer/src/types/diagnostic.test.js
+++ b/viewer/src/types/diagnostic.test.js
@@ -36,4 +36,50 @@ describe('contract mirrors', () => {
       expect(new Set(list).size).toBe(list.length);
     }
   });
+
+  // Mirror of visivo/models/diagnostic.py DIAGNOSTIC_CODES. The Python side
+  // pins the two files against each other (tests/models/test_diagnostic.py
+  // ::test_viewer_mirror_lists_every_diagnostic_code); this names the code the
+  // Explorer's positional-axis 400 arrives with, so a viewer surface that
+  // branches on it has something to branch on.
+  test('carries the compile-time positional-axis code', () => {
+    expect(DIAGNOSTIC_CODES).toContain('non_plottable_axis_type');
+  });
+});
+
+describe('the draft endpoints 400 body', () => {
+  // The exact shape visivo/server/views/insight_draft_common.py::
+  // diagnostic_fields puts on the wire for a positional axis bound to a
+  // STRUCT (WB9 / S5-14). A singular `diagnostic` object — the shape that
+  // shipped first — reads as [] here, which is why it changed to a list.
+  const body = {
+    error: "Insight 'blank_chart': positional axis prop 'props.x' resolves to a STRUCT.",
+    diagnostics: [
+      {
+        id: 'compile:non_plottable_axis_type:blank_chart:props.x',
+        severity: 'error',
+        phase: 'compile',
+        code: 'non_plottable_axis_type',
+        message: "Insight 'blank_chart': positional axis prop 'props.x' resolves to a STRUCT.",
+        object: { type: 'insight', name: 'blank_chart' },
+        field: 'props.x',
+        hint: "Bind 'props.x' to a single scalar column or expression.",
+      },
+    ],
+  };
+
+  test('is readable by the universal reader', () => {
+    const diagnostics = diagnosticsFrom(body);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].code).toBe('non_plottable_axis_type');
+    expect(diagnostics[0].field).toBe('props.x');
+    expect(DIAGNOSTIC_CODES).toContain(diagnostics[0].code);
+    expect(DIAGNOSTIC_PHASES).toContain(diagnostics[0].phase);
+    expect(DIAGNOSTIC_SEVERITIES).toContain(diagnostics[0].severity);
+  });
+
+  test('a singular `diagnostic` object would have been invisible', () => {
+    const singular = { error: body.error, diagnostic: body.diagnostics[0] };
+    expect(diagnosticsFrom(singular)).toEqual([]);
+  });
 });

--- a/visivo/models/diagnostic.py
+++ b/visivo/models/diagnostic.py
@@ -61,7 +61,7 @@ DIAGNOSTIC_CODES = {
     "expression_parse_failed": "A query-string/context-string expression failed to parse.",
     "non_plottable_axis_type": (
         "A prop bound to a positional axis (x/y/lat/r/...) resolves to a SQL type no "
-        "axis can render — a record-shaped STRUCT/MAP/OBJECT/UNION/NESTED — so the "
+        "axis can render — a record-shaped STRUCT/MAP/UNION/NESTED — so the "
         "chart would build successfully and draw nothing."
     ),
     "yaml_parse_failed": "The YAML file itself did not parse (before any schema validation).",

--- a/visivo/models/diagnostic.py
+++ b/visivo/models/diagnostic.py
@@ -59,6 +59,11 @@ DIAGNOSTIC_CODES = {
     "invalid_value": "A field is present but its value fails validation.",
     "broken_reference": "A ${ref(...)} names an object that does not exist.",
     "expression_parse_failed": "A query-string/context-string expression failed to parse.",
+    "non_plottable_axis_type": (
+        "A prop bound to a positional axis (x/y/lat/r/...) resolves to a SQL type no "
+        "axis can render — a record-shaped STRUCT/MAP/OBJECT/UNION/NESTED — so the "
+        "chart would build successfully and draw nothing."
+    ),
     "yaml_parse_failed": "The YAML file itself did not parse (before any schema validation).",
     # Sources
     "source_locked": "The database file is held by another connection/process.",

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -6,7 +6,10 @@ from visivo.query.insight.default_ordering import (
     post_query_order_clause,
 )
 from visivo.query.insight.prop_type_validator import (
+    PositionalAxisTypeError,
+    check_positional_axis_plottability,
     check_slice_type_compatibility,
+    is_positional_axis_prop,
     is_scalar_slice,
 )
 from visivo.models.base.project_dag import ProjectDag
@@ -1228,6 +1231,19 @@ class InsightQueryBuilder:
 
         return order_by_expressions
 
+    def _resolved_props_sql(self) -> Dict[str, str]:
+        """Map prop path -> the resolved SQL for that prop, alias included.
+
+        ``resolved_query_statements`` is ``[(key, sql_with_alias)]``; the
+        alias is left ON the fragment and unwrapped by SQLGlot downstream
+        (``_infer_expression_type``) rather than stripped with a regex.
+        """
+        return {
+            key: sql
+            for key, sql in (self.resolved_query_statements or [])
+            if key and "props." in key
+        }
+
     def _validate_prop_slice_types(self, props_slices: Dict[str, str]) -> None:
         """Type-check each sliced ``?{...}[N|a:b]`` prop against the broad
         type class the Plotly schema expects at that path.
@@ -1247,15 +1263,7 @@ class InsightQueryBuilder:
         if not trace_type:
             return
 
-        # Map prop path -> resolved SQL expression (no alias suffix).
-        # `resolved_query_statements` is `[(key, sql_with_alias)]`. We
-        # strip a trailing `AS "<hash>"` to get a usable bare expression.
-        resolved_by_path: Dict[str, str] = {}
-        for key, sql in self.resolved_query_statements or []:
-            if not key or "props." not in key:
-                continue
-            bare = re.sub(r"\s+AS\s+\"[^\"]+\"\s*$", "", sql, flags=re.IGNORECASE)
-            resolved_by_path[key] = bare
+        resolved_by_path = self._resolved_props_sql()
 
         for prop_path, slice_expr in props_slices.items():
             if not is_scalar_slice(slice_expr):
@@ -1276,6 +1284,39 @@ class InsightQueryBuilder:
             if not ok:
                 raise ValueError(message)
 
+    def _validate_positional_axis_types(self) -> None:
+        """WB9 / S5-14: hard-fail the build when a prop bound to a
+        POSITIONAL AXIS (``x``, ``y``, ``lat``, ``r``, ...) resolves to a
+        record-shaped SQL type (STRUCT/MAP/OBJECT/UNION/NESTED).
+
+        Such an insight builds "successfully" today and renders a blank
+        chart with a SUCCESS job — the silent failure S5-14 reports. The
+        canonical producer is a doubled query string ``?{?{col}}``, which
+        SQLGlot parses as a DuckDB struct literal.
+
+        Raises ``PositionalAxisTypeError`` (a ``ValueError``) carrying the
+        structured ``Diagnostic``. Types the gate does not recognise, and
+        every type an axis can render, pass through untouched — see
+        ``prop_type_validator.axis_plottability``.
+        """
+        from visivo.query.sqlglot_utils import get_sqlglot_dialect
+
+        sqlglot_dialect = get_sqlglot_dialect(self.native_dialect)
+        for prop_path, resolved_sql in self._resolved_props_sql().items():
+            if not is_positional_axis_prop(prop_path):
+                continue
+            if not resolved_sql:
+                continue
+            diagnostic = check_positional_axis_plottability(
+                insight_name=self.insight_name,
+                prop_path=prop_path,
+                sqlglot_dtype=self._infer_expression_type(resolved_sql),
+                resolved_sql=resolved_sql,
+                dialect=sqlglot_dialect,
+            )
+            if diagnostic is not None:
+                raise PositionalAxisTypeError(diagnostic)
+
     def _infer_expression_type(self, expression_sql: str) -> Optional[exp.DataType]:
         """Best-effort sqlglot type inference for a resolved expression.
 
@@ -1283,6 +1324,11 @@ class InsightQueryBuilder:
         ``annotate_types`` against the union of all referenced models'
         schemas. Returns None if any step fails — callers treat that as
         ``unknown`` and skip validation.
+
+        ``expression_sql`` may carry its own trailing ``AS "<alias>"`` (the
+        form ``resolved_query_statements`` holds); the alias is unwrapped
+        from the parsed AST rather than stripped from the text, so no
+        caller has to regex SQL apart.
         """
         try:
             from visivo.query.sqlglot_utils import get_sqlglot_dialect
@@ -1316,7 +1362,7 @@ class InsightQueryBuilder:
             # Wrap the expression in a tiny SELECT so annotate_types has
             # somewhere to attach its inferences.
             from_table = next(iter(mapping.keys()))
-            wrapped = f'SELECT {expression_sql} AS _vtype FROM "{from_table}"'
+            wrapped = f'SELECT {expression_sql} FROM "{from_table}"'
             parsed = sqlglot.parse_one(wrapped, dialect=sqlglot_dialect)
             annotated = annotate_types(parsed, schema=mapping_schema)
             select = annotated.find(exp.Select)
@@ -1405,6 +1451,11 @@ class InsightQueryBuilder:
         # unknown SQL type) pass through.
         if props_slices:
             self._validate_prop_slice_types(props_slices)
+
+        # WB9 / S5-14: a positional axis bound to a record-shaped column
+        # (STRUCT/MAP/...) builds fine and renders nothing. Fail here, with
+        # a Diagnostic, instead of shipping a SUCCESS job and a blank chart.
+        self._validate_positional_axis_types()
 
         data = {
             "pre_query": pre_query,

--- a/visivo/query/insight/insight_query_builder.py
+++ b/visivo/query/insight/insight_query_builder.py
@@ -267,6 +267,9 @@ def restore_input_placeholders(sql: str) -> str:
     return re.sub(pattern, replace_marker, sql)
 
 
+_UNSET = object()
+
+
 class InsightQueryBuilder:
     """
     1. If the insight is NOT dynamic
@@ -458,12 +461,10 @@ class InsightQueryBuilder:
         self._default_sort_applied = False
         if not has_sort and renders_as_line(self.insight.props):
             resolved_x = next((s for k, s in resolved_query_statements if k == "props.x"), None)
-            bare_x = (
-                re.sub(r"\s+AS\s+\"[^\"]+\"\s*$", "", resolved_x, flags=re.IGNORECASE)
-                if resolved_x
-                else None
-            )
-            x_type = self._infer_expression_type(bare_x) if bare_x else None
+            # No alias strip needed: `_infer_expression_type` unwraps a trailing
+            # `AS "<hash>"` from the parsed AST, so the aliased fragment goes in
+            # as-is (regex-over-SQL removed, per SQLGLOT.md).
+            x_type = self._infer_expression_type(resolved_x) if resolved_x else None
             if is_deterministically_orderable(x_type):
                 for expression in default_sort_expressions(self.unresolved_query_statements):
                     resolved_query_statements.append(
@@ -1287,7 +1288,7 @@ class InsightQueryBuilder:
     def _validate_positional_axis_types(self) -> None:
         """WB9 / S5-14: hard-fail the build when a prop bound to a
         POSITIONAL AXIS (``x``, ``y``, ``lat``, ``r``, ...) resolves to a
-        record-shaped SQL type (STRUCT/MAP/OBJECT/UNION/NESTED).
+        record-shaped SQL type (STRUCT/MAP/UNION/NESTED).
 
         Such an insight builds "successfully" today and renders a blank
         chart with a SUCCESS job — the silent failure S5-14 reports. The
@@ -1307,15 +1308,101 @@ class InsightQueryBuilder:
                 continue
             if not resolved_sql:
                 continue
+            dtype = self._infer_expression_type(resolved_sql)
+            if dtype is None:
+                # A prop that references an input keeps its ``${input.accessor}``
+                # placeholder in the resolved SQL (the viewer substitutes it at
+                # render time), and SQLGlot cannot parse that — so inference
+                # returns None and the gate would fall open on exactly the
+                # dynamic path where the blank chart is actually SEEN. Retry
+                # against the same sample-value substitution the GROUP BY
+                # analysis already uses. A doubled query string then infers
+                # STRUCT (MAP on ClickHouse) and is caught; an ordinary column
+                # picker infers the sample's own scalar type and still builds.
+                parseable_sql = self._sql_with_input_samples(resolved_sql)
+                if parseable_sql is not None:
+                    dtype = self._infer_expression_type(parseable_sql)
             diagnostic = check_positional_axis_plottability(
                 insight_name=self.insight_name,
                 prop_path=prop_path,
-                sqlglot_dtype=self._infer_expression_type(resolved_sql),
+                sqlglot_dtype=dtype,
+                # Always the AUTHORED-shape SQL, never the sample-substituted
+                # one: the message must name the user's own expression.
                 resolved_sql=resolved_sql,
                 dialect=sqlglot_dialect,
             )
             if diagnostic is not None:
                 raise PositionalAxisTypeError(diagnostic)
+
+    def _sql_with_input_samples(self, resolved_sql: str) -> Optional[str]:
+        """``resolved_sql`` with every ``${input.accessor}`` replaced by a
+        parseable sample value, or ``None`` when it carries no placeholder or
+        the substitution cannot be made.
+
+        Substitution is applied ONLY here, never inside
+        ``_infer_expression_type`` itself: a sample value has the sample's
+        type, not the runtime column's, so letting it leak into the slice-class
+        check or the default-ordering decision would change two unrelated
+        behaviours on a guess. The plottability gate is insensitive to that —
+        every sample value is a plottable scalar — so it can safely use it.
+        """
+        try:
+            substituted, replacements = replace_input_placeholders_for_parsing(
+                resolved_sql, dag=self.dag, insight=self.insight, output_dir=self.output_dir
+            )
+        except Exception:
+            # Undefined input / bad accessor: a different validator's error to
+            # raise. Fail open here rather than mask it.
+            return None
+        if not replacements or substituted == resolved_sql:
+            return None
+        return substituted
+
+    def _type_inference_schema(self):
+        """``(mapping, MappingSchema)`` over every dependent model's columns,
+        built at most ONCE per builder.
+
+        Both inputs — ``self.models`` and ``self.native_dialect`` — are fixed
+        for the builder's lifetime, so the schema is invariant. Before WB9 the
+        only caller of ``_infer_expression_type`` was the slice check, which
+        returns early when no prop carries a slice (the overwhelming majority
+        of insights), so rebuilding per call cost nothing. The positional-axis
+        gate now calls it once per bound coordinate on EVERY build, and
+        ``MappingSchema`` construction is measurable on a wide model — so
+        memoize it rather than pay it per prop.
+
+        Returns ``None`` when no dependent model has a loadable schema.
+        """
+        cached = getattr(self, "_type_inference_schema_cache", _UNSET)
+        if cached is not _UNSET:
+            return cached
+
+        from visivo.query.sqlglot_utils import get_sqlglot_dialect
+        from sqlglot.schema import MappingSchema
+
+        sqlglot_dialect = get_sqlglot_dialect(self.native_dialect)
+
+        # Aggregate the schemas of every model the insight depends on
+        # into a single MappingSchema keyed by model_hash.
+        mapping = {}
+        for model in self.models:
+            schema = self.field_resolver._load_model_schema(model.name)
+            if not schema:
+                continue
+            model_hash = model.name_hash()
+            # On Snowflake the resolver uppercases the table-ref key;
+            # mirror that here so qualify can find the columns.
+            if sqlglot_dialect == "snowflake":
+                table_ref = model_hash.upper()
+                mapping[table_ref] = {
+                    col: dtype for col, dtype in schema.get(model_hash, {}).items()
+                }
+            else:
+                mapping[model_hash] = schema.get(model_hash, {})
+
+        result = None if not mapping else (mapping, MappingSchema(schema=mapping))
+        self._type_inference_schema_cache = result
+        return result
 
     def _infer_expression_type(self, expression_sql: str) -> Optional[exp.DataType]:
         """Best-effort sqlglot type inference for a resolved expression.
@@ -1333,32 +1420,14 @@ class InsightQueryBuilder:
         try:
             from visivo.query.sqlglot_utils import get_sqlglot_dialect
             from sqlglot.optimizer.annotate_types import annotate_types
-            from sqlglot.schema import MappingSchema
 
             sqlglot_dialect = get_sqlglot_dialect(self.native_dialect)
 
-            # Aggregate the schemas of every model the insight depends on
-            # into a single MappingSchema keyed by model_hash.
-            mapping = {}
-            for model in self.models:
-                schema = self.field_resolver._load_model_schema(model.name)
-                if not schema:
-                    continue
-                model_hash = model.name_hash()
-                # On Snowflake the resolver uppercases the table-ref key;
-                # mirror that here so qualify can find the columns.
-                if sqlglot_dialect == "snowflake":
-                    table_ref = model_hash.upper()
-                    mapping[table_ref] = {
-                        col: dtype for col, dtype in schema.get(model_hash, {}).items()
-                    }
-                else:
-                    mapping[model_hash] = schema.get(model_hash, {})
-
-            if not mapping:
+            built = self._type_inference_schema()
+            if built is None:
                 return None
+            mapping, mapping_schema = built
 
-            mapping_schema = MappingSchema(schema=mapping)
             # Wrap the expression in a tiny SELECT so annotate_types has
             # somewhere to attach its inferences.
             from_table = next(iter(mapping.keys()))

--- a/visivo/query/insight/prop_type_validator.py
+++ b/visivo/query/insight/prop_type_validator.py
@@ -17,8 +17,8 @@ Two independent checks live here:
 
 2. **Positional-axis plottability gate** (WB9 / S5-14): a prop bound to a
    coordinate of the chart (``x``, ``y``, ``lat``, ``r``, ...) whose SQL
-   resolves to a *record-shaped* type — a STRUCT, MAP, OBJECT, UNION or
-   NESTED — cannot be drawn on an axis. Today that combination builds
+   resolves to a *record-shaped* type — a STRUCT, MAP, UNION or NESTED —
+   cannot be drawn on an axis. Today that combination builds
    "successfully" and renders a blank chart: the worst failure mode there
    is, because the run reports SUCCESS. The gate turns it into a build
    error carrying a :class:`~visivo.models.diagnostic.Diagnostic`.
@@ -288,6 +288,12 @@ def check_slice_type_compatibility(
 #   parents            the hierarchy edge that places a node (sunburst,
 #                      treemap, icicle) — a record here blanks the chart the
 #                      same way ``labels`` does
+#   value              the datum itself — the number an ``indicator`` displays,
+#                      and the 4th dimension of ``isosurface``/``volume``. It is
+#                      the only top-level ``value`` prop in ``visivo/schema``,
+#                      it is numeric in all three, and it is this module's
+#                      motivating example (see the header docstring), so a
+#                      record there is the same silent blank.
 #
 # Deliberately EXCLUDED, with reasons:
 #   * ``ids`` — present on every trace type but it is a key for animation
@@ -326,6 +332,7 @@ POSITIONAL_AXIS_PROP_NAMES = frozenset(
         "values",
         "labels",
         "parents",
+        "value",
     }
 )
 
@@ -338,8 +345,8 @@ POSITIONAL_AXIS_PROP_NAMES = frozenset(
 #   * numerics of every width/sign/precision, including the unsigned and
 #     wide integer types ClickHouse/DuckDB emit;
 #   * strings of every flavour (categorical axes), plus the string-backed
-#     scalars (UUID, INET, IP*, ENUM*, MONEY, XML, JSON/JSONB/VARIANT/SUPER
-#     — semi-structured columns arrive as JSON *text* and plot as categories);
+#     scalars (UUID, INET, IP*, ENUM*, MONEY, XML, and the semi-structured
+#     JSON/JSONB/VARIANT/SUPER/OBJECT — see the note on OBJECT below);
 #   * temporals (date/time axes) and INTERVAL;
 #   * BOOLEAN, which plots as a two-value categorical axis.
 #
@@ -407,6 +414,17 @@ PLOTTABLE_AXIS_TYPES = frozenset(
         "JSONB",
         "VARIANT",
         "SUPER",
+        # OBJECT is sqlglot's name for Snowflake's ``OBJECT`` — a VARIANT
+        # constrained to objects, and the ONLY dialect Visivo supports whose
+        # information_schema reports a bare ``OBJECT`` data_type. It has the
+        # same wire shape as VARIANT (the connector hands both back as JSON
+        # text) and the same parquet column, so it plots as a category exactly
+        # like VARIANT does. Denylisting it while allowlisting VARIANT would
+        # hard-fail a project that builds and renders today — a false positive,
+        # which this gate treats as strictly worse than a missed blank chart.
+        # sqlglot files OBJECT under ``DataType.STRUCT_TYPES``; that grouping is
+        # about SQL-level shape, not about what reaches the browser.
+        "OBJECT",
         # --- temporal ---------------------------------------------------
         "DATE",
         "DATE32",
@@ -435,15 +453,30 @@ PLOTTABLE_AXIS_TYPES = frozenset(
 # an axis of objects — the exact silent-blank failure WB9 exists to stop.
 #
 # This is sqlglot's own ``exp.DataType.STRUCT_TYPES`` (STRUCT / OBJECT /
-# NESTED / UNION) plus MAP, spelled out here rather than imported so the
-# rejected set is pinned by THIS file and cannot widen under us when sqlglot
-# reclassifies a type.
+# NESTED / UNION) plus MAP, MINUS OBJECT, spelled out here rather than imported
+# so the rejected set is pinned by THIS file and cannot widen under us when
+# sqlglot reclassifies a type. Every name left here is record-shaped ON THE
+# WIRE for the dialects Visivo supports: DuckDB/BigQuery STRUCT, DuckDB/
+# ClickHouse/Trino MAP, ClickHouse Nested, DuckDB UNION. OBJECT is the one
+# STRUCT_TYPES member that is not (Snowflake hands it back as JSON text) — see
+# its entry in PLOTTABLE_AXIS_TYPES.
 #
-# ARRAY and LIST are deliberately NOT here even though they are also nested:
-# a positional prop carrying a scalar slice (``x: ?{...}[0]``) binds a SINGLE
-# row's value to the prop, so an array-valued column becomes a perfectly
-# plottable array of scalars. Rejecting arrays would be a real false positive.
-NON_PLOTTABLE_AXIS_TYPES = frozenset({"STRUCT", "OBJECT", "NESTED", "UNION", "MAP"})
+# ARRAY and LIST are deliberately NOT here, for a reason narrower than the
+# denylist and broader than a single authoring form:
+#   * With a scalar slice (``x: ?{...}[0]``) the prop binds a SINGLE row's
+#     value, so an array-valued column becomes a plottable array of scalars.
+#     Rejecting that would be a plain false positive.
+#   * WITHOUT a slice the prop binds an array-of-arrays, which a linear axis
+#     does render as nothing — but ARRAY is exactly as ambiguous as OBJECT is.
+#     sqlglot spells DuckDB's genuinely-nested LIST and Snowflake's ARRAY (a
+#     VARIANT constrained to arrays, delivered as JSON *text*, categorical and
+#     perfectly plottable) with the SAME ``DataType.Type.ARRAY``, and nothing
+#     in ``DataType.this`` tells them apart. Rejecting the unsliced case would
+#     therefore hard-fail every Snowflake ARRAY column bound to an axis.
+# So ARRAY/LIST classify "unknown" and the gate stays silent on them —
+# deliberately fail-open, not an oversight. Splitting the sliced from the
+# unsliced case would not help: the Snowflake half is a false positive in both.
+NON_PLOTTABLE_AXIS_TYPES = frozenset({"STRUCT", "NESTED", "UNION", "MAP"})
 
 
 def axis_plottability(sqlglot_dtype: Optional[exp.DataType]) -> str:
@@ -467,6 +500,17 @@ def axis_plottability(sqlglot_dtype: Optional[exp.DataType]) -> str:
     if name in PLOTTABLE_AXIS_TYPES:
         return "plottable"
     return "unknown"
+
+
+def _article_for(type_name: str) -> str:
+    """``"an"`` before a type name that reads as vowel-initial, else ``"a"``.
+
+    Type names are ASCII SQL keywords, so first-letter is enough — there is no
+    "a UNION"-style consonant-sounding vowel among them. Kept as a helper (not
+    hardcoded to the current denylist) so a later addition — OBJECT, ARRAY,
+    INTERVAL — cannot silently reintroduce "a OBJECT".
+    """
+    return "an" if type_name[:1].upper() in "AEIOU" else "a"
 
 
 def is_positional_axis_prop(prop_path: str) -> bool:
@@ -541,10 +585,12 @@ def check_positional_axis_plottability(
     else:
         column_clause = ""
 
+    article = _article_for(type_name)
     message = (
-        f"Insight '{insight_name}': positional axis prop '{prop_path}' resolves to a "
-        f"{type_name}{column_clause}. A chart axis cannot plot a {type_name}, so this "
-        f"insight would build successfully and then render an empty chart."
+        f"Insight '{insight_name}': positional axis prop '{prop_path}' resolves to "
+        f"{article} {type_name}{column_clause}. A chart axis cannot plot {article} "
+        f"{type_name}, so this insight would build successfully and then render an "
+        f"empty chart."
     )
 
     hint = f"Bind '{prop_path}' to a single scalar column or expression."

--- a/visivo/query/insight/prop_type_validator.py
+++ b/visivo/query/insight/prop_type_validator.py
@@ -1,17 +1,34 @@
-"""Lightweight type compatibility check for sliced ``?{...}`` query strings.
+"""Compile-time type checks on the SQL a prop's ``?{...}`` resolves to.
 
-Goal: when a user writes ``value: ?{MAX(x)}[0]`` on an indicator (which
-expects a numeric scalar) but the underlying column resolves to a string
-type, fail at compile time with a clean message rather than rendering a
-broken or empty value.
+Two independent checks live here:
 
-Scope: BROAD type class only (numeric vs string). We deliberately do NOT
-validate value content (e.g. "is this a valid hex color?") because the
-prop schema doesn't expose the necessary granularity and Plotly will
-either parse or warn at render time. The check fires only when the
-authored value is a slice form ``?{expr}[N]`` (single index → scalar)
-*and* the prop's allowed primitive types in the trace JSON schema make
-the class evident.
+1. **Sliced-scalar class check** (the original): when a user writes
+   ``value: ?{MAX(x)}[0]`` on an indicator (which expects a numeric scalar)
+   but the underlying column resolves to a string type, fail at compile
+   time with a clean message rather than rendering a broken or empty value.
+
+   Scope: BROAD type class only (numeric vs string). We deliberately do NOT
+   validate value content (e.g. "is this a valid hex color?") because the
+   prop schema doesn't expose the necessary granularity and Plotly will
+   either parse or warn at render time. The check fires only when the
+   authored value is a slice form ``?{expr}[N]`` (single index → scalar)
+   *and* the prop's allowed primitive types in the trace JSON schema make
+   the class evident.
+
+2. **Positional-axis plottability gate** (WB9 / S5-14): a prop bound to a
+   coordinate of the chart (``x``, ``y``, ``lat``, ``r``, ...) whose SQL
+   resolves to a *record-shaped* type — a STRUCT, MAP, OBJECT, UNION or
+   NESTED — cannot be drawn on an axis. Today that combination builds
+   "successfully" and renders a blank chart: the worst failure mode there
+   is, because the run reports SUCCESS. The gate turns it into a build
+   error carrying a :class:`~visivo.models.diagnostic.Diagnostic`.
+
+   The concrete production case is a doubled query string. ``?{?{site}}``
+   leaves a residual ``?{...}`` in the resolved SQL, and
+   ``sqlglot.parse_one("?{site}")`` silently parses that as a DuckDB
+   STRUCT literal ``{'_0': site}``. Nothing downstream complains; the
+   parquet column comes back as ``STRUCT(VARCHAR)`` and Plotly draws
+   nothing.
 """
 
 from __future__ import annotations
@@ -19,9 +36,17 @@ from __future__ import annotations
 import json
 import re
 from importlib.resources import files
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
+import sqlglot
 from sqlglot import exp
+
+from visivo.models.diagnostic import (
+    Diagnostic,
+    DiagnosticObjectRef,
+    DiagnosticPhase,
+    DiagnosticSeverity,
+)
 
 # Minimum mapping from sqlglot DataType.this names to broad classes.
 # Anything not in this set defaults to "unknown" (no validation fires).
@@ -241,3 +266,324 @@ def check_slice_type_compatibility(
         f"({sqlglot_dtype.sql() if sqlglot_dtype else 'unknown'} in SQL). "
         f"Either change the source column type or remove the slice suffix."
     )
+
+
+# ---------------------------------------------------------------------------
+# WB9 / S5-14: positional-axis plottability gate
+# ---------------------------------------------------------------------------
+
+# The props whose value IS a coordinate of the rendered chart — the ones a
+# record-shaped value silently blanks. Derived by reading every trace schema
+# in ``visivo/schema/*.schema.json`` and keeping the props that place a datum
+# on an axis:
+#
+#   x, y, z            cartesian / 3-D (scatter, bar, box, heatmap, surface, ...)
+#   lat, lon           geographic (scattergeo, scattermap*, densitymap*)
+#   r, theta           polar (scatterpolar, barpolar, area)
+#   a, b, c            ternary / carpet (scatterternary, scattercarpet, carpet)
+#   real, imag         smith chart (scattersmith)
+#   open, high, low, close   price axes (candlestick, ohlc)
+#   values, labels     magnitude + category axes (pie, funnelarea, sunburst,
+#                      treemap, icicle)
+#   parents            the hierarchy edge that places a node (sunburst,
+#                      treemap, icicle) — a record here blanks the chart the
+#                      same way ``labels`` does
+#
+# Deliberately EXCLUDED, with reasons:
+#   * ``ids`` — present on every trace type but it is a key for animation
+#     frames / selection, not a coordinate. A weird value there does not
+#     blank the plot.
+#   * ``customdata``, ``text``, ``hovertext``, ``meta`` — Plotly explicitly
+#     allows arbitrary nested values in these; rejecting a STRUCT there
+#     would be a false positive.
+#   * ``props.domain.x`` / ``props.error_x.array`` / ``props.marker.*`` —
+#     leaves that happen to share a name with an axis. Matching is on the
+#     EXACT top-level path ``props.<name>`` for exactly this reason.
+#   * ``parcoords`` / ``parcats`` / ``splom`` ``dimensions[i].values`` and
+#     ``sankey``'s ``node``/``link`` — genuinely positional but nested inside
+#     array-of-object props with their own binding rules. Out of scope here
+#     rather than guessed at.
+#   * ``area``'s legacy ``t`` — a single-letter prop on a deprecated trace
+#     type; too generic a name to claim on the strength of one schema.
+POSITIONAL_AXIS_PROP_NAMES = frozenset(
+    {
+        "x",
+        "y",
+        "z",
+        "lat",
+        "lon",
+        "r",
+        "theta",
+        "a",
+        "b",
+        "c",
+        "real",
+        "imag",
+        "open",
+        "high",
+        "low",
+        "close",
+        "values",
+        "labels",
+        "parents",
+    }
+)
+
+
+# Types a Plotly axis CAN render. Enumerated deliberately (the positive half
+# of the classification) so that "did we just start rejecting something that
+# used to work?" is answerable by reading one list. Everything here reaches
+# the browser as a number, a string or a date after the parquet round-trip,
+# and Plotly plots all three on an axis:
+#   * numerics of every width/sign/precision, including the unsigned and
+#     wide integer types ClickHouse/DuckDB emit;
+#   * strings of every flavour (categorical axes), plus the string-backed
+#     scalars (UUID, INET, IP*, ENUM*, MONEY, XML, JSON/JSONB/VARIANT/SUPER
+#     — semi-structured columns arrive as JSON *text* and plot as categories);
+#   * temporals (date/time axes) and INTERVAL;
+#   * BOOLEAN, which plots as a two-value categorical axis.
+#
+# Names are sqlglot ``exp.DataType.Type`` MEMBERS (what ``annotate_types``
+# puts in ``DataType.this``), not SQL spellings — so "INT" and not "INTEGER",
+# "DOUBLE" and not "REAL". A test asserts every name here is a real member,
+# so a typo cannot quietly become a dead entry.
+PLOTTABLE_AXIS_TYPES = frozenset(
+    {
+        # --- numeric ---------------------------------------------------
+        "TINYINT",
+        "SMALLINT",
+        "MEDIUMINT",
+        "INT",
+        "BIGINT",
+        "INT128",
+        "INT256",
+        "UTINYINT",
+        "USMALLINT",
+        "UMEDIUMINT",
+        "UINT",
+        "UBIGINT",
+        "UINT128",
+        "UINT256",
+        "FLOAT",
+        "DOUBLE",
+        "UDOUBLE",
+        "DECIMAL",
+        "UDECIMAL",
+        "BIGDECIMAL",
+        "DECIMAL32",
+        "DECIMAL64",
+        "DECIMAL128",
+        "DECIMAL256",
+        "MONEY",
+        "SMALLMONEY",
+        "SERIAL",
+        "SMALLSERIAL",
+        "BIGSERIAL",
+        "YEAR",
+        # --- string / string-backed scalars -----------------------------
+        "CHAR",
+        "NCHAR",
+        "VARCHAR",
+        "NVARCHAR",
+        "BPCHAR",
+        "TEXT",
+        "TINYTEXT",
+        "MEDIUMTEXT",
+        "LONGTEXT",
+        "FIXEDSTRING",
+        "NAME",
+        "ENUM",
+        "ENUM8",
+        "ENUM16",
+        "LOWCARDINALITY",
+        "UUID",
+        "INET",
+        "IPADDRESS",
+        "IPPREFIX",
+        "IPV4",
+        "IPV6",
+        "XML",
+        "JSON",
+        "JSONB",
+        "VARIANT",
+        "SUPER",
+        # --- temporal ---------------------------------------------------
+        "DATE",
+        "DATE32",
+        "DATETIME",
+        "DATETIME2",
+        "DATETIME64",
+        "SMALLDATETIME",
+        "TIME",
+        "TIMETZ",
+        "TIMESTAMP",
+        "TIMESTAMPTZ",
+        "TIMESTAMPNTZ",
+        "TIMESTAMPLTZ",
+        "TIMESTAMP_S",
+        "TIMESTAMP_MS",
+        "TIMESTAMP_NS",
+        "INTERVAL",
+        # --- boolean ----------------------------------------------------
+        "BOOLEAN",
+    }
+)
+
+
+# Types an axis CANNOT render: record-shaped values. After the parquet
+# round-trip each row's value is an object/dict, and Plotly draws nothing for
+# an axis of objects — the exact silent-blank failure WB9 exists to stop.
+#
+# This is sqlglot's own ``exp.DataType.STRUCT_TYPES`` (STRUCT / OBJECT /
+# NESTED / UNION) plus MAP, spelled out here rather than imported so the
+# rejected set is pinned by THIS file and cannot widen under us when sqlglot
+# reclassifies a type.
+#
+# ARRAY and LIST are deliberately NOT here even though they are also nested:
+# a positional prop carrying a scalar slice (``x: ?{...}[0]``) binds a SINGLE
+# row's value to the prop, so an array-valued column becomes a perfectly
+# plottable array of scalars. Rejecting arrays would be a real false positive.
+NON_PLOTTABLE_AXIS_TYPES = frozenset({"STRUCT", "OBJECT", "NESTED", "UNION", "MAP"})
+
+
+def axis_plottability(sqlglot_dtype: Optional[exp.DataType]) -> str:
+    """Classify a resolved SQL type for use on a positional axis.
+
+    Returns ``"plottable"``, ``"non_plottable"``, or ``"unknown"``.
+
+    The classification is deliberately THREE-way, not a bare allowlist test.
+    sqlglot knows ~120 type names and dialects keep adding more; a type in
+    neither list is reported ``"unknown"`` and the gate does nothing. The
+    cost of a missed silent-blank chart is one bad render; the cost of a
+    false positive is a build that used to work now refusing to run, so the
+    gate only ever fails on a type we are certain about.
+    """
+    if sqlglot_dtype is None:
+        return "unknown"
+    this = getattr(sqlglot_dtype, "this", None)
+    name = this.value if hasattr(this, "value") else str(this)
+    if name in NON_PLOTTABLE_AXIS_TYPES:
+        return "non_plottable"
+    if name in PLOTTABLE_AXIS_TYPES:
+        return "plottable"
+    return "unknown"
+
+
+def is_positional_axis_prop(prop_path: str) -> bool:
+    """True when ``prop_path`` is a TOP-LEVEL positional axis prop.
+
+    Matches ``props.x`` but not ``props.domain.x``, ``props.error_x.array``
+    or ``props.marker.color`` — see ``POSITIONAL_AXIS_PROP_NAMES`` for why
+    the match is anchored to the top level.
+    """
+    if not prop_path:
+        return False
+    parts = prop_path.split(".")
+    if len(parts) != 2 or parts[0] != "props":
+        return False
+    return parts[1] in POSITIONAL_AXIS_PROP_NAMES
+
+
+def _column_names_in(sql: Optional[str], dialect: Optional[str] = None) -> List[str]:
+    """Column identifiers referenced by ``sql``, in order, deduped.
+
+    Parsed with SQLGlot (never a regex). Returns ``[]`` when the fragment
+    does not parse — the caller then names the expression instead.
+    """
+    if not sql:
+        return []
+    try:
+        parsed = sqlglot.parse_one(sql, dialect=dialect) if dialect else sqlglot.parse_one(sql)
+    except Exception:
+        return []
+    if parsed is None:
+        return []
+    names: List[str] = []
+    for column in parsed.find_all(exp.Column):
+        name = column.name
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def check_positional_axis_plottability(
+    *,
+    insight_name: str,
+    prop_path: str,
+    sqlglot_dtype: Optional[exp.DataType],
+    resolved_sql: Optional[str] = None,
+    dialect: Optional[str] = None,
+) -> Optional[Diagnostic]:
+    """Gate a positional-axis prop on the type its SQL resolves to.
+
+    Returns ``None`` when the prop is fine (not positional, type unknown, or
+    a type an axis can render) and a :class:`Diagnostic` describing the
+    failure otherwise. Never raises — a caller inside a build should be able
+    to trust it.
+    """
+    if not is_positional_axis_prop(prop_path):
+        return None
+    if axis_plottability(sqlglot_dtype) != "non_plottable":
+        return None
+
+    this = getattr(sqlglot_dtype, "this", None)
+    type_name = this.value if hasattr(this, "value") else str(this)
+    try:
+        full_type = sqlglot_dtype.sql()
+    except Exception:
+        full_type = type_name
+
+    columns = _column_names_in(resolved_sql, dialect)
+    if columns:
+        column_clause = f" built from column{'s' if len(columns) > 1 else ''} " + ", ".join(
+            f"'{c}'" for c in columns
+        )
+    else:
+        column_clause = ""
+
+    message = (
+        f"Insight '{insight_name}': positional axis prop '{prop_path}' resolves to a "
+        f"{type_name}{column_clause}. A chart axis cannot plot a {type_name}, so this "
+        f"insight would build successfully and then render an empty chart."
+    )
+
+    hint = f"Bind '{prop_path}' to a single scalar column or expression."
+    if type_name == "STRUCT":
+        hint += (
+            " A STRUCT here is almost always a doubled query string — check the prop's "
+            "value for a nested '?{?{ ... }}', which SQLGlot parses as a struct literal."
+        )
+
+    detail_lines = [f"Resolved SQL type: {full_type}"]
+    if resolved_sql:
+        detail_lines.append(f"Resolved expression: {resolved_sql}")
+
+    return Diagnostic(
+        id=f"compile:non_plottable_axis_type:{insight_name}:{prop_path}",
+        severity=DiagnosticSeverity.ERROR,
+        phase=DiagnosticPhase.COMPILE,
+        code="non_plottable_axis_type",
+        message=message,
+        object=DiagnosticObjectRef(type="insight", name=insight_name),
+        field=prop_path,
+        detail="\n".join(detail_lines),
+        hint=hint,
+    )
+
+
+class PositionalAxisTypeError(ValueError):
+    """A positional-axis prop resolved to a type no axis can render.
+
+    Subclasses ``ValueError`` so every existing ``except Exception`` /
+    ``except ValueError`` build handler keeps behaving exactly as it does
+    for the other compile-time prop failures, while carrying the structured
+    :attr:`diagnostic` for callers that can render it (the same pattern
+    ``JoinPathError`` uses for its structured join fields).
+    """
+
+    def __init__(self, diagnostic: Diagnostic):
+        self.diagnostic = diagnostic
+        message = diagnostic.message
+        if diagnostic.hint:
+            message = f"{message} {diagnostic.hint}"
+        super().__init__(message)

--- a/visivo/server/views/insight_compile_views.py
+++ b/visivo/server/views/insight_compile_views.py
@@ -19,11 +19,13 @@ text via ``Insight.get_query_info(..., force_dynamic=True)``, and stops.
 Response contract:
   200 { post_query, pre_query: null, props_mapping, static_props,
         props_slices, split_key, type, models: [{name, name_hash}] }
-  400 { error, diagnostic? } — malformed body / draft Pydantic validation /
-        ref-resolution / SQLGlot failure. `diagnostic` is the structured
-        `Diagnostic` (visivo/models/diagnostic.py) when the build failure
-        carried one (e.g. a positional axis bound to a STRUCT, WB9/S5-14);
-        absent otherwise, so `error` stays the only field a client needs.
+  400 { error, diagnostics? } — malformed body / draft Pydantic validation /
+        ref-resolution / SQLGlot failure. `diagnostics` is a LIST of structured
+        `Diagnostic` objects (visivo/models/diagnostic.py) when the build
+        failure carried one (e.g. a positional axis bound to a STRUCT,
+        WB9/S5-14) — the plural shape `diagnosticsFrom` in
+        viewer/src/types/diagnostic.js reads. Absent otherwise, so `error`
+        stays the only field a client needs.
   422 { error, error_type: "model_not_run", model: str|null } — a raw-column
         ref names a scratch model with no schema (client never sent
         `model_schemas` for it, and it has never been run for real either) —

--- a/visivo/server/views/insight_compile_views.py
+++ b/visivo/server/views/insight_compile_views.py
@@ -19,8 +19,11 @@ text via ``Insight.get_query_info(..., force_dynamic=True)``, and stops.
 Response contract:
   200 { post_query, pre_query: null, props_mapping, static_props,
         props_slices, split_key, type, models: [{name, name_hash}] }
-  400 { error } — malformed body / draft Pydantic validation / ref-resolution
-        / SQLGlot failure
+  400 { error, diagnostic? } — malformed body / draft Pydantic validation /
+        ref-resolution / SQLGlot failure. `diagnostic` is the structured
+        `Diagnostic` (visivo/models/diagnostic.py) when the build failure
+        carried one (e.g. a positional axis bound to a STRUCT, WB9/S5-14);
+        absent otherwise, so `error` stays the only field a client needs.
   422 { error, error_type: "model_not_run", model: str|null } — a raw-column
         ref names a scratch model with no schema (client never sent
         `model_schemas` for it, and it has never been run for real either) —
@@ -36,6 +39,7 @@ from visivo.query.insight.draft_overlay import build_draft_overlay, DraftOverlay
 from visivo.server.views.insight_draft_common import (
     parse_draft_request,
     build_schema_overrides,
+    diagnostic_fields,
     is_model_not_run_error,
     extract_model_not_run_name,
 )
@@ -91,7 +95,7 @@ def register_insight_compile_views(app, flask_app, output_dir):
                     422,
                 )
             Logger.instance().error(f"compile-draft: query build failed: {e}")
-            return jsonify({"error": message}), 400
+            return jsonify({"error": message, **diagnostic_fields(e)}), 400
 
         try:
             dependent_models = insight.get_all_dependent_models(dag)

--- a/visivo/server/views/insight_draft_common.py
+++ b/visivo/server/views/insight_draft_common.py
@@ -93,3 +93,17 @@ def extract_model_not_run_name(message):
         if match:
             return match.group(1).strip()
     return None
+
+
+def diagnostic_fields(exc):
+    """Structured ``{"diagnostic": {...}}`` for a build failure that carries a
+    :class:`~visivo.models.diagnostic.Diagnostic`, ``{}`` for one that doesn't.
+
+    Additive by design: the 400 body keeps its ``error`` string exactly as it
+    was, and a client that doesn't know about diagnostics never sees a
+    difference. Producers today: ``PositionalAxisTypeError`` (WB9 / S5-14).
+    """
+    diagnostic = getattr(exc, "diagnostic", None)
+    if diagnostic is None or not hasattr(diagnostic, "model_dump"):
+        return {}
+    return {"diagnostic": diagnostic.model_dump(mode="json", exclude_none=True)}

--- a/visivo/server/views/insight_draft_common.py
+++ b/visivo/server/views/insight_draft_common.py
@@ -96,8 +96,18 @@ def extract_model_not_run_name(message):
 
 
 def diagnostic_fields(exc):
-    """Structured ``{"diagnostic": {...}}`` for a build failure that carries a
-    :class:`~visivo.models.diagnostic.Diagnostic`, ``{}`` for one that doesn't.
+    """Structured ``{"diagnostics": [ {...} ]}`` for a build failure that
+    carries a :class:`~visivo.models.diagnostic.Diagnostic`, ``{}`` for one
+    that doesn't.
+
+    The key is PLURAL and the value is a LIST because that is the wire shape
+    the contract already specifies: ``visivo/models/diagnostic.py`` documents
+    payloads as growing "a ``diagnostics`` key", and the viewer's single
+    universal reader — ``diagnosticsFrom`` in ``viewer/src/types/diagnostic.js``
+    — returns ``[]`` for anything that is not ``Array.isArray(payload
+    .diagnostics)``. This is the FIRST producer on the wire, so it sets the
+    precedent for every later one; a singular ``diagnostic`` object would have
+    forced a second, incompatible reader for the same contract.
 
     Additive by design: the 400 body keeps its ``error`` string exactly as it
     was, and a client that doesn't know about diagnostics never sees a
@@ -106,4 +116,4 @@ def diagnostic_fields(exc):
     diagnostic = getattr(exc, "diagnostic", None)
     if diagnostic is None or not hasattr(diagnostic, "model_dump"):
         return {}
-    return {"diagnostic": diagnostic.model_dump(mode="json", exclude_none=True)}
+    return {"diagnostics": [diagnostic.model_dump(mode="json", exclude_none=True)]}

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -30,9 +30,11 @@ Response contract:
         baked server-side; the client falls back to its DuckDB sample lane.
   422 { error, error_type: "model_not_run", model } — a ref names a scratch
         model with no schema (never run, and no ``model_schemas`` sent).
-  400 bodies additionally carry `diagnostic` (visivo/models/diagnostic.py)
-        when the build failure produced one — e.g. a positional axis bound to
-        a STRUCT (WB9/S5-14). Absent otherwise.
+  400 bodies additionally carry `diagnostics` — a LIST of structured
+        `Diagnostic` objects (visivo/models/diagnostic.py), the plural shape
+        `diagnosticsFrom` in viewer/src/types/diagnostic.js reads — when the
+        build failure produced one, e.g. a positional axis bound to a STRUCT
+        (WB9/S5-14). Absent otherwise.
 """
 
 from flask import request, jsonify

--- a/visivo/server/views/insight_execute_views.py
+++ b/visivo/server/views/insight_execute_views.py
@@ -30,6 +30,9 @@ Response contract:
         baked server-side; the client falls back to its DuckDB sample lane.
   422 { error, error_type: "model_not_run", model } — a ref names a scratch
         model with no schema (never run, and no ``model_schemas`` sent).
+  400 bodies additionally carry `diagnostic` (visivo/models/diagnostic.py)
+        when the build failure produced one — e.g. a positional axis bound to
+        a STRUCT (WB9/S5-14). Absent otherwise.
 """
 
 from flask import request, jsonify
@@ -42,6 +45,7 @@ from visivo.query.insight.draft_overlay import build_draft_overlay, DraftOverlay
 from visivo.server.views.insight_draft_common import (
     parse_draft_request,
     build_schema_overrides,
+    diagnostic_fields,
     is_model_not_run_error,
     extract_model_not_run_name,
 )
@@ -133,7 +137,7 @@ def register_insight_execute_views(app, flask_app, output_dir):
                     422,
                 )
             Logger.instance().error(f"execute-draft: query build failed: {e}")
-            return jsonify({"error": message}), 400
+            return jsonify({"error": message, **diagnostic_fields(e)}), 400
 
         # A dynamic insight (references a real Input) has pre_query=None — its
         # query carries unfilled ${input} placeholders the server can't bake, so


### PR DESCRIPTION
## Problem (S5-14)

An insight whose `x` — or any other positional axis — resolves to a **STRUCT** builds *successfully* and renders a **blank chart with a SUCCESS job**. Nothing anywhere reports a problem. That is the worst failure shape we ship: the user sees an empty panel and has no thread to pull.

Root cause, reproduced end to end on `main`:

```python
sqlglot.parse_one("?{site}", read="duckdb")
# Struct(expressions=[Column(this=Identifier(this=site))])   →  {'_0': site}
```

A doubled query string `x: ?{?{${ref(m).site}}}` leaves a residual `?{...}` in the resolved SQL; SQLGlot silently reads it as a DuckDB struct literal, the pre-query becomes `SELECT STRUCT("m"."site") AS "…"`, and the parquet column comes back `STRUCT(VARCHAR)`. Plotly draws nothing.

`prop_type_validator.py` already existed but could not catch it: it fires **only** on slice forms `?{expr}[N]`, and its `_NUMERIC`/`_STRING`/`_BOOLEAN` sets omit STRUCT, so STRUCT classed as `"unknown"` → no validation. S5-14 was fully unguarded.

The editor-side cause of the double-wrap is M24 (Stream G right-rail); this gate stops the *failure mode* in general, not just that one producer.

## Fix

`prop_type_validator.py` grows a second, independent check: a **positional-axis plottability gate** that runs on every bound prop at build time (`InsightQueryBuilder.build()`, both the static and the `force_dynamic` Explorer-preview path).

On a hit it raises `PositionalAxisTypeError` — a `ValueError` (so every existing `except Exception` build handler behaves exactly as before) carrying a structured **`Diagnostic`**, the same way `JoinPathError` carries its structured join fields. New append-only code in `DIAGNOSTIC_CODES`: `non_plottable_axis_type`.

The message names all four things the user needs:

```
Insight 'site_totals': positional axis prop 'props.x' resolves to a STRUCT built
from column 'site'. A chart axis cannot plot a STRUCT, so this insight would build
successfully and then render an empty chart. Bind 'props.x' to a single scalar
column or expression. A STRUCT here is almost always a doubled query string —
check the prop's value for a nested '?{?{ ... }}', which SQLGlot parses as a
struct literal.
```

Where the surrounding code supports it, the Diagnostic is *emitted*, not just carried: `/api/insight-compile-draft/` and `/api/insight-execute-draft/` add an **additive** `diagnostic` key to their existing 400 body (`error` unchanged; the key is absent for failures that produced no Diagnostic, so no client sees a difference until it opts in).

Incidental cleanup: the builder's `AS "<hash>"` alias strip was a regex over SQL. It is gone — the alias now rides along on the fragment and is unwrapped from the parsed AST by `_infer_expression_type`.

## False positives — the allowlist and why it is shaped this way

**This was the main design risk**, so classification is deliberately **three-way**, not a bare allowlist test:

| bucket | contents | gate behaviour |
|---|---|---|
| `plottable` | `PLOTTABLE_AXIS_TYPES` — 73 enumerated sqlglot type members | pass |
| `non_plottable` | `NON_PLOTTABLE_AXIS_TYPES` = `{STRUCT, OBJECT, NESTED, UNION, MAP}` | **fail** |
| `unknown` | everything else (sqlglot knows ~123 type names) | pass |

The costs are asymmetric. A missed silent-blank chart costs one bad render; a false positive turns a build that used to work into a hard failure and blocks everything. So the gate only ever fails on a type we are *certain* about, and a type we have not triaged — or one a future sqlglot release adds — can never start failing a working build.

**Allowlist contents** (`PLOTTABLE_AXIS_TYPES`, the positive half, enumerated so "did we just start rejecting something?" is answerable by reading one list):
- **numerics** of every width/sign/precision, including the unsigned and wide integer types ClickHouse/DuckDB emit (`UBIGINT`, `INT128`, `UDECIMAL`, `DECIMAL256`, …) and the serial/money/year scalars;
- **strings** of every flavour (categorical axes) plus the string-backed scalars — `UUID`, `INET`, `IP*`, `ENUM*`, `LOWCARDINALITY`, `XML`, and `JSON`/`JSONB`/`VARIANT`/`SUPER` (semi-structured columns arrive as JSON **text** after the parquet round-trip and plot fine as categories);
- **temporals** (`DATE*`, `TIME*`, `TIMESTAMP*`, `INTERVAL`) — date axes;
- **BOOLEAN**, which plots as a two-value categorical axis.

Names are `exp.DataType.Type` **members** (what `annotate_types` puts in `DataType.this`), not SQL spellings — so `INT` not `INTEGER`, `DOUBLE` not `REAL`. A test asserts every name in both sets is a real member, so a typo cannot become a dead entry that silently never matches. (The six alias spellings I first wrote — `INTEGER`, `REAL`, `NUMERIC`, `NUMBER`, `STRING`, `BOOL` — were caught by exactly that test and removed.)

**Denylist reasoning:** sqlglot's own `exp.DataType.STRUCT_TYPES` (`STRUCT`/`OBJECT`/`NESTED`/`UNION`) plus `MAP`. After the parquet round-trip each row's value is an object; an axis of objects draws nothing, and no slice rescues it (slicing picks one row's value — still a record). Spelled out in this file rather than imported, so the rejected set is pinned here and cannot widen under us when sqlglot reclassifies a type. A test asserts `STRUCT_TYPES ⊆` our denylist so a future sqlglot record type shows up as a failure rather than a silent gap.

**`ARRAY`/`LIST` are deliberately NOT rejected** even though they are also nested: a positional prop with a scalar slice (`x: ?{...}[0]`) binds a **single row's** value, so an array column becomes a perfectly plottable array of scalars. Rejecting arrays would be a real false positive.

**Prop scoping.** Only the **exact top-level** paths `props.<name>` for: `x`, `y`, `z` (cartesian/3-D), `lat`, `lon` (geo), `r`, `theta` (polar), `a`, `b`, `c` (ternary/carpet), `real`, `imag` (smith), `open`/`high`/`low`/`close` (OHLC), `values`/`labels`/`parents` (pie/funnelarea/sunburst/treemap/icicle). Derived by reading all 51 trace schemas in `visivo/schema/`. Deliberately excluded, each for a reason recorded in the source:
- `ids` — on every trace type, but it keys animation frames/selection, not a coordinate;
- `customdata`, `text`, `hovertext`, `meta` — Plotly explicitly allows arbitrary nested values here; rejecting a STRUCT would be a false positive;
- `props.domain.x`, `props.error_x.array`, `props.marker.*` — leaves that merely *share a name* with an axis, which is why matching is anchored to the top level;
- `parcoords`/`parcats`/`splom` `dimensions[i].values` and `sankey`'s `node`/`link` — genuinely positional but nested inside array-of-object props with their own binding rules; out of scope rather than guessed at;
- `area`'s legacy `t` — too generic a name to claim on one deprecated trace type.

## Falsification evidence

Every guard was falsified by stashing the implementation and keeping the tests.

**A — remove the gate call from `build()`** (i.e. `main`'s behaviour):
```
FAILED test_struct_on_x_fails_the_build_naming_insight_prop_column_and_type - Failed: DID NOT RAISE PositionalAxisTypeError
FAILED test_struct_on_x_carries_a_structured_diagnostic              - Failed: DID NOT RAISE PositionalAxisTypeError
FAILED test_struct_on_y_also_fails                                   - Failed: DID NOT RAISE PositionalAxisTypeError
FAILED test_struct_on_the_dynamic_preview_path_also_fails            - Failed: DID NOT RAISE PositionalAxisTypeError
FAILED TestCompileDraftPositionalAxisTypeGate::test_struct_bound_to_x_is_a_400_not_a_blank_200 - assert 200 == 400
FAILED TestCompileDraftPositionalAxisTypeGate::test_the_400_carries_the_structured_diagnostic  - KeyError: 'diagnostic'
6 failed, 115 passed
```
Note `assert 200 == 400` — that is the bug itself: on `main` the compile-draft endpoint returns a cheerful 200 the Explorer renders as an empty chart.

**B — drop the positional-prop scoping (gate every prop):**
```
FAILED test_struct_on_a_non_positional_prop_is_unaffected - PositionalAxisTypeError: ... positional axis prop 'props.customdata' resolves to a STRUCT ...
FAILED test_struct_on_a_nested_prop_named_like_an_axis_is_unaffected - AssertionError: assert True is False
FAILED test_check_returns_none_for_a_non_positional_prop  - assert Diagnostic(id='compile:non_plottable_axis_type:i:props.customdata', ...) is None
3 failed, 102 passed
```

**C1 — the naive allowlist-only design** (reject anything not on the allowlist, no third bucket):
```
FAILED test_unrecognised_types_pass_through_rather_than_failing - AssertionError: GEOMETRY
FAILED test_array_types_are_deliberately_not_rejected           - AssertionError: ARRAY
2 failed, 103 passed
```

**C2 — an over-broad denylist that swallows `DATE`/`TIMESTAMP`/`BOOLEAN`** (through the *real* builder, not just the classifier):
```
FAILED test_real_columns_of_every_common_type_still_build[DATE]      - PositionalAxisTypeError: ... resolves to a DATE built from column 'col' ...
FAILED test_real_columns_of_every_common_type_still_build[TIMESTAMP] - PositionalAxisTypeError: ... resolves to a TIMESTAMP ...
FAILED test_real_columns_of_every_common_type_still_build[BOOLEAN]   - PositionalAxisTypeError: ... resolves to a BOOLEAN ...
3 failed, 102 passed
```

All restored; 105 pass in the new file.

## Test results

- `tests/query/insight/test_positional_axis_type_gate.py` — **105 passed** (new file). Covers all three asks: STRUCT on x rejected with the message (insight + prop + column + type); STRUCT on a non-positional prop unaffected; every plottable type still accepted — parametrised over all 73 allowlist entries, plus an end-to-end pass through the real builder for `VARCHAR/DOUBLE/BIGINT/DATE/TIMESTAMP/BOOLEAN/DECIMAL(10,2)`.
- Endpoint + helper coverage in `tests/server/views/test_insight_compile_views.py` and `test_insight_draft_common.py`, `non_plottable_axis_type` registration in `tests/models/test_diagnostic.py`.
- **Full suite: `2577 passed, 2 skipped, 5 xfailed, 1 xpassed`.**
- `black --check --target-version py312 .` — clean (544 files unchanged).
- Real-project smoke: `visivo run` clean on `test-projects/integration` (every trace type, indicators, waterfalls, surfaces, splits, inputs), `demo`, `complex-project`, and `docs-examples` (95s, every documented chart). Zero over-rejection. `docs-interactivity` fails on a missing uncommitted `local.duckdb` — pre-existing and unrelated.

## Schema regeneration

`python -m visivo.generate_project_schema_json` was run after the `visivo/models/diagnostic.py` edit: **no diff** — `Diagnostic` is a runtime contract, not a project config object, so it is not part of `visivo_project_schema.json`. Nothing to commit, and therefore **no actual conflict with open PR #642**, which does regenerate that file. Flagging the nominal overlap anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
