### PR TITLE
Quick Start: lead with the command that actually works (C46/C79)

### DIFF
--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -2,7 +2,7 @@
 
 ## 🚀 Data to Dashboard in 90 Seconds
 
-Transform your data into interactive dashboards with a single command. No configuration files, no complex setup—just instant visualization.
+Visivo is BI-as-code: your dashboards are YAML you can read, diff, and review. The fastest way to see what that looks like is to start from an example that already works.
 
 ### 1. Install Visivo
 
@@ -10,90 +10,149 @@ Transform your data into interactive dashboards with a single command. No config
 curl -fsSL https://visivo.sh | bash
 ```
 
-!!! success "One command, all platforms"
-    Our installation script handles macOS, Linux, and Windows automatically. If you have an unsupported environment, check out our [pip installation guide](installation.md#python-package-pip).
+The script installs the `visivo` binary to `~/.visivo/bin` and adds it to your `PATH`. On Windows, run it inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), or use the [pip installation](installation.md#python-package-pip) instead.
 
-### 2. Start the Local Server
+Confirm it landed:
 
 ```bash
-visivo serve
+visivo --version
 ```
 
-This single command gives you a complete environment in seconds!
+### 2. Start From a Bundled Example
 
-### 3. Choose an Example
+```bash
+visivo init --example ev-sales
+```
 
-Visivo will prompt you to select from several example dashboards, then:
+That single command:
 
-- Initialize the chosen example into your current directory
-- Create a complete `project.visivo.yml` configuration file
-- Load sample data and refresh your browser to show the new configuration
+1. Copies the `ev-sales` sample into the current directory — a `project.visivo.yml`, the DuckDB file it queries, and the CSV that data came from.
+2. Names the project after the directory you ran it in.
+3. Compiles the project and runs every model and insight query.
+4. Starts the dev server at `http://localhost:8000` and opens your browser.
 
-Each example includes:
-- Pre-configured sample data
-- Multiple chart types to explore
-- Interactive filters and controls
-- A complete configuration to learn from
+!!! success "No downloads, no database to set up"
+    The examples ship inside the Visivo package and query a small bundled DuckDB file, so this works offline and the YAML always matches the version of Visivo you just installed.
 
-### 4. Make It Your Own
+Three examples ship with the CLI:
 
-The example dashboard is fully functional and editable:
-- Open the generated `project.visivo.yml` in your editor
-- Modify any part of the configuration
-- Save and watch your changes appear instantly
+| `--example` value | What it builds | Chart types it shows |
+| --- | --- | --- |
+| `ev-sales` | Electric-vehicle units and revenue by region, powertrain, and quarter | `indicator`, `bar`, `pie` |
+| `github-releases` | Release counts, downloads over time, and contributors per repo | `indicator`, `bar`, `scatter` |
+| `college-football` | 2024 game scores and attendance by team and conference | `indicator`, `bar`, `box` |
 
-!!! tip "What happens behind the scenes"
-    When you run `visivo serve` without a config file, Visivo:
-    
-    1. Prompts you to choose from available examples
-    2. Initializes the selected example into your directory
-    3. Loads sample data into DuckDB
-    4. Renders the dashboard with hot-reload enabled
-    5. Opens your browser to show the result
+Each one is deliberately small — one source, one model, five insights, five charts, one dashboard — so you can read the whole file in a couple of minutes.
 
-Now jump to [Experience Live Development](#experience-live-development) to see the magic of instant updates!
+!!! tip "Useful `init` flags"
+    - `--bare` — write the project files and stop, without launching the dev server.
+    - `--headless` — start the dev server but don't open a browser.
+    - `-p, --port` — serve on a port other than `8000`.
+    - `-pd, --project-dir` — initialize into a subdirectory instead of the current one.
 
+    So the fully scripted version of the walkthrough is:
 
----
+    ```bash
+    visivo init --example ev-sales --project-dir ev-demo --bare
+    cd ev-demo
+    visivo run     # build the data once
+    visivo serve   # then watch and hot-reload; prints the URL to open
+    ```
 
-## Experience Live Development
+### 3. Read the Project
 
-Once your dashboard is running (from either path), experience the magic of hot-reload. This is especially powerful when combined with Agent AI iteration:
+Open `project.visivo.yml`. Every Visivo project is the same five-object chain, and the example is a complete, working instance of it:
 
-### The Development Cycle
+```yaml
+name: ev-demo
 
-1. **:material-file-edit: Edit** - Open `project.visivo.yml` in your editor and make any change:
-   
-   ```yaml
-   charts:
-     - name: revenue_chart
-       layout:
-         title: Monthly Revenue  # ← Change this
-   ```
+sources:
+  # Where the data lives.
+  - name: ev_sales_db
+    type: duckdb
+    database: ev_sales.duckdb
 
-2. **:material-content-save: Save** - Save the file (Cmd+S / Ctrl+S). That's it! No build command needed.
+defaults:
+  source_name: ev_sales_db
 
-3. **:material-eye: See** - Your dashboard updates instantly in the browser.
-   - ✅ No compilation
-   - ✅ No build step  
-   - ✅ No page refresh
+models:
+  # A named SQL query against that source.
+  - name: ev_sales
+    sql: SELECT * FROM ev_sales
+
+insights:
+  # A chart definition, written against the model's columns.
+  - name: units_by_quarter
+    props:
+      type: bar
+      x: ?{ ${ref(ev_sales).quarter} }
+      y: ?{ SUM(${ref(ev_sales).units_sold}) }
+    interactions:
+      - sort: ?{ ${ref(ev_sales).quarter} ASC }
+
+charts:
+  # A chart wraps one or more insights and owns the Plotly layout.
+  - name: units_by_quarter_chart
+    insights:
+      - ${ref(units_by_quarter)}
+    layout:
+      title:
+        text: "EV units sold by quarter"
+
+dashboards:
+  # Rows of items place the charts on a page.
+  - name: EV Sales
+    rows:
+      - height: medium
+        items:
+          - chart: ${ref(units_by_quarter_chart)}
+```
+
+!!! warning "A dashboard item takes a chart, not an insight"
+    A dashboard item holds a `chart`, `table`, `markdown`, or `input` (plus `rows`, `path`, and `file_path` for composition) — never a bare `insight`. The `Item` model rejects unknown keys, so `insight:` inside a dashboard row is a validation error. Wrap insights in a chart first, exactly as above. See [Insight](concepts/insight.md) for why charts are the wrapper, and [Dashboard](concepts/dashboard.md) for the full row/item vocabulary.
+
+### 4. Edit It and Watch It Reload
+
+With the dev server running, find `units_by_quarter_chart` in `project.visivo.yml` and change its title:
+
+```yaml
+charts:
+  - name: units_by_quarter_chart
+    layout:
+      title:
+        text: "Quarterly EV demand"
+```
+
+Save the file (Cmd+S / Ctrl+S). That's it — no build command, no page refresh. Visivo recompiles the project, re-runs the queries, and pushes the result to the open browser tab.
 
 <figure markdown>
   ![Live reload demonstration](assets/interactivity-example.gif)
   <figcaption>Every save triggers an instant update. Watch your dashboard evolve in real-time!</figcaption>
 </figure>
 
-### Why This Matters
-
-This instant feedback loop revolutionizes dashboard development:
-
-- **Experiment Freely** - Try different visualizations instantly
-- **Learn Faster** - See the impact of each change immediately  
-- **Debug Visually** - Spot issues as they happen
-- **Iterate Quickly** - From idea to implementation in seconds
-
 !!! tip "Pro Tip: Split Screen Development"
     Open your editor and browser side-by-side. As you type and save, watch your dashboard transform in real-time. It's like having a conversation with your data!
+
+---
+
+## Starting From Scratch Instead
+
+If you'd rather not start from an example, run `init` with no flags:
+
+```bash
+visivo init
+```
+
+This writes a `project.visivo.yml` scaffold of commented examples, plus a `.gitignore` and a `.env.example` if you don't already have them, and then opens the in-browser setup wizard so you can add a source without hand-writing connection details.
+
+!!! note "The scaffold is empty on purpose"
+    Everything in the scaffold is commented out, so `visivo run` reports `No jobs run. Ensure your filter contains nodes that are runnable.` until you define a real source and model. That message is expected here — it means there is nothing to build yet, not that something failed. Uncomment the examples in the file, or add a source through the wizard.
+
+## What `visivo serve` Does
+
+`visivo serve` is the command for a directory that **already has a project**. It compiles and runs the project on launch, watches your files, and hot-reloads the browser on every save.
+
+Run it in an empty directory, or pass `--new`, and it starts an empty in-memory project and opens the in-browser setup wizard. In that mode it writes no project file, and the initial build logs `No jobs run.` because there is nothing to build. It does **not** offer to install an example — that's what `visivo init --example` is for.
 
 ---
 
@@ -115,17 +174,17 @@ Now that you have a running dashboard, explore what's possible:
 
     ---
 
-    Learn how to modify layouts, colors, and styling
+    Learn how to modify layouts, rows, items, and styling
     
-    [:octicons-arrow-right-24: Dashboard customization](reference/configuration/Dashboards/Dashboard/index.md)
+    [:octicons-arrow-right-24: Dashboard reference](reference/configuration/Dashboards/Dashboard/index.md)
 
 -   :material-chart-line:{ .lg .middle } **Add Charts & Visualizations**
 
     ---
 
-    Explore 40+ chart types with rich customization options
+    Explore 40+ insight types with rich customization options
     
-    [:octicons-arrow-right-24: Chart gallery](reference/configuration/Chart/index.md)
+    [:octicons-arrow-right-24: Insight props](reference/configuration/Insight/Props/index.md)
 
 -   :material-database:{ .lg .middle } **Connect Your Data**
 
@@ -135,6 +194,14 @@ Now that you have a running dashboard, explore what's possible:
     
     [:octicons-arrow-right-24: Data sources](topics/sources.md)
 
+-   :material-tune:{ .lg .middle } **Make It Interactive**
+
+    ---
+
+    Add filters, splits, sorts, and dropdown inputs
+    
+    [:octicons-arrow-right-24: Interactivity](topics/interactivity.md)
+
 -   :material-cloud-upload:{ .lg .middle } **Deploy & Share**
 
     ---
@@ -143,13 +210,13 @@ Now that you have a running dashboard, explore what's possible:
     
     [:octicons-arrow-right-24: Deployment guide](topics/deployments.md)
 
--   :material-github:{ .lg .middle } **Examples**
+-   :material-console:{ .lg .middle } **Every Command & Flag**
 
     ---
 
-    Explore real-world examples and templates
+    The full CLI reference, generated from the code itself
     
-    [:octicons-arrow-right-24: View examples](https://visivo.io/examples)
+    [:octicons-arrow-right-24: CLI reference](reference/cli.md)
 
 </div>
 
@@ -160,7 +227,7 @@ Now that you have a running dashboard, explore what's possible:
 ---
 
 !!! quote "Why Visivo?"
-    "Unlike other tools that require complex setup and configuration, Visivo gets you from zero to dashboard in 90 seconds. Whether you're using our interactive wizard or AI assistance, you'll have a working dashboard before your coffee gets cold."
+    "Unlike other tools that require complex setup and configuration, Visivo gets you from zero to dashboard in 90 seconds. Start from a bundled example, from a blank scaffold, or hand the YAML to an AI agent — any of the three gets you a working dashboard before your coffee gets cold."
 
 ---
 

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -12,6 +12,9 @@ curl -fsSL https://visivo.sh | bash
 
 The script installs the `visivo` binary to `~/.visivo/bin` and adds it to your `PATH`. On Windows, run it inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), or use the [pip installation](installation.md#python-package-pip) instead.
 
+!!! warning "The installer requires macOS 15 or later"
+    On macOS the script checks `sw_vers -productVersion` before it downloads anything, and exits with `Error: macOS version <yours> is not supported. Requires macOS 15 or later.` on anything older. There is no flag to override it — install with [pip](installation.md#python-package-pip) instead on macOS 14 and below. Linux needs `x86_64`; Apple Silicon and Intel Macs are both covered.
+
 Confirm it landed:
 
 ```bash
@@ -28,8 +31,18 @@ That single command:
 
 1. Copies the `ev-sales` sample into the current directory — a `project.visivo.yml`, the DuckDB file it queries, and the CSV that data came from.
 2. Names the project after the directory you ran it in.
-3. Compiles the project and runs every model and insight query.
-4. Starts the dev server at `http://localhost:8000` and opens your browser.
+3. Parses and validates the YAML — a syntax error stops you here, at the command line.
+4. Starts the dev server at `http://localhost:8000`.
+5. *Then* compiles and runs every model and insight query. The build runs after the server is already listening, not before, so the terminal is your progress bar: wait for `Initial Data Refresh Complete.`
+6. Opens your browser at `http://localhost:8000/?onboarding=1`.
+
+!!! warning "Your browser opens on the onboarding wizard, not on the dashboard"
+    That `?onboarding=1` is not decoration: the viewer redirects it to the in-browser setup wizard ("Welcome to Visivo — you will leave this 2 minute flow with a working dashboard"), even though the example already ships a source, a model, and data that just finished building. To get to the EV Sales dashboard:
+
+    - click **Skip onboarding and go straight to the editor**, or re-run with `visivo init --example ev-sales --no-onboarding` to skip the redirect entirely; then
+    - from the project home — a three-card chooser, not a dashboard — pick **Dashboards** (`http://localhost:8000/project`) and open **EV Sales**.
+
+    The wizard exists for `visivo init` with no `--example`, where you really do have no source yet. Skip it here.
 
 !!! success "No downloads, no database to set up"
     The examples ship inside the Visivo package and query a small bundled DuckDB file, so this works offline and the YAML always matches the version of Visivo you just installed.
@@ -47,6 +60,7 @@ Each one is deliberately small — one source, one model, five insights, five ch
 !!! tip "Useful `init` flags"
     - `--bare` — write the project files and stop, without launching the dev server.
     - `--headless` — start the dev server but don't open a browser.
+    - `--no-onboarding` — open the browser at the project home instead of the onboarding wizard.
     - `-p, --port` — serve on a port other than `8000`.
     - `-pd, --project-dir` — initialize into a subdirectory instead of the current one.
 
@@ -61,7 +75,7 @@ Each one is deliberately small — one source, one model, five insights, five ch
 
 ### 3. Read the Project
 
-Open `project.visivo.yml`. Every Visivo project is the same five-object chain, and the example is a complete, working instance of it:
+Open `project.visivo.yml`. Every Visivo project is the same five-object chain, and the example is a complete, working instance of it. Below is that chain trimmed to one insight and one chart so it fits on a screen — the file you just installed carries five of each, wired the same way:
 
 ```yaml
 name: ev-demo
@@ -113,17 +127,28 @@ dashboards:
 
 ### 4. Edit It and Watch It Reload
 
-With the dev server running, find `units_by_quarter_chart` in `project.visivo.yml` and change its title:
+With the dev server running — and with the EV Sales dashboard on screen, not the onboarding wizard — find `units_by_quarter_chart` in `project.visivo.yml` and edit exactly one line, the `text:` under its `layout.title`:
 
-```yaml
-charts:
-  - name: units_by_quarter_chart
-    layout:
-      title:
-        text: "Quarterly EV demand"
+- from `text: "EV units sold by quarter"`
+- to `text: "Quarterly EV demand"`
+
+!!! danger "Change the line — don't replace the block"
+    Leave the chart's `insights:` list where it is. `Chart.insights` defaults to an empty list, so a chart that lists none is perfectly valid: the project compiles, `visivo run` exits `0`, and the dashboard item renders an *empty* chart with no error anywhere. The only hint you would get is `No jobs run.` in the terminal — which, one section down, this page tells you is normal.
+
+Save the file (Cmd+S / Ctrl+S). That's it — no build command, no page refresh. Visivo recompiles the project and pushes the result to the open browser tab. Your terminal shows:
+
+```text
+Server has detected changes to the project. Re-running project...
+Compile completed in 0.03s imports: 0.91s, parse: 0.03s
+Running project across 8 threads
+
+No jobs run. Ensure your filter contains nodes that are runnable.
+File Change Data Refresh Complete.
+View your project at: http://localhost:8000
 ```
 
-Save the file (Cmd+S / Ctrl+S). That's it — no build command, no page refresh. Visivo recompiles the project, re-runs the queries, and pushes the result to the open browser tab.
+!!! note "`No jobs run.` after a title change is the right answer"
+    A title lives in `layout`, so nothing needed re-querying — the watcher recompiled, found no runnable node in the changed slice, and pushed the new title to the browser anyway. Nothing failed. Change an insight's `props` or a model's `sql` instead and the same watcher does re-run the affected queries, logging `Updated data for insight ...` before `File Change Data Refresh Complete.`
 
 <figure markdown>
   ![Live reload demonstration](assets/interactivity-example.gif)
@@ -146,7 +171,9 @@ visivo init
 This writes a `project.visivo.yml` scaffold of commented examples, plus a `.gitignore` and a `.env.example` if you don't already have them, and then opens the in-browser setup wizard so you can add a source without hand-writing connection details.
 
 !!! note "The scaffold is empty on purpose"
-    Everything in the scaffold is commented out, so `visivo run` reports `No jobs run. Ensure your filter contains nodes that are runnable.` until you define a real source and model. That message is expected here — it means there is nothing to build yet, not that something failed. Uncomment the examples in the file, or add a source through the wizard.
+    Everything in the scaffold is commented out, so `visivo run` reports `No jobs run. Ensure your filter contains nodes that are runnable.` until you define a real source and model. That message is expected here — it means nothing failed, only that this run selected no runnable node. Uncomment the examples in the file, or add a source through the wizard.
+
+    The same line shows up in two other places, and it never means "something broke": after a layout-only edit in a complete project (nothing needed re-querying), and after a chart lost its `insights:` list (nothing is attached to build). Read it as *this run had no work*, then check which of the three you are in.
 
 ## What `visivo serve` Does
 

--- a/mkdocs/llms.txt
+++ b/mkdocs/llms.txt
@@ -2,7 +2,7 @@
 
 > Documentation for Visivo, the AI-native, open-source business intelligence platform that brings software-engineering best practices to data work. Define data sources, a semantic layer (metrics, dimensions, and relations), and dashboards as version-controlled YAML, then explore them interactively with Insights. Develop locally with instant feedback and deploy to Visivo Cloud without breaking production.
 
-Install the open-source CLI with `pip install visivo` or `curl -fsSL https://visivo.sh | bash`, then run `visivo serve` to develop dashboards locally. The hosted cloud platform lives at https://app.visivo.io and the marketing site at https://visivo.io. Visivo connects to data sources including PostgreSQL, MySQL, SQLite, Snowflake, BigQuery, Redshift, ClickHouse, and DuckDB, and renders charts with Plotly.js.
+Install the open-source CLI with `pip install visivo` or `curl -fsSL https://visivo.sh | bash`, then run `visivo init --example ev-sales` to scaffold a working project from a bundled sample, or `visivo serve` inside an existing project to develop with hot reload. The hosted cloud platform lives at https://app.visivo.io and the marketing site at https://visivo.io. Visivo connects to data sources including PostgreSQL, MySQL, SQLite, Snowflake, BigQuery, Redshift, ClickHouse, and DuckDB, and renders charts with Plotly.js.
 
 Key facts for accurate citation:
 - Charts are produced by Insights backed by a semantic layer of Metrics, Dimensions, and Relations. (Visivo 2.0 builds charts only through Insights and the semantic layer.)
@@ -13,7 +13,7 @@ Key facts for accurate citation:
 
 ## Get Started
 
-- [Quick Start](https://docs.visivo.io/): Data to dashboard in 90 seconds. Install the CLI, run visivo serve, and build your first project.
+- [Quick Start](https://docs.visivo.io/): Data to dashboard in 90 seconds. Install the CLI, run `visivo init --example ev-sales` to get a working project on disk, then edit the YAML with hot reload. (`visivo serve` never prompts for an example; `visivo init --example` is the command that installs one.)
 - [Installation](https://docs.visivo.io/installation/): Install Visivo via the install script or pip (Python 3.10+); covers macOS, Linux, and Windows.
 - [Build with AI](https://docs.visivo.io/ai-usage/): Use AI and agentic workflows to scaffold and edit Visivo projects against the semantic layer.
 

--- a/tests/docs/test_quickstart_truth.py
+++ b/tests/docs/test_quickstart_truth.py
@@ -1,0 +1,169 @@
+"""The Quick Start page must be executable, not aspirational.
+
+``mkdocs/index.md`` is the single most-read page Visivo publishes, and in the
+2.1 field test it was also the least true one. It told new users three things
+that the CLI does not do:
+
+1. "``visivo serve``  ... Visivo will prompt you to select from several example
+   dashboards" — ``visivo/commands/serve.py`` contains no prompt of any kind.
+   In an empty directory it builds an in-memory ``Project(name="Quickstart
+   Visivo")`` with empty lists and logs "No jobs run."
+2. The same claim repeated in a "what happens behind the scenes" tip block.
+3. A YAML sample (``layout: {title: Monthly Revenue}``) that the tool's own
+   parser rejects — ``layout.title`` must be an object, not a string.
+
+Every one of those was *checkable from the code*, so this module checks them
+on every PR. Two guards:
+
+``test_quickstart_yaml_fences_parse``
+    Every ``yaml`` fence on the page is loaded and constructed with the real
+    ``Project`` model (the technique landed in #636 for the ``init`` scaffold).
+    A fence that a new user copies must be a fence the parser accepts.
+
+``test_quickstart_commands_and_flags_exist``
+    Every ``visivo ...`` invocation in a ``bash`` fence is resolved against the
+    real Click app: the subcommand must exist and every flag must be a declared
+    option on it. This is what would have caught "``--example`` loads from
+    GitHub" style drift, and it is why the page can name flags at all.
+
+Both guards are page-scoped on purpose. Widening them to the whole ``mkdocs/``
+tree is tracked separately (docs example harness); the Quick Start is the page
+that earns a dedicated gate.
+"""
+
+import re
+import warnings
+from pathlib import Path
+
+import pytest
+import yaml
+
+from visivo.command_line import visivo
+from visivo.models.project import Project
+
+# tests/docs/test_quickstart_truth.py -> parents[2] == repo root.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART = REPO_ROOT / "mkdocs" / "index.md"
+
+FENCE_RE = re.compile(r"^([ \t]*)```(\w+)[ \t]*\n(.*?)^\1```[ \t]*$", re.MULTILINE | re.DOTALL)
+
+
+def _fences(language):
+    """Yield (line_number, dedented_body) for every fence of ``language``.
+
+    Fences nested inside an admonition are indented; the body is dedented by
+    the fence's own indent so it round-trips through a YAML parser.
+    """
+    text = QUICKSTART.read_text()
+    for match in FENCE_RE.finditer(text):
+        indent, lang, body = match.group(1), match.group(2), match.group(3)
+        if lang != language:
+            continue
+        line_no = text.count("\n", 0, match.start()) + 1
+        if indent:
+            body = "\n".join(
+                line[len(indent) :] if line.startswith(indent) else line
+                for line in body.splitlines()
+            )
+        yield line_no, body
+
+
+def test_quickstart_page_exists():
+    assert QUICKSTART.is_file(), f"Quick Start page missing at {QUICKSTART}"
+
+
+@pytest.mark.parametrize("language,minimum", [("yaml", 2), ("bash", 4)])
+def test_fences_are_discovered(language, minimum):
+    """Discovery sanity: if the extractor silently matches nothing, the two
+    guards below pass vacuously and the page is unguarded again."""
+    found = list(_fences(language))
+    assert len(found) >= minimum, f"Only found {len(found)} {language} fences in {QUICKSTART}"
+
+
+def test_quickstart_yaml_fences_parse():
+    """Every YAML fence must construct the real Project model.
+
+    Partial fences (an excerpt showing only ``charts:``) are wrapped into a
+    minimal project document, which is exactly how a reader would paste them.
+    """
+    failures = []
+    for line_no, body in _fences("yaml"):
+        try:
+            document = yaml.safe_load(body)
+        except yaml.YAMLError as error:
+            failures.append(f"{QUICKSTART.name}:{line_no} is not valid YAML: {error}")
+            continue
+
+        assert isinstance(document, dict), f"{QUICKSTART.name}:{line_no} is not a YAML mapping"
+        if "name" not in document:
+            document = {"name": "docs-example", **document}
+
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                Project.model_validate(document)
+        except Exception as error:  # pydantic ValidationError and friends
+            failures.append(f"{QUICKSTART.name}:{line_no} rejected by Project: {error}")
+
+    assert failures == [], "Quick Start YAML the parser rejects:\n" + "\n\n".join(failures)
+
+
+def _option_flags(command):
+    flags = set()
+    for param in command.params:
+        if param.param_type_name == "option":
+            flags.update(param.opts)
+            flags.update(param.secondary_opts)
+    return flags
+
+
+def test_quickstart_commands_and_flags_exist():
+    """Every `visivo ...` line on the page must resolve against the real CLI."""
+    failures = []
+    for line_no, body in _fences("bash"):
+        for raw_line in body.splitlines():
+            line = raw_line.split("#", 1)[0].strip()
+            if not line.startswith("visivo"):
+                continue
+            tokens = line.split()[1:]
+            words = [token for token in tokens if not token.startswith("-")]
+            flags = [token.split("=", 1)[0] for token in tokens if token.startswith("-")]
+
+            if not words:
+                # A group-level invocation such as `visivo --version`.
+                group_flags = _option_flags(visivo) | {"--help"}
+                unknown = [flag for flag in flags if flag not in group_flags]
+                if unknown:
+                    failures.append(f"{QUICKSTART.name}:{line_no} unknown group flags {unknown}")
+                continue
+
+            name = words[0]
+            command = visivo.commands.get(name)
+            if command is None:
+                failures.append(f"{QUICKSTART.name}:{line_no} `visivo {name}` is not a command")
+                continue
+
+            known = _option_flags(command) | {"--help"}
+            unknown = [flag for flag in flags if flag not in known]
+            if unknown:
+                failures.append(f"{QUICKSTART.name}:{line_no} `visivo {name}` has no {unknown}")
+
+    assert failures == [], "Quick Start CLI usage that does not exist:\n" + "\n".join(failures)
+
+
+def test_quickstart_does_not_claim_serve_prompts_for_an_example():
+    """`visivo serve` has never had a prompt; `visivo init --example` is the
+    command that installs one. Keep the page from regrowing the claim."""
+    text = QUICKSTART.read_text().lower()
+    failures = []
+    if "visivo init --example" not in text:
+        failures.append("Quick Start must lead with `visivo init --example`")
+    for phrase in (
+        "prompt you to select",
+        "prompts you to choose",
+        "choose from available examples",
+        "initializes the selected example",
+    ):
+        if phrase in text:
+            failures.append(f"Quick Start re-states the refuted claim: {phrase!r}")
+    assert failures == [], "\n".join(failures)

--- a/tests/docs/test_quickstart_truth.py
+++ b/tests/docs/test_quickstart_truth.py
@@ -13,39 +13,65 @@ that the CLI does not do:
    parser rejects — ``layout.title`` must be an object, not a string.
 
 Every one of those was *checkable from the code*, so this module checks them
-on every PR. Two guards:
+on every PR. The guards:
 
 ``test_quickstart_yaml_fences_parse``
     Every ``yaml`` fence on the page is loaded and constructed with the real
     ``Project`` model (the technique landed in #636 for the ``init`` scaffold).
     A fence that a new user copies must be a fence the parser accepts.
 
+``test_quickstart_chart_examples_keep_their_insights``
+    Parsing is not enough. ``Chart.insights`` defaults to ``[]``, so a chart
+    that lists none validates, compiles, exits 0 and renders an *empty* chart —
+    the only signal is ``No jobs run.``, which this same page teaches means
+    "nothing to build yet". A chart example that a reader may paste over their
+    working one must therefore carry its ``insights:`` list.
+
 ``test_quickstart_commands_and_flags_exist``
     Every ``visivo ...`` invocation in a ``bash`` fence is resolved against the
-    real Click app: the subcommand must exist and every flag must be a declared
-    option on it. This is what would have caught "``--example`` loads from
-    GitHub" style drift, and it is why the page can name flags at all.
+    real Click app: the subcommand must exist, every flag must be a declared
+    option on it, **and** every value handed to a ``click.Choice`` option must
+    be one of that option's real choices. Names alone were not enough — with
+    only the name check, rewriting the page's headline command to ``visivo init
+    --example nyc-taxi`` kept the whole module green while the real CLI answers
+    ``Invalid value for '--example'``.
 
-Both guards are page-scoped on purpose. Widening them to the whole ``mkdocs/``
-tree is tracked separately (docs example harness); the Quick Start is the page
-that earns a dedicated gate.
+``test_example_table_matches_the_enum`` / ``..._chart_types_match_the_samples``
+    The three example names and the chart types each one shows are advertised in
+    a markdown table, which no fence guard can see. They are pinned to
+    ``ExampleTypeEnum`` and to ``visivo/templates/samples/`` directly.
+
+``test_quickstart_names_the_macos_floor_install_sh_enforces``
+    Step 1 is a ``curl | bash`` line, and ``install.sh`` hard-exits on macOS
+    below a version it hardcodes. The page must name the same number.
+
+Both fence guards are page-scoped on purpose. Widening them to the whole
+``mkdocs/`` tree is tracked separately (docs example harness); the Quick Start
+is the page that earns a dedicated gate.
 """
 
 import re
+import shlex
 import warnings
 from pathlib import Path
 
+import click
 import pytest
 import yaml
 
 from visivo.command_line import visivo
+from visivo.models.example_type import ExampleTypeEnum
 from visivo.models.project import Project
 
 # tests/docs/test_quickstart_truth.py -> parents[2] == repo root.
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUICKSTART = REPO_ROOT / "mkdocs" / "index.md"
+INSTALL_SCRIPT = REPO_ROOT / "install.sh"
 
 FENCE_RE = re.compile(r"^([ \t]*)```(\w+)[ \t]*\n(.*?)^\1```[ \t]*$", re.MULTILINE | re.DOTALL)
+# Any fence opener at all, tagged or not. `_fences` can only see tagged ones,
+# so an untagged fence is content nothing on this page validates.
+ANY_FENCE_OPEN_RE = re.compile(r"^[ \t]*```(\S*)[ \t]*$", re.MULTILINE)
 
 
 def _fences(language):
@@ -72,12 +98,35 @@ def test_quickstart_page_exists():
     assert QUICKSTART.is_file(), f"Quick Start page missing at {QUICKSTART}"
 
 
-@pytest.mark.parametrize("language,minimum", [("yaml", 2), ("bash", 4)])
+@pytest.mark.parametrize("language,minimum", [("yaml", 1), ("bash", 5)])
 def test_fences_are_discovered(language, minimum):
-    """Discovery sanity: if the extractor silently matches nothing, the two
-    guards below pass vacuously and the page is unguarded again."""
+    """Discovery sanity: if the extractor silently matches nothing, the guards
+    below pass vacuously and the page is unguarded again.
+
+    The floors are the page's *current* counts, deliberately with no slack. A
+    floor of 4 against 5 real bash fences let the headline
+    ``visivo init --example ev-sales`` fence lose its ```bash tag and stop being
+    checked while this test stayed green.
+    """
     found = list(_fences(language))
     assert len(found) >= minimum, f"Only found {len(found)} {language} fences in {QUICKSTART}"
+
+
+def test_every_fence_declares_a_language():
+    """The other half of the anti-vacuity check.
+
+    ``FENCE_RE`` needs a language tag, so an untagged fence is invisible to both
+    guards — dropping a tag is the cheapest way to smuggle unvalidated YAML or
+    an unvalidated command onto the page. Openers and closers alternate, so the
+    tag on every odd-numbered opener must be non-empty.
+    """
+    tags = ANY_FENCE_OPEN_RE.findall(QUICKSTART.read_text())
+    assert len(tags) % 2 == 0, f"Unbalanced code fences in {QUICKSTART}: {tags}"
+    untagged = [index for index, tag in enumerate(tags) if index % 2 == 0 and not tag]
+    assert untagged == [], (
+        f"{QUICKSTART.name} has {len(untagged)} fence(s) with no language tag; "
+        "nothing on this page validates their contents."
+    )
 
 
 def test_quickstart_yaml_fences_parse():
@@ -108,6 +157,35 @@ def test_quickstart_yaml_fences_parse():
     assert failures == [], "Quick Start YAML the parser rejects:\n" + "\n\n".join(failures)
 
 
+def test_quickstart_chart_examples_keep_their_insights():
+    """A chart example on this page must carry the insights it wraps.
+
+    ``Chart.insights`` is ``List[InsightRef] = Field([])``. A chart that lists
+    none is therefore *valid*: the project compiles, ``visivo run`` exits 0, the
+    dashboard item renders an empty chart, and the only diagnostic anywhere is
+    ``No jobs run. Ensure your filter contains nodes that are runnable.`` — the
+    exact string this page elsewhere teaches means "nothing to build yet".
+
+    So an excerpt that shows a ``- name:`` line without ``insights:`` is a trap:
+    a reader who pastes it over their working chart silently orphans the
+    insight. Either elide the ``- name:`` line, or keep ``insights:``.
+    """
+    failures = []
+    for line_no, body in _fences("yaml"):
+        document = yaml.safe_load(body)
+        if not isinstance(document, dict):
+            continue
+        for chart in document.get("charts") or []:
+            if not isinstance(chart, dict) or "name" not in chart:
+                continue
+            if not chart.get("insights"):
+                failures.append(
+                    f"{QUICKSTART.name}:{line_no} chart {chart['name']!r} declares no `insights:`; "
+                    "pasted over a working chart it renders empty and only logs `No jobs run.`"
+                )
+    assert failures == [], "Quick Start charts that build nothing:\n" + "\n".join(failures)
+
+
 def _option_flags(command):
     flags = set()
     for param in command.params:
@@ -115,6 +193,48 @@ def _option_flags(command):
             flags.update(param.opts)
             flags.update(param.secondary_opts)
     return flags
+
+
+def _options_by_flag(command):
+    """Map every spelling of every option back to the Click ``Option`` itself.
+
+    ``_option_flags`` answers "does this flag exist"; this answers "and what may
+    follow it", which is what catches ``--example nyc-taxi``.
+    """
+    mapping = {}
+    for param in command.params:
+        if param.param_type_name == "option":
+            for opt in list(param.opts) + list(param.secondary_opts):
+                mapping[opt] = param
+    return mapping
+
+
+def _choice_failures(command_label, line_label, tokens, options):
+    """Check every ``click.Choice`` option's VALUE, not just its name."""
+    failures = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if not token.startswith("-"):
+            continue
+        flag, separator, inline_value = token.partition("=")
+        param = options.get(flag)
+        if param is None or getattr(param, "is_flag", False):
+            continue
+        if separator:
+            value = inline_value
+        elif index < len(tokens) and not tokens[index].startswith("-"):
+            value = tokens[index]
+            index += 1
+        else:
+            continue
+        if isinstance(param.type, click.Choice) and value not in param.type.choices:
+            failures.append(
+                f"{line_label} `{command_label} {flag} {value}` is rejected by the CLI: "
+                f"{flag} accepts {list(param.type.choices)}"
+            )
+    return failures
 
 
 def test_quickstart_commands_and_flags_exist():
@@ -125,30 +245,129 @@ def test_quickstart_commands_and_flags_exist():
             line = raw_line.split("#", 1)[0].strip()
             if not line.startswith("visivo"):
                 continue
-            tokens = line.split()[1:]
-            words = [token for token in tokens if not token.startswith("-")]
-            flags = [token.split("=", 1)[0] for token in tokens if token.startswith("-")]
+            tokens = shlex.split(line)[1:]
+            label = f"{QUICKSTART.name}:{line_no}"
 
-            if not words:
+            if not tokens or tokens[0].startswith("-"):
                 # A group-level invocation such as `visivo --version`.
                 group_flags = _option_flags(visivo) | {"--help"}
-                unknown = [flag for flag in flags if flag not in group_flags]
+                unknown = [
+                    token.split("=", 1)[0]
+                    for token in tokens
+                    if token.startswith("-") and token.split("=", 1)[0] not in group_flags
+                ]
                 if unknown:
-                    failures.append(f"{QUICKSTART.name}:{line_no} unknown group flags {unknown}")
+                    failures.append(f"{label} unknown group flags {unknown}")
                 continue
 
-            name = words[0]
+            name = tokens[0]
             command = visivo.commands.get(name)
             if command is None:
-                failures.append(f"{QUICKSTART.name}:{line_no} `visivo {name}` is not a command")
+                failures.append(f"{label} `visivo {name}` is not a command")
                 continue
 
+            arguments = tokens[1:]
             known = _option_flags(command) | {"--help"}
-            unknown = [flag for flag in flags if flag not in known]
+            unknown = [
+                token.split("=", 1)[0]
+                for token in arguments
+                if token.startswith("-") and token.split("=", 1)[0] not in known
+            ]
             if unknown:
-                failures.append(f"{QUICKSTART.name}:{line_no} `visivo {name}` has no {unknown}")
+                failures.append(f"{label} `visivo {name}` has no {unknown}")
+                continue
+
+            failures.extend(
+                _choice_failures(f"visivo {name}", label, arguments, _options_by_flag(command))
+            )
 
     assert failures == [], "Quick Start CLI usage that does not exist:\n" + "\n".join(failures)
+
+
+EXAMPLE_ROW_NAME_RE = re.compile(r"^`([a-z0-9-]+)`$")
+
+
+def _example_table_rows():
+    """Return ``{example_name: [cell, ...]}`` for the ``--example`` table.
+
+    The header row's first cell is ``` `--example` value ```, which does not
+    match ``EXAMPLE_ROW_NAME_RE``, so it drops out along with the ``| --- |``
+    separator.
+    """
+    text = QUICKSTART.read_text()
+    header = text.find("| `--example` value |")
+    assert header != -1, (
+        f"{QUICKSTART.name} no longer has an `--example` table. Either restore it or "
+        "delete this guard deliberately — do not let it pass vacuously."
+    )
+    rows = {}
+    for line in text[header:].split("\n\n", 1)[0].splitlines():
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        match = EXAMPLE_ROW_NAME_RE.match(cells[0])
+        if match:
+            rows[match.group(1)] = cells
+    return rows
+
+
+def test_example_table_matches_the_enum():
+    """The example names live in a markdown table, which no fence guard sees.
+
+    ``--example`` is a ``click.Choice`` over ``ExampleTypeEnum``; drop or rename
+    a member and the table starts advertising a value that hard-errors. The
+    table is the page's answer to "which examples can I pick", so it is pinned
+    to the enum in both directions.
+    """
+    advertised = set(_example_table_rows())
+    real = {member.value for member in ExampleTypeEnum}
+    assert (
+        advertised == real
+    ), f"Quick Start advertises {sorted(advertised)} but ExampleTypeEnum is {sorted(real)}"
+
+
+SAMPLES_DIR = REPO_ROOT / "visivo" / "templates" / "samples"
+
+
+def _sample_insight_types(example):
+    """Every ``props.type`` the bundled sample actually uses."""
+    document = yaml.safe_load((SAMPLES_DIR / example / "project.visivo.yml").read_text())
+    types = set()
+    for insight in document.get("insights") or []:
+        props = insight.get("props") if isinstance(insight, dict) else None
+        if isinstance(props, dict) and "type" in props:
+            types.add(props["type"])
+    return types
+
+
+def test_example_table_chart_types_match_the_samples():
+    """The third column promises which chart types each example shows.
+
+    That column is prose about files sitting in this repo, so nothing stops it
+    drifting when a sample is retuned. Pin it to the samples themselves.
+    """
+    failures = []
+    for name, cells in _example_table_rows().items():
+        advertised = {cell.strip().strip("`") for cell in cells[2].split(",")}
+        real = _sample_insight_types(name)
+        if advertised != real:
+            failures.append(
+                f"{name}: page says {sorted(advertised)}, "
+                f"templates/samples/{name} uses {sorted(real)}"
+            )
+    assert failures == [], "Quick Start example table drifted from the samples:\n" + "\n".join(
+        failures
+    )
+
+
+def test_quickstart_names_the_macos_floor_install_sh_enforces():
+    """Step 1 pipes ``install.sh`` into bash, and that script hard-exits on old
+    macOS before it downloads anything. The page has to name the same floor."""
+    match = re.search(r'BASH_REMATCH\[1\]\}"\s*-lt\s*(\d+)', INSTALL_SCRIPT.read_text())
+    assert match, f"Could not find the macOS version gate in {INSTALL_SCRIPT}"
+    floor = match.group(1)
+    assert f"macOS {floor} or later" in QUICKSTART.read_text(), (
+        f"{INSTALL_SCRIPT.name} requires macOS {floor} or later; "
+        f"{QUICKSTART.name} must say so in step 1."
+    )
 
 
 def test_quickstart_does_not_claim_serve_prompts_for_an_example():


### PR DESCRIPTION
Linear: [VIS-1271](https://linear.app/visivo/issue/VIS-1271/quick-start-rewrite-url-stability-remove-false-serve-prompts-for) (items 1 & 2 — the truth pass; redirects + `--strict` CI left open, see below)

## The problem

`mkdocs/index.md` is the single most-read page Visivo publishes, and it told new users to do something the CLI has never done. Three claims, every one of them checkable from the code:

| Where | Claim | Reality |
| --- | --- | --- |
| `index.md:26` | "Visivo will prompt you to select from several example dashboards" | `visivo/commands/serve.py` contains no `click.prompt`. In an empty directory it sets `new = not discover.project_file_exists` and builds an in-memory `Project(name="Quickstart Visivo")` with empty lists. |
| `index.md:48` | The tip block repeats it: "Prompts you to choose from available examples / Initializes the selected example into your directory" | Same code path. It writes no project file at all. |
| `index.md:67` | ```yaml\ncharts:\n  - name: revenue_chart\n    layout:\n      title: Monthly Revenue\n``` | The tool's own parser rejects this: `Validation error for layout at location: ['title']: "Monthly Revenue" is not of type "object"`. |

A new user following that page ran `visivo serve`, got a blank workspace and a `No jobs run.` log line, and had nothing to compare it against.

## What I verified by hand

Fresh arm64 venv on `origin/main`, `VISIVO_TELEMETRY_DISABLED=true`, each in its own clean tmp dir:

```
$ visivo init --example ev-sales --bare
Loading example project 'ev-sales' for 'ev'
Successfully loaded example project 'ev-sales'
Done                                                  (1.27s)
-> .env  data/  ev_sales.duckdb  project.visivo.yml

$ visivo run
Built schema for source ev_sales_db (1 tables, 5 columns)  [SUCCESS]
Updated data for insight total_revenue_kpi ...             [SUCCESS]
  (5 insights)                                        Run finished in 0.23s

$ visivo init --example college-football --headless --port 8007
-> server up, initial build green, GET / -> 200,
   /api/project/ -> {"name":"full","dashboard_count":1,...}

$ visivo serve --port 8007 < /dev/null          # empty directory
Project loaded in 0.05s
Running initial project build...
No jobs run. Ensure your filter contains nodes that are runnable.
View your project at: http://localhost:8007
-> no prompt, no project.visivo.yml written, GET / -> 200
```

So: `visivo init --example` is the 90-second path, and `visivo serve` in an empty directory is the *setup wizard* path, not the example picker.

## What changed

**`mkdocs/index.md`** — rewritten around what runs:

- Leads with `visivo init --example ev-sales`, and says exactly what that one command does (copies the sample + its DuckDB file + the CSV, names the project after the directory, compiles, runs, serves on `:8000`, opens the browser).
- Enumerates the **real** example names from `visivo/models/example_type.py` and `visivo/templates/samples/` — `ev-sales`, `github-releases`, `college-football` — with the chart types each one actually uses, read out of the sample YAML rather than guessed.
- New "Read the Project" section: the `sources -> models -> insights -> charts -> dashboards` chain as one fence that validates against the real `Project` model, plus a warning admonition on the `Item` rule (items hold `chart`/`table`/`markdown`/`input`, never a bare `insight`; `Item` is `extra="forbid"`), linking `concepts/insight.md` and `concepts/dashboard.md` per VIS-1271 item 2.
- The edit-and-reload sample is now the real `units_by_quarter_chart` from `ev-sales`, in the object form the parser accepts.
- New "Starting From Scratch Instead" section for `visivo init` with no flags, including the honest note that the scaffold is all comments so `visivo run` says `No jobs run.` until you add a source — that's expected, not a failure.
- New "What `visivo serve` Does" section that states the empty-directory behaviour plainly and points at `visivo init --example` for the thing it does not do.
- Every flag named on the page (`--bare`, `--headless`, `-p/--port`, `-pd/--project-dir`, `--new`) is one Click declares. `visivo init --example` opens the browser (`init.py` passes `new=not headless`); `visivo serve` in an existing project does **not** (`serve_phase.py:146` gates `webbrowser.open` on `new`) — the page now says "prints the URL" there instead.
- Fixed the install admonition (the script needs WSL on Windows — it does not "handle Windows automatically", per `installation.md`), repointed the "40+ chart types" card at `reference/configuration/Insight/Props/` (48 prop types in the schema; `Chart/` is the wrapper, not the type list), and added Interactivity + CLI-reference cards.

**`tests/docs/test_quickstart_truth.py`** (new) — so it cannot drift back:

- `test_quickstart_yaml_fences_parse` — every ```yaml fence is `yaml.safe_load`ed and constructed with the real `Project` model (the technique merged in #636 for the `init` scaffold). Partial fences are wrapped into a minimal project document, which is how a reader would paste them.
- `test_quickstart_commands_and_flags_exist` — every `visivo ...` line in a ```bash fence resolves against the real Click app: the subcommand must exist and every flag must be a declared option on it.
- `test_fences_are_discovered` — discovery sanity, so the two guards above can never pass vacuously.
- `test_quickstart_does_not_claim_serve_prompts_for_an_example` — bans the refuted phrasings by name and requires the page to lead with `visivo init --example`.

**`mkdocs/llms.txt`** — the two lines that told AI crawlers "run `visivo serve`" as the first-run command now name `visivo init --example ev-sales`, with an explicit "`visivo serve` never prompts for an example" fact for citation.

## Falsification

Stashed the fix (`git checkout mkdocs/index.md`), kept the tests, re-ran — 4 of 6 fail, each naming a real defect:

```
FAILED test_fences_are_discovered[yaml-2]
E   Only found 1 yaml fences in mkdocs/index.md

FAILED test_fences_are_discovered[bash-4]
E   Only found 2 bash fences in mkdocs/index.md
E    + where 2 = len([(9, 'curl -fsSL https://visivo.sh | bash'), (18, 'visivo serve')])

FAILED test_quickstart_yaml_fences_parse
E   Quick Start YAML the parser rejects:
E     index.md:67 rejected by Project: 1 validation error for Project
E     charts.0.layout
E       Value error, Validation error for layout at location: ['title']:
E       "Monthly Revenue" is not of type "object"

FAILED test_quickstart_does_not_claim_serve_prompts_for_an_example
E   Quick Start must lead with `visivo init --example`
E   Quick Start re-states the refuted claim: 'prompt you to select'
E   Quick Start re-states the refuted claim: 'prompts you to choose'
E   Quick Start re-states the refuted claim: 'choose from available examples'
```

Restored: 6/6 pass, `tests/docs/` 14/14.

## Validations actually run

| Gate | Result |
| --- | --- |
| `python mkdocs/src/write_mkdocs_markdown_files.py` | exit 0 (generated tree unchanged apart from the pre-existing `Test:` nav entry that main is behind on — reverted, not mine) |
| `mkdocs build` | exit 0, "Documentation built in 8.7s" |
| build warnings | 10, byte-identical to the `origin/main` baseline — all `AutoLinksPlugin: Duplicate filename` noise, none from this page |
| `bash validate_mkdocs_build.sh` | "You spel purtty guod" (0 `mkdocs_spellcheck` warnings) |
| `pytest tests/ -q` | 2477 passed, 2 skipped, 5 xfailed, 1 xpassed |
| `black --check --target-version py312 .` | 544 files unchanged |
| rendered page, 1440px + 390px | 6 admonitions, 1 table, 7 code blocks, 6 cards all render; no stray backticks; no page-level horizontal overflow on mobile (table scrolls in its own box); all 9 internal links `200`, `installation/#python-package-pip` anchor exists |

No Python source changes — `visivo/` is untouched. The only new code is a test.

## Deliberately left open (follow-ups, not regressions)

1. **`mkdocs/topics/dashboards.md` is not linked.** #644 is still `OPEN` at the time of writing, so linking it would 404. Once #644 merges, add it to the "Read the Project" section and the What's Next grid.
2. **VIS-1271 items 3 & 4 are untouched**: `mkdocs-redirects` for the `/get-started/installation/` and `/quickstart/` 404s, and `mkdocs build --strict` in `.rwx/test_docs.yml`. `--strict` will fail today on the 10 pre-existing `AutoLinksPlugin` duplicate-filename warnings, so it needs those cleaned first — a distinct piece of work from this truth pass.
3. **`visivo init --bare && visivo run` prints `No jobs run.`** because the scaffold is entirely commented out. Documented honestly here rather than papered over; making the blank scaffold runnable is a scaffold change (init_phase.py), not a docs change.
4. **`visivo init --example` writes no `.gitignore`** (`load_example_project` skips it), unlike `visivo init`. The page doesn't claim otherwise; the fix belongs to the onboarding stream.
5. **`mkdocs/installation.md` says "Python 3.12 or higher"** while `llms.txt` and `pyproject.toml`'s `[project]` table say 3.10+. Out of scope for this page, but it is a real contradiction worth one issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
