### PR TITLE
Explorer chart: fill the pane, and follow it when it moves (M28)

### DIFF
--- a/viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs
+++ b/viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs
@@ -1,0 +1,297 @@
+/**
+ * Story: the Explorer's chart preview FILLS its pane, and TRACKS it when the
+ * pane changes size without the window changing size (M28).
+ *
+ * This file measures rendered geometry — `getBoundingClientRect()` of the pane
+ * versus the Plotly root — rather than eyeballing a screenshot, because the
+ * two failure modes it guards are both invisible to a "looks fine" glance at a
+ * single viewport:
+ *
+ *   FILL — `ExplorerChartPreview`'s root used to be `flex flex-1 min-h-0
+ *   flex-col`. Its parent (`CenterPanel`'s chart pane) is `display:block`, so
+ *   `flex-1` was inert there: the root had NO definite height, every `h-full`
+ *   below it resolved against an indefinite parent and collapsed to `auto`,
+ *   and Plotly fell back to its built-in 450px default no matter how tall the
+ *   pane actually was. At a tall viewport that reads as a chart floating in
+ *   dead space; at a short one it reads as a chart overflowing its pane.
+ *
+ *   TRACK — Plotly measures its container only when something tells it to, and
+ *   the only thing that ever does is a window `resize` event (`react-plotly.js`
+ *   installs a window listener for `useResizeHandler`; plotly.js contains no
+ *   `ResizeObserver`). `CenterPanel` papers over its OWN dividers by
+ *   dispatching a synthetic window resize whenever its split ratios change,
+ *   but nothing covers a pane that resizes for any other reason. Dragging the
+ *   workspace's RIGHT-RAIL gutter is exactly such a gesture: it changes the
+ *   chart pane's width, changes none of `CenterPanel`'s ratio state, and never
+ *   resizes the window — so before the fix the plot kept its stale width.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=m28 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3001 npx playwright test explorer-chart-fills-pane
+ *
+ * Creates an exploration per test and deletes it in afterEach; it promotes
+ * nothing, so it needs no object cleanup beyond that.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+import { BASE_URL, apiBase } from '../helpers/sandbox.mjs';
+
+const SOURCE = 'local-duckdb';
+const TABLE = 'test_table';
+
+/** The pane the chart is supposed to fill: `CenterPanel`'s chart slot, whose
+ *  height is definite (a flex child of a `h-full flex-col` section). */
+const PANE = '[data-testid="chart-preview-pane"]';
+/** Plotly's own root node — what actually got drawn, at whatever size Plotly
+ *  decided on. `.js-plotly-plot` is Plotly's class, not ours. */
+const PLOT = '.js-plotly-plot';
+
+async function dragAndDrop(page, sourceLocator, targetLocator) {
+  const sourceBox = await sourceLocator.boundingBox();
+  const targetBox = await targetLocator.boundingBox();
+  expect(sourceBox && targetBox, 'both drag endpoints have a box').toBeTruthy();
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(sourceX + 10, sourceY, { steps: 3 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(targetX, targetY, { steps: 12 });
+  await page.mouse.move(targetX, targetY, { steps: 4 });
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+}
+
+async function expandSourceTable(page) {
+  const sourceHeader = page.getByTestId('library-subsection-source-header');
+  const sourceBody = page.getByTestId('library-subsection-source-body');
+  if (!(await sourceBody.isVisible().catch(() => false))) await sourceHeader.click();
+  await expect(sourceBody).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId(`library-row-source-${SOURCE}-toggle`).click();
+  const tableRow = page.getByTestId(`library-source-table-${SOURCE}-${TABLE}`);
+  await expect(tableRow).toBeVisible({ timeout: 15000 });
+  return tableRow;
+}
+
+async function firstColumn(page, tableRow) {
+  await tableRow.getByTestId(`library-source-table-${SOURCE}-${TABLE}-toggle`).click();
+  const col = page.locator('[data-testid^="library-source-column-"]').first();
+  await expect(col).toBeVisible({ timeout: 10000 });
+  return col;
+}
+
+/** `CenterPanel` is responsive: under its internal 600px width threshold the
+ *  SQL editor and chart become a tab toggle instead of a side-by-side split,
+ *  and `ExplorerChartPreview` only mounts on the Chart tab. The no-op call in
+ *  wide mode keeps this file working at either width. */
+async function ensureChartTabVisible(page) {
+  const toggle = page.getByTestId('toggle-chart');
+  if (await toggle.isVisible().catch(() => false)) {
+    await toggle.click();
+  }
+}
+
+/** Build a live draft chart: query, then drop a column on the x well. */
+async function buildDraftChart(page) {
+  await gotoExplorerHome(page);
+  await newExploration(page);
+  await typeSql(page, `SELECT * FROM ${TABLE}`);
+  await runQuery(page);
+
+  const tableRow = await expandSourceTable(page);
+  const column = await firstColumn(page, tableRow);
+  const xSlot = page.locator('[data-testid*="droppable-property-x"]').first();
+  await expect(xSlot).toBeVisible({ timeout: 15000 });
+  await dragAndDrop(page, column, xSlot);
+  await ensureChartTabVisible(page);
+
+  const insightName = await page.evaluate(
+    () => window.useStore.getState().explorerChartInsightNames[0]
+  );
+  await expect(async () => {
+    const data = await page.evaluate(
+      name => window.useStore.getState().insightJobs[`__draft__:${name}`]?.data ?? null,
+      insightName
+    );
+    expect(data).not.toBeNull();
+  }).toPass({ timeout: 30000 });
+
+  await expect(page.locator(PLOT)).toBeVisible({ timeout: 20000 });
+}
+
+/**
+ * Read every box in ONE evaluate so they all describe the same layout frame.
+ *
+ * Three numbers, because two of them can disagree and only the third is proof:
+ *
+ *   pane  — the box the chart is supposed to fill.
+ *   box   — the Plotly root's CSS box. `Chart.jsx` gives it
+ *           `style={{width:'100%',height:'100%'}}`, so its WIDTH always equals
+ *           its parent's whether or not anything is wired correctly. Its
+ *           height is the honest one: `height:100%` against an
+ *           indefinite-height parent collapses to `auto`, i.e. to whatever
+ *           Plotly drew inside.
+ *   drawn  — `gd._fullLayout.width/height`: the dimensions Plotly itself
+ *           resolved and rendered the figure at. This is the only number that
+ *           shows whether Plotly ever RE-MEASURED, which is the whole question
+ *           for the tracking case — a CSS box that stretches while the figure
+ *           inside it stays at its old size is precisely the bug.
+ */
+async function measure(page) {
+  return page.evaluate(
+    ([paneSel, plotSel]) => {
+      const pane = document.querySelector(paneSel);
+      const gd = document.querySelector(plotSel);
+      if (!pane || !gd) return null;
+      const p = pane.getBoundingClientRect();
+      const q = gd.getBoundingClientRect();
+      return {
+        pane: { width: p.width, height: p.height },
+        box: { width: q.width, height: q.height },
+        drawn: gd._fullLayout
+          ? { width: gd._fullLayout.width, height: gd._fullLayout.height }
+          : null,
+      };
+    },
+    [PANE, PLOT]
+  );
+}
+
+test.describe('Explorer chart preview fills and tracks its pane (M28)', () => {
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    idsBeforeTest = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+  });
+
+  test.afterEach(async ({ page }) => {
+    const res = await page.request.get(`${apiBase}/api/explorations/`).catch(() => null);
+    const idsAfter = res && res.ok() ? (await res.json()).map(e => e.id) : [];
+    for (const id of idsAfter.filter(i => !idsBeforeTest.includes(i))) {
+      await page.request.delete(`${apiBase}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  // FILL, at two widths. 1280 and 1600 are the dossier's acceptance widths;
+  // they also straddle `CenterPanel`'s 600px narrow/wide threshold once the
+  // rails are subtracted, so this covers the tab-toggle layout AND the
+  // side-by-side layout — two different ancestor chains to the same pane.
+  for (const width of [1280, 1600]) {
+    test(`the plot fills its pane at ${width}px — never Plotly's 450px default`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 1000 });
+      await buildDraftChart(page);
+
+      // Plotly settles asynchronously after its own resize debounce (100ms).
+      await expect(async () => {
+        const m = await measure(page);
+        expect(m, 'both the pane and the Plotly root are in the DOM').not.toBeNull();
+        expect(m.drawn, 'Plotly has resolved a full layout').not.toBeNull();
+        expect(m.pane.height, 'the pane itself has a real height').toBeGreaterThan(200);
+        // Two claims, because either can fail alone: the CSS chain resolves to
+        // the pane's height (the `h-full` half), AND Plotly drew the figure at
+        // that height (the measurement half). Sub-pixel layout rounding is the
+        // only slack allowed.
+        const geom = `pane ${m.pane.height} / box ${m.box.height} / drawn ${m.drawn.height}`;
+        expect(
+          Math.abs(m.box.height - m.pane.height),
+          `CSS box fills pane — ${geom}`
+        ).toBeLessThanOrEqual(2);
+        expect(
+          Math.abs(m.drawn.height - m.pane.height),
+          `Plotly drew at the pane height — ${geom}`
+        ).toBeLessThanOrEqual(2);
+      }).toPass({ timeout: 20000 });
+
+      const m = await measure(page);
+      // Guard the specific pre-fix signature as well as the general one: 450 is
+      // plotly.js's built-in default height, which is what an indefinite-height
+      // container produces. Skipped when the pane happens to be ~450 tall.
+      if (Math.abs(m.pane.height - 450) > 5) {
+        expect(Math.round(m.drawn.height), 'not the Plotly default').not.toBe(450);
+      }
+    });
+  }
+
+  // TRACK. The right-rail gutter changes the chart pane's WIDTH while leaving
+  // every `CenterPanel` split ratio untouched and never resizing the window —
+  // so nothing but a container observation can make Plotly re-measure.
+  test('the plot re-lays-out when the right rail is dragged — no window resize involved', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await buildDraftChart(page);
+
+    await expect(async () => {
+      const m = await measure(page);
+      expect(m).not.toBeNull();
+      expect(m.drawn).not.toBeNull();
+      expect(Math.abs(m.drawn.width - m.pane.width)).toBeLessThanOrEqual(2);
+    }).toPass({ timeout: 20000 });
+
+    const before = await measure(page);
+
+    const handle = page.getByTestId('workspace-drag-handle-right');
+    await expect(handle).toBeVisible({ timeout: 10000 });
+    const box = await handle.boundingBox();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    // Drag left: the right rail gets wider, the middle (and so the chart pane)
+    // gets narrower.
+    await page.mouse.move(box.x + box.width / 2 - 220, box.y + box.height / 2, { steps: 12 });
+    await page.mouse.up();
+
+    await expect(async () => {
+      const after = await measure(page);
+      expect(after).not.toBeNull();
+      expect(after.drawn).not.toBeNull();
+      expect(after.pane.width, 'the gesture actually narrowed the pane').toBeLessThan(
+        before.pane.width - 50
+      );
+      // `box.width` would pass here even completely unwired — the Plotly root
+      // is `width:100%`, so its CSS box follows the pane by itself. Only the
+      // width Plotly RESOLVED proves it re-measured.
+      const geom =
+        `pane ${before.pane.width}→${after.pane.width}, ` +
+        `drawn ${before.drawn.width}→${after.drawn.width}`;
+      expect(
+        Math.abs(after.drawn.width - after.pane.width),
+        `Plotly re-measured and re-drew at the new pane width — ${geom}`
+      ).toBeLessThanOrEqual(2);
+      expect(after.drawn.width, `the drawn width actually moved — ${geom}`).toBeLessThan(
+        before.drawn.width - 50
+      );
+    }).toPass({ timeout: 20000 });
+
+    // The window was never resized — the viewport is pinned for the whole
+    // test, so nothing but a container observation could have triggered the
+    // re-measure asserted above.
+    const viewport = page.viewportSize();
+    expect(viewport.width).toBe(1600);
+    expect(viewport.height).toBe(1000);
+  });
+});

--- a/viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs
+++ b/viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs
@@ -2,10 +2,10 @@
  * Story: the Explorer's chart preview FILLS its pane, and TRACKS it when the
  * pane changes size without the window changing size (M28).
  *
- * This file measures rendered geometry — `getBoundingClientRect()` of the pane
- * versus the Plotly root — rather than eyeballing a screenshot, because the
- * two failure modes it guards are both invisible to a "looks fine" glance at a
- * single viewport:
+ * This file measures rendered geometry — `getBoundingClientRect()` of the pane,
+ * the chart's slot within it, and the Plotly root — rather than eyeballing a
+ * screenshot, because the two failure modes it guards are both invisible to a
+ * "looks fine" glance at a single viewport:
  *
  *   FILL — `ExplorerChartPreview`'s root used to be `flex flex-1 min-h-0
  *   flex-col`. Its parent (`CenterPanel`'s chart pane) is `display:block`, so
@@ -40,12 +40,31 @@ import { BASE_URL, apiBase } from '../helpers/sandbox.mjs';
 const SOURCE = 'local-duckdb';
 const TABLE = 'test_table';
 
-/** The pane the chart is supposed to fill: `CenterPanel`'s chart slot, whose
+/** The pane the preview is supposed to fill: `CenterPanel`'s chart slot, whose
  *  height is definite (a flex child of a `h-full flex-col` section). */
 const PANE = '[data-testid="chart-preview-pane"]';
+/** The chart's OWN slot inside that pane — `ExplorerChartPreview`'s `flex-1
+ *  min-h-0` div. The pane is not the chart's box: the preview renders its own
+ *  chrome above the chart (`PreviewInputControls`, the unresolved-inputs
+ *  banner, the promoted-poll-failed banner), so measuring the plot against the
+ *  PANE would read a ~50px input strip as a broken flex chain and fail on a
+ *  chart that is filling its slot exactly. The pane stays in the chain — the
+ *  slot has to reach its bottom edge — but the chart is measured against the
+ *  box it is actually given. */
+const SLOT = '[data-testid="chart-preview-slot"]';
 /** Plotly's own root node — what actually got drawn, at whatever size Plotly
  *  decided on. `.js-plotly-plot` is Plotly's class, not ours. */
 const PLOT = '.js-plotly-plot';
+
+/** `ItemContainer` (inside `ChartPreview`) is `border` — 1px, box-border — so
+ *  the Plot's `height:100%`/`width:100%` resolve against a content box exactly
+ *  2px smaller than the slot in each axis. Anything beyond that is real
+ *  mis-sizing; the pre-fix signature was 59px and 190px. Named rather than
+ *  spelled `2` inline so a future 1px of padding in the chain reads as a
+ *  deliberate change to this constant, not a mystery off-by-one. */
+const CHROME_PX = 2;
+/** Sub-pixel layout rounding, on top of the border above. */
+const ROUNDING_PX = 2;
 
 async function dragAndDrop(page, sourceLocator, targetLocator) {
   const sourceBox = await sourceLocator.boundingBox();
@@ -144,9 +163,13 @@ async function buildDraftChart(page) {
 /**
  * Read every box in ONE evaluate so they all describe the same layout frame.
  *
- * Three numbers, because two of them can disagree and only the third is proof:
+ * Four numbers, because three of them can disagree and only the last is proof:
  *
- *   pane  — the box the chart is supposed to fill.
+ *   pane  — the box the PREVIEW is supposed to fill, chrome included.
+ *   slot  — the box the CHART is given: the pane minus whatever chrome the
+ *           preview rendered above it. Its bottom edge is what proves the
+ *           height chain, since a root without `h-full` is auto-height and
+ *           stops short of the pane's bottom.
  *   box   — the Plotly root's CSS box. `Chart.jsx` gives it
  *           `style={{width:'100%',height:'100%'}}`, so its WIDTH always equals
  *           its parent's whether or not anything is wired correctly. Its
@@ -161,21 +184,25 @@ async function buildDraftChart(page) {
  */
 async function measure(page) {
   return page.evaluate(
-    ([paneSel, plotSel]) => {
+    ([paneSel, slotSel, plotSel]) => {
+      const rect = el => {
+        const r = el.getBoundingClientRect();
+        return { width: r.width, height: r.height, top: r.top, bottom: r.bottom };
+      };
       const pane = document.querySelector(paneSel);
+      const slot = document.querySelector(slotSel);
       const gd = document.querySelector(plotSel);
-      if (!pane || !gd) return null;
-      const p = pane.getBoundingClientRect();
-      const q = gd.getBoundingClientRect();
+      if (!pane || !slot || !gd) return null;
       return {
-        pane: { width: p.width, height: p.height },
-        box: { width: q.width, height: q.height },
+        pane: rect(pane),
+        slot: rect(slot),
+        box: rect(gd),
         drawn: gd._fullLayout
           ? { width: gd._fullLayout.width, height: gd._fullLayout.height }
           : null,
       };
     },
-    [PANE, PLOT]
+    [PANE, SLOT, PLOT]
   );
 }
 
@@ -209,33 +236,138 @@ test.describe('Explorer chart preview fills and tracks its pane (M28)', () => {
       // Plotly settles asynchronously after its own resize debounce (100ms).
       await expect(async () => {
         const m = await measure(page);
-        expect(m, 'both the pane and the Plotly root are in the DOM').not.toBeNull();
+        expect(m, 'the pane, the chart slot and the Plotly root are in the DOM').not.toBeNull();
         expect(m.drawn, 'Plotly has resolved a full layout').not.toBeNull();
         expect(m.pane.height, 'the pane itself has a real height').toBeGreaterThan(200);
-        // Two claims, because either can fail alone: the CSS chain resolves to
-        // the pane's height (the `h-full` half), AND Plotly drew the figure at
-        // that height (the measurement half). Sub-pixel layout rounding is the
-        // only slack allowed.
-        const geom = `pane ${m.pane.height} / box ${m.box.height} / drawn ${m.drawn.height}`;
+        const geom =
+          `pane ${m.pane.height} / slot ${m.slot.height} / ` +
+          `box ${m.box.height} / drawn ${m.drawn.height}`;
+
+        // 1. The HEIGHT CHAIN, measured against the pane. The slot is the last
+        //    thing in a `h-full` column, so its bottom edge lands on the
+        //    pane's — unless the chain broke, in which case the root is
+        //    auto-height and the slot stops at whatever Plotly drew inside it
+        //    (the pre-fix 450px), well short of the pane. Comparing edges
+        //    rather than heights is what lets the preview's own chrome sit
+        //    above the chart without the assertion mistaking it for the bug.
         expect(
-          Math.abs(m.box.height - m.pane.height),
-          `CSS box fills pane — ${geom}`
-        ).toBeLessThanOrEqual(2);
+          Math.abs(m.slot.bottom - m.pane.bottom),
+          `the chart slot reaches the pane's bottom edge — ${geom}`
+        ).toBeLessThanOrEqual(ROUNDING_PX);
+        expect(m.slot.top, 'the slot starts inside the pane').toBeGreaterThanOrEqual(
+          m.pane.top - ROUNDING_PX
+        );
+        expect(m.slot.height, 'the slot has a real height of its own').toBeGreaterThan(200);
+
+        // 2. The chart fills that slot — two claims, because either can fail
+        //    alone: the CSS chain resolves to the slot's height, AND Plotly
+        //    drew the figure at that height. `ItemContainer`'s 1px border plus
+        //    sub-pixel rounding is the only slack allowed.
+        expect(Math.abs(m.box.height - m.slot.height), `CSS box fills slot — ${geom}`)
+          .toBeLessThanOrEqual(CHROME_PX + ROUNDING_PX);
         expect(
-          Math.abs(m.drawn.height - m.pane.height),
-          `Plotly drew at the pane height — ${geom}`
-        ).toBeLessThanOrEqual(2);
+          Math.abs(m.drawn.height - m.slot.height),
+          `Plotly drew at the slot height — ${geom}`
+        ).toBeLessThanOrEqual(CHROME_PX + ROUNDING_PX);
       }).toPass({ timeout: 20000 });
 
       const m = await measure(page);
       // Guard the specific pre-fix signature as well as the general one: 450 is
       // plotly.js's built-in default height, which is what an indefinite-height
-      // container produces. Skipped when the pane happens to be ~450 tall.
-      if (Math.abs(m.pane.height - 450) > 5) {
+      // container produces. Skipped when the slot happens to be ~450 tall.
+      if (Math.abs(m.slot.height - 450) > 5) {
         expect(Math.round(m.drawn.height), 'not the Plotly default').not.toBe(450);
       }
     });
   }
+
+  // CHROME. The preview is entitled to render things above the chart — the
+  // `PreviewInputControls` strip whenever the insight references an input, the
+  // unresolved-inputs banner, the promoted-poll-failed banner. None of those is
+  // a sizing bug, but a fill assertion anchored on the PANE reads every one of
+  // them as ~50px of missing chart and fails a chart that is filling its slot
+  // exactly. This test creates that chrome deliberately and pins both halves:
+  // the chart still fills its slot, and the pane-anchored comparison is exactly
+  // the one that would have lied.
+  //
+  // The chrome is injected rather than provoked with a real input because the
+  // geometry is what is under test, not the input machinery — and injecting it
+  // has a second payoff: the slot shrinks while the WINDOW does not, so
+  // settling back to the new height is the M28 container observation doing its
+  // job on the vertical axis (the rail-drag test below covers the horizontal).
+  test('the preview\'s own chrome is not mistaken for a chart that stopped short', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await buildDraftChart(page);
+
+    const CHROME_HEIGHT = 50;
+    await expect(async () => {
+      const m = await measure(page);
+      expect(m).not.toBeNull();
+      expect(m.drawn).not.toBeNull();
+      expect(Math.abs(m.drawn.height - m.slot.height)).toBeLessThanOrEqual(
+        CHROME_PX + ROUNDING_PX
+      );
+    }).toPass({ timeout: 20000 });
+
+    // Stand in for `PreviewInputControls`: a fixed-height, non-shrinking strip
+    // as the slot's previous sibling, i.e. exactly where the real chrome sits.
+    // Idempotent so `toPass` can re-run it if React reconciles it away.
+    const insertChrome = () =>
+      page.evaluate(
+        ([slotSel, h]) => {
+          if (document.getElementById('m28-fake-chrome')) return;
+          const slot = document.querySelector(slotSel);
+          const strip = document.createElement('div');
+          strip.id = 'm28-fake-chrome';
+          strip.style.height = `${h}px`;
+          strip.style.flex = '0 0 auto';
+          slot.parentElement.insertBefore(strip, slot);
+        },
+        [SLOT, CHROME_HEIGHT]
+      );
+    await insertChrome();
+
+    await expect(async () => {
+      await insertChrome();
+      const m = await measure(page);
+      expect(m).not.toBeNull();
+      expect(m.drawn).not.toBeNull();
+      const geom =
+        `pane ${m.pane.height} / slot ${m.slot.height} / ` +
+        `box ${m.box.height} / drawn ${m.drawn.height}`;
+
+      // The chrome really took its bite out of the slot…
+      expect(
+        Math.abs(m.slot.height - (m.pane.height - CHROME_HEIGHT)),
+        `the slot gave up exactly the chrome's height — ${geom}`
+      ).toBeLessThanOrEqual(ROUNDING_PX);
+      // …the slot still reaches the pane's bottom edge (the height chain is
+      // intact — this is the claim the pane is still needed for)…
+      expect(
+        Math.abs(m.slot.bottom - m.pane.bottom),
+        `the slot still reaches the pane's bottom — ${geom}`
+      ).toBeLessThanOrEqual(ROUNDING_PX);
+      // …and the chart fills what it was given, Plotly's own resolved height
+      // included: nothing about this is a defect.
+      expect(Math.abs(m.box.height - m.slot.height), `CSS box fills slot — ${geom}`)
+        .toBeLessThanOrEqual(CHROME_PX + ROUNDING_PX);
+      expect(
+        Math.abs(m.drawn.height - m.slot.height),
+        `Plotly re-measured to the shrunken slot — ${geom}`
+      ).toBeLessThanOrEqual(CHROME_PX + ROUNDING_PX);
+
+      // The load-bearing half: measured against the PANE instead, this exact
+      // healthy state is off by the chrome — which is the false failure the
+      // slot anchor exists to prevent. If this ever stops holding, the chrome
+      // is gone and this test is no longer testing anything.
+      expect(
+        m.pane.height - m.box.height,
+        `a pane-anchored assertion would have failed here — ${geom}`
+      ).toBeGreaterThan(CHROME_PX + ROUNDING_PX);
+    }).toPass({ timeout: 20000 });
+  });
 
   // TRACK. The right-rail gutter changes the chart pane's WIDTH while leaving
   // every `CenterPanel` split ratio untouched and never resizing the window —
@@ -250,7 +382,9 @@ test.describe('Explorer chart preview fills and tracks its pane (M28)', () => {
       const m = await measure(page);
       expect(m).not.toBeNull();
       expect(m.drawn).not.toBeNull();
-      expect(Math.abs(m.drawn.width - m.pane.width)).toBeLessThanOrEqual(2);
+      expect(Math.abs(m.drawn.width - m.slot.width)).toBeLessThanOrEqual(
+        CHROME_PX + ROUNDING_PX
+      );
     }).toPass({ timeout: 20000 });
 
     const before = await measure(page);
@@ -277,11 +411,12 @@ test.describe('Explorer chart preview fills and tracks its pane (M28)', () => {
       // width Plotly RESOLVED proves it re-measured.
       const geom =
         `pane ${before.pane.width}→${after.pane.width}, ` +
+        `slot ${before.slot.width}→${after.slot.width}, ` +
         `drawn ${before.drawn.width}→${after.drawn.width}`;
       expect(
-        Math.abs(after.drawn.width - after.pane.width),
-        `Plotly re-measured and re-drew at the new pane width — ${geom}`
-      ).toBeLessThanOrEqual(2);
+        Math.abs(after.drawn.width - after.slot.width),
+        `Plotly re-measured and re-drew at the new slot width — ${geom}`
+      ).toBeLessThanOrEqual(CHROME_PX + ROUNDING_PX);
       expect(after.drawn.width, `the drawn width actually moved — ${geom}`).toBeLessThan(
         before.drawn.width - 50
       );

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -126,6 +126,12 @@ export default defineConfig({
         // edit, type switch): mints a real exploration + computed columns
         // against the shared `.visivo/explorations/` repository.
         '**/exploration-chart-build-updates.spec.mjs',
+        // M28 geometry guard: mints a real exploration to get a live draft
+        // chart on screen, then measures pane-vs-plot rects. Same shared
+        // `.visivo/explorations/` isolation need as its siblings above; it
+        // also drags the workspace right rail, so a concurrent worker's
+        // layout must not be sharing the page.
+        '**/explorer-chart-fills-pane.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -291,6 +297,9 @@ export default defineConfig({
         // edit, type switch): mints a real exploration + computed columns
         // against the shared `.visivo/explorations/` repository.
         '**/exploration-chart-build-updates.spec.mjs',
+        // M28 geometry guard — see the 'parallel' project's testIgnore entry
+        // for the same file for why.
+        '**/explorer-chart-fills-pane.spec.mjs',
         // Smoke-test bug #1 regression (computed metric grouped by a
         // dimension): mints a real exploration + a computed column and hits
         // the draft compile/execute endpoints — same shared-repository

--- a/viewer/src/components/explorer/CenterPanel.jsx
+++ b/viewer/src/components/explorer/CenterPanel.jsx
@@ -293,7 +293,12 @@ const CenterPanel = ({
   const renderChartSection = () => (
     <div className="h-full flex flex-col" data-testid="chart-section">
       <ExplorerInputsToolbar projectId={projectId} />
-      <div className="flex-1 min-h-0 overflow-hidden">
+      {/* M28 — the box the chart is supposed to fill. Its height is definite
+          (a flex child of the `h-full flex-col` section above), which is what
+          makes `h-full` resolvable all the way down to the Plotly root; the
+          testid exists so an e2e story can measure pane-vs-plot geometry
+          instead of eyeballing a screenshot. */}
+      <div className="flex-1 min-h-0 overflow-hidden" data-testid="chart-preview-pane">
         <ExplorerErrorBoundary fallback="Chart preview error">
           <ExplorerChartPreview />
         </ExplorerErrorBoundary>

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -417,7 +417,7 @@ const ExplorerChartPreview = () => {
   // the chain. Every branch above this one already returned `h-full`, which is
   // why the placeholders looked right and only the real chart was wrong.
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="flex h-full min-h-0 flex-col" data-testid="explorer-chart-preview">
       <PreviewInputControls inputConfigs={inputConfigs} projectId={projectId} />
       {unresolvedNames.length > 0 && (
         <div
@@ -442,7 +442,15 @@ const ExplorerChartPreview = () => {
           It may still be running server-side — try reopening this exploration.
         </div>
       )}
-      <div className="flex-1 min-h-0">
+      {/* M28 — the chart's own slot: whatever height the pane has left after
+          the chrome above (the input strip and either banner). The testid is
+          what the e2e story anchors its geometry on, because measuring the
+          plot against the PANE instead would read that chrome as a broken
+          flex chain and fail on a perfectly-filling chart the moment an
+          insight references an input. The story still proves the chain from
+          the pane down, by asserting this slot reaches the pane's bottom
+          edge. */}
+      <div className="flex-1 min-h-0" data-testid="chart-preview-slot">
         <ChartPreview
           chartConfig={chartConfig}
           insightKeys={previewInsightKeys}

--- a/viewer/src/components/explorer/ExplorerChartPreview.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.jsx
@@ -403,8 +403,21 @@ const ExplorerChartPreview = () => {
     );
   }
 
+  // M28 — `h-full`, NOT `flex-1`. This root's parent is CenterPanel's chart
+  // pane, a `display:block` div (`flex-1 min-h-0 overflow-hidden`), so
+  // `flex-1` here was inert: it only means anything to a flex CONTAINER's
+  // child, and a block parent is not one. With no `h-full` either, this div's
+  // height was `auto` — indefinite — which made every percentage height below
+  // it (ChartPreview's `h-full`, ItemContainer's `h-full`, the Plot's
+  // `style.height: 100%`) resolve to `auto` in turn, and Plotly fell back to
+  // its built-in 450px default no matter how tall the pane was. Measured
+  // before the fix: pane 509px / plot 450px at a 1280px viewport, and pane
+  // 260px / plot 450px at 1600px — short in one layout, overflowing in the
+  // other. `h-full` resolves against the pane's definite height and restores
+  // the chain. Every branch above this one already returned `h-full`, which is
+  // why the placeholders looked right and only the real chart was wrong.
   return (
-    <div className="flex flex-1 min-h-0 flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <PreviewInputControls inputConfigs={inputConfigs} projectId={projectId} />
       {unresolvedNames.length > 0 && (
         <div

--- a/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
+++ b/viewer/src/components/explorer/ExplorerChartPreview.test.jsx
@@ -145,6 +145,34 @@ describe('ExplorerChartPreview', () => {
     );
   });
 
+  // M28 — the height chain, pinned where CI can actually see it.
+  //
+  // The geometry proof lives in e2e/stories/explorer-chart-fills-pane.spec.mjs,
+  // but `.rwx/test_visivo.yml` runs `viewer-test` (jest) and `viewer-lint` and
+  // no Playwright story task at all, so that file only ever runs by hand. This
+  // assertion is the half a merge gate sees. It is a class-string check
+  // because the defect IS a class string: jsdom computes no layout, so nothing
+  // cheaper than a browser can observe the resulting height.
+  //
+  // `flex-1` here is inert — this root's parent is CenterPanel's chart pane, a
+  // `display:block` div, and `flex-1` only means something to a flex
+  // container's child. With no `h-full` either the root's height was `auto`,
+  // every percentage height below it (ChartPreview's `h-full`, ItemContainer's
+  // `h-full`, the Plot's `style.height: 100%`) resolved against an indefinite
+  // parent and collapsed in turn, and Plotly fell back to its built-in 450px
+  // regardless of the pane: measured at 509px pane / 450px plot at a 1280px
+  // viewport, and 260px pane / 450px plot at 1600px.
+  it('roots the chart at h-full, not the inert flex-1 — the height chain to Plotly', () => {
+    render(<ExplorerChartPreview />);
+    const root = screen.getByTestId('explorer-chart-preview');
+    expect(root).toHaveClass('h-full');
+    expect(root).not.toHaveClass('flex-1');
+    // …and the chart's own slot, which takes whatever the chrome above leaves,
+    // is still the flex child that consumes it (and the anchor the e2e story
+    // measures against).
+    expect(screen.getByTestId('chart-preview-slot')).toHaveClass('flex-1', 'min-h-0');
+  });
+
   // VIS-1224 Bug 1: an empty draft insight (isNew, no props) can never produce
   // data — it must be excluded from the chart's keys so it can't block
   // Chart.jsx's all-or-nothing data gate (the infinite-spinner bug).

--- a/viewer/src/components/items/Chart.jsx
+++ b/viewer/src/components/items/Chart.jsx
@@ -136,7 +136,24 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
     // them anyway is not merely redundant — it hands Plotly two authorities, so
     // a re-render can paint at the fixed size before autosize strips it back.
     // Honour whichever the caller actually asked for rather than both.
-    if (!layout.autosize) {
+    //
+    // The dimensions can arrive from EITHER side — the `height`/`width` props
+    // (the dashboard's slot) or the chart's own authored `layout` — and until
+    // this branch stripped the second source, only the prop side was guarded.
+    // A config that carries `width`/`height` (e.g. integration's `surface-chart`:
+    // `{autosize: false, width: 500, height: 500}`) therefore reached Plotly as
+    // `{autosize: true, width: 500, height: 500}` once `hideToolbar` above
+    // forced autosize on, and Plotly resolves that contradiction in favour of
+    // the explicit values, silently: `initialAutoSize = (!width || !height) &&
+    // autosize` is false (plots.js), `plotAutoSize` only moves a dimension when
+    // `!layout.width` / `!layout.height`, and `Plots.resize` early-returns
+    // outright when `layout.width && layout.height`. So the chart stayed at its
+    // authored 500x500 in a preview pane of any other size AND ignored every
+    // resize sent to it. Exactly one authority reaches Plotly.
+    if (layout.autosize) {
+      delete layout.width;
+      delete layout.height;
+    } else {
       if (height !== undefined) layout.height = height;
       if (width !== undefined) layout.width = width;
     }
@@ -164,11 +181,24 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
   // Observing the container and re-firing that same window event adds a
   // TRIGGER for the sizing authority that already exists; it never introduces
   // a second one (#634 — "don't give Plotly two sizing authorities"). The
-  // corollary is the `plotlyOwnsSizing` gate: when the caller passes explicit
-  // width/height, `autosize` is off, the CALLER owns the dimensions, and
-  // re-measuring the container would be exactly the second authority #634
-  // removed — so we don't observe at all. (This is also why the dashboard is
-  // untouched: it passes both dimensions.)
+  // corollary is the `plotlyOwnsSizing` gate: when the layout carries explicit
+  // width AND height, the CALLER owns the dimensions, and re-measuring the
+  // container would be exactly the second authority #634 removed — so we don't
+  // observe at all. (This is also why the dashboard is untouched: it passes
+  // both dimensions.)
+  //
+  // The gate is plotly's OWN predicate, not a paraphrase of it. plots.js
+  // decides whether it is sizing itself in three places and all three test the
+  // dimensions, never the `autosize` key alone:
+  //   supplyLayoutGlobalDefaults: `coerce('autosize', !(layoutIn.width && layoutIn.height))`
+  //   plotAutoSize:               `!layout.width` / `!layout.height`
+  //   Plots.resize:               early-returns when `layout.width && layout.height`
+  // Gating on `!!layout.autosize` instead got BOTH sides wrong. It said yes to
+  // a chart Plotly refuses to resize (a config carrying width+height, whose
+  // forced `autosize: true` plotly discards — an observer whose every dispatch
+  // is a no-op that still wakes every window-resize listener in the app), and
+  // it said no to charts Plotly autosizes IMPLICITLY, which is any layout
+  // missing either dimension — the `autosize` key need never appear.
   //
   // Cost of using the window event rather than reaching into react-plotly.js
   // for the private per-plot handler: it wakes every other window-resize
@@ -177,7 +207,7 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
   // reflows, it is bounded to autosize charts, it is coalesced to one dispatch
   // per animation frame below, and it depends on no library internals.
   const containerRef = useRef(null);
-  const plotlyOwnsSizing = !!plotLayout.autosize;
+  const plotlyOwnsSizing = !(plotLayout.width && plotLayout.height);
   useEffect(() => {
     if (!plotlyOwnsSizing || isDataLoading) return undefined;
     const node = containerRef.current;

--- a/viewer/src/components/items/Chart.jsx
+++ b/viewer/src/components/items/Chart.jsx
@@ -1,6 +1,6 @@
 import Loading from '../common/Loading';
 import Plot from 'react-plotly.js';
-import React, { useState, useMemo, useImperativeHandle } from 'react';
+import React, { useState, useMemo, useImperativeHandle, useEffect, useRef } from 'react';
 import { ItemContainer } from './ItemContainer';
 import { itemNameToSlug } from './utils';
 import { chartDataFromInsightData } from '../../models/Insight';
@@ -148,12 +148,68 @@ const Chart = React.forwardRef(({ chart, projectId, itemWidth, height, width, sh
     [plotlyConfig]
   );
 
+  // M28 — make a CONTAINER resize reach Plotly.
+  //
+  // Plotly only ever re-measures its node when something tells it to, and the
+  // only thing that ever does is a window `resize` event: react-plotly.js's
+  // `useResizeHandler` (below) installs a window listener, and plotly.js
+  // itself contains no ResizeObserver at all (upstream plotly.js#3984/#7059,
+  // react-plotly.js#41/#64). So a pane that changes size while the WINDOW does
+  // not — a rail drag, a collapsed editor, a banner appearing above the plot —
+  // leaves the figure drawn at its last measured size. Measured before this
+  // fix: dragging the workspace right rail took the chart pane from 454px to
+  // 354px wide while Plotly's own resolved width moved 452 → 442, i.e. 88px
+  // stale.
+  //
+  // Observing the container and re-firing that same window event adds a
+  // TRIGGER for the sizing authority that already exists; it never introduces
+  // a second one (#634 — "don't give Plotly two sizing authorities"). The
+  // corollary is the `plotlyOwnsSizing` gate: when the caller passes explicit
+  // width/height, `autosize` is off, the CALLER owns the dimensions, and
+  // re-measuring the container would be exactly the second authority #634
+  // removed — so we don't observe at all. (This is also why the dashboard is
+  // untouched: it passes both dimensions.)
+  //
+  // Cost of using the window event rather than reaching into react-plotly.js
+  // for the private per-plot handler: it wakes every other window-resize
+  // listener on the page. That is the same trade CenterPanel.jsx and
+  // ExplorerInputsToolbar.jsx already make for their own divider/toolbar
+  // reflows, it is bounded to autosize charts, it is coalesced to one dispatch
+  // per animation frame below, and it depends on no library internals.
+  const containerRef = useRef(null);
+  const plotlyOwnsSizing = !!plotLayout.autosize;
+  useEffect(() => {
+    if (!plotlyOwnsSizing || isDataLoading) return undefined;
+    const node = containerRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return undefined;
+
+    let frame = null;
+    const observer = new ResizeObserver(entries => {
+      // A zero box means the pane is hidden (display:none) or detached;
+      // Plotly rejects a resize on a non-displayed div, so skip it.
+      const rect = entries[0]?.contentRect;
+      if (rect && rect.width === 0 && rect.height === 0) return;
+      // A drag emits an entry per frame — coalesce them into one dispatch.
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        window.dispatchEvent(new Event('resize'));
+      });
+    });
+    observer.observe(node);
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [plotlyOwnsSizing, isDataLoading]);
+
   if (isDataLoading) {
     return <Loading text={chart.name} width={itemWidth} />;
   }
 
   return (
     <ItemContainer
+      ref={containerRef}
       className={hideToolbar ? 'h-full' : ''}
       id={itemNameToSlug(chart.name)}
     >

--- a/viewer/src/components/items/Chart.test.jsx
+++ b/viewer/src/components/items/Chart.test.jsx
@@ -241,3 +241,165 @@ describe('Chart — autosize and explicit dimensions are mutually exclusive', ()
     expect(capturedLayout.width).toBe(640);
   });
 });
+
+// M28 — Plotly re-measures its node only on a window `resize` event
+// (react-plotly.js's `useResizeHandler` is a window listener; plotly.js ships
+// no ResizeObserver). A pane that resizes without the window resizing — a rail
+// drag, a collapsed editor, a banner appearing above the plot — therefore left
+// the figure at its last measured size. Chart observes its container and
+// re-fires that same event.
+//
+// The geometry itself is proven in the browser (e2e/stories/
+// explorer-chart-fills-pane.spec.mjs measures pane-vs-plot rects); jsdom has no
+// layout, so these tests pin the WIRING: what gets observed, that a resize is
+// forwarded, that a burst is coalesced, that it is torn down, and — the #634
+// constraint — that a caller-sized chart is never observed at all.
+describe('Chart — a container resize reaches Plotly (M28)', () => {
+  let observers;
+  let originalResizeObserver;
+  let rafQueue;
+  let rafSpy;
+  let cancelSpy;
+  let resizeEvents;
+  let onWindowResize;
+
+  const flushFrames = () => {
+    const queued = rafQueue.splice(0);
+    queued.forEach(cb => cb());
+  };
+
+  beforeEach(() => {
+    observers = [];
+    originalResizeObserver = global.ResizeObserver;
+    global.ResizeObserver = class MockResizeObserver {
+      constructor(callback) {
+        this.callback = callback;
+        this.targets = [];
+        this.disconnected = false;
+        observers.push(this);
+      }
+      observe(node) {
+        this.targets.push(node);
+      }
+      unobserve(node) {
+        this.targets = this.targets.filter(t => t !== node);
+      }
+      disconnect() {
+        this.disconnected = true;
+      }
+      /** Test-only: emulate the browser delivering a size change. */
+      emit(contentRect = { width: 800, height: 600 }) {
+        this.callback([{ contentRect, target: this.targets[0] }], this);
+      }
+    };
+
+    // Hold rAF callbacks so a burst can be observed before it is flushed.
+    rafQueue = [];
+    rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    cancelSpy = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    resizeEvents = 0;
+    onWindowResize = () => {
+      resizeEvents += 1;
+    };
+    window.addEventListener('resize', onWindowResize);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('resize', onWindowResize);
+    rafSpy.mockRestore();
+    cancelSpy.mockRestore();
+    global.ResizeObserver = originalResizeObserver;
+  });
+
+  test('observes the rendered plot container when Plotly owns the sizing', () => {
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    expect(observers).toHaveLength(1);
+    const [observed] = observers[0].targets;
+    // Not just "something was observed": it must be the real DOM node that
+    // wraps the plot, which also proves the ref reaches ItemContainer.
+    expect(observed).toBeInstanceOf(HTMLElement);
+    expect(observed).toContainElement(screen.getByText('Mock Plot'));
+  });
+
+  test('forwards a container resize as the window event Plotly listens for', () => {
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    expect(resizeEvents).toBe(0);
+    observers[0].emit({ width: 640, height: 480 });
+    // Deferred to the next frame, never dispatched inline from the callback.
+    expect(resizeEvents).toBe(0);
+    flushFrames();
+    expect(resizeEvents).toBe(1);
+  });
+
+  test('coalesces a burst of resize entries into one dispatch per frame', () => {
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    // What a drag actually produces: an entry every frame.
+    observers[0].emit({ width: 640, height: 480 });
+    observers[0].emit({ width: 620, height: 480 });
+    observers[0].emit({ width: 600, height: 480 });
+    expect(rafQueue).toHaveLength(1);
+    flushFrames();
+    expect(resizeEvents).toBe(1);
+
+    // …and the next frame's change is not swallowed by the coalescing.
+    observers[0].emit({ width: 580, height: 480 });
+    flushFrames();
+    expect(resizeEvents).toBe(2);
+  });
+
+  test('ignores a zero-size box — a hidden pane must not trigger a Plotly resize', () => {
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    observers[0].emit({ width: 0, height: 0 });
+    expect(rafQueue).toHaveLength(0);
+    flushFrames();
+    expect(resizeEvents).toBe(0);
+  });
+
+  test('disconnects the observer on unmount', () => {
+    const { unmount } = render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    expect(observers[0].disconnected).toBe(false);
+    unmount();
+    expect(observers[0].disconnected).toBe(true);
+  });
+
+  test('cancels a pending frame on unmount rather than dispatching after teardown', () => {
+    const { unmount } = render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    observers[0].emit({ width: 640, height: 480 });
+    expect(rafQueue).toHaveLength(1);
+    unmount();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  test('does NOT observe when the caller owns the size — #634 stays intact', () => {
+    // The dashboard path: explicit width and height, no autosize. Plotly is not
+    // measuring anything here, so re-measuring the container would reintroduce
+    // exactly the second sizing authority #634 removed.
+    render(<Chart chart={chart} projectId="p1" height={320} width={640} shouldLoad />);
+
+    expect(capturedLayout.autosize).toBeFalsy();
+    expect(observers).toHaveLength(0);
+  });
+
+  test('does not observe while the chart is still showing Loading', () => {
+    // No container is rendered yet, so there is nothing to observe; the effect
+    // must attach once data lands, not fail silently on a null ref.
+    const { rerender } = render(
+      <Chart chart={chart} projectId="p1" hideToolbar shouldLoad={false} />
+    );
+    expect(observers).toHaveLength(0);
+
+    rerender(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+    expect(observers).toHaveLength(1);
+    expect(observers[0].targets[0]).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/viewer/src/components/items/Chart.test.jsx
+++ b/viewer/src/components/items/Chart.test.jsx
@@ -240,6 +240,32 @@ describe('Chart — autosize and explicit dimensions are mutually exclusive', ()
     expect(capturedLayout.height).toBe(320);
     expect(capturedLayout.width).toBe(640);
   });
+
+  // The mirror of the case above, and the one that was unguarded: the fixed
+  // dimensions can come from the chart's OWN layout rather than from a prop.
+  // `surface-chart` in test-projects/integration is exactly this config, and
+  // every one of its keys is schema-allowed. Previewing it (workspace
+  // ChartPreview passes `hideToolbar`) produced `{autosize: true, width: 500,
+  // height: 500}` — two authorities, which Plotly resolves in favour of the
+  // dimensions, so the "fill the pane" the `hideToolbar` autosize exists to
+  // produce never happened and the plot stayed 500x500 in a pane of any size.
+  test('a config-supplied width/height does not survive the autosize hideToolbar forces', () => {
+    chart.layout = { title: { text: 'Plot' }, autosize: false, width: 500, height: 500 };
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+    expect(capturedLayout.autosize).toBe(true);
+    expect(capturedLayout.width).toBeUndefined();
+    expect(capturedLayout.height).toBeUndefined();
+    // Everything else about the authored layout is untouched.
+    expect(capturedLayout.title).toEqual({ text: 'Plot' });
+  });
+
+  test('a config-supplied width/height IS honoured when nothing forces autosize', () => {
+    chart.layout = { autosize: false, width: 500, height: 500 };
+    render(<Chart chart={chart} projectId="p1" shouldLoad />);
+    expect(capturedLayout.autosize).toBe(false);
+    expect(capturedLayout.width).toBe(500);
+    expect(capturedLayout.height).toBe(500);
+  });
 });
 
 // M28 — Plotly re-measures its node only on a window `resize` event
@@ -388,6 +414,56 @@ describe('Chart — a container resize reaches Plotly (M28)', () => {
 
     expect(capturedLayout.autosize).toBeFalsy();
     expect(observers).toHaveLength(0);
+  });
+
+  // The gate has to be Plotly's own predicate — "is either dimension missing?"
+  // — rather than the `autosize` key, because Plotly answers that question
+  // three times (supplyLayoutGlobalDefaults' `coerce('autosize', !(width &&
+  // height))`, plotAutoSize's `!layout.width`/`!layout.height`, Plots.resize's
+  // `layout.width && layout.height` early return) and never once by looking at
+  // `autosize` alone. The next three cases are where the two predicates
+  // disagree; all three were wrong before.
+  test('observes a chart with NO dimensions at all — Plotly autosizes it implicitly', () => {
+    // No `hideToolbar`, so nothing sets `autosize`; Plotly turns it on itself
+    // because both dimensions are missing. Gating on the key skipped this.
+    render(<Chart chart={chart} projectId="p1" shouldLoad />);
+
+    expect(capturedLayout.autosize).toBeUndefined();
+    expect(observers).toHaveLength(1);
+    expect(observers[0].targets[0]).toBeInstanceOf(HTMLElement);
+  });
+
+  test('observes a chart given only ONE dimension — Plotly still sizes the other', () => {
+    render(<Chart chart={chart} projectId="p1" height={320} shouldLoad />);
+
+    expect(capturedLayout.height).toBe(320);
+    expect(capturedLayout.width).toBeUndefined();
+    expect(observers).toHaveLength(1);
+  });
+
+  test('does NOT observe a chart sized by its own config — the dimensions still win', () => {
+    // `surface-chart` from test-projects/integration, rendered without
+    // `hideToolbar`: the layout keeps its authored 500x500, so Plotly owns
+    // nothing and there is nothing for a container resize to change.
+    chart.layout = { autosize: false, width: 500, height: 500 };
+    render(<Chart chart={chart} projectId="p1" shouldLoad />);
+
+    expect(capturedLayout.width).toBe(500);
+    expect(capturedLayout.height).toBe(500);
+    expect(observers).toHaveLength(0);
+  });
+
+  test('observes that same config once hideToolbar hands sizing to the container', () => {
+    // …and now the observation is real work rather than a no-op dispatch:
+    // `Plots.resize` early-returns on `layout.width && layout.height`, so
+    // before the dimensions were stripped every one of these dispatches woke
+    // every window-resize listener in the app and moved nothing.
+    chart.layout = { autosize: false, width: 500, height: 500 };
+    render(<Chart chart={chart} projectId="p1" hideToolbar shouldLoad />);
+
+    expect(capturedLayout.width).toBeUndefined();
+    expect(capturedLayout.height).toBeUndefined();
+    expect(observers).toHaveLength(1);
   });
 
   test('does not observe while the chart is still showing Loading', () => {


### PR DESCRIPTION
## Problem (M28)

The Explorer's live chart preview does not fill its pane, and does not re-lay-out when the pane changes size. Both halves were **measured in a real browser** (`getBoundingClientRect()` on the pane vs. Plotly's own resolved layout) before and after — never eyeballed.

**(a) Fill — broken flex chain.** `ExplorerChartPreview`'s root was `flex flex-1 min-h-0 flex-col`, but its parent (CenterPanel's chart pane) is a `display:block` div. `flex-1` is inert against a block parent, and there was no `h-full`, so the root's height was `auto`. Every percentage height below it — `ChartPreview`'s `h-full`, `ItemContainer`'s `h-full`, the Plot's `style.height: 100%` — then resolved against an indefinite parent and collapsed to `auto` too, leaving Plotly on its built-in **450px default**. Every earlier branch of the component already returned `h-full`, which is exactly why the loading/error/empty placeholders looked right and only the real chart was wrong.

**(b) Track — nothing observes the container.** Plotly re-measures its node only when told to, and the only thing that ever tells it is a window `resize` event: `react-plotly.js`'s `useResizeHandler` is a window listener, and plotly.js ships no `ResizeObserver` (upstream plotly.js#3984/#7059, react-plotly.js#41/#64). `CenterPanel` papers over its *own* dividers by dispatching a synthetic window resize when its split ratios change; nothing covers a pane that resizes for any other reason — a rail drag, a banner appearing above the plot.

## Fix

- `ExplorerChartPreview` root: `flex-1` → `h-full`.
- `Chart.jsx`: a `ResizeObserver` on the plot container that re-fires the window `resize` event, rAF-coalesced, skipped for a zero-size (hidden) box.
- `CenterPanel`: a `chart-preview-pane` testid so the story measures the pane instead of guessing at it.

### Staying consistent with #634 (3029258b)

#634 removed a *second* sizing authority (explicit `height` alongside `autosize`). This change adds a **trigger** for the authority that already exists, never a second one — and the observer is **gated on `layout.autosize`**: when a caller passes explicit width/height it owns the dimensions, and re-measuring the container there would reintroduce exactly what #634 removed. The dashboard passes both `height` and `width`, so it is not observed at all and its behaviour is unchanged. A unit test pins that gate directly.

## Falsification evidence

**Geometry, measured (sandbox :3001, integration project).** `pane / box / drawn`, where `drawn` is `gd._fullLayout` — what Plotly actually resolved:

| case | before | after |
|---|---|---|
| fill @1280px viewport | pane 509.14 / box 450 / drawn 450 — **59.1px short** | all within 2px |
| fill @1600px viewport | pane 260 / box 450 / drawn 450 — **190px of overflow** | all within 2px |
| right-rail drag (no window resize) | pane 454→354, drawn 452→442 — **87.8px stale** | all within 2px |

Both fill cases land on Plotly's literal 450px default in opposite directions — short at one layout, overflowing at the other.

**Each half is independently load-bearing** (e2e, impl mutated, tests kept):

- `h-full` reverted to `flex-1`, observer kept → the two fill tests fail with the *original* numbers (59.14 / 190); the track test still passes.
- Observer removed, `h-full` kept → the fill tests pass; the track test fails at **78.7px stale** (`pane 454→354, drawn 452→432.67`).
- Both present → 3/3 pass.

**Unit tests falsified** (`Chart.test.jsx`, 8 new tests):

- Effect deleted → **7 of 8 fail**: `observes the rendered plot container…`, `forwards a container resize…`, `coalesces a burst…`, `ignores a zero-size box…`, `disconnects the observer on unmount`, `cancels a pending frame on unmount`, `does not observe while the chart is still showing Loading` — e.g. `expect(received).toHaveLength(expected) / Expected length: 1 / Received length: 0 / Received array: []`.
- The 8th (`does NOT observe when the caller owns the size — #634 stays intact`) asserts an *absence*, so it survives that mutation by construction. It was falsified separately by removing the `plotlyOwnsSizing` gate: `Expected length: 0 / Received length: 1`.

## Test results

- `viewer`: **366 suites / 7045 tests pass**, `yarn lint` clean.
- New e2e story `viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs`: 3/3 pass under its registered `exploration-mutations` project (it mints a real exploration and drags the workspace rail, so it is serial like its siblings).

### Pre-existing e2e failures — NOT dismissed, controlled for

A regression sweep (`dashboard-viewing`, `workspace-canvas-charts`, `exploration-preview`) shows 12 failures. I ran the **same sweep with this branch's `viewer/src` + config changes stashed** (i.e. at `7d31ea69`): **identical 12 failures, identical test names**. They are not caused by this change. Observed causes worth their own triage:

- `dashboard-viewing` Step 1 looks for `a[href="/lineage"]`, which the nav no longer renders — a stale spec.
- `workspace-canvas-charts` (4) and `exploration-preview` (7) exhaust the 30s **test** timeout at `expandSourceTable`'s source-toggle click; the button is present in the failure snapshot, so it is a budget/fragility problem in that helper, reproducible at `--workers=1`. The new story uses the same helper and passes in 6–9s, so it is not the helper alone.

## Files

- `viewer/src/components/items/Chart.jsx` (+ `Chart.test.jsx`)
- `viewer/src/components/explorer/ExplorerChartPreview.jsx`
- `viewer/src/components/explorer/CenterPanel.jsx`
- `viewer/e2e/stories/explorer-chart-fills-pane.spec.mjs`, `viewer/playwright.config.mjs`

No Pydantic models touched, so no schema regeneration — no overlap with #642.

**Cross-stream note:** the dossier assigns `Chart.jsx` to the Chart Presentation stream (I4) and suggested handing the observer over rather than editing it here. This lane was directed to ship both halves; the `Chart.jsx` change is 50 lines in one new effect plus a `ref` on `ItemContainer`, additive and gated, and should rebase cleanly — but I4 should be aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
