### PR TITLE
`visivo dist`: read the envelope off the model, not the dereferenced dump

### DIFF
--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -29,7 +29,7 @@ def dist_dir():
     return temp_folder()
 
 
-def _make_runnable_project():
+def _make_runnable_project(**overrides):
     """Create a project with an insight that references a model, suitable for running."""
     model = SqlModelFactory(name="model", source="ref(source)")
     insight = InsightFactory(name="insight", model=model)
@@ -43,18 +43,37 @@ def _make_runnable_project():
     return ProjectFactory(
         models=[model],
         dashboards=[dashboard],
+        **overrides,
     )
+
+
+def _write_project(project, output_dir):
+    """Put `project` on disk as a working dir `dist` can be pointed at."""
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    tmp = temp_yml_file(
+        dict=json.loads(project.model_dump_json(exclude_none=True)), name=PROJECT_FILE_NAME
+    )
+    return os.path.dirname(tmp)
 
 
 @pytest.fixture
 def setup_project(output_dir):
     project = _make_runnable_project()
+    return project, _write_project(project, output_dir)
 
-    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
 
-    tmp = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
-    working_dir = os.path.dirname(tmp)
-    return project, working_dir
+@pytest.fixture
+def setup_unnamed_project(output_dir):
+    """A project with no `name:` — which the schema allows.
+
+    `ProjectFactory` supplies `name = "project"`, so every fixture in this file
+    had one and the optional case was never represented. That is why a
+    KeyError on `project_json["name"]` shipped: the assertion covering it
+    (`data["name"] == project.name`) was real, the fixture just never varied.
+    """
+    project = _make_runnable_project(name=None)
+    assert project.name is None
+    return project, _write_project(project, output_dir)
 
 
 def test_dist_creates_dist_folder(setup_project, output_dir, dist_dir):
@@ -87,8 +106,51 @@ def test_dist_creates_dist_folder(setup_project, output_dir, dist_dir):
         assert "project_json" not in data
         assert data["name"] == project.name
         assert "defaults" in data["config"]
-        assert "dashboard_count" in data
-        assert "source_count" in data
+        # COUNTS, not just presence. These were read out of the dereferenced
+        # dump, and `Serializer.dereference` deliberately empties the
+        # top-level collections once everything is inlined into the dashboards
+        # (`project.sources = []`, and the same for charts/models/insights/…).
+        # So `source_count` was structurally guaranteed to be 0 in every bundle
+        # ever built, for every project, no matter how many sources it had.
+        assert data["dashboard_count"] == len(project.dashboards)
+        assert data["source_count"] == len(project.sources)
+        assert data["source_count"] > 0
+
+
+def test_dist_works_for_a_project_with_no_name(setup_unnamed_project, output_dir, dist_dir):
+    """`visivo dist` used to die with `KeyError: 'name'` on any project that
+    didn't declare one.
+
+    The envelope is dumped with `exclude_none=True`, so an optional field left
+    unset is not `null` in the JSON — it is ABSENT. `project_json["name"]` was
+    the one field here read without a default, so the whole command failed for
+    a perfectly valid project. Reading it off the model, the way the server's
+    `/api/project/` does, gives `None` instead: the viewer already falls back
+    to "project" for display.
+    """
+    project, working_dir = setup_unnamed_project
+
+    from visivo.commands.run import run
+
+    run_result = runner.invoke(run, ["-w", working_dir, "-o", output_dir, "-s", "source"])
+    assert run_result.exit_code == 0
+
+    result = runner.invoke(
+        dist,
+        ["-w", working_dir, "-s", "source", "--output-dir", output_dir, "--dist-dir", dist_dir],
+    )
+
+    assert result.exit_code == 0, result.output
+    with open(os.path.join(dist_dir, "data", "project.json")) as project_json:
+        data = json.load(project_json)
+    # Present and null, matching the server envelope — not missing, which would
+    # move the same failure into the viewer.
+    assert "name" in data
+    assert data["name"] is None
+    # The rest of the bundle is unaffected.
+    assert data["dashboard_count"] == 1
+    assert data["source_count"] == 1
+    assert "defaults" in data["config"]
 
 
 def test_dist_writes_a_dashboards_list_with_layout(setup_project, output_dir, dist_dir):

--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -153,6 +153,100 @@ def test_dist_works_for_a_project_with_no_name(setup_unnamed_project, output_dir
     assert "defaults" in data["config"]
 
 
+class TestCurrentArtifacts:
+    """`visivo run` only ever ADDS artifacts — it never removes the ones a
+    rename or a naming-scheme change orphaned.
+
+    Before VIS-1128 each artifact was written as `alpha_hash(name).json`; now it
+    is `<name>.json`. A project that predates the change has both on disk,
+    carrying the same `"name"`. dist globbed the directory, so every object
+    shipped TWICE in `insights.json` / `inputs.json` — and the stale copy's
+    parquet URL used the old hashed filename, which nothing copies any more. A
+    hosted bundle 404'd on its own data and DuckDB reported
+    `Table with name m… does not exist`.
+    """
+
+    def _write(self, directory, filename, payload):
+        # `temp_folder()` only names a path; nothing has created it yet.
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, filename)
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_the_current_artifact_wins_over_the_hashed_one(self):
+        from visivo.commands.dist_phase import _current_artifacts
+        from visivo.models.base.named_model import alpha_hash
+
+        directory = temp_folder()
+        stale = self._write(
+            directory,
+            f"{alpha_hash('station-bubbles')}.json",
+            {"name": "station-bubbles", "files": [{"signed_data_file_url": "/old.parquet"}]},
+        )
+        current = self._write(
+            directory,
+            "station-bubbles.json",
+            {"name": "station-bubbles", "files": [{"signed_data_file_url": "/new.parquet"}]},
+        )
+
+        resolved = _current_artifacts([stale, current])
+
+        assert len(resolved) == 1
+        path, data = resolved[0]
+        assert path == current
+        assert data["files"][0]["signed_data_file_url"] == "/new.parquet"
+
+    def test_order_on_disk_does_not_decide_it(self):
+        """The glob's order is arbitrary; the answer must not be."""
+        from visivo.commands.dist_phase import _current_artifacts
+        from visivo.models.base.named_model import alpha_hash
+
+        directory = temp_folder()
+        stale = self._write(directory, f"{alpha_hash('x')}.json", {"name": "x"})
+        current = self._write(directory, "x.json", {"name": "x"})
+
+        for order in ([stale, current], [current, stale]):
+            ((path, _),) = _current_artifacts(order)
+            assert path == current
+
+    def test_distinct_objects_are_all_kept(self):
+        from visivo.commands.dist_phase import _current_artifacts
+
+        directory = temp_folder()
+        paths = [
+            self._write(directory, "a.json", {"name": "a"}),
+            self._write(directory, "b.json", {"name": "b"}),
+        ]
+
+        assert sorted(d["name"] for _p, d in _current_artifacts(paths)) == ["a", "b"]
+
+    def test_an_object_with_only_a_stale_artifact_still_ships(self):
+        """Dropping it would turn a cosmetic staleness into a missing insight."""
+        from visivo.commands.dist_phase import _current_artifacts
+        from visivo.models.base.named_model import alpha_hash
+
+        directory = temp_folder()
+        stale = self._write(directory, f"{alpha_hash('only')}.json", {"name": "only"})
+
+        ((path, data),) = _current_artifacts([stale])
+        assert path == stale
+        assert data["name"] == "only"
+
+    def test_unreadable_or_nameless_files_are_skipped_not_fatal(self):
+        from visivo.commands.dist_phase import _current_artifacts
+
+        directory = temp_folder()
+        nameless = self._write(directory, "nameless.json", {"files": []})
+        broken = os.path.join(directory, "broken.json")
+        os.makedirs(directory, exist_ok=True)
+        with open(broken, "w") as f:
+            f.write("{not json")
+        good = self._write(directory, "good.json", {"name": "good"})
+
+        assert [d["name"] for _p, d in _current_artifacts([nameless, broken, good])] == ["good"]
+
+
 def test_dist_writes_a_dashboards_list_with_layout(setup_project, output_dir, dist_dir):
     """The bundle must carry the dashboards LIST, with each config's layout.
 

--- a/tests/commands/test_dist.py
+++ b/tests/commands/test_dist.py
@@ -96,6 +96,12 @@ def test_dist_creates_dist_folder(setup_project, output_dir, dist_dir):
     assert os.path.exists(os.path.join(os.getcwd(), dist_dir, "data", "project.json"))
     assert os.path.exists(os.path.join(os.getcwd(), dist_dir, "data", "dashboards"))
     assert os.path.exists(os.path.join(os.getcwd(), dist_dir, "data", "insights"))
+    # Traces are gone from the product — there is no Trace model, `Project` has
+    # no `traces` field, and nothing writes `target/traces/`. dist kept a block
+    # that globbed for them anyway, so every bundle shipped an empty
+    # `data/traces/` and a `data/traces.json` of `[]`.
+    assert not os.path.exists(os.path.join(os.getcwd(), dist_dir, "data", "traces"))
+    assert not os.path.exists(os.path.join(os.getcwd(), dist_dir, "data", "traces.json"))
 
     with open(os.path.join(dist_dir, "data", "project.json")) as project_json:
         data = json.load(project_json)

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -59,19 +59,37 @@ def dist_phase(
             shutil.copytree(dashboards_dir, dist_dashboards_dir, dirs_exist_ok=True)
         created_at = datetime.datetime.now().isoformat()
         # Same canonical envelope the server serves at /api/project/, so the
-        # viewer reads one shape in both modes. ``project_json`` below stays a
-        # local variable — it drives the per-dashboard files written further
-        # down — but the whole blob is no longer shipped in the bundle.
+        # viewer reads one shape in both modes. The whole blob stopped being
+        # shipped in the bundle a while back; `project_json` survives for ONE
+        # reason — it is the DEREFERENCED project, so a dashboard's
+        # `${ref(chart)}` is expanded into the inline chart the per-dashboard
+        # config below has to carry. Anything that doesn't need that expansion
+        # reads the model directly.
+        #
+        # Every field here comes off the MODEL, exactly as
+        # `data_views.projects_api` builds the same envelope. Nothing in it
+        # needs dereferencing, and reading it out of `project_json` cost us a
+        # crash: that dump is taken with `exclude_none=True`, so an optional
+        # field left unset is not null in the JSON — it is ABSENT.
+        # `project_json["name"]` therefore raised KeyError for any project
+        # without a `name:`, which the schema allows (`NamedModel.name` is
+        # Optional). The model always has the attribute.
         with open(f"{dist_dir}/data/project.json", "w") as f:
             f.write(
                 json.dumps(
                     {
                         "id": "id",
-                        "name": project_json["name"],
-                        "project_dir": project_json.get("project_dir") or "",
-                        "config": {"defaults": project_json.get("defaults", {})},
-                        "dashboard_count": len(project_json.get("dashboards") or []),
-                        "source_count": len(project_json.get("sources") or []),
+                        "name": project.name,
+                        "project_dir": project.project_dir or "",
+                        "config": {
+                            "defaults": (
+                                project.defaults.model_dump(exclude_none=True, mode="json")
+                                if project.defaults
+                                else {}
+                            )
+                        },
+                        "dashboard_count": len(project.dashboards or []),
+                        "source_count": len(project.sources or []),
                         "created_at": created_at,
                     }
                 )

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -4,6 +4,58 @@ from visivo.models.base.named_model import alpha_hash
 import traceback
 
 
+def _current_artifacts(json_paths):
+    """One artifact per object name, dropping residue from older runs.
+
+    `visivo run` writes each artifact as `<object_name>.json` (VIS-1128). It did
+    NOT always: the previous scheme named them by `alpha_hash(name)`, and a run
+    only ever ADDS files — it never removes the ones a rename or a scheme change
+    orphaned. A project that predates VIS-1128 therefore has both on disk:
+
+        target/main/insights/station-bubbles.json                 <- current
+        target/main/insights/mifawvncyzdkmlywzcggvituhvlwb.json   <- residue
+
+    Both carry `"name": "station-bubbles"`, so globbing the directory shipped
+    every object TWICE in `insights.json` / `inputs.json`. The viewer took the
+    first entry for a name — often the stale one — and asked for a parquet whose
+    hashed filename no longer exists, so a hosted bundle 404'd on its own data
+    and DuckDB reported `Table with name m… does not exist`.
+
+    Serve never hit this: it reads objects through the managers, from the
+    project. Only dist derived its manifest from whatever was lying in the
+    directory.
+
+    Resolution is by NAME, preferring the file whose stem matches the name it
+    declares — that is exactly what distinguishes a current artifact from
+    residue. When nothing matches (every candidate is from an older scheme), the
+    most recently written one wins, so a bundle still gets built.
+    """
+    import json
+    import os
+
+    by_name = {}
+    for path in sorted(json_paths):
+        try:
+            with open(path, "r") as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            continue
+        name = data.get("name")
+        if not name:
+            continue
+        stem = os.path.splitext(os.path.basename(path))[0]
+        current = by_name.get(name)
+        if current is None:
+            by_name[name] = (path, data, stem == name)
+            continue
+        _, _, current_is_named = current
+        if current_is_named:
+            continue
+        if stem == name or os.path.getmtime(path) > os.path.getmtime(current[0]):
+            by_name[name] = (path, data, stem == name)
+    return [(path, data) for path, data, _ in by_name.values()]
+
+
 def dist_phase(
     output_dir,
     dist_dir,
@@ -149,10 +201,7 @@ def dist_phase(
         insights_list = []
         if os.path.isdir(insights_src):
             os.makedirs(f"{dist_dir}/data/insights", exist_ok=True)
-            for insight_file in glob(f"{insights_src}/*.json"):
-                with open(insight_file, "r") as f:
-                    insight_data = json.load(f)
-
+            for insight_file, insight_data in _current_artifacts(glob(f"{insights_src}/*.json")):
                 insight_data["id"] = insight_data["name"]
 
                 # Rewrite file URLs to dist paths
@@ -180,10 +229,7 @@ def dist_phase(
         inputs_list = []
         if os.path.isdir(inputs_src):
             os.makedirs(f"{dist_dir}/data/inputs", exist_ok=True)
-            for input_file in glob(f"{inputs_src}/*.json"):
-                with open(input_file, "r") as f:
-                    input_data = json.load(f)
-
+            for input_file, input_data in _current_artifacts(glob(f"{inputs_src}/*.json")):
                 input_data["id"] = input_data["name"]
 
                 # Rewrite file URLs to dist paths

--- a/visivo/commands/dist_phase.py
+++ b/visivo/commands/dist_phase.py
@@ -1,6 +1,5 @@
 from visivo.utils import DIST_PATH
 from visivo.logger.logger import Logger
-from visivo.models.base.named_model import alpha_hash
 import traceback
 
 
@@ -153,34 +152,6 @@ def dist_phase(
             f.write(json.dumps({}))
         with open(f"{dist_dir}/data/project_history.json", "w") as f:
             f.write(json.dumps([{"created_at": created_at, "id": "id"}]))
-
-        # Generate traces.json for dist mode
-
-        trace_dirs = glob(f"{output_dir}/traces/*/", recursive=True)
-        traces_list = []
-        os.makedirs(f"{dist_dir}/data/traces", exist_ok=True)
-
-        for trace_dir in trace_dirs:
-            trace_name = os.path.basename(os.path.normpath(trace_dir))
-            if os.path.exists(f"{output_dir}/traces/{trace_name}/data.json"):
-                # Create hash-based filename for trace data
-                trace_name_hash = alpha_hash(trace_name)
-                shutil.copyfile(
-                    f"{output_dir}/traces/{trace_name}/data.json",
-                    f"{dist_dir}/data/traces/{trace_name_hash}.json",
-                )
-                # Add trace info for traces.json
-                traces_list.append(
-                    {
-                        "name": trace_name,
-                        "id": trace_name,
-                        "signed_data_file_url": f"{deployment_root}/data/traces/{trace_name_hash}.json",
-                    }
-                )
-
-        # Write traces.json
-        with open(f"{dist_dir}/data/traces.json", "w") as f:
-            json.dump(traces_list, f)
 
         # Copy parquet data files used by insights and inputs. The run writes
         # them into the directory named for what produced them (VIS-1128), but


### PR DESCRIPTION
## The crash

```
✖ Error creating dist. Try running `visivo run` to ensure your project is up to date.
  File "visivo/commands/dist_phase.py", line 70, in dist_phase
      "name": project_json["name"],
KeyError: 'name'
```

A `name:` at project level is **optional** — `NamedModel.name` is `Optional[str] = None` — and `nyc-resturant-dashboard` simply doesn't declare one. `run` and `serve` are both fine with it; only `dist` fell over, after the dbt phase, with a message pointing at `visivo run`, which is not where the problem was.

## Why `project_json` was the wrong source

Two reasons, and the second was doing quiet damage.

**1. The dump hides optional fields.** `project_json` is built with `exclude_none=True`, so a field left unset isn't `null` in the JSON — it's **absent**. Every other field in that block was read with `.get()` and a fallback. `name` was read by subscript.

**2. It isn't the project any more.** `Serializer.dereference` inlines everything into the dashboards and then **empties the top-level collections**:

```python
project.charts = []
project.insights = []
project.tables = []
project.models = []
project.sources = []
project.inputs = []
```

So `len(project_json.get("sources") or [])` was structurally guaranteed to be `0`. **Every dist bundle ever built reported `source_count: 0`**, for every project. The nyc project has one source; its bundle claimed none.

## The fix

The envelope reads the **model** throughout — exactly how the server builds the same envelope in `data_views.projects_api`. The comment above that block always claimed the two were one shape; they weren't, and this is where they diverged.

`project_json` stays for the one thing that genuinely needs it: the per-dashboard `config`, where dereferencing is the whole point — a dashboard's `${ref(chart)}` has to arrive as the inline chart, or the viewer gets a name with no layout.

## Why the smoke test passed

Worth stating plainly, because the coverage looked fine:

- **`name`** — `ProjectFactory` supplies `name = "project"`, so every fixture in `test_dist.py` had one and the optional case was never represented. The covering assertion (`data["name"] == project.name`) was real; the fixture just never varied.
- **`source_count`** — different failure. The test asserted the key was *present*, never that it was *right*, so a permanent `0` sailed through.

Both are now pinned by `setup_unnamed_project` plus real count assertions, and **both fail without this change** (verified by reverting `dist_phase.py` and re-running: 2 failed, 5 passed).

## Verification

Against the reporting project:

| | before | after |
|---|---|---|
| `visivo dist` | `KeyError: 'name'` | succeeds |
| `name` | — | `null` (matches the server; the viewer already falls back to "project") |
| `source_count` | `0` | `1` |

`poetry run pytest tests/` — 2466 passed. `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3

---

# Second fix: the bundle 404s on its own data

Reported after the first fix landed on this branch — same command, same file, so it rides along here.

```
data/files/mhsoodpmiytlgraxmxvdlbqopqnga_options.parquet  404
Catalog Error: Table with name msdrqrtcivwhghbbqlovquedljuaa does not exist!
```

Those hashed names are `alpha_hash()` of real objects — `cuisine-select`, `station-counts`. Before VIS-1128 that was how `run` named its artifacts; now it writes `<object_name>.json`. **A run only ever ADDS files**, so a project from before the change has both on disk:

```
target/main/insights/station-bubbles.json                <- current
target/main/insights/mifawvncyzdkmlywzcggvituhvlwb.json  <- residue
```

Both declare `"name": "station-bubbles"`. dist globbed the directory and shipped both, so every object appeared **twice** in `insights.json` / `inputs.json` — once pointing at a parquet dist still copies, once at a hashed filename nothing has written for months:

```
cuisine-select -> /data/files/mhsoodpmiytlgraxmxvdlbqopqnga_options.parquet   (dead)
cuisine-select -> /data/files/cuisine-select_options.parquet                  (live)
```

The viewer takes the first entry for a name, which is as likely to be the dead one.

Serve never had this — it reads objects through the managers, from the project. Only dist built its manifest out of whatever was lying in the directory.

## The fix

`_current_artifacts` resolves by **name**, preferring the file whose stem matches the name it declares — precisely what separates a current artifact from residue. Order on disk doesn't decide it. An object with *only* a stale artifact still ships (dropping it would turn cosmetic staleness into a missing insight), and an unreadable or nameless file is skipped rather than fatal.

## Verification

On the reporting project, every referenced parquet now exists in the bundle and each object appears once:

```
cuisine-select     -> /data/files/cuisine-select_options.parquet
restaurant-markers -> /data/files/restaurants.parquet
station-bubbles    -> /data/files/station-counts.parquet
MISSING REFERENCED FILES: none
```

`poetry run pytest tests/` — 2471 passed.

## Left for follow-ups

- **`visivo run` leaves the orphans behind.** This makes dist immune to them, but the residue is still accumulating in `target/`.
- **socket.io polling in a static bundle.** The other 404s in the report (`socket.io/?EIO=4&transport=polling`) — a hosted bundle has no server to talk to. Harmless but noisy; not diagnosed here.

---

# Third fix: stop emitting traces

Every bundle shipped an empty `data/traces/` directory and a `data/traces.json` of `[]`.

Traces are gone from the product: there is **no `Trace` model anywhere** in `visivo/`, `Project` has no `traces` field, and nothing writes `target/traces/`. The block globbed a directory that is never created, found nothing, and wrote the empty results out anyway — on every build, for every project.

Removing it leaves `alpha_hash` unused in this module (the trace filenames were its only caller here), so that import goes too.

The bundle is now exactly what the viewer reads:

```
dashboards/  dashboards.json
insights/    insights.json
inputs/      inputs.json
files/
error.json   project.json   project_history.json
```

**Leftover, not touched here:** `Project.coerce_null_list_fields` still lists `"traces"` — along with `"targets"` and `"selectors"` — among the keys it coerces from `None` to `[]`. Harmless, since `Project` forbids extras and such a key is rejected regardless, but it is the same dead vocabulary and worth a sweep.
