### PR TITLE
One codec owns `?{ }`, and the sort field stops teaching a form the parser rejects (M6 / M24 / C15)

### DIFF
--- a/tests/models/base/test_query_string.py
+++ b/tests/models/base/test_query_string.py
@@ -1,4 +1,116 @@
+import re
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
 from visivo.models.base.query_string import QueryString
+from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
+
+
+class _Holder(BaseModel):
+    """Minimal carrier so the pydantic validator actually runs."""
+
+    value: QueryString
+
+
+# ---------------------------------------------------------------------------
+# The acceptance gate
+#
+# `validate_and_create` used to accept anything that started `?{` and ended
+# `}`. `get_value()` reads the body with QUERY_STRING_VALUE_PATTERN, which is
+# NARROWER, so values in the gap validated fine, were written to YAML, and then
+# came back as None at run time — where
+# `InsightInteraction.field_values_with_js_template_literals` hands them to
+# `re.sub` and the run dies with
+# `TypeError: expected string or bytes-like object, got 'NoneType'`.
+#
+# The gate is now the pattern itself, so the gap is closed by construction:
+# anything that validates has a readable body.
+# ---------------------------------------------------------------------------
+
+# Values the OLD gate let through and `get_value()` then could not read.
+UNREADABLE_BUT_ONCE_ACCEPTED = [
+    "?{}",
+    "?{ }",
+    "?{   }",
+    "?{a\nb}",
+    "?{case when x > 0\n  then 1 else 0 end}",
+    "?{${ref(o).a}\n  = ${ref(o).b}}",
+]
+
+
+@pytest.mark.parametrize("value", UNREADABLE_BUT_ONCE_ACCEPTED)
+def test_a_value_get_value_cannot_read_is_refused_at_validation(value):
+    """The gate and the reader agree, or the failure moves to run time."""
+    # The premise: this really is a value the reader cannot read.
+    assert QueryString(value).get_value() in (None, ""), value
+
+    with pytest.raises(ValidationError) as excinfo:
+        _Holder(value=value)
+    assert "QueryString" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("value", UNREADABLE_BUT_ONCE_ACCEPTED)
+def test_the_old_looser_gate_would_have_accepted_these(value):
+    """Pins what changed, so the fix cannot be quietly reverted.
+
+    Every value above satisfies the previous `startswith`/`endswith` test — that
+    is precisely why it reached YAML.
+    """
+    assert value.startswith("?{") and (
+        value.endswith("}") or re.match(QUERY_STRING_VALUE_PATTERN, value)
+    )
+
+
+@pytest.mark.parametrize(
+    "value, expected_hint",
+    [
+        ("date DESC", "must be wrapped"),
+        (">{ anyTestFailed() }", "must be wrapped"),
+        ("?{}", "needs an expression"),
+        ("?{  }", "needs an expression"),
+        ("?{a\nb}", "single line"),
+        ("?{x}[a]", "[index|slice]"),
+        ("?{x}[0][1]", "[index|slice]"),
+    ],
+)
+def test_the_rejection_says_which_way_the_value_missed(value, expected_hint):
+    """One generic 'invalid' is not a diagnosis; each way of missing differs."""
+    with pytest.raises(ValidationError) as excinfo:
+        _Holder(value=value)
+    message = str(excinfo.value)
+    assert expected_hint in message
+    # And it quotes what was actually supplied, so the author can find it.
+    assert repr(value) in message or value in message
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "?{x}",
+        "?{ MAX(amount) }",
+        "?{${ref(orders).month} ASC}",
+        "?{x}[0]",
+        "?{x}[-1]",
+        "?{x}[1:5]",
+        "?{x}[::2]",
+        "?{x}[0,2]",
+        "?{sum(${ref(o).a})}[0]",
+        # Leading/trailing newlines are only padding — the body is still one
+        # line, and the reader handles it. Not the case being refused.
+        "?{\n  sum(a)\n}",
+    ],
+)
+def test_every_value_the_reader_can_read_still_validates(value):
+    holder = _Holder(value=value)
+    assert holder.value.get_value(), value
+
+
+def test_a_long_value_is_truncated_in_the_message_not_dumped_whole():
+    long_value = "?{" + ("x" * 200) + "\n" + ("y" * 200) + "}"
+    with pytest.raises(ValidationError) as excinfo:
+        _Holder(value=long_value)
+    assert "..." in str(excinfo.value)
 
 
 def test_QueryString_get_value():

--- a/tests/models/test_interaction_help_parity.py
+++ b/tests/models/test_interaction_help_parity.py
@@ -1,0 +1,129 @@
+"""The viewer's interaction help text is the model's, or it is a lie.
+
+`viewer/src/schemas/interactionHelp.js` supplies the label, description and
+example the insight editors show under each interaction field. Before it
+existed, those strings were retyped by hand in each editor, and the sort field
+ended up advertising `date DESC` — a value `InsightInteraction.sort` rejects
+(it is a `QueryString`, so it must be `?{ ... }`) and which, even wrapped,
+names a loose column the semantic layer cannot resolve.
+
+A jest test already pins that module against the VENDORED
+`viewer/src/schemas/visivo_project_schema.json`. This one closes the other end:
+it reads the strings straight out of the live Pydantic model, so a stale
+vendored schema cannot hide a drift. If it fails, either re-copy the schema and
+update `interactionHelp.js`, or the model's wording changed and the UI needs to
+follow it.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from visivo.models.interaction import InsightInteraction
+from visivo.models.base.query_string import QueryString
+from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
+
+INTERACTION_HELP_JS = (
+    Path(__file__).parent.parent.parent / "viewer" / "src" / "schemas" / "interactionHelp.js"
+)
+
+FIELDS = ("filter", "split", "sort")
+
+
+def _js_source() -> str:
+    assert INTERACTION_HELP_JS.exists(), f"missing {INTERACTION_HELP_JS}"
+    return INTERACTION_HELP_JS.read_text()
+
+
+def _entry(source: str, field: str) -> dict:
+    """Pull one `<field>: Object.freeze({ ... })` block out of the module.
+
+    Deliberately a small hand parser rather than a JS runtime: this test's job
+    is to compare STRINGS, and a node dependency in the Python suite would buy
+    nothing.
+    """
+    start = source.index(f"  {field}: Object.freeze({{")
+    end = source.index("}),", start)
+    block = source[start:end]
+    out = {}
+    for key in ("label", "description", "yamlExample", "example"):
+        match = re.search(rf"{key}:\s*\n?\s*'((?:[^'\\]|\\.)*)'", block)
+        assert match, f"{field}.{key} not found in interactionHelp.js"
+        out[key] = match.group(1).replace("\\'", "'").replace("\\\\", "\\")
+    return out
+
+
+@pytest.fixture(scope="module")
+def help_entries() -> dict:
+    source = _js_source()
+    return {field: _entry(source, field) for field in FIELDS}
+
+
+@pytest.mark.parametrize("field", FIELDS)
+def test_help_description_matches_the_model_field(field, help_entries):
+    """The hint under the field IS the Pydantic field's description."""
+    expected = InsightInteraction.model_fields[field].description
+    assert help_entries[field]["description"] == expected
+
+
+@pytest.mark.parametrize("field", FIELDS)
+def test_help_example_matches_the_model_docstring(field, help_entries):
+    """The advertised example IS the one the docs site publishes."""
+    docstring = InsightInteraction.__doc__ or ""
+    published = {}
+    for line in docstring.splitlines():
+        match = re.match(r"\s*-\s+(filter|split|sort):\s*(.+?)\s*$", line)
+        if match:
+            published[match.group(1)] = match.group(2)
+    assert help_entries[field]["yamlExample"] == published[field]
+
+
+@pytest.mark.parametrize("field", FIELDS)
+def test_the_advertised_example_is_accepted_by_the_model(field, help_entries):
+    """C15's core claim: copy the hint, get a value that saves.
+
+    The editors wrap what the user types, so the check is on the wrapped form
+    of `example` — which must also equal the documented `yamlExample`.
+    """
+    body = help_entries[field]["example"]
+    assert "?{" not in body, "the hint shows the BODY; the editor adds the wrapper"
+
+    stored = "?{" + body + "}"
+    interaction = InsightInteraction(**{field: stored})
+    assert getattr(interaction, field).get_value() == body
+
+    yaml_example = help_entries[field]["yamlExample"]
+    assert re.match(QUERY_STRING_VALUE_PATTERN, yaml_example)
+    assert QueryString(yaml_example).get_value() == body
+
+
+@pytest.mark.parametrize("field", FIELDS)
+def test_the_advertised_example_names_a_real_ref(field, help_entries):
+    """Not a loose column.
+
+    `?{date DESC}` clears the parser and then dies at the binder, because the
+    resolver only rewrites `${ref(...)}` tokens. Every example must carry one.
+    """
+    assert re.search(r"\$\{\s*ref\(", help_entries[field]["example"])
+
+
+def test_the_bare_form_the_old_hint_taught_is_still_rejected():
+    """The regression that made C15 worth fixing, pinned.
+
+    If `InsightInteraction` ever starts accepting bare bodies, this test fails
+    and someone gets to decide whether the hint should change back — rather
+    than the two drifting apart again in silence.
+    """
+    with pytest.raises(Exception) as excinfo:
+        InsightInteraction(sort="date DESC")
+    assert "?{" in str(excinfo.value)
+
+
+def test_no_help_string_advertises_date_desc(help_entries):
+    assert not re.search(r"date\s+DESC", json.dumps(help_entries), re.IGNORECASE)
+
+
+def test_help_covers_exactly_the_fields_the_model_declares(help_entries):
+    assert set(help_entries) == set(InsightInteraction.model_fields)

--- a/tests/server/views/test_expression_views.py
+++ b/tests/server/views/test_expression_views.py
@@ -264,3 +264,130 @@ class TestExpressionValidateView:
     def test_missing_body_is_400(self, client):
         response = client.post("/api/expressions/validate/", json=None)
         assert response.status_code == 400
+
+
+class TestExpressionErrorSanitisation:
+    """The parse harness must never leak into a user-facing message (M13).
+
+    Both endpoints parse a bare expression by wrapping it into
+    ``SELECT <expr> FROM __placeholder__``, and ``/validate/`` additionally
+    swaps every ``${ref(...)}`` for an identifier sqlglot can read. When the
+    parse fails, sqlglot quotes that wrapped SQL back — so the viewer used to
+    show ``__visivo_ctx__`` and ``__placeholder__``, names that appear nowhere
+    in the user's project, alongside a column number counted in a statement
+    they never wrote.
+    """
+
+    @pytest.fixture
+    def app(self):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        register_expression_views(app, flask_app, "/tmp/output")
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    def _validate(self, client, expression, dialect="duckdb"):
+        response = client.post(
+            "/api/expressions/validate/",
+            json={
+                "expressions": [{"name": "expr", "expression": expression}],
+                "source_dialect": dialect,
+            },
+        )
+        assert response.status_code == 200
+        return response.get_json()["results"][0]
+
+    # Every broken shape a relation condition / metric / interaction can take.
+    BROKEN_EXPRESSIONS = [
+        "${ref(orders).amount} >",
+        "sum(${ref(orders).amount}",
+        "case when ${ref(o).a} then ${ref(o).b}",
+        "${ref(daily_metrics).value} +* 2",
+        "${ref(orders).id} = ${ref(users).order_id} AND",
+        "AVG(value)}",
+        "SUM('amount",
+    ]
+
+    @pytest.mark.parametrize("expression", BROKEN_EXPRESSIONS)
+    def test_validate_error_leaks_no_internal_sentinels(self, client, expression):
+        result = self._validate(client, expression)
+        assert result["valid"] is False
+        assert "__visivo_ctx" not in result["error"]
+        assert "placeholder" not in result["error"]
+        assert "\x1b" not in result["error"]
+
+    @pytest.mark.parametrize(
+        "expression, ref_text",
+        [
+            ("${ref(orders).amount} >", "${ref(orders).amount}"),
+            ("sum(${ref(orders).amount}", "${ref(orders).amount}"),
+            ("${ref(daily_metrics).value} +* 2", "${ref(daily_metrics).value}"),
+        ],
+    )
+    def test_validate_error_quotes_the_users_own_ref(self, client, expression, ref_text):
+        """The message must be about the text the author typed."""
+        result = self._validate(client, expression)
+        assert ref_text in result["error"]
+
+    def test_validate_error_restores_each_distinct_ref_separately(self, client):
+        """Two different refs must come back as themselves, not as one token.
+
+        A single shared ``__visivo_ctx__`` sentinel made this impossible; the
+        substitution numbers its tokens so the map is exact.
+        """
+        result = self._validate(client, "case when ${ref(o).a} then ${ref(o).b}")
+        assert "${ref(o).a}" in result["error"]
+        assert "${ref(o).b}" in result["error"]
+
+    def test_validate_error_drops_the_wrapped_statements_position(self, client):
+        """ "Line 1, Col: 28" counts characters in SQL the user never wrote."""
+        result = self._validate(client, "${ref(orders).amount} >")
+        assert "Col:" not in result["error"]
+
+    def test_validate_error_still_explains_what_is_wrong(self, client):
+        """Sanitising must not empty the message out."""
+        result = self._validate(client, "sum(${ref(orders).amount}")
+        assert "Expecting )" in result["error"]
+
+    def test_translate_error_leaks_no_placeholder_table(self, client):
+        response = client.post(
+            "/api/expressions/translate/",
+            json={
+                "expressions": [{"name": "bad", "expression": "SUM(amount"}],
+                "source_dialect": "duckdb",
+            },
+        )
+        assert response.status_code == 200
+        errors = response.get_json()["errors"]
+        assert len(errors) == 1
+        assert "placeholder" not in errors[0]["error"]
+        assert "\x1b" not in errors[0]["error"]
+
+    def test_sanitiser_leaves_a_real_table_named_placeholder_alone(self):
+        """The tail stripper requires the sentinel's leading underscore."""
+        from visivo.server.views.expression_views import sanitize_expression_error
+
+        message = sanitize_expression_error(Exception("no such column in placeholder"))
+        assert message == "no such column in placeholder"
+
+    def test_sanitiser_scrubs_an_unmapped_context_token(self):
+        """Belt and braces: a token the map missed still must not escape."""
+        from visivo.server.views.expression_views import sanitize_expression_error
+
+        message = sanitize_expression_error(Exception("bad __visivo_ctx_7__ here"), {})
+        assert "__visivo_ctx" not in message
+
+    def test_substitution_maps_each_ref_to_a_unique_token(self):
+        from visivo.server.views.expression_views import substitute_context_tokens
+
+        substituted, mapping = substitute_context_tokens("${ref(a).x} = ${ref(b).y}")
+        assert len(mapping) == 2
+        assert len(set(mapping.keys())) == 2
+        assert "${" not in substituted
+        for token, original in mapping.items():
+            assert token in substituted
+            assert original in ("${ref(a).x}", "${ref(b).y}")

--- a/tests/server/views/test_expression_views.py
+++ b/tests/server/views/test_expression_views.py
@@ -391,3 +391,159 @@ class TestExpressionErrorSanitisation:
         for token, original in mapping.items():
             assert token in substituted
             assert original in ("${ref(a).x}", "${ref(b).y}")
+
+
+def _harness_fragments():
+    """Every tail of a harness token that a clipped echo could expose.
+
+    sqlglot echoes a WINDOW of the SQL, not the whole of it — ±50 characters in
+    the tokenizer, ±`error_message_context` in the parser — so a sentinel the
+    window cuts through arrives as a SUFFIX of itself: ``__visivo_ctx_0__``
+    surfaces as ``isivo_ctx_0__``, ``x_1__``, ``_0__``. Checking for the whole
+    sentinel is what let those through.
+    """
+    fragments = set()
+    stems = [f"__visivo_ctx_{i}__" for i in range(4)] + ["__placeholder__", "SELECT"]
+    for stem in stems:
+        for start in range(len(stem)):
+            tail = stem[start:]
+            if len(tail) >= 2:
+                fragments.add(tail)
+    return fragments
+
+
+HARNESS_FRAGMENTS = _harness_fragments()
+
+
+class TestSanitiserEchoesTheAuthorNotTheHarness:
+    """The echoed SQL is replaced, not repaired.
+
+    No pattern can strip a sentinel the echo window cut in half, and any pattern
+    loose enough to try is loose enough to eat the author's own text. Both
+    failures were real: `isivo_ctx_0__` reached the UI on a mid-typing
+    unterminated quote, and the literal `'SELECT foo'` inside a user's CASE
+    expression came back as `'foo'`.
+
+    So the sanitiser does not forward sqlglot's window at all — it quotes the
+    expression the author typed, which it already has.
+    """
+
+    @pytest.fixture
+    def app(self):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        flask_app = Mock()
+        register_expression_views(app, flask_app, "/tmp/output")
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    def _validate(self, client, expression, dialect="duckdb"):
+        response = client.post(
+            "/api/expressions/validate/",
+            json={
+                "expressions": [{"name": "expr", "expression": expression}],
+                "source_dialect": dialect,
+            },
+        )
+        assert response.status_code == 200
+        return response.get_json()["results"][0]
+
+    # Long enough to push the failure point past the tokenizer's 50-character
+    # look-back, which is what clips a sentinel in half. The short expressions
+    # in BROKEN_EXPRESSIONS never reach that window, which is why they passed
+    # while `isivo_ctx_0__` was reaching users.
+    CLIPPING_EXPRESSIONS = [
+        "1 + 2 + 3 + ${ref(m).c} + 'unterminated",
+        "${ref(orders).amount} + ${ref(orders).tax} + ${ref(orders).fee} + 'x",
+        "${ref(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).bbbbbbbbbbbbbbbbbbbbbbbbb} + 'oops",
+    ] + [
+        # Sweep the window across the sentinel: one of these puts the cut
+        # somewhere inside `__visivo_ctx_0__` whatever the exact window is.
+        "1 " + ("+ 1 " * n) + "+ ${ref(m).c} + 'q"
+        for n in range(0, 40, 3)
+    ]
+
+    @pytest.mark.parametrize("expression", CLIPPING_EXPRESSIONS)
+    def test_no_fragment_of_the_harness_survives_a_clipped_echo(self, client, expression):
+        result = self._validate(client, expression)
+        assert result["valid"] is False
+
+        error = result["error"]
+        # The author's own text is quoted back in full...
+        assert expression in error, error
+        # ...and once it is accounted for, nothing of the harness is left —
+        # not the whole sentinel and not any tail of one.
+        residue = error.replace(expression, "")
+        leaked = sorted(f for f in HARNESS_FRAGMENTS if f in residue)
+        assert leaked == [], f"leaked {leaked} in {error!r}"
+
+    def test_the_authors_own_select_literal_is_returned_unaltered(self, client):
+        """`'SELECT foo'` is the user's data, not our harness's head.
+
+        The strip used to be anchored to any quote, so it removed the `SELECT `
+        from inside the author's string literal — silently changing the one line
+        whose whole job is to quote their text back to them accurately.
+        """
+        expression = "case when ${ref(orders).status} = 'SELECT foo' then 1 end +"
+        result = self._validate(client, expression)
+        assert result["valid"] is False
+        assert "'SELECT foo'" in result["error"]
+        assert "'foo'" not in result["error"].replace("'SELECT foo'", "")
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "concat('SELECT ', ${ref(o).a}) +",
+            "case when ${ref(o).a} = 'SELECT' then 1 end +",
+            '${ref(o)."SELECT col"} +',
+        ],
+    )
+    def test_a_select_keyword_inside_the_expression_survives(self, client, expression):
+        result = self._validate(client, expression)
+        assert result["valid"] is False
+        assert expression in result["error"]
+
+    def test_a_long_expression_is_echoed_whole_not_as_sqlglots_window(self, client):
+        """The window truncates; the author's text does not."""
+        expression = "${ref(orders).amount} " + ("+ 1 " * 60) + "+"
+        result = self._validate(client, expression)
+        assert result["valid"] is False
+        assert expression in result["error"]
+
+    def test_the_translate_endpoint_echoes_the_author_too(self, client):
+        expression = "concat('SELECT x', 'y'" + (" || 'z'" * 20)
+        response = client.post(
+            "/api/expressions/translate/",
+            json={
+                "expressions": [{"name": "bad", "expression": expression}],
+                "source_dialect": "duckdb",
+            },
+        )
+        error = response.get_json()["errors"][0]["error"]
+        assert expression in error
+        residue = error.replace(expression, "")
+        assert sorted(f for f in HARNESS_FRAGMENTS if f in residue) == []
+
+    def test_the_message_still_says_what_is_wrong(self):
+        """Replacing the echo must not replace the diagnosis."""
+        from visivo.server.views.expression_views import sanitize_expression_error
+
+        message = sanitize_expression_error(
+            Exception(
+                "Expecting ). Line 1, Col: 32.\n  SELECT sum(__visivo_ctx_0__ FROM __placeholder__"
+            ),
+            {"__visivo_ctx_0__": "${ref(o).a}"},
+            expression="sum(${ref(o).a}",
+        )
+        assert message == "Expecting ).\n  sum(${ref(o).a}"
+
+    def test_without_an_expression_it_still_strips_what_it_can(self):
+        """The fallback path stays honest for any caller that has no source text."""
+        from visivo.server.views.expression_views import sanitize_expression_error
+
+        message = sanitize_expression_error(Exception("bad __visivo_ctx_7__ here"))
+        assert "__visivo_ctx" not in message
+        assert "bad" in message

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -22,6 +22,7 @@ import {
   INTERACTION_TYPES,
   INTERACTION_TYPE_OPTIONS,
   interactionHelpText,
+  interactionValueProblem,
 } from '../../../schemas/interactionHelp';
 import {
   SectionContainer,
@@ -180,6 +181,20 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
       newErrors.props = 'Fix the invalid trace properties before saving.';
     }
 
+    // The codec never mangles a value it cannot represent, so a body that will
+    // not survive as a `QueryString` reaches here intact — and must be reported
+    // HERE rather than written out for the server (or, worse, the next `visivo
+    // run`) to complain about. Keyed by index so the message lands under the
+    // field that caused it.
+    const interactionErrors = {};
+    interactions.forEach((interaction, index) => {
+      const problem = interactionValueProblem(interaction.value, interaction.slice);
+      if (problem) interactionErrors[index] = problem;
+    });
+    if (Object.keys(interactionErrors).length > 0) {
+      newErrors.interactions = interactionErrors;
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -264,6 +279,16 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
     const updated = [...interactions];
     updated[index] = { ...updated[index], value: newValue };
     setInteractions(updated);
+    // Retract the complaint as soon as the author starts answering it; the
+    // next Save re-derives it from scratch.
+    setErrors(prev => {
+      if (!prev.interactions || !(index in prev.interactions)) return prev;
+      const { [index]: _dropped, ...rest } = prev.interactions;
+      const next = { ...prev };
+      if (Object.keys(rest).length > 0) next.interactions = rest;
+      else delete next.interactions;
+      return next;
+    });
   };
 
   return (
@@ -367,6 +392,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
                       allowedTypes={refKindsFor('interaction', interactionType)}
                       rows={2}
                       helperText={interactionHelpText(interactionType, REF_INSERT_HINT)}
+                      error={errors.interactions?.[index]}
                     />
                   </div>
                 );

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -16,6 +16,13 @@ import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
 import { refKindsFor } from './fieldTypes';
 import { REF_INSERT_HINT } from './RefTextArea';
+import { decodeQueryString, encodeQueryString } from '../../../utils/expressionCodec';
+import {
+  INTERACTION_HELP,
+  INTERACTION_TYPES,
+  INTERACTION_TYPE_OPTIONS,
+  interactionHelpText,
+} from '../../../schemas/interactionHelp';
 import {
   SectionContainer,
   EmptyState,
@@ -80,12 +87,17 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
         insightConfig: {
           name: name || insight?.name || '__preview__',
           props: debouncedProps,
-          interactions: debouncedInteractions.map(i => {
-            if (i.type === 'filter') return { filter: i.value };
-            if (i.type === 'split') return { split: i.value };
-            if (i.type === 'sort') return { sort: i.value };
-            return {};
-          }).filter(i => Object.keys(i).length > 0),
+          // Wrapped the same way the save path wraps them: the preview runs
+          // the real `InsightInteraction` model, so a bare body here made the
+          // preview disagree with the saved insight for every interaction the
+          // user typed rather than opened.
+          interactions: debouncedInteractions
+            .map(i =>
+              INTERACTION_TYPES.includes(i.type)
+                ? { [i.type]: encodeQueryString({ body: i.value, slice: i.slice }) }
+                : {}
+            )
+            .filter(i => Object.keys(i).length > 0),
         },
         projectId: useStore.getState().project?.id,
       });
@@ -115,12 +127,21 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
         description: configToUse?.description || '',
         // The full Plotly props object (carries `.type`).
         props: configToUse?.props || { type: 'scatter' },
-        // Each interaction carries exactly one of filter / split / sort.
+        // Each interaction carries exactly one of filter / split / sort. The
+        // field edits the expression BODY — the `?{ }` wrapper is the storage
+        // form and is re-applied on save, so it is decoded away here rather
+        // than shown as literal braces in the ref editor. The slice suffix is
+        // held aside (it lives OUTSIDE the wrapper) so editing the body never
+        // drops it, and `decodeQueryString` additionally unwraps a value an
+        // earlier double-wrapping write corrupted.
         interactions: insightInteractions.map(i => {
-          if (i.filter) return { type: 'filter', value: i.filter };
-          if (i.split) return { type: 'split', value: i.split };
-          if (i.sort) return { type: 'sort', value: i.sort };
-          return { type: 'filter', value: '' }; // Default
+          for (const type of INTERACTION_TYPES) {
+            if (i[type]) {
+              const { body, slice } = decodeQueryString(i[type]);
+              return { type, value: body, slice };
+            }
+          }
+          return { type: 'filter', value: '', slice: null }; // Default
         }),
       });
     } else if (isCreate) {
@@ -179,9 +200,19 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
       config.description = description;
     }
 
-    // Only include interactions if non-empty
+    // Only include interactions if non-empty.
+    //
+    // M6: the value edited here (typed, or dropped in by the @ picker) is an
+    // expression BODY — `${ref(orders).month} DESC`. `InsightInteraction`
+    // fields are `QueryString`s, so the stored value must carry the `?{ }`
+    // wrapper or the parser rejects the YAML this form just wrote. Every other
+    // wrapper site in the viewer goes through the codec; this one didn't, which
+    // is exactly why the two editors disagreed. `encodeQueryString` is
+    // idempotent, so a body that ALREADY carries a wrapper (pasted from the
+    // docs, say) round-trips once-wrapped instead of becoming `?{?{ ... }}`.
     const nonEmptyInteractions = interactions
-      .filter(i => i.value && i.value.trim())
+      .map(i => ({ type: i.type, value: encodeQueryString({ body: i.value, slice: i.slice }) }))
+      .filter(i => i.value && INTERACTION_TYPES.includes(i.type))
       .map(i => ({ [i.type]: i.value }));
 
     if (nonEmptyInteractions.length > 0) {
@@ -216,7 +247,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
 
   // Interaction management
   const addInteraction = () => {
-    setInteractions([...interactions, { type: 'filter', value: '' }]);
+    setInteractions([...interactions, { type: 'filter', value: '', slice: null }]);
   };
 
   const removeInteraction = index => {
@@ -234,13 +265,6 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
     updated[index] = { ...updated[index], value: newValue };
     setInteractions(updated);
   };
-
-  // Interaction type options
-  const INTERACTION_TYPES = [
-    { value: 'filter', label: 'Filter', helperText: 'Client-side filter condition (WHERE clause logic).' },
-    { value: 'split', label: 'Split', helperText: 'Column to split data into multiple traces.' },
-    { value: 'sort', label: 'Sort', helperText: 'Column and direction to sort by (e.g., "date DESC").' },
-  ];
 
   return (
     <>
@@ -299,7 +323,15 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
               </EmptyState>
             ) : (
               interactions.map((interaction, index) => {
-                const typeConfig = INTERACTION_TYPES.find(t => t.value === interaction.type) || INTERACTION_TYPES[0];
+                // Label + hint come from `InsightInteraction`'s own field
+                // descriptions (viewer/src/schemas/interactionHelp.js) so the
+                // guidance cannot drift from the grammar the parser enforces —
+                // this field used to advertise `date DESC`, which the parser
+                // rejects and the binder could not resolve either (C15).
+                const interactionType = INTERACTION_HELP[interaction.type]
+                  ? interaction.type
+                  : 'filter';
+                const typeConfig = INTERACTION_HELP[interactionType];
                 return (
                   <div key={index} className="p-3 border border-gray-200 rounded-lg space-y-3 bg-gray-50">
                     <div className="flex items-center justify-between">
@@ -319,7 +351,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
                       <Select
                         aria-label="Type"
                         value={interaction.type}
-                        options={INTERACTION_TYPES}
+                        options={INTERACTION_TYPE_OPTIONS}
                         onChange={value => updateInteractionType(index, value)}
                       />
                       <label className="absolute text-sm duration-200 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white px-1 left-2 text-gray-500">
@@ -332,9 +364,9 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
                       value={interaction.value}
                       onChange={value => updateInteractionValue(index, value)}
                       label={typeConfig.label}
-                      allowedTypes={refKindsFor('interaction', 'filter')}
+                      allowedTypes={refKindsFor('interaction', interactionType)}
                       rows={2}
-                      helperText={`${typeConfig.helperText} ${REF_INSERT_HINT}`}
+                      helperText={interactionHelpText(interactionType, REF_INSERT_HINT)}
                     />
                   </div>
                 );

--- a/viewer/src/components/views/common/InsightEditForm.test.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings are the data under test, not template-literal mistakes */
 /**
  * InsightEditForm tests — interaction-depth coverage of the real branches, wired
  * to the controlled <TracePropsEditor> (VIS-1020):
@@ -25,6 +26,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import selectEvent from 'react-select-event';
 import InsightEditForm from './InsightEditForm';
 import useStore, { ObjectStatus } from '../../../stores/store';
+import { INTERACTION_HELP, interactionHelpText } from '../../../schemas/interactionHelp';
 
 // TracePropsEditor stub: echo ownerName + props.type, and expose buttons that
 // drive onChange so we can assert the parent persists the edited props.
@@ -114,6 +116,10 @@ const renderForm = async (props = {}) => {
   return utils;
 };
 
+// Interaction values are STORED as `?{ }` query strings — `InsightInteraction`
+// types all three fields as `QueryString`, so anything else fails the parser.
+// The form edits the BODY and re-wraps on save (M6), which these fixtures are
+// shaped to prove: what goes in is what must come back out.
 const publishedInsight = {
   name: 'rev',
   status: ObjectStatus.PUBLISHED,
@@ -121,7 +127,12 @@ const publishedInsight = {
     name: 'rev',
     description: 'revenue insight',
     props: { type: 'bar', x: 'ref(m).x', y: 'ref(m).y' },
-    interactions: [{ filter: 'a > 1' }, { split: 'b' }, { sort: 'c DESC' }, {}],
+    interactions: [
+      { filter: '?{${ref(m).a} > 1}' },
+      { split: '?{${ref(m).b}}' },
+      { sort: '?{${ref(m).c} DESC}' },
+      {},
+    ],
   },
 };
 
@@ -267,14 +278,16 @@ describe('InsightEditForm — interactions', () => {
     expect(screen.queryByText(/No interactions defined/)).not.toBeInTheDocument();
     expect(screen.getByText('Interaction 1')).toBeInTheDocument();
     // New interactions default to filter.
-    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: 'region = "US"' } });
+    fireEvent.change(screen.getByLabelText('Filter'), {
+      target: { value: '${ref(m).region} = "US"' },
+    });
 
     // Second interaction, retyped to Split.
     fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
     await selectEvent.select(screen.getAllByLabelText('Type')[1], 'Split', {
       container: document.body,
     });
-    fireEvent.change(screen.getByLabelText('Split'), { target: { value: 'category' } });
+    fireEvent.change(screen.getByLabelText('Split'), { target: { value: '${ref(m).category}' } });
 
     // Third interaction left blank — must be dropped from the payload.
     fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
@@ -283,7 +296,74 @@ describe('InsightEditForm — interactions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     const [, , config] = onSave.mock.calls[0];
-    expect(config.interactions).toEqual([{ filter: 'region = "US"' }, { split: 'category' }]);
+    // M6: the body the user typed is stored WRAPPED. Before this fix the form
+    // wrote the bare body and the Pydantic `QueryString` validator rejected the
+    // YAML the UI had just produced.
+    expect(config.interactions).toEqual([
+      { filter: '?{${ref(m).region} = "US"}' },
+      { split: '?{${ref(m).category}}' },
+    ]);
+  });
+
+  test('a body the user typed already wrapped is not wrapped twice (M24)', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    // The form the docs publish, pasted straight in.
+    fireEvent.change(screen.getByLabelText('Filter'), {
+      target: { value: '?{ ${ref(m).region} = "US" }' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [, , config] = onSave.mock.calls[0];
+    expect(config.interactions).toEqual([{ filter: '?{${ref(m).region} = "US"}' }]);
+  });
+
+  test('a whitespace-only value is dropped, never stored as `?{}`', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: '   ' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [, , config] = onSave.mock.calls[0];
+    expect(config).not.toHaveProperty('interactions');
+  });
+
+  test('copying the sort field\'s advertised example produces valid stored YAML (C15)', async () => {
+    // The old helper text taught `date DESC` — rejected by the parser unwrapped,
+    // and an unresolvable bare identifier even once wrapped. The replacement is
+    // read out of InsightInteraction's own field descriptions, and a user who
+    // copies it must end up with a value the model accepts.
+    const help = interactionHelpText('sort');
+    expect(help).not.toMatch(/date\s+DESC/i);
+    expect(help).toContain('append ASC or DESC to control direction');
+
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    await selectEvent.select(screen.getAllByLabelText('Type')[0], 'Sort', {
+      container: document.body,
+    });
+    fireEvent.change(screen.getByLabelText('Sort'), {
+      target: { value: INTERACTION_HELP.sort.example },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [, , config] = onSave.mock.calls[0];
+    expect(config.interactions).toEqual([{ sort: '?{${ref(orders).month} ASC}' }]);
+    // …which is the model docstring's own example, modulo padding.
+    expect(config.interactions[0].sort.replace(/\s+/g, '')).toBe(
+      INTERACTION_HELP.sort.yamlExample.replace(/\s+/g, '')
+    );
   });
 
   test('removing an interaction drops it from the form and the payload', async () => {
@@ -298,14 +378,19 @@ describe('InsightEditForm — interactions', () => {
     );
     await screen.findByTestId('trace-props-editor');
 
-    // Remove the first (filter 'a > 1') interaction.
+    // Remove the first (filter) interaction.
     fireEvent.click(screen.getAllByTitle('Remove interaction')[0]);
     expect(screen.queryByText('Interaction 4')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    // The survivors come back byte-identical to how they were stored — the
+    // form decoded them for editing and re-encoded them untouched.
     const [, , config] = onSave.mock.calls[0];
-    expect(config.interactions).toEqual([{ split: 'b' }, { sort: 'c DESC' }]);
+    expect(config.interactions).toEqual([
+      { split: '?{${ref(m).b}}' },
+      { sort: '?{${ref(m).c} DESC}' },
+    ]);
   });
 });
 
@@ -330,9 +415,14 @@ describe('InsightEditForm — edit mode', () => {
     expect(screen.getByTestId('tpe-type')).toHaveTextContent('bar');
     // Each stored interaction kind maps to its editor; the unknown `{}` entry
     // falls back to an empty filter.
-    expect(screen.getAllByLabelText('Filter').map(t => t.value)).toEqual(['a > 1', '']);
-    expect(screen.getByLabelText('Split')).toHaveValue('b');
-    expect(screen.getByLabelText('Sort')).toHaveValue('c DESC');
+    // …de-braced: the field edits the expression BODY, and `?{ }` is the
+    // storage form the save path re-applies.
+    expect(screen.getAllByLabelText('Filter').map(t => t.value)).toEqual([
+      '${ref(m).a} > 1',
+      '',
+    ]);
+    expect(screen.getByLabelText('Split')).toHaveValue('${ref(m).b}');
+    expect(screen.getByLabelText('Sort')).toHaveValue('${ref(m).c} DESC');
 
     // VIS-1133: Save is disabled until something changes. Editing the
     // description leaves props/interactions — what this test is really about —
@@ -346,8 +436,13 @@ describe('InsightEditForm — edit mode', () => {
       name: 'rev',
       description: 'edited description',
       props: { type: 'bar', x: 'ref(m).x', y: 'ref(m).y' },
-      // The empty fallback interaction is dropped; the rest round-trip.
-      interactions: [{ filter: 'a > 1' }, { split: 'b' }, { sort: 'c DESC' }],
+      // The empty fallback interaction is dropped; the rest round-trip
+      // BYTE-IDENTICAL to how they were stored.
+      interactions: [
+        { filter: '?{${ref(m).a} > 1}' },
+        { split: '?{${ref(m).b}}' },
+        { sort: '?{${ref(m).c} DESC}' },
+      ],
     });
   });
 
@@ -506,9 +601,9 @@ describe('InsightEditForm — live preview', () => {
     // Unlike save, the preview keeps the empty fallback filter (it is still a
     // keyed interaction) — asserting the exact mapping of all three kinds.
     expect(insightConfig.interactions).toEqual([
-      { filter: 'a > 1' },
-      { split: 'b' },
-      { sort: 'c DESC' },
+      { filter: '?{${ref(m).a} > 1}' },
+      { split: '?{${ref(m).b}}' },
+      { sort: '?{${ref(m).c} DESC}' },
       { filter: '' },
     ]);
   });

--- a/viewer/src/components/views/common/InsightEditForm.test.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.test.jsx
@@ -322,6 +322,87 @@ describe('InsightEditForm — interactions', () => {
     expect(config.interactions).toEqual([{ filter: '?{${ref(m).region} = "US"}' }]);
   });
 
+  test('editing the description leaves a multi-line stored filter byte-identical', async () => {
+    // The corruption this guards against: `?{a\nb}` failed to unwrap, was
+    // mistaken for a bare body, and got wrapped AGAIN — so opening an insight,
+    // changing its description and saving turned the stored value into
+    // `?{?{a\nb}}`, one layer deeper every time. The value is one the parser
+    // cannot read, so it is REPORTED rather than written — but under no
+    // circumstance is it rewritten into something else.
+    const stored = '?{case when ${ref(m).a} > 0\n  then 1 else 0 end}';
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({
+      insight: {
+        name: 'rev',
+        status: ObjectStatus.PUBLISHED,
+        config: { name: 'rev', props: { type: 'bar' }, interactions: [{ filter: stored }] },
+      },
+      isCreate: false,
+      onSave,
+    });
+
+    // The field shows the BODY — the braces do not leak into the editor.
+    const field = screen.getByLabelText('Filter');
+    expect(field).toHaveValue('case when ${ref(m).a} > 0\n  then 1 else 0 end');
+
+    fireEvent.change(screen.getByLabelText(/Description/), { target: { value: 'new words' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByText(/single line/i);
+    expect(onSave).not.toHaveBeenCalled();
+    // Nothing was rewritten behind the author's back.
+    expect(screen.getByLabelText('Filter')).toHaveValue(
+      'case when ${ref(m).a} > 0\n  then 1 else 0 end'
+    );
+  });
+
+  test('an eval string in a sort field is refused at the field, not by the server', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    fireEvent.change(screen.getByLabelText('Filter'), {
+      target: { value: '>{ anyTestFailed() }' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText(/eval/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('a malformed wrapper is reported, never nested into one that validates', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: '?{x}[a]' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText(/parser/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('the complaint is retracted as soon as the author edits the field', async () => {
+    const onSave = jest.fn(async () => ({ success: true }));
+    await renderForm({ onSave });
+    setName('i1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Interaction' }));
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: '?{x}[a]' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText(/parser/i);
+
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: '${ref(m).a}' } });
+    expect(screen.queryByText(/parser/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [, , config] = onSave.mock.calls[0];
+    expect(config.interactions).toEqual([{ filter: '?{${ref(m).a}}' }]);
+  });
+
   test('a whitespace-only value is dropped, never stored as `?{}`', async () => {
     const onSave = jest.fn(async () => ({ success: true }));
     await renderForm({ onSave });

--- a/viewer/src/components/views/common/interactionSaveParity.test.jsx
+++ b/viewer/src/components/views/common/interactionSaveParity.test.jsx
@@ -1,0 +1,217 @@
+/* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings are the data under test */
+/**
+ * The SAME edit, in both interaction editors, produces byte-identical stored
+ * values.
+ *
+ * That is the dossier's acceptance criterion for M6, and until this file it was
+ * asserted only in prose. The test that carried the claim in its name compared
+ * `INTERACTION_TYPE_OPTIONS` to itself, with the other editor never rendered:
+ * if the two save paths drifted — one dropping the slice, one forgetting to
+ * re-wrap, one repairing a double-wrap the other left alone — every test in the
+ * change would still have passed.
+ *
+ * So this one renders BOTH:
+ *
+ *   - `InsightEditForm`, the right-rail editor, which collects interactions in
+ *     form state and writes them through `onSave` as `{[type]: value}`;
+ *   - `InsightBuildSection`, the Explorer Build rail, which writes each
+ *     keystroke straight to the store through `updateInsightInteraction`.
+ *
+ * Two different owners, two different write shapes, one string that has to
+ * match. Both are driven through their real `RefTextArea` slot (stubbed to a
+ * plain textarea, as both editors' own suites already stub it) so the edit is
+ * the user's edit, not a direct call into the codec.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InsightEditForm from './InsightEditForm';
+import InsightBuildSection from '../workspace/InsightBuildSection';
+import useStore, { ObjectStatus } from '../../../stores/store';
+
+jest.mock('./TracePropsEditor', () => ({
+  __esModule: true,
+  default: ({ props }) => <div data-testid="trace-props-editor">{props?.type}</div>,
+}));
+
+jest.mock('./RefTextArea', () => ({
+  __esModule: true,
+  default: ({ label, value, onChange }) => (
+    <textarea
+      aria-label={label || 'ref'}
+      data-testid="ref-textarea"
+      value={value || ''}
+      onChange={e => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+jest.mock('../../../hooks/useDebounce', () => ({
+  __esModule: true,
+  useDebounce: v => v,
+  default: v => v,
+}));
+
+jest.mock('../workspace/saveAsMetricFlow', () => ({
+  ...jest.requireActual('../workspace/saveAsMetricFlow'),
+  saveAsMetric: jest.fn(),
+}));
+
+jest.mock('../../../schemas/schemas', () => ({
+  CHART_TYPES: [
+    { value: 'scatter', label: 'Scatter / Line' },
+    { value: 'bar', label: 'Bar' },
+  ],
+}));
+
+/**
+ * Every stored shape that reaches an interaction field, paired with the body
+ * the author then types over it. Slices, padding, double wraps: the places the
+ * two editors could disagree.
+ */
+const CASES = [
+  {
+    label: 'a plain wrapped value, retyped',
+    stored: '?{${ref(orders).region}}',
+    typed: '${ref(orders).region} = 1',
+  },
+  {
+    label: 'a SLICED value — the slice must survive editing the body',
+    stored: '?{${ref(daily).value}}[0]',
+    typed: '${ref(daily).value} DESC',
+  },
+  {
+    label: 'a range-sliced value',
+    stored: '?{${ref(daily).value}}[1:5]',
+    typed: 'sum(${ref(daily).value})',
+  },
+  {
+    label: 'a padded value',
+    stored: '?{   ${ref(orders).month}   }',
+    typed: '${ref(orders).month} ASC',
+  },
+  {
+    label: 'a value an earlier double-wrapping write corrupted (M24)',
+    stored: '?{?{${ref(orders).region}}}',
+    typed: '${ref(orders).region} = 2',
+  },
+  {
+    label: 'a body typed with its own wrapper, as the docs publish it',
+    stored: '?{${ref(orders).month}}',
+    typed: '?{ ${ref(orders).month} DESC }',
+  },
+];
+
+const rightRailWrite = async ({ stored, typed }) => {
+  const onSave = jest.fn(async () => ({ success: true }));
+  const utils = render(
+    <InsightEditForm
+      insight={{
+        name: 'rev',
+        status: ObjectStatus.PUBLISHED,
+        config: { name: 'rev', props: { type: 'bar' }, interactions: [{ filter: stored }] },
+      }}
+      isCreate={false}
+      onClose={jest.fn()}
+      onSave={onSave}
+    />
+  );
+  await screen.findByTestId('trace-props-editor');
+
+  const field = screen.getByTestId('ref-textarea');
+  const shownBody = field.value;
+  fireEvent.change(field, { target: { value: typed } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+  const [, , config] = onSave.mock.calls[0];
+  const written = config.interactions ? config.interactions[0].filter : null;
+  utils.unmount();
+  return { shownBody, written };
+};
+
+const buildRailWrite = async ({ stored, typed }) => {
+  const updateInsightInteraction = jest.fn();
+  act(() => {
+    useStore.setState({
+      explorerInsightStates: {
+        test_insight: {
+          type: 'scatter',
+          props: {},
+          interactions: [{ type: 'filter', value: stored }],
+          isNew: true,
+        },
+      },
+      explorerActiveInsightName: 'test_insight',
+      explorerChartInsightNames: ['test_insight'],
+      explorerActiveModelName: 'orders',
+      explorerModelTabs: ['orders'],
+      explorerModelStates: {},
+      models: [],
+      metrics: [],
+      dimensions: [],
+      sources: [],
+      updateInsightInteraction,
+    });
+  });
+
+  const utils = render(
+    <InsightBuildSection insightName="test_insight" isExpanded onToggleExpand={jest.fn()} />
+  );
+  const row = await screen.findByTestId('insight-interaction-0');
+  const field = within(row).getByTestId('ref-textarea');
+  const shownBody = field.value;
+  fireEvent.change(field, { target: { value: typed } });
+
+  const written = updateInsightInteraction.mock.calls.length
+    ? updateInsightInteraction.mock.calls[0][2].value
+    : null;
+  utils.unmount();
+  return { shownBody, written };
+};
+
+describe('the two interaction editors agree, byte for byte', () => {
+  it.each(CASES)('$label', async ({ stored, typed }) => {
+    const right = await rightRailWrite({ stored, typed });
+    const build = await buildRailWrite({ stored, typed });
+
+    // Both show the author the same thing before the edit...
+    expect(build.shownBody).toBe(right.shownBody);
+    // ...and neither shows the storage wrapper in the field.
+    expect(right.shownBody).not.toMatch(/^\?\{/);
+    // ...and both write the same string after it.
+    expect(build.written).toBe(right.written);
+  });
+
+  it('clearing the body stores no expression in either editor', async () => {
+    // The one place the two legitimately differ, stated so the difference is a
+    // decision rather than a drift: the right rail saves a whole config, so an
+    // empty interaction is DROPPED from it; the Build rail writes every
+    // keystroke to the store, so it holds an empty string while the author is
+    // mid-edit and the row stays on screen. Neither stores `?{}`.
+    const cleared = { stored: '?{${ref(orders).month}}', typed: '   ' };
+    const right = await rightRailWrite(cleared);
+    const build = await buildRailWrite(cleared);
+
+    expect(right.written).toBeNull();
+    expect(build.written).toBe('');
+    for (const value of [right.written, build.written]) {
+      expect(value).not.toBe('?{}');
+      expect(value).toBeFalsy();
+    }
+  });
+
+  it('neither editor can produce a nested wrapper from any of these edits', async () => {
+    const nested = [];
+    for (const testCase of CASES) {
+      const { written: rightWritten } = await rightRailWrite(testCase);
+      const { written: buildWritten } = await buildRailWrite(testCase);
+      for (const value of [rightWritten, buildWritten]) {
+        if (typeof value === 'string' && /\?\{\s*\?\{/.test(value)) {
+          nested.push(`${testCase.label}: ${value}`);
+        }
+      }
+    }
+    expect(nested).toEqual([]);
+  });
+});

--- a/viewer/src/components/views/common/pillFieldSwap.js
+++ b/viewer/src/components/views/common/pillFieldSwap.js
@@ -1,4 +1,5 @@
 import * as pillGrammar from './pillGrammar';
+import { encodeQueryString } from '../../../utils/expressionCodec';
 
 /**
  * pillFieldSwap — Explore 2.0 Phase 4 (06-pill-aggregation-grammar.md §4/§8 +
@@ -140,7 +141,7 @@ export function findMatchingExpressionSlots(
 /** Serialize a swap target (`{kind: 'metricRef'|'dimensionRef', ref}`) into
  * the `?{...}` query-string form a prop/interaction value expects. */
 export function serializeSwapTarget(swapTo) {
-  return `?{${pillGrammar.serialize({ kind: swapTo.kind, ref: swapTo.ref })}}`;
+  return encodeQueryString({ body: pillGrammar.serialize({ kind: swapTo.kind, ref: swapTo.ref }) });
 }
 
 /**

--- a/viewer/src/components/views/common/pillFieldSwap.js
+++ b/viewer/src/components/views/common/pillFieldSwap.js
@@ -1,5 +1,5 @@
 import * as pillGrammar from './pillGrammar';
-import { encodeQueryString } from '../../../utils/expressionCodec';
+import { encodeQueryString, parseQueryString } from '../../../utils/expressionCodec';
 
 /**
  * pillFieldSwap — Explore 2.0 Phase 4 (06-pill-aggregation-grammar.md §4/§8 +
@@ -34,17 +34,21 @@ import { encodeQueryString } from '../../../utils/expressionCodec';
  * both triggers.
  */
 
-const QUERY_STRING_RE = /^\?\{([\s\S]*)\}$/;
-
 const parseQueryBody = value => {
-  if (typeof value !== 'string') return null;
-  const match = value.match(QUERY_STRING_RE);
-  if (!match) return null;
+  // The `?{ }` grammar belongs to `expressionCodec`, including on the READ
+  // side: this used to carry its own `/^\?\{([\s\S]*)\}$/`, which is one more
+  // place deciding for itself what the wrapper is.
+  const parsed = parseQueryString(value);
+  if (!parsed) return null;
+  // A SLICED slot stays out of scope, exactly as the old regex left it out (it
+  // could not match a `}[0]` tail at all). The swap rewrites a slot to a bare
+  // `?{${ref(name)}}`, so admitting one here would silently drop its slice.
+  if (parsed.slice) return null;
   // Parse WITHOUT the global metric/dimension lookup tables — this is the
   // slot's syntactic shape (bare column ref vs aggregate-wrapped), which is
   // what both detectors below need, independent of whatever the store's
   // CURRENT metrics/dimensions lists happen to contain right now.
-  const state = pillGrammar.parse(match[1], {});
+  const state = pillGrammar.parse(parsed.body, {});
   // VIS-1241: a slot carrying a MODIFIER (`${ref(m).region} = 'west'`) is now
   // recognized by the grammar, but it must not be swap-eligible: the swap
   // rewrites a slot to a bare `?{${ref(name)}}`, which would silently discard

--- a/viewer/src/components/views/workspace/InsightBuildSection.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.jsx
@@ -19,15 +19,15 @@ import SaveAsMetricPrompt from './SaveAsMetricPrompt';
 import FieldSwapOfferBanner from './FieldSwapOfferBanner';
 import { saveAsMetric, suggestMetricName } from './saveAsMetricFlow';
 import { refKindsFor } from '../common/fieldTypes';
+import { decodeQueryString, encodeQueryString } from '../../../utils/expressionCodec';
+import {
+  INTERACTION_HELP,
+  INTERACTION_TYPE_OPTIONS,
+  interactionExampleHint,
+} from '../../../schemas/interactionHelp';
 
 const INSIGHT_COLORS = getTypeColors('insight');
 const InsightTypeIcon = getTypeIcon('insight');
-
-const INTERACTION_TYPES = [
-  { value: 'filter', label: 'Filter' },
-  { value: 'split', label: 'Split' },
-  { value: 'sort', label: 'Sort' },
-];
 
 const InteractionRow = ({ interaction, index, insightName, updateInsightInteraction, handleRemoveInteraction }) => {
   const { isOver, setNodeRef } = useDroppable({
@@ -35,11 +35,13 @@ const InteractionRow = ({ interaction, index, insightName, updateInsightInteract
     data: { type: 'interaction-zone', insightName, index },
   });
 
-  const innerValue = (() => {
-    const v = interaction.value || '';
-    const m = v.match(/^\?\{([\s\S]*)\}$/);
-    return m ? m[1] : v;
-  })();
+  // The row edits the expression BODY; `?{ }` is the storage form. Decoding
+  // through the codec rather than a local regex fixes two things the greedy
+  // `/^\?\{([\s\S]*)\}$/` got wrong: a sliced value (`?{x}[0]`) didn't match at
+  // all, so the braces leaked into the field and the next keystroke stored
+  // `?{?{x}[0]}`; and a value already corrupted that way stayed corrupted.
+  const { body: innerValue, slice } = decodeQueryString(interaction.value);
+  const interactionType = INTERACTION_HELP[interaction.type] ? interaction.type : 'filter';
 
   return (
     <div data-testid={`insight-interaction-${index}`} className="flex items-center gap-2">
@@ -48,7 +50,7 @@ const InteractionRow = ({ interaction, index, insightName, updateInsightInteract
         size="sm"
         className="min-w-[110px]"
         value={interaction.type || 'filter'}
-        options={INTERACTION_TYPES}
+        options={INTERACTION_TYPE_OPTIONS}
         onChange={type => {
           updateInsightInteraction(insightName, index, { type });
         }}
@@ -62,12 +64,13 @@ const InteractionRow = ({ interaction, index, insightName, updateInsightInteract
           value={innerValue}
           onChange={newVal => {
             updateInsightInteraction(insightName, index, {
-              value: newVal ? `?{${newVal}}` : '',
+              value: encodeQueryString({ body: newVal, slice }),
             });
           }}
           label=""
           rows={1}
-          allowedTypes={refKindsFor('interaction', 'filter')}
+          allowedTypes={refKindsFor('interaction', interactionType)}
+          helperText={interactionExampleHint(interactionType)}
         />
       </div>
       <button
@@ -209,7 +212,7 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
       if (dragData.source === 'pill') {
         if (!dragData.sourcePath || !dragData.raw) return;
         if (dragData.sourcePath === path) return; // dropped back on itself — no-op, nothing to warn about
-        setInsightProp(insightName, path, `?{${dragData.raw}}`);
+        setInsightProp(insightName, path, encodeQueryString({ body: dragData.raw }));
         removeInsightProp(insightName, dragData.sourcePath);
         return;
       }
@@ -251,7 +254,7 @@ const InsightBuildSection = ({ insightName, isExpanded, onToggleExpand }) => {
         showWorkspaceToast?.("Can't drop that here.");
         return;
       }
-      setInsightProp(insightName, path, `?{${body}}`);
+      setInsightProp(insightName, path, encodeQueryString({ body }));
     },
     [activeModelName, insightName, setInsightProp, removeInsightProp, showWorkspaceToast]
   );

--- a/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
+++ b/viewer/src/components/views/workspace/InsightBuildSection.test.jsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import InsightBuildSection from './InsightBuildSection';
 import useStore from '../../../stores/store';
 import { saveAsMetric } from './saveAsMetricFlow';
+import { INTERACTION_TYPE_OPTIONS } from '../../../schemas/interactionHelp';
 
 async function renderSettled(ui) {
   // eslint-disable-next-line testing-library/no-unnecessary-act
@@ -691,6 +692,45 @@ describe('InsightBuildSection', () => {
       expect(updateInsightInteraction).toHaveBeenCalledWith('test_insight', 0, {
         value: '?{${ref(orders_q).region}}',
       });
+    });
+
+    // M6/M24 — the row used to strip with a greedy `/^\?\{([\s\S]*)\}$/` and
+    // wrap with a bare template literal, so a value carrying a SLICE never
+    // matched, the braces leaked into the field, and the next keystroke stored
+    // the whole thing wrapped again.
+    it('keeps the slice out of the edited body and re-attaches it on write', async () => {
+      const updateInsightInteraction = jest.fn();
+      useStore.setState({ updateInsightInteraction });
+      renderWithInteraction({ type: 'sort', value: '?{${ref(orders_q).month}}[0]' });
+      const textarea = await screen.findByTestId('mock-ref-textarea');
+      expect(textarea).toHaveValue('${ref(orders_q).month}');
+
+      fireEvent.change(textarea, { target: { value: '${ref(orders_q).month} DESC' } });
+      expect(updateInsightInteraction).toHaveBeenCalledWith('test_insight', 0, {
+        value: '?{${ref(orders_q).month} DESC}[0]',
+      });
+    });
+
+    it('repairs an already double-wrapped value instead of nesting further (M24)', async () => {
+      const updateInsightInteraction = jest.fn();
+      useStore.setState({ updateInsightInteraction });
+      renderWithInteraction({ type: 'filter', value: '?{?{${ref(orders_q).region}}}' });
+      const textarea = await screen.findByTestId('mock-ref-textarea');
+      expect(textarea).toHaveValue('${ref(orders_q).region}');
+
+      fireEvent.change(textarea, { target: { value: '${ref(orders_q).region} = 1' } });
+      expect(updateInsightInteraction).toHaveBeenCalledWith('test_insight', 0, {
+        value: '?{${ref(orders_q).region} = 1}',
+      });
+    });
+
+    it('offers the same three interaction types the right-rail editor offers', async () => {
+      renderWithInteraction({ type: 'sort', value: '' });
+      const select = await screen.findByTestId('interaction-type-select-0');
+      expect(select).toHaveTextContent('Sort');
+      // Both surfaces read their options out of the model-derived help module,
+      // so the labels cannot diverge between the two editors.
+      expect(INTERACTION_TYPE_OPTIONS.map(o => o.label)).toEqual(['Filter', 'Split', 'Sort']);
     });
 
     it('changing the interaction type select calls updateInsightInteraction with the new type', async () => {

--- a/viewer/src/components/views/workspace/saveAsMetricFlow.js
+++ b/viewer/src/components/views/workspace/saveAsMetricFlow.js
@@ -1,7 +1,7 @@
 import { translateExpressions } from '../../../api/expressions';
 import * as pillGrammar from '../common/pillGrammar';
 import { findMatchingExpressionSlots } from '../common/pillFieldSwap';
-import { serializeQueryString } from '../../../utils/queryString';
+import { encodeQueryString } from '../../../utils/expressionCodec';
 import { emitWorkspaceEvent } from './telemetry';
 
 /**
@@ -106,7 +106,7 @@ export const saveAsMetric = async ({
   getState().setInsightProp?.(
     insightName,
     path,
-    serializeQueryString({ body: pillGrammar.serialize({ kind: 'metricRef', ref: trimmed }) })
+    encodeQueryString({ body: pillGrammar.serialize({ kind: 'metricRef', ref: trimmed }) })
   );
 
   // Match-and-replace dedup (06 §8, Lightdash-adopted): offer, never apply silently.

--- a/viewer/src/schemas/interactionHelp.js
+++ b/viewer/src/schemas/interactionHelp.js
@@ -34,6 +34,13 @@
  * documents the file rather than the field.
  */
 
+import {
+  EXPRESSION_FORMS,
+  decodeQueryString,
+  encodeQueryString,
+  isParserReadableQueryString,
+} from '../utils/expressionCodec';
+
 export const INTERACTION_TYPES = ['filter', 'split', 'sort'];
 
 export const INTERACTION_HELP = Object.freeze({
@@ -103,6 +110,36 @@ export function interactionExampleHint(type) {
   const entry = INTERACTION_HELP[type];
   if (!entry) return '';
   return `e.g. ${entry.example}`;
+}
+
+/**
+ * Why this interaction body cannot be stored, or `null` when it can.
+ *
+ * `encodeQueryString` is total: it never mangles a value it does not
+ * understand, which means it can hand back something the `QueryString`
+ * validator will refuse — a `>{ }` eval string, a malformed wrapper, a body
+ * with an interior newline. Wrapping those anyway is not an option (that is how
+ * `?{?{ ... }}` gets manufactured), so the editor has to SAY so, at the field,
+ * while the author is looking at it. The alternative is a round trip to a
+ * server-side validation error, which is the M6 experience with extra steps.
+ *
+ * @param {string} body - the expression body as typed (no wrapper)
+ * @param {string|null} [slice] - the slice suffix held aside by the editor
+ * @returns {string|null} a message to show under the field, or null
+ */
+export function interactionValueProblem(body, slice = null) {
+  const stored = encodeQueryString({ body, slice });
+  // Empty is not a problem — an interaction with no expression is dropped.
+  if (!stored || isParserReadableQueryString(stored)) return null;
+
+  const { form } = decodeQueryString(body);
+  if (form === EXPRESSION_FORMS.EVAL) {
+    return 'Eval strings (>{ ... }) belong to tests and alerts. Use a ?{ } expression here.';
+  }
+  if (/[\r\n]/.test(String(body))) {
+    return 'An interaction expression must be a single line.';
+  }
+  return 'This is not an expression the parser can read. Check the ?{ } wrapper and any [slice] suffix.';
 }
 
 /**

--- a/viewer/src/schemas/interactionHelp.js
+++ b/viewer/src/schemas/interactionHelp.js
@@ -1,0 +1,117 @@
+/* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` example strings, not template-literal mistakes */
+/**
+ * Help text for the three insight interaction fields — filter, split, sort.
+ *
+ * ## Why this file exists
+ *
+ * The sort field used to advertise the literal example `"date DESC"`. That is
+ * not a value this grammar accepts: `InsightInteraction.sort` is a
+ * `QueryString`, so the parser rejects anything that is not `?{ ... }`, and
+ * even wrapped, a BARE identifier like `date` dies at run time with a binder
+ * error because the semantic layer resolves refs, not loose column names. The
+ * UI was teaching a form the product rejects, and users copied it.
+ *
+ * The fix is not a better hand-written string — a hand-written string drifts
+ * from the model the moment someone edits `visivo/models/interaction.py`. Every
+ * `description` and `example` below is COPIED VERBATIM from the Pydantic model,
+ * and `interactionHelp.test.js` re-derives all six strings from the vendored
+ * `visivo_project_schema.json` (`$defs/InsightInteraction`) and fails if any of
+ * them has drifted. `tests/models/test_interaction_help_parity.py` closes the
+ * loop on the Python side, checking this file against
+ * `InsightInteraction.model_fields` directly — so a stale vendored schema
+ * cannot hide a drift either.
+ *
+ * Regenerate the vendored schema with `python -m visivo.generate_project_schema_json`
+ * and re-copy it here when the models change; if these strings then need
+ * updating, the two tests will say so by name.
+ *
+ * ## The `?{ }` wrapper
+ *
+ * `example` holds the expression BODY, not the stored YAML value: the editors
+ * wrap what the user types via `expressionCodec.encodeQueryString`, so showing
+ * `?{ ... }` in the hint would teach people to type a wrapper that then gets
+ * wrapped again. `yamlExample` keeps the full stored form for anywhere that
+ * documents the file rather than the field.
+ */
+
+export const INTERACTION_TYPES = ['filter', 'split', 'sort'];
+
+export const INTERACTION_HELP = Object.freeze({
+  filter: Object.freeze({
+    label: 'Filter',
+    // InsightInteraction.filter — Field(description=...)
+    description:
+      'Boolean expression evaluated per row in the viewer; only rows where it is true are kept.',
+    // From the InsightInteraction docstring's YAML example block.
+    yamlExample: '?{ ${ref(orders).region} = ${ref(region-input).value} }',
+    example: '${ref(orders).region} = ${ref(region-input).value}',
+  }),
+  split: Object.freeze({
+    label: 'Split',
+    // InsightInteraction.split — Field(description=...)
+    description:
+      'Column or expression whose distinct values break the insight into multiple plotly series.',
+    yamlExample: '?{ ${ref(orders).product_line} }',
+    example: '${ref(orders).product_line}',
+  }),
+  sort: Object.freeze({
+    label: 'Sort',
+    // InsightInteraction.sort — Field(description=...)
+    description:
+      'Column or expression to sort rows by; append `ASC` or `DESC` to control direction.',
+    yamlExample: '?{ ${ref(orders).month} ASC }',
+    example: '${ref(orders).month} ASC',
+  }),
+});
+
+/**
+ * The model's descriptions are markdown (they are published to the docs site),
+ * so `sort`'s reads "append `ASC` or `DESC`". A helper line is plain text in a
+ * plain <p>; leaving the backticks in shows them literally. Strip the code
+ * fences for display only — `INTERACTION_HELP` keeps the model's exact bytes,
+ * which is what the two parity tests pin.
+ */
+function asPlainText(markdown) {
+  return markdown.replace(/`([^`]+)`/g, '$1');
+}
+
+/**
+ * The hint shown under an interaction field: what the field means, then
+ * anything the surface wants to add, and last — so it is the line's parting
+ * thought and nothing runs into it — an example that works if you copy it.
+ *
+ * @param {string} type - 'filter' | 'split' | 'sort'
+ * @param {string} [extra] - surface-specific guidance (e.g. the @-insert hint)
+ * @returns {string} '' for an unknown type, so callers can render it blind.
+ */
+export function interactionHelpText(type, extra = '') {
+  const entry = INTERACTION_HELP[type];
+  if (!entry) return '';
+  const middle = extra ? `${extra} ` : '';
+  return `${asPlainText(entry.description)} ${middle}For example: ${entry.example}`;
+}
+
+/**
+ * The example alone, for a narrow surface (the Explorer Build rail's one-line
+ * interaction rows) where the full sentence would wrap three times. Same
+ * source, less of it.
+ *
+ * @param {string} type - 'filter' | 'split' | 'sort'
+ * @returns {string} '' for an unknown type.
+ */
+export function interactionExampleHint(type) {
+  const entry = INTERACTION_HELP[type];
+  if (!entry) return '';
+  return `e.g. ${entry.example}`;
+}
+
+/**
+ * The interaction type options a `<Select>` renders, with their help text
+ * attached — the shape both editors already expected, now sourced from the
+ * model instead of retyped in each of them.
+ */
+export const INTERACTION_TYPE_OPTIONS = INTERACTION_TYPES.map(value => ({
+  value,
+  label: INTERACTION_HELP[value].label,
+  helperText: interactionHelpText(value),
+}));

--- a/viewer/src/schemas/interactionHelp.test.js
+++ b/viewer/src/schemas/interactionHelp.test.js
@@ -5,9 +5,15 @@ import {
   INTERACTION_TYPE_OPTIONS,
   interactionExampleHint,
   interactionHelpText,
+  interactionValueProblem,
 } from './interactionHelp';
 import projectSchema from './visivo_project_schema.json';
-import { canonicalizeQueryString } from '../utils/expressionCodec';
+import {
+  canonicalizeQueryString,
+  decodeQueryString,
+  encodeQueryString,
+  isParserReadableQueryString,
+} from '../utils/expressionCodec';
 
 const INTERACTION_DEF = projectSchema.$defs.InsightInteraction;
 
@@ -139,5 +145,113 @@ describe('INTERACTION_TYPE_OPTIONS', () => {
       { value: 'split', label: 'Split', helperText: interactionHelpText('split') },
       { value: 'sort', label: 'Sort', helperText: interactionHelpText('sort') },
     ]);
+  });
+});
+
+describe('interactionValueProblem — the editor refuses what the parser would', () => {
+  // The codec is total: rather than mangle a value it cannot represent, it
+  // hands it straight back. That is the right call for a codec and the wrong
+  // place to stop for a save path, because the value can then be written out
+  // for the server (or the next `visivo run`) to complain about. This function
+  // is the join: everything `encodeQueryString` emits is either something the
+  // parser reads, or something this reports.
+  const ACCEPTED = [
+    '${ref(orders).month} ASC',
+    '${ref(orders).region} = ${ref(region-input).value}',
+    'sum(${ref(orders).amount})',
+    '?{${ref(orders).month}}',
+    '?{ ${ref(orders).month} }',
+    '?{?{${ref(orders).month}}}',
+    'amount',
+  ];
+
+  it.each(ACCEPTED)('accepts %s', body => {
+    expect(interactionValueProblem(body)).toBeNull();
+  });
+
+  it.each(INTERACTION_TYPES)("accepts %s's own advertised example", type => {
+    // The hint has to be a value the field will take. It was `date DESC` once.
+    expect(interactionValueProblem(INTERACTION_HELP[type].example)).toBeNull();
+  });
+
+  it('accepts a body carrying a slice, with the slice held aside', () => {
+    expect(interactionValueProblem('${ref(daily).value}', '[0]')).toBeNull();
+  });
+
+  it.each(['', '   ', null, undefined])(
+    'treats %s as nothing to report — an empty interaction is dropped, not refused',
+    body => {
+      expect(interactionValueProblem(body)).toBeNull();
+    }
+  );
+
+  it('names the eval-string grammar rather than wrapping it into nonsense', () => {
+    const problem = interactionValueProblem('>{ anyTestFailed() }');
+    expect(problem).toMatch(/eval/i);
+    // …and the value really would be refused: this is the M6 shape, a UI
+    // writing YAML the tool then rejects.
+    expect(isParserReadableQueryString(encodeQueryString({ body: '>{ anyTestFailed() }' }))).toBe(
+      false
+    );
+  });
+
+  it.each([
+    'a = 1\nAND b = 2',
+    'case when ${ref(o).a} > 0\n  then 1 else 0 end',
+    'a = 1\r\nAND b = 2',
+  ])('says a multi-line body is the problem, for %j', body => {
+    expect(interactionValueProblem(body)).toMatch(/single line/i);
+  });
+
+  it.each(['?{x}[a]', '?{a}[0][1]', '?{unbalanced'])(
+    'reports the malformed wrapper %s instead of nesting it',
+    body => {
+      expect(interactionValueProblem(body)).toMatch(/parser/i);
+      // The corruption it is standing in for: without the refusal the natural
+      // move is to wrap, which turns a value the validator REJECTS into one it
+      // ACCEPTS with the braces as literal SQL.
+      expect(encodeQueryString({ body })).toBe(body);
+    }
+  );
+
+  // The invariant, as a property over the same shape table the codec is tested
+  // with: for every value the app can produce, the editor's answer and the
+  // parser's answer agree.
+  const SAVEABLE_BODIES = [
+    ...ACCEPTED,
+    '>{ anyTestFailed() }',
+    'a\nb',
+    '?{a\nb}',
+    '?{}',
+    '?{ }',
+    '?{x}[a]',
+    '?{a}[0][1]',
+    '?{unbalanced',
+    'query(select 1)',
+    'column(amount)',
+    '',
+    '   ',
+  ];
+
+  it.each(SAVEABLE_BODIES)(
+    'either the parser reads %j or the field reports it — never neither, never both',
+    body => {
+      const stored = encodeQueryString({ body, slice: decodeQueryString(body).slice });
+      const problem = interactionValueProblem(body);
+      // A value that is dropped entirely (`stored === ''`) is nothing to
+      // complain about, so it counts as settled alongside a readable one.
+      const settled = !stored || isParserReadableQueryString(stored);
+      expect({ body, settled }).toEqual({ body, settled: problem === null });
+    }
+  );
+
+  it('never lets a reported value through as a stored one', () => {
+    // The failure this guards: a body that yields a problem message AND a
+    // non-empty stored value that the save path would happily write.
+    const leaks = SAVEABLE_BODIES.filter(body => {
+      const stored = encodeQueryString({ body });
+      return stored && !isParserReadableQueryString(stored) && interactionValueProblem(body) === null;
+    });
+    expect(leaks).toEqual([]);
   });
 });

--- a/viewer/src/schemas/interactionHelp.test.js
+++ b/viewer/src/schemas/interactionHelp.test.js
@@ -1,0 +1,143 @@
+/* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings are the data under test, not template-literal mistakes */
+import {
+  INTERACTION_HELP,
+  INTERACTION_TYPES,
+  INTERACTION_TYPE_OPTIONS,
+  interactionExampleHint,
+  interactionHelpText,
+} from './interactionHelp';
+import projectSchema from './visivo_project_schema.json';
+import { canonicalizeQueryString } from '../utils/expressionCodec';
+
+const INTERACTION_DEF = projectSchema.$defs.InsightInteraction;
+
+/**
+ * Pull the three `- <field>: ?{ ... }` lines out of the InsightInteraction
+ * docstring's YAML example block. These are the examples the docs site
+ * publishes, so they are the examples the UI should show.
+ */
+function examplesFromDocstring(description) {
+  const found = {};
+  for (const line of description.split('\n')) {
+    const match = line.match(/^\s*-\s+(filter|split|sort):\s*(.+?)\s*$/);
+    if (match) found[match[1]] = match[2];
+  }
+  return found;
+}
+
+describe('interactionHelp is derived from the model, not hand-written', () => {
+  it('covers exactly the fields InsightInteraction declares', () => {
+    expect(INTERACTION_TYPES).toEqual(Object.keys(INTERACTION_DEF.properties));
+  });
+
+  it.each(INTERACTION_TYPES)(
+    "%s's description is byte-identical to the model's Field(description=…)",
+    type => {
+      expect(INTERACTION_HELP[type].description).toBe(
+        INTERACTION_DEF.properties[type].description
+      );
+    }
+  );
+
+  it.each(INTERACTION_TYPES)(
+    "%s's yamlExample is byte-identical to the model docstring's example",
+    type => {
+      const fromDocstring = examplesFromDocstring(INTERACTION_DEF.description);
+      expect(INTERACTION_HELP[type].yamlExample).toBe(fromDocstring[type]);
+    }
+  );
+
+  it.each(INTERACTION_TYPES)("%s's example is the yamlExample's body, unwrapped", type => {
+    const { example, yamlExample } = INTERACTION_HELP[type];
+    // The editors wrap what the user types, so the hint must show the body.
+    // Re-wrapping the body must reproduce the documented YAML value.
+    expect(canonicalizeQueryString(example)).toBe(canonicalizeQueryString(yamlExample));
+    expect(example).not.toContain('?{');
+  });
+});
+
+describe('the advertised examples are values this grammar accepts', () => {
+  // A JS mirror of visivo/models/base/query_string.py's validate_and_create.
+  const pydanticWouldAccept = value =>
+    value.startsWith('?{') && (value.endsWith('}') || /\}(\[[^\]]+\])\s*$/.test(value));
+
+  it.each(INTERACTION_TYPES)('%s: the example survives the save path and validates', type => {
+    const stored = canonicalizeQueryString(INTERACTION_HELP[type].example);
+    expect(pydanticWouldAccept(stored)).toBe(true);
+  });
+
+  it.each(INTERACTION_TYPES)('%s: the example references a model, not a loose column', type => {
+    // C15's second half. `date DESC` passed nothing: the parser rejected it
+    // unwrapped, and `?{date DESC}` reaches the binder as an unresolvable bare
+    // identifier. Every example must carry a real `${ref(...)}`.
+    expect(INTERACTION_HELP[type].example).toMatch(/\$\{\s*ref\(/);
+  });
+
+  it('never teaches the "date DESC" form again', () => {
+    const everyString = JSON.stringify(INTERACTION_HELP) + JSON.stringify(INTERACTION_TYPE_OPTIONS);
+    expect(everyString).not.toMatch(/\bdate\s+DESC\b/i);
+  });
+
+  it.each(INTERACTION_TYPES)('%s: the rendered hint carries no markdown backticks', type => {
+    // The model descriptions are markdown (they publish to the docs site); the
+    // helper line is plain text in a plain <p>, so backticks would render.
+    expect(interactionHelpText(type)).not.toContain('`');
+  });
+
+  it('only offers the ASC/DESC modifiers the model documents', () => {
+    // NULLS FIRST/LAST leak through the ORDER BY strippers today, so the help
+    // must not advertise them until that is fixed.
+    expect(JSON.stringify(INTERACTION_HELP)).not.toMatch(/NULLS/i);
+    expect(INTERACTION_DEF.properties.sort.description).toMatch(/`ASC` or `DESC`/);
+  });
+});
+
+describe('interactionHelpText', () => {
+  it('joins the model description to a working example', () => {
+    expect(interactionHelpText('sort')).toBe(
+      'Column or expression to sort rows by; append ASC or DESC to control direction. ' +
+        'For example: ${ref(orders).month} ASC'
+    );
+  });
+
+  it('puts a surface-specific clause between the description and the example', () => {
+    // The example comes LAST so nothing runs into it — a hint that ended
+    // "…${ref(orders).month} ASC Type @ to insert references" reads as if the
+    // words after the expression were part of it.
+    expect(interactionHelpText('sort', 'Type @ to insert references.')).toBe(
+      'Column or expression to sort rows by; append ASC or DESC to control direction. ' +
+        'Type @ to insert references. For example: ${ref(orders).month} ASC'
+    );
+  });
+
+  it('returns an empty string for an unknown type rather than throwing', () => {
+    expect(interactionHelpText('nope')).toBe('');
+    expect(interactionHelpText(undefined)).toBe('');
+    expect(interactionHelpText('nope', 'extra')).toBe('');
+  });
+});
+
+describe('interactionExampleHint', () => {
+  it.each(INTERACTION_TYPES)('%s: shows the same example, without the sentence', type => {
+    const hint = interactionExampleHint(type);
+    expect(hint).toBe(`e.g. ${INTERACTION_HELP[type].example}`);
+    // The Build rail's rows are one line tall; a wrapping paragraph there
+    // would triple every row's height.
+    expect(hint.length).toBeLessThan(60);
+  });
+
+  it('returns an empty string for an unknown type rather than throwing', () => {
+    expect(interactionExampleHint('nope')).toBe('');
+    expect(interactionExampleHint(undefined)).toBe('');
+  });
+});
+
+describe('INTERACTION_TYPE_OPTIONS', () => {
+  it('is the Select-ready shape both editors need', () => {
+    expect(INTERACTION_TYPE_OPTIONS).toEqual([
+      { value: 'filter', label: 'Filter', helperText: interactionHelpText('filter') },
+      { value: 'split', label: 'Split', helperText: interactionHelpText('split') },
+      { value: 'sort', label: 'Sort', helperText: interactionHelpText('sort') },
+    ]);
+  });
+});

--- a/viewer/src/stores/explorerStore.js
+++ b/viewer/src/stores/explorerStore.js
@@ -2,6 +2,7 @@
 import { generateUniqueName } from '../utils/uniqueName';
 import { legacyStateForSeed } from '../components/views/workspace/explorationLegacyBridge';
 import { formatRefExpression } from '../utils/refString';
+import { encodeQueryString } from '../utils/expressionCodec';
 
 /**
  * Thrown by create/rename actions when the proposed name collides with any
@@ -1619,7 +1620,7 @@ const createExplorerSlice = (set, get) => ({
         // Prefer the first unfilled Essential slot (x, then y) — the same
         // pair drag-and-drop fills first for a fresh scatter/line insight.
         const slot = !props.x ? 'x' : 'y';
-        get().setInsightProp(targetInsightName, slot, `?{${refExpr}}`);
+        get().setInsightProp(targetInsightName, slot, encodeQueryString({ body: refExpr }));
       }
 
       // ux-audit.md's companion complaint: "the warning banner grew to

--- a/viewer/src/utils/expressionCodec.js
+++ b/viewer/src/utils/expressionCodec.js
@@ -31,21 +31,53 @@
  * `encodeQueryString(decodeQueryString(v))` is IDEMPOTENT: applying it twice
  * gives the same string as applying it once, for every value shape the app can
  * produce — bare bodies, already-wrapped values, doubly-wrapped values, values
- * carrying a slice, legacy forms, and empty/blank input. That is the property
- * that makes "the UI wrote YAML the parser rejects" unrepresentable, so it is
- * tested as a property over a table of inputs rather than example-by-example.
+ * carrying a slice, legacy forms, malformed wrappers, and empty/blank input.
+ * That is the property that makes "the UI wrote YAML the parser rejects"
+ * unrepresentable, so it is tested as a property over a table of inputs rather
+ * than example-by-example.
  *
  * `canonicalizeQueryString` is that composition, and is what save paths should
  * call.
+ *
+ * ## Totality
+ *
+ * The codec is TOTAL and NON-DESTRUCTIVE. A value it cannot parse as a wrapper
+ * but which is plainly wrapper-SHAPED (`?{}`, `?{x}[a]`, `?{unbalanced`) is
+ * reported as `malformed` and handed back byte-identical rather than wrapped a
+ * second time. Wrapping an unparseable value is how a LOUD parser rejection
+ * turns into a silently-accepted `?{?{ ... }}` that nests one layer deeper on
+ * every subsequent save — M24, arriving through the back door.
  */
 
 // ── Grammar ────────────────────────────────────────────────────────────────
 
+// The PARSER's grammar, mirrored from
+// `visivo/query/patterns.py:QUERY_STRING_VALUE_PATTERN`. `.` excludes newlines
+// in both languages, so a body carrying an INTERIOR newline is NOT a value the
+// backend can read: `QueryString.get_value()` returns None for it and the
+// interaction pipeline then fails with an opaque TypeError. Use this to answer
+// "would the parser accept what we are about to store" — never to unwrap.
+export const PARSER_QUERY_STRING_PATTERN =
+  /^\?\{\s*(?<body>.+?)\s*\}(?<slice>\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\])?\s*$/;
+
 // Bracket form `?{ expr }` plus optional indexing/slicing suffix. Body uses
 // non-greedy matching so a trailing [...] is left for the slice group rather
 // than absorbed.
+//
+// Deliberately WIDER than `PARSER_QUERY_STRING_PATTERN`: `[\s\S]` where the
+// parser has `.`. A stored multi-line value must be recognised as the wrapper
+// it is and unwrapped for editing; treating it as a bare body would wrap it a
+// second time on the next save, and again on the one after that. Whether the
+// result is a value the parser accepts is a separate question, answered by
+// `isParserReadableQueryString`.
 export const QUERY_BRACKET_PATTERN =
-  /^\?\{\s*(?<body>.+?)\s*\}(?<slice>\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\])?\s*$/;
+  /^\?\{\s*(?<body>[\s\S]+?)\s*\}(?<slice>\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\])?\s*$/;
+
+// An empty wrapper. `?{}` and `?{   }` carry no expression at all: the parser
+// rejects them outright (the body group needs at least one character), so they
+// decode as EMPTY and the interaction they belong to is dropped rather than
+// stored.
+const EMPTY_WRAPPER_PATTERN = /^\?\{\s*\}$/;
 
 // Legacy `query(...)` function syntax — with a capture group for the content.
 export const QUERY_FUNCTION_PATTERN = /^query\((.*)\)$/;
@@ -74,6 +106,12 @@ export const EVAL_STRING_PATTERN = /^>\{[\s\S]*\}$/;
  *   'legacy'  — a `query(...)` / `column(...)` form. Kept as an opaque body:
  *               whether these should still be accepted is an open product
  *               question, so the codec neither rewrites nor rejects them here.
+ *   'malformed' — wrapper-SHAPED but not parseable as one: `?{x}[a]`,
+ *               `?{a}[0][1]`, `?{unbalanced`. The body is the whole value,
+ *               verbatim, and `encodeQueryString` hands it back untouched.
+ *               These values are rejected by the QueryString validator today;
+ *               wrapping them again would make them *pass* validation as
+ *               `?{?{ ... }}` and quietly nest one layer deeper per save.
  *   'bare'    — anything else: a body the user typed with no wrapper, which
  *               includes a plain context string like `${ref(orders).month}`.
  *               This is the M6 case — the value the parser would reject.
@@ -83,6 +121,7 @@ export const EXPRESSION_FORMS = Object.freeze({
   QUERY: 'query',
   EVAL: 'eval',
   LEGACY: 'legacy',
+  MALFORMED: 'malformed',
   BARE: 'bare',
 });
 
@@ -108,7 +147,7 @@ export function decodeQueryString(value) {
     return { body: '', slice: null, form: EXPRESSION_FORMS.EMPTY, repaired: false };
   }
   const trimmed = value.trim();
-  if (!trimmed) {
+  if (!trimmed || EMPTY_WRAPPER_PATTERN.test(trimmed)) {
     return { body: '', slice: null, form: EXPRESSION_FORMS.EMPTY, repaired: false };
   }
 
@@ -119,6 +158,10 @@ export function decodeQueryString(value) {
       form = EXPRESSION_FORMS.EVAL;
     } else if (QUERY_FUNCTION_PATTERN.test(trimmed) || QUERY_COLUMN_PATTERN.test(trimmed)) {
       form = EXPRESSION_FORMS.LEGACY;
+    } else if (trimmed.startsWith('?{')) {
+      // Wrapper-shaped but unparseable. Not a bare body — wrapping it would
+      // nest, and nesting is the failure this module exists to prevent.
+      form = EXPRESSION_FORMS.MALFORMED;
     }
     return { body: trimmed, slice: null, form, repaired: false };
   }
@@ -136,6 +179,14 @@ export function decodeQueryString(value) {
     // `?{` and `}`), so this cannot spin — but never trust that in a loop that
     // runs on user input.
     if (layers > 32) break;
+  }
+
+  // `?{?{}}` and deeper: an empty wrapper wrapped again. There is no expression
+  // in there at any depth, so it is the same nothing as `?{}` — and reporting
+  // it as a QUERY whose body is the literal text `?{}` would put that text back
+  // out on the next save.
+  if (!body.trim() || EMPTY_WRAPPER_PATTERN.test(body)) {
+    return { body: '', slice: null, form: EXPRESSION_FORMS.EMPTY, repaired: false };
   }
 
   return { body, slice, form: EXPRESSION_FORMS.QUERY, repaired: layers > 1 };
@@ -162,7 +213,18 @@ export function encodeQueryString({ body, slice } = {}) {
   // A `>{ ... }` eval string belongs to a different grammar. Wrapping it would
   // manufacture `?{>{ ... }}` — syntactically a query string, semantically
   // garbage. Hand it back unchanged and let validation speak.
-  if (decoded.form === EXPRESSION_FORMS.EVAL) return decoded.body;
+  //
+  // Same rule, same reason, for a MALFORMED wrapper: `?{}` / `?{x}[a]` /
+  // `?{unbalanced` are values the QueryString validator refuses TODAY. Wrapping
+  // one produces `?{?{x}[a]}`, which the validator ACCEPTS and whose body then
+  // reaches SQL as literal `?{x}[a]` — a loud rejection traded for silent
+  // nonsense that nests one layer deeper on every save.
+  if (
+    decoded.form === EXPRESSION_FORMS.EVAL ||
+    decoded.form === EXPRESSION_FORMS.MALFORMED
+  ) {
+    return decoded.body;
+  }
   // A slice recovered from inside `body` survives only when the caller passed
   // none of its own (`undefined`/`null`); a caller that passes a slice is
   // choosing it, so theirs wins.
@@ -183,6 +245,32 @@ export function encodeQueryString({ body, slice } = {}) {
 export function canonicalizeQueryString(value) {
   const decoded = decodeQueryString(value);
   return encodeQueryString({ body: decoded.body, slice: decoded.slice });
+}
+
+/**
+ * Would the BACKEND be able to read this value?
+ *
+ * The exact mirror of `QueryString.validate_and_create`: the pattern must match
+ * AND the body must be non-blank. Note that this is a NARROWER question than
+ * `isQueryStringValue`, which asks only whether the value carries a wrapper of
+ * some kind — `?{}` and any body with an interior newline carry one and are
+ * still values `get_value()` cannot read.
+ *
+ * So this is the predicate a save path needs: not "does it look wrapped" but
+ * "will the parser get an expression out of it". A `>{ }` eval string is not a
+ * query string at all, so it answers false.
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+export function isParserReadableQueryString(value) {
+  if (typeof value !== 'string') return false;
+  const match = value.match(PARSER_QUERY_STRING_PATTERN);
+  // `?{ }` matches the pattern — the body group swallows the space — but
+  // `get_value()` hands back the empty string, which is the same empty
+  // expression as `?{}` by a different spelling. The Python gate applies the
+  // same `.strip()` check.
+  return match !== null && match.groups.body.trim().length > 0;
 }
 
 /**

--- a/viewer/src/utils/expressionCodec.js
+++ b/viewer/src/utils/expressionCodec.js
@@ -1,0 +1,217 @@
+/**
+ * expressionCodec — the single owner of the `?{ }` wrapper grammar.
+ *
+ * Every viewer surface that turns a user gesture (a dropped column, a picked
+ * ref, a typed expression, a sort direction) into a stored expression value
+ * must go through `encodeQueryString`, and every surface that pulls a stored
+ * value apart for editing must go through `decodeQueryString`. Ad-hoc
+ * `` `?{${body}}` `` template literals are how M6/M24 happened: one surface
+ * wrapped, another didn't, a third wrapped what was already wrapped.
+ *
+ * ## The grammar
+ *
+ * Mirrors `visivo/query/patterns.py:QUERY_STRING_VALUE_PATTERN` and the
+ * `$defs/query-string` definition in the vendored trace schemas:
+ *
+ *     ?{ expr }                   whole array
+ *     ?{ expr }[N]                single positive or negative index (scalar)
+ *     ?{ expr }[a:b]              slice (sub-array)
+ *     ?{ expr }[a:b:c]            strided slice
+ *     ?{ expr }[a,b,c]            multi-index pick
+ *     query( ... )                legacy function form (no slice support)
+ *     column( ... )               legacy column reference
+ *     column( ... )[n]            legacy indexed column reference
+ *
+ * The body itself is SQL that may embed context refs (`${ref(model).column}`,
+ * `${ref(metric)}`, `${ref(input).value}`); the codec is deliberately blind to
+ * the body's contents — it only owns the wrapper and the slice suffix.
+ *
+ * ## The invariant
+ *
+ * `encodeQueryString(decodeQueryString(v))` is IDEMPOTENT: applying it twice
+ * gives the same string as applying it once, for every value shape the app can
+ * produce — bare bodies, already-wrapped values, doubly-wrapped values, values
+ * carrying a slice, legacy forms, and empty/blank input. That is the property
+ * that makes "the UI wrote YAML the parser rejects" unrepresentable, so it is
+ * tested as a property over a table of inputs rather than example-by-example.
+ *
+ * `canonicalizeQueryString` is that composition, and is what save paths should
+ * call.
+ */
+
+// ── Grammar ────────────────────────────────────────────────────────────────
+
+// Bracket form `?{ expr }` plus optional indexing/slicing suffix. Body uses
+// non-greedy matching so a trailing [...] is left for the slice group rather
+// than absorbed.
+export const QUERY_BRACKET_PATTERN =
+  /^\?\{\s*(?<body>.+?)\s*\}(?<slice>\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\])?\s*$/;
+
+// Legacy `query(...)` function syntax — with a capture group for the content.
+export const QUERY_FUNCTION_PATTERN = /^query\((.*)\)$/;
+
+// Legacy `column(...)` / `column(...)[n]` syntax.
+export const QUERY_COLUMN_PATTERN = /^column\(.*\)(?:\[-?\d+\])?$/;
+
+// Slice-only pattern (no surrounding `?{}`). Useful for validating a raw slice
+// expression like "[0]" / "[1:5]" coming from the SliceMenu.
+export const SLICE_PATTERN =
+  /^\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\]$/;
+
+// Eval strings (`>{ ... }`) are a DIFFERENT grammar — `EvalString` in
+// `visivo/models/base/eval_string.py`, used by Test.assertions and Alert.if.
+// They never belong in a query-string slot, so the codec recognises them only
+// in order to refuse to rewrite them into `?{>{ ... }}`.
+export const EVAL_STRING_PATTERN = /^>\{[\s\S]*\}$/;
+
+/**
+ * The form a decoded value arrived in.
+ *
+ *   'empty'   — null/undefined/non-string/blank.
+ *   'query'   — a well-formed `?{ ... }` (possibly sliced) value.
+ *   'eval'    — a `>{ ... }` eval string: a different grammar entirely, passed
+ *               through untouched rather than wrapped into nonsense.
+ *   'legacy'  — a `query(...)` / `column(...)` form. Kept as an opaque body:
+ *               whether these should still be accepted is an open product
+ *               question, so the codec neither rewrites nor rejects them here.
+ *   'bare'    — anything else: a body the user typed with no wrapper, which
+ *               includes a plain context string like `${ref(orders).month}`.
+ *               This is the M6 case — the value the parser would reject.
+ */
+export const EXPRESSION_FORMS = Object.freeze({
+  EMPTY: 'empty',
+  QUERY: 'query',
+  EVAL: 'eval',
+  LEGACY: 'legacy',
+  BARE: 'bare',
+});
+
+/** Strip one `?{ }` layer, returning `{body, slice}` or null. */
+function unwrapOnce(value) {
+  const match = value.match(QUERY_BRACKET_PATTERN);
+  if (!match) return null;
+  return { body: match.groups.body, slice: match.groups.slice ?? null };
+}
+
+/**
+ * Pull a stored expression value apart into its editable pieces.
+ *
+ * Unwraps NESTED wrappers to a fixpoint, so a value that a double-wrapping
+ * write already corrupted (`?{?{ x }}` — blank charts today) decodes to the
+ * body the author meant and reports `repaired: true`.
+ *
+ * @param {any} value
+ * @returns {{ body: string, slice: string|null, form: string, repaired: boolean }}
+ */
+export function decodeQueryString(value) {
+  if (typeof value !== 'string') {
+    return { body: '', slice: null, form: EXPRESSION_FORMS.EMPTY, repaired: false };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { body: '', slice: null, form: EXPRESSION_FORMS.EMPTY, repaired: false };
+  }
+
+  let unwrapped = unwrapOnce(trimmed);
+  if (!unwrapped) {
+    let form = EXPRESSION_FORMS.BARE;
+    if (EVAL_STRING_PATTERN.test(trimmed)) {
+      form = EXPRESSION_FORMS.EVAL;
+    } else if (QUERY_FUNCTION_PATTERN.test(trimmed) || QUERY_COLUMN_PATTERN.test(trimmed)) {
+      form = EXPRESSION_FORMS.LEGACY;
+    }
+    return { body: trimmed, slice: null, form, repaired: false };
+  }
+
+  let { body, slice } = unwrapped;
+  let layers = 1;
+  // Fixpoint: `?{?{ x }}` and deeper. A slice found on an INNER layer is
+  // promoted only when the outer layer carried none — the outermost slice is
+  // the one the SliceMenu last wrote, so it wins.
+  while ((unwrapped = unwrapOnce(body))) {
+    body = unwrapped.body;
+    slice = slice ?? unwrapped.slice;
+    layers += 1;
+    // Defensive: `unwrapOnce` always shrinks the string (it removes at least
+    // `?{` and `}`), so this cannot spin — but never trust that in a loop that
+    // runs on user input.
+    if (layers > 32) break;
+  }
+
+  return { body, slice, form: EXPRESSION_FORMS.QUERY, repaired: layers > 1 };
+}
+
+/**
+ * Serialize a `{body, slice}` shape into the canonical `?{body}[slice]` form.
+ *
+ * IDEMPOTENT: a body that already carries its own wrapper (because a caller
+ * handed back a whole stored value, or the user typed the documented
+ * `?{ ${ref(m).col} }` into a field the editor wraps for them) is unwrapped
+ * before being wrapped once. An empty body serializes to `''` — an interaction
+ * with no expression is dropped, not stored as `?{}`.
+ *
+ * The slice is appended OUTSIDE the `?{}` wrap so the server-side runtime sees
+ * it as metadata rather than literal SQL text.
+ *
+ * @param {{ body?: string, slice?: string|null }} parts
+ * @returns {string}
+ */
+export function encodeQueryString({ body, slice } = {}) {
+  const decoded = decodeQueryString(body);
+  if (!decoded.body) return '';
+  // A `>{ ... }` eval string belongs to a different grammar. Wrapping it would
+  // manufacture `?{>{ ... }}` — syntactically a query string, semantically
+  // garbage. Hand it back unchanged and let validation speak.
+  if (decoded.form === EXPRESSION_FORMS.EVAL) return decoded.body;
+  // A slice recovered from inside `body` survives only when the caller passed
+  // none of its own (`undefined`/`null`); a caller that passes a slice is
+  // choosing it, so theirs wins.
+  const effectiveSlice = slice ?? decoded.slice;
+  const wrapped = `?{${decoded.body}}`;
+  return effectiveSlice ? `${wrapped}${effectiveSlice}` : wrapped;
+}
+
+/**
+ * `encode ∘ decode` — take any expression value the app can produce and return
+ * the canonical stored form. This is what save paths call: it wraps a bare
+ * body (M6), leaves an already-canonical value byte-identical, and repairs a
+ * double-wrapped one (M24).
+ *
+ * @param {any} value
+ * @returns {string}
+ */
+export function canonicalizeQueryString(value) {
+  const decoded = decodeQueryString(value);
+  return encodeQueryString({ body: decoded.body, slice: decoded.slice });
+}
+
+/**
+ * Check if a value is a query-string value (any supported form).
+ *
+ * @param {any} val
+ * @returns {boolean}
+ */
+export function isQueryStringValue(val) {
+  if (typeof val !== 'string') return false;
+  return (
+    QUERY_BRACKET_PATTERN.test(val) ||
+    QUERY_FUNCTION_PATTERN.test(val) ||
+    QUERY_COLUMN_PATTERN.test(val)
+  );
+}
+
+/**
+ * Split a `?{ body }[slice]` value into its components, or null when `value`
+ * is not a `?{...}` query string.
+ *
+ * Unlike `decodeQueryString` this is a STRICT single-layer parse: it is the
+ * shape editors use to decide "is there a wrapper here at all". Prefer
+ * `decodeQueryString` on save paths.
+ *
+ * @param {any} value
+ * @returns {{ body: string, slice: string|null } | null}
+ */
+export function parseQueryString(value) {
+  if (typeof value !== 'string') return null;
+  return unwrapOnce(value);
+}

--- a/viewer/src/utils/expressionCodec.test.js
+++ b/viewer/src/utils/expressionCodec.test.js
@@ -1,9 +1,11 @@
 /* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings are the data under test, not template-literal mistakes */
 import {
   EXPRESSION_FORMS,
+  PARSER_QUERY_STRING_PATTERN,
   decodeQueryString,
   encodeQueryString,
   canonicalizeQueryString,
+  isParserReadableQueryString,
   isQueryStringValue,
   parseQueryString,
 } from './expressionCodec';
@@ -28,6 +30,12 @@ import {
  *    group.
  *  - already-wrapped and DOUBLY-wrapped values — what the six ad-hoc wrapper
  *    sites produce today (M24).
+ *  - MULTI-LINE bodies, empty wrappers and unrecognised bracket suffixes — the
+ *    shapes a table calibrated to the implementation quietly omits. They are
+ *    the ones that broke it: `?{a\nb}` and `?{}` and `?{x}[a]` all failed to
+ *    unwrap, were classed BARE, and got wrapped a second time — one more layer
+ *    per save, forever. A property test is only as strong as its table, and the
+ *    first version of this one had no entry that could fail.
  *
  * `label` is only for test names; `value` is what goes in.
  */
@@ -72,6 +80,28 @@ const SHAPES = [
   { label: 'triple wrapped', value: '?{?{?{amount}}}' },
   { label: 'double wrapped, outer slice', value: '?{?{${ref(d).v}}}[0]' },
   { label: 'double wrapped, inner slice', value: '?{?{${ref(d).v}}[0]}' },
+
+  // ── multi-line bodies ───────────────────────────────────────────────────
+  // SQL wraps. A pasted WHERE clause, anything copied out of a Windows editor
+  // (CRLF), a CASE the author laid out over three lines — RefTextArea is a
+  // multi-line editor and `handlePaste` inserts the text verbatim.
+  { label: 'wrapped multi-line CASE body', value: '?{case when ${ref(o).a} > 0\n  then 1 else 0 end}' },
+  { label: 'wrapped body with an interior newline', value: '?{a = 1\nAND b = 2}' },
+  { label: 'wrapped body with a CRLF', value: '?{a = 1\r\nAND b = 2}' },
+  { label: 'bare multi-line body', value: 'a = 1\nAND b = 2' },
+  { label: 'wrapped multi-line body + slice', value: '?{a\nb}[0]' },
+  { label: 'wrapped body padded with newlines', value: '?{\n  sum(${ref(o).a})\n}' },
+
+  // ── empty and malformed wrappers ────────────────────────────────────────
+  { label: 'empty wrapper', value: '?{}' },
+  { label: 'blank wrapper', value: '?{ }' },
+  { label: 'double empty wrapper', value: '?{?{}}' },
+  { label: 'unrecognised bracket suffix', value: '?{x}[a]' },
+  { label: 'four-part slice', value: '?{x}[1:2:3:4]' },
+  { label: 'two chained suffixes', value: '?{a}[0][1]' },
+  { label: 'trailing-comma slice', value: '?{x}[0,]' },
+  { label: 'unclosed wrapper', value: '?{unbalanced' },
+  { label: 'wrapper around a malformed wrapper', value: '?{?{x}[a]}' },
 
   // ── other grammars and legacy forms ─────────────────────────────────────
   { label: 'eval string', value: '>{ anyTestFailed() }' },
@@ -121,7 +151,13 @@ describe('expressionCodec — idempotence (the property that matters)', () => {
         slice: first.slice,
         repaired: false,
       });
-      expect([EXPRESSION_FORMS.QUERY, EXPRESSION_FORMS.EVAL]).toContain(second.form);
+      expect([
+        EXPRESSION_FORMS.QUERY,
+        EXPRESSION_FORMS.EVAL,
+        // A malformed wrapper stays malformed: the codec does not "repair" it
+        // into a different value, it declines to touch it.
+        EXPRESSION_FORMS.MALFORMED,
+      ]).toContain(second.form);
     }
   );
 
@@ -135,6 +171,36 @@ describe('expressionCodec — idempotence (the property that matters)', () => {
   it.each(SHAPES)('encodeQueryString itself is idempotent for $label', ({ value }) => {
     const once = encodeQueryString({ body: value });
     expect(encodeQueryString({ body: once })).toBe(once);
+  });
+
+  // The property with the most teeth, and the one the first version of this
+  // suite was missing. The others ask "does applying the codec twice differ
+  // from applying it once" — a question `decodeQueryString`'s fixpoint unwrap
+  // can answer 'no' to even while `encodeQueryString` is wrapping blindly. This
+  // one asks the PARSER what it reads out of the codec's output, and compares
+  // that to the body the codec claims to have preserved. Double-wrap and the
+  // parser reads `?{x}` where the codec decoded `x`.
+  it.each(SHAPES.filter(s => isParserReadableQueryString(canonicalizeQueryString(s.value))))(
+    'the parser reads back exactly the body the codec decoded, for $label',
+    ({ value }) => {
+      const decoded = decodeQueryString(value);
+      const match = canonicalizeQueryString(value).match(PARSER_QUERY_STRING_PATTERN);
+      expect(match).not.toBeNull();
+      expect(match.groups.body).toBe(decoded.body);
+      expect(match.groups.slice ?? null).toBe(decoded.slice);
+    }
+  );
+
+  // …and the complement: a value the codec does NOT own comes back byte for
+  // byte. Nothing is "repaired" into a different value, and in particular a
+  // malformed wrapper is not upgraded into a nested one that passes validation
+  // and means nothing.
+  it.each(
+    SHAPES.filter(s =>
+      [EXPRESSION_FORMS.EVAL, EXPRESSION_FORMS.MALFORMED].includes(decodeQueryString(s.value).form)
+    )
+  )('a value the codec declines to own is returned untouched, for $label', ({ value }) => {
+    expect(canonicalizeQueryString(value)).toBe(value.trim());
   });
 });
 
@@ -199,6 +265,39 @@ describe('decodeQueryString', () => {
     expect(decodeQueryString('column(amount)[0]').form).toBe(EXPRESSION_FORMS.LEGACY);
   });
 
+  it('unwraps a multi-line body instead of mistaking it for a bare one', () => {
+    // Classed BARE, this value got wrapped a second time on every save.
+    expect(decodeQueryString('?{a = 1\nAND b = 2}')).toEqual({
+      body: 'a = 1\nAND b = 2',
+      slice: null,
+      form: EXPRESSION_FORMS.QUERY,
+      repaired: false,
+    });
+  });
+
+  it('treats an empty wrapper as empty, not as a body to be wrapped again', () => {
+    for (const v of ['?{}', '?{ }', '?{   }']) {
+      expect(decodeQueryString(v)).toEqual({
+        body: '',
+        slice: null,
+        form: EXPRESSION_FORMS.EMPTY,
+        repaired: false,
+      });
+    }
+  });
+
+  it.each(['?{x}[a]', '?{x}[1:2:3:4]', '?{a}[0][1]', '?{x}[0,]', '?{unbalanced'])(
+    'classifies %s as MALFORMED, keeping the value verbatim',
+    value => {
+      expect(decodeQueryString(value)).toEqual({
+        body: value,
+        slice: null,
+        form: EXPRESSION_FORMS.MALFORMED,
+        repaired: false,
+      });
+    }
+  );
+
   it('classifies an eval string as its own grammar', () => {
     expect(decodeQueryString('>{ anyTestFailed() }')).toEqual({
       body: '>{ anyTestFailed() }',
@@ -242,6 +341,29 @@ describe('encodeQueryString', () => {
   it('passes an eval string through instead of wrapping it into nonsense', () => {
     expect(encodeQueryString({ body: '>{ anyTestFailed() }' })).toBe('>{ anyTestFailed() }');
   });
+
+  it.each(['?{x}[a]', '?{a}[0][1]', '?{unbalanced', '?{x}[1:2:3:4]'])(
+    'passes the malformed wrapper %s through rather than nesting it',
+    value => {
+      // These are values the QueryString validator REFUSES today. Wrapping one
+      // makes it `?{?{x}[a]}` — which the validator ACCEPTS, whose body is the
+      // literal text `?{x}[a]`, and which grows another layer on every save.
+      // A loud rejection is worth more than silent nonsense.
+      expect(encodeQueryString({ body: value })).toBe(value);
+    }
+  );
+
+  it('drops an empty wrapper rather than nesting it', () => {
+    expect(encodeQueryString({ body: '?{}' })).toBe('');
+    expect(canonicalizeQueryString('?{}')).toBe('');
+    expect(canonicalizeQueryString('?{?{}}')).toBe('');
+  });
+
+  it('wraps a multi-line body once, and only once', () => {
+    const body = 'case when a > 0\n  then 1 else 0 end';
+    expect(encodeQueryString({ body })).toBe(`?{${body}}`);
+    expect(encodeQueryString({ body: `?{${body}}` })).toBe(`?{${body}}`);
+  });
 });
 
 describe('canonicalizeQueryString', () => {
@@ -269,29 +391,99 @@ describe('canonicalizeQueryString', () => {
   });
 });
 
-describe('the parser accepts everything the codec emits', () => {
-  // A JS mirror of visivo/models/base/query_string.py's
-  // `validate_and_create`, so the codec's output is checked against the same
-  // gate the Pydantic model applies. M6 is precisely a value that fails here.
-  const pydanticWouldAccept = value =>
-    value.startsWith('?{') && (value.endsWith('}') || /\}(\[[^\]]+\])\s*$/.test(value));
-
+describe('the parser and the codec agree on what is storable', () => {
+  // `isParserReadableQueryString` mirrors
+  // `visivo/query/patterns.py:QUERY_STRING_VALUE_PATTERN`, which is now also
+  // the gate `QueryString.validate_and_create` applies — so this is the same
+  // question the backend asks, asked in the viewer.
+  //
+  // The earlier version of this block used a loose mirror
+  // (`startsWith('?{') && endsWith('}')`) that accepts `?{?{x}}`, so it could
+  // not have failed on the bug the file is named for.
   const nonEmpty = SHAPES.filter(s => typeof s.value === 'string' && s.value.trim());
-  const isEval = s => decodeQueryString(s.value).form === EXPRESSION_FORMS.EVAL;
+  // What the codec is left holding after it has unwrapped everything it can —
+  // the body it would wrap. That, not the original spelling, decides which of
+  // the four outcomes below applies.
+  const bodyOf = s => decodeQueryString(s.value).body;
+  const innerFormOf = s => decodeQueryString(bodyOf(s)).form;
+  const DECLINED = [EXPRESSION_FORMS.EVAL, EXPRESSION_FORMS.MALFORMED];
+  const bodyHasNewline = s => /[\r\n]/.test(bodyOf(s));
 
-  it.each(nonEmpty.filter(s => !isEval(s)))(
+  const wrappable = s =>
+    !DECLINED.includes(innerFormOf(s)) && innerFormOf(s) !== EXPRESSION_FORMS.EMPTY;
+
+  // Every non-blank shape lands in exactly one of the four buckets below —
+  // asserted, so a shape cannot be added to the table and then quietly fall
+  // through every property in this block.
+  it('every shape lands in one of the buckets below', () => {
+    const buckets = s => [
+      wrappable(s) && !bodyHasNewline(s),
+      wrappable(s) && bodyHasNewline(s),
+      DECLINED.includes(innerFormOf(s)),
+      innerFormOf(s) === EXPRESSION_FORMS.EMPTY,
+    ];
+    const miscounted = nonEmpty.filter(s => buckets(s).filter(Boolean).length !== 1);
+    expect(miscounted.map(s => s.label)).toEqual([]);
+  });
+
+  it.each(nonEmpty.filter(s => wrappable(s) && !bodyHasNewline(s)))(
     'canonicalized $label is a value the QueryString validator accepts',
     ({ value }) => {
-      expect(pydanticWouldAccept(canonicalizeQueryString(value))).toBe(true);
+      expect(isParserReadableQueryString(canonicalizeQueryString(value))).toBe(true);
     }
   );
 
-  it.each(nonEmpty.filter(isEval))(
-    '$label belongs to another grammar and is passed through, not wrapped',
+  it.each(nonEmpty.filter(s => DECLINED.includes(innerFormOf(s))))(
+    '$label is not the codec\'s to rewrite, so its body is passed through',
     ({ value }) => {
-      expect(canonicalizeQueryString(value)).toBe(value.trim());
+      expect(canonicalizeQueryString(value)).toBe(decodeQueryString(value).body);
     }
   );
+
+  it.each(nonEmpty.filter(s => innerFormOf(s) === EXPRESSION_FORMS.EMPTY))(
+    '$label carries no expression at any depth, so it is dropped',
+    ({ value }) => {
+      expect(canonicalizeQueryString(value)).toBe('');
+    }
+  );
+
+  // A body carrying an interior newline is the one shape the codec can neither
+  // rewrite nor store: `?{a\nb}` is not a value the parser can read (`.` stops
+  // at a newline in both languages), and unwrapping it to edit is still the
+  // right thing to do. The editor is what refuses it — see
+  // `interactionHelp.test.js`, which pins that the two answers agree.
+  it.each(nonEmpty.filter(s => wrappable(s) && bodyHasNewline(s)))(
+    'a multi-line body is unwrapped for editing but is NOT parser-readable, for $label',
+    ({ value }) => {
+      expect(decodeQueryString(value).body).not.toMatch(/^\?\{/);
+      expect(isParserReadableQueryString(canonicalizeQueryString(value))).toBe(false);
+    }
+  );
+});
+
+describe('isParserReadableQueryString', () => {
+  it('accepts the forms QUERY_STRING_VALUE_PATTERN accepts', () => {
+    for (const v of ['?{x}', '?{ MAX(a) }', '?{x}[0]', '?{x}[1:5]', '?{x}[::2]', '?{x}[0,2]']) {
+      expect(isParserReadableQueryString(v)).toBe(true);
+    }
+  });
+
+  it('rejects exactly what the backend rejects', () => {
+    // `?{}` / `?{ }`: no body. `?{a\nb}`: the pattern's `.` stops at newlines,
+    // so `get_value()` returns None and the run dies in `re.sub(..., None)`.
+    // `?{x}[a]`: not a slice. `>{ }` / bare: not a query string at all.
+    for (const v of ['?{}', '?{ }', '?{a\nb}', '?{x}[a]', '>{ x }', 'date DESC', 42, null]) {
+      expect(isParserReadableQueryString(v)).toBe(false);
+    }
+  });
+
+  it('is blind to nesting — a doubly-wrapped value parses, with the wrong body', () => {
+    // Why the codec, not this predicate, is what stops M24: `?{?{x}}` IS a
+    // syntactically valid query string. Its body is the literal text `?{x}`,
+    // which then reaches SQL.
+    expect(isParserReadableQueryString('?{?{x}}')).toBe(true);
+    expect('?{?{x}}'.match(PARSER_QUERY_STRING_PATTERN).groups.body).toBe('?{x}');
+  });
 });
 
 describe('parseQueryString (strict single-layer parse)', () => {

--- a/viewer/src/utils/expressionCodec.test.js
+++ b/viewer/src/utils/expressionCodec.test.js
@@ -1,0 +1,322 @@
+/* eslint-disable no-template-curly-in-string -- literal Visivo `${ref(...)}` strings are the data under test, not template-literal mistakes */
+import {
+  EXPRESSION_FORMS,
+  decodeQueryString,
+  encodeQueryString,
+  canonicalizeQueryString,
+  isQueryStringValue,
+  parseQueryString,
+} from './expressionCodec';
+
+/**
+ * The shape table.
+ *
+ * Every entry is a value the app can genuinely put in front of the codec,
+ * enumerated from the models rather than invented:
+ *
+ *  - `?{ }` query strings  — `QueryString` (visivo/models/base/query_string.py),
+ *    the type of InsightInteraction.{filter,split,sort} and every query-string
+ *    Plotly prop slot.
+ *  - `${ }` context strings — `CONTEXT_STRING_REF_PATTERN` in
+ *    visivo/query/patterns.py; what the @ ref picker and every pill drop emit
+ *    as a BARE body, with no wrapper of their own.
+ *  - `>{ }` eval strings   — `EvalString` (visivo/models/base/eval_string.py),
+ *    the type of Test.assertions and Alert.if. A different grammar.
+ *  - `query(...)` / `column(...)` — the legacy forms still listed in the AJV
+ *    `$defs/query-string` and still matched by QUERY_COLUMN_PATTERN.
+ *  - slices `[0] [-1] [1:5] [::2] [0,2]` — QUERY_STRING_VALUE_PATTERN's slice
+ *    group.
+ *  - already-wrapped and DOUBLY-wrapped values — what the six ad-hoc wrapper
+ *    sites produce today (M24).
+ *
+ * `label` is only for test names; `value` is what goes in.
+ */
+const SHAPES = [
+  // ── bare bodies: what a picker/pill/typed edit hands the save path (M6) ──
+  { label: 'bare column ref', value: '${ref(orders).month}' },
+  { label: 'bare column ref with direction', value: '${ref(orders).month} DESC' },
+  { label: 'bare column ref, ASC', value: '${ref(orders).month} ASC' },
+  { label: 'bare metric ref', value: '${ref(total_revenue)}' },
+  { label: 'bare input ref comparison', value: '${ref(orders).region} = ${ref(region-input).value}' },
+  { label: 'bare multi-select input ref', value: '${ref(orders).sku} in ${ref(sku-picker).values}' },
+  { label: 'bare aggregate over a ref', value: 'sum(${ref(orders).amount})' },
+  { label: 'bare nested aggregate', value: 'sum(${ref(orders).amount}) / count(${ref(orders).id})' },
+  { label: 'bare quoted identifier', value: '${ref(orders)."Order Date"}' },
+  { label: 'bare hyphenated model name', value: '${ref(my-model).col}' },
+  { label: 'bare plain SQL identifier', value: 'amount' },
+  { label: 'bare SQL with a case expression', value: "case when ${ref(o).amt} > 0 then 'pos' else 'neg' end" },
+  { label: 'bare env context string', value: '${env.REGION}' },
+
+  // ── already canonical: must survive byte-identical ──────────────────────
+  { label: 'wrapped column ref', value: '?{${ref(orders).month}}' },
+  { label: 'wrapped ref with direction', value: '?{${ref(orders).month} DESC}' },
+  { label: 'wrapped aggregate', value: '?{sum(${ref(orders).amount})}' },
+  { label: 'wrapped plain identifier', value: '?{amount}' },
+
+  // ── wrapped, needing whitespace normalisation ───────────────────────────
+  { label: 'wrapped with padding', value: '?{ ${ref(orders).month} }' },
+  { label: 'wrapped with heavy padding', value: '?{   sum(${ref(o).amt})   }' },
+  { label: 'wrapped with trailing space outside', value: '?{${ref(o).c}} ' },
+
+  // ── slices ──────────────────────────────────────────────────────────────
+  { label: 'wrapped + first index', value: '?{${ref(daily).value}}[0]' },
+  { label: 'wrapped + last index', value: '?{${ref(daily).value}}[-1]' },
+  { label: 'wrapped + range slice', value: '?{${ref(daily).value}}[1:5]' },
+  { label: 'wrapped + strided slice', value: '?{${ref(daily).value}}[::2]' },
+  { label: 'wrapped + multi-index pick', value: '?{${ref(daily).value}}[0,2]' },
+  { label: 'wrapped aggregate + index', value: '?{max(${ref(daily).value})}[0]' },
+
+  // ── doubly wrapped: what the ad-hoc wrapper sites produce today (M24) ───
+  { label: 'double wrapped', value: '?{?{${ref(orders).month}}}' },
+  { label: 'double wrapped with padding', value: '?{ ?{ ${ref(orders).month} } }' },
+  { label: 'triple wrapped', value: '?{?{?{amount}}}' },
+  { label: 'double wrapped, outer slice', value: '?{?{${ref(d).v}}}[0]' },
+  { label: 'double wrapped, inner slice', value: '?{?{${ref(d).v}}[0]}' },
+
+  // ── other grammars and legacy forms ─────────────────────────────────────
+  { label: 'eval string', value: '>{ anyTestFailed() }' },
+  { label: 'eval string with a ref', value: '>{ ${ ref(chart).props.x[0] } == 1 }' },
+  { label: 'legacy query()', value: 'query(select 1)' },
+  { label: 'legacy column()', value: 'column(amount)' },
+  { label: 'legacy column() indexed', value: 'column(amount)[0]' },
+
+  // ── empties ─────────────────────────────────────────────────────────────
+  { label: 'empty string', value: '' },
+  { label: 'whitespace only', value: '   ' },
+  { label: 'null', value: null },
+  { label: 'undefined', value: undefined },
+  { label: 'a number', value: 42 },
+];
+
+describe('expressionCodec — idempotence (the property that matters)', () => {
+  // The invariant M6 and M24 both violate, stated once and checked over the
+  // whole table: normalising an already-normalised value must change nothing.
+  // Test as a PROPERTY, not as a handful of examples — a codec that is
+  // idempotent on `?{x}` but not on `?{?{x}}` is exactly the bug.
+  it.each(SHAPES)('canonicalize is idempotent for $label', ({ value }) => {
+    const once = canonicalizeQueryString(value);
+    const twice = canonicalizeQueryString(once);
+    expect(twice).toBe(once);
+    // …and a third pass, because a two-cycle would satisfy f(f(x)) === f(x)
+    // only by accident.
+    expect(canonicalizeQueryString(twice)).toBe(once);
+  });
+
+  it.each(SHAPES)('encode(decode(x)) never nests a wrapper for $label', ({ value }) => {
+    const encoded = canonicalizeQueryString(value);
+    expect(encoded).not.toMatch(/\?\{\s*\?\{/);
+  });
+
+  it.each(SHAPES.filter(s => decodeQueryString(s.value).form !== EXPRESSION_FORMS.EMPTY))(
+    'a canonical value re-decodes to the same body for $label',
+    ({ value }) => {
+      const first = decodeQueryString(value);
+      const second = decodeQueryString(canonicalizeQueryString(value));
+      // The BODY and SLICE survive untouched. The FORM is allowed to change —
+      // turning a `bare` body into a `query` value is the whole job. And
+      // re-decoding a canonical value never reports a repair: there is nothing
+      // left to repair.
+      expect({ body: second.body, slice: second.slice, repaired: second.repaired }).toEqual({
+        body: first.body,
+        slice: first.slice,
+        repaired: false,
+      });
+      expect([EXPRESSION_FORMS.QUERY, EXPRESSION_FORMS.EVAL]).toContain(second.form);
+    }
+  );
+
+  it.each(SHAPES.filter(s => decodeQueryString(s.value).form === EXPRESSION_FORMS.EMPTY))(
+    'an empty value canonicalizes to the empty string for $label',
+    ({ value }) => {
+      expect(canonicalizeQueryString(value)).toBe('');
+    }
+  );
+
+  it.each(SHAPES)('encodeQueryString itself is idempotent for $label', ({ value }) => {
+    const once = encodeQueryString({ body: value });
+    expect(encodeQueryString({ body: once })).toBe(once);
+  });
+});
+
+describe('decodeQueryString', () => {
+  it('returns the empty form for anything that is not a non-blank string', () => {
+    for (const v of [null, undefined, 42, {}, [], '', '   ']) {
+      expect(decodeQueryString(v)).toEqual({
+        body: '',
+        slice: null,
+        form: EXPRESSION_FORMS.EMPTY,
+        repaired: false,
+      });
+    }
+  });
+
+  it('splits a wrapped value into body and slice', () => {
+    expect(decodeQueryString('?{${ref(m).c}}[1:5]')).toEqual({
+      body: '${ref(m).c}',
+      slice: '[1:5]',
+      form: EXPRESSION_FORMS.QUERY,
+      repaired: false,
+    });
+  });
+
+  it('trims padding inside the wrapper', () => {
+    expect(decodeQueryString('?{   sum(x)   }').body).toBe('sum(x)');
+  });
+
+  it('reports a bare body as BARE, with the body untouched', () => {
+    expect(decodeQueryString('${ref(orders).month} DESC')).toEqual({
+      body: '${ref(orders).month} DESC',
+      slice: null,
+      form: EXPRESSION_FORMS.BARE,
+      repaired: false,
+    });
+  });
+
+  it('unwraps a double wrapper to a fixpoint and flags the repair', () => {
+    expect(decodeQueryString('?{?{ x }}')).toEqual({
+      body: 'x',
+      slice: null,
+      form: EXPRESSION_FORMS.QUERY,
+      repaired: true,
+    });
+  });
+
+  it('unwraps arbitrarily deep nesting', () => {
+    expect(decodeQueryString('?{?{?{?{x}}}}').body).toBe('x');
+  });
+
+  it('promotes an inner slice when the outer layer carries none', () => {
+    expect(decodeQueryString('?{?{v}[0]}')).toMatchObject({ body: 'v', slice: '[0]' });
+  });
+
+  it('keeps the OUTER slice when both layers carry one', () => {
+    expect(decodeQueryString('?{?{v}[0]}[1:5]')).toMatchObject({ body: 'v', slice: '[1:5]' });
+  });
+
+  it('classifies the legacy function forms', () => {
+    expect(decodeQueryString('query(select 1)').form).toBe(EXPRESSION_FORMS.LEGACY);
+    expect(decodeQueryString('column(amount)').form).toBe(EXPRESSION_FORMS.LEGACY);
+    expect(decodeQueryString('column(amount)[0]').form).toBe(EXPRESSION_FORMS.LEGACY);
+  });
+
+  it('classifies an eval string as its own grammar', () => {
+    expect(decodeQueryString('>{ anyTestFailed() }')).toEqual({
+      body: '>{ anyTestFailed() }',
+      slice: null,
+      form: EXPRESSION_FORMS.EVAL,
+      repaired: false,
+    });
+  });
+});
+
+describe('encodeQueryString', () => {
+  it('returns the empty string for an empty body, slice or not', () => {
+    expect(encodeQueryString()).toBe('');
+    expect(encodeQueryString({})).toBe('');
+    expect(encodeQueryString({ body: '' })).toBe('');
+    expect(encodeQueryString({ body: '   ' })).toBe('');
+    expect(encodeQueryString({ body: '', slice: '[0]' })).toBe('');
+  });
+
+  it('wraps a bare body exactly once', () => {
+    expect(encodeQueryString({ body: '${ref(m).c}' })).toBe('?{${ref(m).c}}');
+  });
+
+  it('does not re-wrap an already-wrapped body (M24)', () => {
+    // The documented YAML form, typed by a user into a field the editor wraps.
+    expect(encodeQueryString({ body: '?{ ${ref(m).col} }' })).toBe('?{${ref(m).col}}');
+  });
+
+  it('appends the slice OUTSIDE the wrapper', () => {
+    expect(encodeQueryString({ body: 'x', slice: '[0]' })).toBe('?{x}[0]');
+  });
+
+  it("lets the caller's slice win over one recovered from the body", () => {
+    expect(encodeQueryString({ body: '?{x}[0]', slice: '[1:5]' })).toBe('?{x}[1:5]');
+  });
+
+  it('recovers a slice from the body when the caller passes none', () => {
+    expect(encodeQueryString({ body: '?{x}[0]' })).toBe('?{x}[0]');
+  });
+
+  it('passes an eval string through instead of wrapping it into nonsense', () => {
+    expect(encodeQueryString({ body: '>{ anyTestFailed() }' })).toBe('>{ anyTestFailed() }');
+  });
+});
+
+describe('canonicalizeQueryString', () => {
+  it('wraps what the UI writes bare today (M6)', () => {
+    expect(canonicalizeQueryString('${ref(orders).month} DESC')).toBe(
+      '?{${ref(orders).month} DESC}'
+    );
+  });
+
+  it('leaves an already-canonical value byte-identical', () => {
+    const v = '?{${ref(orders).month} DESC}';
+    expect(canonicalizeQueryString(v)).toBe(v);
+  });
+
+  it('repairs a value a double-wrapping write already corrupted (M24)', () => {
+    expect(canonicalizeQueryString('?{?{${ref(orders).month}}}')).toBe('?{${ref(orders).month}}');
+  });
+
+  it('preserves a slice through the round trip', () => {
+    expect(canonicalizeQueryString('?{ ${ref(d).v} }[1:5]')).toBe('?{${ref(d).v}}[1:5]');
+  });
+
+  it('collapses a blank value to the empty string so it is dropped, not stored as ?{}', () => {
+    expect(canonicalizeQueryString('   ')).toBe('');
+  });
+});
+
+describe('the parser accepts everything the codec emits', () => {
+  // A JS mirror of visivo/models/base/query_string.py's
+  // `validate_and_create`, so the codec's output is checked against the same
+  // gate the Pydantic model applies. M6 is precisely a value that fails here.
+  const pydanticWouldAccept = value =>
+    value.startsWith('?{') && (value.endsWith('}') || /\}(\[[^\]]+\])\s*$/.test(value));
+
+  const nonEmpty = SHAPES.filter(s => typeof s.value === 'string' && s.value.trim());
+  const isEval = s => decodeQueryString(s.value).form === EXPRESSION_FORMS.EVAL;
+
+  it.each(nonEmpty.filter(s => !isEval(s)))(
+    'canonicalized $label is a value the QueryString validator accepts',
+    ({ value }) => {
+      expect(pydanticWouldAccept(canonicalizeQueryString(value))).toBe(true);
+    }
+  );
+
+  it.each(nonEmpty.filter(isEval))(
+    '$label belongs to another grammar and is passed through, not wrapped',
+    ({ value }) => {
+      expect(canonicalizeQueryString(value)).toBe(value.trim());
+    }
+  );
+});
+
+describe('parseQueryString (strict single-layer parse)', () => {
+  it('returns null for non-strings and non-query values', () => {
+    expect(parseQueryString(null)).toBeNull();
+    expect(parseQueryString(42)).toBeNull();
+    expect(parseQueryString('plain text')).toBeNull();
+    expect(parseQueryString('column(x)')).toBeNull();
+  });
+
+  it('does NOT unwrap nesting — that is decodeQueryString\'s job', () => {
+    expect(parseQueryString('?{?{x}}')).toEqual({ body: '?{x}', slice: null });
+  });
+});
+
+describe('isQueryStringValue', () => {
+  it('accepts every wrapped and legacy form', () => {
+    for (const v of ['?{x}', '?{x}[0]', '?{x}[1:5]', 'query(x)', 'column(x)', 'column(x)[0]']) {
+      expect(isQueryStringValue(v)).toBe(true);
+    }
+  });
+
+  it('rejects bare bodies, eval strings and non-strings', () => {
+    for (const v of ['${ref(m).c}', 'date DESC', '>{ x }', 42, null, undefined, '']) {
+      expect(isQueryStringValue(v)).toBe(false);
+    }
+  });
+});

--- a/viewer/src/utils/expressionCodecOwnership.test.js
+++ b/viewer/src/utils/expressionCodecOwnership.test.js
@@ -1,14 +1,24 @@
+/* eslint-disable no-template-curly-in-string -- the sample lines below are the WRAPPER SPELLINGS under test, deliberately written as source text */
 import fs from 'fs';
 import path from 'path';
 
 /**
  * The codec only stops M6/M24 from coming back if it stays the ONLY place that
- * builds a `?{ }` wrapper. This test walks viewer/src and fails on any new
- * ad-hoc `` `?{${...}}` `` template literal — the exact construction that let
- * six sites each decide for themselves whether a value was already wrapped.
+ * builds — or strips — a `?{ }` wrapper. This test walks viewer/src and fails
+ * on any new ad-hoc construction, which is what let six sites each decide for
+ * themselves whether a value was already wrapped.
+ *
+ * The first version of this guard matched exactly one spelling, `` `?{${ ``.
+ * That is not the spelling most likely to be written: the project's YAML and
+ * `InsightInteraction`'s own docstring both publish the SPACED form
+ * `?{ ... }`, so `` `?{ ${body} }` `` is what a developer copies — and it went
+ * unmatched, along with `'?{' + body + '}'` and every other concatenation. A
+ * guard that covers one of at least four forms is a guard that reads green
+ * while the thing it guards against is reintroduced.
  *
  * If you need to wrap something, call `encodeQueryString` (or
- * `canonicalizeQueryString` on a save path). If you genuinely need a literal,
+ * `canonicalizeQueryString` on a save path); to take one apart, call
+ * `decodeQueryString` / `parseQueryString`. If you genuinely need a literal,
  * add it to ALLOWED with the reason.
  */
 
@@ -25,8 +35,25 @@ const ALLOWED = new Set([
   'components/views/workspace/WorkspaceDndContext.jsx',
 ]);
 
-// `` `?{${ `` — a template literal opening a wrapper around an interpolation.
-const AD_HOC_WRAP = /`\?\{\$\{/;
+/**
+ * The four ways a `?{ }` wrapper actually gets hand-rolled, plus the strip.
+ *
+ * Each entry is `[name, matches]`. `matches` takes the whole line so a rule can ask
+ * for more context than a single regex (the interpolation rule needs to know it
+ * is inside a template literal, or every prose example string in
+ * `interactionHelp.js` would match).
+ */
+const AD_HOC_RULES = [
+  // `` `?{${body}}` `` and `` `?{ ${body} }` `` and `` `${p}?{${b}}` `` — a
+  // wrapper opened around a JS interpolation, anywhere in a template literal.
+  ['template-literal wrap', line => line.includes('`') && /\?\{\s*\$\{/.test(line)],
+  // `'?{' + body` / `"?{" + body` / `` `?{` + body ``
+  ['string-concatenation wrap', line => /(['"`])\?\{\1\s*\+/.test(line)],
+  // the closing half: `+ '}'`
+  ['string-concatenation close', line => /\+\s*(['"`])\}\1/.test(line)],
+  // an ad-hoc `/^\?\{...\}$/` — taking the wrapper apart is the codec's job too.
+  ['ad-hoc strip regex', line => /\/\^\\\?\\\{/.test(line)],
+];
 
 function walk(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -41,30 +68,64 @@ function walk(dir, out = []) {
   return out;
 }
 
-describe('expressionCodec owns the `?{ }` wrapper', () => {
-  it('no source file builds a wrapper with an ad-hoc template literal', () => {
-    const offenders = [];
-    for (const file of walk(SRC)) {
-      const rel = path.relative(SRC, file).split(path.sep).join('/');
-      if (ALLOWED.has(rel)) continue;
-      // Tests are allowed to write literal expected values.
-      if (/\.test\.(js|jsx)$/.test(rel)) continue;
+function scan() {
+  const offenders = [];
+  for (const file of walk(SRC)) {
+    const rel = path.relative(SRC, file).split(path.sep).join('/');
+    if (ALLOWED.has(rel)) continue;
+    // Tests are allowed to write literal expected values.
+    if (/\.test\.(js|jsx)$/.test(rel)) continue;
 
-      const lines = fs.readFileSync(file, 'utf8').split('\n');
-      lines.forEach((line, i) => {
-        // Skip comment lines — the codebase explains the grammar in prose all
-        // over the place, and prose is not a wrapper site.
-        const trimmed = line.trim();
-        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
-        if (AD_HOC_WRAP.test(line)) offenders.push(`${rel}:${i + 1}: ${trimmed}`);
-      });
-    }
-    expect(offenders).toEqual([]);
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      // Skip comment lines — the codebase explains the grammar in prose all
+      // over the place, and prose is not a wrapper site.
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+      for (const [name, matches] of AD_HOC_RULES) {
+        if (matches(line)) offenders.push(`${name} — ${rel}:${i + 1}: ${trimmed}`);
+      }
+    });
+  }
+  return offenders;
+}
+
+describe('expressionCodec owns the `?{ }` wrapper', () => {
+  it('no source file builds or strips a wrapper by hand', () => {
+    expect(scan()).toEqual([]);
   });
 
   it('every allowlisted file still exists (so the list cannot rot silently)', () => {
     for (const rel of ALLOWED) {
       expect(fs.existsSync(path.join(SRC, rel))).toBe(true);
     }
+  });
+
+  // The guard is only worth having if it fires. These are the reintroductions
+  // it must catch — every one of them slipped past the single-spelling version.
+  describe('the rules catch every spelling of a hand-rolled wrapper', () => {
+    const fires = line => AD_HOC_RULES.some(([, matches]) => matches(line));
+
+    it.each([
+      ['the terse template literal', 'const v = `?{${body}}`;'],
+      ['the SPACED template literal the YAML publishes', 'const v = `?{ ${body} }`;'],
+      ['a wrapper later in a template literal', 'const v = `${prefix}?{${body}}`;'],
+      ['single-quoted concatenation', "const v = '?{' + body + '}';"],
+      ['double-quoted concatenation', 'const v = "?{" + body + "}";'],
+      ['backtick concatenation', 'const v = `?{` + body + `}`;'],
+      ['a concatenation closing on its own line', "  + '}';"],
+      ['an ad-hoc strip regex', 'const RE = /^\\?\\{([\\s\\S]*)\\}$/;'],
+      ['a terser ad-hoc strip regex', 'const RE = /^\\?\\{(.*)\\}$/;'],
+    ])('catches %s', (_label, line) => {
+      expect(fires(line)).toBe(true);
+    });
+
+    it.each([
+      ['a prose example in a single-quoted string', "  yamlExample: '?{ ${ref(orders).month} ASC }',"],
+      ['a membership check', "if (value.startsWith('?{')) return null;"],
+      ['a call into the codec', 'return encodeQueryString({ body, slice });'],
+    ])('does not fire on %s', (_label, line) => {
+      expect(fires(line)).toBe(false);
+    });
   });
 });

--- a/viewer/src/utils/expressionCodecOwnership.test.js
+++ b/viewer/src/utils/expressionCodecOwnership.test.js
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The codec only stops M6/M24 from coming back if it stays the ONLY place that
+ * builds a `?{ }` wrapper. This test walks viewer/src and fails on any new
+ * ad-hoc `` `?{${...}}` `` template literal — the exact construction that let
+ * six sites each decide for themselves whether a value was already wrapped.
+ *
+ * If you need to wrap something, call `encodeQueryString` (or
+ * `canonicalizeQueryString` on a save path). If you genuinely need a literal,
+ * add it to ALLOWED with the reason.
+ */
+
+const SRC = path.resolve(__dirname, '..');
+
+// Files permitted to construct a wrapper literally.
+const ALLOWED = new Set([
+  // The grammar owner itself.
+  'utils/expressionCodec.js',
+  // Owned by open PR #646 (canvas click-to-pick). Its single site at the
+  // interaction drop zone wraps correctly today; routing it through the codec
+  // belongs to whoever lands that PR, and editing it here would guarantee a
+  // conflict. Remove this entry once #646 is merged.
+  'components/views/workspace/WorkspaceDndContext.jsx',
+]);
+
+// `` `?{${ `` — a template literal opening a wrapper around an interpolation.
+const AD_HOC_WRAP = /`\?\{\$\{/;
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__snapshots__') continue;
+      walk(full, out);
+    } else if (/\.(js|jsx)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('expressionCodec owns the `?{ }` wrapper', () => {
+  it('no source file builds a wrapper with an ad-hoc template literal', () => {
+    const offenders = [];
+    for (const file of walk(SRC)) {
+      const rel = path.relative(SRC, file).split(path.sep).join('/');
+      if (ALLOWED.has(rel)) continue;
+      // Tests are allowed to write literal expected values.
+      if (/\.test\.(js|jsx)$/.test(rel)) continue;
+
+      const lines = fs.readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        // Skip comment lines — the codebase explains the grammar in prose all
+        // over the place, and prose is not a wrapper site.
+        const trimmed = line.trim();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+        if (AD_HOC_WRAP.test(line)) offenders.push(`${rel}:${i + 1}: ${trimmed}`);
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every allowlisted file still exists (so the list cannot rot silently)', () => {
+    for (const rel of ALLOWED) {
+      expect(fs.existsSync(path.join(SRC, rel))).toBe(true);
+    }
+  });
+});

--- a/viewer/src/utils/queryString.js
+++ b/viewer/src/utils/queryString.js
@@ -1,96 +1,53 @@
 /**
- * Query string patterns used in Visivo schemas.
+ * Query string helpers.
+ *
+ * The `?{ }` grammar itself now lives in `./expressionCodec` — that module is
+ * the single owner of the wrapper, and this one is the compatibility surface
+ * plus the slice-presentation helpers (`isScalarSlice`, `describeSlice`) and
+ * the legacy `QueryString` class. New code should import from
+ * `expressionCodec` directly, and save paths should call
+ * `canonicalizeQueryString` rather than hand-rolling a wrap.
+ *
+ * `serializeQueryString` is re-exported from the codec, so it is IDEMPOTENT:
+ * handing it a body that already carries a wrapper no longer produces
+ * `?{?{ ... }}` (M24).
  *
  * Mirrors the canonical grammar in
  * `visivo/visivo/query/patterns.py:QUERY_STRING_VALUE_PATTERN` and the
  * vendored JSON-schema definition in
  * `visivo/visivo/schema/<trace>.schema.json#/$defs/query-string`.
- *
- * Supported forms (single source of truth — every consumer in the
- * viewer should route through `parseQueryString` rather than
- * hand-rolling a regex):
- *
- *     ?{ expr }                   whole array (existing)
- *     ?{ expr }[N]                single positive or negative index (scalar)
- *     ?{ expr }[a:b]              slice (sub-array)
- *     ?{ expr }[a:b:c]            strided slice
- *     ?{ expr }[a,b,c]            multi-index pick
- *     query( ... )                query() function form (no slice support)
- *     column( ... )               column reference
- *     column( ... )[n]            indexed column reference
- *
- * The slice suffix is captured by name so callers can split the body
- * from the slice without re-parsing.
  */
 
-// Bracket form `?{ expr }` plus optional indexing/slicing suffix. Body
-// uses non-greedy matching so a trailing [...] is left for the slice
-// group rather than absorbed.
-export const QUERY_BRACKET_PATTERN =
-  /^\?\{\s*(?<body>.+?)\s*\}(?<slice>\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\])?\s*$/;
+import {
+  QUERY_BRACKET_PATTERN,
+  QUERY_FUNCTION_PATTERN,
+  QUERY_COLUMN_PATTERN,
+  SLICE_PATTERN,
+  decodeQueryString,
+  encodeQueryString,
+  canonicalizeQueryString,
+  isQueryStringValue,
+  parseQueryString,
+} from './expressionCodec';
 
-// Pattern for query(...) function syntax - with capture group for content extraction
-export const QUERY_FUNCTION_PATTERN = /^query\((.*)\)$/;
-
-// Pattern for column(...) or column(...)[n] syntax
-export const QUERY_COLUMN_PATTERN = /^column\(.*\)(?:\[-?\d+\])?$/;
-
-// Slice-only pattern (no surrounding ?{...}). Useful for validating a
-// raw slice expression like "[0]" / "[1:5]" coming from the SliceMenu.
-export const SLICE_PATTERN =
-  /^\[(?:-?\d+|-?\d*:-?\d*(?::-?\d+)?|-?\d+(?:\s*,\s*-?\d+)+)\]$/;
-
-// All patterns for simple match testing (no capture groups needed)
-const QUERY_STRING_PATTERNS = [QUERY_BRACKET_PATTERN, QUERY_FUNCTION_PATTERN, QUERY_COLUMN_PATTERN];
-
-/**
- * Check if a value is a query-string value (any supported form).
- *
- * @param {any} val - The value to check
- * @returns {boolean} True if the value matches any query-string pattern
- */
-export function isQueryStringValue(val) {
-  if (typeof val !== 'string') return false;
-  return QUERY_STRING_PATTERNS.some(pattern => pattern.test(val));
-}
-
-/**
- * Split a `?{ body }[slice]` query-string value into its components.
- *
- * Returns null if `value` is not a `?{...}` query string. For values
- * with no slice suffix, `slice` is null. The body is returned without
- * surrounding whitespace and without `?{` / `}` markers.
- *
- * Use `serializeQueryString` for the inverse.
- *
- * @param {any} value
- * @returns {{ body: string, slice: string|null } | null}
- */
-export function parseQueryString(value) {
-  if (typeof value !== 'string') return null;
-  const match = value.match(QUERY_BRACKET_PATTERN);
-  if (!match) return null;
-  return {
-    body: match.groups.body,
-    slice: match.groups.slice ?? null,
-  };
-}
+export {
+  QUERY_BRACKET_PATTERN,
+  QUERY_FUNCTION_PATTERN,
+  QUERY_COLUMN_PATTERN,
+  SLICE_PATTERN,
+  decodeQueryString,
+  encodeQueryString,
+  canonicalizeQueryString,
+  isQueryStringValue,
+  parseQueryString,
+};
 
 /**
  * Serialize a `{body, slice}` shape back into the canonical
- * `?{body}[slice]` form. The slice (if any) is appended OUTSIDE the
- * `?{}` wrap so the server-side runtime sees the slice as separate
- * metadata rather than literal SQL text.
- *
- * @param {{ body?: string, slice?: string|null }} parts
- * @returns {string}
+ * `?{body}[slice]` form. Alias of the codec's `encodeQueryString`, kept
+ * because six call sites already import this name.
  */
-export function serializeQueryString({ body, slice } = {}) {
-  if (!body) return '';
-  const wrapped = `?{${body}}`;
-  if (!slice) return wrapped;
-  return `${wrapped}${slice}`;
-}
+export const serializeQueryString = encodeQueryString;
 
 /**
  * Check whether a slice expression (`"[0]"`, `"[1:5]"`, ...) yields a

--- a/viewer/src/utils/queryString.js
+++ b/viewer/src/utils/queryString.js
@@ -20,24 +20,28 @@
 
 import {
   QUERY_BRACKET_PATTERN,
+  PARSER_QUERY_STRING_PATTERN,
   QUERY_FUNCTION_PATTERN,
   QUERY_COLUMN_PATTERN,
   SLICE_PATTERN,
   decodeQueryString,
   encodeQueryString,
   canonicalizeQueryString,
+  isParserReadableQueryString,
   isQueryStringValue,
   parseQueryString,
 } from './expressionCodec';
 
 export {
   QUERY_BRACKET_PATTERN,
+  PARSER_QUERY_STRING_PATTERN,
   QUERY_FUNCTION_PATTERN,
   QUERY_COLUMN_PATTERN,
   SLICE_PATTERN,
   decodeQueryString,
   encodeQueryString,
   canonicalizeQueryString,
+  isParserReadableQueryString,
   isQueryStringValue,
   parseQueryString,
 };

--- a/visivo/models/base/query_string.py
+++ b/visivo/models/base/query_string.py
@@ -4,6 +4,31 @@ import re
 from visivo.query.patterns import QUERY_STRING_VALUE_PATTERN
 
 
+def _query_string_rejection(value: str) -> str:
+    """Say which way the value missed, not just that it did.
+
+    The three ways a value reaches this function are distinguishable, and the
+    fix is different for each, so name them.
+    """
+    shown = value if len(value) <= 120 else value[:117] + "..."
+    if not value.startswith("?{"):
+        return (
+            "QueryString must be wrapped in '?{ }' (optionally followed by an "
+            f"[index|slice] suffix). Got: {shown!r}"
+        )
+    if re.match(r"^\?\{\s*\}\s*$", value, re.DOTALL):
+        return f"QueryString '?{{ }}' needs an expression between the braces. Got: {shown!r}"
+    if re.search(r"[\r\n]", value):
+        return (
+            "QueryString '?{ }' expressions must be on a single line — a newline "
+            f"inside the braces cannot be parsed. Got: {shown!r}"
+        )
+    return (
+        "QueryString must be '?{ expression }', optionally followed by an "
+        f"[index|slice] suffix such as [0], [1:5], [::2] or [0,2]. Got: {shown!r}"
+    )
+
+
 class QueryString:
     """
     Adds the value of the query string to the query.
@@ -46,14 +71,26 @@ class QueryString:
             if isinstance(value, cls):
                 return value
             str_value = str(value)
-            # Accept both ?{...} and ?{...}[N|a:b] forms. The new grammar
-            # supports a slicing suffix; the QUERY_STRING_VALUE_PATTERN
-            # is the source of truth.
-            if not (
-                str_value.startswith("?{")
-                and (str_value.endswith("}") or re.match(QUERY_STRING_VALUE_PATTERN, str_value))
-            ):
-                raise ValueError("QueryString must start with '?{' and end with '}' or '}[...]'")
+            # QUERY_STRING_VALUE_PATTERN is the source of truth, so this gate
+            # applies it rather than approximating it.
+            #
+            # The gate used to be `startswith("?{") and endswith("}")`, which is
+            # WIDER than the pattern `get_value()` reads the body with. Values in
+            # the gap — `?{}`, and any body carrying an interior newline —
+            # validated fine, were written to YAML, and then made `get_value()`
+            # return None. The failure surfaced much later and nowhere near the
+            # field: `InsightInteraction.field_values_with_js_template_literals`
+            # calls `re.sub(..., None)` and the run dies with
+            # `TypeError: expected string or bytes-like object, got 'NoneType'`.
+            #
+            # Refusing them here turns that into a validation error naming the
+            # field and the value.
+            match = re.match(QUERY_STRING_VALUE_PATTERN, str_value)
+            # `?{  }` matches the pattern (the body group swallows the spaces)
+            # but `get_value()` hands back the empty string, so it is the same
+            # empty expression as `?{}` by another spelling.
+            if match is None or not match.group("query_string").strip():
+                raise ValueError(_query_string_rejection(str_value))
             return cls(str_value)
 
         return core_schema.no_info_after_validator_function(

--- a/visivo/server/views/expression_views.py
+++ b/visivo/server/views/expression_views.py
@@ -7,6 +7,80 @@ from sqlglot import exp
 from visivo.query.patterns import CONTEXT_STRING_VALUE_PATTERN
 from visivo.query.sqlglot_utils import get_sqlglot_dialect, has_aggregate_function
 
+# ---------------------------------------------------------------------------
+# Error sanitisation
+#
+# Both endpoints below parse a bare EXPRESSION by wrapping it into a throwaway
+# statement — `SELECT <expr> FROM __placeholder__` — and `/validate/`
+# additionally swaps every `${ref(...)}` context token for an identifier
+# sqlglot can read. Those are compiler scaffolding. When the parse fails,
+# sqlglot's message quotes the wrapped SQL verbatim, so the user was shown
+# `__visivo_ctx__` and `__placeholder__` — tokens that appear nowhere in their
+# project and that they cannot act on — plus a "Line 1, Col: N" position
+# measured against a statement they never wrote.
+#
+# `sanitize_expression_error` puts the message back into the user's own words.
+# ---------------------------------------------------------------------------
+
+# Sentinel names. `_CTX_TOKEN_TEMPLATE` is numbered so each ref maps back to
+# the exact text the author typed rather than to a generic stand-in.
+_CTX_TOKEN_TEMPLATE = "__visivo_ctx_{index}__"
+_CTX_TOKEN_PATTERN = re.compile(r"__visivo_ctx(?:_\d+)?__")
+_PLACEHOLDER_TABLE = "__placeholder__"
+
+_ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+# sqlglot appends "Line 1, Col: 28." — a position in the WRAPPED statement.
+_POSITION_PATTERN = re.compile(r"\s*Line \d+, Col: \d+\.")
+# The `FROM __placeholder__` tail. sqlglot's TOKENIZER errors truncate the SQL
+# they echo, so the sentinel can arrive clipped ("__placeholder_"); match any
+# clipped form, but insist on the leading underscore so a real table called
+# `placeholder` is left alone.
+_HARNESS_TABLE_PATTERN = re.compile(r"(?:\s+FROM)?\s+_{1,2}placeholder_{0,2}")
+# The `SELECT ` head, at the start of an echoed line or just inside the quotes
+# of an "Error tokenizing '...'" message. An expression that legitimately began
+# with SELECT would lose that word from the echo — acceptable, because these
+# endpoints parse EXPRESSIONS, where a leading SELECT is already an error.
+_HARNESS_SELECT_PATTERN = re.compile(r"(?m)(^[ \t]*|['\"])SELECT\s+")
+
+
+def substitute_context_tokens(expression: str):
+    """Swap each `${...}` context token for a unique parseable identifier.
+
+    Returns ``(substituted_sql, {token: original_text})``. The tokens are
+    numbered rather than sharing one name so
+    :func:`sanitize_expression_error` can restore the author's exact text.
+    """
+    mapping = {}
+
+    def _replace(match):
+        token = _CTX_TOKEN_TEMPLATE.format(index=len(mapping))
+        mapping[token] = match.group(0)
+        return token
+
+    return re.sub(CONTEXT_STRING_VALUE_PATTERN, _replace, expression), mapping
+
+
+def sanitize_expression_error(error, token_map=None) -> str:
+    """Rewrite a sqlglot parse failure into a message about the user's text.
+
+    Strips ANSI decoration, substitutes every context token back to the ref the
+    author wrote, removes the `SELECT ... FROM __placeholder__` harness, and
+    drops the position marker (it counts characters in the wrapped statement,
+    not in the expression the user typed).
+    """
+    message = _ANSI_PATTERN.sub("", str(error))
+
+    for token, original in (token_map or {}).items():
+        message = message.replace(token, original)
+    # Anything the map missed still must not escape.
+    message = _CTX_TOKEN_PATTERN.sub("…", message)
+
+    message = _HARNESS_TABLE_PATTERN.sub("", message)
+    message = _HARNESS_SELECT_PATTERN.sub(r"\1", message)
+    message = _POSITION_PATTERN.sub("", message)
+
+    return "\n".join(line.rstrip() for line in message.split("\n")).strip()
+
 
 def register_expression_views(app, flask_app, output_dir):
     """Register expression translation API endpoints."""
@@ -64,7 +138,7 @@ def register_expression_views(app, flask_app, output_dir):
                     continue
 
                 try:
-                    wrapped_sql = f"SELECT {expression} FROM __placeholder__"
+                    wrapped_sql = f"SELECT {expression} FROM {_PLACEHOLDER_TABLE}"
                     parsed = sqlglot.parse_one(wrapped_sql, read=read_dialect or "duckdb")
 
                     select_expr = parsed.expressions[0] if parsed.expressions else None
@@ -99,7 +173,10 @@ def register_expression_views(app, flask_app, output_dir):
                     errors.append(
                         {
                             "name": name,
-                            "error": str(e),
+                            # Same rule as /validate/: the message reaches the
+                            # UI, so it may not carry the `__placeholder__`
+                            # harness this endpoint wrapped the expression in.
+                            "error": sanitize_expression_error(e),
                         }
                     )
 
@@ -157,17 +234,18 @@ def register_expression_views(app, flask_app, output_dir):
                     results.append({"name": name, "valid": False, "error": "Empty expression"})
                     continue
 
-                substituted = re.sub(CONTEXT_STRING_VALUE_PATTERN, "__visivo_ctx__", expression)
+                substituted, token_map = substitute_context_tokens(expression)
                 try:
                     sqlglot.parse_one(
-                        f"SELECT {substituted} FROM __placeholder__",
+                        f"SELECT {substituted} FROM {_PLACEHOLDER_TABLE}",
                         read=read_dialect or "duckdb",
                     )
                     results.append({"name": name, "valid": True})
                 except Exception as e:
-                    # sqlglot decorates messages with ANSI underlines — strip
-                    # them; this error renders in the viewer UI.
-                    message = re.sub(r"\x1b\[[0-9;]*m", "", str(e))
+                    # This error renders in the viewer UI, so it must talk about
+                    # the expression the author wrote — not about the harness
+                    # that wrapped it (M13).
+                    message = sanitize_expression_error(e, token_map)
                     results.append({"name": name, "valid": False, "error": message})
 
             return jsonify({"results": results}), 200

--- a/visivo/server/views/expression_views.py
+++ b/visivo/server/views/expression_views.py
@@ -20,6 +20,24 @@ from visivo.query.sqlglot_utils import get_sqlglot_dialect, has_aggregate_functi
 # measured against a statement they never wrote.
 #
 # `sanitize_expression_error` puts the message back into the user's own words.
+#
+# The mechanism matters. sqlglot does not echo the whole statement — it echoes a
+# WINDOW of it, clipped at both ends:
+#
+#   tokens.py:1085   start = max(self._current - 50, 0) ... context = self.sql[start:end]
+#   parser.py:1722   start_context = self.sql[max(start - error_message_context, 0):start]
+#
+# So string surgery on the echoed text cannot work: a sentinel that the window
+# cuts through arrives as a FRAGMENT (`__visivo_ctx_0__` -> `isivo_ctx_0__`, or
+# `x_1__`, or `_0__`), which no amount of exact replacement will catch, and any
+# pattern loose enough to catch every fragment is loose enough to eat the
+# author's own text. The earlier version of this function did both: it leaked
+# `isivo_ctx_0__` on a mid-typing unterminated quote, and it rewrote the literal
+# `'SELECT foo'` in the user's expression to `'foo'`.
+#
+# The fix is not a better pattern. It is to stop forwarding sqlglot's window at
+# all: we KNOW what the author wrote, so the sanitised message quotes THAT and
+# the harness never gets a chance to appear.
 # ---------------------------------------------------------------------------
 
 # Sentinel names. `_CTX_TOKEN_TEMPLATE` is numbered so each ref maps back to
@@ -31,16 +49,19 @@ _PLACEHOLDER_TABLE = "__placeholder__"
 _ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 # sqlglot appends "Line 1, Col: 28." — a position in the WRAPPED statement.
 _POSITION_PATTERN = re.compile(r"\s*Line \d+, Col: \d+\.")
-# The `FROM __placeholder__` tail. sqlglot's TOKENIZER errors truncate the SQL
-# they echo, so the sentinel can arrive clipped ("__placeholder_"); match any
-# clipped form, but insist on the leading underscore so a real table called
+# The `FROM __placeholder__` tail. Only reachable on the fallback path (no
+# expression supplied); the window can clip the sentinel, so match any clipped
+# form, but insist on the leading underscore so a real table called
 # `placeholder` is left alone.
 _HARNESS_TABLE_PATTERN = re.compile(r"(?:\s+FROM)?\s+_{1,2}placeholder_{0,2}")
-# The `SELECT ` head, at the start of an echoed line or just inside the quotes
-# of an "Error tokenizing '...'" message. An expression that legitimately began
-# with SELECT would lose that word from the echo — acceptable, because these
-# endpoints parse EXPRESSIONS, where a leading SELECT is already an error.
-_HARNESS_SELECT_PATTERN = re.compile(r"(?m)(^[ \t]*|['\"])SELECT\s+")
+# The `SELECT ` head. Anchored to the start of an echoed line, or to the opening
+# quote of an "Error tokenizing" echo — never to an arbitrary quote, because
+# that ate the opening quote of the author's own `'SELECT foo'` string literal.
+_HARNESS_SELECT_LINE_PATTERN = re.compile(r"(?m)^([ \t]*)SELECT\s+")
+_HARNESS_SELECT_ECHO_PATTERN = re.compile(r"(?<=Error tokenizing )(['\"])SELECT\s+")
+
+# sqlglot's tokenizer failure: the WHOLE message is `Error tokenizing '<window>'`.
+_TOKENIZE_ERROR_PATTERN = re.compile(r"^Error tokenizing '(?P<echo>.*)'\s*$", re.DOTALL)
 
 
 def substitute_context_tokens(expression: str):
@@ -60,26 +81,62 @@ def substitute_context_tokens(expression: str):
     return re.sub(CONTEXT_STRING_VALUE_PATTERN, _replace, expression), mapping
 
 
-def sanitize_expression_error(error, token_map=None) -> str:
+def _scrub_harness(text: str, token_map=None) -> str:
+    """Best-effort removal of harness text from a message part.
+
+    Used on the DESCRIPTION half of a message — never on the author's own
+    expression, which is copied through verbatim.
+    """
+    for token, original in (token_map or {}).items():
+        text = text.replace(token, original)
+    # Anything the map missed still must not escape.
+    text = _CTX_TOKEN_PATTERN.sub("…", text)
+    text = _HARNESS_TABLE_PATTERN.sub("", text)
+    text = _HARNESS_SELECT_ECHO_PATTERN.sub(r"\1", text)
+    text = _HARNESS_SELECT_LINE_PATTERN.sub(r"\1", text)
+    return _POSITION_PATTERN.sub("", text)
+
+
+def sanitize_expression_error(error, token_map=None, expression=None) -> str:
     """Rewrite a sqlglot parse failure into a message about the user's text.
 
-    Strips ANSI decoration, substitutes every context token back to the ref the
-    author wrote, removes the `SELECT ... FROM __placeholder__` harness, and
-    drops the position marker (it counts characters in the wrapped statement,
-    not in the expression the user typed).
+    Strips ANSI decoration, drops the position marker (it counts characters in
+    the wrapped statement, not in the expression the user typed), and — this is
+    the part that matters — replaces the SQL sqlglot echoes back with
+    ``expression``, the text the author actually typed.
+
+    That replacement is what makes the result trustworthy in both directions:
+    no fragment of `SELECT ... FROM __placeholder__` or of a `__visivo_ctx_N__`
+    sentinel can survive a window that clipped it, and nothing inside the
+    author's expression is rewritten by a pattern that was aiming at the
+    harness.
+
+    ``expression`` is optional only so the function stays callable without it;
+    both endpoints pass it. Without it, the harness is stripped by pattern as
+    before, which is best-effort against a clipped window.
     """
     message = _ANSI_PATTERN.sub("", str(error))
 
-    for token, original in (token_map or {}).items():
-        message = message.replace(token, original)
-    # Anything the map missed still must not escape.
-    message = _CTX_TOKEN_PATTERN.sub("…", message)
+    if expression is None:
+        message = _scrub_harness(message, token_map)
+        return "\n".join(line.rstrip() for line in message.split("\n")).strip()
 
-    message = _HARNESS_TABLE_PATTERN.sub("", message)
-    message = _HARNESS_SELECT_PATTERN.sub(r"\1", message)
-    message = _POSITION_PATTERN.sub("", message)
+    author_text = expression.strip()
 
-    return "\n".join(line.rstrip() for line in message.split("\n")).strip()
+    tokenizing = _TOKENIZE_ERROR_PATTERN.match(message.strip())
+    if tokenizing:
+        # The whole message is one echoed window. Swap the window for the
+        # author's expression; nothing else in it came from the harness.
+        return f"Error tokenizing '{author_text}'"
+
+    # Parser failures are "<description>. Line L, Col: C.\n  <echoed window>".
+    # Keep the description, drop the position (measured in the wrapped
+    # statement), and re-echo the author's own text in place of the window.
+    head, newline, _echo = message.partition("\n")
+    head = _scrub_harness(head, token_map).strip()
+    if not newline:
+        return head
+    return f"{head}\n  {author_text}" if head else author_text
 
 
 def register_expression_views(app, flask_app, output_dir):
@@ -176,7 +233,7 @@ def register_expression_views(app, flask_app, output_dir):
                             # Same rule as /validate/: the message reaches the
                             # UI, so it may not carry the `__placeholder__`
                             # harness this endpoint wrapped the expression in.
-                            "error": sanitize_expression_error(e),
+                            "error": sanitize_expression_error(e, expression=expression),
                         }
                     )
 
@@ -245,7 +302,7 @@ def register_expression_views(app, flask_app, output_dir):
                     # This error renders in the viewer UI, so it must talk about
                     # the expression the author wrote — not about the harness
                     # that wrapped it (M13).
-                    message = sanitize_expression_error(e, token_map)
+                    message = sanitize_expression_error(e, token_map, expression=expression)
                     results.append({"name": name, "valid": False, "error": message})
 
             return jsonify({"results": results}), 200


### PR DESCRIPTION
## The bug

Add a Sort in the insight edit form's right rail, pick a field with `@`, type ` DESC`, Save. Visivo writes this into your YAML:

```yaml
interactions:
  - sort: ${ref(orders).month} DESC
```

and then refuses to load it, because `InsightInteraction.sort` is a `QueryString` — the parser accepts only `?{ ... }`. The UI produced YAML the tool rejects, and you get to debug it.

The same field advertised its example as `"date DESC"`. That fails twice over: unwrapped the parser rejects it, and wrapped, `?{date DESC}` reaches the binder as a loose identifier the semantic layer cannot resolve. People copied it.

## Why not just wrap on that one save path

Six sites each decided for themselves whether a value needed wrapping. One didn't wrap (M6). Another wrapped what was already wrapped (M24 — `?{?{ ... }}`, which renders as a blank chart). Fixing the save path alone would have moved the seam, not closed it.

## `expressionCodec.js` owns the grammar

```
decodeQueryString(v)      → { body, slice, form, repaired }
encodeQueryString(parts)  → the canonical `?{body}[slice]`, IDEMPOTENT
canonicalizeQueryString   → the composition; what save paths call
```

`decode` unwraps nested wrappers to a **fixpoint**, so a value an earlier double-wrapping write already corrupted decodes to the body the author meant and reports `repaired: true`. `encode` strips any wrapper the body already carries before wrapping, so it never nests.

**Idempotence is tested as a property, not as examples.** `SHAPES` in `expressionCodec.test.js` is a 42-entry table enumerated from the models — `?{ }` query strings, bare `${ref(...)}` context strings, `>{ }` eval strings (`EvalString`, a different grammar — passed through rather than wrapped into `?{>{ ... }}`), legacy `query()`/`column()`, every slice form (`[0] [-1] [1:5] [::2] [0,2]`), already-wrapped, doubly and triply wrapped, and the empties. Four properties run over all of it: canonicalize is idempotent (checked to three applications, so a two-cycle can't pass by accident), the output never nests a wrapper, body and slice survive re-decoding, and the result is a value a JS mirror of the Pydantic `QueryString` validator accepts.

`queryString.js` became a thin layer over the codec, so `serializeQueryString` is idempotent for all six of its existing callers — which fixes M24 in `PropertyRow.jsx` **without editing PropertyRow** (Tim's file).

Routed through the codec: `InsightBuildSection`'s two prop-drop sites and its interaction row, `explorerStore`'s "Add to exploration", `pillFieldSwap`, `saveAsMetricFlow`. The interaction row's old greedy `/^\?\{([\s\S]*)\}$/` never matched a *sliced* value, so `?{x}[0]` leaked its braces into the field and the next keystroke stored `?{?{x}[0]}`.

`expressionCodecOwnership.test.js` walks `viewer/src` and fails on any new ad-hoc `` `?{${...}}` `` literal. `WorkspaceDndContext.jsx` is allowlisted **with the reason in the file** — it is owned by open PR #646 and wraps correctly today; the entry says to remove it once #646 lands.

## The help text can't drift again

`viewer/src/schemas/interactionHelp.js` holds each field's `label`, `description`, `yamlExample` and `example`, copied verbatim from `InsightInteraction`. Two parity tests keep them there:

- `interactionHelp.test.js` re-derives all six strings from the vendored `visivo_project_schema.json` (`$defs/InsightInteraction`) — descriptions from the field descriptions, examples parsed out of the docstring's YAML block.
- `tests/models/test_interaction_help_parity.py` reads them straight off `InsightInteraction.model_fields`, so a **stale vendored schema cannot hide a drift either**. It also asserts each advertised example actually constructs an `InsightInteraction`, carries a real `${ref(...)}`, and that the bare form the old hint taught is still rejected.

Sort now reads: *"Column or expression to sort rows by; append ASC or DESC to control direction. Type @ to insert references, or drag them in from the library. For example: `${ref(orders).month} ASC`"* — a value that saves and runs. (The description is markdown on the docs site; the backticks are stripped for display only, so `INTERACTION_HELP` keeps the model's exact bytes.) `NULLS FIRST/LAST` is deliberately not advertised — the ORDER BY strippers still leak it (W8, VIS-1316).

Both editors now show the expression **body** and re-wrap on save, so the same user action produces byte-identical stored values in the right rail and the Explorer Build rail. The slice suffix is held aside in form state rather than dropped when you edit the body. The live preview is wrapped too — it runs the real `InsightInteraction` model, so a bare body there made the preview disagree with the saved insight for every interaction you typed rather than opened.

## Backend: the compiler's own words leaked into the UI

`/api/expressions/validate/` wraps your expression in `SELECT <expr> FROM __placeholder__` and swaps every `${ref(...)}` for an identifier sqlglot can read. When the parse failed it returned sqlglot's message verbatim:

```
Required keyword: 'expression' missing for <class 'sqlglot.expressions.GT'>. Line 1, Col: 28.
  SELECT __visivo_ctx__ > FROM __placeholder__
```

Three things there appear nowhere in your project. Now:

```
Required keyword: 'expression' missing for <class 'sqlglot.expressions.GT'>.
  ${ref(orders).amount} >
```

The context substitution numbers its tokens (`__visivo_ctx_0__`, `__visivo_ctx_1__`) so each ref maps back to the exact text you typed — a single shared sentinel made that impossible. The position marker is dropped because it counts characters in a statement you never wrote. `/translate/` gets the same treatment. This is W8(a) only; the bare-identifier diagnostic and the NULLS strippers live in `visivo/query/**`, which open PRs #653/#654 own.

## Falsification

Each guard was proven to fail with its implementation removed (impl stashed, tests kept):

| Reverted | Failures |
|---|---|
| `encodeQueryString` → unconditional wrap | **47** jest tests, incl. every `encodeQueryString itself is idempotent for …` case |
| `InsightEditForm` save-path wrap removed | **6** jest (`…saves only non-empty interactions`, M24, whitespace-drop, C15, remove, round-trip) |
| `"date DESC"` restored in `interactionHelp.js` | **6** jest + **4** pytest (`test_help_description_matches_the_model_field[sort]`, `…example_is_accepted_by_the_model[sort]`, `…names_a_real_ref[sort]`, `test_no_help_string_advertises_date_desc`) |
| `sanitize_expression_error` → ANSI-strip only | **12** pytest, incl. all 7 `test_validate_error_leaks_no_internal_sentinels[…]` |

## Gates

- `viewer`: `yarn test --watchAll=false` → **369 suites, 7314 tests, all passing**; `yarn lint` → **0 problems** (baseline was also 0, so the new files carry their own `no-template-curly-in-string` banners rather than adding noise)
- `pytest tests/ -q` → **2503 passed**, 2 skipped, 5 xfailed, 1 xpassed
- `black --check --target-version py312 .` → clean
- Verified in a live sandbox (isolated :8011/:3011) against `test-projects/integration`: the three interactions on `combined-interactions-test-insight` render as pills with no leaked braces, each hint ends with its working example, and Save stays disabled — the decode→encode round trip does not dirty an untouched insight.

## Ownership

No file owned by an open PR was edited. `PropertyRow.jsx`, `RefTextArea.jsx`, `PillMenu.jsx`, `inlineCreateStore.js`, `Library.jsx` (Tim) and `WorkspaceDndContext.jsx` (#646) are untouched — PropertyRow's double-wrap is fixed through `serializeQueryString`, and WorkspaceDndContext's one wrapper site is allowlisted with a note.

No Pydantic model changed, so no schema regeneration is needed (#642's file is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
