### PR TITLE
Instrument time-to-value: an ordered step-mark ladder for the first run (Guided First Run W1)

### DIFF
--- a/tests/server/views/test_data_views_telemetry.py
+++ b/tests/server/views/test_data_views_telemetry.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 
 import pytest
 
+from visivo.telemetry import first_run
+
 
 @pytest.fixture(autouse=True)
 def isolated_first_run(tmp_path, monkeypatch):
@@ -27,14 +29,22 @@ def isolated_first_run(tmp_path, monkeypatch):
 
     Without this, serving index.html in a test would write to the real
     ~/.visivo/first_run.json and send a real event.
+
+    A journey is only minted on an interactive run (the ``_is_interactive``
+    backstop that keeps containers/CI with a fresh $HOME from reporting a
+    brand-new first run on every cold start). pytest captures stdout, so these
+    tests have to say they are standing in for a human at a terminal.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("visivo.telemetry.first_run._is_interactive_run", lambda: True)
+    first_run.reset_journey_cache()
     monkeypatch.setattr(
         "visivo.telemetry.client.get_telemetry_client",
         lambda enabled=True: _RecordingClient.instance,
     )
     _RecordingClient.instance = _RecordingClient()
-    return _RecordingClient.instance
+    yield _RecordingClient.instance
+    first_run.reset_journey_cache()
 
 
 class _RecordingClient:
@@ -147,14 +157,55 @@ class TestFirstRunJourneyInjection:
         # And no ledger file is left behind on an opted-out machine at all.
         assert not (tmp_path / ".visivo" / "first_run.json").exists()
 
+    def test_the_injected_journey_carries_what_the_gate_metric_needs(
+        self, integration_client, monkeypatch
+    ):
+        """`install_age_ms` and `sample_dashboards` have to reach the browser.
+
+        Steps 2-6 are emitted by the viewer, so a property that only rides on
+        the CLI's step 1 cannot filter the terminal mark — which is the one the
+        exit gate is read off.
+        """
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        journey = _injected_journey(_get_index_html(integration_client))
+
+        assert "install_age_ms" in journey
+        assert "College Football" in journey["sample_dashboards"]
+
     def test_injected_journey_cannot_break_out_of_the_script_tag(
         self, integration_client, monkeypatch
     ):
+        """Falsifiable version: a journey that actually contains `</script>`.
+
+        The real journey is UUIDs and integers, so asserting on it exercises
+        nothing — the escaping could be deleted outright and the test would
+        still pass. `sample_dashboards` made the journey carry strings for the
+        first time, so this now guards a live edge rather than a hypothetical.
+        """
         monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setattr(
+            "visivo.telemetry.first_run.viewer_journey_context",
+            lambda project_defaults=None: {
+                "journey_id": "j-1",
+                "started_at_ms": 1,
+                "install_age_ms": None,
+                "machine_id": "m-1",
+                "steps": {},
+                "sample_dashboards": ["</script><script>window.__pwned=1</script>"],
+            },
+        )
         html = _get_index_html(integration_client)
 
-        # The journey is JSON built from UUIDs and integers, but the escaping
-        # is what keeps it that way if a value ever changes shape.
-        script = re.search(r"<script>window\.__VISIVO_FIRST_RUN=.*?</script>", html)
-        assert script, "journey script tag missing"
-        assert script.group(0).count("</script>") == 1
+        # Read the assignment exactly the way a browser's tokenizer does: the
+        # <script> element ends at the FIRST literal `</script>`. Everything up
+        # to it must still be the complete journey. Without the escaping the
+        # element is cut mid-JSON and this raises.
+        marker = "window.__VISIVO_FIRST_RUN="
+        start = html.index(marker) + len(marker)
+        end = html.index("</script>", start)
+        raw = html[start:end]
+
+        assert "</script>" not in raw
+        assert json.loads(raw)["sample_dashboards"] == [
+            "</script><script>window.__pwned=1</script>"
+        ]

--- a/tests/server/views/test_data_views_telemetry.py
+++ b/tests/server/views/test_data_views_telemetry.py
@@ -1,18 +1,62 @@
-"""Tests for the viewer telemetry opt-out injection in data_views (VIS-843).
+"""Tests for the viewer telemetry injection in data_views.
 
-`visivo serve` must honor the CLI/local telemetry opt-out: when telemetry is
-disabled, the served index.html sets `window.__VISIVO_TELEMETRY_DISABLED=true`
-so the viewer's PostHog client never initializes. When telemetry is enabled,
-that flag must be absent so the viewer's default-on telemetry runs.
+Two things ride on serving index.html:
+
+  VIS-843 — `visivo serve` must honor the CLI/local telemetry opt-out: when
+  telemetry is disabled, the served page sets
+  `window.__VISIVO_TELEMETRY_DISABLED=true` so the viewer's PostHog client
+  never initializes, and when enabled that flag must be absent.
+
+  Guided First Run W1 — serving the page is the first moment the product is
+  in front of the user, so it is where the time-to-value ladder's step 1
+  (`first_run_launched`) fires, once per machine. The journey is then injected
+  as `window.__VISIVO_FIRST_RUN` so the viewer's marks (steps 2-6) carry the
+  same journey_id and machine_id and the whole span is one subtraction.
 """
 
+import json
+import re
 from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_first_run(tmp_path, monkeypatch):
+    """Keep the journey ledger and PostHog out of the developer's machine.
+
+    Without this, serving index.html in a test would write to the real
+    ~/.visivo/first_run.json and send a real event.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "visivo.telemetry.client.get_telemetry_client",
+        lambda enabled=True: _RecordingClient.instance,
+    )
+    _RecordingClient.instance = _RecordingClient()
+    return _RecordingClient.instance
+
+
+class _RecordingClient:
+    instance = None
+
+    def __init__(self):
+        self.events = []
+
+    def track(self, event):
+        self.events.append(event)
 
 
 def _get_index_html(integration_client):
     response = integration_client.get("/")
     assert response.status_code == 200
     return response.get_data(as_text=True)
+
+
+def _injected_journey(html):
+    match = re.search(r"window\.__VISIVO_FIRST_RUN=(\{.*?\})</script>", html)
+    assert match, f"no __VISIVO_FIRST_RUN in served html: {html[:400]}"
+    return json.loads(match.group(1))
 
 
 class TestViewerTelemetryInjection:
@@ -47,3 +91,70 @@ class TestViewerTelemetryInjection:
         ):
             html = _get_index_html(integration_client)
         assert "__VISIVO_TELEMETRY_DISABLED" not in html
+
+
+class TestFirstRunJourneyInjection:
+    """Guided First Run W1 — the CLI half of the time-to-value ladder."""
+
+    def test_serving_the_viewer_marks_first_run_launched(
+        self, integration_client, monkeypatch, isolated_first_run
+    ):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        _get_index_html(integration_client)
+
+        assert [event.event_type for event in isolated_first_run.events] == ["first_run_launched"]
+        props = isolated_first_run.events[0].properties
+        assert props["step_id"] == "first_run_launched"
+        assert props["step_index"] == 1
+        assert props["surface"] == "cli"
+
+    def test_the_mark_fires_once_per_machine_not_once_per_page_load(
+        self, integration_client, monkeypatch, isolated_first_run
+    ):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        for _ in range(4):
+            _get_index_html(integration_client)
+
+        assert len(isolated_first_run.events) == 1
+
+    def test_journey_is_injected_so_viewer_marks_join_the_cli_ones(
+        self, integration_client, monkeypatch
+    ):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        journey = _injected_journey(_get_index_html(integration_client))
+
+        assert journey["journey_id"]
+        assert isinstance(journey["started_at_ms"], int)
+        assert journey["machine_id"]
+        assert isinstance(journey["steps"]["first_run_launched"], int)
+
+    def test_the_same_journey_is_injected_on_every_page_load(self, integration_client, monkeypatch):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        first = _injected_journey(_get_index_html(integration_client))
+        second = _injected_journey(_get_index_html(integration_client))
+
+        assert first["journey_id"] == second["journey_id"]
+        assert first["started_at_ms"] == second["started_at_ms"]
+
+    def test_opt_out_emits_nothing_and_injects_no_journey(
+        self, integration_client, monkeypatch, isolated_first_run, tmp_path
+    ):
+        monkeypatch.setenv("VISIVO_TELEMETRY_DISABLED", "true")
+        html = _get_index_html(integration_client)
+
+        assert "__VISIVO_FIRST_RUN" not in html
+        assert isolated_first_run.events == []
+        # And no ledger file is left behind on an opted-out machine at all.
+        assert not (tmp_path / ".visivo" / "first_run.json").exists()
+
+    def test_injected_journey_cannot_break_out_of_the_script_tag(
+        self, integration_client, monkeypatch
+    ):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        html = _get_index_html(integration_client)
+
+        # The journey is JSON built from UUIDs and integers, but the escaping
+        # is what keeps it that way if a value ever changes shape.
+        script = re.search(r"<script>window\.__VISIVO_FIRST_RUN=.*?</script>", html)
+        assert script, "journey script tag missing"
+        assert script.group(0).count("</script>") == 1

--- a/tests/server/views/test_telemetry_views.py
+++ b/tests/server/views/test_telemetry_views.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from flask import Flask
 
+from visivo.telemetry import first_run
 from visivo.server.views.telemetry_views import (
     MAX_PAYLOAD_BYTES,
     RESERVED_EVENT_NAMES,
@@ -145,3 +146,105 @@ class TestTelemetryViews:
         response = self.post_event(client, {"name": "cli_command"})
         assert response.status_code == 400
         get_client.assert_not_called()
+
+
+class TestFirstRunStepWriteBack:
+    """`/api/telemetry/first-run/step/` — the viewer's marks land in the ledger.
+
+    The viewer's own idempotence lives in `localStorage`, which is scoped to
+    `http://localhost:<port>`. A second browser, an incognito window, a cleared
+    site-data, or simply `visivo serve -p 8001` re-fires every viewer mark under
+    the SAME journey_id — precisely the funnel inflation the persisted ledger is
+    supposed to prevent. The file is not origin-scoped, so the write-back is what
+    makes "once per journey" true off the origin the mark was made in.
+    """
+
+    @pytest.fixture(autouse=True)
+    def isolated_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setattr("visivo.telemetry.first_run._is_interactive_run", lambda: True)
+        first_run.reset_journey_cache()
+        yield tmp_path
+        first_run.reset_journey_cache()
+
+    @pytest.fixture
+    def flask_app(self):
+        flask_app = Mock()
+        flask_app.project = Mock()
+        flask_app.project.defaults = None
+        return flask_app
+
+    @pytest.fixture
+    def client(self, flask_app):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        register_telemetry_views(app, flask_app, "/tmp/output")
+        return app.test_client()
+
+    def post_step(self, client, body):
+        return client.post(
+            "/api/telemetry/first-run/step/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    def test_a_recorded_mark_is_handed_back_to_the_next_page_load(self, client):
+        journey = first_run.get_or_create_journey()
+
+        response = self.post_step(
+            client,
+            {
+                "step_id": "source_connected",
+                "journey_id": journey["journey_id"],
+                "at_ms": 1_700_000_000_000,
+            },
+        )
+
+        assert response.status_code == 204
+        # This is the dedupe: a browser that never saw the original mark is
+        # seeded from here and refuses to fire it again.
+        context = first_run.viewer_journey_context()
+        assert context["steps"]["source_connected"] == 1_700_000_000_000
+
+    @patch("visivo.telemetry.client.get_telemetry_client")
+    def test_the_write_back_emits_nothing(self, get_client, client):
+        telemetry_client = Mock()
+        get_client.return_value = telemetry_client
+        journey = first_run.get_or_create_journey()
+
+        self.post_step(client, {"step_id": "source_connected", "journey_id": journey["journey_id"]})
+
+        # The browser already sent this event; re-emitting it server-side would
+        # double every viewer mark.
+        telemetry_client.track.assert_not_called()
+
+    def test_an_unknown_step_is_refused(self, client):
+        first_run.get_or_create_journey()
+
+        assert self.post_step(client, {"step_id": "definitely_not_a_step"}).status_code == 400
+        assert first_run.read_ledger()["steps"] == {}
+
+    def test_a_non_object_body_is_refused(self, client):
+        response = client.post(
+            "/api/telemetry/first-run/step/",
+            data=json.dumps(["source_connected"]),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_a_mark_for_a_different_journey_is_dropped(self, client):
+        first_run.get_or_create_journey()
+
+        response = self.post_step(
+            client, {"step_id": "source_connected", "journey_id": "some-other-journey"}
+        )
+
+        assert response.status_code == 204
+        assert "source_connected" not in first_run.read_ledger()["steps"]
+
+    def test_the_opt_out_covers_the_write_back(self, client, monkeypatch, isolated_home):
+        monkeypatch.setenv("VISIVO_TELEMETRY_DISABLED", "true")
+
+        assert self.post_step(client, {"step_id": "source_connected"}).status_code == 204
+        assert not (isolated_home / ".visivo" / "first_run.json").exists()

--- a/tests/telemetry/test_first_run.py
+++ b/tests/telemetry/test_first_run.py
@@ -1,0 +1,249 @@
+"""Tests for the time-to-value journey ledger (Guided First Run W1).
+
+The 2.1 exit gate ("8 of 8 new users build a dashboard in under 20 minutes")
+is read off this ladder, so the properties these tests pin are the metric:
+
+  - a mark fires EXACTLY ONCE per journey, not once per session — a mark that
+    re-fired on reload would inflate the funnel and destroy the median;
+  - every mark carries the required properties from
+    specs/marketing-relaunch/event-taxonomy.md §4;
+  - the opt-out suppresses everything AND leaves no ledger file behind;
+  - no payload and no ledger contains PII or any user-authored string.
+
+Every test isolates HOME so the real ~/.visivo is never touched.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from visivo.telemetry import first_run
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Point ~ at a tmp dir so the ledger never lands in the real home."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+    return tmp_path
+
+
+class RecordingClient:
+    """Stand-in for the PostHog client that records the events it is handed."""
+
+    def __init__(self):
+        self.events = []
+
+    def track(self, event):
+        self.events.append(event)
+
+
+@pytest.fixture
+def recording_client(monkeypatch):
+    client = RecordingClient()
+    monkeypatch.setattr(
+        "visivo.telemetry.client.get_telemetry_client",
+        lambda enabled=True: client,
+    )
+    return client
+
+
+class TestJourneyLedger:
+    def test_creates_a_journey_with_a_random_id_and_a_start(self, isolated_home):
+        journey = first_run.get_or_create_journey()
+
+        assert journey is not None
+        uuid.UUID(journey["journey_id"])  # random UUID, not derived from anything
+        assert isinstance(journey["started_at_ms"], int)
+        assert journey["steps"] == {}
+        assert first_run.ledger_path().exists()
+
+    def test_journey_is_stable_across_calls(self):
+        first = first_run.get_or_create_journey()
+        second = first_run.get_or_create_journey()
+
+        assert first["journey_id"] == second["journey_id"]
+        assert first["started_at_ms"] == second["started_at_ms"]
+
+    def test_corrupt_ledger_is_treated_as_absent_not_raised(self, isolated_home):
+        path = first_run.ledger_path()
+        path.parent.mkdir(exist_ok=True)
+        path.write_text("{not json at all")
+
+        assert first_run.read_ledger() is None
+        # And the caller still gets a usable journey rather than an exception.
+        assert first_run.get_or_create_journey() is not None
+
+    def test_ledger_without_a_journey_id_is_rejected(self, isolated_home):
+        path = first_run.ledger_path()
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(json.dumps({"started_at_ms": 1, "steps": {}}))
+
+        assert first_run.read_ledger() is None
+
+
+class TestMarkStep:
+    def test_marks_the_step_once_and_only_once(self, recording_client):
+        assert first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED) is True
+        assert first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED) is False
+        assert first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED) is False
+
+        assert len(recording_client.events) == 1
+
+    def test_idempotence_survives_a_new_process(self, recording_client):
+        """The ledger, not in-memory state, is what makes 'once' true."""
+        assert first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED) is True
+
+        # Simulate a restart: nothing cached, only the file on disk.
+        reread = first_run.read_ledger()
+        assert first_run.STEP_FIRST_RUN_LAUNCHED in reread["steps"]
+        assert first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED) is False
+        assert len(recording_client.events) == 1
+
+    def test_event_carries_every_required_property(self, recording_client):
+        first_run.mark_step(first_run.STEP_FIRST_RUN_LAUNCHED)
+
+        event = recording_client.events[0]
+        assert event.event_type == "first_run_launched"
+        props = event.properties
+        uuid.UUID(props["journey_id"])
+        assert props["step_id"] == "first_run_launched"
+        assert props["step_index"] == 1
+        assert isinstance(props["ms_since_first_run"], int)
+        assert props["ms_since_first_run"] >= 0
+        # First mark of the journey: there is no previous step to measure from.
+        assert props["ms_since_previous_step"] is None
+        assert props["out_of_order"] is False
+        assert props["machine_id"] == event.machine_id
+        assert props["surface"] == "cli"
+        assert props["plan"] == "anonymous"
+        assert "is_ci" in props and "visivo_version" in props and "platform" in props
+
+    def test_step_index_matches_the_frozen_ladder(self):
+        assert first_run.STEP_INDEXES == {
+            "first_run_launched": 1,
+            "source_connected": 2,
+            "first_query_run": 3,
+            "first_model_created": 4,
+            "first_insight_created": 5,
+            "first_dashboard_rendered": 6,
+        }
+
+    def test_second_step_measures_from_the_previous_one(self, recording_client):
+        first_run.mark_step("first_run_launched")
+        first_run.mark_step("source_connected")
+
+        second = recording_client.events[1].properties
+        assert second["step_index"] == 2
+        assert isinstance(second["ms_since_previous_step"], int)
+        assert second["ms_since_previous_step"] >= 0
+        assert second["out_of_order"] is False
+
+    def test_marks_are_emitted_in_ladder_order(self, recording_client):
+        for step in ["first_run_launched", "source_connected", "first_query_run"]:
+            first_run.mark_step(step)
+
+        indexes = [event.properties["step_index"] for event in recording_client.events]
+        timestamps = [event.properties["ms_since_first_run"] for event in recording_client.events]
+        assert indexes == [1, 2, 3]
+        assert timestamps == sorted(timestamps)
+
+    def test_a_step_recorded_in_the_future_is_flagged_out_of_order(self, recording_client):
+        """A clock jump must show up as data, not as a silently wrong median."""
+        journey = first_run.get_or_create_journey()
+        journey["steps"] = {"first_run_launched": journey["started_at_ms"] + 10_000_000}
+        first_run._write_ledger(journey)
+
+        assert first_run.mark_step("source_connected") is True
+        assert recording_client.events[0].properties["out_of_order"] is True
+
+    def test_unknown_step_is_refused(self, recording_client):
+        assert first_run.mark_step("definitely_not_a_step") is False
+        assert recording_client.events == []
+        # And it is not silently written into the ledger either.
+        assert first_run.read_ledger() is None
+
+    def test_a_throwing_client_does_not_re_fire_on_every_call(self, monkeypatch):
+        def explode(enabled=True):
+            raise RuntimeError("posthog is down")
+
+        monkeypatch.setattr("visivo.telemetry.client.get_telemetry_client", explode)
+
+        assert first_run.mark_step("first_run_launched") is False
+        # The step is still claimed: a network failure must not turn into a
+        # retry storm that re-fires the mark on every page load.
+        assert "first_run_launched" in first_run.read_ledger()["steps"]
+
+
+class TestOptOut:
+    @pytest.fixture(autouse=True)
+    def opted_out(self, monkeypatch):
+        monkeypatch.setenv("VISIVO_TELEMETRY_DISABLED", "true")
+
+    def test_no_journey_is_created(self):
+        assert first_run.get_or_create_journey() is None
+        assert not first_run.ledger_path().exists()
+
+    def test_no_step_is_marked_and_nothing_is_written(self, recording_client):
+        assert first_run.mark_step("first_run_launched") is False
+        assert recording_client.events == []
+        assert not first_run.ledger_path().exists()
+
+    def test_no_journey_is_handed_to_the_viewer(self):
+        assert first_run.viewer_journey_context() is None
+        assert not first_run.ledger_path().exists()
+
+    def test_project_defaults_opt_out_is_honored(self, monkeypatch, recording_client):
+        monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
+
+        class Defaults:
+            telemetry_enabled = False
+
+        assert first_run.mark_step("first_run_launched", project_defaults=Defaults()) is False
+        assert recording_client.events == []
+        assert not first_run.ledger_path().exists()
+
+
+class TestViewerJourneyContext:
+    def test_hands_the_viewer_the_journey_the_cli_started(self, recording_client):
+        first_run.mark_step("first_run_launched")
+
+        context = first_run.viewer_journey_context()
+
+        ledger = first_run.read_ledger()
+        assert context["journey_id"] == ledger["journey_id"]
+        assert context["started_at_ms"] == ledger["started_at_ms"]
+        # Timestamps, not just names: the viewer's FIRST mark measures
+        # ms_since_previous_step against the CLI's real mark.
+        assert context["steps"] == ledger["steps"]
+        assert isinstance(context["steps"]["first_run_launched"], int)
+
+    def test_machine_id_is_present_so_the_two_halves_can_be_joined(self):
+        context = first_run.viewer_journey_context()
+        assert context["machine_id"]
+
+
+class TestNoPii:
+    def test_payload_contains_no_user_authored_strings_or_paths(
+        self, recording_client, isolated_home
+    ):
+        first_run.mark_step("first_run_launched")
+        first_run.mark_step("source_connected")
+
+        home = str(isolated_home)
+        for event in recording_client.events:
+            for key, value in event.properties.items():
+                assert "@" not in key
+                if isinstance(value, str):
+                    assert home not in value, f"{key} leaked a filesystem path"
+                    assert "@" not in value, f"{key} looks like an email address"
+                    assert "/" not in value, f"{key} looks like a path"
+
+    def test_the_ledger_on_disk_holds_only_ids_and_timestamps(self):
+        first_run.mark_step("first_run_launched")
+
+        ledger = json.loads(first_run.ledger_path().read_text())
+        assert set(ledger.keys()) == {"journey_id", "started_at_ms", "steps"}
+        uuid.UUID(ledger["journey_id"])
+        assert all(isinstance(value, int) for value in ledger["steps"].values())

--- a/tests/telemetry/test_first_run.py
+++ b/tests/telemetry/test_first_run.py
@@ -14,6 +14,8 @@ Every test isolates HOME so the real ~/.visivo is never touched.
 """
 
 import json
+import os
+import time
 import uuid
 
 import pytest
@@ -23,10 +25,18 @@ from visivo.telemetry import first_run
 
 @pytest.fixture(autouse=True)
 def isolated_home(tmp_path, monkeypatch):
-    """Point ~ at a tmp dir so the ledger never lands in the real home."""
+    """Point ~ at a tmp dir so the ledger never lands in the real home.
+
+    Also stands in for "a human is at a terminal": a journey is only MINTED on
+    an interactive run, and pytest captures stdout so the real check is False
+    here. The suppression itself is pinned by TestNotAFirstRun below.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("VISIVO_TELEMETRY_DISABLED", raising=False)
-    return tmp_path
+    monkeypatch.setattr("visivo.telemetry.first_run._is_interactive_run", lambda: True)
+    first_run.reset_journey_cache()
+    yield tmp_path
+    first_run.reset_journey_cache()
 
 
 class RecordingClient:
@@ -223,6 +233,252 @@ class TestViewerJourneyContext:
         context = first_run.viewer_journey_context()
         assert context["machine_id"]
 
+    def test_injected_machine_id_is_the_one_the_event_shipped_under(
+        self, recording_client, monkeypatch
+    ):
+        """Truthy is not enough — it has to be the SAME id, or nothing joins.
+
+        In any CI / container / serverless context ``get_machine_id()`` returns
+        a fresh ``ci-<uuid>`` on every call and persists nothing, so reading it
+        again here hands the browser an id that matches no event and rotates on
+        every page load. That is the join the whole ladder is built on.
+        """
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr("visivo.telemetry.events.MACHINE_ID", None)
+
+        first_run.mark_step("first_run_launched")
+        event_machine_id = recording_client.events[0].properties["machine_id"]
+
+        first_context = first_run.viewer_journey_context()
+        second_context = first_run.viewer_journey_context()
+
+        assert first_context["machine_id"] == event_machine_id
+        assert second_context["machine_id"] == event_machine_id
+
+    def test_sample_dashboards_are_handed_over_so_from_sample_is_about_the_dashboard(self):
+        context = first_run.viewer_journey_context()
+
+        # The bundled samples, read off visivo/templates/samples — NOT which
+        # onboarding branch the user happened to take.
+        assert "College Football" in context["sample_dashboards"]
+        assert "EV Sales" in context["sample_dashboards"]
+        assert "GitHub Releases" in context["sample_dashboards"]
+
+    def test_install_age_reaches_the_viewer_too(self, isolated_home):
+        """Viewer marks carry it as well, or only step 1 is filterable."""
+        visivo_dir = isolated_home / ".visivo"
+        visivo_dir.mkdir(exist_ok=True)
+        (visivo_dir / "machine_id").write_text(str(uuid.uuid4()))
+        aged = time.time() - 90 * 86400
+        os.utime(visivo_dir / "machine_id", (aged, aged))
+
+        context = first_run.viewer_journey_context()
+
+        assert context["install_age_ms"] > 60 * 86400 * 1000
+
+
+class TestNotAFirstRun:
+    """The two ways a journey gets minted for something that is not a first run."""
+
+    def test_an_established_install_is_reported_as_one(self, recording_client, isolated_home):
+        """The ledger's absence cannot mean "new" — no install has one yet.
+
+        On rollout day every existing machine has a machine_id months old and
+        no first_run.json, so it mints a journey and reaches
+        first_dashboard_rendered seconds later. ``install_age_ms`` is what lets
+        the gate metric tell that apart from a 2-second time-to-value.
+        """
+        visivo_dir = isolated_home / ".visivo"
+        visivo_dir.mkdir(exist_ok=True)
+        (visivo_dir / "machine_id").write_text(str(uuid.uuid4()))
+        a_year_ago = time.time() - 365 * 86400
+        os.utime(visivo_dir / "machine_id", (a_year_ago, a_year_ago))
+
+        assert first_run.mark_step("first_run_launched") is True
+
+        install_age_ms = recording_client.events[0].properties["install_age_ms"]
+        assert install_age_ms > 300 * 86400 * 1000, "an upgrade must not look like a first run"
+
+    def test_a_genuinely_new_install_reports_a_young_one(self, recording_client, isolated_home):
+        visivo_dir = isolated_home / ".visivo"
+        visivo_dir.mkdir(exist_ok=True)
+        (visivo_dir / "machine_id").write_text(str(uuid.uuid4()))
+
+        assert first_run.mark_step("first_run_launched") is True
+
+        install_age_ms = recording_client.events[0].properties["install_age_ms"]
+        assert 0 <= install_age_ms < 60_000
+
+    def test_install_age_is_null_when_there_is_no_persisted_machine_id(
+        self, recording_client, monkeypatch
+    ):
+        """CI never persists a machine id, so the install has no knowable age."""
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr("visivo.telemetry.events.MACHINE_ID", None)
+
+        assert first_run.mark_step("first_run_launched") is True
+        assert recording_client.events[0].properties["install_age_ms"] is None
+
+    def test_a_brand_new_install_created_by_this_very_run_is_not_unknown(
+        self, recording_client, monkeypatch, isolated_home
+    ):
+        """`visivo serve` as the literal first command must still report ~0.
+
+        The machine id file is created during this same request, so reading the
+        mtime without resolving it first would report `null` — "unknown" — for
+        the one cohort the gate metric is entirely about.
+        """
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr("visivo.telemetry.events.MACHINE_ID", None)
+        monkeypatch.setattr("visivo.telemetry.machine_id._is_interactive", lambda: False)
+        assert not (isolated_home / ".visivo" / "machine_id").exists()
+
+        assert first_run.mark_step("first_run_launched") is True
+
+        install_age_ms = recording_client.events[0].properties["install_age_ms"]
+        assert install_age_ms is not None and install_age_ms < 60_000
+
+    def test_a_non_interactive_run_mints_no_journey_at_all(self, recording_client, monkeypatch):
+        """A container with a fresh $HOME per cold start is not a first run.
+
+        Same backstop `new_installation` already uses (machine_id.py) — it needs
+        no platform-specific signal, so Cloud Run / Lambda / a K8s pod / any CI
+        runner cannot report a brand-new first run on every start.
+        """
+        monkeypatch.setattr("visivo.telemetry.first_run._is_interactive_run", lambda: False)
+
+        assert first_run.get_or_create_journey() is None
+        assert first_run.mark_step("first_run_launched") is False
+        assert first_run.viewer_journey_context() is None
+        assert recording_client.events == []
+        assert not first_run.ledger_path().exists()
+
+    def test_an_existing_journey_still_marks_on_a_non_interactive_run(
+        self, recording_client, monkeypatch
+    ):
+        """Only MINTING is gated — a user who started at a terminal is still measured."""
+        first_run.get_or_create_journey()
+        first_run.reset_journey_cache()
+        monkeypatch.setattr("visivo.telemetry.first_run._is_interactive_run", lambda: False)
+
+        assert first_run.mark_step("first_run_launched") is True
+        assert len(recording_client.events) == 1
+
+
+class TestUnwritableLedger:
+    """A read-only / unwritable $HOME must not multiply journeys."""
+
+    @pytest.fixture(autouse=True)
+    def unwritable(self, monkeypatch):
+        monkeypatch.setattr(first_run, "_write_ledger", lambda data: False)
+
+    def test_step_one_does_not_re_fire_on_every_page_load(self, recording_client):
+        for _ in range(3):
+            first_run.mark_step("first_run_launched")
+
+        assert len(recording_client.events) == 1
+
+    def test_the_injected_journey_id_is_the_one_the_event_carried(self, recording_client):
+        first_run.mark_step("first_run_launched")
+        context = first_run.viewer_journey_context()
+
+        # Without a per-process journey, mark_step and viewer_journey_context
+        # each mint their own id and the CLI/viewer halves never join.
+        assert context["journey_id"] == recording_client.events[0].properties["journey_id"]
+
+    def test_the_same_journey_is_handed_to_every_page_load(self):
+        first = first_run.viewer_journey_context()
+        second = first_run.viewer_journey_context()
+
+        assert first["journey_id"] == second["journey_id"]
+        assert first["started_at_ms"] == second["started_at_ms"]
+
+
+class TestWriteIsAtomic:
+    def test_a_failed_write_leaves_the_previous_ledger_intact(self, monkeypatch):
+        """A truncating write turns a crash into a SECOND journey.
+
+        `read_ledger` reports an unparseable file as absent, and an absent
+        ledger mints a fresh journey_id whose ms_since_first_run restarts from
+        zero — one first run silently split in two.
+        """
+        first_run.mark_step("first_run_launched")
+        before = first_run.ledger_path().read_text()
+
+        def explode(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("visivo.telemetry.first_run.json.dump", explode)
+        assert first_run._write_ledger({"journey_id": "nope", "steps": {}}) is False
+
+        assert first_run.ledger_path().read_text() == before
+        assert first_run.read_ledger()["journey_id"] == json.loads(before)["journey_id"]
+
+    def test_no_temp_files_are_left_behind(self, monkeypatch, isolated_home):
+        def explode(*args, **kwargs):
+            raise OSError("disk full")
+
+        first_run.mark_step("first_run_launched")
+        monkeypatch.setattr("visivo.telemetry.first_run.json.dump", explode)
+        first_run._write_ledger({"journey_id": "nope", "steps": {}})
+
+        leftovers = list((isolated_home / ".visivo").glob(".first_run.*"))
+        assert leftovers == []
+
+
+class TestRecordViewerStep:
+    """The viewer's marks are written back so "once" survives a browser change.
+
+    localStorage is scoped to `http://localhost:<port>`; the ledger is not. A
+    second browser, an incognito window, a cleared site-data, or `visivo serve
+    -p 8001` would otherwise re-fire every viewer mark under the same
+    journey_id.
+    """
+
+    def test_a_recorded_mark_comes_back_in_the_injected_journey(self, recording_client):
+        journey = first_run.get_or_create_journey()
+
+        assert (
+            first_run.record_viewer_step(
+                "source_connected", journey_id=journey["journey_id"], at_ms=1_700_000_000_000
+            )
+            is True
+        )
+
+        context = first_run.viewer_journey_context()
+        assert context["steps"]["source_connected"] == 1_700_000_000_000
+        # And it emits nothing: the browser already sent the event.
+        assert recording_client.events == []
+
+    def test_recording_the_same_step_twice_is_a_no_op(self):
+        journey = first_run.get_or_create_journey()
+        journey_id = journey["journey_id"]
+
+        assert first_run.record_viewer_step("source_connected", journey_id=journey_id) is True
+        assert first_run.record_viewer_step("source_connected", journey_id=journey_id) is False
+
+    def test_a_mark_from_another_journey_is_refused(self):
+        first_run.get_or_create_journey()
+
+        assert first_run.record_viewer_step("source_connected", journey_id="not-this-one") is False
+        assert "source_connected" not in first_run.read_ledger()["steps"]
+
+    def test_an_unknown_step_is_refused(self):
+        first_run.get_or_create_journey()
+
+        assert first_run.record_viewer_step("definitely_not_a_step") is False
+        assert first_run.read_ledger()["steps"] == {}
+
+    def test_nothing_is_recorded_without_a_journey(self):
+        assert first_run.record_viewer_step("source_connected") is False
+        assert not first_run.ledger_path().exists()
+
+    def test_the_opt_out_covers_the_write_back_too(self, monkeypatch):
+        monkeypatch.setenv("VISIVO_TELEMETRY_DISABLED", "true")
+
+        assert first_run.record_viewer_step("source_connected") is False
+        assert not first_run.ledger_path().exists()
+
 
 class TestNoPii:
     def test_payload_contains_no_user_authored_strings_or_paths(
@@ -244,6 +500,17 @@ class TestNoPii:
         first_run.mark_step("first_run_launched")
 
         ledger = json.loads(first_run.ledger_path().read_text())
-        assert set(ledger.keys()) == {"journey_id", "started_at_ms", "steps"}
+        assert set(ledger.keys()) == {
+            "journey_id",
+            "started_at_ms",
+            "install_age_ms",
+            "steps",
+        }
         uuid.UUID(ledger["journey_id"])
         assert all(isinstance(value, int) for value in ledger["steps"].values())
+        # journey_id is the ONLY string in the file — nothing else may become
+        # a place a name or a path can hide.
+        assert [key for key, value in ledger.items() if isinstance(value, str)] == ["journey_id"]
+        assert all(
+            isinstance(key, str) and key in first_run.STEP_INDEXES for key in ledger["steps"]
+        )

--- a/viewer/src/api/firstRunSteps.js
+++ b/viewer/src/api/firstRunSteps.js
@@ -1,0 +1,73 @@
+import { isAvailable, getUrl } from '../contexts/URLContext';
+
+/**
+ * Time-to-value mark write-back (Guided First Run W1).
+ *
+ * This sends NO event. `markTimeToValueStep` has already emitted to PostHog;
+ * what it cannot do on its own is make "once per journey" survive leaving the
+ * browser origin the mark was made in.
+ *
+ * The viewer's idempotence ledger lives in `localStorage`, which is scoped to
+ * `http://localhost:<port>` — so `visivo serve -p 8001`, a second browser, an
+ * incognito window, or a cleared site-data all present as "no marks yet" while
+ * `~/.visivo/first_run.json` still holds the SAME journey_id. Every viewer mark
+ * would then fire a second time under that id, inflating the funnel and
+ * destroying the median the 2.1 exit gate is read off.
+ *
+ * Posting the mark to `/api/telemetry/first-run/step/` records it in the
+ * server-side ledger, and the next page load is seeded from there
+ * (`viewer_journey_context().steps`), whichever origin it happens on.
+ *
+ * Guarantees, matching the workspace telemetry sink next door:
+ *   - NEVER throws into the render path (every failure is swallowed).
+ *   - No-op under jest (`JEST_WORKER_ID`), so unit tests fire no network calls.
+ *   - No-op in the dist/cloud viewer (the URL key is `null` there) and before
+ *     the URLConfig is initialized.
+ */
+
+const isJest = () =>
+  typeof process !== 'undefined' && !!(process.env && process.env.JEST_WORKER_ID);
+
+/**
+ * Build the fetch request for a mark write-back, or `null` when the sink is
+ * unavailable. Exported so tests can cover the request shape without
+ * dispatching network calls.
+ *
+ * @param {{journeyId?: string, stepId: string, atMs?: number}} mark
+ * @returns {{url: string, options: object}|null}
+ */
+export function buildFirstRunStepRequest(mark) {
+  if (!mark || typeof mark.stepId !== 'string' || !mark.stepId) return null;
+  if (!isAvailable('firstRunStep')) return null;
+  return {
+    url: getUrl('firstRunStep'),
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        step_id: mark.stepId,
+        journey_id: mark.journeyId ?? null,
+        at_ms: mark.atMs ?? null,
+      }),
+      // The terminal mark fires as a dashboard mounts, which is often followed
+      // immediately by navigation; keepalive is what lets it land anyway.
+      keepalive: true,
+    },
+  };
+}
+
+/**
+ * Fire-and-forget a mark write-back. Telemetry must never break the app.
+ *
+ * @param {{journeyId?: string, stepId: string, atMs?: number}} mark
+ */
+export function postFirstRunStep(mark) {
+  if (isJest()) return;
+  try {
+    const request = buildFirstRunStepRequest(mark);
+    if (!request || typeof fetch !== 'function') return;
+    fetch(request.url, request.options).catch(() => {});
+  } catch {
+    // Swallow — telemetry must never throw into the render path.
+  }
+}

--- a/viewer/src/api/firstRunSteps.test.js
+++ b/viewer/src/api/firstRunSteps.test.js
@@ -1,0 +1,96 @@
+/**
+ * Time-to-value mark write-back (Guided First Run W1).
+ *
+ * `buildFirstRunStepRequest` is the testable core — it resolves the local-only
+ * endpoint through the urls.js null-pattern and shapes the POST body.
+ * `postFirstRunStep` is a thin fire-and-forget dispatcher that is a deliberate
+ * no-op under jest (asserted here).
+ */
+import { buildFirstRunStepRequest, postFirstRunStep } from './firstRunSteps';
+import { isAvailable, getUrl } from '../contexts/URLContext';
+
+jest.mock('../contexts/URLContext', () => ({
+  isAvailable: jest.fn(),
+  getUrl: jest.fn(),
+}));
+
+describe('buildFirstRunStepRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isAvailable.mockReturnValue(true);
+    getUrl.mockReturnValue('/api/telemetry/first-run/step/');
+  });
+
+  test('builds a keepalive POST carrying the step, the journey and the timestamp', () => {
+    const request = buildFirstRunStepRequest({
+      journeyId: 'J-1',
+      stepId: 'source_connected',
+      atMs: 1718000000000,
+    });
+
+    expect(request.url).toBe('/api/telemetry/first-run/step/');
+    expect(request.options.method).toBe('POST');
+    // The terminal mark fires as a dashboard mounts, often right before a
+    // navigation; without keepalive that mark is the one most likely to be lost.
+    expect(request.options.keepalive).toBe(true);
+    expect(JSON.parse(request.options.body)).toEqual({
+      step_id: 'source_connected',
+      journey_id: 'J-1',
+      at_ms: 1718000000000,
+    });
+  });
+
+  test('a mark with no journey id still round-trips as explicit nulls', () => {
+    const body = JSON.parse(
+      buildFirstRunStepRequest({ stepId: 'first_model_created' }).options.body
+    );
+    expect(body).toEqual({ step_id: 'first_model_created', journey_id: null, at_ms: null });
+  });
+
+  test('carries nothing but ids and a timestamp — no name, no path, no SQL', () => {
+    const body = JSON.parse(
+      buildFirstRunStepRequest({
+        journeyId: 'J-1',
+        stepId: 'first_query_run',
+        atMs: 1718000000000,
+      }).options.body
+    );
+    expect(Object.keys(body).sort()).toEqual(['at_ms', 'journey_id', 'step_id']);
+  });
+
+  test('returns null in the dist/cloud viewer, where there is no server to write to', () => {
+    isAvailable.mockReturnValue(false);
+
+    expect(buildFirstRunStepRequest({ stepId: 'source_connected' })).toBeNull();
+    expect(getUrl).not.toHaveBeenCalled();
+  });
+
+  test('returns null for a malformed mark', () => {
+    expect(buildFirstRunStepRequest(null)).toBeNull();
+    expect(buildFirstRunStepRequest({})).toBeNull();
+    expect(buildFirstRunStepRequest({ stepId: '' })).toBeNull();
+    expect(buildFirstRunStepRequest({ stepId: 42 })).toBeNull();
+  });
+});
+
+describe('postFirstRunStep', () => {
+  test('is a no-op under jest so unit tests never dispatch network calls', () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy;
+    isAvailable.mockReturnValue(true);
+    getUrl.mockReturnValue('/api/telemetry/first-run/step/');
+
+    postFirstRunStep({ journeyId: 'J-1', stepId: 'source_connected', atMs: 1 });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    delete global.fetch;
+  });
+
+  test('never throws into the caller, whatever the sink does', () => {
+    isAvailable.mockImplementation(() => {
+      throw new Error('URLConfig exploded');
+    });
+
+    expect(() => postFirstRunStep({ stepId: 'source_connected' })).not.toThrow();
+  });
+});

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -42,6 +42,10 @@ const SQLEditor = ({
   // onQueryComplete so the caller can route results to the tab/model that
   // started the run even if the context changed while the job was in flight.
   const runContextRef = useRef(null);
+  // Set when the user actually pressed Run here, so the ladder's step 3 is
+  // claimed by a query THIS editor sent rather than by any result that happens
+  // to arrive.
+  const ranAQueryRef = useRef(false);
 
   const [sql, setSql] = useState(initialValue);
   const [showError, setShowError] = useState(true);
@@ -66,6 +70,20 @@ const SQLEditor = ({
     if (result) {
       setResultsPage(0);
     }
+  }, [result]);
+
+  // Step 3 of the time-to-value ladder (Guided First Run W1) — the moment the
+  // user first asks their own data a question AND GETS AN ANSWER. The taxonomy
+  // says "executes in the SQL editor and returns", and the distinction is not
+  // cosmetic: claiming the step on submit means a query that fails on a typo,
+  // times out, or is cancelled permanently consumes the once-per-journey mark,
+  // and step 4's `ms_since_previous_step` is then measured from a submit that
+  // produced nothing. The ladder's four other viewer marks are all on the
+  // success path; this one now is too. Metadata only: never the SQL text, the
+  // source name, or anything else the user typed.
+  useEffect(() => {
+    if (!result || !ranAQueryRef.current) return;
+    markTimeToValueStep(TTV_STEPS.FIRST_QUERY_RUN);
   }, [result]);
 
   // Notify parent when query completes
@@ -123,10 +141,9 @@ const SQLEditor = ({
     runContextRef.current = queryContext ?? null;
     executeQuery(sourceName, queryText.trim());
     recordOnboardingAction('query_run');
-    // Step 3 of the time-to-value ladder (Guided First Run W1) — the moment
-    // the user first asks their own data a question. Metadata only: never the
-    // SQL text, the source name, or anything else the user typed.
-    markTimeToValueStep(TTV_STEPS.FIRST_QUERY_RUN);
+    // Step 3 of the ladder is claimed on the RETURN, not here — see the effect
+    // below. This only records that the user asked.
+    ranAQueryRef.current = true;
   }, [sourceName, sql, executeQuery, queryContext]);
 
   // Handle cancel

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -10,6 +10,7 @@ import { computeColumnProfile } from '../../utils/computeColumnProfile';
 import DataTable from '../common/DataTable';
 import ColumnProfilePanel from './ColumnProfilePanel';
 import { recordOnboardingAction } from '../onboarding/onboardingState';
+import { markTimeToValueStep, TTV_STEPS } from '../onboarding/timeToValue';
 
 const SQLEditor = ({
   initialValue = '',
@@ -122,6 +123,10 @@ const SQLEditor = ({
     runContextRef.current = queryContext ?? null;
     executeQuery(sourceName, queryText.trim());
     recordOnboardingAction('query_run');
+    // Step 3 of the time-to-value ladder (Guided First Run W1) — the moment
+    // the user first asks their own data a question. Metadata only: never the
+    // SQL text, the source name, or anything else the user typed.
+    markTimeToValueStep(TTV_STEPS.FIRST_QUERY_RUN);
   }, [sourceName, sql, executeQuery, queryContext]);
 
   // Handle cancel

--- a/viewer/src/components/explorer/SQLEditor.test.jsx
+++ b/viewer/src/components/explorer/SQLEditor.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { useDroppable } from '@dnd-kit/core';
 import SQLEditor from './SQLEditor';
+import { clearEventBuffer, getEventBuffer } from '../onboarding/telemetry';
+import { clearTimeToValueLedger } from '../onboarding/timeToValue';
 
 // Mock Monaco editor — selection state is configurable per-test
 let mockSelectionIsEmpty = true;
@@ -219,6 +221,30 @@ describe('SQLEditor', () => {
     await waitFor(() => {
       expect(mockExecuteQuery).toHaveBeenCalledWith('test_source', 'SELECT 1');
     });
+  });
+
+  // Guided First Run W1: running a query is step 3 of the time-to-value
+  // ladder — the moment the user first asks their own data a question. Uses
+  // the REAL timeToValue module (not a mock) so this covers the thing that
+  // actually has to hold: two runs, one mark, and never the user's SQL.
+  it('marks the time-to-value first_query_run step exactly once, with no SQL in the payload', async () => {
+    clearTimeToValueLedger();
+    clearEventBuffer();
+
+    render(<SQLEditor initialValue="SELECT customer_email FROM users" sourceName="test_source" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+
+    await waitFor(() => {
+      expect(mockExecuteQuery).toHaveBeenCalled();
+    });
+
+    const runMarks = getEventBuffer().filter(e => e.event === 'first_query_run');
+    expect(runMarks).toHaveLength(1);
+    expect(runMarks[0].props.step_index).toBe(3);
+    expect(JSON.stringify(runMarks[0].props)).not.toContain('SELECT');
+    expect(JSON.stringify(runMarks[0].props)).not.toContain('test_source');
   });
 
   it('shows Cancel button when query is running', () => {

--- a/viewer/src/components/explorer/SQLEditor.test.jsx
+++ b/viewer/src/components/explorer/SQLEditor.test.jsx
@@ -224,14 +224,21 @@ describe('SQLEditor', () => {
   });
 
   // Guided First Run W1: running a query is step 3 of the time-to-value
-  // ladder — the moment the user first asks their own data a question. Uses
-  // the REAL timeToValue module (not a mock) so this covers the thing that
-  // actually has to hold: two runs, one mark, and never the user's SQL.
+  // ladder — the moment the user first asks their own data a question AND
+  // GETS AN ANSWER. Uses the REAL timeToValue module (not a mock) so these
+  // cover the thing that actually has to hold: the mark waits for the return,
+  // two runs make one mark, and the user's SQL never rides along.
+  const queryMarks = () => getEventBuffer().filter(e => e.event === 'first_query_run');
+
   it('marks the time-to-value first_query_run step exactly once, with no SQL in the payload', async () => {
     clearTimeToValueLedger();
     clearEventBuffer();
 
-    render(<SQLEditor initialValue="SELECT customer_email FROM users" sourceName="test_source" />);
+    const props = {
+      initialValue: 'SELECT customer_email FROM users',
+      sourceName: 'test_source',
+    };
+    const { rerender } = render(<SQLEditor {...props} />);
 
     fireEvent.click(screen.getByRole('button', { name: /run/i }));
     fireEvent.click(screen.getByRole('button', { name: /run/i }));
@@ -240,11 +247,68 @@ describe('SQLEditor', () => {
       expect(mockExecuteQuery).toHaveBeenCalled();
     });
 
-    const runMarks = getEventBuffer().filter(e => e.event === 'first_query_run');
-    expect(runMarks).toHaveLength(1);
-    expect(runMarks[0].props.step_index).toBe(3);
-    expect(JSON.stringify(runMarks[0].props)).not.toContain('SELECT');
-    expect(JSON.stringify(runMarks[0].props)).not.toContain('test_source');
+    // Both queries return.
+    mockQueryJobState.result = { columns: ['a'], rows: [[1]] };
+    rerender(<SQLEditor {...props} />);
+    mockQueryJobState.result = { columns: ['a'], rows: [[2]] };
+    rerender(<SQLEditor {...props} />);
+
+    expect(queryMarks()).toHaveLength(1);
+    expect(queryMarks()[0].props.step_index).toBe(3);
+    expect(JSON.stringify(queryMarks()[0].props)).not.toContain('SELECT');
+    expect(JSON.stringify(queryMarks()[0].props)).not.toContain('test_source');
+  });
+
+  it('does not mark first_query_run on submit — the contract says the query must RETURN', async () => {
+    // A query that fails on a typo, times out, or is cancelled would otherwise
+    // permanently consume the once-per-journey step 3, and step 4's
+    // ms_since_previous_step would be measured from a submit that produced
+    // nothing. The ladder's four other viewer marks are all on the success
+    // path; this one is too.
+    clearTimeToValueLedger();
+    clearEventBuffer();
+
+    render(<SQLEditor initialValue="SELECT 1" sourceName="test_source" />);
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+
+    await waitFor(() => {
+      expect(mockExecuteQuery).toHaveBeenCalled();
+    });
+
+    expect(queryMarks()).toHaveLength(0);
+  });
+
+  it('a query that errors marks nothing — the clock must not start on a failure', async () => {
+    clearTimeToValueLedger();
+    clearEventBuffer();
+
+    const props = { initialValue: 'SELEKT 1', sourceName: 'test_source' };
+    const { rerender } = render(<SQLEditor {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+
+    await waitFor(() => {
+      expect(mockExecuteQuery).toHaveBeenCalled();
+    });
+
+    mockQueryJobState.error = 'syntax error at or near "SELEKT"';
+    rerender(<SQLEditor {...props} />);
+
+    expect(queryMarks()).toHaveLength(0);
+  });
+
+  it('a result the user did not ask for here marks nothing', async () => {
+    // The editor is shared (the Workspace model-edit form mounts it too); the
+    // mark belongs to a query THIS editor sent.
+    clearTimeToValueLedger();
+    clearEventBuffer();
+
+    const props = { initialValue: 'SELECT 1', sourceName: 'test_source' };
+    const { rerender } = render(<SQLEditor {...props} />);
+
+    mockQueryJobState.result = { columns: ['a'], rows: [[1]] };
+    rerender(<SQLEditor {...props} />);
+
+    expect(queryMarks()).toHaveLength(0);
   });
 
   it('shows Cancel button when query is running', () => {

--- a/viewer/src/components/onboarding/OnboardingFlow.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.jsx
@@ -9,6 +9,7 @@ import Data from './screens/Data';
 import Cloud from './screens/Cloud';
 import Handoff from './screens/Handoff';
 import { fireEvent } from './telemetry';
+import { markTimeToValueStep, TTV_STEPS } from './timeToValue';
 import { readOnboardingState, writeOnboardingState } from './onboardingState';
 import SourceEditForm from '../views/common/SourceEditForm';
 import useStore from '../../stores/store';
@@ -199,6 +200,14 @@ export default function OnboardingFlow() {
   const handleConnected = useCallback(
     sourceType => {
       fire('onboarding_data_connect_succeeded', { source_type: sourceType });
+      // Step 2 of the time-to-value ladder. Deliberately a separate mark from
+      // the onboarding-specific event above: `source_connected` also fires for
+      // a source created outside this flow (sourceStore.saveSource), and the
+      // ladder has to measure the journey whichever door the user came in.
+      markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED, {
+        source_type: sourceType,
+        via: 'onboarding',
+      });
       setShowSourceModal(false);
       setOutcome(o => ({ ...o, path: 'data', sourceConnected: true }));
       const cloudIdx = steps.findIndex(s => s.kind === 'cloud');

--- a/viewer/src/components/onboarding/OnboardingFlow.test.jsx
+++ b/viewer/src/components/onboarding/OnboardingFlow.test.jsx
@@ -10,6 +10,7 @@ import {
   writeOnboardingState,
 } from './onboardingState';
 import { clearEventBuffer, getEventBuffer } from './telemetry';
+import { clearTimeToValueLedger } from './timeToValue';
 
 jest.mock('../../stores/store');
 jest.mock('../views/common/SourceEditForm', () => ({ onSave }) => (
@@ -147,6 +148,33 @@ describe('OnboardingFlow', () => {
     expect(await screen.findByTestId('onb-step-cloud')).toBeInTheDocument();
     const events = getEventBuffer().map(e => e.event);
     expect(events).toContain('onboarding_data_connect_succeeded');
+  });
+
+  // Guided First Run W1: connecting a source is step 2 of the time-to-value
+  // ladder. It is a mark of its own rather than a rename of the onboarding
+  // event above, because `source_connected` also has to fire for a source
+  // created outside this flow — the ladder measures the journey whichever
+  // door the user came in.
+  test('connect-data path marks the time-to-value source_connected step', async () => {
+    clearTimeToValueLedger();
+    renderFlow();
+    fireEvent.click(screen.getByTestId('onb-welcome-continue'));
+    fireEvent.click(screen.getByTestId('onb-role-analytics_engineer'));
+    fireEvent.click(screen.getByTestId('onb-role-continue'));
+    for (let i = 0; i < 7; i++) {
+      fireEvent.click(screen.getByTestId('onb-concept-continue'));
+    }
+    fireEvent.click(screen.getByTestId('onb-data-connect'));
+    fireEvent.click(screen.getByText('mock-connect'));
+    expect(await screen.findByTestId('onb-step-cloud')).toBeInTheDocument();
+
+    const marks = getEventBuffer().filter(e => e.event === 'source_connected');
+    expect(marks).toHaveLength(1);
+    expect(marks[0].props.step_index).toBe(2);
+    expect(marks[0].props.source_type).toBe('postgres');
+    expect(marks[0].props.via).toBe('onboarding');
+    // Type, never the name the user typed.
+    expect(JSON.stringify(marks[0].props)).not.toContain('demo');
   });
 
   test('cloud "maybe later" advances to handoff', () => {

--- a/viewer/src/components/onboarding/firstDashboardRendered.js
+++ b/viewer/src/components/onboarding/firstDashboardRendered.js
@@ -1,0 +1,92 @@
+/* The terminal mark of the time-to-value ladder (Guided First Run W1, step 6).
+ *
+ * Lives here rather than in one view because there are TWO surfaces on which a
+ * user's first dashboard actually renders, and the ladder has to end on
+ * whichever they reach first:
+ *
+ *   /project/:dashboardName          → components/project/Project.jsx (View mode)
+ *   /workspace/dashboard/:name       → views/project/canvas/ProjectCanvas.jsx
+ *
+ * The workspace canvas is not an editor mock-up — it wraps the same render-only
+ * <Dashboard>, so a user watching their first chart paint there has reached
+ * value. It is also where onboarding's DATA path lands: `completeAndNavigate`
+ * sends a user who connected their own source to `/workspace/…`, i.e. exactly
+ * the cohort the exit gate measures. Wiring the mark to View mode alone left
+ * that cohort contributing no data point at all.
+ *
+ * `from_sample` is finding TTV-5, and it is decided from the DASHBOARD, not
+ * from the onboarding branch the user took. Rendering the bundled example takes
+ * ~1s while rendering a dashboard built from the user's own data took field
+ * testers 26-108 minutes, and the gate metric is `ms_since_first_run` where
+ * `from_sample = false`. The onboarding `path` is written once at the end of the
+ * flow and never updated, so reading it is wrong in both directions: a user who
+ * SKIPPED onboarding and opened the bundled example reported `false` (a ~1s
+ * render landing in the gate metric — the very trap the property exists to
+ * close), and a user who took the sample tour and then built a real dashboard
+ * forty minutes later reported `true` and was filtered OUT of it.
+ */
+
+import { useEffect } from 'react';
+import { markTimeToValueStep, TTV_STEPS, getSampleDashboardNames } from './timeToValue';
+import { readOnboardingState } from './onboardingState';
+
+/**
+ * Count the leaf items in a dashboard config, recursing into `Item.rows`
+ * (the nested-row layout primitive). Used only to decide whether the
+ * dashboard about to render is a real one and to report `item_count` on the
+ * time-to-value terminal mark — never to read a name or any other content.
+ */
+export function countDashboardItems(dashboardConfig) {
+  const countRows = rows =>
+    (Array.isArray(rows) ? rows : []).reduce((total, row) => {
+      const items = Array.isArray(row?.items) ? row.items : [];
+      return (
+        total +
+        items.reduce((rowTotal, item) => {
+          // An item that is itself a stack of rows contributes its leaves, not
+          // itself — otherwise a row-first dashboard reports 1 for any depth.
+          if (Array.isArray(item?.rows) && item.rows.length > 0) {
+            return rowTotal + countRows(item.rows);
+          }
+          return rowTotal + 1;
+        }, 0)
+      );
+    }, 0);
+  return countRows(dashboardConfig?.rows);
+}
+
+/**
+ * Is the dashboard being rendered one of the bundled examples?
+ *
+ * The local server names them (`sample_dashboards` on the injected journey,
+ * read off visivo/templates/samples), so this is a fact about the dashboard.
+ * Only when there is no server to ask — the cloud/dist viewer — does it fall
+ * back to the onboarding path, which is the best signal available there.
+ */
+export function isSampleDashboard(dashboardName) {
+  const sampleDashboards = getSampleDashboardNames();
+  if (sampleDashboards) return sampleDashboards.includes(dashboardName);
+  return (readOnboardingState() || {}).path === 'sample';
+}
+
+/**
+ * Mark step 6 when a named dashboard with at least one item mounts.
+ *
+ * Gated on the item count so an empty shell doesn't stop the clock early.
+ * `markTimeToValueStep` is idempotent per journey, so whichever surface the
+ * user reaches first wins and the other is a no-op.
+ *
+ * @param {string} dashboardName
+ * @param {object} dashboardConfig
+ */
+export function useFirstDashboardRenderedMark(dashboardName, dashboardConfig) {
+  useEffect(() => {
+    if (!dashboardName || !dashboardConfig) return;
+    const itemCount = countDashboardItems(dashboardConfig);
+    if (itemCount === 0) return;
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: itemCount,
+      from_sample: isSampleDashboard(dashboardName),
+    });
+  }, [dashboardName, dashboardConfig]);
+}

--- a/viewer/src/components/onboarding/posthogClient.js
+++ b/viewer/src/components/onboarding/posthogClient.js
@@ -43,7 +43,7 @@ let initStarted = false;
  * window.__VISIVO_TELEMETRY_DISABLED === true. Absent/undefined => enabled, so
  * cloud and local-not-opted-out both send; only an explicit `true` (injected by
  * `visivo serve` when the CLI telemetry opt-out is active) disables it. */
-function isTelemetryDisabled() {
+export function isTelemetryDisabled() {
   return typeof window !== 'undefined' && window.__VISIVO_TELEMETRY_DISABLED === true;
 }
 

--- a/viewer/src/components/onboarding/timeToValue.js
+++ b/viewer/src/components/onboarding/timeToValue.js
@@ -1,0 +1,236 @@
+/* Time-to-value step marks (Guided First Run W1).
+ *
+ * The 2.1 exit gate is "8 of 8 new users build a dashboard in under 20 minutes
+ * with zero hand-written YAML". Nothing in the product could measure that.
+ * This module emits the viewer's half of the one canonical ladder that can:
+ *
+ *   1. first_run_launched       — CLI (visivo/telemetry/first_run.py)
+ *   2. source_connected         — here
+ *   3. first_query_run          — here
+ *   4. first_model_created      — here
+ *   5. first_insight_created    — here
+ *   6. first_dashboard_rendered — here (terminal — the metric's end)
+ *
+ * The contract — required properties, the FROZEN step_index, and the
+ * `from_sample` filter the gate metric must be read with — is specified in
+ * specs/marketing-relaunch/event-taxonomy.md §4, which is the source of record.
+ *
+ * Three things this module exists to guarantee:
+ *
+ *   ONCE PER JOURNEY, NOT ONCE PER SESSION. The journey spans reloads, tabs and
+ *   a CLI process; a mark that re-fired on reload would inflate the funnel and
+ *   destroy the median. Emitted marks are persisted in localStorage under
+ *   `visivo.ttv.v1`, seeded from the steps the CLI already marked.
+ *
+ *   ONE JOURNEY IDENTITY. `window.__VISIVO_FIRST_RUN` (injected by the local
+ *   Flask server, see server/views/data_views.py) carries the journey_id,
+ *   its start, the anonymous machine_id, and the CLI-side marks. Carrying the
+ *   machine_id is what lets these join to `new_installation` / `cli_command`,
+ *   which ship under it as their distinct_id.
+ *
+ *   THE OPT-OUT, WITHOUT A SECOND IMPLEMENTATION. When telemetry is disabled
+ *   the server injects `__VISIVO_TELEMETRY_DISABLED` and NO journey at all, so
+ *   there is nothing to mark. We also check the flag directly and return before
+ *   touching the event buffer, localStorage, or PostHog — a disabled run emits
+ *   nothing and leaves nothing behind.
+ *
+ * PRIVACY: counts and booleans only. No source / model / insight / dashboard /
+ * column / file / project name and no path ever enters a payload here.
+ * `journey_id` and `machine_id` are random UUIDs identifying a first run, not a
+ * person. Callers pass metadata, never user-authored strings.
+ */
+
+import { fireEvent } from './telemetry';
+import { isTelemetryDisabled } from './posthogClient';
+
+const LEDGER_KEY = 'visivo.ttv.v1';
+
+/* FROZEN step identities. Assigned once, never reassigned — a step added later
+ * (W3's `table_profiled` / `scaffold_shown` / `scaffold_applied`) takes the
+ * NEXT UNUSED integer even though it falls mid-journey chronologically,
+ * because renumbering silently redefines every historical funnel. Funnels
+ * order by timestamp; step_index is identity, not sort order. Mirrors
+ * STEP_INDEXES in visivo/telemetry/first_run.py. */
+export const TTV_STEP_INDEXES = Object.freeze({
+  first_run_launched: 1,
+  source_connected: 2,
+  first_query_run: 3,
+  first_model_created: 4,
+  first_insight_created: 5,
+  first_dashboard_rendered: 6,
+});
+
+/* The steps this module owns. `first_run_launched` is the CLI's. */
+export const TTV_STEPS = Object.freeze({
+  SOURCE_CONNECTED: 'source_connected',
+  FIRST_QUERY_RUN: 'first_query_run',
+  FIRST_MODEL_CREATED: 'first_model_created',
+  FIRST_INSIGHT_CREATED: 'first_insight_created',
+  FIRST_DASHBOARD_RENDERED: 'first_dashboard_rendered',
+});
+
+function injectedJourney() {
+  if (typeof window === 'undefined') return null;
+  const injected = window.__VISIVO_FIRST_RUN;
+  if (!injected || typeof injected !== 'object') return null;
+  if (typeof injected.journey_id !== 'string' || !injected.journey_id) return null;
+  return injected;
+}
+
+function readLedger() {
+  try {
+    const raw = window.localStorage.getItem(LEDGER_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (typeof parsed.journey_id !== 'string' || !parsed.journey_id) return null;
+    if (!parsed.steps || typeof parsed.steps !== 'object') parsed.steps = {};
+    return parsed;
+  } catch {
+    // Unreadable / quota / disabled storage: treat as no journey recorded yet.
+    // Losing idempotence is better than throwing into a store action.
+    return null;
+  }
+}
+
+function writeLedger(ledger) {
+  try {
+    window.localStorage.setItem(LEDGER_KEY, JSON.stringify(ledger));
+  } catch {
+    /* storage unavailable — the mark still fires, it just isn't deduped */
+  }
+}
+
+function newJourneyId() {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through to the Math.random id below */
+  }
+  // Not cryptographically strong, and it does not need to be: this is a
+  // throwaway grouping key for one first run, never an identifier of a person.
+  return `ttv-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/* Resolve the journey this page belongs to, creating a viewer-local one when
+ * the CLI did not supply one (the cloud/dist viewer has no Flask server, so
+ * there is no injection there — but its first run is just as worth measuring).
+ * A viewer-local journey has a null machine_id; there is no CLI to join to.
+ *
+ * When the injected journey_id differs from the stored one the ledger is
+ * replaced rather than merged: that is a genuinely new first run (the user
+ * cleared ~/.visivo, or this browser profile is looking at a different
+ * machine's server) and merging would silently suppress its marks. */
+function resolveJourney() {
+  const injected = injectedJourney();
+  const stored = readLedger();
+
+  if (injected) {
+    if (stored && stored.journey_id === injected.journey_id) {
+      return {
+        ...stored,
+        // Refresh the CLI-side facts from the page — the server is authoritative
+        // for them and may have marked a step since this ledger was written.
+        started_at_ms: injected.started_at_ms ?? stored.started_at_ms ?? null,
+        machine_id: injected.machine_id ?? stored.machine_id ?? null,
+        steps: { ...(injected.steps || {}), ...stored.steps },
+      };
+    }
+    return {
+      journey_id: injected.journey_id,
+      started_at_ms: injected.started_at_ms ?? null,
+      machine_id: injected.machine_id ?? null,
+      steps: { ...(injected.steps || {}) },
+    };
+  }
+
+  if (stored) return stored;
+
+  const created = {
+    journey_id: newJourneyId(),
+    started_at_ms: Date.now(),
+    machine_id: null,
+    steps: {},
+  };
+  writeLedger(created);
+  return created;
+}
+
+/* Largest timestamp among the marks already recorded for this journey — the
+ * "previous step" `ms_since_previous_step` is measured from. Uses max rather
+ * than the highest step_index so a clock that jumps cannot produce a negative
+ * gap; a genuinely out-of-order mark is reported via `out_of_order` instead. */
+function previousStepMs(steps) {
+  const values = Object.values(steps || {}).filter(v => typeof v === 'number' && isFinite(v));
+  if (values.length === 0) return null;
+  return Math.max(...values);
+}
+
+/**
+ * Mark one step of the time-to-value journey. At most once per journey.
+ *
+ * @param {string} stepId  — a key of TTV_STEP_INDEXES.
+ * @param {object} [props] — extra event properties. Metadata only: counts and
+ *                           booleans, NEVER a user-authored string or path.
+ * @returns {boolean} true only when a mark was actually emitted, so callers
+ *                    and tests can tell "fired" from "already fired" and from
+ *                    "telemetry off".
+ */
+export function markTimeToValueStep(stepId, props = {}) {
+  if (typeof window === 'undefined') return false;
+  // Opt-out first: before the event buffer, before localStorage, before
+  // PostHog. A disabled run emits nothing and writes nothing.
+  if (isTelemetryDisabled()) return false;
+  const stepIndex = TTV_STEP_INDEXES[stepId];
+  if (!stepIndex) return false;
+
+  const journey = resolveJourney();
+  if (journey.steps && journey.steps[stepId] != null) return false;
+
+  const now = Date.now();
+  const previousMs = previousStepMs(journey.steps);
+  const startedAtMs = typeof journey.started_at_ms === 'number' ? journey.started_at_ms : null;
+
+  // Claim the step before firing, so a throwing sink cannot turn into a mark
+  // that re-fires on every subsequent call.
+  const nextLedger = {
+    journey_id: journey.journey_id,
+    started_at_ms: startedAtMs,
+    machine_id: journey.machine_id ?? null,
+    steps: { ...journey.steps, [stepId]: now },
+  };
+  writeLedger(nextLedger);
+
+  fireEvent(stepId, {
+    journey_id: journey.journey_id,
+    step_id: stepId,
+    step_index: stepIndex,
+    ms_since_first_run: startedAtMs === null ? null : Math.max(0, now - startedAtMs),
+    ms_since_previous_step: previousMs === null ? null : Math.max(0, now - previousMs),
+    machine_id: journey.machine_id ?? null,
+    out_of_order: previousMs !== null && now < previousMs,
+    ...props,
+  });
+  return true;
+}
+
+/**
+ * Read-only view of the journey, for tests and for surfaces that want to show
+ * elapsed time. Returns null when telemetry is disabled.
+ */
+export function getTimeToValueJourney() {
+  if (typeof window === 'undefined') return null;
+  if (isTelemetryDisabled()) return null;
+  return resolveJourney();
+}
+
+/** Drop the persisted ledger. Test helper; not called by product code. */
+export function clearTimeToValueLedger() {
+  try {
+    window.localStorage.removeItem(LEDGER_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/viewer/src/components/onboarding/timeToValue.js
+++ b/viewer/src/components/onboarding/timeToValue.js
@@ -20,7 +20,12 @@
  *   ONCE PER JOURNEY, NOT ONCE PER SESSION. The journey spans reloads, tabs and
  *   a CLI process; a mark that re-fired on reload would inflate the funnel and
  *   destroy the median. Emitted marks are persisted in localStorage under
- *   `visivo.ttv.v1`, seeded from the steps the CLI already marked.
+ *   `visivo.ttv.v1`, seeded from the steps the CLI already marked — AND written
+ *   back to the server's ledger, because `localStorage` is scoped to one origin
+ *   (`http://localhost:8000` and `:8001` are different origins) while the
+ *   journey is not. Without the write-back a second browser, an incognito
+ *   window, a cleared site-data, or `visivo serve -p 8001` re-fires every mark
+ *   under the same journey_id — exactly the inflation this is meant to prevent.
  *
  *   ONE JOURNEY IDENTITY. `window.__VISIVO_FIRST_RUN` (injected by the local
  *   Flask server, see server/views/data_views.py) carries the journey_id,
@@ -42,6 +47,7 @@
 
 import { fireEvent } from './telemetry';
 import { isTelemetryDisabled } from './posthogClient';
+import { postFirstRunStep } from '../../api/firstRunSteps';
 
 const LEDGER_KEY = 'visivo.ttv.v1';
 
@@ -119,6 +125,14 @@ function newJourneyId() {
  * there is no injection there — but its first run is just as worth measuring).
  * A viewer-local journey has a null machine_id; there is no CLI to join to.
  *
+ * It also has a NULL `started_at_ms`, and that is load-bearing. There is no
+ * first run to measure from here, so the taxonomy specifies
+ * `ms_since_first_run: null` — "the journey start is unknown (cloud viewer, or
+ * a machine whose ledger predates this contract)". Minting `Date.now()` instead
+ * would report a ~0ms time-to-value for every cloud dashboard view, straight
+ * into the single number the 2.1 exit gate is read off, and the cloud
+ * population is far larger than the CLI one.
+ *
  * When the injected journey_id differs from the stored one the ledger is
  * replaced rather than merged: that is a genuinely new first run (the user
  * cleared ~/.visivo, or this browser profile is looking at a different
@@ -134,6 +148,7 @@ function resolveJourney() {
         // Refresh the CLI-side facts from the page — the server is authoritative
         // for them and may have marked a step since this ledger was written.
         started_at_ms: injected.started_at_ms ?? stored.started_at_ms ?? null,
+        install_age_ms: injected.install_age_ms ?? stored.install_age_ms ?? null,
         machine_id: injected.machine_id ?? stored.machine_id ?? null,
         steps: { ...(injected.steps || {}), ...stored.steps },
       };
@@ -141,6 +156,7 @@ function resolveJourney() {
     return {
       journey_id: injected.journey_id,
       started_at_ms: injected.started_at_ms ?? null,
+      install_age_ms: injected.install_age_ms ?? null,
       machine_id: injected.machine_id ?? null,
       steps: { ...(injected.steps || {}) },
     };
@@ -150,12 +166,22 @@ function resolveJourney() {
 
   const created = {
     journey_id: newJourneyId(),
-    started_at_ms: Date.now(),
+    started_at_ms: null,
+    install_age_ms: null,
     machine_id: null,
     steps: {},
   };
   writeLedger(created);
   return created;
+}
+
+/** The bundled sample dashboards the server named, or null when it named none
+ *  (the cloud/dist viewer, which has no Flask server to ask). Lets the terminal
+ *  mark decide `from_sample` from the dashboard being rendered. */
+export function getSampleDashboardNames() {
+  const injected = injectedJourney();
+  const names = injected && injected.sample_dashboards;
+  return Array.isArray(names) ? names : null;
 }
 
 /* Largest timestamp among the marks already recorded for this journey — the
@@ -198,6 +224,7 @@ export function markTimeToValueStep(stepId, props = {}) {
   const nextLedger = {
     journey_id: journey.journey_id,
     started_at_ms: startedAtMs,
+    install_age_ms: typeof journey.install_age_ms === 'number' ? journey.install_age_ms : null,
     machine_id: journey.machine_id ?? null,
     steps: { ...journey.steps, [stepId]: now },
   };
@@ -209,10 +236,18 @@ export function markTimeToValueStep(stepId, props = {}) {
     step_index: stepIndex,
     ms_since_first_run: startedAtMs === null ? null : Math.max(0, now - startedAtMs),
     ms_since_previous_step: previousMs === null ? null : Math.max(0, now - previousMs),
+    install_age_ms: nextLedger.install_age_ms,
     machine_id: journey.machine_id ?? null,
     out_of_order: previousMs !== null && now < previousMs,
     ...props,
   });
+
+  // Tell the server the mark fired, so "once per journey" survives this origin.
+  // Only when the CLI handed us the journey: there is nowhere to write back to
+  // in the cloud/dist viewer, and a POST there would 404 on every mark.
+  if (injectedJourney()) {
+    postFirstRunStep({ journeyId: journey.journey_id, stepId, atMs: now });
+  }
   return true;
 }
 

--- a/viewer/src/components/onboarding/timeToValue.test.js
+++ b/viewer/src/components/onboarding/timeToValue.test.js
@@ -20,6 +20,9 @@ import {
   TTV_STEP_INDEXES,
 } from './timeToValue';
 import { getEventBuffer, clearEventBuffer } from './telemetry';
+import { postFirstRunStep } from '../../api/firstRunSteps';
+
+jest.mock('../../api/firstRunSteps', () => ({ postFirstRunStep: jest.fn() }));
 
 const LEDGER_KEY = 'visivo.ttv.v1';
 
@@ -45,6 +48,7 @@ function marks() {
 beforeEach(() => {
   clearEventBuffer();
   clearTimeToValueLedger();
+  postFirstRunStep.mockClear();
   delete window.__VISIVO_FIRST_RUN;
   delete window.__VISIVO_TELEMETRY_DISABLED;
 });
@@ -213,7 +217,33 @@ describe('journey identity', () => {
     expect(typeof props.journey_id).toBe('string');
     expect(props.journey_id.length).toBeGreaterThan(0);
     expect(props.machine_id).toBeNull();
-    expect(props.ms_since_first_run).toBeGreaterThanOrEqual(0);
+  });
+
+  test('a viewer-minted journey reports ms_since_first_run as null, not zero', () => {
+    // The contract (taxonomy §4) says `null` "when the journey start is
+    // unknown (cloud viewer, or a machine whose ledger predates this
+    // contract)". Minting Date.now() as the start instead reports a ~0ms
+    // time-to-value into the exact number the 2.1 exit gate is read off —
+    // and the cloud population is far larger than the CLI one.
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: 1,
+      from_sample: false,
+    });
+
+    const props = marks()[0].props;
+    expect(props.ms_since_first_run).toBeNull();
+    expect(props.install_age_ms).toBeNull();
+  });
+
+  test('a later mark in a viewer-minted journey still measures the gap it does know', () => {
+    // ms_since_first_run stays null, but ms_since_previous_step is real: the
+    // journey start is unknown, the gap between two marks is not.
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+
+    const second = marks()[1].props;
+    expect(second.ms_since_first_run).toBeNull();
+    expect(second.ms_since_previous_step).toBeGreaterThanOrEqual(0);
   });
 
   test('a locally-minted journey persists across marks', () => {
@@ -295,12 +325,19 @@ describe('privacy', () => {
 
     const ledger = JSON.parse(window.localStorage.getItem(LEDGER_KEY));
     expect(Object.keys(ledger).sort()).toEqual([
+      'install_age_ms',
       'journey_id',
       'machine_id',
       'started_at_ms',
       'steps',
     ]);
     expect(Object.values(ledger.steps).every(v => typeof v === 'number')).toBe(true);
+    // journey_id and machine_id are the only strings — nothing else may become
+    // somewhere a name or a path can hide.
+    expect(Object.entries(ledger)
+      .filter(([, value]) => typeof value === 'string')
+      .map(([key]) => key)
+      .sort()).toEqual(['journey_id', 'machine_id']);
   });
 });
 
@@ -321,5 +358,111 @@ describe('robustness', () => {
     // with no id.
     expect(marks()[0].props.machine_id).toBeNull();
     expect(marks()[0].props.journey_id).toBeTruthy();
+  });
+});
+
+describe('idempotence off this browser origin', () => {
+  /* `localStorage` is scoped to `http://localhost:<port>`. The journey is not:
+   * it lives in ~/.visivo/first_run.json and survives a port change, a second
+   * browser, an incognito window, and a site-data clear. Without the write-back
+   * every viewer mark re-fires under the SAME journey_id — precisely the funnel
+   * inflation the persisted ledger is supposed to prevent. */
+
+  test('a mark is written back to the server so the next origin can dedupe it', () => {
+    injectCliJourney({ journeyId: 'J-1' });
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(postFirstRunStep).toHaveBeenCalledTimes(1);
+    const call = postFirstRunStep.mock.calls[0][0];
+    expect(call.journeyId).toBe('J-1');
+    expect(call.stepId).toBe('source_connected');
+    expect(typeof call.atMs).toBe('number');
+  });
+
+  test('a step the server already knows about is NOT re-fired on a fresh origin', () => {
+    // The exact scenario: `visivo serve -p 8001` (a new localStorage origin),
+    // or a second browser. The viewer ledger is empty; the injected journey
+    // carries the mark because the server recorded it.
+    injectCliJourney({
+      journeyId: 'J-1',
+      steps: { first_run_launched: 1000, source_connected: 2000 },
+    });
+    expect(window.localStorage.getItem(LEDGER_KEY)).toBeNull();
+
+    expect(markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED)).toBe(false);
+    expect(marks()).toHaveLength(0);
+  });
+
+  test('a cleared site-data mid-journey does not re-fire what already fired', () => {
+    injectCliJourney({ journeyId: 'J-1', steps: { first_run_launched: 1000 } });
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+    const writtenBack = postFirstRunStep.mock.calls[0][0];
+
+    // The user clears site data. The server, which was told, hands the same
+    // journey back with the mark on it.
+    clearTimeToValueLedger();
+    injectCliJourney({
+      journeyId: 'J-1',
+      steps: { first_run_launched: 1000, [writtenBack.stepId]: writtenBack.atMs },
+    });
+
+    expect(markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED)).toBe(false);
+    expect(marks().filter(m => m.event === 'source_connected')).toHaveLength(1);
+  });
+
+  test('the cloud viewer writes nothing back — there is no server to write to', () => {
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(postFirstRunStep).not.toHaveBeenCalled();
+  });
+
+  test('an opted-out run writes nothing back either', () => {
+    window.__VISIVO_TELEMETRY_DISABLED = true;
+    injectCliJourney();
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(postFirstRunStep).not.toHaveBeenCalled();
+  });
+});
+
+describe('install age', () => {
+  /* The ledger's absence cannot mean "this is a first run" — no install has one
+   * until this ships, so on rollout day every established machine mints a
+   * journey and reaches first_dashboard_rendered seconds later. install_age_ms
+   * is how the gate metric tells that apart from a 2-second time-to-value. */
+
+  test('the CLI-reported install age rides on every viewer mark', () => {
+    window.__VISIVO_FIRST_RUN = {
+      journey_id: 'J-1',
+      started_at_ms: Date.now() - 1000,
+      install_age_ms: 400 * 86400 * 1000,
+      machine_id: 'machine-abc',
+      steps: {},
+    };
+
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: 1,
+      from_sample: false,
+    });
+
+    expect(marks()[0].props.install_age_ms).toBe(400 * 86400 * 1000);
+  });
+
+  test('it survives a reload, because the terminal mark is what needs it', () => {
+    window.__VISIVO_FIRST_RUN = {
+      journey_id: 'J-1',
+      started_at_ms: Date.now() - 1000,
+      install_age_ms: 12345,
+      machine_id: 'machine-abc',
+      steps: {},
+    };
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    // A reload: the ledger is read back from localStorage, journey unchanged.
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+
+    expect(marks()[1].props.install_age_ms).toBe(12345);
   });
 });

--- a/viewer/src/components/onboarding/timeToValue.test.js
+++ b/viewer/src/components/onboarding/timeToValue.test.js
@@ -1,0 +1,325 @@
+/* Tests for the time-to-value step marks (Guided First Run W1).
+ *
+ * The 2.1 exit gate ("8 of 8 new users build a dashboard in under 20 minutes")
+ * is read off this ladder, so these are tests of the metric, not of a shim:
+ *
+ *   - a mark fires EXACTLY ONCE per journey, including across a reload — a
+ *     mark that re-fired would inflate the funnel and destroy the median;
+ *   - marks come out in ladder order with monotonic timestamps;
+ *   - every mark carries the required properties from
+ *     specs/marketing-relaunch/event-taxonomy.md §4;
+ *   - the opt-out suppresses all of them and writes nothing;
+ *   - no payload contains a user-authored string.
+ */
+
+import {
+  markTimeToValueStep,
+  getTimeToValueJourney,
+  clearTimeToValueLedger,
+  TTV_STEPS,
+  TTV_STEP_INDEXES,
+} from './timeToValue';
+import { getEventBuffer, clearEventBuffer } from './telemetry';
+
+const LEDGER_KEY = 'visivo.ttv.v1';
+
+/* A journey as the local Flask server injects it (data_views.py). */
+function injectCliJourney({
+  journeyId = 'journey-from-the-cli',
+  startedAtMs = Date.now() - 60_000,
+  machineId = 'machine-abc',
+  steps = { first_run_launched: Date.now() - 60_000 },
+} = {}) {
+  window.__VISIVO_FIRST_RUN = {
+    journey_id: journeyId,
+    started_at_ms: startedAtMs,
+    machine_id: machineId,
+    steps,
+  };
+}
+
+function marks() {
+  return getEventBuffer();
+}
+
+beforeEach(() => {
+  clearEventBuffer();
+  clearTimeToValueLedger();
+  delete window.__VISIVO_FIRST_RUN;
+  delete window.__VISIVO_TELEMETRY_DISABLED;
+});
+
+describe('the ladder', () => {
+  test('step indexes are the frozen contract, matching first_run.py', () => {
+    expect(TTV_STEP_INDEXES).toEqual({
+      first_run_launched: 1,
+      source_connected: 2,
+      first_query_run: 3,
+      first_model_created: 4,
+      first_insight_created: 5,
+      first_dashboard_rendered: 6,
+    });
+  });
+
+  test('step indexes cannot be mutated into a different ladder', () => {
+    expect(Object.isFrozen(TTV_STEP_INDEXES)).toBe(true);
+  });
+
+  test('a full first run emits every step once, in order, with rising timestamps', () => {
+    injectCliJourney();
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED, { source_type: 'duckdb' });
+    markTimeToValueStep(TTV_STEPS.FIRST_QUERY_RUN);
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+    markTimeToValueStep(TTV_STEPS.FIRST_INSIGHT_CREATED);
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: 2,
+      from_sample: false,
+    });
+
+    expect(marks().map(m => m.event)).toEqual([
+      'source_connected',
+      'first_query_run',
+      'first_model_created',
+      'first_insight_created',
+      'first_dashboard_rendered',
+    ]);
+    expect(marks().map(m => m.props.step_index)).toEqual([2, 3, 4, 5, 6]);
+    const timestamps = marks().map(m => m.ts);
+    expect([...timestamps].sort((a, b) => a - b)).toEqual(timestamps);
+    expect(marks().every(m => m.props.out_of_order === false)).toBe(true);
+  });
+
+  test('an unknown step is refused and emits nothing', () => {
+    injectCliJourney();
+    expect(markTimeToValueStep('scaffold_shown')).toBe(false);
+    expect(marks()).toHaveLength(0);
+  });
+});
+
+describe('required properties', () => {
+  test('every mark carries the taxonomy §4 property set', () => {
+    const startedAtMs = Date.now() - 120_000;
+    injectCliJourney({ startedAtMs, steps: { first_run_launched: startedAtMs } });
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED, { source_type: 'postgresql' });
+
+    const props = marks()[0].props;
+    expect(props.journey_id).toBe('journey-from-the-cli');
+    expect(props.step_id).toBe('source_connected');
+    expect(props.step_index).toBe(2);
+    expect(props.machine_id).toBe('machine-abc');
+    expect(props.out_of_order).toBe(false);
+    expect(props.ms_since_first_run).toBeGreaterThanOrEqual(120_000);
+    // Measured against the CLI's real mark, not guessed.
+    expect(props.ms_since_previous_step).toBeGreaterThanOrEqual(120_000);
+    expect(props.source_type).toBe('postgresql');
+  });
+
+  test('ms_since_previous_step is null for the first mark of a journey', () => {
+    // No CLI step yet — e.g. the cloud viewer, which has no server to mark one.
+    injectCliJourney({ steps: {} });
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(marks()[0].props.ms_since_previous_step).toBeNull();
+  });
+
+  test('a mark timestamped before the previous one is flagged out_of_order', () => {
+    // A clock jump must show up as data, not as a silently wrong median.
+    injectCliJourney({ steps: { first_run_launched: Date.now() + 10_000_000 } });
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(marks()[0].props.out_of_order).toBe(true);
+  });
+
+  test('the terminal mark carries from_sample so the TTV-5 trap is filterable', () => {
+    injectCliJourney();
+
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: 3,
+      from_sample: true,
+    });
+
+    expect(marks()[0].props).toMatchObject({
+      step_id: 'first_dashboard_rendered',
+      step_index: 6,
+      item_count: 3,
+      from_sample: true,
+    });
+  });
+});
+
+describe('exactly once per journey', () => {
+  test('a repeated mark is a no-op', () => {
+    injectCliJourney();
+
+    expect(markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED)).toBe(true);
+    expect(markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED)).toBe(false);
+    expect(markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED)).toBe(false);
+
+    expect(marks()).toHaveLength(1);
+  });
+
+  test('a reload does not re-fire an already-marked step', () => {
+    injectCliJourney();
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+
+    // Reload: the buffer is a window-scoped array and does not survive; the
+    // localStorage ledger is what has to.
+    clearEventBuffer();
+    injectCliJourney();
+
+    expect(markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED)).toBe(false);
+    expect(marks()).toHaveLength(0);
+  });
+
+  test('a step the CLI already marked is never re-fired by the viewer', () => {
+    injectCliJourney({ steps: { first_run_launched: Date.now() - 1000 } });
+
+    expect(markTimeToValueStep('first_run_launched')).toBe(false);
+    expect(marks()).toHaveLength(0);
+  });
+
+  test('a genuinely new CLI journey replaces the stored one and marks again', () => {
+    injectCliJourney({ journeyId: 'journey-one' });
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+    clearEventBuffer();
+
+    injectCliJourney({ journeyId: 'journey-two', steps: {} });
+
+    expect(markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED)).toBe(true);
+    expect(marks()[0].props.journey_id).toBe('journey-two');
+  });
+});
+
+describe('journey identity', () => {
+  test('the CLI journey is adopted verbatim so both halves join on it', () => {
+    injectCliJourney({ journeyId: 'j-1', machineId: 'm-1' });
+
+    const journey = getTimeToValueJourney();
+
+    expect(journey.journey_id).toBe('j-1');
+    expect(journey.machine_id).toBe('m-1');
+  });
+
+  test('with no server-injected journey the viewer mints its own', () => {
+    // The cloud/dist viewer has no Flask server, so nothing is injected — its
+    // first run is still worth measuring, just with no CLI to join to.
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    const props = marks()[0].props;
+    expect(typeof props.journey_id).toBe('string');
+    expect(props.journey_id.length).toBeGreaterThan(0);
+    expect(props.machine_id).toBeNull();
+    expect(props.ms_since_first_run).toBeGreaterThanOrEqual(0);
+  });
+
+  test('a locally-minted journey persists across marks', () => {
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+
+    const [first, second] = marks();
+    expect(second.props.journey_id).toBe(first.props.journey_id);
+  });
+});
+
+describe('the opt-out', () => {
+  beforeEach(() => {
+    window.__VISIVO_TELEMETRY_DISABLED = true;
+  });
+
+  test('no step mark is emitted', () => {
+    injectCliJourney();
+
+    Object.values(TTV_STEPS).forEach(step => {
+      expect(markTimeToValueStep(step)).toBe(false);
+    });
+
+    expect(marks()).toHaveLength(0);
+  });
+
+  test('nothing is written to storage either', () => {
+    injectCliJourney();
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    expect(window.localStorage.getItem(LEDGER_KEY)).toBeNull();
+  });
+
+  test('no journey is even resolvable', () => {
+    injectCliJourney();
+    expect(getTimeToValueJourney()).toBeNull();
+  });
+
+  test('a non-boolean flag does not count as opting out', () => {
+    // Matches posthogClient's gate exactly: only an explicit `true` disables.
+    window.__VISIVO_TELEMETRY_DISABLED = 'true';
+    injectCliJourney();
+
+    expect(markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED)).toBe(true);
+  });
+});
+
+describe('privacy', () => {
+  test('no payload carries a user-authored string', () => {
+    injectCliJourney();
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED, { source_type: 'duckdb', via: 'onboarding' });
+    markTimeToValueStep(TTV_STEPS.FIRST_QUERY_RUN);
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+    markTimeToValueStep(TTV_STEPS.FIRST_INSIGHT_CREATED);
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, { item_count: 1, from_sample: false });
+
+    const stringEntries = marks().flatMap(mark =>
+      Object.entries(mark.props).filter(([, value]) => typeof value === 'string')
+    );
+
+    // Only the fixed vocabulary below may appear as a string; anything else is
+    // a user-authored value that has no business in a telemetry payload.
+    expect(stringEntries.map(([key]) => key).sort()).toEqual(
+      expect.arrayContaining(['journey_id', 'machine_id', 'source_type', 'step_id', 'via'])
+    );
+    expect(
+      stringEntries.filter(
+        ([key]) => !['journey_id', 'step_id', 'machine_id', 'source_type', 'via'].includes(key)
+      )
+    ).toEqual([]);
+    // No paths, emails, or anything else with a separator in it.
+    expect(stringEntries.filter(([, value]) => /[/\\@]/.test(value))).toEqual([]);
+  });
+
+  test('the persisted ledger holds only ids and timestamps', () => {
+    injectCliJourney();
+    markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
+
+    const ledger = JSON.parse(window.localStorage.getItem(LEDGER_KEY));
+    expect(Object.keys(ledger).sort()).toEqual([
+      'journey_id',
+      'machine_id',
+      'started_at_ms',
+      'steps',
+    ]);
+    expect(Object.values(ledger.steps).every(v => typeof v === 'number')).toBe(true);
+  });
+});
+
+describe('robustness', () => {
+  test('a corrupt ledger does not throw and does not stop the mark', () => {
+    window.localStorage.setItem(LEDGER_KEY, '{not json');
+
+    expect(() => markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED)).not.toThrow();
+    expect(marks()).toHaveLength(1);
+  });
+
+  test('a malformed injected journey is ignored rather than adopted', () => {
+    window.__VISIVO_FIRST_RUN = { started_at_ms: 1, machine_id: 'm' };
+
+    markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED);
+
+    // Fell back to a locally-minted journey rather than trusting a journey
+    // with no id.
+    expect(marks()[0].props.machine_id).toBeNull();
+    expect(marks()[0].props.journey_id).toBeTruthy();
+  });
+});

--- a/viewer/src/components/project/Project.jsx
+++ b/viewer/src/components/project/Project.jsx
@@ -9,35 +9,7 @@ import { HiTemplate } from 'react-icons/hi';
 import DashboardSection from '../project/DashboardSection';
 import FilterBar from '../project/FilterBar';
 import useProjectChangeListener from '../views/workspace/useProjectChangeListener';
-import { markTimeToValueStep, TTV_STEPS } from '../onboarding/timeToValue';
-import { readOnboardingState } from '../onboarding/onboardingState';
-
-/**
- * Count the leaf items in a dashboard config, recursing into `Item.rows`
- * (the nested-row layout primitive). Used only to decide whether the
- * dashboard about to render is a real one and to report `item_count` on the
- * time-to-value terminal mark — never to read a name or any other content.
- *
- * Exported for the test that pins the terminal mark's payload.
- */
-export function countDashboardItems(dashboardConfig) {
-  const countRows = rows =>
-    (Array.isArray(rows) ? rows : []).reduce((total, row) => {
-      const items = Array.isArray(row?.items) ? row.items : [];
-      return (
-        total +
-        items.reduce((rowTotal, item) => {
-          // An item that is itself a stack of rows contributes its leaves, not
-          // itself — otherwise a row-first dashboard reports 1 for any depth.
-          if (Array.isArray(item?.rows) && item.rows.length > 0) {
-            return rowTotal + countRows(item.rows);
-          }
-          return rowTotal + 1;
-        }, 0)
-      );
-    }, 0);
-  return countRows(dashboardConfig?.rows);
-}
+import { useFirstDashboardRenderedMark } from '../onboarding/firstDashboardRendered';
 
 /**
  * Project - Container component for the new project view
@@ -113,23 +85,9 @@ function Project() {
   // Terminal mark of the time-to-value ladder (Guided First Run W1, step 6).
   // `/project/:dashboardName` is the consumer surface — a dashboard actually
   // mounting here is the end of the span the 2.1 exit gate is measured over.
-  // Gated on the dashboard having at least one item so an empty shell doesn't
-  // stop the clock early.
-  //
-  // `from_sample` is the point of finding TTV-5: rendering the bundled example
-  // takes ~1s while rendering a dashboard built from the user's own data took
-  // field testers 26-108 minutes. The gate metric is ms_since_first_run where
-  // from_sample is false; without this property the two are indistinguishable
-  // and "time to first dashboard" would report success it hasn't earned.
-  useEffect(() => {
-    if (!dashboardName || !activeDashboardConfig) return;
-    const itemCount = countDashboardItems(activeDashboardConfig);
-    if (itemCount === 0) return;
-    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
-      item_count: itemCount,
-      from_sample: (readOnboardingState() || {}).path === 'sample',
-    });
-  }, [dashboardName, activeDashboardConfig]);
+  // The Workspace canvas mounts the same mark (see firstDashboardRendered.js);
+  // whichever the user reaches first wins.
+  useFirstDashboardRenderedMark(dashboardName, activeDashboardConfig);
 
   // Both servers answer the whole-project read with the same envelope, so
   // there is one shape to read defaults out of.

--- a/viewer/src/components/project/Project.jsx
+++ b/viewer/src/components/project/Project.jsx
@@ -9,6 +9,35 @@ import { HiTemplate } from 'react-icons/hi';
 import DashboardSection from '../project/DashboardSection';
 import FilterBar from '../project/FilterBar';
 import useProjectChangeListener from '../views/workspace/useProjectChangeListener';
+import { markTimeToValueStep, TTV_STEPS } from '../onboarding/timeToValue';
+import { readOnboardingState } from '../onboarding/onboardingState';
+
+/**
+ * Count the leaf items in a dashboard config, recursing into `Item.rows`
+ * (the nested-row layout primitive). Used only to decide whether the
+ * dashboard about to render is a real one and to report `item_count` on the
+ * time-to-value terminal mark — never to read a name or any other content.
+ *
+ * Exported for the test that pins the terminal mark's payload.
+ */
+export function countDashboardItems(dashboardConfig) {
+  const countRows = rows =>
+    (Array.isArray(rows) ? rows : []).reduce((total, row) => {
+      const items = Array.isArray(row?.items) ? row.items : [];
+      return (
+        total +
+        items.reduce((rowTotal, item) => {
+          // An item that is itself a stack of rows contributes its leaves, not
+          // itself — otherwise a row-first dashboard reports 1 for any depth.
+          if (Array.isArray(item?.rows) && item.rows.length > 0) {
+            return rowTotal + countRows(item.rows);
+          }
+          return rowTotal + 1;
+        }, 0)
+      );
+    }, 0);
+  return countRows(dashboardConfig?.rows);
+}
 
 /**
  * Project - Container component for the new project view
@@ -80,6 +109,27 @@ function Project() {
     if (!entry) return null;
     return entry.config || entry;
   }, [dashboards, dashboardName]);
+
+  // Terminal mark of the time-to-value ladder (Guided First Run W1, step 6).
+  // `/project/:dashboardName` is the consumer surface — a dashboard actually
+  // mounting here is the end of the span the 2.1 exit gate is measured over.
+  // Gated on the dashboard having at least one item so an empty shell doesn't
+  // stop the clock early.
+  //
+  // `from_sample` is the point of finding TTV-5: rendering the bundled example
+  // takes ~1s while rendering a dashboard built from the user's own data took
+  // field testers 26-108 minutes. The gate metric is ms_since_first_run where
+  // from_sample is false; without this property the two are indistinguishable
+  // and "time to first dashboard" would report success it hasn't earned.
+  useEffect(() => {
+    if (!dashboardName || !activeDashboardConfig) return;
+    const itemCount = countDashboardItems(activeDashboardConfig);
+    if (itemCount === 0) return;
+    markTimeToValueStep(TTV_STEPS.FIRST_DASHBOARD_RENDERED, {
+      item_count: itemCount,
+      from_sample: (readOnboardingState() || {}).path === 'sample',
+    });
+  }, [dashboardName, activeDashboardConfig]);
 
   // Both servers answer the whole-project read with the same envelope, so
   // there is one shape to read defaults out of.

--- a/viewer/src/components/project/Project.timeToValue.test.jsx
+++ b/viewer/src/components/project/Project.timeToValue.test.jsx
@@ -12,10 +12,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { useParams } from 'react-router-dom';
-import Project, { countDashboardItems } from './Project';
+import Project from './Project';
 import useStore from '../../stores/store';
 import { clearEventBuffer, getEventBuffer } from '../onboarding/telemetry';
 import { clearTimeToValueLedger } from '../onboarding/timeToValue';
+import { countDashboardItems } from '../onboarding/firstDashboardRendered';
 import { writeOnboardingState } from '../onboarding/onboardingState';
 
 jest.mock('../../stores/store');
@@ -140,6 +141,8 @@ describe('first_dashboard_rendered', () => {
     // Rendering the sample takes ~1s; rendering a dashboard from the user's
     // own data took field testers 26-108 minutes. Without this flag the exit
     // gate would read the wrong number and report success it has not earned.
+    // With no server to ask (the cloud/dist viewer) the onboarding path is the
+    // best signal there is; the local viewer uses the list below instead.
     writeOnboardingState({ completed_at: '2026-01-01', path: 'sample' });
     mockStore(buildState());
 
@@ -163,5 +166,70 @@ describe('first_dashboard_rendered', () => {
     render(<Project />);
 
     expect(getEventBuffer()).toHaveLength(0);
+  });
+});
+
+describe('from_sample is about the dashboard, not the onboarding branch', () => {
+  /* The onboarding `path` is written once at the end of the flow and never
+   * updated, so reading it is wrong in BOTH directions. The local server names
+   * the bundled sample dashboards on the injected journey; that is a fact about
+   * what is being rendered. */
+
+  const injectServerJourney = (sampleDashboards = ['College Football', 'EV Sales']) => {
+    window.__VISIVO_FIRST_RUN = {
+      journey_id: 'J-1',
+      started_at_ms: Date.now() - 60_000,
+      install_age_ms: 1000,
+      machine_id: 'machine-abc',
+      steps: {},
+      sample_dashboards: sampleDashboards,
+    };
+  };
+
+  test('a skipped-onboarding user opening the bundled sample still reports true', () => {
+    // The false NEGATIVE: a ~1s sample render landing in the bucket reserved
+    // for dashboards the user actually built.
+    writeOnboardingState({ completed_at: '2026-01-01', path: 'skipped' });
+    injectServerJourney();
+    useParams.mockReturnValue({ dashboardName: 'College Football' });
+    mockStore(
+      buildState({
+        dashboards: [
+          { name: 'College Football', config: { rows: [{ items: [{ chart: { name: 'c' } }] }] } },
+        ],
+      })
+    );
+
+    render(<Project />);
+
+    expect(renderedMarks()[0].props.from_sample).toBe(true);
+  });
+
+  test('a user with no onboarding state at all still reports true for the sample', () => {
+    injectServerJourney();
+    useParams.mockReturnValue({ dashboardName: 'EV Sales' });
+    mockStore(
+      buildState({
+        dashboards: [
+          { name: 'EV Sales', config: { rows: [{ items: [{ chart: { name: 'c' } }] }] } },
+        ],
+      })
+    );
+
+    render(<Project />);
+
+    expect(renderedMarks()[0].props.from_sample).toBe(true);
+  });
+
+  test('a sample-path user who then built their own dashboard reports false', () => {
+    // The false POSITIVE: their genuine 40-minute journey was being filtered
+    // OUT of the gate metric because `path` still said 'sample'.
+    writeOnboardingState({ completed_at: '2026-01-01', path: 'sample' });
+    injectServerJourney();
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(renderedMarks()[0].props.from_sample).toBe(false);
   });
 });

--- a/viewer/src/components/project/Project.timeToValue.test.jsx
+++ b/viewer/src/components/project/Project.timeToValue.test.jsx
@@ -1,0 +1,167 @@
+/* The terminal mark of the time-to-value ladder (Guided First Run W1, step 6).
+ *
+ * `/project/:dashboardName` is the consumer surface — a dashboard mounting
+ * here is the end of the span the 2.1 exit gate is measured over, so this is
+ * the mark the whole metric terminates on.
+ *
+ * Kept in its own file rather than folded into Project.test.jsx: that suite
+ * mocks the store per-test for branching coverage, and these need the real
+ * timeToValue module plus a clean ledger per test.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
+import Project, { countDashboardItems } from './Project';
+import useStore from '../../stores/store';
+import { clearEventBuffer, getEventBuffer } from '../onboarding/telemetry';
+import { clearTimeToValueLedger } from '../onboarding/timeToValue';
+import { writeOnboardingState } from '../onboarding/onboardingState';
+
+jest.mock('../../stores/store');
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => ({ on: jest.fn(), close: jest.fn() })),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+jest.mock('./Dashboard', () => () => <div data-testid="dashboard" />);
+jest.mock('./ProjectViewFlipLayer', () => () => <div data-testid="view-flip-layer" />);
+jest.mock('../project/DashboardSection', () => () => <div data-testid="dashboard-section" />);
+jest.mock('../project/FilterBar', () => () => <div data-testid="filter-bar" />);
+jest.mock('../common/Loading', () => () => <div data-testid="loading" />);
+jest.mock('../styled/Container', () => ({
+  Container: ({ children }) => <div>{children}</div>,
+}));
+
+const ONE_ITEM_DASHBOARD = {
+  name: 'revenue',
+  config: { rows: [{ items: [{ chart: { name: 'c' } }] }] },
+};
+
+const buildState = (overrides = {}) => ({
+  project: { id: 'project-1', name: 'Test Project', config: { defaults: {} } },
+  dashboards: [ONE_ITEM_DASHBOARD],
+  dashboardsLoading: false,
+  fetchDashboards: jest.fn(),
+  filteredDashboards: [],
+  dashboardsByLevel: {},
+  initializeDashboardView: jest.fn(),
+  ...overrides,
+});
+
+const mockStore = state => useStore.mockImplementation(selector => selector(state));
+const renderedMarks = () => getEventBuffer().filter(e => e.event === 'first_dashboard_rendered');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearEventBuffer();
+  clearTimeToValueLedger();
+  window.localStorage.clear();
+  delete window.__VISIVO_FIRST_RUN;
+  delete window.__VISIVO_TELEMETRY_DISABLED;
+  useParams.mockReturnValue({ dashboardName: 'revenue' });
+});
+
+describe('countDashboardItems', () => {
+  test('counts the items of a flat dashboard', () => {
+    expect(
+      countDashboardItems({ rows: [{ items: [{}, {}] }, { items: [{}] }] })
+    ).toBe(3);
+  });
+
+  test('recurses into nested Item.rows rather than counting the wrapper as one', () => {
+    expect(
+      countDashboardItems({
+        rows: [{ items: [{ rows: [{ items: [{}, {}] }] }, {}] }],
+      })
+    ).toBe(3);
+  });
+
+  test('an empty or malformed dashboard counts zero rather than throwing', () => {
+    expect(countDashboardItems(null)).toBe(0);
+    expect(countDashboardItems({})).toBe(0);
+    expect(countDashboardItems({ rows: [{}] })).toBe(0);
+  });
+});
+
+describe('first_dashboard_rendered', () => {
+  test('fires when a dashboard with items mounts, with item_count', () => {
+    mockStore(buildState());
+
+    render(<Project />);
+
+    const [mark] = renderedMarks();
+    expect(mark.props.step_index).toBe(6);
+    expect(mark.props.item_count).toBe(1);
+  });
+
+  test('does not fire for an empty dashboard — an empty shell is not value', () => {
+    mockStore(
+      buildState({ dashboards: [{ name: 'revenue', config: { rows: [{ items: [] }] } }] })
+    );
+
+    render(<Project />);
+
+    expect(renderedMarks()).toHaveLength(0);
+  });
+
+  test('does not fire on the dashboard list route', () => {
+    useParams.mockReturnValue({});
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(renderedMarks()).toHaveLength(0);
+  });
+
+  test('fires once even across re-renders and re-mounts', () => {
+    mockStore(buildState());
+
+    const { rerender, unmount } = render(<Project />);
+    rerender(<Project />);
+    unmount();
+    render(<Project />);
+
+    expect(renderedMarks()).toHaveLength(1);
+  });
+
+  test('from_sample is false for a dashboard built from the user’s own data', () => {
+    writeOnboardingState({ completed_at: '2026-01-01', path: 'data' });
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(renderedMarks()[0].props.from_sample).toBe(false);
+  });
+
+  test('from_sample is true for the bundled example — the TTV-5 trap', () => {
+    // Rendering the sample takes ~1s; rendering a dashboard from the user's
+    // own data took field testers 26-108 minutes. Without this flag the exit
+    // gate would read the wrong number and report success it has not earned.
+    writeOnboardingState({ completed_at: '2026-01-01', path: 'sample' });
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(renderedMarks()[0].props.from_sample).toBe(true);
+  });
+
+  test('carries no dashboard name', () => {
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(JSON.stringify(renderedMarks()[0].props)).not.toContain('revenue');
+  });
+
+  test('emits nothing when telemetry is disabled', () => {
+    window.__VISIVO_TELEMETRY_DISABLED = true;
+    mockStore(buildState());
+
+    render(<Project />);
+
+    expect(getEventBuffer()).toHaveLength(0);
+  });
+});

--- a/viewer/src/components/views/project/canvas/ProjectCanvas.jsx
+++ b/viewer/src/components/views/project/canvas/ProjectCanvas.jsx
@@ -12,6 +12,7 @@ import CanvasAddRow from './CanvasAddRow';
 import CanvasContextMenu from './CanvasContextMenu';
 import CanvasKeyboardLayer from './CanvasKeyboardLayer';
 import CanvasItemFlipLayer from './CanvasItemFlipLayer';
+import { useFirstDashboardRenderedMark } from '../../../onboarding/firstDashboardRendered';
 
 /**
  * ProjectCanvas (VIS-D1 / VIS-767, extended by VIS-D2 / VIS-768) — the
@@ -64,6 +65,13 @@ const ProjectCanvas = ({ projectId, dashboardName }) => {
     if (!entry) return null;
     return entry.config || entry;
   }, [dashboards, dashboardName]);
+
+  // Terminal mark of the time-to-value ladder (Guided First Run W1, step 6).
+  // The canvas wraps the SAME render-only <Dashboard> View mode does, and it is
+  // where onboarding's data path lands — the cohort the 2.1 exit gate measures
+  // builds and watches its first dashboard here, not on /project/:name. The
+  // mark is idempotent per journey, so mounting it on both surfaces counts once.
+  useFirstDashboardRenderedMark(dashboardName, dashboardConfig);
 
   const handleCreateNew = useCallback(
     typeKey => {

--- a/viewer/src/components/views/project/canvas/ProjectCanvas.timeToValue.test.jsx
+++ b/viewer/src/components/views/project/canvas/ProjectCanvas.timeToValue.test.jsx
@@ -1,0 +1,111 @@
+/* The terminal mark of the time-to-value ladder on the WORKSPACE canvas
+ * (Guided First Run W1, step 6).
+ *
+ * `/workspace/dashboard/:dashboardName` renders <Workspace> → <ProjectCanvas>,
+ * never <Project>. Wiring the mark only to `/project/:dashboardName` left the
+ * exact cohort the 2.1 exit gate measures contributing NO data point at all:
+ * `OnboardingFlow.completeAndNavigate` sends a user who connected their own
+ * source — the non-sample path — into the workspace, and the build-and-view
+ * loop for a new dashboard is this canvas.
+ *
+ * Kept out of ProjectCanvas.test.jsx: that suite mocks Dashboard and drives the
+ * broken-ref wiring; these need the real timeToValue module and a clean ledger
+ * per test.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ProjectCanvas from './ProjectCanvas';
+import useStore from '../../../../stores/store';
+import { clearEventBuffer, getEventBuffer } from '../../../onboarding/telemetry';
+import { clearTimeToValueLedger } from '../../../onboarding/timeToValue';
+
+jest.mock('../../../project/Dashboard', () => {
+  const Mock = () => <div data-testid="dashboard-mock" />;
+  Mock.displayName = 'MockDashboard';
+  return { __esModule: true, default: Mock };
+});
+
+const SALES = {
+  name: 'sales',
+  config: { rows: [{ items: [{ chart: 'ref(a)' }, { chart: 'ref(b)' }] }] },
+};
+
+const renderCanvas = (dashboardName = 'sales') =>
+  render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <ProjectCanvas projectId="proj-1" dashboardName={dashboardName} />
+    </MemoryRouter>
+  );
+
+const renderedMarks = () => getEventBuffer().filter(e => e.event === 'first_dashboard_rendered');
+
+beforeEach(() => {
+  clearEventBuffer();
+  clearTimeToValueLedger();
+  window.localStorage.clear();
+  delete window.__VISIVO_FIRST_RUN;
+  delete window.__VISIVO_TELEMETRY_DISABLED;
+  useStore.setState({ dashboards: [SALES] });
+});
+
+describe('first_dashboard_rendered on the workspace canvas', () => {
+  test('fires when a dashboard with items mounts on the canvas', () => {
+    renderCanvas();
+
+    const [mark] = renderedMarks();
+    expect(mark.props.step_index).toBe(6);
+    expect(mark.props.item_count).toBe(2);
+  });
+
+  test('does not fire for an empty canvas — an empty shell is not value', () => {
+    useStore.setState({ dashboards: [{ name: 'sales', config: { rows: [{ items: [] }] } }] });
+
+    renderCanvas();
+
+    expect(renderedMarks()).toHaveLength(0);
+  });
+
+  test('does not fire for a dashboard that is not in the project', () => {
+    renderCanvas('not-a-dashboard');
+
+    expect(renderedMarks()).toHaveLength(0);
+  });
+
+  test('counts once across the canvas and View mode — the journey has one end', () => {
+    renderCanvas();
+    renderCanvas();
+
+    expect(renderedMarks()).toHaveLength(1);
+  });
+
+  test('from_sample comes from the server-named samples here too', () => {
+    window.__VISIVO_FIRST_RUN = {
+      journey_id: 'J-1',
+      started_at_ms: Date.now() - 1000,
+      install_age_ms: 1000,
+      machine_id: 'm-1',
+      steps: {},
+      sample_dashboards: ['sales'],
+    };
+
+    renderCanvas();
+
+    expect(renderedMarks()[0].props.from_sample).toBe(true);
+  });
+
+  test('carries no dashboard name', () => {
+    renderCanvas();
+
+    expect(JSON.stringify(renderedMarks()[0].props)).not.toContain('sales');
+  });
+
+  test('emits nothing when telemetry is disabled', () => {
+    window.__VISIVO_TELEMETRY_DISABLED = true;
+
+    renderCanvas();
+
+    expect(getEventBuffer()).toHaveLength(0);
+  });
+});

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -167,6 +167,12 @@ const URL_PATTERNS = {
     // The local Flask server relays workspace events through the CLI's PostHog
     // client so the CLI telemetry opt-out + anonymization apply (VIS-822).
     workspaceTelemetry: '/api/telemetry/workspace-event/',
+    // Writes a time-to-value mark the viewer ALREADY emitted into
+    // ~/.visivo/first_run.json (Guided First Run W1). Sends no event — it is
+    // what makes "once per journey" survive a second browser or a different
+    // serve port, since localStorage is scoped to one origin and the ledger
+    // is not.
+    firstRunStep: '/api/telemetry/first-run/step/',
   },
 
   // A dist build is static files — there is no server, so almost nothing

--- a/viewer/src/stores/insightStore.js
+++ b/viewer/src/stores/insightStore.js
@@ -1,5 +1,6 @@
 import * as insightsApi from '../api/insights';
 import { recordOnboardingAction } from '../components/onboarding/onboardingState';
+import { markTimeToValueStep, TTV_STEPS } from '../components/onboarding/timeToValue';
 
 /**
  * Insight Store Slice
@@ -40,6 +41,10 @@ const createInsightSlice = (set, get) => ({
       }
       // Tap for the onboarding "Create an Insight" checklist row.
       recordOnboardingAction('insight_saved');
+      // Step 5 of the time-to-value ladder (Guided First Run W1). Distinct
+      // from the tap above, which no-ops until onboarding is complete. No
+      // name in the payload.
+      markTimeToValueStep(TTV_STEPS.FIRST_INSIGHT_CREATED);
       return { success: true, result };
     } catch (error) {
       return { success: false, error: error.message };

--- a/viewer/src/stores/modelStore.js
+++ b/viewer/src/stores/modelStore.js
@@ -1,5 +1,6 @@
 import * as modelsApi from '../api/models';
 import { recordOnboardingAction } from '../components/onboarding/onboardingState';
+import { markTimeToValueStep, TTV_STEPS } from '../components/onboarding/timeToValue';
 
 /**
  * Model Store Slice
@@ -60,6 +61,11 @@ const createModelSlice = (set, get) => ({
       }
       // Tap for the onboarding "Build a Model" checklist row.
       recordOnboardingAction('model_saved');
+      // Step 4 of the time-to-value ladder (Guided First Run W1). Distinct
+      // from the tap above, which no-ops until onboarding is complete — the
+      // ladder has to measure users who skipped onboarding too. No name in
+      // the payload.
+      markTimeToValueStep(TTV_STEPS.FIRST_MODEL_CREATED);
       return { success: true, result };
     } catch (error) {
       return { success: false, error: error.message };

--- a/viewer/src/stores/sourceStore.js
+++ b/viewer/src/stores/sourceStore.js
@@ -1,4 +1,5 @@
 import * as sourcesApi from '../api/sources';
+import { markTimeToValueStep, TTV_STEPS } from '../components/onboarding/timeToValue';
 
 // Object status constants (matches backend ObjectStatus enum)
 export const ObjectStatus = {
@@ -46,6 +47,15 @@ const createSourceSlice = (set, get) => ({
       if (get().checkCommitStatus) {
         await get().checkCommitStatus();
       }
+      // Step 2 of the time-to-value ladder (Guided First Run W1). The
+      // onboarding flow has its own call site; this covers every other door
+      // into a first source — Library "New", the Explorer, an import. The
+      // mark is idempotent per journey, so whichever fires first wins and the
+      // other is a no-op. Type only, never the source name.
+      markTimeToValueStep(TTV_STEPS.SOURCE_CONNECTED, {
+        source_type: config?.type ?? null,
+        via: 'source_store',
+      });
       return { success: true, result };
     } catch (error) {
       return { success: false, error: error.message };

--- a/viewer/src/stores/timeToValueMarks.test.js
+++ b/viewer/src/stores/timeToValueMarks.test.js
@@ -1,0 +1,189 @@
+/* Time-to-value ladder call sites in the per-type stores (Guided First Run W1).
+ *
+ * timeToValue.test.js proves the ladder itself. This proves the three store
+ * writes that feed it are actually wired, fire once, fire only on SUCCESS, and
+ * never put a user-authored name into a payload — which is the failure mode
+ * that would quietly poison the metric or leak a name.
+ *
+ * Uses the real timeToValue module and asserts against the event buffer rather
+ * than a mock, so a call site that passes the wrong step id fails here.
+ */
+
+import createSourceSlice from './sourceStore';
+import createModelSlice from './modelStore';
+import createInsightSlice from './insightStore';
+import * as sourcesApi from '../api/sources';
+import * as modelsApi from '../api/models';
+import * as insightsApi from '../api/insights';
+import { clearEventBuffer, getEventBuffer } from '../components/onboarding/telemetry';
+import { clearTimeToValueLedger } from '../components/onboarding/timeToValue';
+
+jest.mock('../api/sources');
+jest.mock('../api/models');
+jest.mock('../api/insights');
+
+/* Minimal stand-in for a zustand store, matching perTypeStores.test.js. */
+const makeStore = (slice, initial = {}) => {
+  let state = { ...initial };
+  const set = patch => {
+    const next = typeof patch === 'function' ? patch(state) : patch;
+    state = { ...state, ...next };
+  };
+  const get = () => state;
+  state = { ...state, ...slice(set, get) };
+  return { get };
+};
+
+const marksFor = event => getEventBuffer().filter(e => e.event === event);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearEventBuffer();
+  clearTimeToValueLedger();
+  delete window.__VISIVO_FIRST_RUN;
+  delete window.__VISIVO_TELEMETRY_DISABLED;
+});
+
+describe('source_connected (step 2)', () => {
+  test('a successful save marks the step, carrying the type but not the name', async () => {
+    sourcesApi.saveSource.mockResolvedValue({ ok: true });
+    sourcesApi.fetchAllSources.mockResolvedValue({ sources: [] });
+    const store = makeStore(createSourceSlice);
+
+    await store.get().saveSource('acme_production_warehouse', {
+      name: 'acme_production_warehouse',
+      type: 'snowflake',
+    });
+
+    const [mark] = marksFor('source_connected');
+    expect(mark.props.step_index).toBe(2);
+    expect(mark.props.source_type).toBe('snowflake');
+    expect(mark.props.via).toBe('source_store');
+    expect(JSON.stringify(mark.props)).not.toContain('acme_production_warehouse');
+  });
+
+  test('a second source does not re-mark the step', async () => {
+    sourcesApi.saveSource.mockResolvedValue({ ok: true });
+    sourcesApi.fetchAllSources.mockResolvedValue({ sources: [] });
+    const store = makeStore(createSourceSlice);
+
+    await store.get().saveSource('one', { name: 'one', type: 'duckdb' });
+    await store.get().saveSource('two', { name: 'two', type: 'postgresql' });
+
+    expect(marksFor('source_connected')).toHaveLength(1);
+  });
+
+  test('a failed save marks nothing — the clock must not start on an error', async () => {
+    sourcesApi.saveSource.mockRejectedValue(new Error('could not connect'));
+    const store = makeStore(createSourceSlice);
+
+    const result = await store.get().saveSource('one', { name: 'one', type: 'duckdb' });
+
+    expect(result.success).toBe(false);
+    expect(marksFor('source_connected')).toHaveLength(0);
+  });
+});
+
+describe('first_model_created (step 4)', () => {
+  test('a successful save marks the step with no name in the payload', async () => {
+    modelsApi.saveModel.mockResolvedValue({ ok: true });
+    modelsApi.fetchAllModels.mockResolvedValue({ models: [] });
+    const store = makeStore(createModelSlice);
+
+    await store.get().saveModel('quarterly_revenue_by_rep', { name: 'quarterly_revenue_by_rep' });
+
+    const [mark] = marksFor('first_model_created');
+    expect(mark.props.step_index).toBe(4);
+    expect(JSON.stringify(mark.props)).not.toContain('quarterly_revenue_by_rep');
+  });
+
+  test('a second model does not re-mark the step', async () => {
+    modelsApi.saveModel.mockResolvedValue({ ok: true });
+    modelsApi.fetchAllModels.mockResolvedValue({ models: [] });
+    const store = makeStore(createModelSlice);
+
+    await store.get().saveModel('a', {});
+    await store.get().saveModel('b', {});
+
+    expect(marksFor('first_model_created')).toHaveLength(1);
+  });
+
+  test('a failed save marks nothing', async () => {
+    modelsApi.saveModel.mockRejectedValue(new Error('invalid sql'));
+    const store = makeStore(createModelSlice);
+
+    await store.get().saveModel('a', {});
+
+    expect(marksFor('first_model_created')).toHaveLength(0);
+  });
+});
+
+describe('first_insight_created (step 5)', () => {
+  test('a successful save marks the step with no name in the payload', async () => {
+    insightsApi.saveInsight.mockResolvedValue({ ok: true });
+    insightsApi.fetchAllInsights.mockResolvedValue({ insights: [] });
+    const store = makeStore(createInsightSlice);
+
+    await store.get().saveInsight('revenue_by_month', { name: 'revenue_by_month' });
+
+    const [mark] = marksFor('first_insight_created');
+    expect(mark.props.step_index).toBe(5);
+    expect(JSON.stringify(mark.props)).not.toContain('revenue_by_month');
+  });
+
+  test('a second insight does not re-mark the step', async () => {
+    insightsApi.saveInsight.mockResolvedValue({ ok: true });
+    insightsApi.fetchAllInsights.mockResolvedValue({ insights: [] });
+    const store = makeStore(createInsightSlice);
+
+    await store.get().saveInsight('a', {});
+    await store.get().saveInsight('b', {});
+
+    expect(marksFor('first_insight_created')).toHaveLength(1);
+  });
+
+  test('a failed save marks nothing', async () => {
+    insightsApi.saveInsight.mockRejectedValue(new Error('bad props'));
+    const store = makeStore(createInsightSlice);
+
+    await store.get().saveInsight('a', {});
+
+    expect(marksFor('first_insight_created')).toHaveLength(0);
+  });
+});
+
+describe('the journey across stores', () => {
+  test('marks accumulate into one journey, in ladder order', async () => {
+    sourcesApi.saveSource.mockResolvedValue({ ok: true });
+    sourcesApi.fetchAllSources.mockResolvedValue({ sources: [] });
+    modelsApi.saveModel.mockResolvedValue({ ok: true });
+    modelsApi.fetchAllModels.mockResolvedValue({ models: [] });
+    insightsApi.saveInsight.mockResolvedValue({ ok: true });
+    insightsApi.fetchAllInsights.mockResolvedValue({ insights: [] });
+
+    await makeStore(createSourceSlice).get().saveSource('s', { name: 's', type: 'duckdb' });
+    await makeStore(createModelSlice).get().saveModel('m', {});
+    await makeStore(createInsightSlice).get().saveInsight('i', {});
+
+    const journeyIds = new Set(getEventBuffer().map(e => e.props.journey_id));
+    expect(journeyIds.size).toBe(1);
+    expect(getEventBuffer().map(e => e.props.step_index)).toEqual([2, 4, 5]);
+  });
+
+  test('with telemetry disabled, no store write marks anything', async () => {
+    window.__VISIVO_TELEMETRY_DISABLED = true;
+    sourcesApi.saveSource.mockResolvedValue({ ok: true });
+    sourcesApi.fetchAllSources.mockResolvedValue({ sources: [] });
+    modelsApi.saveModel.mockResolvedValue({ ok: true });
+    modelsApi.fetchAllModels.mockResolvedValue({ models: [] });
+    insightsApi.saveInsight.mockResolvedValue({ ok: true });
+    insightsApi.fetchAllInsights.mockResolvedValue({ insights: [] });
+
+    await makeStore(createSourceSlice).get().saveSource('s', { name: 's', type: 'duckdb' });
+    await makeStore(createModelSlice).get().saveModel('m', {});
+    await makeStore(createInsightSlice).get().saveInsight('i', {});
+
+    expect(getEventBuffer()).toHaveLength(0);
+    expect(window.localStorage.getItem('visivo.ttv.v1')).toBeNull();
+  });
+});

--- a/visivo/server/views/data_views.py
+++ b/visivo/server/views/data_views.py
@@ -4,6 +4,7 @@ import os
 import re
 from flask import jsonify, request, send_file, send_from_directory
 from visivo.utils import SCHEMA_FILE, VIEWER_PATH
+from visivo.telemetry import first_run
 from visivo.telemetry.config import is_telemetry_enabled
 
 
@@ -86,6 +87,26 @@ def register_data_views(app, flask_app, output_dir):
         project_defaults = getattr(flask_app._project, "defaults", None)
         if not is_telemetry_enabled(project_defaults):
             scripts = "<script>window.__VISIVO_TELEMETRY_DISABLED=true</script>" + scripts
+        else:
+            # Time-to-value ladder (Guided First Run W1). Serving the viewer's
+            # HTML is the first moment the product is actually in front of the
+            # user, so this is where step 1 fires — once per machine, guarded by
+            # the ledger in ~/.visivo/first_run.json, not by this request.
+            #
+            # The journey is then handed to the page so the viewer's marks
+            # (steps 2-6) carry the same journey_id and machine_id and the whole
+            # span is one subtraction. Under the opt-out this branch never runs:
+            # no ledger is written, no journey is injected, and the viewer has
+            # nothing to mark — the opt-out needs no second implementation in JS.
+            first_run.mark_step(
+                first_run.STEP_FIRST_RUN_LAUNCHED, project_defaults=project_defaults
+            )
+            journey = first_run.viewer_journey_context(project_defaults=project_defaults)
+            if journey:
+                # json.dumps handles the escaping; `</` is split so a value can
+                # never terminate the <script> element early.
+                journey_json = json.dumps(journey).replace("</", "<\\/")
+                scripts = f"<script>window.__VISIVO_FIRST_RUN={journey_json}</script>" + scripts
 
         html = html.replace("</head>", f"{scripts}</head>")
 

--- a/visivo/server/views/telemetry_views.py
+++ b/visivo/server/views/telemetry_views.py
@@ -12,6 +12,12 @@ JS bundle.
 
 The dist/cloud viewer has no Flask server; its `urls.js` entry for this
 endpoint is `null`, so the viewer-side sink is a no-op there.
+
+A second endpoint here, `/api/telemetry/first-run/step/`, does the opposite:
+it forwards nothing to PostHog and only records that a time-to-value mark
+already fired, so the server-side journey ledger stays the one authority on
+"once per journey" even when the browser's own ledger is not there to consult
+(Guided First Run W1 — see visivo/telemetry/first_run.py).
 """
 
 import json
@@ -19,6 +25,7 @@ import re
 
 from flask import jsonify, request
 
+from visivo.telemetry import first_run
 from visivo.telemetry.config import is_telemetry_enabled
 from visivo.telemetry.events import WorkspaceEvent
 
@@ -82,6 +89,51 @@ def register_telemetry_views(app, flask_app, output_dir):
         try:
             client = get_telemetry_client(enabled=True)
             client.track(WorkspaceEvent.create(name=name, properties=payload))
+        except Exception:
+            # Telemetry must never break the viewer — accept-and-drop.
+            pass
+
+        return "", 204
+
+    @app.route("/api/telemetry/first-run/step/", methods=["POST"])
+    def post_first_run_step():
+        """Write a time-to-value mark the VIEWER already emitted into the ledger.
+
+        This endpoint emits nothing. The browser has already sent the event; what
+        it cannot do is make "once per journey" survive leaving its own origin.
+        The viewer's idempotence lives in ``localStorage``, which is scoped to
+        ``http://localhost:<port>`` — so a second browser, an incognito window, a
+        cleared site-data, or simply ``visivo serve -p 8001`` re-fires every
+        viewer mark under the same ``journey_id`` and inflates the funnel. The
+        ledger file is not origin-scoped, and ``viewer_journey_context`` seeds
+        the next page load from it.
+        """
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "Expected a JSON object body"}), 400
+
+        step_id = body.get("step_id")
+        if not isinstance(step_id, str) or step_id not in first_run.STEP_INDEXES:
+            return jsonify({"error": "Unknown step id"}), 400
+
+        journey_id = body.get("journey_id")
+        if journey_id is not None and not isinstance(journey_id, str):
+            return jsonify({"error": "journey_id must be a string"}), 400
+
+        at_ms = body.get("at_ms")
+        if not isinstance(at_ms, int) or isinstance(at_ms, bool):
+            at_ms = None
+
+        project = getattr(flask_app, "project", None)
+        defaults = getattr(project, "defaults", None) if project is not None else None
+
+        try:
+            first_run.record_viewer_step(
+                step_id,
+                journey_id=journey_id,
+                at_ms=at_ms,
+                project_defaults=defaults,
+            )
         except Exception:
             # Telemetry must never break the viewer — accept-and-drop.
             pass

--- a/visivo/telemetry/events.py
+++ b/visivo/telemetry/events.py
@@ -158,6 +158,57 @@ class NewInstallationEvent(BaseEvent):
 
 
 @dataclass
+class FirstRunStepEvent(BaseEvent):
+    """
+    Event for one step mark on the time-to-value ladder (Guided First Run W1).
+
+    The ladder and every required property are specified in
+    ``specs/marketing-relaunch/event-taxonomy.md`` §4. The event NAME is the
+    step id itself (``first_run_launched``, ...) so a funnel reads the ladder
+    step-by-step; ``step_id``/``step_index`` ride along as properties so a
+    single insight can read it generically too.
+
+    ``surface: "cli"`` is set explicitly here — the taxonomy requires a
+    ``surface`` on every event, and the viewer's half of the same ladder
+    carries ``surface: "viewer"`` from its PostHog super properties.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        step_id: str,
+        properties: Optional[Dict[str, Any]] = None,
+        project_hash: Optional[str] = None,
+    ) -> "FirstRunStepEvent":
+        """Create a first-run step event carrying the ladder payload plus system properties."""
+        # machine_id is the distinct_id already, but the taxonomy requires it as
+        # a PROPERTY on every step mark: the viewer's half of the ladder ships
+        # under a browser distinct_id, so `machine_id` is the only column the
+        # two halves can be joined on.
+        merged_properties = {
+            **(properties or {}),
+            "machine_id": _get_machine_id(),
+            "surface": "cli",
+            "plan": "anonymous",
+            "visivo_version": VISIVO_VERSION,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "platform": platform.system().lower(),
+            "is_ci": is_ci_environment(),
+        }
+
+        if project_hash:
+            merged_properties["project_hash"] = project_hash
+
+        return cls(
+            event_type=step_id,
+            timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            session_id=SESSION_ID,
+            machine_id=_get_machine_id(),
+            properties=merged_properties,
+        )
+
+
+@dataclass
 class WorkspaceEvent(BaseEvent):
     """
     Event for a viewer Workspace interaction (dashboard-building telemetry).

--- a/visivo/telemetry/first_run.py
+++ b/visivo/telemetry/first_run.py
@@ -23,6 +23,30 @@ half an hour). ``~/.visivo/first_run.json`` sits beside ``machine_id``, holds a
 random ``journey_id`` plus the timestamps of the marks already emitted, and is
 what makes "exactly once per journey" true rather than "once per page load".
 
+Three things the ledger has to get right, each of which is a way the gate
+metric silently reads zero if it doesn't:
+
+  ONE IDENTITY PER PROCESS. Every caller resolves the journey through
+  ``get_or_create_journey``, and the resolved journey is cached per ledger path.
+  Without the cache an unwritable ``$HOME`` (a read-only container, a user with
+  no writable home) mints a FRESH journey on every call — so ``first_run_launched``
+  re-fires on every page load AND the ``journey_id`` handed to the browser never
+  matches the one the CLI emitted, leaving the two halves of the span unjoinable.
+
+  A FIRST RUN, NOT AN UPGRADE. A journey is only *minted* on an interactive run
+  (the same backstop ``machine_id._is_interactive`` gives ``new_installation``),
+  and every mark carries ``install_age_ms`` — how long ``~/.visivo/machine_id``
+  had existed when the journey started. A machine that has had visivo installed
+  for weeks reaching ``first_dashboard_rendered`` two seconds after ``visivo
+  serve`` is an upgrade opening an existing dashboard, not a 2-second
+  time-to-value, and the gate metric has to be able to exclude it.
+
+  THE VIEWER'S MARKS COUNT TOO. ``record_viewer_step`` writes a mark the browser
+  already emitted back into this ledger. The viewer's own idempotence lives in
+  ``localStorage``, which is scoped to one origin — a different serve port, a
+  second browser, or a cleared site-data would otherwise re-fire every viewer
+  mark under the same ``journey_id``. The file is not origin-scoped.
+
 Privacy posture, matching the rest of visivo.telemetry:
 
   - ``journey_id`` is a random UUID. It identifies a *first run*, not a person,
@@ -35,10 +59,13 @@ Privacy posture, matching the rest of visivo.telemetry:
 """
 
 import json
+import os
+import tempfile
+import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .config import is_telemetry_enabled
 
@@ -57,10 +84,26 @@ STEP_INDEXES: Dict[str, int] = {
     "first_dashboard_rendered": 6,
 }
 
-# The only step this module emits. The rest happen in the browser.
+# The only step this module *emits*. The rest happen in the browser (and are
+# written back here by `record_viewer_step` so the file stays the one authority
+# on what has already fired).
 STEP_FIRST_RUN_LAUNCHED = "first_run_launched"
 
 LEDGER_FILENAME = "first_run.json"
+
+# One lock for the whole read-modify-write. `visivo serve` is threaded, so two
+# simultaneous index.html requests (two tabs opened at once, a reload racing a
+# hot-reload navigation) would otherwise both find a step unclaimed and both
+# emit it — exactly the double-count the once-per-journey contract forbids.
+_LEDGER_LOCK = threading.RLock()
+
+# (ledger path, journey) — see "ONE IDENTITY PER PROCESS" above. Keyed by path
+# so a test (or anything else) that repoints $HOME cannot pick up a stale
+# journey from a previous home.
+_JOURNEY_CACHE: Optional[Any] = None
+
+# Dashboard names shipped in visivo/templates/samples. Read once per process.
+_SAMPLE_DASHBOARDS_CACHE: Optional[List[str]] = None
 
 
 def ledger_path() -> Path:
@@ -68,8 +111,35 @@ def ledger_path() -> Path:
     return Path.home() / ".visivo" / LEDGER_FILENAME
 
 
+def machine_id_path() -> Path:
+    """Path to the anonymous machine id file — the install's age is read off it."""
+    return Path.home() / ".visivo" / "machine_id"
+
+
 def _now_ms() -> int:
     return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def reset_journey_cache() -> None:
+    """Drop the per-process journey cache. Test helper; product code never calls it."""
+    global _JOURNEY_CACHE
+    with _LEDGER_LOCK:
+        _JOURNEY_CACHE = None
+
+
+def _cached_journey() -> Optional[Dict[str, Any]]:
+    cached = _JOURNEY_CACHE
+    if not cached:
+        return None
+    path, journey = cached
+    if path != str(ledger_path()):
+        return None
+    return journey
+
+
+def _remember_journey(journey: Dict[str, Any]) -> None:
+    global _JOURNEY_CACHE
+    _JOURNEY_CACHE = (str(ledger_path()), journey)
 
 
 def read_ledger() -> Optional[Dict[str, Any]]:
@@ -97,39 +167,194 @@ def read_ledger() -> Optional[Dict[str, Any]]:
 
 
 def _write_ledger(data: Dict[str, Any]) -> bool:
-    """Best-effort ledger write. Returns True on success."""
+    """Best-effort ATOMIC ledger write. Returns True on success.
+
+    Written to a sibling temp file and ``os.replace``d into position: a crash,
+    a full disk, or a kill mid-write would otherwise leave a truncated file,
+    which ``read_ledger`` reports as absent — and an absent ledger mints a
+    SECOND journey whose ``ms_since_first_run`` restarts from zero, splitting
+    one first run across two ids.
+    """
+    tmp_path = None
     try:
         path = ledger_path()
         path.parent.mkdir(exist_ok=True)
-        with open(path, "w") as ledger_file:
+        handle, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".first_run.", suffix=".tmp"
+        )
+        with os.fdopen(handle, "w") as ledger_file:
             json.dump(data, ledger_file)
+        os.replace(tmp_path, path)
         return True
     except Exception:
         # An unwritable home directory means we lose the journey, not that the
         # server fails to serve a page.
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
         return False
+
+
+def _install_age_ms(now_ms: int) -> Optional[int]:
+    """How long ``~/.visivo/machine_id`` had existed when the journey started.
+
+    ``None`` when there is no persisted machine id (CI, an unwritable home).
+    This is the property that separates a genuine first run from an established
+    install that merely upgraded into this telemetry: the ledger's absence
+    cannot tell them apart, because NO install has a ledger until this ships.
+    See the gate-metric note in the taxonomy §4.
+
+    Resolves the machine id first so a genuinely new install — where `visivo
+    serve` is the very first command and the file is created in this same
+    request — reports ~0 rather than the "unknown" a missing file would mean.
+    """
+    try:
+        _stable_machine_id()
+        path = machine_id_path()
+        if not path.exists():
+            return None
+        return max(0, now_ms - int(path.stat().st_mtime * 1000))
+    except Exception:
+        return None
+
+
+def _is_interactive_run() -> bool:
+    """True when a human is plausibly at a terminal.
+
+    Reuses ``machine_id._is_interactive`` — the same universal backstop that
+    stops containers/serverless with a fresh ``$HOME`` per cold start from
+    reporting a spurious ``new_installation`` on every run. A journey is only
+    *minted* behind it; an existing journey keeps marking regardless, so a user
+    who started interactively is still measured from a detached follow-up run.
+    """
+    try:
+        from .machine_id import _is_interactive
+
+        return _is_interactive()
+    except Exception:
+        return False
+
+
+def _stable_machine_id() -> Optional[str]:
+    """The SAME machine id the emitted events ship under.
+
+    ``machine_id.get_machine_id()`` is not idempotent in CI/container contexts —
+    it returns a fresh ``ci-<uuid>`` on every call and persists nothing — so
+    calling it directly here would hand the browser a machine id that differs
+    from the one on ``first_run_launched`` and rotates on every page load,
+    silently breaking the CLI↔viewer join this whole ladder is built on.
+    ``events._get_machine_id`` is the process-wide memo every CLI event uses.
+    """
+    try:
+        from .events import _get_machine_id
+
+        return _get_machine_id()
+    except Exception:
+        return None
+
+
+def bundled_sample_dashboard_names() -> List[str]:
+    """Dashboard names shipped in ``visivo/templates/samples``.
+
+    Handed to the viewer so the terminal mark's ``from_sample`` is decided by
+    the dashboard actually being rendered rather than by which onboarding
+    branch the user happened to take. The onboarding path is written once and
+    never updated, so it is wrong in both directions: a user who skipped
+    onboarding and opened the bundled example reported ``from_sample: false``
+    (the TTV-5 trap, a ~1s render landing in the gate metric), and a user who
+    took the sample tour and then built a real dashboard 40 minutes later
+    reported ``from_sample: true`` and was filtered OUT of it.
+
+    These are visivo's own names, not user-authored strings, and they never
+    enter an event payload — only the boolean derived from them does.
+    """
+    global _SAMPLE_DASHBOARDS_CACHE
+    if _SAMPLE_DASHBOARDS_CACHE is not None:
+        return _SAMPLE_DASHBOARDS_CACHE
+
+    names: List[str] = []
+    try:
+        import yaml
+
+        samples_root = Path(__file__).resolve().parent.parent / "templates" / "samples"
+        for project_file in sorted(samples_root.glob("*/project.visivo.yml")):
+            with open(project_file, "r") as sample_file:
+                data = yaml.safe_load(sample_file)
+            dashboards = (data or {}).get("dashboards") or []
+            for dashboard in dashboards:
+                if not isinstance(dashboard, dict):
+                    continue
+                name = dashboard.get("name")
+                if isinstance(name, str) and name and name not in names:
+                    names.append(name)
+    except Exception:
+        # A build without the samples directory must not break serving a page.
+        names = []
+
+    _SAMPLE_DASHBOARDS_CACHE = sorted(names)
+    return _SAMPLE_DASHBOARDS_CACHE
 
 
 def get_or_create_journey(project_defaults: Optional[object] = None) -> Optional[Dict[str, Any]]:
     """Return this machine's first-run journey, creating it on first call.
 
     Returns None when telemetry is disabled — and, critically, writes nothing
-    in that case, so an opted-out user never gets a ledger file at all.
+    in that case, so an opted-out user never gets a ledger file at all. Also
+    returns None when there is no journey yet and the run is not interactive:
+    a container or CI runner with a fresh ``$HOME`` per cold start would
+    otherwise mint a brand-new "first run" on every start.
     """
     if not is_telemetry_enabled(project_defaults):
         return None
 
-    existing = read_ledger()
-    if existing is not None:
-        return existing
+    with _LEDGER_LOCK:
+        existing = read_ledger()
+        if existing is not None:
+            _remember_journey(existing)
+            return existing
 
-    journey = {
-        "journey_id": str(uuid.uuid4()),
-        "started_at_ms": _now_ms(),
-        "steps": {},
+        # The ledger is gone or unwritable. If this process already resolved a
+        # journey, keep it: minting a second one here is what re-fires step 1
+        # on every page load and splits the CLI's id from the viewer's.
+        cached = _cached_journey()
+        if cached is not None:
+            return cached
+
+        if not _is_interactive_run():
+            return None
+
+        now_ms = _now_ms()
+        journey = {
+            "journey_id": str(uuid.uuid4()),
+            "started_at_ms": now_ms,
+            "install_age_ms": _install_age_ms(now_ms),
+            "steps": {},
+        }
+        _write_ledger(journey)
+        _remember_journey(journey)
+        return journey
+
+
+def _step_payload(
+    journey: Dict[str, Any], step_id: str, now_ms: int, previous_ms
+) -> Dict[str, Any]:
+    started_at_ms = journey.get("started_at_ms")
+    install_age_ms = journey.get("install_age_ms")
+    return {
+        "journey_id": journey.get("journey_id"),
+        "step_id": step_id,
+        "step_index": STEP_INDEXES[step_id],
+        "ms_since_first_run": (
+            max(0, now_ms - started_at_ms) if isinstance(started_at_ms, int) else None
+        ),
+        "ms_since_previous_step": (
+            max(0, now_ms - previous_ms) if isinstance(previous_ms, int) else None
+        ),
+        "install_age_ms": install_age_ms if isinstance(install_age_ms, int) else None,
+        "out_of_order": bool(isinstance(previous_ms, int) and now_ms < previous_ms),
     }
-    _write_ledger(journey)
-    return journey
 
 
 def mark_step(
@@ -149,38 +374,28 @@ def mark_step(
     if not is_telemetry_enabled(project_defaults):
         return False
 
-    journey = get_or_create_journey(project_defaults)
-    if journey is None:
-        return False
+    # The claim is the whole once-per-journey guarantee, so it happens under the
+    # lock; the network call does not, so a slow PostHog cannot stall a request.
+    with _LEDGER_LOCK:
+        journey = get_or_create_journey(project_defaults)
+        if journey is None:
+            return False
 
-    steps = journey.get("steps") or {}
-    if step_id in steps:
-        return False
+        steps = journey.get("steps") or {}
+        if step_id in steps:
+            return False
 
-    now_ms = _now_ms()
-    started_at_ms = journey.get("started_at_ms")
-    previous_ms = max(steps.values()) if steps else None
+        now_ms = _now_ms()
+        previous_ms = max(steps.values()) if steps else None
 
-    # Claim the step BEFORE tracking. If the PostHog call throws we still do
-    # not want a retry storm re-firing the same mark on every page load; the
-    # ledger is the once-per-journey guarantee, not the network call.
-    steps[step_id] = now_ms
-    journey["steps"] = steps
-    _write_ledger(journey)
+        # Claim the step BEFORE tracking. If the PostHog call throws we still do
+        # not want a retry storm re-firing the same mark on every page load; the
+        # ledger is the once-per-journey guarantee, not the network call.
+        steps[step_id] = now_ms
+        journey["steps"] = steps
+        _write_ledger(journey)
 
-    payload = {
-        "journey_id": journey.get("journey_id"),
-        "step_id": step_id,
-        "step_index": STEP_INDEXES[step_id],
-        "ms_since_first_run": (
-            max(0, now_ms - started_at_ms) if isinstance(started_at_ms, int) else None
-        ),
-        "ms_since_previous_step": (
-            max(0, now_ms - previous_ms) if isinstance(previous_ms, int) else None
-        ),
-        "out_of_order": bool(isinstance(previous_ms, int) and now_ms < previous_ms),
-        **(properties or {}),
-    }
+        payload = {**_step_payload(journey, step_id, now_ms, previous_ms), **(properties or {})}
 
     try:
         from .client import get_telemetry_client
@@ -194,6 +409,51 @@ def mark_step(
     return True
 
 
+def record_viewer_step(
+    step_id: str,
+    journey_id: Optional[str] = None,
+    at_ms: Optional[int] = None,
+    project_defaults: Optional[object] = None,
+) -> bool:
+    """Record a mark the VIEWER already emitted into the server-side ledger.
+
+    Emits nothing — the browser has already sent the event. This exists so
+    "once per journey" survives leaving the browser origin the mark was made
+    in: ``localStorage`` is scoped to ``http://localhost:<port>``, so a second
+    browser, an incognito window, a cleared site-data, or simply ``visivo serve
+    -p 8001`` would otherwise re-fire every viewer mark under the same
+    ``journey_id`` and inflate the funnel. The file is not origin-scoped, and
+    the next page load seeds the viewer from it.
+
+    Never CREATES a journey: a mark can only be recorded against the journey
+    the server already handed the page.
+    """
+    if step_id not in STEP_INDEXES:
+        return False
+    if not is_telemetry_enabled(project_defaults):
+        return False
+
+    with _LEDGER_LOCK:
+        journey = read_ledger() or _cached_journey()
+        if journey is None:
+            return False
+        if journey_id and journey.get("journey_id") != journey_id:
+            # A mark from a different journey (a stale tab pointed at a home
+            # that has since been cleared) is not this journey's business.
+            return False
+
+        steps = journey.get("steps") or {}
+        if step_id in steps:
+            return False
+
+        recorded_at = at_ms if isinstance(at_ms, int) and at_ms > 0 else _now_ms()
+        steps[step_id] = recorded_at
+        journey["steps"] = steps
+        _write_ledger(journey)
+        _remember_journey(journey)
+        return True
+
+
 def viewer_journey_context(project_defaults: Optional[object] = None) -> Optional[Dict[str, Any]]:
     """The journey handed to the browser so viewer marks join the CLI's.
 
@@ -205,28 +465,29 @@ def viewer_journey_context(project_defaults: Optional[object] = None) -> Optiona
     ``~/.visivo/machine_id``); including it is what lets a viewer-side mark be
     joined to ``new_installation`` / ``cli_command`` in PostHog. It is already
     the distinct_id every CLI event ships under, and the page is served over
-    loopback to the person who owns the machine.
+    loopback to the person who owns the machine. It is read through the same
+    process-wide memo the events use — see ``_stable_machine_id``.
     """
     journey = get_or_create_journey(project_defaults)
     if journey is None:
         return None
 
-    machine_id = None
-    try:
-        from .machine_id import get_machine_id
-
-        machine_id = get_machine_id()
-    except Exception:
-        machine_id = None
+    install_age_ms = journey.get("install_age_ms")
 
     return {
         "journey_id": journey.get("journey_id"),
         "started_at_ms": journey.get("started_at_ms"),
-        "machine_id": machine_id,
+        "install_age_ms": install_age_ms if isinstance(install_age_ms, int) else None,
+        "machine_id": _stable_machine_id(),
         # Steps the CLI has already marked, with their timestamps: the viewer
         # never re-fires a step the server owns, and it can compute
         # `ms_since_previous_step` for its FIRST mark against the real previous
         # mark instead of guessing. A future CLI-side step is honoured without
-        # another round of JS changes.
+        # another round of JS changes. Viewer marks written back through
+        # `record_viewer_step` come back down this same channel, which is what
+        # dedupes them across browser origins.
         "steps": dict(journey.get("steps") or {}),
+        # Lets the terminal mark decide `from_sample` from the dashboard being
+        # rendered rather than from the onboarding branch the user took.
+        "sample_dashboards": bundled_sample_dashboard_names(),
     }

--- a/visivo/telemetry/first_run.py
+++ b/visivo/telemetry/first_run.py
@@ -1,0 +1,232 @@
+"""
+Time-to-value journey ledger (Guided First Run W1).
+
+The 2.1 exit gate is "8 of 8 new users build a dashboard in under 20 minutes
+with zero hand-written YAML". Nothing in the product could measure that, so
+this module owns the *start* of the ladder that makes it measurable:
+
+  1. first_run_launched      (here — the local server serving the viewer)
+  2. source_connected        (viewer)
+  3. first_query_run         (viewer)
+  4. first_model_created     (viewer)
+  5. first_insight_created   (viewer)
+  6. first_dashboard_rendered(viewer, terminal)
+
+The contract for every one of those marks — required properties, the frozen
+``step_index``, the ``from_sample`` filter the gate metric MUST be read with —
+lives in ``specs/marketing-relaunch/event-taxonomy.md`` §4 and is the source of
+record. This module implements steps that live on the CLI side of it.
+
+Why a file rather than in-memory state: the journey spans processes (a CLI that
+starts the server) and page reloads (a viewer the user navigates around for
+half an hour). ``~/.visivo/first_run.json`` sits beside ``machine_id``, holds a
+random ``journey_id`` plus the timestamps of the marks already emitted, and is
+what makes "exactly once per journey" true rather than "once per page load".
+
+Privacy posture, matching the rest of visivo.telemetry:
+
+  - ``journey_id`` is a random UUID. It identifies a *first run*, not a person,
+    and is derived from nothing about the user or their machine.
+  - No user-authored string ever enters a payload here — no project name, no
+    path, no source name. Counts and booleans only.
+  - When telemetry is disabled the ledger is never even created. An opted-out
+    user leaves no new file behind, which is a stronger guarantee than "we
+    write it but don't send it".
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .config import is_telemetry_enabled
+
+# Frozen step identities. See the taxonomy doc: these integers are assigned
+# once and never reassigned — a step added later takes the next unused integer
+# even when it falls mid-journey chronologically, because renumbering silently
+# redefines every historical funnel. Steps 2-6 are emitted by the viewer
+# (viewer/src/components/onboarding/timeToValue.js); they are listed here so
+# there is one place to read the ladder, and so the two sides cannot drift.
+STEP_INDEXES: Dict[str, int] = {
+    "first_run_launched": 1,
+    "source_connected": 2,
+    "first_query_run": 3,
+    "first_model_created": 4,
+    "first_insight_created": 5,
+    "first_dashboard_rendered": 6,
+}
+
+# The only step this module emits. The rest happen in the browser.
+STEP_FIRST_RUN_LAUNCHED = "first_run_launched"
+
+LEDGER_FILENAME = "first_run.json"
+
+
+def ledger_path() -> Path:
+    """Path to the journey ledger, beside ``machine_id`` in ``~/.visivo``."""
+    return Path.home() / ".visivo" / LEDGER_FILENAME
+
+
+def _now_ms() -> int:
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def read_ledger() -> Optional[Dict[str, Any]]:
+    """Return the parsed ledger, or None when absent/unreadable/corrupt.
+
+    A corrupt ledger is treated as absent rather than raising: telemetry must
+    never be able to break `visivo serve`.
+    """
+    try:
+        path = ledger_path()
+        if not path.exists():
+            return None
+        with open(path, "r") as ledger_file:
+            data = json.load(ledger_file)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not isinstance(data.get("journey_id"), str) or not data["journey_id"]:
+        return None
+    steps = data.get("steps")
+    if not isinstance(steps, dict):
+        data["steps"] = {}
+    return data
+
+
+def _write_ledger(data: Dict[str, Any]) -> bool:
+    """Best-effort ledger write. Returns True on success."""
+    try:
+        path = ledger_path()
+        path.parent.mkdir(exist_ok=True)
+        with open(path, "w") as ledger_file:
+            json.dump(data, ledger_file)
+        return True
+    except Exception:
+        # An unwritable home directory means we lose the journey, not that the
+        # server fails to serve a page.
+        return False
+
+
+def get_or_create_journey(project_defaults: Optional[object] = None) -> Optional[Dict[str, Any]]:
+    """Return this machine's first-run journey, creating it on first call.
+
+    Returns None when telemetry is disabled — and, critically, writes nothing
+    in that case, so an opted-out user never gets a ledger file at all.
+    """
+    if not is_telemetry_enabled(project_defaults):
+        return None
+
+    existing = read_ledger()
+    if existing is not None:
+        return existing
+
+    journey = {
+        "journey_id": str(uuid.uuid4()),
+        "started_at_ms": _now_ms(),
+        "steps": {},
+    }
+    _write_ledger(journey)
+    return journey
+
+
+def mark_step(
+    step_id: str,
+    properties: Optional[Dict[str, Any]] = None,
+    project_defaults: Optional[object] = None,
+) -> bool:
+    """Emit a time-to-value step mark, at most once per journey.
+
+    Returns True only when an event was actually tracked, so callers (and
+    tests) can distinguish "fired" from "already fired" and from "opted out".
+    Every failure mode — disabled telemetry, unknown step, unwritable ledger,
+    a PostHog client that raises — is swallowed into a False.
+    """
+    if step_id not in STEP_INDEXES:
+        return False
+    if not is_telemetry_enabled(project_defaults):
+        return False
+
+    journey = get_or_create_journey(project_defaults)
+    if journey is None:
+        return False
+
+    steps = journey.get("steps") or {}
+    if step_id in steps:
+        return False
+
+    now_ms = _now_ms()
+    started_at_ms = journey.get("started_at_ms")
+    previous_ms = max(steps.values()) if steps else None
+
+    # Claim the step BEFORE tracking. If the PostHog call throws we still do
+    # not want a retry storm re-firing the same mark on every page load; the
+    # ledger is the once-per-journey guarantee, not the network call.
+    steps[step_id] = now_ms
+    journey["steps"] = steps
+    _write_ledger(journey)
+
+    payload = {
+        "journey_id": journey.get("journey_id"),
+        "step_id": step_id,
+        "step_index": STEP_INDEXES[step_id],
+        "ms_since_first_run": (
+            max(0, now_ms - started_at_ms) if isinstance(started_at_ms, int) else None
+        ),
+        "ms_since_previous_step": (
+            max(0, now_ms - previous_ms) if isinstance(previous_ms, int) else None
+        ),
+        "out_of_order": bool(isinstance(previous_ms, int) and now_ms < previous_ms),
+        **(properties or {}),
+    }
+
+    try:
+        from .client import get_telemetry_client
+        from .events import FirstRunStepEvent
+
+        client = get_telemetry_client(enabled=True)
+        client.track(FirstRunStepEvent.create(step_id=step_id, properties=payload))
+    except Exception:
+        # Telemetry must never break the server.
+        return False
+    return True
+
+
+def viewer_journey_context(project_defaults: Optional[object] = None) -> Optional[Dict[str, Any]]:
+    """The journey handed to the browser so viewer marks join the CLI's.
+
+    Returns None when telemetry is disabled, so the served page carries no
+    journey and the viewer has nothing to mark — the opt-out needs no second
+    implementation on the JS side.
+
+    ``machine_id`` is the existing anonymous CLI identifier (a random UUID in
+    ``~/.visivo/machine_id``); including it is what lets a viewer-side mark be
+    joined to ``new_installation`` / ``cli_command`` in PostHog. It is already
+    the distinct_id every CLI event ships under, and the page is served over
+    loopback to the person who owns the machine.
+    """
+    journey = get_or_create_journey(project_defaults)
+    if journey is None:
+        return None
+
+    machine_id = None
+    try:
+        from .machine_id import get_machine_id
+
+        machine_id = get_machine_id()
+    except Exception:
+        machine_id = None
+
+    return {
+        "journey_id": journey.get("journey_id"),
+        "started_at_ms": journey.get("started_at_ms"),
+        "machine_id": machine_id,
+        # Steps the CLI has already marked, with their timestamps: the viewer
+        # never re-fires a step the server owns, and it can compute
+        # `ms_since_previous_step` for its FIRST mark against the real previous
+        # mark instead of guessing. A future CLI-side step is honoured without
+        # another round of JS changes.
+        "steps": dict(journey.get("steps") or {}),
+    }


### PR DESCRIPTION
## The problem

The 2.1 exit gate is **"8 of 8 new users build a dashboard in under 20 minutes with zero hand-written YAML"**, and today nothing in the product can measure it.

- The onboarding shim emits *gesture* events — clicks, dismissals, checklist rows — but nothing that marks where a first run actually **is**.
- The CLI emits `new_installation` / `cli_command` under an anonymous `machine_id`; the viewer's events ship under a browser distinct_id. The two halves of a first run could not be joined, so no span crossed the CLI→browser boundary.

The number the release is gated on was not computable from anything we ship. This PR emits the ladder it is read off.

## The ladder

| `step_index` | event | surface | fires when |
|---|---|---|---|
| 1 | `first_run_launched` | `cli` | the local Flask server serves the viewer's `index.html` for the first time on this machine |
| 2 | `source_connected` | `viewer` | a source save succeeds — onboarding's connect step **or** `sourceStore.saveSource` anywhere else |
| 3 | `first_query_run` | `viewer` | the first query executes in the SQL editor |
| 4 | `first_model_created` | `viewer` | the first `modelStore.saveModel` succeeds |
| 5 | `first_insight_created` | `viewer` | the first `insightStore.saveInsight` succeeds |
| 6 | `first_dashboard_rendered` | `viewer` | a named dashboard with ≥1 item mounts on `/project/:dashboardName` — **terminal** |

Every mark carries `journey_id`, `step_id`, `step_index`, `ms_since_first_run`, `ms_since_previous_step`, `machine_id`, and `out_of_order`. The whole span is one subtraction, and the minutes are attributable to a specific step rather than to "onboarding".

The ladder was derived from the onboarding + workspace code as it stands, not invented: steps 2–5 sit at the same choke points the onboarding checklist already taps (`recordOnboardingAction`), but as separate marks — that helper **no-ops until onboarding is complete**, and the ladder has to measure users who skipped onboarding too.

## Three decisions worth arguing with

**1. `from_sample` on the terminal mark.** This is finding TTV-5, and without it the metric is worse than nothing: rendering the bundled example project takes ~1s, while rendering a dashboard built from the user's own data took the field testers 26–108 minutes. Optimising the wrong one would look exactly like success. **The gate metric is `ms_since_first_run` on `first_dashboard_rendered` where `from_sample = false`.** Read without that filter it measures nothing, and the taxonomy says so in bold.

**2. The journey lives in `~/.visivo/first_run.json`, not in memory.** A first run spans a CLI process, a browser, and every reload in between. "Once per session" would re-fire marks on reload, inflate the funnel, and destroy the median. The server hands the journey to the page as `window.__VISIVO_FIRST_RUN` — beside the existing telemetry-disabled flag in `data_views.py` — so the browser's marks carry the CLI's `journey_id` and `machine_id` and join to `new_installation` / `cli_command` in PostHog.

**3. `step_index` is frozen identity, not sort order.** W3's scaffold marks (`table_profiled`, `scaffold_shown`, `scaffold_applied`) will take the **next unused integers** even though they fall mid-journey chronologically. Renumbering would silently redefine every historical funnel. Funnels order by timestamp.

## Contract first

Per `visivo/CLAUDE.md`, PostHog is the single source of activation truth and the cross-repo contract is `specs/marketing-relaunch/event-taxonomy.md`. **The taxonomy edit landed first**, in the separate `specs` repo, on branch **`guided-first-run-ttv-taxonomy`** (commit `744a299`) — §4 gains a "Time-to-value step marks" section with the ladder, the required properties, the `from_sample` rule, the frozen-index rule, and the opt-out posture; §6 gains an implementation pointer. Events are `snake_case`, additive, and nothing existing is renamed — note `source_connected` is deliberately the name the VIS-879 role-flow list already reserved, not a new `first_source_connected`.

## Opt-out and privacy

With telemetry disabled (`VISIVO_TELEMETRY_DISABLED`, `~/.visivo/config.yml`, or project `defaults.telemetry_enabled: false`) the server writes **no ledger at all**, injects no journey, and emits nothing; the viewer checks `window.__VISIVO_TELEMETRY_DISABLED` again before touching the event buffer, `localStorage`, or PostHog. A disabled run emits nothing **and leaves no new file behind** — a stronger guarantee than "we write it but don't send it". Verified by test on both sides, including that the real `~/.visivo/first_run.json` is never created by the full pytest run.

Payloads are counts, booleans, and random UUIDs. No source / model / insight / dashboard / column / file / project name, no SQL, no path. `journey_id` and `machine_id` identify a first run, not a person. The CLI still never sends or stores email.

## Files

**New**
- `visivo/telemetry/first_run.py` — the journey ledger, the frozen `STEP_INDEXES`, `mark_step`, `viewer_journey_context`
- `viewer/src/components/onboarding/timeToValue.js` — `markTimeToValueStep`, emitting through the existing `fireEvent` shim (`surface: viewer`)

**Changed**
- `visivo/telemetry/events.py` — `FirstRunStepEvent` (`surface: "cli"`, `machine_id` as a property so the halves join)
- `visivo/server/views/data_views.py` — mark step 1, inject the journey
- `viewer/.../onboarding/posthogClient.js` — export the existing `isTelemetryDisabled` gate (one word)
- `viewer/.../onboarding/OnboardingFlow.jsx`, `stores/sourceStore.js`, `stores/modelStore.js`, `stores/insightStore.js`, `explorer/SQLEditor.jsx`, `project/Project.jsx` — the five call sites

No pydantic model changed, so no schema regeneration and no conflict with #642. No file on the hot-conflict list is touched.

## Tests

- `viewer/.../onboarding/timeToValue.test.js` — 23
- `viewer/src/stores/timeToValueMarks.test.js` — 11 (call sites; success-only, once-per-journey, no names)
- `viewer/.../project/Project.timeToValue.test.jsx` — 11 (terminal mark, `from_sample`, item counting)
- `tests/telemetry/test_first_run.py` — 21
- `tests/server/views/test_data_views_telemetry.py` — +6

**Gates:** `yarn test --watchAll=false` → **369/369 suites, 7098/7098 tests**. `yarn lint` → clean. `pytest tests/` → **2497 passed, 2 skipped, 5 xfailed, 1 xpassed**. `black --check --target-version py312 .` → clean.

### Falsification

Each guard was removed, the tests re-run, and the tree restored. Every one failed as it should:

| Guard removed | Result |
|---|---|
| once-per-journey ledger check in `mark_step` | `test_marks_the_step_once_and_only_once`, `test_idempotence_survives_a_new_process` fail; server-side `test_the_mark_fires_once_per_machine_not_once_per_page_load` fails with `assert 4 == 1` |
| opt-out check in `mark_step` / `get_or_create_journey` | 4 `TestOptOut` failures, incl. a journey being handed to the viewer under an opt-out |
| journey injection in `data_views.py` | 3 failures — `journey script tag missing` |
| once-per-journey check in `markTimeToValueStep` | 3 failures, incl. the viewer re-firing a step the CLI owns |
| opt-out early return in `markTimeToValueStep` | opt-out marks emitted **and** a ledger written to `localStorage`; store-level "telemetry disabled" test fails too |
| `from_sample` on the terminal mark | 2 failures — `Expected: true, Received: undefined` (the TTV-5 trap goes unguarded) |
| `Item.rows` recursion in `countDashboardItems` | `Expected: 3, Received: 2` |

Full output: `scratchpad/lanes3/falsify_ttv_out.txt`.

## Known limit, stated plainly

`first_dashboard_rendered` fires when the dashboard **mounts** with ≥1 item, not when a chart has painted data. The paint-level signal lives in `items/Chart.jsx`, which is owned by an open PR (#656); tightening this to a real first-paint is a one-line follow-up there. Mount-with-items is the honest available proxy and the taxonomy describes it as exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
