### PR TITLE
fix(viewer/canvas): the resize ghost tells the truth — derive the preview from the row total, not COLS=12 (M26 / VIS-1260)

### DIFF
--- a/viewer/e2e/stories/canvas-resize-truthful-ghost.spec.mjs
+++ b/viewer/e2e/stories/canvas-resize-truthful-ghost.spec.mjs
@@ -13,9 +13,16 @@
  *
  *   1. TRUTHFUL PREVIEW — the ghost's box at release and the slot the drop
  *      actually renders agree within 2px, on a row whose widths do NOT sum to 12.
+ *      Checked on a NON-FIRST item as well: sum-normalization shrinks the tracks
+ *      in front of the dragged slot too, so the slot MOVES as it grows, and a
+ *      ghost pinned at the item's measured left is right about size and wrong
+ *      about place for every item except the first.
  *   2. HONEST READOUT — the readout's denominator is the live row total.
  *   3. DIRECT MANIPULATION — exactly ONE emphasized outline is on screen during
- *      the gesture, and the card being resized is faded underneath it.
+ *      the gesture, and the card being resized is faded underneath it. The count
+ *      spans the whole overlay stack: the selection overlay's persistent ring
+ *      carries the same marker (src/.../canvasEmphasis.js) and stands down for
+ *      the gesture, so "1" here is a real property, not a private label.
  *   4. ABORT — Escape drops the gesture: nothing commits and the card un-fades.
  *
  * Precondition: an isolated sandbox running the integration project.
@@ -99,8 +106,15 @@ const pressAndDrag = async (page, handle, dx) => {
   return { sx, sy };
 };
 
+// Mirrors EMPHASIZED_OUTLINE_SELECTOR in
+// src/components/views/project/canvas/canvasEmphasis.js. Every STRONG (2px
+// mulberry) outline on the canvas carries it — the resize ghost AND the
+// selection overlay's persistent ring — so this counts what the user sees, not
+// one component's private marker.
+const EMPHASIZED = '[data-canvas-outline="emphasized"]';
+
 const countEmphasizedOutlines = page =>
-  page.evaluate(() => document.querySelectorAll('[data-canvas-outline="emphasized"]').length);
+  page.evaluate(sel => document.querySelectorAll(sel).length, EMPHASIZED);
 
 const opacityOf = (page, canvasPath) =>
   page.evaluate(
@@ -193,6 +207,56 @@ test.describe('canvas resize ghost == drop (M26 / W7)', () => {
     expect(Number(total)).toBe(liveTotal);
   });
 
+  test('the ghost LANDS where it is painted on a NON-FIRST item', async () => {
+    // Item 0 is the one index whose left edge cannot move (its offset is 0 by
+    // construction), so the truthful-preview check above cannot see a frozen
+    // ghost `left`. Item 1 can — and on a `[1, 2]` row that grows to `[1, 6]`
+    // the slot slides left by a third of the row while the ghost, pre-fix,
+    // stayed put and hung off the right edge.
+    await openCanvas(page);
+    await setRowWidths(page, [1, 2]);
+    await expect
+      .poll(async () => (await readRows(page))[0].items.map(i => i.width).join(','), {
+        timeout: WAIT,
+      })
+      .toBe('1,2');
+
+    const itemKey = 'row.0.item.1';
+    await selectKey(page, itemKey);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
+    const before = (await readRows(page))[0].items[1].width;
+    await pressAndDrag(page, handle, Math.round(rowBox.width * 0.2));
+
+    const ghost = page.getByTestId('canvas-resize-ghost');
+    await expect(ghost).toBeVisible({ timeout: 4000 });
+    const ghostBox = await ghost.boundingBox();
+    // The ghost must stay INSIDE the row it previews — the frozen-left ghost
+    // was painted past the row's right edge on every last-item drag.
+    expect(
+      ghostBox.x + ghostBox.width,
+      `ghost right ${(ghostBox.x + ghostBox.width).toFixed(1)} vs row right ` +
+        `${(rowBox.x + rowBox.width).toFixed(1)}`
+    ).toBeLessThanOrEqual(rowBox.x + rowBox.width + 2);
+    await page.screenshot({ path: `${SCREENS}/m26-03-non-first-item.png`, fullPage: true });
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => (await readRows(page))[0].items[1].width, { timeout: WAIT })
+      .not.toBe(before);
+    const slot = await page.locator(`[data-canvas-path="${itemKey}"]`).first().boundingBox();
+    expect(
+      Math.abs(slot.width - ghostBox.width),
+      `ghost ${ghostBox.width.toFixed(1)}px vs rendered ${slot.width.toFixed(1)}px`
+    ).toBeLessThan(2);
+    expect(
+      Math.abs(slot.x - ghostBox.x),
+      `ghost left ${ghostBox.x.toFixed(1)}px vs rendered ${slot.x.toFixed(1)}px`
+    ).toBeLessThan(2);
+  });
+
   test('exactly one emphasized outline, and the card under it is faded', async () => {
     await openCanvas(page);
     await setRowWidths(page, [1, 2]);
@@ -201,19 +265,47 @@ test.describe('canvas resize ghost == drop (M26 / W7)', () => {
     const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
     await expect(handle).toBeVisible({ timeout: WAIT });
 
-    expect(await countEmphasizedOutlines(page)).toBe(0);
+    // At rest the one emphasized outline is the SELECTION ring — it carries the
+    // same marker, which is what makes the mid-gesture count below falsifiable.
+    await expect.poll(() => countEmphasizedOutlines(page), { timeout: 4000 }).toBe(1);
+    expect(await page.getByTestId('canvas-overlay-selected-item').count()).toBe(1);
     expect(await opacityOf(page, itemKey)).toBe('');
 
     const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
     await pressAndDrag(page, handle, Math.round(rowBox.width * 0.17));
 
+    // Still exactly one — now the ghost, with the selection ring stood down.
     expect(await countEmphasizedOutlines(page)).toBe(1);
+    expect(await page.getByTestId('canvas-resize-ghost').count()).toBe(1);
+    expect(await page.getByTestId('canvas-overlay-selected-item').count()).toBe(0);
     expect(await opacityOf(page, itemKey)).toBe('0.35');
     await page.screenshot({ path: `${SCREENS}/m26-02-single-outline.png`, fullPage: true });
 
     await page.mouse.up();
-    await expect.poll(() => countEmphasizedOutlines(page), { timeout: 4000 }).toBe(0);
+    // Back to one: the selection ring returns, the ghost is gone.
+    await expect.poll(() => countEmphasizedOutlines(page), { timeout: 4000 }).toBe(1);
+    await expect(page.getByTestId('canvas-resize-ghost')).toBeHidden({ timeout: 4000 });
     await expect.poll(() => opacityOf(page, itemKey), { timeout: 4000 }).toBe('');
+  });
+
+  test('a SOLO-item row gets no width handle — nothing there can move', async () => {
+    // Σ widths is the item's own width, so every span renders full-bleed. The
+    // affordance is withheld rather than painted-and-inert; the row's HEIGHT
+    // handle is still reachable from the same selection.
+    await openCanvas(page);
+    await setRowWidths(page, [12]);
+    await expect
+      .poll(async () => (await readRows(page))[0].items.map(i => i.width).join(','), {
+        timeout: WAIT,
+      })
+      .toBe('12');
+
+    const itemKey = 'row.0.item.0';
+    await selectKey(page, itemKey);
+    await expect(page.getByTestId(`canvas-resize-height-${itemKey}`)).toBeVisible({
+      timeout: WAIT,
+    });
+    expect(await page.getByTestId(`canvas-resize-width-${itemKey}`).count()).toBe(0);
   });
 
   test('Escape aborts the gesture: nothing commits and the card un-fades', async () => {

--- a/viewer/e2e/stories/canvas-resize-truthful-ghost.spec.mjs
+++ b/viewer/e2e/stories/canvas-resize-truthful-ghost.spec.mjs
@@ -1,0 +1,256 @@
+/**
+ * Story: the canvas resize ghost tells the truth (M26 / W7).
+ *
+ * `Item.width` is a RELATIVE weight, not a column index in a fixed 12-column
+ * grid: <Dashboard> lays a row out as `repeat(Σ widths, minmax(0, 1fr))` with a
+ * `0.7rem` gap, so growing one item grows the row's denominator too. The resize
+ * overlay used to preview against a hardcoded `COLS = 12` and scale the item's
+ * start box by `live / start`, which promised a size the drop could not deliver
+ * (a 1000px 6/6 row previewed 667px and committed 571px) and printed an `N / 12`
+ * readout on rows that were never 12 wide.
+ *
+ * What this story proves, by MEASURING the DOM rather than eyeballing it:
+ *
+ *   1. TRUTHFUL PREVIEW — the ghost's box at release and the slot the drop
+ *      actually renders agree within 2px, on a row whose widths do NOT sum to 12.
+ *   2. HONEST READOUT — the readout's denominator is the live row total.
+ *   3. DIRECT MANIPULATION — exactly ONE emphasized outline is on screen during
+ *      the gesture, and the card being resized is faded underneath it.
+ *   4. ABORT — Escape drops the gesture: nothing commits and the card un-fades.
+ *
+ * Precondition: an isolated sandbox running the integration project.
+ *   VISIVO_SANDBOX_BACKEND_PORT=8060 VISIVO_SANDBOX_FRONTEND_PORT=3060 \
+ *   VISIVO_SANDBOX_NAME=m26ghost bash scripts/sandbox.sh start
+ *   # then: VIS_GHOST_BASE=http://localhost:3060 npx playwright test canvas-resize-truthful-ghost
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.VIS_GHOST_BASE || 'http://localhost:3060';
+
+// Requires the DEDICATED isolated sandbox documented above (:8060/:3060). This
+// story REWRITES a dashboard row's widths to a deliberately non-12 shape, so it
+// must never be pointed at the shared :3001 sandbox. Without VIS_GHOST_BASE the
+// target does not exist and every test here would fail on
+// ERR_CONNECTION_REFUSED — skip loudly instead of going vacuously red. This is
+// an env-var opt-in gate, not a result-dependent skip.
+test.skip(
+  !process.env.VIS_GHOST_BASE,
+  'requires the isolated VIS_GHOST_BASE sandbox (see header) — not the shared :3001 sandbox'
+);
+
+const SCREENS = 'e2e/stories/__screens__';
+const DASHBOARD = 'simple-dashboard';
+const WAIT = 20000;
+
+// Wide enough that the row lays out side-by-side (below the stack breakpoint the
+// renderer switches to a column and there is no relative grid to preview).
+test.use({ viewport: { width: 1600, height: 1200 } });
+
+const readRows = page =>
+  page.evaluate(name => {
+    const s = window.useStore.getState();
+    const d = (s.dashboards || []).find(x => x.name === name);
+    const cfg = d ? d.config || d : null;
+    return cfg && Array.isArray(cfg.rows) ? cfg.rows : [];
+  }, DASHBOARD);
+
+const selectKey = (page, key) =>
+  page.evaluate(k => window.useStore.getState().setWorkspaceOutlineSelectedKey(k), key);
+
+// Force row 0 into a shape whose widths do NOT total 12 — the case the old
+// hardcoded grid got wrong on every drag.
+const setRowWidths = (page, widths) =>
+  page.evaluate(
+    ({ name, ws }) => {
+      const s = window.useStore.getState();
+      const entry = (s.dashboards || []).find(d => d.name === name);
+      const cfg = JSON.parse(JSON.stringify(entry.config || entry));
+      cfg.rows[0].items = cfg.rows[0].items
+        .slice(0, ws.length)
+        .map((item, i) => ({ ...item, width: ws[i] }));
+      s.updateDashboardConfigOptimistic(name, cfg);
+    },
+    { name: DASHBOARD, ws: widths }
+  );
+
+const openCanvas = async page => {
+  await page.goto(`${BASE}/workspace/dashboard/${DASHBOARD}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('project-canvas')).toBeVisible({ timeout: WAIT });
+  const dash = page.getByTestId(`dashboard_${DASHBOARD}`);
+  await expect(dash).toBeVisible({ timeout: WAIT });
+  await expect(dash.locator('[data-row-index]').first()).toBeVisible({ timeout: WAIT });
+};
+
+// Press the handle and travel to (centre + dx) WITHOUT releasing, so the caller
+// can measure the live ghost mid-gesture.
+const pressAndDrag = async (page, handle, dx) => {
+  await handle.scrollIntoViewIfNeeded();
+  const b = await handle.boundingBox();
+  expect(b, 'the resize handle has a box').toBeTruthy();
+  const sx = b.x + b.width / 2;
+  const sy = b.y + b.height / 2;
+  await page.mouse.move(sx, sy);
+  await page.mouse.down();
+  await page.mouse.move(sx + Math.sign(dx) * 4, sy, { steps: 4 });
+  await page.mouse.move(sx + dx, sy, { steps: 20 });
+  await page.mouse.move(sx + dx, sy, { steps: 4 });
+  return { sx, sy };
+};
+
+const countEmphasizedOutlines = page =>
+  page.evaluate(() => document.querySelectorAll('[data-canvas-outline="emphasized"]').length);
+
+const opacityOf = (page, canvasPath) =>
+  page.evaluate(
+    p => document.querySelector(`[data-canvas-path="${p}"]`)?.style.opacity ?? null,
+    canvasPath
+  );
+
+test.describe('canvas resize ghost == drop (M26 / W7)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120000);
+
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page._consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') page._consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('the ghost at release is the slot the drop renders (row total ≠ 12)', async () => {
+    await openCanvas(page);
+    const rows = await readRows(page);
+    expect(rows[0].items.length, 'row 0 has ≥2 items').toBeGreaterThanOrEqual(2);
+
+    // A 1 + 2 row: three grid columns, nothing like twelve.
+    await setRowWidths(page, [1, 2]);
+    await expect
+      .poll(async () => (await readRows(page))[0].items.map(i => i.width).join(','), {
+        timeout: WAIT,
+      })
+      .toBe('1,2');
+
+    const itemKey = 'row.0.item.0';
+    await selectKey(page, itemKey);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
+    // Ask for roughly half the row — on a 1/3 slot that is a real change.
+    await pressAndDrag(page, handle, Math.round(rowBox.width * 0.17));
+
+    const ghost = page.getByTestId('canvas-resize-ghost');
+    await expect(ghost).toBeVisible({ timeout: 4000 });
+    const ghostBox = await ghost.boundingBox();
+    await page.screenshot({ path: `${SCREENS}/m26-01-truthful-ghost.png`, fullPage: true });
+    await page.mouse.up();
+
+    // The commit re-lays the row out; wait for the width to land, then MEASURE
+    // the slot the renderer produced and compare it to the ghost we just saw.
+    await expect
+      .poll(async () => (await readRows(page))[0].items[0].width, { timeout: WAIT })
+      .not.toBe(1);
+    const slot = await page.locator(`[data-canvas-path="${itemKey}"]`).first().boundingBox();
+    expect(
+      Math.abs(slot.width - ghostBox.width),
+      `ghost ${ghostBox.width.toFixed(1)}px vs rendered ${slot.width.toFixed(1)}px`
+    ).toBeLessThan(2);
+    expect(Math.abs(slot.x - ghostBox.x)).toBeLessThan(2);
+  });
+
+  test('the readout denominator is the live row total, never a hardcoded 12', async () => {
+    await openCanvas(page);
+    await setRowWidths(page, [1, 2]);
+    const itemKey = 'row.0.item.0';
+    await selectKey(page, itemKey);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
+    await pressAndDrag(page, handle, Math.round(rowBox.width * 0.17));
+
+    const readout = page.getByTestId('canvas-resize-readout');
+    await expect(readout).toBeVisible({ timeout: 4000 });
+    const text = (await readout.textContent()).trim();
+    await page.mouse.up();
+
+    // `N / <row total>`: the total this drag rebalances TO — 2 + 2 = 4 here.
+    const [, span, total] = text.match(/(\d+)\s*\/\s*(\d+)/) || [];
+    expect(span, `readout was "${text}"`).toBeTruthy();
+    const rowsAfter = await readRows(page);
+    const liveTotal = rowsAfter[0].items.reduce((s, i) => s + (i.width || 1), 0);
+    expect(Number(span)).toBe(rowsAfter[0].items[0].width);
+    expect(Number(total)).toBe(liveTotal);
+  });
+
+  test('exactly one emphasized outline, and the card under it is faded', async () => {
+    await openCanvas(page);
+    await setRowWidths(page, [1, 2]);
+    const itemKey = 'row.0.item.0';
+    await selectKey(page, itemKey);
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+
+    expect(await countEmphasizedOutlines(page)).toBe(0);
+    expect(await opacityOf(page, itemKey)).toBe('');
+
+    const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
+    await pressAndDrag(page, handle, Math.round(rowBox.width * 0.17));
+
+    expect(await countEmphasizedOutlines(page)).toBe(1);
+    expect(await opacityOf(page, itemKey)).toBe('0.35');
+    await page.screenshot({ path: `${SCREENS}/m26-02-single-outline.png`, fullPage: true });
+
+    await page.mouse.up();
+    await expect.poll(() => countEmphasizedOutlines(page), { timeout: 4000 }).toBe(0);
+    await expect.poll(() => opacityOf(page, itemKey), { timeout: 4000 }).toBe('');
+  });
+
+  test('Escape aborts the gesture: nothing commits and the card un-fades', async () => {
+    await openCanvas(page);
+    await setRowWidths(page, [1, 2]);
+    const itemKey = 'row.0.item.0';
+    await selectKey(page, itemKey);
+    const before = (await readRows(page))[0].items.map(i => i.width).join(',');
+
+    const handle = page.getByTestId(`canvas-resize-width-${itemKey}`);
+    await expect(handle).toBeVisible({ timeout: WAIT });
+    const rowBox = await page.locator('[data-canvas-path="row.0"]').first().boundingBox();
+    await pressAndDrag(page, handle, Math.round(rowBox.width * 0.17));
+    expect(await countEmphasizedOutlines(page)).toBe(1);
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('canvas-resize-ghost')).toBeHidden({ timeout: 4000 });
+    await page.mouse.up();
+
+    expect(await opacityOf(page, itemKey)).toBe('');
+    await page.waitForTimeout(500);
+    expect((await readRows(page))[0].items.map(i => i.width).join(',')).toBe(before);
+  });
+
+  test('no console errors AND no auto-save 400 across the gestures', async () => {
+    const NOISE = [
+      'favicon',
+      'DevTools',
+      'react-cool',
+      'ResizeObserver',
+      'Download the React DevTools',
+    ];
+    const real = page._consoleErrors.filter(e => !NOISE.some(n => e.includes(n)));
+    const saveFailures = page._consoleErrors.filter(
+      e => e.includes('400') || e.toLowerCase().includes('bad request')
+    );
+    expect(saveFailures, 'resize must persist backend-valid config (sanitize)').toHaveLength(0);
+    expect(real).toHaveLength(0);
+  });
+});

--- a/viewer/e2e/tools/measure-canvas-grid.mjs
+++ b/viewer/e2e/tools/measure-canvas-grid.mjs
@@ -1,0 +1,248 @@
+/**
+ * measure-canvas-grid — the measurement harness behind canvasGridGeometry's
+ * "browser-measured" fixtures (M26 / VIS-1260).
+ *
+ * `canvasGridGeometry.js` claims to reproduce, in arithmetic, the geometry CSS
+ * grid resolves for a <Dashboard> row. That claim is only worth something if
+ * somebody can re-run it, so this script is the runnable proof: it builds rows
+ * in headless Chromium using Dashboard.renderRow's EXACT styles
+ * (`repeat(Σ widths, minmax(0, 1fr))`, `gap: 0.7rem`, `min-width: 0` items),
+ * measures every slot with `getBoundingClientRect()`, and diffs the numbers
+ * against the formulas the overlay previews with — width AND left offset.
+ *
+ * It also replays the full resize round-trip per row shape: for every item and
+ * every reachable span it computes the ghost the overlay paints, commits that
+ * span (sum-normalizing the row exactly as `setItemWidth` does), re-lays the row
+ * out in the browser, and reports the worst |ghost − rendered| for both edges.
+ *
+ * Run (from `viewer/`, browsers already provisioned by Playwright):
+ *
+ *     node e2e/tools/measure-canvas-grid.mjs
+ *     node e2e/tools/measure-canvas-grid.mjs --json    # machine-readable
+ *
+ * It is NOT a Playwright test (no `.spec.mjs` suffix, so `playwright.config.mjs`
+ * never collects it) and it touches no sandbox — it needs nothing but a browser.
+ * Exit code is non-zero if any measured deviation exceeds MAX_DEVIATION_PX.
+ */
+import { readFileSync } from 'node:fs';
+import { chromium } from '@playwright/test';
+
+// `viewer/package.json` has no `"type": "module"`, so Node parses a `.js` file
+// under `src/` as CommonJS and chokes on its `export` statements. The geometry
+// module has NO imports of its own, so loading its real source through a
+// `data:` URL runs the actual shipped code with no build step and no flags —
+// re-implementing the formulas here would defeat the entire point of the check.
+const GEOMETRY_SRC = new URL(
+  '../../src/components/views/project/canvas/canvasGridGeometry.js',
+  import.meta.url
+);
+const {
+  itemSlotWidthPx,
+  precedingColsInRow,
+  previewItemWidthPx,
+  previewItemLeftShiftPx,
+  rowGridTotal,
+  spanLeftOffsetPx,
+  MAX_ITEM_WIDTH,
+} = await import(
+  `data:text/javascript;base64,${readFileSync(GEOMETRY_SRC).toString('base64')}`
+);
+
+// A sub-pixel tolerance: Chromium resolves fr tracks with LayoutUnit (1/64 =
+// 0.015625px) precision and that rounding accumulates across the tracks a slot
+// straddles, so an exact float match is not achievable. Anything approaching a
+// tenth of a pixel would mean the formula is a DIFFERENT formula.
+const MAX_DEVIATION_PX = 0.05;
+
+// Row shapes worth measuring: even splits, lopsided splits, prime totals, the
+// degenerate solo row, and a row whose widths happen to total 12 (the shape the
+// pre-M26 hardcoded grid got right by accident).
+const SHAPES = [
+  { widths: [6, 6], rowWidth: 1000 },
+  { widths: [1, 2], rowWidth: 900 },
+  { widths: [3, 5, 1], rowWidth: 1200 },
+  { widths: [2, 3], rowWidth: 960 },
+  { widths: [9, 2], rowWidth: 800 },
+  { widths: [12], rowWidth: 900 },
+  { widths: [3, 3, 3, 3], rowWidth: 1140 },
+  { widths: [7, 2, 4, 1], rowWidth: 1013 },
+  { widths: [2, 2, 2, 2], rowWidth: 1200 },
+  { widths: [1, 1, 1, 1, 1], rowWidth: 777 },
+];
+
+// Lay a row out with Dashboard.renderRow's exact grid styles and hand back each
+// slot's measured left offset (relative to the row) and width.
+const measureRow = (page, widths, rowWidth) =>
+  page.evaluate(
+    ({ ws, rw }) => {
+      const host = document.getElementById('host');
+      host.style.width = `${rw}px`;
+      host.innerHTML = '';
+      const total = ws.reduce((s, w) => s + (w || 1), 0) || 1;
+      const row = document.createElement('div');
+      // ── Dashboard.jsx renderRow ──────────────────────────────────────────
+      row.style.display = 'grid';
+      row.style.gridTemplateColumns = `repeat(${total}, minmax(0, 1fr))`;
+      row.style.gap = '0.7rem';
+      row.style.marginTop = '0.5rem';
+      row.style.marginBottom = '0.5rem';
+      row.style.minWidth = '0';
+      row.style.width = '100%';
+      row.style.maxWidth = '100%';
+      ws.forEach(w => {
+        const cell = document.createElement('div');
+        cell.style.gridColumn = `span ${w || 1}`;
+        cell.style.width = 'auto';
+        cell.style.minWidth = '0';
+        cell.style.overflow = 'hidden';
+        row.appendChild(cell);
+      });
+      // ─────────────────────────────────────────────────────────────────────
+      host.appendChild(row);
+      const rowRect = row.getBoundingClientRect();
+      return {
+        rowWidth: rowRect.width,
+        columnGapPx: parseFloat(getComputedStyle(row).columnGap),
+        slots: Array.from(row.children).map(cell => {
+          const r = cell.getBoundingClientRect();
+          return { left: r.left - rowRect.left, width: r.width };
+        }),
+      };
+    },
+    { ws: widths, rw: rowWidth }
+  );
+
+// Nothing in this file re-implements the geometry: every number under test
+// comes out of the module itself, so a mutation there shows up here.
+const precedingColsOf = (widths, index) =>
+  precedingColsInRow(
+    widths.map(width => ({ width })),
+    index
+  );
+
+const run = async () => {
+  const asJson = process.argv.includes('--json');
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+  await page.setContent(
+    '<!doctype html><html><body style="margin:0;font-size:16px">' +
+      '<div id="host" style="position:relative"></div></body></html>'
+  );
+
+  const report = [];
+  let worstStatic = 0;
+  let worstGhostWidth = 0;
+  let worstGhostLeft = 0;
+  let worstFrozenLeft = 0; // what a ghost pinned at `box.left` would be off by
+
+  for (const { widths, rowWidth } of SHAPES) {
+    const measured = await measureRow(page, widths, rowWidth);
+    const startTotal = rowGridTotal(widths.map(width => ({ width })));
+    const gap = measured.columnGapPx;
+
+    // 1. STATIC: does the formula reproduce the rendered row as-is?
+    const staticRows = measured.slots.map((slot, index) => {
+      const formulaWidth = itemSlotWidthPx({
+        rowWidth: measured.rowWidth,
+        totalCols: startTotal,
+        spanCols: widths[index],
+        gapPx: gap,
+      });
+      const formulaLeft = spanLeftOffsetPx({
+        rowWidth: measured.rowWidth,
+        totalCols: startTotal,
+        precedingCols: precedingColsOf(widths, index),
+        gapPx: gap,
+      });
+      const dWidth = Math.abs(formulaWidth - slot.width);
+      const dLeft = Math.abs(formulaLeft - slot.left);
+      worstStatic = Math.max(worstStatic, dWidth, dLeft);
+      return { index, dWidth, dLeft };
+    });
+
+    // 2. ROUND TRIP: ghost (what the overlay paints) vs. the committed re-layout.
+    for (let index = 0; index < widths.length; index += 1) {
+      const startCols = widths[index];
+      const preceding = precedingColsOf(widths, index);
+      const startLeft = measured.slots[index].left;
+      for (let span = 1; span <= MAX_ITEM_WIDTH; span += 1) {
+        const ghostWidth = previewItemWidthPx({
+          rowWidth: measured.rowWidth,
+          startTotal,
+          startCols,
+          spanCols: span,
+          gapPx: gap,
+        });
+        const ghostLeft =
+          startLeft +
+          previewItemLeftShiftPx({
+            rowWidth: measured.rowWidth,
+            startTotal,
+            startCols,
+            spanCols: span,
+            precedingCols: preceding,
+            gapPx: gap,
+          });
+
+        const committed = widths.slice();
+        committed[index] = span;
+        const after = await measureRow(page, committed, rowWidth);
+        const rendered = after.slots[index];
+
+        worstGhostWidth = Math.max(worstGhostWidth, Math.abs(ghostWidth - rendered.width));
+        worstGhostLeft = Math.max(worstGhostLeft, Math.abs(ghostLeft - rendered.left));
+        // The pre-fix ghost froze `left` at the item's start box.
+        worstFrozenLeft = Math.max(worstFrozenLeft, Math.abs(startLeft - rendered.left));
+      }
+    }
+
+    report.push({
+      widths,
+      rowWidth,
+      measuredRowWidth: measured.rowWidth,
+      columnGapPx: gap,
+      slots: measured.slots,
+      staticRows,
+    });
+  }
+
+  await browser.close();
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { report, worstStatic, worstGhostWidth, worstGhostLeft, worstFrozenLeft },
+        null,
+        2
+      )
+    );
+  } else {
+    for (const r of report) {
+      console.log(
+        `[${r.widths.join(',')}] @${r.measuredRowWidth.toFixed(2)}px gap=${r.columnGapPx}px`
+      );
+      r.slots.forEach((slot, i) => {
+        console.log(
+          `    item ${i}: left=${slot.left.toFixed(4)}  width=${slot.width.toFixed(4)}` +
+            `   Δleft=${r.staticRows[i].dLeft.toFixed(6)}  Δwidth=${r.staticRows[i].dWidth.toFixed(6)}`
+        );
+      });
+    }
+    console.log('');
+    console.log(`worst |formula − rendered| (static)       = ${worstStatic.toFixed(6)}px`);
+    console.log(`worst |ghost − rendered| (width)          = ${worstGhostWidth.toFixed(6)}px`);
+    console.log(`worst |ghost − rendered| (left)           = ${worstGhostLeft.toFixed(6)}px`);
+    console.log(`worst |frozen box.left − rendered| (left) = ${worstFrozenLeft.toFixed(6)}px  <- pre-fix`);
+  }
+
+  const worst = Math.max(worstStatic, worstGhostWidth, worstGhostLeft);
+  if (worst > MAX_DEVIATION_PX) {
+    console.error(`FAIL: worst deviation ${worst.toFixed(6)}px > ${MAX_DEVIATION_PX}px`);
+    process.exitCode = 1;
+  }
+};
+
+run().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/viewer/src/components/views/project/canvas/CanvasResizeLayer.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasResizeLayer.jsx
@@ -11,9 +11,12 @@ import {
   heightEnumToPixels,
   pixelsToNearestHeightEnum,
 } from './canvasReorder';
+import { EMPHASIZED_OUTLINE_PROPS } from './canvasEmphasis';
 import {
   MAX_ITEM_WIDTH,
   nearestSpanForWidth,
+  precedingColsInRow,
+  previewItemLeftShiftPx,
   previewItemWidthPx,
   readColumnGapPx,
   rowGridTotal,
@@ -58,13 +61,25 @@ import {
  *   - Container CORNER (⤡ both axes): on a container item (Item.rows non-empty)
  *     a se-resize corner resizes width + height in one gesture.
  *
+ * The ghost is truthful in BOTH axes. Width comes from `previewItemWidthPx`;
+ * the LEFT edge comes from `previewItemLeftShiftPx`, because sum-normalization
+ * shrinks the tracks in FRONT of the item too, sliding the slot left as it
+ * grows. A ghost pinned at the item's measured `left` is only right for the
+ * first item in a row — on a `[2,2,2,2]` row the last item's slot lands ~390px
+ * left of a frozen ghost, and the ghost is painted hanging off the row's right
+ * edge (measured: 592px worst case, `e2e/tools/measure-canvas-grid.mjs`).
+ *
  * The chart inside the slot stays STATIC during the drag: we never re-layout the
  * Dashboard mid-gesture. The overlay paints ONE emphasized mulberry ghost at the
  * live target geometry and FADES the card being resized (a direct imperative
  * opacity on the measured node, restored on release / Esc / pointercancel /
- * unmount), so a gesture shows exactly one outline and it is unambiguous which
- * geometry will land. The new config commits on pointer-UP, so the expensive
- * chart re-render happens once, at drag-end.
+ * unmount). The gesture also publishes `workspaceCanvasResizeKey`, which parks
+ * <CanvasSelectionOverlay>'s persistent mulberry ring for the duration — that
+ * ring lives in a SIBLING layer, so the card fade cannot dim it, and leaving it
+ * up would put a full-strength 2px ring at the pre-drag geometry next to an
+ * identical one at the target. One gesture, one emphasized outline. The new
+ * config commits on pointer-UP, so the expensive chart re-render happens once,
+ * at drag-end.
  *
  * Pointer handling is RAW (not dnd-kit): the handle calls `setPointerCapture` on
  * pointer-down so a canvas reflow mid-drag (charts finishing load, the optimistic
@@ -148,6 +163,11 @@ const resolveSelection = (config, key) => {
 const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   const selectedKey = useStore(s => s.workspaceOutlineSelectedKey);
   const dashboards = useStore(s => s.dashboards);
+  // Published to the store for the LIFE OF A GESTURE so the sibling
+  // <CanvasSelectionOverlay> can park its persistent selection ring — the one
+  // competing emphasized outline the card fade cannot reach (it is not inside
+  // the faded node).
+  const setCanvasResizeKey = useStore(s => s.setWorkspaceCanvasResizeKey);
   const commitCanvasConfig = useCommitCanvasConfig();
 
   const dashboardConfig = useMemo(() => {
@@ -262,6 +282,25 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   }, [selection]);
   const hasLeftNeighbor = itemIndexInRow > 0;
 
+  // How many grid columns sit in FRONT of this item in its row. This is what
+  // makes the ghost's left edge truthful: those tracks shrink when a right-edge
+  // drag grows the row total, so the slot slides left as it grows.
+  const precedingCols = useMemo(() => {
+    if (!selection?.isItem || itemIndexInRow < 0) return 0;
+    return precedingColsInRow(selection.itemsInRow, itemIndexInRow);
+  }, [selection, itemIndexInRow]);
+
+  // Is this item the ONLY item in its row? Then Σ widths IS its own width, so
+  // every span renders full-bleed and the width gesture cannot move a single
+  // pixel (see `nearestSpanForWidth`'s tie-break). Painting a width handle there
+  // is a dead affordance — the ghost, the readout and the drag would all sit
+  // still — so the handle is withheld and the row keeps only its height handle.
+  // The item's stored weight stays editable in the right-rail Edit form, where
+  // it is a number, not a promise about geometry.
+  const isSoloInRow = !!(
+    selection?.isItem && rowGridTotal(selection.itemsInRow) === (selection.item?.width || 1)
+  );
+
   // ── Faded card ────────────────────────────────────────────────────────────
   // The gesture paints ONE emphasized outline (the ghost). To keep the target
   // unambiguous, the card being resized fades underneath it rather than getting
@@ -293,9 +332,18 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     [rootRef, restoreFadedNode]
   );
 
+  // End-of-gesture chrome teardown: un-fade the card AND hand the selection
+  // ring back to <CanvasSelectionOverlay>. Every exit path (release, Esc,
+  // pointercancel, unmount) goes through here — a gesture that ends without
+  // clearing the key would leave the canvas with no selection ring at all.
+  const clearGestureChrome = useCallback(() => {
+    restoreFadedNode();
+    if (setCanvasResizeKey) setCanvasResizeKey(null);
+  }, [restoreFadedNode, setCanvasResizeKey]);
+
   // An unmount mid-gesture (route change, canvas teardown) must not leave a card
-  // stranded at 35% opacity.
-  useEffect(() => () => restoreFadedNode(), [restoreFadedNode]);
+  // stranded at 35% opacity — or the selection ring parked forever.
+  useEffect(() => () => clearGestureChrome(), [clearGestureChrome]);
 
   const beginDrag = useCallback(
     (e, kind) => {
@@ -371,6 +419,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         rebalance,
         maxCols,
         startSlotPx,
+        precedingCols,
         startCols,
         liveCols: startCols,
         liveTotal: startTotal,
@@ -394,6 +443,10 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       fadeNodeAtPath(
         kind === 'height' && selectedKind === 'item' ? parentRowPathOf(selectedKey) : selectedKey
       );
+      // …and park the selection overlay's persistent ring. It sits in a SIBLING
+      // layer at the PRE-DRAG geometry, so the fade above cannot touch it and it
+      // would otherwise read as a second, equally emphasized target.
+      if (setCanvasResizeKey) setCanvasResizeKey(selectedKey);
 
       // Capture the pointer on the handle so a reflow mid-drag can't drop the
       // gesture (the canvas-overlay gotcha — the canvas reflows on the
@@ -413,10 +466,12 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       rowPathForItem,
       itemIndexInRow,
       hasLeftNeighbor,
+      precedingCols,
       rootRef,
       selectedKey,
       selectedKind,
       fadeNodeAtPath,
+      setCanvasResizeKey,
     ]
   );
 
@@ -487,7 +542,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     const onAbort = () => {
       dragRef.current = null;
       setDrag(null);
-      restoreFadedNode();
+      clearGestureChrome();
       measureBox();
     };
 
@@ -501,7 +556,7 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       const d = dragRef.current;
       dragRef.current = null;
       setDrag(null);
-      restoreFadedNode();
+      clearGestureChrome();
       if (!d || !selection || !dashboardConfig) {
         measureBox();
         return;
@@ -574,20 +629,30 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     itemIndexInRow,
     commitCanvasConfig,
     measureBox,
-    restoreFadedNode,
+    clearGestureChrome,
   ]);
 
   if (!dashboardConfig || !box || selectedKind === 'chrome' || !selection) return null;
 
-  // Ghost geometry while dragging — THE TRUTHFUL PREVIEW (M26).
+  // Ghost geometry while dragging — THE TRUTHFUL PREVIEW (M26), in BOTH axes.
   //
-  // The width is the pixel width the slot will actually render at once the new
-  // relative weight is committed: `previewItemWidthPx` re-derives it from the
+  // WIDTH: the pixel width the slot will actually render at once the new
+  // relative weight is committed. `previewItemWidthPx` re-derives it from the
   // row's measured width, its live gap and the SUM-NORMALIZED total (which moves
-  // with a right-edge drag), exactly as <Dashboard> lays the row out. We express
-  // it as a RATIO against the item's own start slot so the ghost is anchored to
-  // the measured box — zero travel is pixel-identical to the card underneath,
-  // and any canvas scale/zoom cancels out.
+  // with a right-edge drag), exactly as <Dashboard> lays the row out.
+  //
+  // LEFT: the slot MOVES as well as grows. Sum-normalization shrinks every
+  // track, including the `precedingCols` tracks in front of this item, so a
+  // right-edge drag slides the slot LEFT while widening it. Freezing the ghost's
+  // left at `box.left` was right only for the first item in a row; on
+  // `[2,2,2,2]` the last item's committed slot lands ~390px away from such a
+  // ghost, and the ghost is drawn hanging off the row's right edge.
+  // `previewItemLeftShiftPx` supplies that delta (0 for the first item, and 0
+  // for a left-edge transfer, which anchors the RIGHT edge instead).
+  //
+  // Both are applied as a RATIO/OFFSET against the item's own measured start
+  // box, so zero travel is pixel-identical to the card underneath and any canvas
+  // scale/zoom cancels out.
   //
   // Height gestures stretch the box to their live pixel height. Pure geometry on
   // the overlay — the Dashboard render below is untouched (chart stays static).
@@ -597,6 +662,17 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       startTotal: drag.startTotal,
       startCols: drag.startCols,
       spanCols,
+      gapPx: drag.gapPx,
+      rebalance: drag.rebalance,
+    });
+
+  const previewLeftShiftFor = spanCols =>
+    previewItemLeftShiftPx({
+      rowWidth: drag.rowWidth,
+      startTotal: drag.startTotal,
+      startCols: drag.startCols,
+      spanCols,
+      precedingCols: drag.precedingCols,
       gapPx: drag.gapPx,
       rebalance: drag.rebalance,
     });
@@ -618,11 +694,17 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     let h = box.height;
     let left = box.left;
     if (drag.kind === 'width' || drag.kind === 'corner' || drag.kind === 'width-left') {
-      w = box.width * (previewWidthFor(drag.liveCols) / Math.max(1, drag.startSlotPx));
+      // One scale factor for both axes: the measured box over the formula's
+      // idea of the same slot. It is 1 on an untransformed canvas and absorbs a
+      // zoom otherwise, and it keeps the ghost welded to the card at zero travel.
+      const scale = box.width / Math.max(1, drag.startSlotPx);
+      w = previewWidthFor(drag.liveCols) * scale;
+      left = box.left + previewLeftShiftFor(drag.liveCols) * scale;
     }
     if (drag.kind === 'width-left') {
-      // The left-edge gesture moves the LEFT boundary: anchor the right edge and
-      // extend leftward as the span grows.
+      // The left-edge gesture moves the LEFT boundary: columns only TRANSFER
+      // across the shared boundary, so the row total — and every track — holds
+      // still and the slot's RIGHT edge is the fixed point.
       left = box.left + box.width - w;
     }
     if (drag.kind === 'corner') {
@@ -640,12 +722,17 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   // left-edge width handle that moves the shared boundary; the first item in a
   // row has no shared left boundary and so gets no left handle.
   //
+  // An item that is ALONE in its row gets no width handle at all: Σ widths is
+  // its own width, so every span renders full-bleed and the gesture provably
+  // cannot move a pixel. A handle that paints a ghost, prints a frozen readout
+  // and then does nothing is exactly the kind of lie this lane exists to remove.
+  //
   // DURING a gesture only the handle being dragged is painted: the others sit at
   // the pre-drag geometry, which the ghost has already moved on from, and a
   // solid mulberry bar at a stale edge is exactly the second emphasis M26 asks
   // us to delete.
   const dragging = !!drag;
-  const showWidthHandle = selection.isItem && (!dragging || drag.kind === 'width');
+  const showWidthHandle = selection.isItem && !isSoloInRow && (!dragging || drag.kind === 'width');
   const showLeftWidthHandle =
     selection.isItem && hasLeftNeighbor && (!dragging || drag.kind === 'width-left');
   const showHeightHandle =
@@ -672,14 +759,15 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     >
       {/* Drag ghost — the live target geometry, painted only during a gesture,
           and the ONLY emphasized outline on screen while it is (M26). The card
-          it will replace is faded imperatively instead of getting a second
+          it will replace is faded imperatively and the sibling selection ring is
+          parked (see `setCanvasResizeKey` above) instead of leaving a second
           competing frame, so "what lands where" is unambiguous: one solid 2px
           mulberry ring at the geometry the drop produces, lifted off the canvas
           by a soft drop shadow (a shadow, not a second ring). */}
       {drag && ghost && (
         <div
           data-testid="canvas-resize-ghost"
-          data-canvas-outline="emphasized"
+          {...EMPHASIZED_OUTLINE_PROPS}
           aria-hidden="true"
           className="pointer-events-none absolute rounded-md"
           style={{

--- a/viewer/src/components/views/project/canvas/CanvasResizeLayer.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasResizeLayer.jsx
@@ -11,6 +11,13 @@ import {
   heightEnumToPixels,
   pixelsToNearestHeightEnum,
 } from './canvasReorder';
+import {
+  MAX_ITEM_WIDTH,
+  nearestSpanForWidth,
+  previewItemWidthPx,
+  readColumnGapPx,
+  rowGridTotal,
+} from './canvasGridGeometry';
 
 /**
  * CanvasResizeLayer — VIS-777 / Track D D-4 (design D-3 "Resize handles").
@@ -23,9 +30,21 @@ import {
  * mutation persisted through the shell's shared `commitCanvasConfig`
  * (optimistic → validate → save).
  *
+ * WIDTHS ARE RELATIVE, NOT A 12-COLUMN GRID (M26). <Dashboard> lays a row out as
+ * `repeat(Σ item.width, minmax(0, 1fr))` with a `0.7rem` gap, so growing one
+ * item grows the DENOMINATOR too: a 6/6 row whose first item goes to 8 renders
+ * at 8/14, not 8/12. This layer used to preview against a hardcoded `COLS = 12`
+ * and scale the start box by `live / start`, which promised a size the commit
+ * could not deliver (a 1000px 6/6 row previewed 667px and committed 571px) and
+ * printed an `N / 12` readout on rows that were never 12 wide. Every pixel here
+ * now comes from `canvasGridGeometry` — the single owner of that sum-normalized
+ * formula, verified against real CSS grid layout — so the ghost is exactly the
+ * geometry the drop produces.
+ *
  * Handle types (D-3 contract):
- *   - Item RIGHT-EDGE (↔ width): drag changes the item's integer col-span
- *     (1–12). Widths are relative within the row, so siblings rebalance live. A
+ *   - Item RIGHT-EDGE (↔ width): drag changes the item's integer relative width
+ *     (1–12). Siblings rebalance live, so the row total moves with the drag; the
+ *     span committed is the one whose RENDERED edge lands nearest the pointer. A
  *     `N / total` readout pill rides the handle.
  *   - Item LEFT-EDGE (↔ width): drag moves the boundary shared with the PREVIOUS
  *     sibling, transferring grid columns between this item and its left neighbour
@@ -40,8 +59,11 @@ import {
  *     a se-resize corner resizes width + height in one gesture.
  *
  * The chart inside the slot stays STATIC during the drag: we never re-layout the
- * Dashboard mid-gesture. The overlay paints a mulberry ghost at the live target
- * geometry and only commits the new config on pointer-UP, so the expensive
+ * Dashboard mid-gesture. The overlay paints ONE emphasized mulberry ghost at the
+ * live target geometry and FADES the card being resized (a direct imperative
+ * opacity on the measured node, restored on release / Esc / pointercancel /
+ * unmount), so a gesture shows exactly one outline and it is unambiguous which
+ * geometry will land. The new config commits on pointer-UP, so the expensive
  * chart re-render happens once, at drag-end.
  *
  * Pointer handling is RAW (not dnd-kit): the handle calls `setPointerCapture` on
@@ -55,7 +77,9 @@ import {
  */
 
 const MULBERRY = 'var(--color-primary-500)';
-const COLS = 12;
+
+// How far the card being resized fades while its ghost is on screen.
+const DRAG_FADE_OPACITY = '0.35';
 
 // Classify a composite selection key as item / row / chrome (mirrors the
 // selection overlay's kindForKey).
@@ -140,10 +164,18 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   // sits at the row's bottom edge even when only a single item is selected.
   const [heightBox, setHeightBox] = useState(null);
   // Live drag state — null at rest; otherwise the in-flight gesture descriptor:
-  //   { kind: 'width'|'height'|'corner', startX, startY, colPx, startCols,
-  //     liveCols, startPx, livePx, fluid, label, box }
+  //   { kind: 'width'|'width-left'|'height'|'corner', startX, startY,
+  //     rowWidth, gapPx, startTotal, rebalance, maxCols, startSlotPx,
+  //     startCols, liveCols, liveTotal, startPx, livePx, fluid, label, box }
+  // The rowWidth/gapPx/startTotal trio is the row's MEASURED grid context,
+  // frozen at pointer-down so every frame can re-derive the truthful preview
+  // (canvasGridGeometry) without another DOM read.
   const [drag, setDrag] = useState(null);
   const dragRef = useRef(null);
+  // The canvas node currently faded under its ghost, plus the inline styles to
+  // put back. Held in a ref (not state) because it is imperative DOM the layer
+  // borrows from the render-only <Dashboard> for the length of one gesture.
+  const fadedRef = useRef(null);
 
   const selectedKind = kindForKey(selectedKey);
 
@@ -230,6 +262,41 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   }, [selection]);
   const hasLeftNeighbor = itemIndexInRow > 0;
 
+  // ── Faded card ────────────────────────────────────────────────────────────
+  // The gesture paints ONE emphasized outline (the ghost). To keep the target
+  // unambiguous, the card being resized fades underneath it rather than getting
+  // a second competing frame. We set the opacity directly on the measured
+  // <Dashboard> node — React never wrote an `opacity` style key on it, so a
+  // re-render leaves ours alone — and always restore what was there before.
+  const restoreFadedNode = useCallback(() => {
+    const faded = fadedRef.current;
+    fadedRef.current = null;
+    if (!faded || !faded.el) return;
+    faded.el.style.opacity = faded.prevOpacity || '';
+    faded.el.style.transition = faded.prevTransition || '';
+  }, []);
+
+  const fadeNodeAtPath = useCallback(
+    path => {
+      restoreFadedNode();
+      const root = rootRef.current;
+      const el = root && path ? root.querySelector(`[data-canvas-path="${path}"]`) : null;
+      if (!el) return;
+      fadedRef.current = {
+        el,
+        prevOpacity: el.style.opacity,
+        prevTransition: el.style.transition,
+      };
+      el.style.transition = 'opacity 120ms ease-out';
+      el.style.opacity = DRAG_FADE_OPACITY;
+    },
+    [rootRef, restoreFadedNode]
+  );
+
+  // An unmount mid-gesture (route change, canvas teardown) must not leave a card
+  // stranded at 35% opacity.
+  useEffect(() => () => restoreFadedNode(), [restoreFadedNode]);
+
   const beginDrag = useCallback(
     (e, kind) => {
       if (!box || !selection) return;
@@ -237,24 +304,56 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       e.stopPropagation();
       const root = rootRef.current;
 
-      // Width context: per-column px from the parent row's width / its grid total.
-      let colPx = 0;
-      let startCols = selection.item?.width || 1;
-      if ((kind === 'width' || kind === 'width-left' || kind === 'corner') && rowPathForItem && root) {
-        const rowEl = root.querySelector(`[data-canvas-path="${rowPathForItem}"]`);
-        const rowBox = rowEl ? measure(rowEl, root) : null;
-        const total =
-          (selection.itemsInRow || []).reduce((sum, it) => sum + (it.width || 1), 0) || 1;
-        const rowWidth = rowBox ? rowBox.width : box.width;
-        colPx = rowWidth / total;
-      }
+      const isWidthKind = kind === 'width' || kind === 'width-left' || kind === 'corner';
+      const startCols = selection.item?.width || 1;
 
       // Left-edge context: the previous sibling's start width bounds how far the
       // shared boundary can move (the neighbour can't drop below width 1).
       const neighborStartCols =
         kind === 'width-left' && hasLeftNeighbor
-          ? (selection.itemsInRow?.[itemIndexInRow - 1]?.width || 1)
+          ? selection.itemsInRow?.[itemIndexInRow - 1]?.width || 1
           : 1;
+
+      // Width context — MEASURED, then run through the same sum-normalized
+      // formula <Dashboard> lays the row out with (canvasGridGeometry). We keep
+      // the row's live pixel width, its live column gap and its start grid total
+      // so every frame of the gesture can ask "what will this width RENDER as?"
+      // without touching the DOM again.
+      //
+      // A RIGHT-EDGE (or corner) drag rebalances the row: the item's weight and
+      // the row total both move, so the reachable span is only bounded by the
+      // persistence clamp. A LEFT-EDGE drag TRANSFERS columns across the shared
+      // boundary: the total is fixed and the neighbour cannot drop below 1.
+      let rowWidth = box.width;
+      let gapPx = 0;
+      let startTotal = startCols;
+      const rebalance = kind !== 'width-left';
+      let maxCols = MAX_ITEM_WIDTH;
+      if (isWidthKind && rowPathForItem && root) {
+        const rowEl = root.querySelector(`[data-canvas-path="${rowPathForItem}"]`);
+        const rowBox = rowEl ? measure(rowEl, root) : null;
+        rowWidth = rowBox ? rowBox.width : box.width;
+        gapPx = readColumnGapPx(rowEl);
+        startTotal = rowGridTotal(selection.itemsInRow);
+        maxCols = rebalance
+          ? MAX_ITEM_WIDTH
+          : Math.min(MAX_ITEM_WIDTH, startCols + Math.max(0, neighborStartCols - 1));
+      }
+      // The item's slot width at rest, in the row's measured pixel space. The
+      // pointer delta is applied to THIS (not to the item's own measured box) so
+      // the target width and the candidate widths are quoted in one space, and a
+      // zero-travel gesture resolves back to `startCols` exactly.
+      const startSlotPx = Math.max(
+        1,
+        previewItemWidthPx({
+          rowWidth,
+          startTotal,
+          startCols,
+          spanCols: startCols,
+          gapPx,
+          rebalance,
+        })
+      );
 
       // Height context: the gesture's row is the selection's row (item → parent
       // row; row → itself). startPx from the row's current enum/px height.
@@ -266,10 +365,15 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         kind,
         startX: e.clientX,
         startY: e.clientY,
-        colPx: colPx || 1,
+        rowWidth,
+        gapPx,
+        startTotal,
+        rebalance,
+        maxCols,
+        startSlotPx,
         startCols,
         liveCols: startCols,
-        neighborStartCols,
+        liveTotal: startTotal,
         startPx,
         livePx: startPx,
         fluid: !!e.shiftKey,
@@ -278,11 +382,18 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
             ? e.shiftKey
               ? `${Math.round(startPx)} px`
               : pixelsToNearestHeightEnum(startPx)
-            : `${startCols} / ${COLS}`,
+            : `${startCols} / ${startTotal}`,
         box,
       };
       dragRef.current = next;
       setDrag(next);
+
+      // One emphasized outline (the ghost) + a faded card: dim the node the
+      // gesture actually resizes — the ITEM for a width/corner drag, the whole
+      // ROW for a height drag (the ghost spans the row there).
+      fadeNodeAtPath(
+        kind === 'height' && selectedKind === 'item' ? parentRowPathOf(selectedKey) : selectedKey
+      );
 
       // Capture the pointer on the handle so a reflow mid-drag can't drop the
       // gesture (the canvas-overlay gotcha — the canvas reflows on the
@@ -296,7 +407,17 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         // is the fallback so the gesture still completes.
       }
     },
-    [box, selection, rowPathForItem, itemIndexInRow, hasLeftNeighbor, rootRef]
+    [
+      box,
+      selection,
+      rowPathForItem,
+      itemIndexInRow,
+      hasLeftNeighbor,
+      rootRef,
+      selectedKey,
+      selectedKind,
+      fadeNodeAtPath,
+    ]
   );
 
   // Window-level move/up handlers active only while a drag is in flight. They
@@ -314,42 +435,73 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       let livePx = d.livePx;
       const fluid = !!e.shiftKey;
 
-      if (d.kind === 'width' || d.kind === 'corner') {
-        const deltaCols = Math.round(dx / d.colPx);
-        liveCols = Math.max(1, Math.min(COLS, d.startCols + deltaCols));
-      }
-      if (d.kind === 'width-left') {
-        // Dragging the LEFT edge left (dx < 0) grows the item; dragging it right
-        // shrinks it. Columns transfer across the shared boundary with the left
-        // neighbour, so the live span is bounded by the neighbour's spare width.
-        const deltaCols = -Math.round(dx / d.colPx);
-        const maxGrow = Math.max(0, (d.neighborStartCols || 1) - 1);
-        const transfer = Math.max(-(d.startCols - 1), Math.min(maxGrow, deltaCols));
-        liveCols = d.startCols + transfer;
+      // Width: the pointer drags the slot's EDGE, so the span we pick is the one
+      // whose RENDERED width lands nearest where the edge now is. `startSlotPx`
+      // and the candidate widths both come from canvasGridGeometry, so the ghost
+      // tracks the hand as closely as an integer weight allows — no fixed
+      // `rowWidth / total` step that sum-normalization makes a lie.
+      if (d.kind === 'width' || d.kind === 'corner' || d.kind === 'width-left') {
+        // Right edge: dragging right (dx > 0) grows. Left edge: dragging LEFT
+        // (dx < 0) grows, because the boundary moves away from the item.
+        const targetWidthPx = d.kind === 'width-left' ? d.startSlotPx - dx : d.startSlotPx + dx;
+        liveCols = nearestSpanForWidth({
+          rowWidth: d.rowWidth,
+          startTotal: d.startTotal,
+          startCols: d.startCols,
+          targetWidthPx,
+          gapPx: d.gapPx,
+          minCols: 1,
+          maxCols: d.maxCols,
+          rebalance: d.rebalance,
+        });
       }
       if (d.kind === 'height' || d.kind === 'corner') {
         livePx = Math.max(48, Math.min(2048, d.startPx + dy));
       }
 
+      // The row's grid total AFTER the drag — it moves with a right-edge drag
+      // and holds still for a left-edge transfer. This is the readout's honest
+      // denominator: `8 / 14`, never `8 / 12` on a row that is 14 wide.
+      const liveTotal = d.rebalance
+        ? Math.max(1, d.startTotal - d.startCols + liveCols)
+        : d.startTotal;
+
       let label;
       if (d.kind === 'width' || d.kind === 'width-left') {
-        label = `${liveCols} / ${COLS}`;
+        label = `${liveCols} / ${liveTotal}`;
       } else if (d.kind === 'corner') {
         const hLabel = fluid ? `${Math.round(livePx)} px` : pixelsToNearestHeightEnum(livePx);
-        label = `width ${liveCols} · height ${hLabel}`;
+        label = `width ${liveCols} / ${liveTotal} · height ${hLabel}`;
       } else {
         label = fluid ? `${Math.round(livePx)} px` : pixelsToNearestHeightEnum(livePx);
       }
 
-      const updated = { ...d, liveCols, livePx, fluid, label };
+      const updated = { ...d, liveCols, liveTotal, livePx, fluid, label };
       dragRef.current = updated;
       setDrag(updated);
+    };
+
+    // Abort: drop the gesture WITHOUT committing and un-fade the card. Fires on
+    // Esc and on pointercancel (the browser took the pointer away mid-gesture —
+    // an interrupted drag never expressed an intent to resize).
+    const onAbort = () => {
+      dragRef.current = null;
+      setDrag(null);
+      restoreFadedNode();
+      measureBox();
+    };
+
+    const onKeyDown = e => {
+      if (e.key !== 'Escape' || !dragRef.current) return;
+      e.preventDefault();
+      onAbort();
     };
 
     const onUp = () => {
       const d = dragRef.current;
       dragRef.current = null;
       setDrag(null);
+      restoreFadedNode();
       if (!d || !selection || !dashboardConfig) {
         measureBox();
         return;
@@ -404,11 +556,13 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
 
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
-    window.addEventListener('pointercancel', onUp);
+    window.addEventListener('pointercancel', onAbort);
+    window.addEventListener('keydown', onKeyDown);
     return () => {
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
-      window.removeEventListener('pointercancel', onUp);
+      window.removeEventListener('pointercancel', onAbort);
+      window.removeEventListener('keydown', onKeyDown);
     };
   }, [
     drag,
@@ -420,14 +574,33 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     itemIndexInRow,
     commitCanvasConfig,
     measureBox,
+    restoreFadedNode,
   ]);
 
   if (!dashboardConfig || !box || selectedKind === 'chrome' || !selection) return null;
 
-  // Ghost geometry while dragging: width gesture stretches the item box to its
-  // live col-span (relative to the start span); height gesture stretches the
-  // box to its live pixel height. Pure transform on the overlay — the Dashboard
-  // render below is untouched (chart stays static).
+  // Ghost geometry while dragging — THE TRUTHFUL PREVIEW (M26).
+  //
+  // The width is the pixel width the slot will actually render at once the new
+  // relative weight is committed: `previewItemWidthPx` re-derives it from the
+  // row's measured width, its live gap and the SUM-NORMALIZED total (which moves
+  // with a right-edge drag), exactly as <Dashboard> lays the row out. We express
+  // it as a RATIO against the item's own start slot so the ghost is anchored to
+  // the measured box — zero travel is pixel-identical to the card underneath,
+  // and any canvas scale/zoom cancels out.
+  //
+  // Height gestures stretch the box to their live pixel height. Pure geometry on
+  // the overlay — the Dashboard render below is untouched (chart stays static).
+  const previewWidthFor = spanCols =>
+    previewItemWidthPx({
+      rowWidth: drag.rowWidth,
+      startTotal: drag.startTotal,
+      startCols: drag.startCols,
+      spanCols,
+      gapPx: drag.gapPx,
+      rebalance: drag.rebalance,
+    });
+
   const ghost = (() => {
     if (!drag) return null;
     // A pure height drag resizes the ROW, so preview the full row box
@@ -444,13 +617,12 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
     let w = box.width;
     let h = box.height;
     let left = box.left;
-    if (drag.kind === 'width' || drag.kind === 'corner') {
-      w = box.width * (drag.liveCols / Math.max(1, drag.startCols));
+    if (drag.kind === 'width' || drag.kind === 'corner' || drag.kind === 'width-left') {
+      w = box.width * (previewWidthFor(drag.liveCols) / Math.max(1, drag.startSlotPx));
     }
     if (drag.kind === 'width-left') {
       // The left-edge gesture moves the LEFT boundary: anchor the right edge and
       // extend leftward as the span grows.
-      w = box.width * (drag.liveCols / Math.max(1, drag.startCols));
       left = box.left + box.width - w;
     }
     if (drag.kind === 'corner') {
@@ -467,10 +639,24 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
   // bottom-edge height handle. An item with a LEFT neighbour also gets a
   // left-edge width handle that moves the shared boundary; the first item in a
   // row has no shared left boundary and so gets no left handle.
-  const showWidthHandle = selection.isItem;
-  const showLeftWidthHandle = selection.isItem && hasLeftNeighbor;
-  const showHeightHandle = !isContainerItem && !!heightBox; // rows + non-container items
-  const showCornerHandle = isContainerItem;
+  //
+  // DURING a gesture only the handle being dragged is painted: the others sit at
+  // the pre-drag geometry, which the ghost has already moved on from, and a
+  // solid mulberry bar at a stale edge is exactly the second emphasis M26 asks
+  // us to delete.
+  const dragging = !!drag;
+  const showWidthHandle = selection.isItem && (!dragging || drag.kind === 'width');
+  const showLeftWidthHandle =
+    selection.isItem && hasLeftNeighbor && (!dragging || drag.kind === 'width-left');
+  const showHeightHandle =
+    !isContainerItem && !!heightBox && (!dragging || drag.kind === 'height'); // rows + non-container items
+  const showCornerHandle = isContainerItem && (!dragging || drag.kind === 'corner');
+
+  // The handle you are holding rides the GHOST's matching edge, so the affordance
+  // stays under the pointer and reads as the edge you are dragging; at rest every
+  // handle sits on the measured selection box.
+  const widthAnchor = dragging && ghost && drag.kind !== 'height' ? ghost : box;
+  const heightAnchor = drag?.kind === 'height' && ghost ? ghost : heightBox;
 
   const handleBase =
     'pointer-events-auto absolute z-30 transition-opacity hover:opacity-100';
@@ -484,23 +670,16 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
       // pill steals the row-height resize zone (VIS-986 follow-up).
       className="pointer-events-none absolute inset-0 z-40"
     >
-      {/* Selected-node frame (subtle, so the handles read as edge affordances). */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute rounded-md"
-        style={{
-          top: box.top,
-          left: box.left,
-          width: box.width,
-          height: box.height,
-          boxShadow: drag ? `inset 0 0 0 1px ${MULBERRY}55` : 'none',
-        }}
-      />
-
-      {/* Drag ghost — the live target geometry, painted only during a gesture. */}
+      {/* Drag ghost — the live target geometry, painted only during a gesture,
+          and the ONLY emphasized outline on screen while it is (M26). The card
+          it will replace is faded imperatively instead of getting a second
+          competing frame, so "what lands where" is unambiguous: one solid 2px
+          mulberry ring at the geometry the drop produces, lifted off the canvas
+          by a soft drop shadow (a shadow, not a second ring). */}
       {drag && ghost && (
         <div
           data-testid="canvas-resize-ghost"
+          data-canvas-outline="emphasized"
           aria-hidden="true"
           className="pointer-events-none absolute rounded-md"
           style={{
@@ -508,8 +687,8 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
             left: ghost.left,
             width: ghost.width,
             height: ghost.height,
-            background: 'color-mix(in srgb, var(--color-primary-500) 6%, transparent)',
-            boxShadow: `0 0 0 2px ${MULBERRY}, 0 0 0 5px color-mix(in srgb, var(--color-primary-500) 18%, transparent)`,
+            background: 'color-mix(in srgb, var(--color-primary-500) 8%, transparent)',
+            boxShadow: `0 0 0 2px ${MULBERRY}, 0 10px 24px -8px rgba(17, 12, 15, 0.35)`,
           }}
         />
       )}
@@ -528,10 +707,10 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
           className={`${handleBase} opacity-80`}
           onPointerDown={e => beginDrag(e, 'width-left')}
           style={{
-            top: box.top + 6,
-            left: box.left - 3,
+            top: widthAnchor.top + 6,
+            left: widthAnchor.left - 3,
             width: 6,
-            height: Math.max(0, box.height - 12),
+            height: Math.max(0, widthAnchor.height - 12),
             cursor: 'col-resize',
             background: drag?.kind === 'width-left' ? MULBERRY : `${MULBERRY}99`,
             borderRadius: 3,
@@ -553,10 +732,10 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
           className={`${handleBase} opacity-80`}
           onPointerDown={e => beginDrag(e, 'width')}
           style={{
-            top: box.top + 6,
-            left: box.left + box.width - 3,
+            top: widthAnchor.top + 6,
+            left: widthAnchor.left + widthAnchor.width - 3,
             width: 6,
-            height: Math.max(0, box.height - 12),
+            height: Math.max(0, widthAnchor.height - 12),
             cursor: 'col-resize',
             background: drag?.kind === 'width' ? MULBERRY : `${MULBERRY}99`,
             borderRadius: 3,
@@ -581,9 +760,9 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
           style={{
             // A taller hit zone (10px) so the row-height handle is easy to grab
             // (VIS-986 follow-up — a 6px strip was too fiddly to land on).
-            top: heightBox.top + heightBox.height - 5,
-            left: heightBox.left + 6,
-            width: Math.max(0, heightBox.width - 12),
+            top: heightAnchor.top + heightAnchor.height - 5,
+            left: heightAnchor.left + 6,
+            width: Math.max(0, heightAnchor.width - 12),
             height: 10,
             cursor: 'row-resize',
             background: drag?.kind === 'height' ? MULBERRY : `${MULBERRY}99`,
@@ -605,8 +784,8 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
           className={`${handleBase} opacity-90`}
           onPointerDown={e => beginDrag(e, 'corner')}
           style={{
-            top: box.top + box.height - 9,
-            left: box.left + box.width - 9,
+            top: widthAnchor.top + widthAnchor.height - 9,
+            left: widthAnchor.left + widthAnchor.width - 9,
             width: 14,
             height: 14,
             cursor: 'se-resize',
@@ -618,7 +797,10 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
         />
       )}
 
-      {/* Live readout — rides near the active handle during the gesture. For a
+      {/* Live readout — rides the GHOST's active edge during the gesture, so the
+          number sits on the geometry it describes. A width readout is honest
+          about the row it lands in: `N / <row total>` (the total a right-edge
+          drag rebalances TO), never `N / 12` on a row that is not 12 wide. For a
           height tick drag it shows the HeightEnum stack with the active stop
           mulberry-filled; otherwise a single readout pill. */}
       {drag && (
@@ -627,13 +809,13 @@ const CanvasResizeLayer = ({ rootRef, dashboardName }) => {
           aria-hidden="true"
           className="pointer-events-none absolute z-40"
           style={{
-            top: Math.max(2, box.top - 8),
+            top: Math.max(2, (ghost || box).top - 8),
             left:
               drag.kind === 'height'
-                ? (heightBox || box).left + (heightBox || box).width / 2 - 40
+                ? (heightAnchor || box).left + (heightAnchor || box).width / 2 - 40
                 : drag.kind === 'width-left'
-                  ? box.left
-                  : box.left + box.width - 30,
+                  ? widthAnchor.left
+                  : widthAnchor.left + widthAnchor.width - 30,
           }}
         >
           {drag.kind === 'height' && !drag.fluid ? (

--- a/viewer/src/components/views/project/canvas/CanvasResizeLayer.test.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasResizeLayer.test.jsx
@@ -16,7 +16,13 @@ import React, { useRef } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import CanvasResizeLayer from './CanvasResizeLayer';
 import useStore from '../../../../stores/store';
-import { itemSlotWidthPx, rowGridTotal } from './canvasGridGeometry';
+import {
+  itemSlotWidthPx,
+  precedingColsInRow,
+  rowGridTotal,
+  spanLeftOffsetPx,
+} from './canvasGridGeometry';
+import { EMPHASIZED_OUTLINE_SELECTOR } from './canvasEmphasis';
 
 // jsdom's PointerEvent drops clientX/clientY from its init dict, so the
 // component's window-level pointermove/up handlers would see `undefined`
@@ -477,10 +483,16 @@ describe('CanvasResizeLayer — truthful resize preview (M26 / W7)', () => {
     expect(mockCommit).not.toHaveBeenCalled(); // clamped back to its own width
   });
 
-  test('DIRECT MANIPULATION: exactly one emphasized outline during a gesture', () => {
+  // NOTE: this test only sees THIS layer. It proves the resize layer contributes
+  // exactly one outline and drops its own stale handles — it can say nothing
+  // about the sibling <CanvasSelectionOverlay>, which used to keep a
+  // full-strength ring at the pre-drag geometry throughout the gesture. The
+  // cross-overlay count (the property a user actually sees) is guarded in
+  // canvasOutlineEmphasis.test.jsx, where BOTH overlays are mounted.
+  test('DIRECT MANIPULATION: this layer contributes exactly one outline', () => {
     const { container } = render(<OddHost />);
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const outlinesNow = () => container.querySelectorAll('[data-canvas-outline="emphasized"]');
+    const outlinesNow = () => container.querySelectorAll(EMPHASIZED_OUTLINE_SELECTOR);
     expect(outlinesNow()).toHaveLength(0);
 
     const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
@@ -569,9 +581,11 @@ describe('CanvasResizeLayer — truthful resize preview (M26 / W7)', () => {
     expect(card.style.opacity).toBe('');
   });
 
-  test('a SOLO-item row never rewrites its width: the geometry cannot respond', () => {
-    // Σ widths is the item's own width, so every span renders full-bleed. The
-    // gesture must be an honest no-op, not a silent `width: 12` → `width: 1`.
+  test('a SOLO-item row gets NO width handle: the gesture provably cannot move a pixel', () => {
+    // Σ widths is the item's own width, so every span renders full-bleed and the
+    // drag can never change the geometry. A handle there would paint a ghost,
+    // print a frozen readout and do nothing — a dead affordance. The row keeps
+    // its HEIGHT handle, which does work.
     useStore.setState({
       dashboards: [
         { name: 'odd', config: { rows: [{ height: 'medium', items: [{ width: 12, chart: 'ref(a)' }] }] } },
@@ -579,11 +593,295 @@ describe('CanvasResizeLayer — truthful resize preview (M26 / W7)', () => {
       workspaceOutlineSelectedKey: 'row.0.item.0',
     });
     render(<OddHost />);
+    expect(screen.queryByTestId('canvas-resize-width-row.0.item.0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('canvas-resize-width-left-row.0.item.0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('canvas-resize-height-row.0.item.0')).toBeInTheDocument();
+  });
+
+  test('a solo item that GAINS a sibling gets its width handle back', () => {
+    // The handle is withheld because of the ROW's shape, not the item's — the
+    // moment a sibling exists the gesture has real geometry to move again.
+    useStore.setState({
+      dashboards: [
+        {
+          name: 'odd',
+          config: {
+            rows: [
+              {
+                height: 'medium',
+                items: [{ width: 12, chart: 'ref(a)' }, { width: 4, table: 'ref(b)' }],
+              },
+            ],
+          },
+        },
+      ],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+    });
+    render(<OddHost />);
+    expect(screen.getByTestId('canvas-resize-width-row.0.item.0')).toBeInTheDocument();
+  });
+});
+
+// ── M26 second half: the ghost's LEFT edge ───────────────────────────────────
+//
+// The width fix alone still dropped the card somewhere other than the ghost.
+// Sum-normalization shrinks EVERY track when the row total grows, including the
+// ones in front of the dragged item, so the slot slides LEFT as it widens. A
+// ghost frozen at the item's measured `left` is therefore only correct for item
+// 0 — the single index every pre-existing truthful-preview guard happened to
+// use — and on the LAST item of a row it is painted hanging off the row's right
+// edge entirely.
+//
+// jsdom reports no column-gap, so these are the clean gapless numbers; the
+// gapped case is covered by canvasGridGeometry.test.js and by the browser
+// harness (e2e/tools/measure-canvas-grid.mjs).
+
+const ROW_PX = 800;
+
+// Build the measured boxes a real gapless `repeat(Σ widths, 1fr)` row would
+// produce, so the fixture and the layer's own formula start from the SAME
+// layout rather than hand-typed numbers that quietly disagree.
+const boxesForWidths = widths => {
+  const total = widths.reduce((sum, w) => sum + (w || 1), 0);
+  const track = ROW_PX / total;
+  const row = { top: 0, left: 0, width: ROW_PX, height: 200, bottom: 200, right: ROW_PX };
+  const boxes = { root: row, p0: row };
+  let preceding = 0;
+  widths.forEach((w, i) => {
+    const left = preceding * track;
+    const width = (w || 1) * track;
+    boxes[`p0i${i}`] = { top: 0, left, width, height: 200, bottom: 200, right: left + width };
+    preceding += w || 1;
+  });
+  return boxes;
+};
+
+const PAIR_BOXES = boxesForWidths([6, 6]);
+const QUAD_BOXES = boxesForWidths([1, 1, 1, 1]);
+
+const PairHost = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="p0">
+        <div data-canvas-path="row.0.item.0" data-testid="p0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="p0i1" />
+      </div>
+      <CanvasResizeLayer rootRef={rootRef} dashboardName="pair" />
+    </div>
+  );
+};
+
+const QuadHost = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="p0">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} data-canvas-path={`row.0.item.${i}`} data-testid={`p0i${i}`} />
+        ))}
+      </div>
+      <CanvasResizeLayer rootRef={rootRef} dashboardName="pair" />
+    </div>
+  );
+};
+
+const useBoxes = boxes => {
+  Element.prototype.getBoundingClientRect = function () {
+    const tid = this.getAttribute && this.getAttribute('data-testid');
+    if (tid && boxes[tid]) return boxes[tid];
+    return boxes.root;
+  };
+};
+
+const dashboardWithWidths = widths => ({
+  name: 'pair',
+  config: {
+    rows: [{ height: 'medium', items: widths.map(width => ({ width, chart: 'ref(a)' })) }],
+  },
+});
+
+// Lay the COMMITTED row out from scratch — the independent side of the round
+// trip. Mirrors what <Dashboard> does with the config the drop produced.
+const laidOutSlot = (items, index, rowWidth) => ({
+  left: spanLeftOffsetPx({
+    rowWidth,
+    totalCols: rowGridTotal(items),
+    precedingCols: precedingColsInRow(items, index),
+    gapPx: 0,
+  }),
+  width: itemSlotWidthPx({
+    rowWidth,
+    totalCols: rowGridTotal(items),
+    spanCols: items[index].width || 1,
+    gapPx: 0,
+  }),
+});
+
+describe('CanvasResizeLayer — the ghost LANDS where it is painted (M26)', () => {
+  test('a NON-FIRST item: the ghost moves left as it grows, and the drop matches it', () => {
+    useStore.setState({
+      dashboards: [dashboardWithWidths([6, 6])],
+      workspaceOutlineSelectedKey: 'row.0.item.1',
+    });
+    useBoxes(PAIR_BOXES);
+    render(<PairHost />);
+
+    // Item 1 occupies 400–800 of an 800px row. Drag its RIGHT edge +57px: the
+    // row becomes 6 + 8 = 14 wide, so the slot renders 457.1px — starting at
+    // 6/14 · 800 = 342.9px, i.e. 57px to the LEFT of where it is now.
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.1');
+    firePointerDown(handle, { clientX: 797, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 797 + 57, clientY: 100 });
+
+    const ghost = screen.getByTestId('canvas-resize-ghost');
+    const ghostLeft = px(ghost.style.left);
+    const ghostWidth = px(ghost.style.width);
+    expect(ghostWidth).toBeCloseTo(457.14, 1);
+    expect(ghostLeft).toBeCloseTo(342.86, 1);
+    // The pre-fix ghost froze `left` at the measured box (400) — 57px of lie,
+    // and its right edge landed at 857px on an 800px row.
+    expect(ghostLeft).not.toBeCloseTo(400, 0);
+    expect(ghostLeft + ghostWidth).toBeLessThanOrEqual(PAIR_BOXES.p0.width + 0.01);
+
+    firePointer('pointerup', { clientX: 797 + 57, clientY: 100 });
+
+    // GHOST == DROP, in BOTH axes, against the config the commit produced.
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    const items = nextConfig.rows[0].items;
+    expect(items.map(i => i.width)).toEqual([6, 8]);
+    const laid = laidOutSlot(items, 1, PAIR_BOXES.p0.width);
+    expect(Math.abs(laid.width - ghostWidth)).toBeLessThan(2);
+    expect(Math.abs(laid.left - ghostLeft)).toBeLessThan(2);
+  });
+
+  test('the LAST item of a 4-up row: a 440px lie becomes a 0px one', () => {
+    useStore.setState({
+      dashboards: [dashboardWithWidths([1, 1, 1, 1])],
+      workspaceOutlineSelectedKey: 'row.0.item.3',
+    });
+    useBoxes(QUAD_BOXES);
+    render(<QuadHost />);
+
+    // Item 3 sits at 600–800. Dragging its right edge +440px asks for a 640px
+    // slot, which is width 12 on a row that becomes 3 + 12 = 15 wide — and that
+    // slot starts at 3/15 · 800 = 160px, 440px LEFT of where the item is now.
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.3');
+    firePointerDown(handle, { clientX: 797, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 797 + 440, clientY: 100 });
+
+    const ghost = screen.getByTestId('canvas-resize-ghost');
+    const ghostLeft = px(ghost.style.left);
+    const ghostWidth = px(ghost.style.width);
+    expect(ghostWidth).toBeCloseTo(640, 1);
+    expect(ghostLeft).toBeCloseTo(160, 1);
+    // Pre-fix: left frozen at 600, so the ghost spanned 600→1240 on an 800px
+    // row — 440px of horizontal lie and 440px painted outside the canvas.
+    expect(Math.abs(ghostLeft - QUAD_BOXES.p0i3.left)).toBeGreaterThan(400);
+
+    firePointer('pointerup', { clientX: 797 + 440, clientY: 100 });
+
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    const items = nextConfig.rows[0].items;
+    expect(items.map(i => i.width)).toEqual([1, 1, 1, 12]);
+    const laid = laidOutSlot(items, 3, QUAD_BOXES.p0.width);
+    expect(Math.abs(laid.width - ghostWidth)).toBeLessThan(2);
+    expect(Math.abs(laid.left - ghostLeft)).toBeLessThan(2);
+  });
+
+  test('SHRINKING a non-first item pushes the ghost RIGHT', () => {
+    // The tracks in FRONT of the item grow when the row total falls, so a
+    // shrink slides the slot the other way. Same formula, opposite sign — a
+    // preview that only ever grew leftward would fail this.
+    const boxes = boxesForWidths([1, 1, 4, 1]);
+    useStore.setState({
+      dashboards: [dashboardWithWidths([1, 1, 4, 1])],
+      workspaceOutlineSelectedKey: 'row.0.item.2',
+    });
+    useBoxes(boxes);
+    render(<QuadHost />);
+
+    // Row total 7; item 2 renders 4/7 · 800 = 457.1px starting at 2/7 · 800 =
+    // 228.6px. Shrinking it to 1 makes the row 4 wide: the slot becomes 200px
+    // and starts at 2/4 · 800 = 400px — 171px to the RIGHT.
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.2');
+    firePointerDown(handle, { clientX: 686, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 686 - 258, clientY: 100 });
+
+    const ghost = screen.getByTestId('canvas-resize-ghost');
+    const ghostLeft = px(ghost.style.left);
+    const ghostWidth = px(ghost.style.width);
+    firePointer('pointerup', { clientX: 686 - 258, clientY: 100 });
+
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    const items = nextConfig.rows[0].items;
+    expect(items.map(i => i.width)).toEqual([1, 1, 1, 1]);
+    const laid = laidOutSlot(items, 2, ROW_PX);
+    expect(laid.left).toBeCloseTo(400, 1);
+    expect(Math.abs(laid.left - ghostLeft)).toBeLessThan(2);
+    expect(Math.abs(laid.width - ghostWidth)).toBeLessThan(2);
+    // …and it moved the OPPOSITE way from a grow: right, not left.
+    expect(ghostLeft).toBeGreaterThan(boxes.p0i2.left);
+  });
+
+  test('the FIRST item still stays put — the fix is a shift, not an offset', () => {
+    useStore.setState({
+      dashboards: [dashboardWithWidths([6, 6])],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+    });
+    useBoxes(PAIR_BOXES);
+    render(<PairHost />);
     const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
-    firePointerDown(handle, { clientX: 900, clientY: 100, pointerId: 1 });
-    firePointer('pointermove', { clientX: 300, clientY: 100 });
-    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('12 / 12');
-    firePointer('pointerup', { clientX: 300, clientY: 100 });
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    expect(px(screen.getByTestId('canvas-resize-ghost').style.left)).toBeCloseTo(0, 6);
+    firePointer('pointerup', { clientX: 397 + 57, clientY: 100 });
+  });
+
+  test('zero travel leaves the ghost welded to the card it covers', () => {
+    useStore.setState({
+      dashboards: [dashboardWithWidths([6, 6])],
+      workspaceOutlineSelectedKey: 'row.0.item.1',
+    });
+    useBoxes(PAIR_BOXES);
+    render(<PairHost />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.1');
+    firePointerDown(handle, { clientX: 797, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 798, clientY: 100 }); // <1 column
+
+    const ghost = screen.getByTestId('canvas-resize-ghost');
+    expect(px(ghost.style.left)).toBeCloseTo(PAIR_BOXES.p0i1.left, 6);
+    expect(px(ghost.style.width)).toBeCloseTo(PAIR_BOXES.p0i1.width, 6);
+    firePointer('pointerup', { clientX: 798, clientY: 100 });
     expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  test('a LEFT-edge transfer still anchors the RIGHT edge (the total holds still)', () => {
+    useStore.setState({
+      dashboards: [dashboardWithWidths([6, 6])],
+      workspaceOutlineSelectedKey: 'row.0.item.1',
+    });
+    useBoxes(PAIR_BOXES);
+    render(<PairHost />);
+    const handle = screen.getByTestId('canvas-resize-width-left-row.0.item.1');
+    // Columns only TRANSFER: the row stays 12 wide, so the track size — and the
+    // slot's right edge — never move. Drag the left edge 133px out (2 columns).
+    firePointerDown(handle, { clientX: 400, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 400 - 133, clientY: 100 });
+
+    const ghost = screen.getByTestId('canvas-resize-ghost');
+    const left = px(ghost.style.left);
+    const width = px(ghost.style.width);
+    expect(width).toBeCloseTo(533.33, 1); // 8/12 of 800
+    expect(left + width).toBeCloseTo(PAIR_BOXES.p0i1.right, 6); // right edge pinned
+    firePointer('pointerup', { clientX: 400 - 133, clientY: 100 });
+
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    const items = nextConfig.rows[0].items;
+    expect(items.map(i => i.width)).toEqual([4, 8]);
+    const laid = laidOutSlot(items, 1, PAIR_BOXES.p0.width);
+    expect(Math.abs(laid.left - left)).toBeLessThan(2);
+    expect(Math.abs(laid.width - width)).toBeLessThan(2);
   });
 });

--- a/viewer/src/components/views/project/canvas/CanvasResizeLayer.test.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasResizeLayer.test.jsx
@@ -16,6 +16,7 @@ import React, { useRef } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import CanvasResizeLayer from './CanvasResizeLayer';
 import useStore from '../../../../stores/store';
+import { itemSlotWidthPx, rowGridTotal } from './canvasGridGeometry';
 
 // jsdom's PointerEvent drops clientX/clientY from its init dict, so the
 // component's window-level pointermove/up handlers would see `undefined`
@@ -216,13 +217,18 @@ describe('CanvasResizeLayer (VIS-777)', () => {
     render(<Host />);
     const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
 
-    // Down on the handle, move +135px right (~2 columns at 66.7px/col), release.
+    // Item 0 is 6/12 of the 800px row → a 400px slot. Widening it to 8 makes the
+    // row 8 + 6 = 14 wide, so the slot renders at 8/14 · 800 = 457.1px: a 57px
+    // drag right. (The pre-M26 layer read the row as a fixed 12 columns and made
+    // this a 2 × 66.7px = 135px drag, which actually lands on width 12.)
     firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
     // A ghost + readout appear during the drag.
     expect(screen.getByTestId('canvas-resize-ghost')).toBeInTheDocument();
-    firePointer("pointermove", { clientX: 397 + 135, clientY: 100 });
-    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('8 / 12');
-    firePointer("pointerup", { clientX: 397 + 135, clientY: 100 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    // HONEST READOUT: the denominator is the row total this drag rebalances to
+    // (14), never the hardcoded 12.
+    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('8 / 14');
+    firePointer('pointerup', { clientX: 397 + 57, clientY: 100 });
 
     expect(mockCommit).toHaveBeenCalledTimes(1);
     const [name, nextConfig, meta] = mockCommit.mock.calls[0];
@@ -352,6 +358,232 @@ describe('CanvasResizeLayer (VIS-777)', () => {
     firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
     firePointer("pointermove", { clientX: 400, clientY: 100 }); // <1 col
     firePointer("pointerup", { clientX: 400, clientY: 100 });
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+});
+
+// ── M26 / W7: the ghost tells the truth ──────────────────────────────────────
+//
+// `Item.width` is a RELATIVE weight; <Dashboard> lays a row out as
+// `repeat(Σ widths, minmax(0,1fr))`. The layer used to preview against a
+// hardcoded 12-column grid, so on any row whose widths did not total 12 the
+// ghost showed one width and the drop produced another.
+//
+// The row below is deliberately `[1, 2]` — a 3-column row, nothing like 12.
+const ODD_ROW_DASHBOARD = {
+  name: 'odd',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 1, chart: 'ref(a)' }, { width: 2, table: 'ref(b)' }] },
+    ],
+  },
+};
+
+// Row is 900px. Rendered slots: 1/3 → 300px, 2/3 → 600px (jsdom reports no
+// column-gap, so the geometry is the clean proportional case).
+const ODD_BOXES = {
+  o0: { top: 0, left: 0, width: 900, height: 200, bottom: 200, right: 900 },
+  o0i0: { top: 0, left: 0, width: 300, height: 200, bottom: 200, right: 300 },
+  o0i1: { top: 0, left: 300, width: 600, height: 200, bottom: 200, right: 900 },
+  root: { top: 0, left: 0, width: 900, height: 200, bottom: 200, right: 900 },
+};
+
+const OddHost = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="o0">
+        <div data-canvas-path="row.0.item.0" data-testid="o0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="o0i1" />
+      </div>
+      <CanvasResizeLayer rootRef={rootRef} dashboardName="odd" />
+    </div>
+  );
+};
+
+const px = value => parseFloat(value);
+
+describe('CanvasResizeLayer — truthful resize preview (M26 / W7)', () => {
+  beforeEach(() => {
+    useStore.setState({
+      dashboards: [ODD_ROW_DASHBOARD],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+    });
+    Element.prototype.getBoundingClientRect = function () {
+      const tid = this.getAttribute && this.getAttribute('data-testid');
+      if (tid && ODD_BOXES[tid]) return ODD_BOXES[tid];
+      return ODD_BOXES.root;
+    };
+  });
+
+  test('TRUTHFUL PREVIEW: the ghost is the width the drop actually renders', () => {
+    render(<OddHost />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+
+    // Item 0 is 1/3 of a 900px row (300px). Dragging its right edge +150px asks
+    // for a 450px slot — which is width 2, because the row becomes 2 + 2 = 4
+    // wide and 2/4 · 900 = 450px.
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+
+    const ghostWidth = px(screen.getByTestId('canvas-resize-ghost').style.width);
+    expect(ghostWidth).toBeCloseTo(450, 1);
+    // The pre-M26 ghost scaled the start box by live/start against a fixed
+    // 12-column grid: 300 · (2/1) = 600px. 150px of lie on a 900px row.
+    expect(ghostWidth).not.toBeCloseTo(600, 0);
+
+    firePointer('pointerup', { clientX: 450, clientY: 100 });
+
+    // GHOST == DROP: lay the COMMITTED row out and compare to the ghost.
+    expect(mockCommit).toHaveBeenCalledTimes(1);
+    const [, nextConfig] = mockCommit.mock.calls[0];
+    const items = nextConfig.rows[0].items;
+    expect(items.map(i => i.width)).toEqual([2, 2]);
+    const rendered = itemSlotWidthPx({
+      rowWidth: ODD_BOXES.o0.width,
+      totalCols: rowGridTotal(items),
+      spanCols: items[0].width,
+      gapPx: 0,
+    });
+    expect(Math.abs(rendered - ghostWidth)).toBeLessThan(2);
+  });
+
+  test('HONEST READOUT: the denominator is the row total, never a hardcoded 12', () => {
+    render(<OddHost />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+
+    const readout = screen.getByTestId('canvas-resize-readout').textContent;
+    expect(readout).toContain('2 / 4'); // the row this drag rebalances TO
+    expect(readout).not.toContain('/ 12');
+  });
+
+  test('a LEFT-edge transfer previews against the UNCHANGED row total', () => {
+    useStore.setState({ workspaceOutlineSelectedKey: 'row.0.item.1' });
+    render(<OddHost />);
+    const handle = screen.getByTestId('canvas-resize-width-left-row.0.item.1');
+
+    // Item 1 is 2/3 (600px). Columns only TRANSFER across the shared boundary,
+    // so the row stays 3 wide: dragging the left edge out to a 900px slot is
+    // width 3 — except the neighbour cannot drop below 1, which caps it at 2.
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 0, clientY: 100 });
+
+    const readout = screen.getByTestId('canvas-resize-readout').textContent;
+    expect(readout).toContain('2 / 3');
+    expect(px(screen.getByTestId('canvas-resize-ghost').style.width)).toBeCloseTo(600, 1);
+    firePointer('pointerup', { clientX: 0, clientY: 100 });
+    expect(mockCommit).not.toHaveBeenCalled(); // clamped back to its own width
+  });
+
+  test('DIRECT MANIPULATION: exactly one emphasized outline during a gesture', () => {
+    const { container } = render(<OddHost />);
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const outlinesNow = () => container.querySelectorAll('[data-canvas-outline="emphasized"]');
+    expect(outlinesNow()).toHaveLength(0);
+
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+
+    // One ring, on the ghost — not a second frame at the pre-drag geometry.
+    const outlines = outlinesNow();
+    expect(outlines).toHaveLength(1);
+    expect(outlines[0]).toBe(screen.getByTestId('canvas-resize-ghost'));
+
+    // …and only the handle being dragged is painted; the stale ones are gone.
+    expect(screen.queryByTestId('canvas-resize-height-row.0.item.0')).not.toBeInTheDocument();
+
+    firePointer('pointerup', { clientX: 450, clientY: 100 });
+    expect(outlinesNow()).toHaveLength(0);
+  });
+
+  test('DIRECT MANIPULATION: the card being resized fades, and un-fades on release', () => {
+    render(<OddHost />);
+    const card = screen.getByTestId('o0i0');
+    expect(card.style.opacity).toBe('');
+
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+    expect(card.style.opacity).toBe('0.35');
+
+    firePointer('pointerup', { clientX: 450, clientY: 100 });
+    expect(card.style.opacity).toBe('');
+  });
+
+  test('a height drag fades the ROW it resizes, not just the clicked item', () => {
+    render(<OddHost />);
+    const handle = screen.getByTestId('canvas-resize-height-row.0.item.0');
+    firePointerDown(handle, { clientX: 400, clientY: 195, pointerId: 1 });
+    firePointer('pointermove', { clientX: 400, clientY: 315 });
+
+    expect(screen.getByTestId('o0').style.opacity).toBe('0.35');
+    expect(screen.getByTestId('o0i0').style.opacity).toBe('');
+
+    firePointer('pointerup', { clientX: 400, clientY: 315 });
+    expect(screen.getByTestId('o0').style.opacity).toBe('');
+  });
+
+  test('Escape ABORTS the gesture: no commit, and the card un-fades', () => {
+    render(<OddHost />);
+    const card = screen.getByTestId('o0i0');
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+    expect(card.style.opacity).toBe('0.35');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(screen.queryByTestId('canvas-resize-ghost')).not.toBeInTheDocument();
+    expect(card.style.opacity).toBe('');
+    // A later pointerup must not resurrect the abandoned gesture.
+    firePointer('pointerup', { clientX: 450, clientY: 100 });
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  test('pointercancel ABORTS rather than committing an interrupted drag', () => {
+    render(<OddHost />);
+    const card = screen.getByTestId('o0i0');
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+    firePointer('pointercancel', { clientX: 450, clientY: 100 });
+
+    expect(mockCommit).not.toHaveBeenCalled();
+    expect(card.style.opacity).toBe('');
+  });
+
+  test('unmounting mid-gesture restores the faded card', () => {
+    const { unmount } = render(<OddHost />);
+    const card = screen.getByTestId('o0i0');
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 300, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 450, clientY: 100 });
+    expect(card.style.opacity).toBe('0.35');
+
+    unmount();
+    expect(card.style.opacity).toBe('');
+  });
+
+  test('a SOLO-item row never rewrites its width: the geometry cannot respond', () => {
+    // Σ widths is the item's own width, so every span renders full-bleed. The
+    // gesture must be an honest no-op, not a silent `width: 12` → `width: 1`.
+    useStore.setState({
+      dashboards: [
+        { name: 'odd', config: { rows: [{ height: 'medium', items: [{ width: 12, chart: 'ref(a)' }] }] } },
+      ],
+      workspaceOutlineSelectedKey: 'row.0.item.0',
+    });
+    render(<OddHost />);
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 900, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 300, clientY: 100 });
+    expect(screen.getByTestId('canvas-resize-readout').textContent).toContain('12 / 12');
+    firePointer('pointerup', { clientX: 300, clientY: 100 });
     expect(mockCommit).not.toHaveBeenCalled();
   });
 });

--- a/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.jsx
+++ b/viewer/src/components/views/project/canvas/CanvasSelectionOverlay.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import useStore from '../../../../stores/store';
 import { emitWorkspaceEvent } from '../../workspace/telemetry';
+import { EMPHASIZED_OUTLINE_PROPS } from './canvasEmphasis';
 
 /**
  * CanvasSelectionOverlay — VIS-D2 / VIS-768.
@@ -102,6 +103,14 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
   // This overlay is the single hover source (it already resolves the target);
   // sharing the key keeps the grip reveal aligned 1:1 with the hover ring.
   const setHoverKey = useStore(s => s.setWorkspaceCanvasHoverKey);
+  // Non-null for the LIFE of a <CanvasResizeLayer> gesture. During a resize the
+  // only truthful geometry on the canvas is that layer's ghost: our ring is
+  // frozen at the PRE-DRAG box (the Dashboard deliberately does not re-lay-out
+  // mid-gesture) and lives in a sibling layer the resize layer's card-fade
+  // cannot reach, so leaving it up puts a full-strength 2px mulberry ring at the
+  // OLD geometry beside an identical one at the target. We stand down instead —
+  // one gesture, one emphasized outline (see `canvasEmphasis`).
+  const canvasResizeKey = useStore(s => s.workspaceCanvasResizeKey);
 
   // Hovered + selected box geometry, measured from the live Dashboard DOM.
   const [hoverBox, setHoverBox] = useState(null); // { rect, kind }
@@ -243,6 +252,11 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
   }, [rootRef, handleMouseMove, handleMouseLeave, handleClick]);
 
   const chromeSelected = selectedKey === 'dashboard';
+  // A resize gesture owns the canvas's emphasis. Both of our rings are stale for
+  // its duration (the ring is pinned to the pre-drag box; the hover ring tracks
+  // a pointer that is dragging a handle, not browsing), so both stand down and
+  // come straight back on release / Esc / pointercancel.
+  const resizing = !!canvasResizeKey;
 
   return (
     <div
@@ -264,7 +278,8 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
           node; the former hover-time resize-handle placeholder is removed so
           there is exactly one resize affordance. Suppressed when this exact
           node is the persistent selection, so the selection ring reads cleanly. */}
-      {hoverBox &&
+      {!resizing &&
+        hoverBox &&
         hoverBox.rect &&
         !(
           selectedBox &&
@@ -292,10 +307,18 @@ const CanvasSelectionOverlay = ({ rootRef }) => {
         )}
 
       {/* Selection overlay — persistent mulberry-500 ring with offset
-          (D-1 states 05/06). Chrome selection is handled above. */}
-      {selectedBox && selectedBox.rect && (
+          (D-1 states 05/06). Chrome selection is handled above. Hidden while a
+          resize gesture is in flight: that layer's ghost is then the canvas's
+          single emphasized outline (M26), and this ring would sit at the
+          superseded pre-drag geometry. */}
+      {!resizing && selectedBox && selectedBox.rect && (
         <div
           data-testid={`canvas-overlay-selected-${selectedBox.kind}`}
+          // The 2px mulberry ring is a STRONG outline, so it joins the canvas's
+          // one-emphasized-outline invariant (`canvasEmphasis`) — that is what
+          // makes "exactly one ring during a gesture" a countable, falsifiable
+          // property instead of a marker only the ghost ever carries.
+          {...EMPHASIZED_OUTLINE_PROPS}
           // rounded-lg (matches the card radius) + NO ring-offset: the offset
           // gap was what produced the ugly double line against the card's own
           // border (VIS-990 polish). The 2px mulberry ring now hugs the card edge.

--- a/viewer/src/components/views/project/canvas/canvasEmphasis.js
+++ b/viewer/src/components/views/project/canvas/canvasEmphasis.js
@@ -1,0 +1,35 @@
+/**
+ * canvasEmphasis — the canvas's "there is exactly ONE emphasized outline"
+ * contract (M26 / VIS-1260).
+ *
+ * The dashboard canvas stacks several sibling overlays over the render-only
+ * <Dashboard> (selection, DnD, resize, add-row, context menu, keyboard, flip).
+ * More than one of them can want to draw a strong mulberry ring, and because
+ * they are SIBLINGS none of them can see — or dim — another's ring. The failure
+ * that produced this module: during a resize gesture <CanvasSelectionOverlay>
+ * kept a full-strength 2px ring at the PRE-DRAG geometry while
+ * <CanvasResizeLayer> painted an identical one at the target, so the canvas
+ * showed two equally-emphasized boxes and the drop landed on neither obviously.
+ *
+ * Every overlay that paints a strong (2px, `primary`) outline stamps
+ * `EMPHASIZED_OUTLINE_PROPS` on it. That turns "how many emphasized outlines are
+ * on screen?" into a question the DOM can answer — a real invariant a test can
+ * FALSIFY, rather than a private marker only one component ever sets.
+ *
+ * Subtle rings (hover hints, insertion bars, 1px tints) are deliberately NOT
+ * marked: the invariant is about the strong "this is the thing" outline.
+ */
+
+/** The attribute every strong canvas outline carries. */
+export const EMPHASIZED_OUTLINE_ATTR = 'data-canvas-outline';
+
+/** Its value. Spread `EMPHASIZED_OUTLINE_PROPS` onto the element instead. */
+export const EMPHASIZED_OUTLINE_VALUE = 'emphasized';
+
+/** Spread onto the outline element: `<div {...EMPHASIZED_OUTLINE_PROPS} …>`. */
+export const EMPHASIZED_OUTLINE_PROPS = {
+  [EMPHASIZED_OUTLINE_ATTR]: EMPHASIZED_OUTLINE_VALUE,
+};
+
+/** `querySelectorAll` selector for the invariant's assertions (unit + e2e). */
+export const EMPHASIZED_OUTLINE_SELECTOR = `[${EMPHASIZED_OUTLINE_ATTR}="${EMPHASIZED_OUTLINE_VALUE}"]`;

--- a/viewer/src/components/views/project/canvas/canvasGridGeometry.js
+++ b/viewer/src/components/views/project/canvas/canvasGridGeometry.js
@@ -27,13 +27,24 @@
  *      `minmax(0, 1fr)` tracks as `(rowWidth - (total - 1) * gap) / total`, and a
  *      `span N` slot then also swallows the N-1 gaps it straddles.
  *
+ *   3. THE SLOT MOVES, not just grows. Because every track shrinks when the
+ *      total grows, an item's LEFT edge slides left as it (or any sibling
+ *      before it) is widened. A preview that keeps the item's measured
+ *      `left` and only stretches its width is truthful about size and wrong
+ *      about position for every item that is not first in its row — which is
+ *      still a drop that does not land on the ghost. `previewItemLeftShiftPx`
+ *      is that missing half.
+ *
  * Everything here is pure arithmetic over MEASURED pixels: callers pass the
  * row's live `getBoundingClientRect().width` and its live computed column gap
  * (`readColumnGapPx`), so a zoomed/transformed canvas stays consistent — the
  * inputs and the outputs are in the same measured space.
  *
- * Verified against real CSS grid layout in headless Chromium across 10 row
- * shapes (worst |formula − rendered| = 0.0000px). See the PR body.
+ * The formulas are checked against real CSS grid layout by a COMMITTED harness:
+ * `viewer/e2e/tools/measure-canvas-grid.mjs` builds rows in headless Chromium
+ * from Dashboard.renderRow's exact styles, measures every slot, and diffs the
+ * numbers against this module (`node e2e/tools/measure-canvas-grid.mjs`). The
+ * pixel fixtures in the unit tests are that script's output.
  */
 
 /**
@@ -100,6 +111,67 @@ export const previewItemWidthPx = ({
   });
 
 /**
+ * The sum of the widths of the items BEFORE `index` in a row — i.e. how many
+ * grid columns a slot starts after. This is the row's own ordering, so it is
+ * the number CSS uses to place the item's implicit `grid-column-start`.
+ */
+export const precedingColsInRow = (items, index) =>
+  (Array.isArray(items) ? items : [])
+    .slice(0, Math.max(0, index))
+    .reduce((sum, it) => sum + (it?.width || 1), 0);
+
+/**
+ * The pixel distance from the row's content-box left edge to the left edge of a
+ * slot that starts after `precedingCols` columns: those tracks PLUS the one gap
+ * that follows each of them.
+ *
+ *   left = precedingCols · (track + gap)
+ */
+export const spanLeftOffsetPx = ({ rowWidth, totalCols, precedingCols = 0, gapPx = 0 }) => {
+  const preceding = Math.max(0, precedingCols || 0);
+  const gap = Number.isFinite(gapPx) ? gapPx : 0;
+  return preceding * (gridTrackPx({ rowWidth, totalCols, gapPx: gap }) + gap);
+};
+
+/**
+ * THE OTHER HALF OF THE TRUTHFUL PREVIEW: how far the dragged slot's LEFT edge
+ * MOVES when its span becomes `spanCols`.
+ *
+ * A right-edge drag rebalances the row, which shrinks every track — including
+ * the `precedingCols` tracks in front of this item — so the item slides LEFT as
+ * it grows. Pinning the ghost's `left` to the item's measured box is therefore
+ * only correct for the first item in a row (`precedingCols === 0`); everywhere
+ * else the ghost is the right size in the wrong place, and on the last item of a
+ * row it is painted hanging off the row's right edge entirely.
+ *
+ * Expressed as a SHIFT (not an absolute left) on purpose: the caller adds it to
+ * the item's own measured `left`, so zero travel is pixel-identical to the card
+ * underneath and any row padding / canvas transform cancels out.
+ *
+ * A left-edge TRANSFER (`rebalance: false`) leaves the total — and therefore the
+ * track size — alone, so this is 0 there; that gesture anchors the slot's RIGHT
+ * edge instead.
+ */
+export const previewItemLeftShiftPx = ({
+  rowWidth,
+  startTotal,
+  startCols,
+  spanCols,
+  precedingCols = 0,
+  gapPx = 0,
+  rebalance = true,
+}) => {
+  const preceding = Math.max(0, precedingCols || 0);
+  if (!preceding) return 0;
+  const gap = Number.isFinite(gapPx) ? gapPx : 0;
+  const nextTotal = rowTotalForSpan({ startTotal, startCols, spanCols, rebalance });
+  return (
+    spanLeftOffsetPx({ rowWidth, totalCols: nextTotal, precedingCols: preceding, gapPx: gap }) -
+    spanLeftOffsetPx({ rowWidth, totalCols: startTotal, precedingCols: preceding, gapPx: gap })
+  );
+};
+
+/**
  * The INVERSE of `previewItemWidthPx`: the integer span whose rendered width
  * lands nearest `targetWidthPx`.
  *
@@ -120,6 +192,11 @@ export const previewItemWidthPx = ({
  * geometry cannot respond to the drag at all. Every candidate ties, and biasing
  * to the start makes that gesture an honest no-op instead of silently rewriting
  * a `width: 12` row to `width: 1`.
+ *
+ * <CanvasResizeLayer> withholds the width handle on such a row outright — a
+ * handle that cannot move anything is a dead affordance — so this tie-break is
+ * the backstop, not the user-facing behaviour. It still matters: any other
+ * caller (a keyboard nudge, a future gesture) gets the same honest answer.
  */
 export const nearestSpanForWidth = ({
   rowWidth,

--- a/viewer/src/components/views/project/canvas/canvasGridGeometry.js
+++ b/viewer/src/components/views/project/canvas/canvasGridGeometry.js
@@ -1,0 +1,176 @@
+/**
+ * canvasGridGeometry — the ONE place the canvas overlays turn a dashboard row's
+ * relative item widths into pixels (VIS-777 follow-up / M26).
+ *
+ * `Item.width` is NOT a column index in a fixed 12-column grid. It is a RELATIVE
+ * WEIGHT, and <Dashboard> renders a row by SUM-NORMALIZING those weights
+ * (Dashboard.jsx `renderRow` / `renderNestedRow`):
+ *
+ *     const totalWidth = visibleItems.reduce((s, i) => s + (i.width || 1), 0);
+ *     style={{ display: 'grid',
+ *              gridTemplateColumns: `repeat(${totalWidth}, minmax(0, 1fr))`,
+ *              gap: '0.7rem' }}
+ *     …each item: style={{ gridColumn: `span ${item.width || 1}` }}
+ *
+ * Two consequences every overlay has to respect:
+ *
+ *   1. The DENOMINATOR MOVES. Growing one item's width grows the row's grid
+ *      total too, so a 6/6 row whose first item goes to 8 becomes 8/14 — the
+ *      item ends up at 57% of the row, not the 67% a "12-column" reading
+ *      predicts. Any preview that scales the item's start box by
+ *      `liveWidth / startWidth` overstates the result on EVERY row (M26: a
+ *      1000px 6/6 row previewed 667px and committed 571px), and understates
+ *      nothing — the error is systematic.
+ *
+ *   2. The GAP IS REAL. `gap: 0.7rem` is subtracted from the track budget, so a
+ *      span's pixel width is NOT `rowWidth * span / total`. CSS resolves equal
+ *      `minmax(0, 1fr)` tracks as `(rowWidth - (total - 1) * gap) / total`, and a
+ *      `span N` slot then also swallows the N-1 gaps it straddles.
+ *
+ * Everything here is pure arithmetic over MEASURED pixels: callers pass the
+ * row's live `getBoundingClientRect().width` and its live computed column gap
+ * (`readColumnGapPx`), so a zoomed/transformed canvas stays consistent — the
+ * inputs and the outputs are in the same measured space.
+ *
+ * Verified against real CSS grid layout in headless Chromium across 10 row
+ * shapes (worst |formula − rendered| = 0.0000px). See the PR body.
+ */
+
+/**
+ * The largest `Item.width` that survives a commit. This is a PERSISTENCE clamp
+ * (canvasReorder.setItemWidth clamps to [1, 12]) — NOT a grid size. The grid is
+ * always `Σ widths` wide; this only bounds a single item's weight so a resize
+ * cannot mint an absurd 400-column row.
+ */
+export const MAX_ITEM_WIDTH = 12;
+
+/** A row's grid total = Σ of its item widths (unset width defaults to 1). */
+export const rowGridTotal = items =>
+  (Array.isArray(items) ? items : []).reduce((sum, it) => sum + (it?.width || 1), 0) || 1;
+
+/**
+ * The pixel size of ONE `minmax(0, 1fr)` track in a `repeat(totalCols, …)` grid
+ * of `rowWidth` px with `gapPx` between tracks.
+ */
+export const gridTrackPx = ({ rowWidth, totalCols, gapPx = 0 }) => {
+  const total = Math.max(1, totalCols);
+  const gap = Number.isFinite(gapPx) ? gapPx : 0;
+  return (rowWidth - (total - 1) * gap) / total;
+};
+
+/**
+ * The pixel width of a `grid-column: span spanCols` slot — `spanCols` tracks
+ * PLUS the `spanCols - 1` gaps the span swallows.
+ */
+export const itemSlotWidthPx = ({ rowWidth, totalCols, spanCols, gapPx = 0 }) => {
+  const span = Math.max(1, spanCols);
+  const gap = Number.isFinite(gapPx) ? gapPx : 0;
+  return span * gridTrackPx({ rowWidth, totalCols, gapPx: gap }) + (span - 1) * gap;
+};
+
+/**
+ * The row's grid total once the dragged item's width becomes `spanCols`.
+ *
+ *   rebalance: true  — a RIGHT-EDGE drag. Only this item's weight changes, so
+ *                      the row total moves with it (6/6 → 8/6, total 12 → 14).
+ *   rebalance: false — a LEFT-EDGE drag. Columns TRANSFER across the boundary
+ *                      with the previous sibling, so the total is unchanged.
+ */
+export const rowTotalForSpan = ({ startTotal, startCols, spanCols, rebalance = true }) =>
+  rebalance ? Math.max(1, startTotal - startCols + spanCols) : Math.max(1, startTotal);
+
+/**
+ * THE formula behind the resize preview: the pixel width the item WILL render
+ * at once `spanCols` is committed — the same sum-normalized geometry
+ * <Dashboard> lays out with.
+ */
+export const previewItemWidthPx = ({
+  rowWidth,
+  startTotal,
+  startCols,
+  spanCols,
+  gapPx = 0,
+  rebalance = true,
+}) =>
+  itemSlotWidthPx({
+    rowWidth,
+    totalCols: rowTotalForSpan({ startTotal, startCols, spanCols, rebalance }),
+    spanCols,
+    gapPx,
+  });
+
+/**
+ * The INVERSE of `previewItemWidthPx`: the integer span whose rendered width
+ * lands nearest `targetWidthPx`.
+ *
+ * A resize gesture is a direct manipulation — the user drags the slot's edge to
+ * where they want it — so the span the drop commits should be the one whose
+ * RENDERED edge is closest to the pointer. Mapping raw pointer travel through a
+ * fixed `rowWidth / total` step instead (the pre-M26 behaviour) assumes each
+ * column is worth a constant number of pixels, which sum-normalization makes
+ * false: on a `[1, 2]` row one extra column is worth 152px of growth but cost
+ * 300px of travel, so the preview visibly detached from the hand.
+ *
+ * `previewItemWidthPx` is monotonically non-decreasing in `spanCols`, so scanning
+ * the clamped candidate range and keeping the nearest is exact.
+ *
+ * Exact ties resolve toward `startCols` — the span the gesture started at. That
+ * matters for the degenerate row: when the dragged item is the row's ONLY item,
+ * `Σ widths` is its own width, so EVERY span renders full-bleed and the rendered
+ * geometry cannot respond to the drag at all. Every candidate ties, and biasing
+ * to the start makes that gesture an honest no-op instead of silently rewriting
+ * a `width: 12` row to `width: 1`.
+ */
+export const nearestSpanForWidth = ({
+  rowWidth,
+  startTotal,
+  startCols,
+  targetWidthPx,
+  gapPx = 0,
+  minCols = 1,
+  maxCols = MAX_ITEM_WIDTH,
+  rebalance = true,
+}) => {
+  const lo = Math.max(1, Math.round(minCols));
+  const hi = Math.max(lo, Math.round(maxCols));
+  const anchor = Math.max(lo, Math.min(hi, startCols));
+  if (!Number.isFinite(targetWidthPx)) return anchor;
+  const EPS = 1e-9;
+  let best = anchor;
+  let bestDist = Infinity;
+  for (let span = lo; span <= hi; span += 1) {
+    const dist = Math.abs(
+      previewItemWidthPx({ rowWidth, startTotal, startCols, spanCols: span, gapPx, rebalance }) -
+        targetWidthPx
+    );
+    const closer = dist < bestDist - EPS;
+    const tiedButSteadier =
+      Math.abs(dist - bestDist) <= EPS && Math.abs(span - anchor) < Math.abs(best - anchor);
+    if (closer || tiedButSteadier) {
+      best = span;
+      bestDist = dist;
+    }
+  }
+  return best;
+};
+
+/**
+ * The row's live computed `column-gap`, in the same measured pixel space as its
+ * `getBoundingClientRect()`. Falls back to 0 when the value is not a length
+ * (jsdom reports the `normal` initial value, and an unmeasurable gap must not
+ * poison the arithmetic with NaN).
+ */
+export const readColumnGapPx = rowEl => {
+  if (!rowEl || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+    return 0;
+  }
+  let raw;
+  try {
+    const style = window.getComputedStyle(rowEl);
+    raw = style ? style.columnGap || style.gap : undefined;
+  } catch {
+    return 0;
+  }
+  const px = parseFloat(raw);
+  return Number.isFinite(px) ? px : 0;
+};

--- a/viewer/src/components/views/project/canvas/canvasGridGeometry.test.js
+++ b/viewer/src/components/views/project/canvas/canvasGridGeometry.test.js
@@ -1,0 +1,335 @@
+/**
+ * canvasGridGeometry tests — the width math behind the truthful resize preview
+ * (M26 / W7).
+ *
+ * The finding: <CanvasResizeLayer> previewed a resize against a hardcoded
+ * 12-column grid while <Dashboard> renders a SUM-NORMALIZED relative grid, so
+ * the ghost promised a width the drop could not deliver on any row whose item
+ * widths did not happen to total 12 (and, because the total MOVES with the drag,
+ * on 12-wide rows too).
+ *
+ * These are the primary guard. The headline assertions are the dossier's own
+ * numbers (rowWidth 1000, total 12, startCols 6 → liveCols 8 renders 571px, not
+ * 667px) plus a round-trip property: the preview must equal the geometry
+ * recomputed from the config the drop ACTUALLY commits, via `setItemWidth` — the
+ * two sides derived independently, so a drift in either is a failure.
+ *
+ * The pixel fixtures below were measured in headless Chromium against a real CSS
+ * grid built with Dashboard.jsx's exact row styles; formula vs. browser agreed to
+ * 0.0161px across ten row shapes.
+ */
+import {
+  MAX_ITEM_WIDTH,
+  gridTrackPx,
+  itemSlotWidthPx,
+  nearestSpanForWidth,
+  previewItemWidthPx,
+  readColumnGapPx,
+  rowGridTotal,
+  rowTotalForSpan,
+} from './canvasGridGeometry';
+import { setItemWidth } from './canvasReorder';
+
+// Dashboard.jsx renders rows with `gap: '0.7rem'` → 11.2px at a 16px root.
+const REAL_GAP = 11.2;
+
+describe('rowGridTotal', () => {
+  test('sums the row item widths — that IS the grid, not a fixed 12', () => {
+    expect(rowGridTotal([{ width: 6 }, { width: 6 }])).toBe(12);
+    expect(rowGridTotal([{ width: 1 }, { width: 2 }])).toBe(3);
+    expect(rowGridTotal([{ width: 3 }, { width: 5 }, { width: 1 }])).toBe(9);
+    expect(rowGridTotal([{ width: 9 }, { width: 2 }])).toBe(11);
+  });
+
+  test('an unset width counts as 1 (mirrors the renderer)', () => {
+    expect(rowGridTotal([{}, { width: 3 }, {}])).toBe(5);
+  });
+
+  test('an empty / unusable row falls back to 1 so nothing divides by zero', () => {
+    expect(rowGridTotal([])).toBe(1);
+    expect(rowGridTotal(null)).toBe(1);
+    expect(rowGridTotal(undefined)).toBe(1);
+  });
+});
+
+describe('gridTrackPx / itemSlotWidthPx — CSS `repeat(T, minmax(0,1fr))` + gap', () => {
+  test('with no gap a track is just an equal share of the row', () => {
+    expect(gridTrackPx({ rowWidth: 1200, totalCols: 12, gapPx: 0 })).toBeCloseTo(100, 9);
+    expect(itemSlotWidthPx({ rowWidth: 1200, totalCols: 12, spanCols: 6, gapPx: 0 })).toBeCloseTo(
+      600,
+      9
+    );
+  });
+
+  test('the gap is subtracted from the track budget and re-added inside a span', () => {
+    // 12 tracks, 11 gaps: (1000 - 11·11.2)/12 = 73.06667 per track; a span of 6
+    // covers 6 tracks + the 5 gaps it straddles.
+    expect(gridTrackPx({ rowWidth: 1000, totalCols: 12, gapPx: REAL_GAP })).toBeCloseTo(
+      73.0666667,
+      6
+    );
+    // Browser-measured: 494.41px (formula 494.40px).
+    expect(
+      itemSlotWidthPx({ rowWidth: 1000, totalCols: 12, spanCols: 6, gapPx: REAL_GAP })
+    ).toBeCloseTo(494.4, 2);
+  });
+
+  test('a full-span single item gets the whole row back, gap or no gap', () => {
+    expect(itemSlotWidthPx({ rowWidth: 777, totalCols: 12, spanCols: 12, gapPx: REAL_GAP })).toBeCloseTo(
+      777,
+      9
+    );
+    expect(itemSlotWidthPx({ rowWidth: 777, totalCols: 1, spanCols: 1, gapPx: REAL_GAP })).toBeCloseTo(
+      777,
+      9
+    );
+  });
+
+  test('browser-measured fixtures reproduce exactly (3 real row shapes)', () => {
+    // [1,2] on a 900px row → 292.53 / 596.28 measured.
+    expect(itemSlotWidthPx({ rowWidth: 900, totalCols: 3, spanCols: 1, gapPx: REAL_GAP })).toBeCloseTo(
+      292.53,
+      2
+    );
+    expect(itemSlotWidthPx({ rowWidth: 900, totalCols: 3, spanCols: 2, gapPx: REAL_GAP })).toBeCloseTo(
+      596.27,
+      2
+    );
+    // [3,5,1] on a 1200px row → 392.53 / 661.70 / 123.38 measured.
+    expect(itemSlotWidthPx({ rowWidth: 1200, totalCols: 9, spanCols: 3, gapPx: REAL_GAP })).toBeCloseTo(
+      392.53,
+      2
+    );
+    expect(itemSlotWidthPx({ rowWidth: 1200, totalCols: 9, spanCols: 5, gapPx: REAL_GAP })).toBeCloseTo(
+      661.69,
+      2
+    );
+    // [7,2,4,1] on a 1013px row → 500.91 measured for the first slot.
+    expect(itemSlotWidthPx({ rowWidth: 1013, totalCols: 14, spanCols: 7, gapPx: REAL_GAP })).toBeCloseTo(
+      500.9,
+      2
+    );
+  });
+
+  test('a non-finite gap degrades to 0 instead of poisoning the arithmetic', () => {
+    expect(itemSlotWidthPx({ rowWidth: 800, totalCols: 4, spanCols: 2, gapPx: NaN })).toBe(400);
+    expect(itemSlotWidthPx({ rowWidth: 800, totalCols: 4, spanCols: 2, gapPx: undefined })).toBe(400);
+  });
+});
+
+describe('rowTotalForSpan — the denominator moves on a right-edge drag', () => {
+  test('a rebalancing (right-edge) drag grows the row total with the item', () => {
+    expect(rowTotalForSpan({ startTotal: 12, startCols: 6, spanCols: 8 })).toBe(14);
+    expect(rowTotalForSpan({ startTotal: 12, startCols: 6, spanCols: 3 })).toBe(9);
+    expect(rowTotalForSpan({ startTotal: 3, startCols: 1, spanCols: 2 })).toBe(4);
+  });
+
+  test('a transferring (left-edge) drag leaves the row total alone', () => {
+    expect(rowTotalForSpan({ startTotal: 12, startCols: 6, spanCols: 8, rebalance: false })).toBe(12);
+  });
+
+  test('never returns a zero denominator', () => {
+    expect(rowTotalForSpan({ startTotal: 0, startCols: 0, spanCols: 0 })).toBe(1);
+  });
+});
+
+describe('previewItemWidthPx — M26: the ghost the drop can actually deliver', () => {
+  test('THE finding: a 6/6 row dragged to width 8 renders 571px, not 667px', () => {
+    const truthful = previewItemWidthPx({
+      rowWidth: 1000,
+      startTotal: 12,
+      startCols: 6,
+      spanCols: 8,
+      gapPx: 0,
+    });
+    // 8 / (12 − 6 + 8) = 8/14 of the row.
+    expect(truthful).toBeCloseTo(571.43, 2);
+
+    // The pre-fix formula — scale the start box by live/start against a fixed
+    // 12-column grid — overstates it by 95px on this row alone.
+    const startBox = itemSlotWidthPx({ rowWidth: 1000, totalCols: 12, spanCols: 6, gapPx: 0 });
+    const oldGhost = startBox * (8 / 6);
+    expect(oldGhost).toBeCloseTo(666.67, 2);
+    expect(oldGhost - truthful).toBeGreaterThan(90);
+  });
+
+  test('the error is systematic — every row shape, not just the exotic ones', () => {
+    const shapes = [
+      { widths: [6, 6], rowWidth: 1000, index: 0, span: 8 },
+      { widths: [1, 2], rowWidth: 900, index: 0, span: 2 },
+      { widths: [3, 5, 1], rowWidth: 1200, index: 0, span: 5 },
+      { widths: [2, 3], rowWidth: 960, index: 1, span: 4 },
+      { widths: [9, 2], rowWidth: 800, index: 0, span: 7 },
+    ];
+    for (const { widths, rowWidth, index, span } of shapes) {
+      const startTotal = rowGridTotal(widths.map(width => ({ width })));
+      const startCols = widths[index];
+      const startBox = itemSlotWidthPx({ rowWidth, totalCols: startTotal, spanCols: startCols, gapPx: 0 });
+      const truthful = previewItemWidthPx({
+        rowWidth,
+        startTotal,
+        startCols,
+        spanCols: span,
+        gapPx: 0,
+      });
+      const oldGhost = startBox * (span / startCols);
+      // The old ghost is wrong in the SAME direction every time: it ignores the
+      // moving denominator, so growth is always overstated and shrink is always
+      // understated. Signed by the drag direction, the lie is always positive.
+      const lie = span > startCols ? oldGhost - truthful : truthful - oldGhost;
+      expect(lie).toBeGreaterThan(2);
+    }
+  });
+
+  test('a left-edge TRANSFER previews against the UNCHANGED row total', () => {
+    // Columns only move across the shared boundary, so 8 of 12 stays 8 of 12.
+    expect(
+      previewItemWidthPx({
+        rowWidth: 1200,
+        startTotal: 12,
+        startCols: 6,
+        spanCols: 8,
+        gapPx: 0,
+        rebalance: false,
+      })
+    ).toBeCloseTo(800, 9);
+  });
+
+  test('zero travel previews the slot the item already occupies', () => {
+    for (const gapPx of [0, REAL_GAP]) {
+      expect(
+        previewItemWidthPx({ rowWidth: 1000, startTotal: 12, startCols: 6, spanCols: 6, gapPx })
+      ).toBeCloseTo(itemSlotWidthPx({ rowWidth: 1000, totalCols: 12, spanCols: 6, gapPx }), 9);
+    }
+  });
+
+  test('GHOST == DROP: the preview matches the geometry recomputed from the COMMITTED config', () => {
+    // Independent derivation: run the real config mutation the gesture commits
+    // (`setItemWidth`), then lay the resulting row out from scratch. If the ghost
+    // and the drop ever disagree again, this is the test that says so.
+    const shapes = [
+      [6, 6],
+      [1, 2],
+      [3, 5, 1],
+      [2, 3],
+      [9, 2],
+      [12],
+      [3, 3, 3, 3],
+      [7, 2, 4, 1],
+    ];
+    const rowWidth = 1140;
+    for (const widths of shapes) {
+      for (let index = 0; index < widths.length; index += 1) {
+        for (let span = 1; span <= MAX_ITEM_WIDTH; span += 1) {
+          const config = { rows: [{ items: widths.map(width => ({ width })) }] };
+          const startTotal = rowGridTotal(config.rows[0].items);
+          const ghost = previewItemWidthPx({
+            rowWidth,
+            startTotal,
+            startCols: widths[index],
+            spanCols: span,
+            gapPx: REAL_GAP,
+          });
+
+          const committed = setItemWidth(config, `row.0.item.${index}`, span);
+          const items = committed.rows[0].items;
+          const dropped = itemSlotWidthPx({
+            rowWidth,
+            totalCols: rowGridTotal(items),
+            spanCols: items[index].width || 1,
+            gapPx: REAL_GAP,
+          });
+          expect(ghost).toBeCloseTo(dropped, 9);
+        }
+      }
+    }
+  });
+});
+
+describe('nearestSpanForWidth — the inverse the gesture picks a span with', () => {
+  const ROW = { rowWidth: 800, startTotal: 12, startCols: 6, gapPx: 0 };
+
+  test('picks the span whose RENDERED width lands nearest the dragged edge', () => {
+    // Candidates on this row: 6→400, 7→430.8, 8→457.1, 9→480.
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: 457 })).toBe(8);
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: 431 })).toBe(7);
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: 479 })).toBe(9);
+  });
+
+  test('is a true inverse of previewItemWidthPx across the whole range', () => {
+    for (let span = 1; span <= MAX_ITEM_WIDTH; span += 1) {
+      const width = previewItemWidthPx({ ...ROW, spanCols: span });
+      expect(nearestSpanForWidth({ ...ROW, targetWidthPx: width })).toBe(span);
+    }
+  });
+
+  test('zero travel is a no-op — the start span round-trips', () => {
+    const startWidth = previewItemWidthPx({ ...ROW, spanCols: ROW.startCols });
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: startWidth })).toBe(6);
+  });
+
+  test('clamps to [1, MAX_ITEM_WIDTH] — the persistence clamp, never a phantom span', () => {
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: -5000 })).toBe(1);
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: 50000 })).toBe(MAX_ITEM_WIDTH);
+  });
+
+  test('a left-edge transfer is bounded by the neighbour it borrows from', () => {
+    // Neighbour is 4 wide, so it can lend at most 3 columns: max span 6 + 3 = 9.
+    const bounded = {
+      rowWidth: 1200,
+      startTotal: 10,
+      startCols: 6,
+      gapPx: 0,
+      rebalance: false,
+      maxCols: 9,
+    };
+    expect(nearestSpanForWidth({ ...bounded, targetWidthPx: 99999 })).toBe(9);
+    expect(nearestSpanForWidth({ ...bounded, targetWidthPx: 0 })).toBe(1);
+  });
+
+  test('a SINGLE-item row is a no-op: every span renders full-bleed, so keep the start', () => {
+    // Σ widths === this item's width, so the rendered slot is the whole row at
+    // ANY span — the drag cannot change the geometry, and it must not silently
+    // rewrite `width: 12` to `width: 1`.
+    const solo = { rowWidth: 900, startTotal: 12, startCols: 12, gapPx: REAL_GAP };
+    expect(previewItemWidthPx({ ...solo, spanCols: 1 })).toBeCloseTo(900, 9);
+    expect(previewItemWidthPx({ ...solo, spanCols: 12 })).toBeCloseTo(900, 9);
+    expect(nearestSpanForWidth({ ...solo, targetWidthPx: 300 })).toBe(12);
+    expect(nearestSpanForWidth({ ...solo, targetWidthPx: 1500 })).toBe(12);
+  });
+
+  test('a non-finite target keeps the start span rather than collapsing to 1', () => {
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: NaN })).toBe(6);
+    expect(nearestSpanForWidth({ ...ROW, targetWidthPx: undefined })).toBe(6);
+  });
+});
+
+describe('readColumnGapPx', () => {
+  test('reads a real computed column-gap off the row', () => {
+    const el = document.createElement('div');
+    el.style.display = 'grid';
+    el.style.columnGap = '11.2px';
+    document.body.appendChild(el);
+    expect(readColumnGapPx(el)).toBeCloseTo(11.2, 2);
+    document.body.removeChild(el);
+  });
+
+  test('a missing element or a non-length value degrades to 0, never NaN', () => {
+    expect(readColumnGapPx(null)).toBe(0);
+    expect(readColumnGapPx(undefined)).toBe(0);
+    const el = document.createElement('div'); // jsdom reports the `normal` initial value
+    expect(readColumnGapPx(el)).toBe(0);
+  });
+
+  test('survives an element whose computed style throws', () => {
+    const original = window.getComputedStyle;
+    window.getComputedStyle = () => {
+      throw new Error('detached');
+    };
+    try {
+      expect(readColumnGapPx(document.createElement('div'))).toBe(0);
+    } finally {
+      window.getComputedStyle = original;
+    }
+  });
+});

--- a/viewer/src/components/views/project/canvas/canvasGridGeometry.test.js
+++ b/viewer/src/components/views/project/canvas/canvasGridGeometry.test.js
@@ -14,24 +14,47 @@
  * recomputed from the config the drop ACTUALLY commits, via `setItemWidth` — the
  * two sides derived independently, so a drift in either is a failure.
  *
- * The pixel fixtures below were measured in headless Chromium against a real CSS
- * grid built with Dashboard.jsx's exact row styles; formula vs. browser agreed to
- * 0.0161px across ten row shapes.
+ * The pixel fixtures below are the OUTPUT of `viewer/e2e/tools/measure-canvas-grid.mjs`,
+ * a committed harness that builds these exact rows in headless Chromium from
+ * Dashboard.renderRow's styles and measures every slot. Re-run it with
+ * `node e2e/tools/measure-canvas-grid.mjs` from `viewer/`. Its last run:
+ *
+ *     worst |formula − rendered| (static)       = 0.021591px
+ *     worst |ghost − rendered| (width)          = 0.022500px
+ *     worst |ghost − rendered| (left)           = 0.017857px
+ *     worst |frozen box.left − rendered| (left) = 592.140625px  <- pre-fix
+ *
+ * That last line is the second half of the finding: the ghost's LEFT edge. See
+ * the `previewItemLeftShiftPx` block below.
+ *
+ * These fixtures pin the formula against regression; they cannot, on their own,
+ * prove it still matches the RENDERER. `dashboardGridContract.test.jsx` is the
+ * test that couples this module to <Dashboard>'s actual row markup.
  */
 import {
   MAX_ITEM_WIDTH,
   gridTrackPx,
   itemSlotWidthPx,
   nearestSpanForWidth,
+  precedingColsInRow,
+  previewItemLeftShiftPx,
   previewItemWidthPx,
   readColumnGapPx,
   rowGridTotal,
   rowTotalForSpan,
+  spanLeftOffsetPx,
 } from './canvasGridGeometry';
 import { setItemWidth } from './canvasReorder';
 
 // Dashboard.jsx renders rows with `gap: '0.7rem'` → 11.2px at a 16px root.
 const REAL_GAP = 11.2;
+
+// Chromium resolves `fr` tracks at LayoutUnit (1/64 = 0.015625px) precision and
+// that rounding accumulates across the tracks a slot straddles, so a browser
+// fixture can never match the float formula exactly. 0.05px is two LayoutUnits
+// wide and still three orders of magnitude below anything a user can see —
+// a genuinely different formula could not slip under it.
+const BROWSER_EPS = 0.05;
 
 describe('rowGridTotal', () => {
   test('sums the row item widths — that IS the grid, not a fixed 12', () => {
@@ -68,10 +91,10 @@ describe('gridTrackPx / itemSlotWidthPx — CSS `repeat(T, minmax(0,1fr))` + gap
       73.0666667,
       6
     );
-    // Browser-measured: 494.41px (formula 494.40px).
+    // Browser measured 494.4063px on the [6,6] @1000 row (formula 494.4px).
     expect(
-      itemSlotWidthPx({ rowWidth: 1000, totalCols: 12, spanCols: 6, gapPx: REAL_GAP })
-    ).toBeCloseTo(494.4, 2);
+      Math.abs(itemSlotWidthPx({ rowWidth: 1000, totalCols: 12, spanCols: 6, gapPx: REAL_GAP }) - 494.4063)
+    ).toBeLessThan(BROWSER_EPS);
   });
 
   test('a full-span single item gets the whole row back, gap or no gap', () => {
@@ -86,29 +109,28 @@ describe('gridTrackPx / itemSlotWidthPx — CSS `repeat(T, minmax(0,1fr))` + gap
   });
 
   test('browser-measured fixtures reproduce exactly (3 real row shapes)', () => {
-    // [1,2] on a 900px row → 292.53 / 596.28 measured.
-    expect(itemSlotWidthPx({ rowWidth: 900, totalCols: 3, spanCols: 1, gapPx: REAL_GAP })).toBeCloseTo(
-      292.53,
-      2
-    );
-    expect(itemSlotWidthPx({ rowWidth: 900, totalCols: 3, spanCols: 2, gapPx: REAL_GAP })).toBeCloseTo(
-      596.27,
-      2
-    );
-    // [3,5,1] on a 1200px row → 392.53 / 661.70 / 123.38 measured.
-    expect(itemSlotWidthPx({ rowWidth: 1200, totalCols: 9, spanCols: 3, gapPx: REAL_GAP })).toBeCloseTo(
-      392.53,
-      2
-    );
-    expect(itemSlotWidthPx({ rowWidth: 1200, totalCols: 9, spanCols: 5, gapPx: REAL_GAP })).toBeCloseTo(
-      661.69,
-      2
-    );
-    // [7,2,4,1] on a 1013px row → 500.91 measured for the first slot.
-    expect(itemSlotWidthPx({ rowWidth: 1013, totalCols: 14, spanCols: 7, gapPx: REAL_GAP })).toBeCloseTo(
-      500.9,
-      2
-    );
+    // VERBATIM `getBoundingClientRect().width` readings from
+    // e2e/tools/measure-canvas-grid.mjs — LayoutUnit rounding included, so they
+    // are the BROWSER's numbers and not the formula's own output rounded.
+    const w = (rowWidth, totalCols, spanCols) =>
+      itemSlotWidthPx({ rowWidth, totalCols, spanCols, gapPx: REAL_GAP });
+    const measured = [
+      // [1,2] @900 → 292.5313 / 596.2813
+      [w(900, 3, 1), 292.5313],
+      [w(900, 3, 2), 596.2813],
+      // [3,5,1] @1200 → 392.5313 / 661.7031 / 123.375
+      [w(1200, 9, 3), 392.5313],
+      [w(1200, 9, 5), 661.7031],
+      [w(1200, 9, 1), 123.375],
+      // [7,2,4,1] @1013 → 500.9063 / 135.125 / 281.4375 / 61.9688
+      [w(1013, 14, 7), 500.9063],
+      [w(1013, 14, 2), 135.125],
+      [w(1013, 14, 4), 281.4375],
+      [w(1013, 14, 1), 61.9688],
+    ];
+    for (const [formula, browser] of measured) {
+      expect(Math.abs(formula - browser)).toBeLessThan(BROWSER_EPS);
+    }
   });
 
   test('a non-finite gap degrades to 0 instead of poisoning the arithmetic', () => {
@@ -243,6 +265,191 @@ describe('previewItemWidthPx — M26: the ghost the drop can actually deliver', 
         }
       }
     }
+  });
+});
+
+describe('precedingColsInRow / spanLeftOffsetPx — where a slot STARTS', () => {
+  test('counts the columns in front of an item, unset widths as 1', () => {
+    const items = [{ width: 3 }, { width: 5 }, {}, { width: 1 }];
+    expect(precedingColsInRow(items, 0)).toBe(0);
+    expect(precedingColsInRow(items, 1)).toBe(3);
+    expect(precedingColsInRow(items, 2)).toBe(8);
+    expect(precedingColsInRow(items, 3)).toBe(9);
+  });
+
+  test('degrades safely on junk input', () => {
+    expect(precedingColsInRow(null, 2)).toBe(0);
+    expect(precedingColsInRow(undefined, 2)).toBe(0);
+    expect(precedingColsInRow([{ width: 4 }], -3)).toBe(0);
+  });
+
+  test('browser-measured left offsets reproduce exactly (4 real row shapes)', () => {
+    // Every number here is a `getBoundingClientRect().left − row.left` read out
+    // of headless Chromium by e2e/tools/measure-canvas-grid.mjs, VERBATIM —
+    // including the browser's LayoutUnit (1/64px) rounding, which is why the
+    // tolerance is BROWSER_EPS and not an arbitrary decimal precision.
+    const at = (rowWidth, totalCols, precedingCols) =>
+      spanLeftOffsetPx({ rowWidth, totalCols, precedingCols, gapPx: REAL_GAP });
+    const measured = [
+      // [6,6] @1000 → item 1
+      [at(1000, 12, 6), 505.5938],
+      // [3,5,1] @1200 → items 1 and 2
+      [at(1200, 9, 3), 403.7188],
+      [at(1200, 9, 8), 1076.6094],
+      // [7,2,4,1] @1013 → items 1 and 3
+      [at(1013, 14, 7), 512.0938],
+      [at(1013, 14, 13), 951.0313],
+      // [2,2,2,2] @1200 → item 3
+      [at(1200, 8, 6), 908.3906],
+    ];
+    for (const [formula, browser] of measured) {
+      expect(Math.abs(formula - browser)).toBeLessThan(BROWSER_EPS);
+    }
+  });
+
+  test('the first slot always starts at the row edge', () => {
+    expect(spanLeftOffsetPx({ rowWidth: 1000, totalCols: 12, precedingCols: 0, gapPx: REAL_GAP })).toBe(0);
+  });
+
+  test('a non-finite gap degrades to 0 instead of poisoning the arithmetic', () => {
+    expect(spanLeftOffsetPx({ rowWidth: 800, totalCols: 4, precedingCols: 2, gapPx: NaN })).toBe(400);
+  });
+});
+
+describe('previewItemLeftShiftPx — M26 second half: the slot MOVES as it grows', () => {
+  test('THE finding: a 6/6 row dragged to width 10 slides item 1 126px LEFT', () => {
+    // The whole row re-tracks: 12 columns of 73.07px become 16 of 52.00px, so
+    // the six columns in FRONT of item 1 shrink and drag it left with them. A
+    // ghost pinned at the item's measured `left` is 126px out — and, being the
+    // last item, is painted hanging 126px off the row's right edge.
+    const shift = previewItemLeftShiftPx({
+      rowWidth: 1000,
+      startTotal: 12,
+      startCols: 6,
+      spanCols: 10,
+      precedingCols: 6,
+      gapPx: REAL_GAP,
+    });
+    expect(shift).toBeCloseTo(-126.4, 1);
+    // Browser: item 1 sits at 505.59 before and 379.19 after.
+    expect(505.59 + shift).toBeCloseTo(379.19, 1);
+  });
+
+  test('the FIRST item in a row never moves — its left edge is the row edge', () => {
+    for (let span = 1; span <= MAX_ITEM_WIDTH; span += 1) {
+      expect(
+        previewItemLeftShiftPx({
+          rowWidth: 1000,
+          startTotal: 12,
+          startCols: 6,
+          spanCols: span,
+          precedingCols: 0,
+          gapPx: REAL_GAP,
+        })
+      ).toBe(0);
+    }
+  });
+
+  test('a left-edge TRANSFER holds the tracks still, so the shift is 0', () => {
+    // Columns only move ACROSS the shared boundary: the total — and therefore
+    // every track — is unchanged, and that gesture anchors the RIGHT edge.
+    expect(
+      previewItemLeftShiftPx({
+        rowWidth: 1200,
+        startTotal: 12,
+        startCols: 6,
+        spanCols: 9,
+        precedingCols: 3,
+        gapPx: REAL_GAP,
+        rebalance: false,
+      })
+    ).toBe(0);
+  });
+
+  test('zero travel is a zero shift — the ghost is welded to the card at rest', () => {
+    for (const gapPx of [0, REAL_GAP]) {
+      expect(
+        previewItemLeftShiftPx({
+          rowWidth: 900,
+          startTotal: 9,
+          startCols: 5,
+          spanCols: 5,
+          precedingCols: 3,
+          gapPx,
+        })
+      ).toBeCloseTo(0, 9);
+    }
+  });
+
+  test('shrinking pushes the slot RIGHT (the tracks in front of it grow)', () => {
+    const shift = previewItemLeftShiftPx({
+      rowWidth: 1000,
+      startTotal: 12,
+      startCols: 4,
+      spanCols: 2,
+      precedingCols: 4,
+      gapPx: REAL_GAP,
+    });
+    expect(shift).toBeGreaterThan(0);
+  });
+
+  test('GHOST LEFT == DROP LEFT: the preview matches the COMMITTED re-layout', () => {
+    // Independent derivation, same shape as the width round-trip: run the real
+    // mutation the gesture commits (`setItemWidth`), lay the resulting row out
+    // from scratch, and check the ghost's left edge against it. Also asserts the
+    // pre-fix ghost (frozen at the start left) really was wrong, so this test
+    // cannot pass by accident on a formula that ignores the shift.
+    const rowWidth = 1140;
+    const shapes = [
+      [6, 6],
+      [1, 2],
+      [3, 5, 1],
+      [2, 3],
+      [9, 2],
+      [12],
+      [3, 3, 3, 3],
+      [7, 2, 4, 1],
+    ];
+    let worstFrozenError = 0;
+    for (const widths of shapes) {
+      for (let index = 0; index < widths.length; index += 1) {
+        for (let span = 1; span <= MAX_ITEM_WIDTH; span += 1) {
+          const config = { rows: [{ items: widths.map(width => ({ width })) }] };
+          const items = config.rows[0].items;
+          const startTotal = rowGridTotal(items);
+          const precedingCols = precedingColsInRow(items, index);
+          const startLeft = spanLeftOffsetPx({
+            rowWidth,
+            totalCols: startTotal,
+            precedingCols,
+            gapPx: REAL_GAP,
+          });
+          const ghostLeft =
+            startLeft +
+            previewItemLeftShiftPx({
+              rowWidth,
+              startTotal,
+              startCols: widths[index],
+              spanCols: span,
+              precedingCols,
+              gapPx: REAL_GAP,
+            });
+
+          const committed = setItemWidth(config, `row.0.item.${index}`, span);
+          const after = committed.rows[0].items;
+          const droppedLeft = spanLeftOffsetPx({
+            rowWidth,
+            totalCols: rowGridTotal(after),
+            precedingCols: precedingColsInRow(after, index),
+            gapPx: REAL_GAP,
+          });
+          expect(ghostLeft).toBeCloseTo(droppedLeft, 9);
+          worstFrozenError = Math.max(worstFrozenError, Math.abs(startLeft - droppedLeft));
+        }
+      }
+    }
+    // The pre-fix ghost froze `left` at the start box: hundreds of pixels off.
+    expect(worstFrozenError).toBeGreaterThan(300);
   });
 });
 

--- a/viewer/src/components/views/project/canvas/canvasOutlineEmphasis.test.jsx
+++ b/viewer/src/components/views/project/canvas/canvasOutlineEmphasis.test.jsx
@@ -1,0 +1,232 @@
+/**
+ * ONE emphasized outline, across the whole overlay STACK (M26 / VIS-1260).
+ *
+ * The canvas mounts <CanvasSelectionOverlay> and <CanvasResizeLayer> as
+ * SIBLINGS (ProjectCanvas.jsx). Each renders into its own absolutely-positioned
+ * layer, so neither can see — or dim — the other's rings, and the resize layer's
+ * card-fade (an imperative opacity on the measured <Dashboard> node) cannot
+ * reach a ring that is not inside that node.
+ *
+ * The bug that made this file necessary: during a resize gesture the selection
+ * overlay kept a full-strength 2px `ring-primary` at the PRE-DRAG geometry while
+ * the resize layer painted an identical 2px ring at the target. Two identical
+ * mulberry boxes, one of them superseded — strictly more ambiguous than no
+ * preview at all, since the bright ring at the old geometry reads as "the
+ * selected thing".
+ *
+ * Counting it inside CanvasResizeLayer's own test file could not catch that: the
+ * marker was private to the ghost, so `toHaveLength(1)` was true by
+ * construction. Here BOTH overlays are mounted and BOTH stamp
+ * `EMPHASIZED_OUTLINE_PROPS` (canvasEmphasis.js), so the count is a real
+ * property of the rendered canvas — delete the suppression in
+ * CanvasSelectionOverlay and these tests go red with 2.
+ */
+import React, { useRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import CanvasSelectionOverlay from './CanvasSelectionOverlay';
+import CanvasResizeLayer from './CanvasResizeLayer';
+import { EMPHASIZED_OUTLINE_SELECTOR } from './canvasEmphasis';
+import useStore from '../../../../stores/store';
+
+const mockCommit = jest.fn();
+jest.mock('../../workspace/WorkspaceDndContext', () => ({
+  useCommitCanvasConfig: () => mockCommit,
+}));
+
+jest.mock('../../workspace/telemetry', () => ({
+  emitWorkspaceEvent: jest.fn(),
+}));
+
+const makeEvt = (type, { clientX, clientY, shiftKey = false }) =>
+  new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, shiftKey });
+
+const firePointer = (type, coords) => {
+  act(() => {
+    window.dispatchEvent(makeEvt(type, coords));
+  });
+};
+
+const firePointerDown = (el, coords) => {
+  act(() => {
+    el.dispatchEvent(makeEvt('pointerdown', coords));
+  });
+};
+
+const DASHBOARD = {
+  name: 'dash',
+  config: {
+    rows: [
+      { height: 'medium', items: [{ width: 6, chart: 'ref(a)' }, { width: 6, table: 'ref(b)' }] },
+    ],
+  },
+};
+
+const BOXES = {
+  r0: { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+  r0i0: { top: 0, left: 0, width: 400, height: 200, bottom: 200, right: 400 },
+  r0i1: { top: 0, left: 400, width: 400, height: 200, bottom: 200, right: 800 },
+  root: { top: 0, left: 0, width: 800, height: 200, bottom: 200, right: 800 },
+};
+
+// The two overlays, mounted exactly as ProjectCanvas mounts them: siblings over
+// the render, sharing one positioned root ref.
+const CanvasHost = () => {
+  const rootRef = useRef(null);
+  return (
+    <div ref={rootRef} data-testid="project-canvas" style={{ position: 'relative' }}>
+      <div data-canvas-path="row.0" data-testid="r0">
+        <div data-canvas-path="row.0.item.0" data-testid="r0i0" />
+        <div data-canvas-path="row.0.item.1" data-testid="r0i1" />
+      </div>
+      <CanvasSelectionOverlay rootRef={rootRef} />
+      <CanvasResizeLayer rootRef={rootRef} dashboardName="dash" />
+    </div>
+  );
+};
+
+let container;
+const emphasized = () =>
+  // eslint-disable-next-line testing-library/no-node-access
+  Array.from(container.querySelectorAll(EMPHASIZED_OUTLINE_SELECTOR));
+
+beforeEach(() => {
+  mockCommit.mockClear();
+  useStore.setState({
+    dashboards: [DASHBOARD],
+    // Selection is applied AFTER mount (below): the overlay measures the canvas
+    // through the root ref, which React attaches during the parent's commit —
+    // i.e. after a child's layout effect. That is the same order a real click
+    // produces, and the idiom CanvasSelectionOverlay.test.jsx already uses.
+    workspaceOutlineSelectedKey: 'dashboard',
+    workspaceCanvasResizeKey: null,
+    workspaceCanvasHoverKey: null,
+  });
+  Element.prototype.getBoundingClientRect = function () {
+    const tid = this.getAttribute && this.getAttribute('data-testid');
+    if (tid && BOXES[tid]) return BOXES[tid];
+    return BOXES.root;
+  };
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+});
+
+const mountCanvas = (selectedKey = 'row.0.item.0') => {
+  // Always mount on chrome so the select below is a real transition (a no-op
+  // set would not re-render, and the first layout effect runs before the
+  // parent's root ref is attached).
+  useStore.setState({ workspaceOutlineSelectedKey: 'dashboard' });
+  const view = render(<CanvasHost />);
+  container = view.container;
+  act(() => {
+    useStore.getState().setWorkspaceOutlineSelectedKey(selectedKey);
+  });
+  return view;
+};
+
+describe('the canvas paints exactly ONE emphasized outline (M26)', () => {
+  test('at rest it is the selection ring', () => {
+    mountCanvas();
+    const outlines = emphasized();
+    expect(outlines).toHaveLength(1);
+    expect(outlines[0]).toBe(screen.getByTestId('canvas-overlay-selected-item'));
+  });
+
+  test('DURING a resize it is the GHOST — the selection ring stands down', () => {
+    mountCanvas();
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+
+    // Without the suppression this is 2: a full-strength 2px mulberry ring at
+    // the pre-drag box AND an identical one at the drag target.
+    const outlines = emphasized();
+    expect(outlines).toHaveLength(1);
+    expect(outlines[0]).toBe(screen.getByTestId('canvas-resize-ghost'));
+    expect(screen.queryByTestId('canvas-overlay-selected-item')).not.toBeInTheDocument();
+
+    firePointer('pointerup', { clientX: 397 + 57, clientY: 100 });
+  });
+
+  test('the ring comes straight back on release', () => {
+    mountCanvas();
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    firePointer('pointerup', { clientX: 397 + 57, clientY: 100 });
+
+    const outlines = emphasized();
+    expect(outlines).toHaveLength(1);
+    expect(outlines[0]).toBe(screen.getByTestId('canvas-overlay-selected-item'));
+    expect(useStore.getState().workspaceCanvasResizeKey).toBeNull();
+  });
+
+  test('an ABORTED gesture hands the ring back too (Esc / pointercancel)', () => {
+    mountCanvas();
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(emphasized()).toHaveLength(1);
+    expect(screen.getByTestId('canvas-overlay-selected-item')).toBeInTheDocument();
+
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 2 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    firePointer('pointercancel', { clientX: 397 + 57, clientY: 100 });
+    expect(emphasized()).toHaveLength(1);
+    expect(screen.getByTestId('canvas-overlay-selected-item')).toBeInTheDocument();
+  });
+
+  test('a height gesture also owns the emphasis (the ghost spans the row)', () => {
+    mountCanvas();
+    const handle = screen.getByTestId('canvas-resize-height-row.0.item.0');
+    firePointerDown(handle, { clientX: 400, clientY: 195, pointerId: 1 });
+    firePointer('pointermove', { clientX: 400, clientY: 315 });
+
+    const outlines = emphasized();
+    expect(outlines).toHaveLength(1);
+    expect(outlines[0]).toBe(screen.getByTestId('canvas-resize-ghost'));
+
+    firePointer('pointerup', { clientX: 400, clientY: 315 });
+    expect(emphasized()).toHaveLength(1);
+  });
+
+  test('the HOVER hint also stands down — no stale ring chasing a dragging pointer', () => {
+    mountCanvas();
+    // Hover the OTHER item, so the hover ring is not suppressed as a duplicate
+    // of the selection ring.
+    act(() => {
+      screen
+        .getByTestId('r0i1')
+        .dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    });
+    expect(screen.getByTestId('canvas-overlay-hover-item')).toBeInTheDocument();
+
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    expect(screen.queryByTestId('canvas-overlay-hover-item')).not.toBeInTheDocument();
+
+    firePointer('pointerup', { clientX: 397 + 57, clientY: 100 });
+    expect(emphasized()).toHaveLength(1);
+  });
+
+  test('unmounting mid-gesture releases the suppression rather than stranding it', () => {
+    // A route change mid-drag must not leave the canvas permanently ring-less.
+    const { unmount } = mountCanvas();
+    const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
+    firePointerDown(handle, { clientX: 397, clientY: 100, pointerId: 1 });
+    firePointer('pointermove', { clientX: 397 + 57, clientY: 100 });
+    expect(useStore.getState().workspaceCanvasResizeKey).toBe('row.0.item.0');
+
+    unmount();
+    expect(useStore.getState().workspaceCanvasResizeKey).toBeNull();
+
+    mountCanvas();
+    expect(emphasized()).toHaveLength(1);
+    expect(screen.getByTestId('canvas-overlay-selected-item')).toBeInTheDocument();
+  });
+});

--- a/viewer/src/components/views/project/canvas/dashboardGridContract.test.jsx
+++ b/viewer/src/components/views/project/canvas/dashboardGridContract.test.jsx
@@ -1,0 +1,191 @@
+/**
+ * The <Dashboard> ↔ canvasGridGeometry CONTRACT (M26 / VIS-1260).
+ *
+ * `canvasGridGeometry` exists to predict, in arithmetic, the geometry
+ * <Dashboard> hands to CSS grid. Every other test in this area checks the
+ * arithmetic against ITSELF: `previewItemWidthPx` vs `itemSlotWidthPx`,
+ * `rowTotalForSpan` vs `setItemWidth`. None of them touch the renderer, so if
+ * Dashboard.renderRow ever changes how it lays a row out — a fixed 12-track
+ * grid, a different gap, a different `totalWidth` derivation — the geometry
+ * module keeps agreeing with itself while the ghost quietly starts lying again.
+ * That drift IS the M26 finding; this file is the test that would have caught
+ * it.
+ *
+ * So: render the REAL <Dashboard> (item leaves mocked — we care about the row
+ * container, not the charts) and read the inline styles it emits, asserting the
+ * three facts the geometry module is built on:
+ *
+ *   1. The grid has `Σ item.width` tracks — `rowGridTotal`, not a constant.
+ *   2. The gap is a real length that `readColumnGapPx` can read (0.7rem/11.2px).
+ *   3. Each item is `grid-column: span <width>`, so `precedingColsInRow`
+ *      predicts where the slot starts.
+ *
+ * jsdom does not RESOLVE grid layout — that is what
+ * `e2e/tools/measure-canvas-grid.mjs` does in a real browser. What jsdom can
+ * check, and what actually drifts, is the INPUT Dashboard feeds to the grid.
+ *
+ * This file deliberately does not import anything from Dashboard.test.jsx: it is
+ * a contract test owned by the canvas overlays, not a Dashboard test.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Dashboard from '../../../project/Dashboard';
+import { futureFlags } from '../../../../router-config';
+import useStore from '../../../../stores/store';
+import {
+  gridTrackPx,
+  itemSlotWidthPx,
+  precedingColsInRow,
+  readColumnGapPx,
+  rowGridTotal,
+  spanLeftOffsetPx,
+} from './canvasGridGeometry';
+
+jest.mock('../../../../stores/store');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: () => [new URLSearchParams(), jest.fn()],
+}));
+
+// Dashboard measures its container through a ResizeObserver-backed hook; give it
+// a wide, stable width so the row lays out side-by-side (below the stacking
+// breakpoint it becomes a flex column and there is no relative grid at all).
+jest.mock('react-cool-dimensions', () => ({
+  __esModule: true,
+  default: (options = {}) => {
+    if (options.onResize) options.onResize({ observe: jest.fn() });
+    return { observe: jest.fn(), width: 1200 };
+  },
+}));
+
+jest.mock('../../../../hooks/useInsightsData', () => ({ useInsightsData: jest.fn() }));
+jest.mock('../../../../hooks/useModelsData', () => ({ useModelsData: jest.fn() }));
+jest.mock('../../../../hooks/useInputsData', () => ({ useInputsData: jest.fn() }));
+jest.mock('../../../../hooks/useVisibleRows', () => ({
+  useVisibleRows: jest.fn(() => ({ visibleRows: new Set([0]), setRowRef: jest.fn() })),
+}));
+
+jest.mock('../../../items/Chart', () => ({
+  __esModule: true,
+  default: () => <div data-testid="chart" />,
+}));
+jest.mock('../../../items/Table', () => ({
+  __esModule: true,
+  default: () => <div data-testid="table" />,
+}));
+jest.mock('../../../items/Markdown', () => ({
+  __esModule: true,
+  default: () => <div data-testid="markdown" />,
+}));
+jest.mock('../../../items/Input', () => ({
+  __esModule: true,
+  default: () => <div data-testid="input" />,
+}));
+
+const DASHBOARD_NAME = 'contract-dashboard';
+
+// Deliberately NOT a 12-wide row: this is the shape a hardcoded-12 renderer and
+// a sum-normalized one disagree about.
+const ROW_WIDTHS = [3, 5, 1];
+
+const mountDashboard = widths => {
+  const dashboard = {
+    name: DASHBOARD_NAME,
+    rows: [{ height: 'medium', items: widths.map(width => ({ chart: 'c', width })) }],
+  };
+  useStore.mockImplementation(selector =>
+    selector({
+      project: { id: 'p1', name: 'P' },
+      dashboards: [dashboard],
+      fetchDashboards: jest.fn(),
+      fetchCharts: jest.fn(),
+      fetchTables: jest.fn(),
+      fetchMarkdowns: jest.fn(),
+      fetchInputs: jest.fn(),
+      fetchModels: jest.fn(),
+      models: [],
+      getChartByName: jest.fn(() => ({ name: 'c', config: { name: 'c' } })),
+      getTableByName: jest.fn(() => null),
+      getMarkdownByName: jest.fn(() => null),
+      getInputByName: jest.fn(() => null),
+    })
+  );
+  render(
+    <BrowserRouter future={futureFlags}>
+      <Dashboard projectId="p1" dashboardName={DASHBOARD_NAME} />
+    </BrowserRouter>
+  );
+  return { items: dashboard.rows[0].items };
+};
+
+describe('Dashboard.renderRow ↔ canvasGridGeometry (M26 contract)', () => {
+  test('the row grid has Σ item.width tracks — exactly rowGridTotal, not a constant', () => {
+    const { items } = mountDashboard(ROW_WIDTHS);
+    const row = screen.getByTestId('dashboard-row-0');
+
+    // If this regex stops matching, renderRow no longer emits the shape
+    // canvasGridGeometry is built on: `repeat(Σ widths, minmax(0, 1fr))`.
+    const declared = row.style.gridTemplateColumns;
+    const match = /^repeat\((\d+),\s*minmax\(0,\s*1fr\)\)$/.exec(declared);
+    expect(match).toBeTruthy();
+    expect(Number(match[1])).toBe(rowGridTotal(items));
+    // …and that total is 9 here, so a hardcoded 12 would be caught.
+    expect(Number(match[1])).toBe(9);
+    expect(Number(match[1])).not.toBe(12);
+  });
+
+  test('the row gap is a real length the overlay can read back', () => {
+    mountDashboard(ROW_WIDTHS);
+    const row = screen.getByTestId('dashboard-row-0');
+    // `readColumnGapPx` reads the COMPUTED gap off the live row. jsdom does not
+    // resolve `rem`, so assert the declaration the overlay's measurement depends
+    // on, then prove the reader round-trips a px value on the same element.
+    expect(row.style.gap).toBe('0.7rem');
+    row.style.columnGap = '11.2px'; // 0.7rem at a 16px root
+    expect(readColumnGapPx(row)).toBeCloseTo(11.2, 6);
+  });
+
+  test('each item is `grid-column: span <width>`, so precedingColsInRow finds its start', () => {
+    const { items } = mountDashboard(ROW_WIDTHS);
+    const totalCols = rowGridTotal(items);
+    const rowWidth = 1200;
+    const gapPx = 11.2;
+
+    items.forEach((item, index) => {
+      // Dashboard's item slots carry no testid — `data-canvas-path` IS the
+      // anchor the overlays address them by, so querying it is the point.
+      // eslint-disable-next-line testing-library/no-node-access
+      const slot = document.querySelector(`[data-canvas-path="row.0.item.${index}"]`);
+      expect(slot).toBeTruthy();
+      expect(slot.style.gridColumn).toBe(`span ${item.width}`);
+    });
+
+    // Rebuild the row from the emitted spans alone and check it tiles the row
+    // exactly: Σ (slot widths + gaps) === rowWidth. If Dashboard ever stopped
+    // spanning by `item.width`, the reconstruction stops closing.
+    const last = items.length - 1;
+    const rightEdge =
+      spanLeftOffsetPx({ rowWidth, totalCols, precedingCols: precedingColsInRow(items, last), gapPx }) +
+      itemSlotWidthPx({ rowWidth, totalCols, spanCols: items[last].width, gapPx });
+    expect(rightEdge).toBeCloseTo(rowWidth, 6);
+    // And the tracks are equal `1fr` tracks, as `gridTrackPx` assumes.
+    expect(gridTrackPx({ rowWidth, totalCols, gapPx })).toBeCloseTo(
+      (rowWidth - (totalCols - 1) * gapPx) / totalCols,
+      9
+    );
+  });
+
+  test('an unset width counts as one track on BOTH sides of the contract', () => {
+    const { items } = mountDashboard([2, undefined, 3]);
+    const row = screen.getByTestId('dashboard-row-0');
+    const [, total] = /^repeat\((\d+),/.exec(row.style.gridTemplateColumns);
+    expect(Number(total)).toBe(rowGridTotal(items));
+    expect(Number(total)).toBe(6);
+    // eslint-disable-next-line testing-library/no-node-access
+    const middle = document.querySelector('[data-canvas-path="row.0.item.1"]');
+    expect(middle.style.gridColumn).toBe('span 1');
+    expect(precedingColsInRow(items, 2)).toBe(3);
+  });
+});

--- a/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
+++ b/viewer/src/components/views/workspace/WorkspaceDndContext.canvasCommit.test.jsx
@@ -532,10 +532,14 @@ describe('full-stack resize gesture → REAL provider commit (jsdom pointer driv
     render(<Host />);
     const handle = screen.getByTestId('canvas-resize-width-row.0.item.0');
 
-    // 12 grid cols over an 800px row → ~66.7px/col. Drag LEFT ~2 columns.
+    // M26: this row is 9 + 2 = 11 grid columns wide, NOT 12, and the total moves
+    // with the drag. Item 0 renders at 9/11 of the 800px row (654.5px); dragging
+    // its right edge LEFT 33px asks for a ~621px slot, and the span that renders
+    // nearest to that is 7 (7/9 of 800 = 622.2px — the next candidates are 6/8 =
+    // 600px and 8/10 = 640px).
     firePointerDown(handle, { clientX: 600, clientY: 100 });
-    firePointer('pointermove', { clientX: 466, clientY: 100 });
-    firePointer('pointerup', { clientX: 466, clientY: 100 });
+    firePointer('pointermove', { clientX: 567, clientY: 100 });
+    firePointer('pointerup', { clientX: 567, clientY: 100 });
 
     await waitFor(() => expect(currentConfig().rows[0].items[0].width).toBe(7));
     // #46: the pre-edit baseline was captured so the Save footer knows it's dirty.

--- a/viewer/src/stores/workspaceStore.js
+++ b/viewer/src/stores/workspaceStore.js
@@ -210,6 +210,21 @@ const createWorkspaceSlice = (set, get) => ({
   // hovering never mutates selection.
   workspaceCanvasHoverKey: null,
 
+  // Canvas resize-in-flight key — the composite `data-canvas-path` of the node
+  // whose resize handle is currently being DRAGGED (`null` at rest). Written by
+  // CanvasResizeLayer for the life of one gesture and read by
+  // CanvasSelectionOverlay, which parks its persistent mulberry ring while it is
+  // set (M26 / VIS-1260).
+  //
+  // Why the store and not a prop: the two overlays are SIBLINGS mounted by
+  // ProjectCanvas, so neither can see the other, and the resize layer's
+  // card-fade — an imperative opacity on the measured <Dashboard> node — cannot
+  // reach a ring that lives in a different layer. Without this the canvas paints
+  // a full-strength 2px ring at the PRE-DRAG geometry beside an identical one at
+  // the drag target, and "what lands where" is ambiguous. Ephemeral view state:
+  // never persisted, always cleared on release / Esc / pointercancel / unmount.
+  workspaceCanvasResizeKey: null,
+
   // Source outline (right-rail "Data" tab when a `source` is the active object,
   // VIS-1004). A DISJOINT selection-key grammar from the dashboard outline so
   // the two consumers never collide:
@@ -940,6 +955,20 @@ const createWorkspaceSlice = (set, get) => ({
       state.workspaceCanvasHoverKey === (key || null)
         ? state
         : { workspaceCanvasHoverKey: key || null }
+    );
+  },
+
+  /**
+   * Mark a canvas resize gesture as in flight on `key` (or `null` to clear).
+   * Only the selection overlay's ring suppression reads this; it never affects
+   * the Outline selection, which must survive the gesture so the handles are
+   * still there when the user releases (M26 / VIS-1260).
+   */
+  setWorkspaceCanvasResizeKey: (key) => {
+    set(state =>
+      state.workspaceCanvasResizeKey === (key || null)
+        ? state
+        : { workspaceCanvasResizeKey: key || null }
     );
   },
 

--- a/viewer/src/stores/workspaceStore.test.js
+++ b/viewer/src/stores/workspaceStore.test.js
@@ -1394,6 +1394,43 @@ describe('workspace store slice', () => {
     expect(useStore.getState().workspaceCanvasHoverKey).toBeNull();
   });
 
+  // Canvas resize-in-flight key (M26 / VIS-1260) ------------------------------
+
+  test('setWorkspaceCanvasResizeKey sets/clears the gesture key, and is a reference-stable no-op when unchanged', () => {
+    expect(useStore.getState().workspaceCanvasResizeKey).toBeNull();
+    act(() => {
+      useStore.getState().setWorkspaceCanvasResizeKey('row.0.item.1');
+    });
+    expect(useStore.getState().workspaceCanvasResizeKey).toBe('row.0.item.1');
+    const stateBefore = useStore.getState();
+    act(() => {
+      useStore.getState().setWorkspaceCanvasResizeKey('row.0.item.1');
+    });
+    // A gesture re-publishing the same key must not re-render the whole canvas
+    // on every pointermove.
+    expect(useStore.getState()).toBe(stateBefore);
+    act(() => {
+      useStore.getState().setWorkspaceCanvasResizeKey(null);
+    });
+    expect(useStore.getState().workspaceCanvasResizeKey).toBeNull();
+  });
+
+  test('the resize key is disjoint from selection and hover — a gesture never moves them', () => {
+    act(() => {
+      useStore.getState().setWorkspaceOutlineSelectedKey('row.0.item.1');
+      useStore.getState().setWorkspaceCanvasHoverKey('row.0.item.0');
+      useStore.getState().setWorkspaceCanvasResizeKey('row.0.item.1');
+    });
+    // The selection MUST survive the gesture: the resize handles are painted on
+    // the selected node, so losing it mid-drag would take the handles with it.
+    expect(useStore.getState().workspaceOutlineSelectedKey).toBe('row.0.item.1');
+    expect(useStore.getState().workspaceCanvasHoverKey).toBe('row.0.item.0');
+    act(() => {
+      useStore.getState().setWorkspaceCanvasResizeKey(null);
+    });
+    expect(useStore.getState().workspaceOutlineSelectedKey).toBe('row.0.item.1');
+  });
+
   // Outline tree (VIS-793 / Track F F-3) ------------------------------------
 
   test('setWorkspaceOutlineSelectedKey updates the selection key', () => {


### PR DESCRIPTION
## The bug

`Item.width` is a **relative weight**, not a column index in a fixed grid. `Dashboard.jsx` lays a row out as

```js
const totalWidth = visibleItems.reduce((s, i) => s + (i.width || 1), 0);
gridTemplateColumns: `repeat(${totalWidth}, minmax(0, 1fr))`,  gap: '0.7rem'
// each item: gridColumn: `span ${item.width || 1}`
```

`CanvasResizeLayer.jsx:58` hardcoded `const COLS = 12` and painted the ghost as `startBox * (liveCols / startCols)`. Two independent errors:

1. **The denominator moves.** Growing item 0 of a `6/6` row to 8 makes the row 14 wide, so the slot renders at 8/14 — not the 8/12 the old ghost drew.
2. **The gap is real.** `gap: 0.7rem` comes out of the track budget, so a span is not `rowWidth · span / total`.

The readout said `N / 12` on rows that were never 12 wide, and the 12 only ever looked right because every `ROW_TEMPLATES` entry happens to sum to 12.

## Measured, not eyeballed

Headless Chromium, real CSS grid built with Dashboard.jsx's exact row styles: run the gesture math, apply the committed widths, measure the rendered slot with `getBoundingClientRect`.

| row shape | drag | start→live | ghost AFTER | rendered | err AFTER | ghost BEFORE | err BEFORE |
|---|---:|---|---:|---:|---:|---:|---:|
| `[6,6]` | +70 | 6→8 (/14) | 566.64 | 566.63 | **0.01** | 659.21 | 92.58 |
| `[6,6]` | −120 | 6→4 (/10) | 393.28 | 393.28 | **0.00** | 329.60 | 63.68 |
| `[1,2]` | +150 | 1→2 (/4) | 444.40 | 444.41 | **0.01** | 585.06 | **140.66** |
| `[3,5,1]` | +140 | 3→5 (/11) | 539.34 | 539.34 | **0.00** | 654.22 | 114.88 |
| `[3,5,1]` | −200 | 5→3 (/7) | 507.90 | 507.89 | **0.01** | 397.02 | 110.87 |
| `[9,2]` | −33 | 9→7 (/9) | 619.72 | 619.73 | **0.01** | 507.50 | 112.23 |
| `[2,3]` | +90 | 3→5 (/7) | 682.53 | 682.53 | **0.00** | 952.55 | **270.02** |
| `[3,3,3,3]` | +55 | 3→5 (/14) | 221.39 | 221.38 | **0.01** | 252.68 | 31.31 |

```
worst |ghost − rendered| BEFORE = 270.02px
worst |ghost − rendered| AFTER  =   0.01px    (dossier acceptance: within 2px)
```

The dossier's own case reproduces exactly: 1000px `6/6` row dragged to width 8 → old ghost **666.7px**, drop **571.4px** (gap-free arithmetic); with the real 11.2px gap, 659.2 vs 566.6.

The formula itself was checked against the browser across 10 row shapes before anything was built on it: **worst |formula − rendered| = 0.0161px** (Chromium resolves layout on a 1/64px grid).

## The fix

**New `viewer/src/components/views/project/canvas/canvasGridGeometry.js`** — one owner for the sum-normalized formula, the identity CSS itself resolves:

```
track  = (rowWidth − (total − 1) · gap) / total
spanPx = span · track + (span − 1) · gap
total' = startTotal − startCols + spanCols     // a right-edge drag rebalances
total' = startTotal                            // a left-edge drag transfers
```

The layer measures the row's live `getBoundingClientRect().width` and its computed `column-gap` at pointer-down and derives every frame from those, so a zoomed/transformed canvas stays consistent.

Three changes in `CanvasResizeLayer.jsx`, as the dossier scoped them:

- **Truthful ghost** — `previewItemWidthPx(liveCols)`, expressed as a ratio against the item's own start slot so zero travel is pixel-identical to the card underneath.
- **Honest readout** — `N / <row total>`: the total a right-edge drag rebalances *to* (`8 / 14`), or the unchanged total for a left-edge transfer. Never `N / 12`.
- **One emphasized outline + a faded card** — the competing origin-geometry frame is deleted. During a gesture there is exactly one ring (the ghost, tagged `data-canvas-outline="emphasized"`), the card being resized fades to 35%, and only the handle being dragged is painted, riding the ghost's matching edge. Esc / pointercancel / unmount abort and un-fade — and pointercancel no longer *commits* an interrupted drag.

### One change beyond the dossier's three — please sanity-check this

The dossier names coarse quantization as a defect but does not list it among the three fixes. I made it a fourth, because a truthful ghost with the old mapping is a *new* legibility bug: `deltaCols = Math.round(dx / (rowWidth / total))` assumes each column is worth a constant number of pixels, which sum-normalization makes false. On a `[1,2]` row, one extra column costs 300px of travel but is worth only 152px of growth — so the honest ghost would visibly detach from the hand.

`nearestSpanForWidth` is the exact inverse of the preview: the span whose **rendered** edge lands nearest the pointer. Consequences worth a look:

- It kills the cited 225px dead zone (a 900px 2-item row now flips at ~75px), and near the top of a row's range it is *more* sensitive than before — dragging item 0 of a `[9,2]` row 33px left now commits `width: 7` where the old mapping needed 134px of travel to move at all.
- The reachable range is asymptotic (an item can never exceed `12 / (siblings + 12)` of the row), so drags past that pin at 12 — same saturation point as before, reached sooner.
- **Degenerate case handled:** on a solo-item row every span renders full-bleed, so the geometry cannot respond at all. Ties resolve toward the start span, making that gesture an honest no-op rather than a silent `width: 12` → `width: 1` rewrite. (Guarded both at the math and component level; mutation G below proves it.)

If you'd rather keep the old `dx → cols` mapping, it's a one-function swap — everything else in this PR stands.

## Tests

- **`canvasGridGeometry.test.js` (26 new)** — the primary guard. The dossier's headline numbers, browser-measured pixel fixtures, and a round-trip: for 8 row shapes × every item × every span 1–12, the preview must equal the geometry recomputed from the config `setItemWidth` **actually commits**. Two independent derivations; a drift in either fails.
- **`CanvasResizeLayer.test.jsx` (10 new)** — truthful ghost pixels and honest readout on a deliberately non-12 `[1,2]` row, ghost-vs-committed-layout agreement within 2px, exactly one emphasized outline, faded card + restore on release / Esc / pointercancel / unmount, solo-row no-op.
- **`canvas-resize-truthful-ghost.spec.mjs`** — new Playwright story. **Written, not run**: it rewrites a row's widths, so it is env-gated to its own isolated `:8060/:3060` sandbox and must never point at the shared one. Verified it parses and lists (5 tests).
- `WorkspaceDndContext.canvasCommit.test.jsx` — the existing full-stack drag updated. Its row is `9 + 2 = 11` wide, and its comment said "12 grid cols over an 800px row"; that mental model was the bug.

Full viewer suite **367 suites / 7087 tests green**, `yarn lint` clean.

### Falsification

Every guard was proven to fail with the implementation broken (tests untouched, tree restored after each):

| mutation | result |
|---|---|
| **A** `rowTotalForSpan` stops moving the denominator (the original bug) | **11 failed** — `THE finding: … renders 571px, not 667px`, `GHOST == DROP`, `TRUTHFUL PREVIEW`, `HONEST READOUT`, `a SOLO-item row…`, `a real width drag…commits` |
| **B** `gridTrackPx` ignores the 0.7rem gap | 4 failed — the browser-measured fixtures |
| **C** readout reverts to `N / 12` | 3 failed — `HONEST READOUT`, the left-edge transfer, the existing width-drag test |
| **D** a second emphasized outline at the pre-drag geometry | 1 failed — `exactly one emphasized outline` |
| **E** the card is never faded | 4 failed — both fade tests, Esc, unmount |
| **F** Esc / pointercancel stop aborting | 2 failed — `Escape ABORTS`, `pointercancel ABORTS` |
| **G** tie-break toward the start span dropped | 2 failed — `a SINGLE-item row is a no-op`, `a SOLO-item row never rewrites its width` |

Restored: 72/72 green.

## Notes

- Does **not** touch `Dashboard.jsx` (owned by #646). Its inline `totalWidth` reduce and `getWidth` are the second copy of this formula and should migrate onto `canvasGridGeometry` once #646 lands — a copy of the formula is exactly how the two drifted apart.
- No Pydantic models touched, so no schema regen.
- Second-wave verdict honoured: the relative-weight schema stays; only the surface written against the wrong mental model changed.

Linear: [VIS-1260](https://linear.app/visivo/issue/VIS-1260/w7m26-truthful-resize-ghost-derive-preview-from-row-totals-not-cols12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
