### PR TITLE
The agent contract: `visivo schema` with a core subset, and `--json` on compile/run/test

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
       - Authentication: cloud/authentication.md
   - Reference:
       - CLI: reference/cli.md
+      - Agent Contract: reference/agent-contract.md
       - Configuration:
           - Alert:
               - reference/configuration/Alert/index.md

--- a/mkdocs/reference/agent-contract.md
+++ b/mkdocs/reference/agent-contract.md
@@ -17,6 +17,7 @@ Both write to **stdout** and send every human-readable line to **stderr**, so
 
 ```bash
 visivo schema                  # the core authoring subset (default)
+visivo schema --core           # the same, said explicitly
 visivo schema -o core.json     # write it to a file
 visivo schema --indent 2       # pretty-print
 visivo schema --full           # the complete schema, Plotly vocabularies included

--- a/mkdocs/reference/agent-contract.md
+++ b/mkdocs/reference/agent-contract.md
@@ -32,7 +32,7 @@ about 3.3 MB across 103 definitions. Most of that is the Plotly property
 vocabulary: the `Layout` definition alone is over 400 KB, and there is one
 definition per chart type. No agent can hold that in a prompt.
 
-The core subset is about 90 KB — roughly 23k tokens, small enough to cache in a
+The core subset is about 95 KB — roughly 24k tokens, small enough to cache in a
 system prompt — and describes the objects you actually write in
 `project.visivo.yml`: sources, models, metrics, dimensions, relations, insights,
 charts, tables, markdowns, inputs, dashboards and tests.
@@ -46,15 +46,19 @@ drift from the models. The rule, in full, lives in the module docstring of
 1. Build from the Pydantic dump of `Project`, before the vendored Plotly JSON is
    merged in. That single choice prunes every trace-prop definition and the
    large `Layout` — and prunes any Plotly type added in future automatically.
-2. Keep only the project fields you author by hand. `dbt`, `alerts`,
+2. Describe only the project fields you author by hand. `dbt`, `alerts`,
    `destinations` and the machine-set bookkeeping fields are out, each with a
    stated reason recorded in the emitted schema itself.
 3. Take the transitive `$ref` closure of what is left and drop everything
    unreachable.
 4. Delete the fields the CLI fills in — `path`, `file_path`, `project_file_path`,
-   `project_dir`, `cli_version` — from every object.
+   `project_dir`, `cli_version` — from every object that *inherits* them.
 5. Delete Pydantic's auto-generated property titles, which restate the key.
-6. Restore the aliases that only carry a trailing underscore because the name is
+6. Rewrite the `oneOf`s that no value can satisfy. A union chosen by a Python
+   callback — a password, which may be a literal or an `${env.*}` reference —
+   dumps as two branches that both accept any string, and `oneOf` demands
+   exactly one match.
+7. Restore the aliases that only carry a trailing underscore because the name is
    a Python keyword, so a test's gate is spelled `if`, as the docs show, and the
    `if_` spelling is marked deprecated.
 
@@ -65,6 +69,17 @@ vocabulary for one chart type it asks for it with `visivo schema --props bar`.
 The emitted document carries an `x-visivo-schema` block naming the mode, the CLI
 version, what was omitted and why, and the commands that return the omitted
 parts.
+
+!!! note "Omitted is not prohibited"
+    `alerts`, `destinations` and `dbt` are undescribed because they are
+    orthogonal to building a dashboard — not because writing them is a mistake.
+    Since the project root forbids unknown keys, each is still *accepted*, as a
+    permissive stub pointing at `--full`. A project that already uses them
+    validates unchanged.
+
+    The same goes for `path` inside `includes:`. It shares a name with the
+    machine-set `path` step 4 removes, but it is declared by `Include` itself
+    and is the only key an include has, so it stays.
 
 !!! note "Authoring vs. compiler output"
     Because step 4 removes the machine-set fields and every Visivo object
@@ -144,10 +159,20 @@ was picked up:
   "project_name": "EV Sales",
   "working_dir": "/work",
   "output_dir": "/work/target",
-  "objects": { "models": ["ev_sales"], "insights": ["units_by_quarter"], "…": [] },
-  "object_counts": { "models": 1, "insights": 1 }
+  "objects": {
+    "models": ["ev_sales"],
+    "metrics": ["revenue", "ev_sales.total_units"],
+    "insights": ["units_by_quarter"],
+    "…": []
+  },
+  "object_counts": { "models": 1, "metrics": 2, "insights": 1 }
 }
 ```
+
+Objects written *inside* another object are reported too, not just the ones at
+the project root: a metric or dimension defined on a model appears qualified as
+`model.name` — which is also how you reference it, `${ref(model).name}` — and an
+insight written inline in a chart appears under `insights` by its own name.
 
 ### `run` result
 
@@ -172,11 +197,22 @@ removed:
 }
 ```
 
+`error` carries the whole diagnostic, which is often several lines — the failing
+expression and the position within it, not just the first sentence. `artifact`
+is a path: the file the job wrote, or the SQL dumped for a query that failed.
+
 Every failed job also appears in `errors` with `"code": "job_failed"`.
 
 A `--json` run reports **every** failing job in one pass rather than stopping at
 the first failing dashboard, which is the one behavioral difference from a
 plain `visivo run`.
+
+!!! note "`total: 0` means nothing ran"
+    A run whose filter matches no runnable node succeeds and exits 0 — the same
+    as `visivo run`, which prints "No jobs run" and also exits 0. `--json` does
+    not turn that into an error, because the exit code is contractually the
+    same with and without the flag. Check `job_counts.total` rather than
+    `success` when you need to know that work actually happened.
 
 ### `test` result
 

--- a/mkdocs/reference/agent-contract.md
+++ b/mkdocs/reference/agent-contract.md
@@ -1,0 +1,205 @@
+# Agent Contract
+
+Two CLI affordances exist so that an LLM agent can author a Visivo project by
+reading the grammar instead of guessing at it, and can read command results
+structurally instead of scraping log lines.
+
+- `visivo schema` — the project JSON Schema, small enough to put in a prompt.
+- `--json` on `visivo compile`, `visivo run` and `visivo test` — one JSON object
+  on stdout describing what happened.
+
+Both write to **stdout** and send every human-readable line to **stderr**, so
+`visivo schema > core.json` and `visivo compile --json | jq` work unmodified.
+
+---
+
+## `visivo schema`
+
+```bash
+visivo schema                  # the core authoring subset (default)
+visivo schema -o core.json     # write it to a file
+visivo schema --indent 2       # pretty-print
+visivo schema --full           # the complete schema, Plotly vocabularies included
+visivo schema --props bar      # every Plotly property valid for `props: {type: bar}`
+visivo schema --layout         # every Plotly layout property
+```
+
+### Why there is a core subset
+
+The schema that ships with Visivo, and that the viewer validates against, is
+about 3.3 MB across 103 definitions. Most of that is the Plotly property
+vocabulary: the `Layout` definition alone is over 400 KB, and there is one
+definition per chart type. No agent can hold that in a prompt.
+
+The core subset is about 90 KB — roughly 23k tokens, small enough to cache in a
+system prompt — and describes the objects you actually write in
+`project.visivo.yml`: sources, models, metrics, dimensions, relations, insights,
+charts, tables, markdowns, inputs, dashboards and tests.
+
+### How the subset is chosen
+
+The subset is derived mechanically every time the command runs, so it cannot
+drift from the models. The rule, in full, lives in the module docstring of
+`visivo/commands/schema_phase.py`; in short:
+
+1. Build from the Pydantic dump of `Project`, before the vendored Plotly JSON is
+   merged in. That single choice prunes every trace-prop definition and the
+   large `Layout` — and prunes any Plotly type added in future automatically.
+2. Keep only the project fields you author by hand. `dbt`, `alerts`,
+   `destinations` and the machine-set bookkeeping fields are out, each with a
+   stated reason recorded in the emitted schema itself.
+3. Take the transitive `$ref` closure of what is left and drop everything
+   unreachable.
+4. Delete the fields the CLI fills in — `path`, `file_path`, `project_file_path`,
+   `project_dir`, `cli_version` — from every object.
+5. Delete Pydantic's auto-generated property titles, which restate the key.
+6. Restore the aliases that only carry a trailing underscore because the name is
+   a Python keyword, so a test's gate is spelled `if`, as the docs show, and the
+   `if_` spelling is marked deprecated.
+
+Nothing dangles as a result. `props` stays an open object that requires `type`,
+and `layout` stays an open object; when an agent needs the real Plotly
+vocabulary for one chart type it asks for it with `visivo schema --props bar`.
+
+The emitted document carries an `x-visivo-schema` block naming the mode, the CLI
+version, what was omitted and why, and the commands that return the omitted
+parts.
+
+!!! note "Authoring vs. compiler output"
+    Because step 4 removes the machine-set fields and every Visivo object
+    forbids unknown keys, the core schema rejects a document that carries them —
+    notably the `project.json` written at compile time. Validate hand-written
+    YAML with the core schema; validate compiler output with `--full`.
+
+---
+
+## `--json` on compile, run and test
+
+```bash
+visivo compile --json
+visivo run --json
+visivo test --json
+```
+
+Each prints exactly one JSON object on stdout and nothing else. The exit code is
+unchanged, so `visivo run --json && visivo test --json` still short-circuits.
+
+### The envelope
+
+Every key is always present.
+
+```json
+{
+  "visivo_json_version": 1,
+  "command": "compile",
+  "success": true,
+  "cli_version": "2.1.1",
+  "duration_ms": 812,
+  "result": { },
+  "errors": [ ]
+}
+```
+
+| Key | Meaning |
+| --- | --- |
+| `visivo_json_version` | Bumped when the shape changes in a way a consumer would notice. |
+| `command` | `compile`, `run` or `test`. |
+| `success` | Whether the command achieved what it was asked to do. |
+| `cli_version` | The CLI that produced the document. |
+| `duration_ms` | Wall clock for the command body. |
+| `result` | Command-specific; see below. |
+| `errors` | Always a list, empty on success. |
+
+### Errors
+
+Each entry has the same seven keys. Any of `name`, `file`, `line`,
+`object_path` and `details` may be `null` when the CLI genuinely does not know
+the value, so a consumer can index without guarding.
+
+```json
+{
+  "code": "bad_reference",
+  "name": "revenue_by_month",
+  "message": "The reference \"ref(orders)\" does not point to an object.",
+  "file": "project.visivo.yml",
+  "line": 31,
+  "object_path": "project.insights[0]",
+  "details": null
+}
+```
+
+`code` is the machine-readable kind: a Pydantic error type such as
+`bad_reference` or `extra_forbidden` for configuration problems, `job_failed`
+for a query that did not run, `test_failed` for a failing assertion, and
+`cli_error` for a usage or YAML-syntax problem.
+
+### `compile` result
+
+What the CLI actually parsed, so an agent can confirm the object it just wrote
+was picked up:
+
+```json
+{
+  "project_name": "EV Sales",
+  "working_dir": "/work",
+  "output_dir": "/work/target",
+  "objects": { "models": ["ev_sales"], "insights": ["units_by_quarter"], "…": [] },
+  "object_counts": { "models": 1, "insights": 1 }
+}
+```
+
+### `run` result
+
+One entry per job the DAG runner executed, with the runner's alignment padding
+removed:
+
+```json
+{
+  "project_name": "EV Sales",
+  "output_dir": "/work/target",
+  "jobs": [
+    {
+      "name": "units_by_quarter",
+      "type": "Insight",
+      "success": false,
+      "summary": "Failed job for insight units_by_quarter",
+      "error": "Column 'quarter' not found on model 'ev_sales'.",
+      "artifact": "target/insights/units_by_quarter/query.sql"
+    }
+  ],
+  "job_counts": { "succeeded": 2, "failed": 1, "total": 3 }
+}
+```
+
+Every failed job also appears in `errors` with `"code": "job_failed"`.
+
+A `--json` run reports **every** failing job in one pass rather than stopping at
+the first failing dashboard, which is the one behavioral difference from a
+plain `visivo run`.
+
+### `test` result
+
+```json
+{
+  "project_name": "EV Sales",
+  "output_dir": "/work/target",
+  "tests": [
+    { "test_id": "project.tests[0]", "name": "quarters-present", "passed": true, "message": null }
+  ],
+  "test_counts": { "passed": 1, "failed": 0, "total": 1 }
+}
+```
+
+Every failing assertion also appears in `errors` with `"code": "test_failed"`.
+
+---
+
+## A minimal agent loop
+
+```bash
+visivo schema -o core.json          # read the grammar once, cache it
+# ...write project.visivo.yml against it...
+visivo compile --json || exit 1     # errors carry name, file and line
+visivo run --json
+visivo test --json
+```

--- a/tests/commands/test_json_mode.py
+++ b/tests/commands/test_json_mode.py
@@ -248,6 +248,52 @@ def test_run_json_failure_reports_the_failing_job():
     assert all(error["name"] for error in document["errors"])
     assert all(error["message"] for error in document["errors"])
 
+    # `error` is the whole point of the envelope over the exit code, and it is
+    # recovered by parsing the runner's log text -- so assert it against a real
+    # run, not only against hand-typed strings. `run_errors` falls back to the
+    # generic "Failed job for <name>" summary when parsing comes up empty, so a
+    # parser that stops extracting the exception degrades silently unless this
+    # says otherwise.
+    failed = [job for job in document["result"]["jobs"] if not job["success"]]
+    assert failed, "the run reported no failing job"
+    for job in failed:
+        assert job["error"], f"failing job {job['name']} carries no error text"
+        assert job["error"] != job["summary"]
+        assert not job["error"].startswith("Failed job for")
+        assert len(job["error"]) > len(job["summary"])
+    by_name = {job["name"]: job for job in failed}
+    for error in document["errors"]:
+        assert not error["message"].startswith("Failed job for")
+        assert error["message"] == by_name[error["name"]]["error"]
+        # `file` is a path a consumer opens, or null -- never a log-line prefix.
+        assert error["file"] is None or not error["file"].startswith(("query", "database"))
+
+
+def test_run_without_json_still_exits_non_zero_on_failure():
+    """`run --json` runs the DAG soft so it can report every failure; the plain
+    path must keep exiting 1, or a broken pipeline goes green in CI."""
+    output_dir = temp_folder()
+    project = runnable_project()
+    project.models[0].sql = "select * from a_table_that_is_not_there"
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+
+    response = runner.invoke(
+        run,
+        [
+            "-w",
+            working_dir,
+            "-o",
+            output_dir,
+            "-s",
+            "source",
+            "-p",
+            str(HotReloadServer.find_available_port()),
+        ],
+    )
+
+    assert response.exit_code == 1
+
 
 def test_run_json_and_compile_json_share_the_envelope():
     output_dir = temp_folder()

--- a/tests/commands/test_json_mode.py
+++ b/tests/commands/test_json_mode.py
@@ -1,0 +1,381 @@
+"""
+``--json`` on compile, run and test: parseable, and the same shape whether the
+command succeeded or failed.
+"""
+
+import json
+import os
+
+from click.testing import CliRunner
+
+from tests.factories.model_factories import (
+    ChartFactory,
+    DashboardFactory,
+    InsightFactory,
+    ItemFactory,
+    ProjectFactory,
+    RowFactory,
+    SqlModelFactory,
+)
+from tests.support.utils import temp_folder, temp_yml_file
+from visivo.commands.compile import compile
+from visivo.commands.run import run
+from visivo.commands.test import test
+from visivo.commands.utils import create_file_database
+from visivo.parsers.file_names import PROJECT_FILE_NAME
+from visivo.server.hot_reload_server import HotReloadServer
+
+runner = CliRunner()
+
+ENVELOPE_KEYS = {
+    "visivo_json_version",
+    "command",
+    "success",
+    "cli_version",
+    "duration_ms",
+    "result",
+    "errors",
+}
+ERROR_KEYS = {"code", "name", "message", "file", "line", "object_path", "details"}
+
+
+def parsed(response):
+    """stdout must be the JSON document and nothing else."""
+    assert response.stdout.strip(), "no JSON document on stdout"
+    document = json.loads(response.stdout)
+    assert set(document) == ENVELOPE_KEYS
+    assert document["visivo_json_version"] == 1
+    for error in document["errors"]:
+        assert set(error) == ERROR_KEYS
+    return document
+
+
+def runnable_project(**kwargs):
+    model = SqlModelFactory(name="model", source="ref(source)")
+    insight = InsightFactory(name="insight", model=model)
+    chart = ChartFactory(name="chart", insights=[insight])
+    item = ItemFactory(name="item", chart=chart)
+    row = RowFactory(name="row", items=[item])
+    dashboard = DashboardFactory(name="dashboard", rows=[row])
+    return ProjectFactory(models=[model], dashboards=[dashboard], **kwargs)
+
+
+def write_project(project):
+    path = temp_yml_file(dict=json.loads(project.model_dump_json()), name=PROJECT_FILE_NAME)
+    return os.path.dirname(path)
+
+
+def write_yaml(document):
+    path = temp_yml_file(dict=document, name=PROJECT_FILE_NAME)
+    return os.path.dirname(path)
+
+
+DANGLING_REF_PROJECT = {
+    "name": "dangling",
+    "sources": [{"name": "source", "type": "duckdb", "database": "tmp/dangling.duckdb"}],
+    "models": [{"name": "model", "sql": "select 1 as one"}],
+    "insights": [
+        {
+            "name": "broken_insight",
+            "props": {
+                "type": "bar",
+                "x": "?{ ${ref(no_such_model).one} }",
+                "y": "?{ count(*) }",
+            },
+        }
+    ],
+}
+
+
+# --------------------------------------------------------------------------
+# compile
+# --------------------------------------------------------------------------
+
+
+def test_compile_json_success():
+    output_dir = temp_folder()
+    project = runnable_project()
+    working_dir = write_project(project)
+
+    response = runner.invoke(
+        compile, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"]
+    )
+
+    document = parsed(response)
+    assert response.exit_code == 0
+    assert document["command"] == "compile"
+    assert document["success"] is True
+    assert document["errors"] == []
+    assert document["result"]["project_name"] == project.name
+    assert document["result"]["objects"]["models"] == ["model"]
+    assert document["result"]["objects"]["dashboards"] == ["dashboard"]
+    assert document["result"]["object_counts"]["models"] == 1
+    assert isinstance(document["duration_ms"], int)
+
+
+def test_compile_json_failure_carries_name_message_file_and_line():
+    output_dir = temp_folder()
+    working_dir = write_yaml(DANGLING_REF_PROJECT)
+
+    response = runner.invoke(
+        compile, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"]
+    )
+
+    document = parsed(response)
+    assert response.exit_code == 1
+    assert document["success"] is False
+    assert len(document["errors"]) == 1
+    error = document["errors"][0]
+    assert error["code"] == "bad_reference"
+    assert error["name"] == "broken_insight"
+    assert "no_such_model" in error["message"]
+    assert error["file"].endswith(PROJECT_FILE_NAME)
+    assert isinstance(error["line"], int) and error["line"] > 0
+    assert error["object_path"] == "project.insights[0]"
+
+
+def test_compile_json_failure_on_an_unknown_key():
+    output_dir = temp_folder()
+    document = json.loads(json.dumps(DANGLING_REF_PROJECT))
+    document["insights"][0]["props"]["x"] = "?{ ${ref(model).one} }"
+    document["models"][0]["not_a_field"] = 1
+    working_dir = write_yaml(document)
+
+    response = runner.invoke(
+        compile, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"]
+    )
+
+    payload = parsed(response)
+    assert response.exit_code == 1
+    error = payload["errors"][0]
+    assert error["code"] == "extra_forbidden"
+    assert error["name"] == "model"
+    assert error["file"].endswith(PROJECT_FILE_NAME)
+    assert isinstance(error["line"], int)
+
+
+def test_compile_json_keeps_human_output_off_stdout():
+    output_dir = temp_folder()
+    working_dir = write_project(runnable_project())
+
+    response = runner.invoke(
+        compile, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"]
+    )
+
+    assert "Compiling" in response.stderr
+    assert "Compiling" not in response.stdout
+
+
+def test_compile_without_json_is_unchanged():
+    output_dir = temp_folder()
+    working_dir = write_project(runnable_project())
+
+    response = runner.invoke(compile, ["-w", working_dir, "-o", output_dir, "-s", "source"])
+
+    assert response.exit_code == 0
+    assert "Compiling" in response.output
+    assert "Done" in response.output
+
+
+# --------------------------------------------------------------------------
+# run
+# --------------------------------------------------------------------------
+
+
+def test_run_json_success():
+    output_dir = temp_folder()
+    project = runnable_project()
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+
+    response = runner.invoke(
+        run,
+        [
+            "-w",
+            working_dir,
+            "-o",
+            output_dir,
+            "-s",
+            "source",
+            "-p",
+            str(HotReloadServer.find_available_port()),
+            "--json",
+        ],
+    )
+
+    document = parsed(response)
+    assert response.exit_code == 0
+    assert document["command"] == "run"
+    assert document["success"] is True
+    assert document["errors"] == []
+    assert document["result"]["job_counts"]["failed"] == 0
+    assert document["result"]["job_counts"]["total"] > 0
+    for job in document["result"]["jobs"]:
+        assert set(job) == {"name", "type", "success", "summary", "error", "artifact"}
+        assert job["success"] is True
+        assert "..." not in (job["summary"] or "")
+
+
+def test_run_json_failure_reports_the_failing_job():
+    output_dir = temp_folder()
+    project = runnable_project()
+    project.models[0].sql = "select * from a_table_that_is_not_there"
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+
+    response = runner.invoke(
+        run,
+        [
+            "-w",
+            working_dir,
+            "-o",
+            output_dir,
+            "-s",
+            "source",
+            "-p",
+            str(HotReloadServer.find_available_port()),
+            "--json",
+        ],
+    )
+
+    document = parsed(response)
+    assert response.exit_code == 1
+    assert document["success"] is False
+    assert document["result"]["job_counts"]["failed"] > 0
+    assert document["errors"], "a failed run must carry structured errors, not just exit 1"
+    codes = {error["code"] for error in document["errors"]}
+    assert codes == {"job_failed"}
+    assert all(error["name"] for error in document["errors"])
+    assert all(error["message"] for error in document["errors"])
+
+
+def test_run_json_and_compile_json_share_the_envelope():
+    output_dir = temp_folder()
+    project = runnable_project()
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+
+    compiled = parsed(
+        runner.invoke(compile, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"])
+    )
+    ran = parsed(
+        runner.invoke(
+            run,
+            [
+                "-w",
+                working_dir,
+                "-o",
+                output_dir,
+                "-s",
+                "source",
+                "-p",
+                str(HotReloadServer.find_available_port()),
+                "--json",
+            ],
+        )
+    )
+    assert set(compiled) == set(ran)
+    assert compiled["cli_version"] == ran["cli_version"]
+
+
+# --------------------------------------------------------------------------
+# test
+# --------------------------------------------------------------------------
+
+
+def _project_with_assertions(assertions):
+    from visivo.models.test import Test
+
+    project = runnable_project()
+    project.tests = [
+        Test(name=f"assertion-{index}", assertions=[assertion])
+        for index, assertion in enumerate(assertions)
+    ]
+    return project
+
+
+def _write_insight_data(output_dir, insight_name="insight"):
+    folder = f"{output_dir}/{insight_name}"
+    os.makedirs(folder, exist_ok=True)
+    with open(f"{folder}/data.json", "w") as file:
+        file.write(json.dumps({insight_name: {"props.x": [1, 2, 3], "props.y": [1, 2, 3]}}))
+
+
+def test_test_json_success():
+    output_dir = temp_folder()
+    project = _project_with_assertions([">{ sum( ${ ref(insight).props.x } ) == 6 }"])
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+    _write_insight_data(output_dir)
+
+    response = runner.invoke(test, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"])
+
+    document = parsed(response)
+    assert response.exit_code == 0
+    assert document["command"] == "test"
+    assert document["success"] is True
+    assert document["errors"] == []
+    assert document["result"]["test_counts"] == {"passed": 1, "failed": 0, "total": 1}
+    assert document["result"]["tests"][0]["name"] == "assertion-0"
+    assert document["result"]["tests"][0]["passed"] is True
+
+
+def test_test_json_failure_reports_each_failing_assertion():
+    output_dir = temp_folder()
+    project = _project_with_assertions(
+        [
+            ">{ sum( ${ ref(insight).props.x } ) == 6 }",
+            ">{ sum( ${ ref(insight).props.x } ) == 999 }",
+        ]
+    )
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+    _write_insight_data(output_dir)
+
+    response = runner.invoke(test, ["-w", working_dir, "-o", output_dir, "-s", "source", "--json"])
+
+    document = parsed(response)
+    assert response.exit_code == 1
+    assert document["success"] is False
+    assert document["result"]["test_counts"] == {"passed": 1, "failed": 1, "total": 2}
+    assert len(document["errors"]) == 1
+    assert document["errors"][0]["code"] == "test_failed"
+    assert document["errors"][0]["name"] == "assertion-1"
+    assert "999" in document["errors"][0]["message"]
+
+
+def test_test_json_success_and_failure_have_the_same_shape():
+    output_dir = temp_folder()
+    passing = _project_with_assertions([">{ sum( ${ ref(insight).props.x } ) == 6 }"])
+    create_file_database(url=passing.sources[0].url(), output_dir=output_dir)
+    _write_insight_data(output_dir)
+    passing_document = parsed(
+        runner.invoke(
+            test, ["-w", write_project(passing), "-o", output_dir, "-s", "source", "--json"]
+        )
+    )
+
+    failing = _project_with_assertions([">{ sum( ${ ref(insight).props.x } ) == 999 }"])
+    failing_document = parsed(
+        runner.invoke(
+            test, ["-w", write_project(failing), "-o", output_dir, "-s", "source", "--json"]
+        )
+    )
+
+    assert set(passing_document) == set(failing_document)
+    assert set(passing_document["result"]) == set(failing_document["result"])
+    assert set(passing_document["result"]["tests"][0]) == set(
+        failing_document["result"]["tests"][0]
+    )
+
+
+def test_test_without_json_still_exits_non_zero_on_failure():
+    output_dir = temp_folder()
+    project = _project_with_assertions([">{ sum( ${ ref(insight).props.x } ) == 999 }"])
+    create_file_database(url=project.sources[0].url(), output_dir=output_dir)
+    working_dir = write_project(project)
+    _write_insight_data(output_dir)
+
+    response = runner.invoke(test, ["-w", working_dir, "-o", output_dir, "-s", "source"])
+
+    assert response.exit_code == 1

--- a/tests/commands/test_json_output.py
+++ b/tests/commands/test_json_output.py
@@ -5,6 +5,14 @@ import click
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from tests.factories.model_factories import (
+    ChartFactory,
+    DimensionFactory,
+    InsightFactory,
+    MetricFactory,
+    ProjectFactory,
+    SqlModelFactory,
+)
 from visivo.commands.json_output import (
     ERROR_KEY_ORDER,
     VISIVO_JSON_VERSION,
@@ -32,6 +40,74 @@ def test_compile_result_covers_every_authorable_collection():
     # `includes` holds file references, not named objects -- an Include has a
     # path, not a name, so reporting it would be a column of nulls.
     assert set(_PROJECT_COLLECTIONS) == list_valued - {"includes"}
+
+
+def _item_class(annotation):
+    """The Pydantic model a `List[X]`-ish annotation holds, or None."""
+    from typing import get_args
+
+    from pydantic import BaseModel as PydanticBaseModel
+
+    for argument in get_args(annotation) or ():
+        if isinstance(argument, type) and issubclass(argument, PydanticBaseModel):
+            return argument
+        found = _item_class(argument)
+        if found is not None:
+            return found
+    return None
+
+
+def test_nested_collections_names_every_place_a_collection_can_be_written():
+    """A collection can have a second home inside another object.
+
+    `metrics` and `dimensions` can be written on a model -- the spelling the
+    semantic-layer docs lead with -- and `insights` inside a chart. Reading only
+    the root would report `"metrics": []` for a project whose metrics compiled
+    fine, and an agent following the documented loop ("write it, compile,
+    confirm it appears") would conclude its edit was dropped.
+
+    Derived from the models, so a model that grows another nested collection
+    fails here rather than going quietly missing from the envelope.
+    """
+    from visivo.commands.json_output import _NESTED_COLLECTIONS, _PROJECT_COLLECTIONS
+    from visivo.models.project import Project
+
+    nested = {}
+    for collection in _PROJECT_COLLECTIONS:
+        item = _item_class(Project.model_fields[collection].annotation)
+        if item is None:
+            continue
+        inner = {name for name in item.model_fields if name in _PROJECT_COLLECTIONS}
+        if inner:
+            nested[collection] = inner
+
+    assert nested == {parent: set(inner) for parent, inner in _NESTED_COLLECTIONS.items()}
+
+
+def test_compile_result_reports_objects_written_inside_another_object():
+    from visivo.commands.json_output import compile_result
+
+    project = ProjectFactory()
+    project.models = [
+        SqlModelFactory(
+            name="ev_sales",
+            metrics=[MetricFactory(name="total_units", expression="SUM(units_sold)")],
+            dimensions=[DimensionFactory(name="region_dim", expression="region")],
+        )
+    ]
+    project.metrics = [MetricFactory(name="global_metric", expression="SUM(1)")]
+    project.charts = [ChartFactory(name="inline_chart", insights=[InsightFactory(name="inline")])]
+    project.insights = []
+
+    result = compile_result(project=project, working_dir="/w", output_dir="/w/target")
+
+    # Model-scoped: qualified, because `${ref(model).metric}` is how it is read.
+    assert result["objects"]["metrics"] == ["global_metric", "ev_sales.total_units"]
+    assert result["objects"]["dimensions"] == ["ev_sales.region_dim"]
+    # Chart-scoped: bare, because an insight keeps a project-wide name.
+    assert result["objects"]["insights"] == ["inline"]
+    assert result["object_counts"]["metrics"] == 2
+    assert result["object_counts"]["insights"] == 1
 
 
 def test_envelope_always_carries_every_key():
@@ -89,6 +165,35 @@ def test_parse_job_message_pulls_out_the_error_and_the_query_path():
     assert "Column 'x' not found" in parsed["error"]
 
 
+def test_parse_job_message_reads_a_real_failed_insight_block():
+    """The shape `run_insight_job` actually produces, not a synthesised one.
+
+    `format_message_failure` puts the exception on an `error:` line and
+    `run_insight_job` appends `at <location>` and `query saved to: <path>`
+    after it. Treating every continuation line as the artifact put the literal
+    string "query saved to: <path>" in `artifact` -- a filename that is not a
+    filename -- and threw away every line of the error after the first, which
+    is exactly the part naming the offending column.
+    """
+    parsed = parse_job_message(
+        "Failed job for insight \033[4mtotal_units\033[0m ....[\033[31mFAILURE 0.06s\033[0m]"
+        "\n\t\033[2merror: Conversion Error: could not convert 'West' to INTEGER"
+        '\nLINE 7:   SUM(CAST("ev_sales"."region" AS INTEGER)) AS ...'
+        "\n        at line 7"
+        "\n        query saved to: target/logs/failed_queries/insight_total_units.sql\033[0m"
+    )
+
+    assert parsed["summary"] == "Failed job for insight total_units"
+    assert parsed["status"] == "FAILURE"
+    assert parsed["artifact"] == "target/logs/failed_queries/insight_total_units.sql"
+    assert "query saved to" not in parsed["artifact"]
+    assert parsed["artifact"].endswith(".sql")
+    # Every line of the error survives, including the one an agent needs.
+    assert parsed["error"].startswith("Conversion Error: could not convert 'West' to INTEGER")
+    assert 'CAST("ev_sales"."region" AS INTEGER)' in parsed["error"]
+    assert "at line 7" in parsed["error"]
+
+
 def test_parse_job_message_survives_an_unpadded_message():
     parsed = parse_job_message("something happened")
 
@@ -120,11 +225,8 @@ class _Runner:
         self.failed_job_results = failed
 
 
-class _Project:
-    name = "p"
-
-
 def test_run_result_and_run_errors_agree():
+    project = ProjectFactory()
     failed = _JobResult(
         item=_Item("kpi", "project.insights[0]"),
         success=False,
@@ -136,9 +238,10 @@ def test_run_result_and_run_errors_agree():
     )
     runner = _Runner(successful=[succeeded], failed=[failed])
 
-    result = run_result(runner=runner, project=_Project(), output_dir="target")
+    result = run_result(runner=runner, project=project, output_dir="target")
     errors = run_errors(runner)
 
+    assert result["project_name"] == project.name
     assert result["job_counts"] == {"succeeded": 1, "failed": 1, "total": 2}
     assert [job["name"] for job in result["jobs"]] == ["model", "kpi"]
     assert len(errors) == 1
@@ -147,6 +250,29 @@ def test_run_result_and_run_errors_agree():
     assert errors[0]["message"] == "boom"
     assert errors[0]["object_path"] == "project.insights[0]"
     assert errors[0]["details"] == {"kind": "missing_relation"}
+
+
+def test_run_errors_never_reports_a_prefix_line_as_the_file():
+    """`file` is opened by whoever reads the envelope; it must be a path."""
+    runner = _Runner(
+        successful=[],
+        failed=[
+            _JobResult(
+                item=_Item("kpi", "project.insights[0]"),
+                success=False,
+                message=(
+                    "Failed job for insight kpi ....[FAILURE 0.0s]"
+                    "\n\terror: Conversion Error"
+                    "\n        query saved to: target/logs/failed_queries/insight_kpi.sql"
+                ),
+            )
+        ],
+    )
+
+    error = run_errors(runner)[0]
+
+    assert error["file"] == "target/logs/failed_queries/insight_kpi.sql"
+    assert error["message"] == "Conversion Error"
 
 
 def test_errors_from_a_click_exception():

--- a/tests/commands/test_json_output.py
+++ b/tests/commands/test_json_output.py
@@ -19,6 +19,21 @@ from visivo.commands.json_output import (
 )
 
 
+def test_compile_result_covers_every_authorable_collection():
+    """`compile --json` must not silently omit a collection the schema advertises."""
+    from visivo.commands.json_output import _PROJECT_COLLECTIONS
+    from visivo.commands.schema_phase import CORE_PROJECT_PROPERTIES
+    from visivo.models.project import Project
+
+    properties = Project.model_json_schema(by_alias=False)["properties"]
+    list_valued = {
+        name for name in CORE_PROJECT_PROPERTIES if properties.get(name, {}).get("type") == "array"
+    }
+    # `includes` holds file references, not named objects -- an Include has a
+    # path, not a name, so reporting it would be a column of nulls.
+    assert set(_PROJECT_COLLECTIONS) == list_valued - {"includes"}
+
+
 def test_envelope_always_carries_every_key():
     payload = envelope(command="compile", success=True)
 

--- a/tests/commands/test_json_output.py
+++ b/tests/commands/test_json_output.py
@@ -165,6 +165,21 @@ def test_errors_from_a_click_exception():
     ]
 
 
+def test_errors_from_a_yaml_syntax_click_exception_carry_file_and_line():
+    """load_yaml_file already knows where the syntax error is -- keep that."""
+    errors = errors_from_exception(
+        click.ClickException(
+            "Invalid yaml in project\n"
+            "  Location: /work/my project/project.visivo.yml:4[4]\n"
+            "  Issue: expected <block end>"
+        )
+    )
+
+    assert errors[0]["code"] == "cli_error"
+    assert errors[0]["file"] == "/work/my project/project.visivo.yml"
+    assert errors[0]["line"] == 4
+
+
 def test_errors_from_an_arbitrary_exception():
     errors = errors_from_exception(RuntimeError("nope"))
 

--- a/tests/commands/test_json_output.py
+++ b/tests/commands/test_json_output.py
@@ -1,0 +1,220 @@
+import io
+import json
+
+import click
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from visivo.commands.json_output import (
+    ERROR_KEY_ORDER,
+    VISIVO_JSON_VERSION,
+    emit,
+    envelope,
+    errors_from_exception,
+    json_command,
+    parse_job_message,
+    run_errors,
+    run_result,
+    strip_ansi,
+)
+
+
+def test_envelope_always_carries_every_key():
+    payload = envelope(command="compile", success=True)
+
+    assert set(payload) == {
+        "visivo_json_version",
+        "command",
+        "success",
+        "cli_version",
+        "duration_ms",
+        "result",
+        "errors",
+    }
+    assert payload["visivo_json_version"] == VISIVO_JSON_VERSION
+    assert payload["result"] == {}
+    assert payload["errors"] == []
+
+
+def test_emit_writes_exactly_one_line_of_json():
+    stream = io.StringIO()
+
+    emit({"a": 1}, stream=stream)
+
+    assert stream.getvalue() == '{"a": 1}\n'
+
+
+def test_strip_ansi_removes_colour_codes():
+    assert strip_ansi("\033[32mgreen\033[0m") == "green"
+    assert strip_ansi(None) == ""
+
+
+def test_parse_job_message_undoes_the_alignment_padding():
+    parsed = parse_job_message(
+        "Wrote schema for model ev_sales ......................[SUCCESS 0.02s]"
+        "\n\ttarget/main/schemas/ev_sales.json"
+    )
+
+    assert parsed["summary"] == "Wrote schema for model ev_sales"
+    assert parsed["status"] == "SUCCESS"
+    assert parsed["error"] is None
+    assert parsed["artifact"] == "target/main/schemas/ev_sales.json"
+
+
+def test_parse_job_message_pulls_out_the_error_and_the_query_path():
+    parsed = parse_job_message(
+        "Failed job for insight kpi ....[FAILURE 0.0s]"
+        "\n\t\033[2mquery: target/insights/kpi/query.sql\033[0m"
+        "\n\t\033[2merror: Exception(\"Column 'x' not found\")\033[0m"
+    )
+
+    assert parsed["summary"] == "Failed job for insight kpi"
+    assert parsed["status"] == "FAILURE"
+    assert parsed["artifact"] == "target/insights/kpi/query.sql"
+    assert "Column 'x' not found" in parsed["error"]
+
+
+def test_parse_job_message_survives_an_unpadded_message():
+    parsed = parse_job_message("something happened")
+
+    assert parsed == {
+        "summary": "something happened",
+        "status": None,
+        "error": None,
+        "artifact": None,
+    }
+
+
+class _Item:
+    def __init__(self, name, path=None):
+        self.name = name
+        self.path = path
+
+
+class _JobResult:
+    def __init__(self, item, success, message, error_details=None):
+        self.item = item
+        self.success = success
+        self.message = message
+        self.error_details = error_details
+
+
+class _Runner:
+    def __init__(self, successful, failed):
+        self.successful_job_results = successful
+        self.failed_job_results = failed
+
+
+class _Project:
+    name = "p"
+
+
+def test_run_result_and_run_errors_agree():
+    failed = _JobResult(
+        item=_Item("kpi", "project.insights[0]"),
+        success=False,
+        message="Failed job for insight kpi ....[FAILURE 0.0s]\n\terror: boom",
+        error_details={"kind": "missing_relation"},
+    )
+    succeeded = _JobResult(
+        item=_Item("model"), success=True, message="Ran model ....[SUCCESS 0.1s]"
+    )
+    runner = _Runner(successful=[succeeded], failed=[failed])
+
+    result = run_result(runner=runner, project=_Project(), output_dir="target")
+    errors = run_errors(runner)
+
+    assert result["job_counts"] == {"succeeded": 1, "failed": 1, "total": 2}
+    assert [job["name"] for job in result["jobs"]] == ["model", "kpi"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == "job_failed"
+    assert errors[0]["name"] == "kpi"
+    assert errors[0]["message"] == "boom"
+    assert errors[0]["object_path"] == "project.insights[0]"
+    assert errors[0]["details"] == {"kind": "missing_relation"}
+
+
+def test_errors_from_a_click_exception():
+    errors = errors_from_exception(click.ClickException("bad yaml at file.yml:3"))
+
+    assert errors == [
+        {
+            "code": "cli_error",
+            "name": None,
+            "message": "bad yaml at file.yml:3",
+            "file": None,
+            "line": None,
+            "object_path": None,
+            "details": None,
+        }
+    ]
+
+
+def test_errors_from_an_arbitrary_exception():
+    errors = errors_from_exception(RuntimeError("nope"))
+
+    assert errors[0]["code"] == "RuntimeError"
+    assert errors[0]["message"] == "nope"
+    assert set(errors[0]) == set(ERROR_KEY_ORDER)
+
+
+def test_errors_from_a_bare_pydantic_validation_error():
+    class Model(BaseModel):
+        count: int
+
+    with pytest.raises(ValidationError) as raised:
+        Model(count="not-a-number")
+
+    errors = errors_from_exception(raised.value)
+
+    assert len(errors) == 1
+    assert errors[0]["code"] == "int_parsing"
+    assert errors[0]["object_path"] == "count"
+    assert errors[0]["file"] is None
+
+
+def test_json_command_emits_on_success(capsys):
+    with json_command("compile") as state:
+        print("a human log line")
+        state["result"] = {"ok": True}
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["success"] is True
+    assert payload["result"] == {"ok": True}
+    assert "a human log line" in captured.err
+    assert "a human log line" not in captured.out
+
+
+def test_json_command_turns_an_exception_into_the_envelope(capsys):
+    with pytest.raises(SystemExit) as raised:
+        with json_command("compile"):
+            raise RuntimeError("kaboom")
+
+    assert raised.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["errors"][0]["message"] == "kaboom"
+
+
+def test_json_command_still_emits_when_the_body_calls_sys_exit(capsys):
+    """An agent that got no JSON cannot tell a crash from a clean run."""
+    import sys
+
+    with pytest.raises(SystemExit) as raised:
+        with json_command("run"):
+            sys.exit(3)
+
+    assert raised.value.code == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["errors"][0]["code"] == "exited"
+
+
+def test_json_command_exits_non_zero_when_the_body_records_errors(capsys):
+    with pytest.raises(SystemExit) as raised:
+        with json_command("test") as state:
+            state["errors"] = [{"code": "test_failed"}]
+
+    assert raised.value.code == 1
+    assert json.loads(capsys.readouterr().out)["success"] is False

--- a/tests/commands/test_schema.py
+++ b/tests/commands/test_schema.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 import sys
 
+import pytest
 from click.testing import CliRunner
 
 from visivo.commands.schema import schema
@@ -181,3 +182,64 @@ def test_end_to_end_compile_json_stdout_is_only_the_envelope():
     assert json.loads(result.stdout)["command"] == "compile"
     assert "Starting Visivo" not in result.stdout
     assert "execution time" not in result.stdout
+
+
+# The `visivo` group takes options *before* the subcommand, so `argv[1]` is not
+# the command name. Detecting `schema` positionally missed every one of these
+# and put the banner and the timing line back on stdout, around the document.
+GROUP_OPTIONS_BEFORE_THE_SUBCOMMAND = [
+    ("-e", ".env"),
+    ("--env-file=.env",),
+    ("--verbose",),
+    ("-p",),
+    ("--verbose", "-e", ".env"),
+]
+
+
+@pytest.mark.parametrize("options", GROUP_OPTIONS_BEFORE_THE_SUBCOMMAND, ids=lambda o: " ".join(o))
+def test_end_to_end_schema_stdout_stays_clean_behind_group_options(options):
+    result = _cli(*options, "schema")
+
+    assert result.returncode == 0, result.stderr[:400]
+    assert "Starting Visivo" not in result.stdout
+    assert "execution time" not in result.stdout
+    assert "Profiling" not in result.stdout
+    # The real assertion: an agent redirects this into a file and parses it.
+    assert json.loads(result.stdout)["x-visivo-schema"]["mode"] == "core"
+
+
+@pytest.mark.parametrize("options", GROUP_OPTIONS_BEFORE_THE_SUBCOMMAND, ids=lambda o: " ".join(o))
+def test_end_to_end_schema_error_stays_off_stdout_behind_group_options(options):
+    """`visivo -e .env schema > core.json` must leave an empty file on failure."""
+    result = _cli(*options, "schema", "--core", "--full")
+
+    assert result.returncode == 1
+    assert result.stdout == "", f"error text landed on stdout: {result.stdout[:200]!r}"
+    assert "--core" in result.stderr
+
+
+@pytest.mark.parametrize("options", GROUP_OPTIONS_BEFORE_THE_SUBCOMMAND, ids=lambda o: " ".join(o))
+def test_end_to_end_compile_json_stays_clean_behind_group_options(options):
+    result = _cli(*options, "compile", "--json")
+
+    document = json.loads(result.stdout)
+    assert document["command"] == "compile"
+    assert "Starting Visivo" not in result.stdout
+    assert "execution time" not in result.stdout
+
+
+def test_subcommand_is_found_past_the_group_options():
+    """The unit behind the end-to-end tests above, including the cases that
+    must *not* be read as a subcommand."""
+    from visivo.command_line import _subcommand
+
+    assert _subcommand(["visivo", "schema"]) == "schema"
+    assert _subcommand(["visivo", "-e", ".env", "schema"]) == "schema"
+    assert _subcommand(["visivo", "--env-file=.env", "schema"]) == "schema"
+    assert _subcommand(["visivo", "-e.env", "schema"]) == "schema"
+    assert _subcommand(["visivo", "--verbose", "-p", "schema", "--core"]) == "schema"
+    assert _subcommand(["visivo", "compile", "--json"]) == "compile"
+    # `schema` here is the value of --env-file, not the command.
+    assert _subcommand(["visivo", "-e", "schema"]) is None
+    assert _subcommand(["visivo"]) is None
+    assert _subcommand(["visivo", "--version"]) is None

--- a/tests/commands/test_schema.py
+++ b/tests/commands/test_schema.py
@@ -1,0 +1,101 @@
+import json
+import os
+
+from click.testing import CliRunner
+
+from visivo.commands.schema import schema
+from visivo.models.props.types import PropType
+from tests.support.utils import temp_folder
+
+runner = CliRunner()
+
+
+def test_schema_emits_valid_json_on_stdout():
+    response = runner.invoke(schema, [])
+
+    assert response.exit_code == 0
+    document = json.loads(response.stdout)
+    assert document["x-visivo-schema"]["mode"] == "core"
+    assert "SqlModel" in document["$defs"]
+
+
+def test_schema_stdout_carries_nothing_but_the_document():
+    """An agent pipes this into a parser; a banner line would break it."""
+    response = runner.invoke(schema, [])
+
+    assert response.stdout.lstrip().startswith("{")
+    assert response.stdout.rstrip().endswith("}")
+    json.loads(response.stdout)
+
+
+def test_schema_full_includes_the_plotly_vocabulary():
+    response = runner.invoke(schema, ["--full"])
+
+    assert response.exit_code == 0
+    document = json.loads(response.stdout)
+    assert "Bar" in document["$defs"]
+    assert len(document["$defs"]["Layout"].get("properties", {})) > 50
+
+
+def test_schema_props_emits_one_trace_type():
+    response = runner.invoke(schema, ["--props", "bar"])
+
+    assert response.exit_code == 0
+    document = json.loads(response.stdout)
+    assert "properties" in document
+    # This is exactly what --core prunes: tens of thousands of bytes of Plotly.
+    assert len(response.stdout) > 50_000
+
+
+def test_schema_props_rejects_an_unknown_type():
+    response = runner.invoke(schema, ["--props", "barchart"])
+
+    assert response.exit_code != 0
+    assert "barchart" in response.output
+    # The error enumerates what IS valid, so an agent can self-correct.
+    assert "scatter" in response.output
+
+
+def test_schema_layout_emits_the_layout_vocabulary():
+    response = runner.invoke(schema, ["--layout"])
+
+    assert response.exit_code == 0
+    assert len(json.loads(response.stdout)["properties"]) > 50
+    assert len(response.stdout) > 100_000
+
+
+def test_schema_rejects_two_selectors():
+    response = runner.invoke(schema, ["--full", "--layout"])
+
+    assert response.exit_code != 0
+    assert "--full" in response.output
+
+
+def test_schema_writes_to_a_file():
+    output = os.path.join(temp_folder(), "core.json")
+    os.makedirs(os.path.dirname(output), exist_ok=True)
+
+    response = runner.invoke(schema, ["-o", output])
+
+    assert response.exit_code == 0
+    with open(output) as file:
+        document = json.load(file)
+    assert document["x-visivo-schema"]["mode"] == "core"
+    assert response.stdout.strip() == ""
+    assert "Schema written to" in response.stderr
+
+
+def test_schema_indent_pretty_prints():
+    response = runner.invoke(schema, ["--indent", "2"])
+
+    assert response.exit_code == 0
+    assert '\n  "' in response.stdout
+    json.loads(response.stdout)
+
+
+def test_every_prop_type_is_emittable():
+    """--props is the escape hatch for the vocabulary --core prunes: it must cover all of it."""
+    for prop_type in PropType:
+        response = runner.invoke(schema, ["--props", prop_type.value])
+        assert response.exit_code == 0, f"--props {prop_type.value} failed"
+        json.loads(response.stdout)

--- a/tests/commands/test_schema.py
+++ b/tests/commands/test_schema.py
@@ -1,5 +1,7 @@
 import json
 import os
+import re
+import shlex
 
 from click.testing import CliRunner
 
@@ -91,6 +93,31 @@ def test_schema_indent_pretty_prints():
     assert response.exit_code == 0
     assert '\n  "' in response.stdout
     json.loads(response.stdout)
+
+
+def test_core_flag_matches_the_default():
+    assert json.loads(runner.invoke(schema, ["--core"]).stdout) == json.loads(
+        runner.invoke(schema, []).stdout
+    )
+
+
+def test_every_command_the_schema_advertises_actually_runs():
+    """The `x-visivo-schema` block tells an agent what to run next. It must work."""
+    document = json.loads(runner.invoke(schema, []).stdout)
+    metadata = document["x-visivo-schema"]
+
+    advertised = {metadata["generated_by"], metadata["full_schema_command"]}
+    for note in metadata["pruned_vocabularies"].values():
+        advertised.update(re.findall(r"`(visivo schema[^`]*)`", note))
+
+    assert advertised, "the schema advertises no commands at all"
+    for command in sorted(advertised):
+        args = shlex.split(command)
+        assert args[:2] == ["visivo", "schema"], command
+        # `--props <type>` is a template; substitute a real type to run it.
+        args = ["bar" if arg == "<type>" else arg for arg in args[2:]]
+        response = runner.invoke(schema, args)
+        assert response.exit_code == 0, f"`{command}` does not run: {response.output[:200]}"
 
 
 def test_every_prop_type_is_emittable():

--- a/tests/commands/test_schema.py
+++ b/tests/commands/test_schema.py
@@ -2,6 +2,8 @@ import json
 import os
 import re
 import shlex
+import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -126,3 +128,56 @@ def test_every_prop_type_is_emittable():
         response = runner.invoke(schema, ["--props", prop_type.value])
         assert response.exit_code == 0, f"--props {prop_type.value} failed"
         json.loads(response.stdout)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end stdout purity.
+#
+# CliRunner invokes the subcommand directly, so it never exercises
+# command_line.py -- and that is where the "Starting Visivo..." banner, the
+# trailing execution-time line and the Halo spinner live, all of which write to
+# stdout and would corrupt the document. Only a real process proves the
+# contract, so these three shell out.
+# ---------------------------------------------------------------------------
+
+
+def _cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "visivo.command_line", *args],
+        capture_output=True,
+        text=True,
+        cwd=temp_folder_created(),
+    )
+
+
+def temp_folder_created():
+    folder = temp_folder()
+    os.makedirs(folder, exist_ok=True)
+    return os.path.abspath(folder)
+
+
+def test_end_to_end_schema_stdout_is_only_the_document():
+    result = _cli("schema")
+
+    assert result.returncode == 0
+    document = json.loads(result.stdout)
+    assert document["x-visivo-schema"]["mode"] == "core"
+    assert "Starting Visivo" not in result.stdout
+    assert "execution time" not in result.stdout
+
+
+def test_end_to_end_schema_error_leaves_stdout_empty():
+    """`visivo schema > core.json` must not write an error message into the file."""
+    result = _cli("schema", "--core", "--full")
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "--core" in result.stderr
+
+
+def test_end_to_end_compile_json_stdout_is_only_the_envelope():
+    result = _cli("compile", "--json")
+
+    assert json.loads(result.stdout)["command"] == "compile"
+    assert "Starting Visivo" not in result.stdout
+    assert "execution time" not in result.stdout

--- a/tests/commands/test_schema_phase.py
+++ b/tests/commands/test_schema_phase.py
@@ -11,6 +11,10 @@ from visivo.commands.schema_phase import (
     MACHINE_SET_FIELDS,
     OMITTED_PROJECT_PROPERTIES,
     SchemaSelectionError,
+    _authored_machine_set_fields,
+    _model_classes,
+    _pydantic_project_schema,
+    _validation_shape,
     core_schema,
     full_schema,
     layout_schema,
@@ -46,12 +50,19 @@ def test_core_schema_is_valid_json_schema():
 
 
 def test_core_schema_fits_in_a_prompt():
-    """The whole point: the full schema cannot go in a prompt, the core one can."""
+    """The whole point: the full schema cannot go in a prompt, the core one can.
+
+    The ceiling is a prompt budget, not a size target -- roughly 30k tokens,
+    with room for the models to grow. What actually keeps the schema small is
+    the selection rule, guarded structurally below (no trace-prop defs, a
+    `Layout` under 500 bytes); a ceiling with no headroom would just turn red
+    for an ordinary model addition and say nothing about the rule.
+    """
     core_bytes = len(json.dumps(core_schema()))
     full_bytes = len(json.dumps(full_schema()))
-    assert core_bytes < 100_000, f"core schema grew to {core_bytes} bytes"
+    assert core_bytes < 125_000, f"core schema grew to {core_bytes} bytes"
     assert full_bytes > 1_000_000
-    assert core_bytes < full_bytes / 20
+    assert core_bytes < full_bytes / 25
 
 
 def test_core_schema_keeps_every_object_an_agent_authors():
@@ -132,23 +143,173 @@ def test_core_schema_raises_when_a_project_field_is_unclassified(monkeypatch):
     assert "CORE_PROJECT_PROPERTIES" in str(error.value)
 
 
-def test_core_schema_root_holds_only_the_authoring_surface():
+def test_core_schema_root_describes_only_the_authoring_surface():
     schema = core_schema()
-    assert list(schema["properties"]) == CORE_PROJECT_PROPERTIES
-    for omitted in OMITTED_PROJECT_PROPERTIES:
-        assert omitted not in schema["properties"]
-    # Alerts and destinations are out, so their defs are unreachable and dropped.
+    assert list(schema["properties"])[: len(CORE_PROJECT_PROPERTIES)] == CORE_PROJECT_PROPERTIES
+    # Alerts and destinations are not *described*, so their defs are unreachable
+    # and dropped -- which is the whole size win.
     for name in ("Alert", "SlackDestination", "EmailDestination", "ConsoleDestination", "Dbt"):
         assert name not in schema["$defs"]
 
 
-def test_core_schema_drops_machine_set_fields_everywhere():
+def test_core_schema_accepts_the_omitted_but_authorable_root_fields():
+    """Omitted must not mean prohibited: the root forbids unknown keys.
+
+    `alerts`, `destinations` and `dbt` are undescribed because they are
+    orthogonal to building a dashboard -- not because writing them is a
+    mistake. Rejecting them would tell an agent that the user's own `alerts:`
+    block is an illegal key, and the obvious repair is to delete it.
+    """
+    schema = core_schema()
+    validator = jsonschema_rs.validator_for(schema)
+
+    for name in OMITTED_PROJECT_PROPERTIES:
+        if name in MACHINE_SET_FIELDS:
+            # Machine-set: a document carrying these is compiler output, and
+            # the core schema is deliberately an authoring contract.
+            assert name not in schema["properties"]
+            assert not validator.is_valid({"name": "p", name: "anything"})
+            continue
+        assert name in schema["properties"], f"{name} is omitted *and* prohibited"
+        assert "--full" in schema["properties"][name]["description"]
+        assert validator.is_valid({"name": "p", name: [{"anything": True}]})
+        assert validator.is_valid({"name": "p", name: {"anything": True}})
+
+
+def test_core_schema_validates_a_project_that_uses_alerts_and_includes():
+    """The shapes real projects in this repo are written in."""
+    validator = jsonschema_rs.validator_for(core_schema())
+    document = {
+        "name": "real",
+        "includes": [{"path": "models/orders.yml"}, {"path": "dashboards/", "depth": 1}],
+        "alerts": [{"name": "nightly", "destinations": [{"name": "slack"}]}],
+        "destinations": [{"name": "slack", "type": "slack", "webhook_url": "https://x"}],
+        "dbt": {"enabled": True},
+    }
+    assert [str(error) for error in validator.iter_errors(document)] == []
+
+
+def test_core_schema_drops_inherited_machine_set_fields_but_keeps_declared_ones():
+    """`MACHINE_SET_FIELDS` is a list of names, and a name is not proof.
+
+    `Include` declares its own `path` -- the only key an include has. Stripping
+    it by name leaves a definition that, being `additionalProperties: false`,
+    rejects the example printed in `Include`'s own description.
+    """
     schema = core_schema()
     for name, definition in schema["$defs"].items():
         properties = definition.get("properties") or {}
-        leaked = MACHINE_SET_FIELDS & set(properties)
-        assert not leaked, f"{name} still exposes machine-set field(s) {sorted(leaked)}"
+        kept = MACHINE_SET_FIELDS & set(properties)
+        expected = _authored_machine_set_fields(name, _model_classes())
+        assert kept == (expected & set(properties)), (
+            f"{name} keeps machine-set field(s) {sorted(kept)}; "
+            f"it declares {sorted(expected)} itself"
+        )
     assert not (MACHINE_SET_FIELDS & set(schema["properties"]))
+
+
+def test_core_schema_keeps_the_one_field_that_makes_includes_writable():
+    schema = core_schema()
+    assert "path" in schema["$defs"]["Include"]["properties"]
+    # ...and every other object still loses the inherited one.
+    assert "path" not in schema["$defs"]["SqlModel"]["properties"]
+    assert "file_path" not in schema["$defs"]["SqlModel"]["properties"]
+
+    validator = jsonschema_rs.validator_for(schema)
+    assert validator.is_valid({"name": "p", "includes": [{"path": "models/orders.yml"}]})
+    assert not validator.is_valid(
+        {"name": "p", "models": [{"name": "m", "sql": "select 1", "path": "project.models[0]"}]}
+    )
+
+
+def test_core_schema_has_no_unsatisfiable_one_of():
+    """Step 6a. A `oneOf` whose branches cannot discriminate rejects everything.
+
+    Pydantic renders `SecretStrOrEnvVar` -- a union chosen by a Python callable
+    -- as `oneOf: [{type: string}, {type: string, format: password}]`. Both
+    branches accept every string, `oneOf` demands exactly one match, so the
+    unrepaired schema rejects `password:` on all ten source types.
+    """
+    unsatisfiable = []
+
+    def walk(node, path):
+        if isinstance(node, dict):
+            branches = node.get("oneOf")
+            if isinstance(branches, list):
+                shapes = [_validation_shape(branch) for branch in branches]
+                if len(set(shapes)) < len(shapes):
+                    unsatisfiable.append(path)
+            for key, value in node.items():
+                walk(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+
+    walk(core_schema(), "")
+    assert unsatisfiable == [], f"unsatisfiable oneOf at {unsatisfiable[:5]}"
+
+    # ...and there really were some to repair, so this cannot pass vacuously.
+    walk(_pydantic_project_schema(), "")
+    assert unsatisfiable, "the Pydantic dump no longer has any to repair"
+
+
+def test_core_schema_accepts_a_password_on_every_source_type():
+    validator = jsonschema_rs.validator_for(core_schema())
+
+    for secret in ("hunter2", "${env.PG_PASSWORD}"):
+        document = {
+            "name": "p",
+            "sources": [
+                {
+                    "name": "pg",
+                    "type": "postgresql",
+                    "database": "postgres",
+                    "host": "localhost",
+                    "username": "postgres",
+                    "password": secret,
+                }
+            ],
+        }
+        errors = [str(error).splitlines()[0] for error in validator.iter_errors(document)]
+        assert errors == [], f"password {secret!r} rejected: {errors}"
+
+
+def test_core_schema_never_rejects_a_project_file_that_lives_in_this_repo():
+    """Every hand-written project YAML in the repo must satisfy the contract.
+
+    This is the test that catches a false negative the sample projects do not
+    cover: the repo's projects use `includes:`, `alerts:`, `dbt:` and database
+    passwords, and a subset that rejects any of those sends an agent to delete
+    working configuration.
+
+    The documented exception is the machine-set root keys. Two checked-in
+    projects carry `path: project`, which is compiler bookkeeping, and the core
+    schema rejects it on purpose -- "validate hand-written YAML with `--core`,
+    compiler output with `--full`". Dropping them here keeps that decision
+    explicit rather than hiding it; `test_core_schema_accepts_the_omitted_but
+    _authorable_root_fields` asserts they are still rejected.
+    """
+    validator = jsonschema_rs.validator_for(core_schema())
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    paths = sorted(
+        glob.glob(os.path.join(root, "test-projects", "**", "*.visivo.yml"), recursive=True)
+    )
+    assert len(paths) > 50, "expected the repo's test projects to be present"
+
+    rejected = {}
+    for path in paths:
+        try:
+            with open(path) as file:
+                document = yaml.safe_load(file)
+        except Exception:
+            continue  # A deliberately broken YAML fixture; not this test's job.
+        if not isinstance(document, dict):
+            continue
+        document = {key: value for key, value in document.items() if key not in MACHINE_SET_FIELDS}
+        errors = [str(error).splitlines()[0] for error in validator.iter_errors(document)]
+        if errors:
+            rejected[os.path.relpath(path, root)] = errors[0]
+    assert rejected == {}, f"{len(rejected)} project file(s) rejected by the core schema"
 
 
 def test_core_schema_has_no_unreachable_defs():
@@ -169,6 +330,31 @@ def test_core_schema_has_no_unreachable_defs():
     walk(schema["properties"])
     walk(schema["$defs"])
     assert set(schema["$defs"]) == referenced
+
+
+def test_core_schema_strips_pydantic_property_titles_but_keeps_def_titles():
+    """Step 5. `"title": "Source Name"` above a key literally named
+    `source_name` is restatement an agent pays tokens for; the `$def`'s own
+    title is the type name and stays.
+    """
+    schema = core_schema()
+
+    titled = [
+        f"{name}.{key}"
+        for name, definition in schema["$defs"].items()
+        for key, prop in (definition.get("properties") or {}).items()
+        if isinstance(prop, dict) and "title" in prop
+    ]
+    assert titled == [], f"property titles survived on {titled[:5]}"
+    assert [key for key, prop in schema["properties"].items() if "title" in prop] == []
+
+    # The definitions keep theirs -- that is the object's name, not a restatement.
+    assert schema["$defs"]["SqlModel"]["title"] == "SqlModel"
+    # ...and there really were titles to strip, so this test cannot pass vacuously.
+    from visivo.commands.schema_phase import _pydantic_project_schema
+
+    source = _pydantic_project_schema()
+    assert "title" in source["$defs"]["SqlModel"]["properties"]["sql"]
 
 
 def test_core_schema_restores_python_keyword_aliases():

--- a/tests/commands/test_schema_phase.py
+++ b/tests/commands/test_schema_phase.py
@@ -1,0 +1,244 @@
+import glob
+import json
+import os
+
+import jsonschema_rs
+import pytest
+import yaml
+
+from visivo.commands.schema_phase import (
+    CORE_PROJECT_PROPERTIES,
+    MACHINE_SET_FIELDS,
+    OMITTED_PROJECT_PROPERTIES,
+    SchemaSelectionError,
+    core_schema,
+    full_schema,
+    layout_schema,
+    props_schema,
+    schema_phase,
+)
+from visivo.models.project import Project
+from visivo.models.props.types import PropType
+
+SAMPLES_GLOB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "visivo",
+    "templates",
+    "samples",
+    "*",
+    "project.visivo.yml",
+)
+
+
+def sample_project_files():
+    files = sorted(glob.glob(SAMPLES_GLOB))
+    assert files, f"No sample projects found at {SAMPLES_GLOB}"
+    return files
+
+
+def test_core_schema_is_valid_json_schema():
+    schema = core_schema()
+    # Compiling the schema is the real assertion: jsonschema_rs raises if any
+    # $ref dangles or any keyword is malformed.
+    jsonschema_rs.validator_for(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["type"] == "object"
+
+
+def test_core_schema_fits_in_a_prompt():
+    """The whole point: the full schema cannot go in a prompt, the core one can."""
+    core_bytes = len(json.dumps(core_schema()))
+    full_bytes = len(json.dumps(full_schema()))
+    assert core_bytes < 100_000, f"core schema grew to {core_bytes} bytes"
+    assert full_bytes > 1_000_000
+    assert core_bytes < full_bytes / 20
+
+
+def test_core_schema_keeps_every_object_an_agent_authors():
+    defs = core_schema()["$defs"]
+    for name in (
+        "SqlModel",
+        "Metric",
+        "Dimension",
+        "Relation",
+        "Insight",
+        "InsightInteraction",
+        "Chart",
+        "Dashboard",
+        "Row",
+        "Item",
+        "Markdown",
+        "Table",
+        "Seed",
+        "SingleSelectInput",
+        "MultiSelectInput",
+    ):
+        assert name in defs, f"{name} missing from the core subset"
+
+
+def test_core_schema_keeps_every_source_type():
+    """An agent connecting to Snowflake needs Snowflake, not just the easy sources."""
+    defs = core_schema()["$defs"]
+    for name in (
+        "SqliteSource",
+        "PostgresqlSource",
+        "MysqlSource",
+        "SnowflakeSource",
+        "BigQuerySource",
+        "RedshiftSource",
+        "DuckdbSource",
+        "CSVFileSource",
+        "ExcelFileSource",
+        "ClickhouseSource",
+    ):
+        assert name in defs, f"{name} missing from the core subset"
+
+
+def test_core_schema_prunes_the_plotly_vocabulary():
+    schema = core_schema()
+    defs = schema["$defs"]
+    trace_defs = {member.value.capitalize() for member in PropType}
+    assert not (trace_defs & set(defs)), "Plotly trace-prop defs leaked into the core subset"
+    for vendored in ("xaxis", "yaxis", "colorscale"):
+        assert vendored not in defs
+
+    # Layout survives only as the open-object stub the $refs need; the 400 KB
+    # Plotly layout is gone.
+    assert len(json.dumps(defs["Layout"])) < 500
+    assert defs["Layout"].get("additionalProperties") is True
+
+    # ...and props still accepts any Plotly key, discriminated by `type`.
+    props = defs["InsightProps"]
+    assert props["additionalProperties"] is True
+    assert props["required"] == ["type"]
+
+
+def test_core_schema_classifies_every_project_field():
+    """The selection rule must stay honest as Project grows fields."""
+    classified = set(CORE_PROJECT_PROPERTIES) | set(OMITTED_PROJECT_PROPERTIES)
+    actual = set(Project.model_json_schema(by_alias=False)["properties"])
+    assert actual - classified == set(), "Project field(s) the selection rule does not classify"
+    assert not (set(CORE_PROJECT_PROPERTIES) & set(OMITTED_PROJECT_PROPERTIES))
+
+
+def test_core_schema_raises_when_a_project_field_is_unclassified(monkeypatch):
+    monkeypatch.setattr(
+        "visivo.commands.schema_phase.CORE_PROJECT_PROPERTIES",
+        [name for name in CORE_PROJECT_PROPERTIES if name != "dashboards"],
+    )
+    with pytest.raises(SchemaSelectionError) as error:
+        core_schema()
+    assert "dashboards" in str(error.value)
+    assert "CORE_PROJECT_PROPERTIES" in str(error.value)
+
+
+def test_core_schema_root_holds_only_the_authoring_surface():
+    schema = core_schema()
+    assert list(schema["properties"]) == CORE_PROJECT_PROPERTIES
+    for omitted in OMITTED_PROJECT_PROPERTIES:
+        assert omitted not in schema["properties"]
+    # Alerts and destinations are out, so their defs are unreachable and dropped.
+    for name in ("Alert", "SlackDestination", "EmailDestination", "ConsoleDestination", "Dbt"):
+        assert name not in schema["$defs"]
+
+
+def test_core_schema_drops_machine_set_fields_everywhere():
+    schema = core_schema()
+    for name, definition in schema["$defs"].items():
+        properties = definition.get("properties") or {}
+        leaked = MACHINE_SET_FIELDS & set(properties)
+        assert not leaked, f"{name} still exposes machine-set field(s) {sorted(leaked)}"
+    assert not (MACHINE_SET_FIELDS & set(schema["properties"]))
+
+
+def test_core_schema_has_no_unreachable_defs():
+    schema = core_schema()
+    referenced = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                referenced.add(ref[len("#/$defs/") :])
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(schema["properties"])
+    walk(schema["$defs"])
+    assert set(schema["$defs"]) == referenced
+
+
+def test_core_schema_restores_python_keyword_aliases():
+    """`if_` is a Python artifact; the YAML key -- and every doc example -- is `if`."""
+    test_def = core_schema()["$defs"]["Test"]
+    assert "if" in test_def["properties"]
+    assert test_def["properties"]["if_"]["deprecated"] is True
+    assert "write `if` instead" in test_def["properties"]["if_"]["description"]
+    # The 1.0-era source/target aliases must NOT come back this way.
+    assert "target" not in core_schema()["$defs"]["SqlModel"]["properties"]
+    assert "targets" not in core_schema()["properties"]
+
+
+def test_core_schema_documents_its_own_selection_rule():
+    metadata = core_schema()["x-visivo-schema"]
+    assert metadata["mode"] == "core"
+    assert metadata["omitted_project_properties"] == OMITTED_PROJECT_PROPERTIES
+    assert "--props" in metadata["pruned_vocabularies"]["insight_props"]
+    assert metadata["full_schema_command"] == "visivo schema --full"
+
+
+@pytest.mark.parametrize("sample_path", sample_project_files())
+def test_core_schema_validates_the_shipped_sample_projects(sample_path):
+    """The contract is only worth shipping if real Visivo projects satisfy it."""
+    validator = jsonschema_rs.validator_for(core_schema())
+    with open(sample_path) as file:
+        document = yaml.safe_load(file)
+    errors = [str(error) for error in validator.iter_errors(document)]
+    assert errors == [], f"{sample_path} does not validate against the core schema"
+
+
+def test_core_schema_rejects_a_misspelled_key():
+    """A schema that accepts anything would validate the samples too."""
+    validator = jsonschema_rs.validator_for(core_schema())
+
+    assert not validator.is_valid(
+        {"name": "p", "models": [{"name": "m", "sql": "select 1", "sqll": "select 1"}]}
+    ), "a misspelled key inside an object must be rejected"
+    assert not validator.is_valid(
+        {"name": "p", "modles": []}
+    ), "a misspelled key at the project root must be rejected"
+    assert validator.is_valid({"name": "p", "models": [{"name": "m", "sql": "select 1"}]})
+
+
+def test_props_schema_returns_the_pruned_plotly_vocabulary():
+    bar = props_schema("bar")
+    assert len(json.dumps(bar)) > 50_000
+    assert "properties" in bar
+    assert props_schema("BAR ") == bar
+
+
+def test_props_schema_rejects_an_unknown_type():
+    with pytest.raises(SchemaSelectionError) as error:
+        props_schema("barchart")
+    assert "barchart" in str(error.value)
+    assert "bar" in str(error.value)
+
+
+def test_layout_schema_is_the_big_one():
+    assert len(json.dumps(layout_schema())) > 100_000
+
+
+def test_schema_phase_defaults_to_core_and_honours_indent():
+    assert json.loads(schema_phase())["x-visivo-schema"]["mode"] == "core"
+    assert "\n" in schema_phase(indent=2)
+    assert "\n" not in schema_phase()
+
+
+def test_schema_phase_rejects_two_selectors():
+    with pytest.raises(SchemaSelectionError) as error:
+        schema_phase(full=True, layout=True)
+    assert "--full" in str(error.value)
+    assert "--layout" in str(error.value)

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -206,28 +206,38 @@ def _track_command_execution(
     telemetry_client.track(event)
 
 
-def _emit_json_error(command_name, exception) -> bool:
+def _report_error_for_agent(command_name, exception, message) -> bool:
     """
-    Last-resort JSON envelope for a `--json` invocation that failed before (or
+    Keep stdout clean for a machine-readable invocation that failed before (or
     outside of) the command body's own handler -- a bad option value, say, or an
-    error raised while click was still parsing. Returns True when it printed.
-    """
-    if not JSON_INVOCATION:
-        return False
-    try:
-        from visivo.commands.json_output import emit, envelope, errors_from_exception
+    error raised while click was still parsing.
 
-        emit(
-            envelope(
-                command=command_name or "visivo",
-                success=False,
-                errors=errors_from_exception(exception),
+    For `--json` that means the structured envelope on stdout; for
+    `visivo schema` it means the human message on stderr, so that
+    `visivo schema > core.json` leaves an empty file rather than one containing
+    an error message. Returns True when it printed.
+    """
+    if JSON_INVOCATION:
+        try:
+            from visivo.commands.json_output import emit, envelope, errors_from_exception
+
+            emit(
+                envelope(
+                    command=command_name or "visivo",
+                    success=False,
+                    errors=errors_from_exception(exception),
+                )
             )
-        )
+            return True
+        except Exception:
+            # Never let the JSON path swallow the original error.
+            return False
+
+    if SCHEMA_INVOCATION:
+        click.echo(message, err=True)
         return True
-    except Exception:
-        # Never let the JSON path swallow the original error.
-        return False
+
+    return False
 
 
 def safe_visivo():
@@ -256,7 +266,7 @@ def safe_visivo():
 
     except (ValidationError, LineValidationError) as e:
         error_type = type(e).__name__
-        if _emit_json_error(command_name, e):
+        if _report_error_for_agent(command_name, e, str(e)):
             sys.exit(1)
         Logger.instance().error(str(e))
         sys.exit(1)
@@ -268,7 +278,7 @@ def safe_visivo():
         # percent-encodes the ENTIRE stack trace into a giant OSC-8 terminal
         # hyperlink (smoke-test bug #14).
         error_type = type(e).__name__
-        if _emit_json_error(command_name, e):
+        if _report_error_for_agent(command_name, e, e.format_message()):
             sys.exit(1)
         Logger.instance().error(e.format_message())
         sys.exit(1)
@@ -276,7 +286,7 @@ def safe_visivo():
         error_type = type(e).__name__
         if "STACKTRACE" in os.environ and os.environ["STACKTRACE"] == "true":
             raise e
-        if _emit_json_error(command_name, e):
+        if _report_error_for_agent(command_name, e, f"An unexpected error has occurred: {e}"):
             sys.exit(1)
         Logger.instance().error("An unexpected error has occurred")
         Logger.instance().error(str(e))

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -10,7 +10,18 @@ from visivo.logger.logger import Logger, TypeEnum
 # Note: "-h" is NOT a help alias in this CLI — it is the short flag for
 # --host on deploy/archive/authorize — so only the long forms are quiet.
 # A bare `visivo` prints usage, which is help-shaped output too.
-QUIET_INVOCATION = len(_sys.argv) <= 1 or bool({"--version", "--help"} & set(_sys.argv[1:]))
+
+# Machine-readable invocations put a JSON document on stdout and must not have
+# it prefixed by a banner or suffixed by a timing line: `--json` on
+# compile/run/test, and every `visivo schema` invocation. They also must not
+# start a Halo spinner, which writes to stdout directly.
+JSON_INVOCATION = "--json" in _sys.argv[1:]
+SCHEMA_INVOCATION = len(_sys.argv) > 1 and _sys.argv[1] == "schema"
+AGENT_INVOCATION = JSON_INVOCATION or SCHEMA_INVOCATION
+
+QUIET_INVOCATION = (
+    len(_sys.argv) <= 1 or bool({"--version", "--help"} & set(_sys.argv[1:])) or AGENT_INVOCATION
+)
 
 if not QUIET_INVOCATION:
     Logger.instance().info("Starting Visivo...")
@@ -38,6 +49,7 @@ from visivo.commands.archive import archive
 from visivo.commands.authorize import authorize
 from visivo.commands.list import list
 from visivo.commands.migrate import migrate
+from visivo.commands.schema import schema
 from visivo.version import VISIVO_VERSION
 
 
@@ -52,7 +64,9 @@ from visivo.version import VISIVO_VERSION
 @click.version_option(version=VISIVO_VERSION)
 @verbose
 def visivo(env_file, profile, verbose):
-    Logger.instance().set_type(TypeEnum.spinner)
+    # A spinner writes escape sequences straight to stdout, which would corrupt
+    # the JSON document an agent-facing invocation prints there.
+    Logger.instance().set_type(TypeEnum.console if AGENT_INVOCATION else TypeEnum.spinner)
     load_env(env_file)
 
     # Profiling can be done with https://github.com/nschloe/tuna
@@ -90,6 +104,7 @@ visivo.add_command(authorize)
 visivo.add_command(create)
 visivo.add_command(list)
 visivo.add_command(migrate)
+visivo.add_command(schema)
 
 
 def load_env(env_file):
@@ -191,6 +206,30 @@ def _track_command_execution(
     telemetry_client.track(event)
 
 
+def _emit_json_error(command_name, exception) -> bool:
+    """
+    Last-resort JSON envelope for a `--json` invocation that failed before (or
+    outside of) the command body's own handler -- a bad option value, say, or an
+    error raised while click was still parsing. Returns True when it printed.
+    """
+    if not JSON_INVOCATION:
+        return False
+    try:
+        from visivo.commands.json_output import emit, envelope, errors_from_exception
+
+        emit(
+            envelope(
+                command=command_name or "visivo",
+                success=False,
+                errors=errors_from_exception(exception),
+            )
+        )
+        return True
+    except Exception:
+        # Never let the JSON path swallow the original error.
+        return False
+
+
 def safe_visivo():
     # Clear telemetry context for fresh start
     get_telemetry_context().clear()
@@ -217,6 +256,8 @@ def safe_visivo():
 
     except (ValidationError, LineValidationError) as e:
         error_type = type(e).__name__
+        if _emit_json_error(command_name, e):
+            sys.exit(1)
         Logger.instance().error(str(e))
         sys.exit(1)
     except click.ClickException as e:
@@ -227,12 +268,16 @@ def safe_visivo():
         # percent-encodes the ENTIRE stack trace into a giant OSC-8 terminal
         # hyperlink (smoke-test bug #14).
         error_type = type(e).__name__
+        if _emit_json_error(command_name, e):
+            sys.exit(1)
         Logger.instance().error(e.format_message())
         sys.exit(1)
     except Exception as e:
         error_type = type(e).__name__
         if "STACKTRACE" in os.environ and os.environ["STACKTRACE"] == "true":
             raise e
+        if _emit_json_error(command_name, e):
+            sys.exit(1)
         Logger.instance().error("An unexpected error has occurred")
         Logger.instance().error(str(e))
         Logger.instance().error(

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -11,12 +11,42 @@ from visivo.logger.logger import Logger, TypeEnum
 # --host on deploy/archive/authorize — so only the long forms are quiet.
 # A bare `visivo` prints usage, which is help-shaped output too.
 
+# Group-level options that consume the token after them. Everything else the
+# `visivo` group takes (-p/--profile, --verbose, --version, --help) is a flag,
+# so the first token that is neither an option nor one of these values is the
+# subcommand. `--env-file=x` and `-e.env` attach their value and need no entry.
+_GROUP_VALUE_OPTIONS = frozenset({"-e", "--env-file"})
+
+
+def _subcommand(argv):
+    """The subcommand name, however many group options precede it.
+
+    Keying off ``argv[1]`` is wrong: the group accepts options before the
+    subcommand, so `visivo -e .env schema` and `visivo --verbose schema` are
+    both still `schema` invocations. Missing them put the startup banner and
+    the trailing execution-time line on stdout, in front of and behind the JSON
+    document -- and routed the error message for a bad `schema` flag to stdout
+    as well, straight into the file the agent was redirecting into.
+    """
+    skip = False
+    for token in argv[1:]:
+        if skip:
+            skip = False
+            continue
+        if token.startswith("-"):
+            skip = token in _GROUP_VALUE_OPTIONS
+            continue
+        return token
+    return None
+
+
 # Machine-readable invocations put a JSON document on stdout and must not have
 # it prefixed by a banner or suffixed by a timing line: `--json` on
 # compile/run/test, and every `visivo schema` invocation. They also must not
 # start a Halo spinner, which writes to stdout directly.
+SUBCOMMAND = _subcommand(_sys.argv)
 JSON_INVOCATION = "--json" in _sys.argv[1:]
-SCHEMA_INVOCATION = len(_sys.argv) > 1 and _sys.argv[1] == "schema"
+SCHEMA_INVOCATION = SUBCOMMAND == "schema"
 AGENT_INVOCATION = JSON_INVOCATION or SCHEMA_INVOCATION
 
 QUIET_INVOCATION = (
@@ -78,13 +108,23 @@ def visivo(env_file, profile, verbose):
         import cProfile
         import atexit
 
-        Logger.instance().info("Profiling...")
+        # `-p` is a group option, so it can precede the subcommand: `visivo -p
+        # schema` is still a schema invocation, and Logger.info writes to
+        # stdout, which would put "Profiling..." in front of the document and
+        # "Profiling completed" behind it.
+        def note(message):
+            if AGENT_INVOCATION:
+                click.echo(message, err=True)
+            else:
+                Logger.instance().info(message)
+
+        note("Profiling...")
         pr = cProfile.Profile()
         pr.enable()
 
         def exit():
             pr.disable()
-            Logger.instance().info("Profiling completed")
+            note("Profiling completed")
             pr.dump_stats("visivo-profile.dmp")
 
         atexit.register(exit)
@@ -223,7 +263,11 @@ def _report_error_for_agent(command_name, exception, message) -> bool:
 
             emit(
                 envelope(
-                    command=command_name or "visivo",
+                    # SUBCOMMAND, not command_name: the telemetry sanitizer
+                    # reads argv[1] and reports "help" for anything starting
+                    # with a dash, so `visivo -e .env compile --json` would
+                    # otherwise label its envelope "help".
+                    command=SUBCOMMAND or command_name or "visivo",
                     success=False,
                     errors=errors_from_exception(exception),
                 )

--- a/visivo/commands/compile.py
+++ b/visivo/commands/compile.py
@@ -6,6 +6,7 @@ from visivo.commands.options import (
     dbt_profile,
     dbt_target,
     no_deprecation_warnings,
+    json_output,
 )
 
 
@@ -16,22 +17,38 @@ from visivo.commands.options import (
 @dbt_profile
 @dbt_target
 @no_deprecation_warnings
-def compile(working_dir, output_dir, source, dbt_profile, dbt_target, no_deprecation_warnings):
+@json_output
+def compile(
+    working_dir, output_dir, source, dbt_profile, dbt_target, no_deprecation_warnings, json_output
+):
     """
     Parses the files in your working directory, extracting visivo configurations and then using those configurations to build the insight queries in your output directory. Queries are not run on compile, just written.
     """
     from visivo.logger.logger import Logger
 
-    Logger.instance().info("Compiling")
+    def _compile():
+        Logger.instance().info("Compiling")
 
-    from visivo.commands.compile_phase import compile_phase
+        from visivo.commands.compile_phase import compile_phase
 
-    compile_phase(
-        default_source=source,
-        working_dir=working_dir,
-        output_dir=output_dir,
-        dbt_profile=dbt_profile,
-        dbt_target=dbt_target,
-        no_deprecation_warnings=no_deprecation_warnings,
-    )
+        return compile_phase(
+            default_source=source,
+            working_dir=working_dir,
+            output_dir=output_dir,
+            dbt_profile=dbt_profile,
+            dbt_target=dbt_target,
+            no_deprecation_warnings=no_deprecation_warnings,
+        )
+
+    if json_output:
+        from visivo.commands.json_output import compile_result, json_command
+
+        with json_command("compile") as state:
+            project = _compile()
+            state["result"] = compile_result(
+                project=project, working_dir=working_dir, output_dir=output_dir
+            )
+        return
+
+    _compile()
     Logger.instance().success("Done")

--- a/visivo/commands/compile.py
+++ b/visivo/commands/compile.py
@@ -1,4 +1,5 @@
 import click
+from visivo.commands.json_output import json_output
 from visivo.commands.options import (
     output_dir,
     working_dir,
@@ -6,7 +7,6 @@ from visivo.commands.options import (
     dbt_profile,
     dbt_target,
     no_deprecation_warnings,
-    json_output,
 )
 
 

--- a/visivo/commands/json_output.py
+++ b/visivo/commands/json_output.py
@@ -1,0 +1,577 @@
+"""
+``--json`` output for ``visivo compile``, ``visivo run`` and ``visivo test``.
+
+An agent driving the CLI should not have to scrape human log lines to find out
+what happened. With ``--json`` each of those three commands prints exactly one
+JSON object on **stdout** and nothing else; every human-readable line the
+command would normally print goes to **stderr** instead. The process exit code
+is unchanged, so ``&&`` chains keep working.
+
+THE ENVELOPE (stable; keys are always present)
+==============================================
+
+.. code-block:: json
+
+    {
+      "visivo_json_version": 1,
+      "command": "compile",
+      "success": true,
+      "cli_version": "2.1.1",
+      "duration_ms": 812,
+      "result": {},
+      "errors": []
+    }
+
+``result`` is command-specific and documented on the three ``*_result``
+builders below. ``errors`` is always a list -- empty on success -- of objects
+with this stable shape:
+
+.. code-block:: json
+
+    {
+      "code": "bad_reference",
+      "name": "total_units_kpi",
+      "message": "The reference \\"ref(orders)\\" does not point to an object.",
+      "file": "project.visivo.yml",
+      "line": 31,
+      "object_path": "project.insights[0]",
+      "details": null
+    }
+
+Any of ``name``, ``file``, ``line``, ``object_path`` and ``details`` may be
+``null`` when the CLI genuinely does not know the value; the key is still
+there, so a consumer can index without guarding.
+
+NOTE FOR THE DIAGNOSTIC WORK (PR #650): this module deliberately defines its
+own flat error shape rather than importing ``visivo.models.diagnostic``, which
+that PR owns. Once #650 lands, ``_error`` should be replaced by the Diagnostic
+contract and ``visivo_json_version`` bumped to 2.
+"""
+
+import json
+import re
+import sys
+from contextlib import contextmanager, redirect_stdout
+from time import time
+from typing import Any, Dict, List, Optional
+
+#: Bump when the envelope changes shape in a way a consumer would notice.
+VISIVO_JSON_VERSION = 1
+
+#: The keys every entry of ``errors`` carries, in order. Documented contract:
+#: add to the end, never remove, and bump ``VISIVO_JSON_VERSION`` if that ever
+#: stops being true.
+ERROR_KEY_ORDER = ("code", "name", "message", "file", "line", "object_path", "details")
+
+#: The keys the envelope itself carries, same rules.
+ENVELOPE_KEY_ORDER = (
+    "visivo_json_version",
+    "command",
+    "success",
+    "cli_version",
+    "duration_ms",
+    "result",
+    "errors",
+)
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+#: Project fields whose members get reported back in ``compile``'s result.
+_PROJECT_COLLECTIONS = (
+    "sources",
+    "models",
+    "metrics",
+    "dimensions",
+    "relations",
+    "insights",
+    "charts",
+    "tables",
+    "markdowns",
+    "inputs",
+    "dashboards",
+    "tests",
+)
+
+
+def strip_ansi(text: Any) -> str:
+    return _ANSI.sub("", str(text)) if text is not None else ""
+
+
+def _error(
+    code: str,
+    message: str,
+    name: Optional[str] = None,
+    file: Optional[str] = None,
+    line: Optional[int] = None,
+    object_path: Optional[str] = None,
+    details: Optional[dict] = None,
+) -> Dict[str, Any]:
+    values = {
+        "code": code,
+        "name": name,
+        "message": strip_ansi(message).strip(),
+        "file": file,
+        "line": line,
+        "object_path": object_path,
+        "details": details,
+    }
+    return {key: values[key] for key in ERROR_KEY_ORDER}
+
+
+def envelope(
+    command: str,
+    success: bool,
+    result: Optional[dict] = None,
+    errors: Optional[List[dict]] = None,
+    duration_ms: Optional[int] = None,
+) -> Dict[str, Any]:
+    from visivo.version import VISIVO_VERSION
+
+    values = {
+        "visivo_json_version": VISIVO_JSON_VERSION,
+        "command": command,
+        "success": success,
+        "cli_version": VISIVO_VERSION,
+        "duration_ms": duration_ms,
+        "result": result if result is not None else {},
+        "errors": errors if errors is not None else [],
+    }
+    return {key: values[key] for key in ENVELOPE_KEY_ORDER}
+
+
+# ---------------------------------------------------------------------------
+# Turning exceptions into the error array.
+# ---------------------------------------------------------------------------
+
+
+def _split_location(location: Optional[str]):
+    """``"project.visivo.yml:14"`` -> ``("project.visivo.yml", 14)``."""
+    if not location:
+        return (None, None)
+    text = location.strip()
+    file_name, separator, line_text = text.rpartition(":")
+    if separator and line_text.isdigit():
+        return (file_name or None, int(line_text))
+    return (text or None, None)
+
+
+def _location_for(line_validation_error, pydantic_error) -> tuple:
+    """Best-effort ``(file, line)`` for one pydantic error entry."""
+    try:
+        message = line_validation_error.get_line_message(pydantic_error)
+    except Exception:
+        return (None, None)
+    if not message:
+        return (None, None)
+    _, _, tail = message.partition("Location:")
+    return _split_location(tail.strip())
+
+
+def _name_and_path(pydantic_error) -> tuple:
+    """Best-effort ``(name, object_path)`` for one pydantic error entry.
+
+    ``name`` stays ``None`` rather than guessing: for
+    ``loc == ("models", 0, "bogus_field")`` the last string is a *field* name,
+    and reporting it as the object's name would send an agent to the wrong
+    place. ``_resolve_in_files`` fills it in from the YAML when it can.
+    """
+    context = pydantic_error.get("ctx")
+    name = None
+    object_path = None
+    if isinstance(context, dict):
+        name = context.get("name")
+        object_path = context.get("path")
+
+    location = pydantic_error.get("loc") or ()
+    if object_path is None and location:
+        object_path = ".".join(str(part) for part in location)
+    return (name, object_path)
+
+
+def _yaml_documents(files):
+    """Re-load the project's YAML with the line-annotating loader."""
+    import yaml
+
+    from visivo.parsers.yaml_ordered_dict import setup_yaml_ordered_dict
+
+    setup_yaml_ordered_dict()
+    documents = []
+    for path in files or []:
+        try:
+            with open(path, "r") as handle:
+                documents.append((str(path), yaml.safe_load(handle)))
+        except Exception:
+            continue
+    return documents
+
+
+def _find_named(node, name):
+    """The mapping in ``node`` whose ``name`` is ``name``, or None."""
+    if isinstance(node, dict):
+        if node.get("name") == name:
+            return node
+        for value in node.values():
+            found = _find_named(value, name)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for value in node:
+            found = _find_named(value, name)
+            if found is not None:
+                return found
+    return None
+
+
+def _key_location(mapping, key: str) -> Optional[str]:
+    locator = getattr(mapping, "key_loc", None)
+    return locator(key) if callable(locator) else None
+
+
+def _resolve_in_files(files, name: Optional[str], location) -> tuple:
+    """Walk the project YAML for ``(name, file, line)`` the error did not carry.
+
+    Two independent lookups, both structural (the YAML is parsed, not pattern
+    matched):
+
+    * a named object -- the ``name:`` key's own file and line;
+    * a ``("<collection>", <index>, ...)`` location -- the object at that
+      index, but only when exactly one file has such an entry, so a project
+      split across ``includes`` reports nothing rather than the wrong object.
+    """
+    documents = _yaml_documents(files)
+    if not documents:
+        return (name, None, None)
+
+    if name:
+        for file_name, document in documents:
+            mapping = _find_named(document, name)
+            if mapping is not None:
+                return (name, file_name, _split_location(_key_location(mapping, "name"))[1])
+        return (name, None, None)
+
+    parts = list(location or ())
+    if len(parts) >= 2 and isinstance(parts[0], str) and isinstance(parts[1], int):
+        collection, index = parts[0], parts[1]
+        candidates = []
+        for file_name, document in documents:
+            entries = document.get(collection) if isinstance(document, dict) else None
+            if isinstance(entries, list) and index < len(entries):
+                entry = entries[index]
+                if isinstance(entry, dict) and entry.get("name"):
+                    candidates.append((entry, file_name))
+        if len(candidates) == 1:
+            entry, file_name = candidates[0]
+            return (
+                entry.get("name"),
+                file_name,
+                _split_location(_key_location(entry, "name"))[1],
+            )
+    return (name, None, None)
+
+
+def errors_from_exception(exception: BaseException) -> List[dict]:
+    """Flatten any exception the CLI raises into the stable error array."""
+    from pydantic import ValidationError
+
+    from visivo.parsers.line_validation_error import LineValidationError
+
+    if isinstance(exception, LineValidationError):
+        errors = []
+        for pydantic_error in exception.validation_error.errors():
+            name, object_path = _name_and_path(pydantic_error)
+            file_name, line = _location_for(exception, pydantic_error)
+            if name is None or file_name is None or line is None:
+                resolved_name, resolved_file, resolved_line = _resolve_in_files(
+                    exception.files, name, pydantic_error.get("loc")
+                )
+                name = name or resolved_name
+                file_name = file_name or resolved_file
+                line = line if line is not None else resolved_line
+            errors.append(
+                _error(
+                    code=pydantic_error.get("type", "validation_error"),
+                    message=pydantic_error.get("msg", ""),
+                    name=name,
+                    file=file_name,
+                    line=line,
+                    object_path=object_path,
+                )
+            )
+        return errors or [_error(code="validation_error", message=str(exception))]
+
+    if isinstance(exception, ValidationError):
+        errors = []
+        for pydantic_error in exception.errors():
+            name, object_path = _name_and_path(pydantic_error)
+            errors.append(
+                _error(
+                    code=pydantic_error.get("type", "validation_error"),
+                    message=pydantic_error.get("msg", ""),
+                    name=name,
+                    object_path=object_path,
+                )
+            )
+        return errors or [_error(code="validation_error", message=str(exception))]
+
+    import click
+
+    if isinstance(exception, click.ClickException):
+        return [_error(code="cli_error", message=exception.format_message())]
+
+    return [_error(code=type(exception).__name__, message=str(exception))]
+
+
+# ---------------------------------------------------------------------------
+# Per-command results.
+# ---------------------------------------------------------------------------
+
+
+def _names(collection) -> List[str]:
+    return [getattr(item, "name", None) or str(item) for item in (collection or [])]
+
+
+def compile_result(project, working_dir: str, output_dir: str) -> Dict[str, Any]:
+    """``compile``: what the CLI actually parsed out of the project files.
+
+    ``objects`` maps each authorable project collection to the names it holds,
+    so an agent can confirm the object it just wrote was picked up.
+    """
+    objects = {
+        collection: _names(getattr(project, collection, None))
+        for collection in _PROJECT_COLLECTIONS
+    }
+    return {
+        "project_name": getattr(project, "name", None),
+        "working_dir": working_dir,
+        "output_dir": output_dir,
+        "objects": objects,
+        "object_counts": {key: len(value) for key, value in objects.items()},
+    }
+
+
+#: The DAG runner formats each job as
+#: ``"<summary> ......[STATUS 0.3s]"`` followed by optional ``error:`` and
+#: artifact-path continuation lines. Undo that padding rather than handing an
+#: agent a log line full of alignment dots.
+_JOB_LINE = re.compile(r"^(?P<summary>.*?)\s*\.{3,}\s*\[(?P<status>[^\]]*)\]\s*$")
+
+
+def parse_job_message(message: Any) -> Dict[str, Optional[str]]:
+    """``(summary, status, error, artifact)`` out of one formatted job message."""
+    lines = [line.strip() for line in strip_ansi(message).split("\n")]
+    lines = [line for line in lines if line]
+    parsed: Dict[str, Optional[str]] = {
+        "summary": lines[0] if lines else None,
+        "status": None,
+        "error": None,
+        "artifact": None,
+    }
+    if lines:
+        match = _JOB_LINE.match(lines[0])
+        if match:
+            parsed["summary"] = match.group("summary").strip()
+            status = match.group("status").split()
+            parsed["status"] = status[0] if status else None
+    for line in lines[1:]:
+        if line.startswith("error:"):
+            parsed["error"] = line[len("error:") :].strip()
+        else:
+            for prefix in ("query:", "database file:"):
+                if line.startswith(prefix):
+                    line = line[len(prefix) :].strip()
+                    break
+            parsed["artifact"] = line
+    return parsed
+
+
+def _job_entry(job_result) -> Dict[str, Any]:
+    item = getattr(job_result, "item", None)
+    parsed = parse_job_message(getattr(job_result, "message", ""))
+    return {
+        "name": getattr(item, "name", None),
+        "type": type(item).__name__ if item is not None else None,
+        "success": bool(getattr(job_result, "success", False)),
+        "summary": parsed["summary"],
+        "error": parsed["error"],
+        "artifact": parsed["artifact"],
+    }
+
+
+def run_result(runner, project, output_dir: str) -> Dict[str, Any]:
+    """``run``: one entry per job the DAG runner executed, in the order it finished.
+
+    Each entry is ``{name, type, success, summary, error, artifact}``: ``summary``
+    is the runner's one-line description with its alignment padding removed,
+    ``error`` is the exception text for a failed job (``null`` otherwise), and
+    ``artifact`` is the file the job wrote or was reading (``null`` when the job
+    did not name one).
+    """
+    succeeded = [_job_entry(result) for result in getattr(runner, "successful_job_results", [])]
+    failed = [_job_entry(result) for result in getattr(runner, "failed_job_results", [])]
+    return {
+        "project_name": getattr(project, "name", None),
+        "output_dir": output_dir,
+        "jobs": succeeded + failed,
+        "job_counts": {
+            "succeeded": len(succeeded),
+            "failed": len(failed),
+            "total": len(succeeded) + len(failed),
+        },
+    }
+
+
+def run_errors(runner) -> List[dict]:
+    errors = []
+    for job_result in getattr(runner, "failed_job_results", []):
+        item = getattr(job_result, "item", None)
+        details = getattr(job_result, "error_details", None)
+        parsed = parse_job_message(getattr(job_result, "message", ""))
+        errors.append(
+            _error(
+                code="job_failed",
+                message=parsed["error"] or parsed["summary"] or "",
+                name=getattr(item, "name", None),
+                file=parsed["artifact"],
+                object_path=getattr(item, "path", None),
+                details=details if isinstance(details, dict) else None,
+            )
+        )
+    return errors
+
+
+def _test_names(project) -> Dict[str, str]:
+    """``{test.path: test.name}`` -- a ``TestRun`` only carries the path."""
+    try:
+        from visivo.models.test import Test
+
+        return {
+            test.path: test.name for test in project.descendants_of_type(type=Test) if test.path
+        }
+    except Exception:
+        return {}
+
+
+def test_result(test_run, project, output_dir: str) -> Dict[str, Any]:
+    """``test``: every assertion the run evaluated, passing and failing.
+
+    Each entry is ``{test_id, name, passed, message}``. ``test_id`` is the
+    test's project path (what the runner reports); ``name`` is the test's own
+    name, resolved off the project, or ``null`` if it cannot be matched.
+    """
+    names = _test_names(project)
+    results = [
+        {
+            "test_id": success.test_id,
+            "name": names.get(success.test_id),
+            "passed": True,
+            "message": None,
+        }
+        for success in getattr(test_run, "successes", [])
+    ]
+    results += [
+        {
+            "test_id": failure.test_id,
+            "name": names.get(failure.test_id),
+            "passed": False,
+            "message": strip_ansi(failure.message),
+        }
+        for failure in getattr(test_run, "failures", [])
+    ]
+    return {
+        "project_name": getattr(project, "name", None),
+        "output_dir": output_dir,
+        "tests": results,
+        "test_counts": {
+            "passed": len(getattr(test_run, "successes", [])),
+            "failed": len(getattr(test_run, "failures", [])),
+            "total": len(results),
+        },
+    }
+
+
+def test_errors(test_run, project=None) -> List[dict]:
+    names = _test_names(project) if project is not None else {}
+    return [
+        _error(
+            code="test_failed",
+            message=failure.message,
+            name=names.get(failure.test_id) or failure.test_id,
+            object_path=failure.test_id,
+        )
+        for failure in getattr(test_run, "failures", [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Emitting.
+# ---------------------------------------------------------------------------
+
+
+def emit(payload: Dict[str, Any], stream=None) -> None:
+    """Write one JSON object, and nothing else, to the real stdout."""
+    target = stream if stream is not None else sys.stdout
+    target.write(json.dumps(payload))
+    target.write("\n")
+    target.flush()
+
+
+@contextmanager
+def json_command(command: str):
+    """Run a command body in ``--json`` mode.
+
+    Everything the body prints to stdout -- ``Logger``, the test runner's dots,
+    a stray ``print`` deep in a job -- is rerouted to stderr for the duration,
+    so the single JSON object this emits is the only thing on stdout.
+
+    The body receives a mutable dict; set ``result`` on it and, if the command
+    failed without raising, ``errors`` and ``success``. Any exception the body
+    raises becomes the error array and a non-zero exit.
+    """
+    real_stdout = sys.stdout
+    started = time()
+    state: Dict[str, Any] = {"result": None, "errors": [], "success": True}
+
+    def fail(errors: List[dict]) -> None:
+        emit(
+            envelope(
+                command=command,
+                success=False,
+                result=state.get("result"),
+                errors=errors,
+                duration_ms=int((time() - started) * 1000),
+            ),
+            stream=real_stdout,
+        )
+
+    try:
+        with redirect_stdout(sys.stderr):
+            yield state
+    except SystemExit as exit_request:
+        # Something deep in the call stack called sys.exit(). Honour the exit
+        # code, but never leave stdout empty -- an agent that got no JSON
+        # cannot tell a crash from a clean run.
+        code = exit_request.code
+        if code in (0, None):
+            raise
+        fail(
+            state.get("errors")
+            or [_error(code="exited", message=f"visivo {command} exited {code}")]
+        )
+        raise
+    except Exception as exception:
+        fail(errors_from_exception(exception))
+        sys.exit(1)
+
+    success = bool(state.get("success")) and not state.get("errors")
+    emit(
+        envelope(
+            command=command,
+            success=success,
+            result=state.get("result"),
+            errors=state.get("errors") or [],
+            duration_ms=int((time() - started) * 1000),
+        ),
+        stream=real_stdout,
+    )
+    if not success:
+        sys.exit(1)

--- a/visivo/commands/json_output.py
+++ b/visivo/commands/json_output.py
@@ -95,6 +95,51 @@ _PROJECT_COLLECTIONS = (
     "tests",
 )
 
+#: Collections that can also be written *inside* another object rather than at
+#: the project root, as ``{parent collection: {nested collection: qualify?}}``.
+#: The semantic-layer docs lead with the model-scoped spelling of a metric, so
+#: reading only the root collections reports ``"metrics": []`` for a project
+#: whose metrics all compiled fine, and an agent following the documented loop
+#: concludes its edit was dropped and writes it again at the root.
+#:
+#: ``qualify`` says whether the nested name means anything on its own. A
+#: model-scoped metric is referenced as ``${ref(model).metric}``, so it is
+#: reported as ``model.metric`` -- which both confirms the pickup and spells the
+#: reference. An insight written inline in a chart keeps a project-wide name and
+#: is reported bare.
+#:
+#: A guard test derives the shape of this mapping from the models, so a model
+#: that grows another home for an authorable collection cannot slip through. It
+#: covers *list* nesting only, which is where the authoring surface is; a
+#: singular inline field (``item.chart``) is a different shape and not counted.
+_NESTED_COLLECTIONS = {
+    "models": {"metrics": True, "dimensions": True},
+    "charts": {"insights": False},
+}
+
+
+def json_output(function):
+    """The ``--json`` flag for compile/run/test.
+
+    Declared here rather than in ``visivo/commands/options.py`` on purpose: the
+    three commands that take it already import this module, so nothing is
+    gained by putting it in the shared options file and a cross-branch edit to
+    that file is avoided.
+    """
+    import click
+
+    return click.option(
+        "--json",
+        "json_output",
+        help=(
+            "Emit a single JSON object on stdout describing the result, and send every "
+            "human-readable line to stderr. The shape is documented in "
+            "visivo/commands/json_output.py. The exit code is unchanged."
+        ),
+        is_flag=True,
+        default=False,
+    )(function)
+
 
 def strip_ansi(text: Any) -> str:
     return _ANSI.sub("", str(text)) if text is not None else ""
@@ -349,16 +394,32 @@ def _names(collection) -> List[Optional[str]]:
     return [getattr(item, "name", None) for item in (collection or [])]
 
 
+def _nested_names(project, parent: str, nested: str, qualify: bool) -> List[Optional[str]]:
+    """Members of ``nested`` written inside a ``parent`` object, not at the root."""
+    names: List[Optional[str]] = []
+    for owner in getattr(project, parent, None) or []:
+        owner_name = getattr(owner, "name", None)
+        for item in getattr(owner, nested, None) or []:
+            name = getattr(item, "name", None)
+            names.append(f"{owner_name}.{name}" if qualify and owner_name and name else name)
+    return names
+
+
 def compile_result(project, working_dir: str, output_dir: str) -> Dict[str, Any]:
     """``compile``: what the CLI actually parsed out of the project files.
 
     ``objects`` maps each authorable project collection to the names it holds,
-    so an agent can confirm the object it just wrote was picked up.
+    so an agent can confirm the object it just wrote was picked up -- including
+    the ones written inside another object rather than at the root, per
+    ``_NESTED_COLLECTIONS``.
     """
     objects = {
         collection: _names(getattr(project, collection, None))
         for collection in _PROJECT_COLLECTIONS
     }
+    for parent, nested_collections in _NESTED_COLLECTIONS.items():
+        for nested, qualify in nested_collections.items():
+            objects[nested] = objects[nested] + _nested_names(project, parent, nested, qualify)
     return {
         "project_name": getattr(project, "name", None),
         "working_dir": working_dir,
@@ -374,9 +435,40 @@ def compile_result(project, working_dir: str, output_dir: str) -> Dict[str, Any]
 #: agent a log line full of alignment dots.
 _JOB_LINE = re.compile(r"^(?P<summary>.*?)\s*\.{3,}\s*\[(?P<status>[^\]]*)\]\s*$")
 
+#: Continuation-line prefixes that introduce a *path*. ``query:`` and
+#: ``database file:`` come from ``job.py``'s ``full_path`` branch;
+#: ``query saved to:`` is appended by ``run_insight_job`` when it dumps the SQL
+#: that failed. Longest first, so a prefix that starts with another still
+#: matches its own.
+_ARTIFACT_PREFIXES = ("query saved to:", "database file:", "query:")
+
+
+def _artifact_path(line: str) -> Optional[str]:
+    for prefix in _ARTIFACT_PREFIXES:
+        if line.startswith(prefix):
+            return line[len(prefix) :].strip()
+    return None
+
 
 def parse_job_message(message: Any) -> Dict[str, Optional[str]]:
-    """``(summary, status, error, artifact)`` out of one formatted job message."""
+    """``(summary, status, error, artifact)`` out of one formatted job message.
+
+    A failing insight produces a *block*, not a line::
+
+        Failed job for insight kpi .....[FAILURE 0.5s]
+            error: Conversion Error: could not convert 'West' to INTEGER
+            LINE 7: SUM(CAST("ev_sales"."region" AS INTEGER)) AS ...
+                        ^
+            at line 7
+            query saved to: target/logs/failed_queries/insight_kpi.sql
+
+    so ``error`` accumulates every line after ``error:`` until a path line ends
+    it, rather than keeping the first and dropping the rest. Without that, the
+    lines carrying the offending column and its position -- the ones an agent
+    needs in order to fix the query -- never reach the envelope, and
+    ``"query saved to: <path>"`` lands in ``artifact`` as a string that is not
+    a path.
+    """
     lines = [line.strip() for line in strip_ansi(message).split("\n")]
     lines = [line for line in lines if line]
     parsed: Dict[str, Optional[str]] = {
@@ -391,15 +483,22 @@ def parse_job_message(message: Any) -> Dict[str, Optional[str]]:
             parsed["summary"] = match.group("summary").strip()
             status = match.group("status").split()
             parsed["status"] = status[0] if status else None
+
+    error_lines: List[str] = []
     for line in lines[1:]:
-        if line.startswith("error:"):
-            parsed["error"] = line[len("error:") :].strip()
+        artifact = _artifact_path(line)
+        if artifact is not None:
+            parsed["artifact"] = artifact
+        elif line.startswith("error:"):
+            error_lines = [line[len("error:") :].strip()]
+        elif error_lines:
+            error_lines.append(line)
         else:
-            for prefix in ("query:", "database file:"):
-                if line.startswith(prefix):
-                    line = line[len(prefix) :].strip()
-                    break
+            # A bare path: the success branch of `_format_message` emits one
+            # with no prefix when the artifact is neither .sql nor .duckdb.
             parsed["artifact"] = line
+    if error_lines:
+        parsed["error"] = "\n".join(line for line in error_lines if line)
     return parsed
 
 
@@ -421,9 +520,15 @@ def run_result(runner, project, output_dir: str) -> Dict[str, Any]:
 
     Each entry is ``{name, type, success, summary, error, artifact}``: ``summary``
     is the runner's one-line description with its alignment padding removed,
-    ``error`` is the exception text for a failed job (``null`` otherwise), and
-    ``artifact`` is the file the job wrote or was reading (``null`` when the job
-    did not name one).
+    ``error`` is the exception text for a failed job (``null`` otherwise, and
+    often several lines), and ``artifact`` is the path the job wrote or was
+    reading (``null`` when the job did not name one).
+
+    ``job_counts.total`` is 0 when the filter matched nothing runnable. That is
+    not an error here, because it is not one for ``visivo run`` either -- the
+    runner logs "No jobs run" and still exits 0, and ``--json`` promises the
+    same exit code as the plain command. A consumer that needs to know work
+    happened reads ``job_counts.total``, not ``success``.
     """
     succeeded = [_job_entry(result) for result in getattr(runner, "successful_job_results", [])]
     failed = [_job_entry(result) for result in getattr(runner, "failed_job_results", [])]

--- a/visivo/commands/json_output.py
+++ b/visivo/commands/json_output.py
@@ -148,10 +148,19 @@ def envelope(
 
 
 def _split_location(location: Optional[str]):
-    """``"project.visivo.yml:14"`` -> ``("project.visivo.yml", 14)``."""
+    """``"project.visivo.yml:14"`` -> ``("project.visivo.yml", 14)``.
+
+    Also accepts the ``file:line[column]`` form ``load_yaml_file`` raises for a
+    YAML syntax error; the column is dropped, since the envelope reports lines.
+    """
     if not location:
         return (None, None)
-    text = location.strip()
+    # First line only -- the YAML-syntax form continues with "\n  Issue: ..." --
+    # and never split on spaces, because a project path may contain one.
+    lines = location.strip().splitlines()
+    text = lines[0].strip() if lines else ""
+    if text.endswith("]") and "[" in text:
+        text = text[: text.rindex("[")]
     file_name, separator, line_text = text.rpartition(":")
     if separator and line_text.isdigit():
         return (file_name or None, int(line_text))
@@ -319,7 +328,12 @@ def errors_from_exception(exception: BaseException) -> List[dict]:
     import click
 
     if isinstance(exception, click.ClickException):
-        return [_error(code="cli_error", message=exception.format_message())]
+        message = exception.format_message()
+        # A YAML syntax error from load_yaml_file already knows where it is:
+        # "Invalid yaml in project\n  Location: <file>:<line>[<col>]\n  Issue: ..."
+        _, marker, tail = message.partition("Location:")
+        file_name, line = _split_location(tail) if marker else (None, None)
+        return [_error(code="cli_error", message=message, file=file_name, line=line)]
 
     return [_error(code=type(exception).__name__, message=str(exception))]
 

--- a/visivo/commands/json_output.py
+++ b/visivo/commands/json_output.py
@@ -76,7 +76,10 @@ ENVELOPE_KEY_ORDER = (
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
-#: Project fields whose members get reported back in ``compile``'s result.
+#: Project fields whose members get reported back in ``compile``'s result: the
+#: list-valued half of ``schema_phase.CORE_PROJECT_PROPERTIES``, minus
+#: ``includes`` (Include objects carry a path, not a name). A guard test in
+#: ``tests/commands/test_json_output.py`` fails if the two drift apart.
 _PROJECT_COLLECTIONS = (
     "sources",
     "models",
@@ -326,8 +329,10 @@ def errors_from_exception(exception: BaseException) -> List[dict]:
 # ---------------------------------------------------------------------------
 
 
-def _names(collection) -> List[str]:
-    return [getattr(item, "name", None) or str(item) for item in (collection or [])]
+def _names(collection) -> List[Optional[str]]:
+    # Never fall back to str(item): a Pydantic repr of a whole dashboard would
+    # bloat the envelope. A null entry is the honest answer for a nameless one.
+    return [getattr(item, "name", None) for item in (collection or [])]
 
 
 def compile_result(project, working_dir: str, output_dir: str) -> Dict[str, Any]:

--- a/visivo/commands/options.py
+++ b/visivo/commands/options.py
@@ -222,18 +222,3 @@ def no_deprecation_warnings(function):
         default=False,
     )(function)
     return function
-
-
-def json_output(function):
-    click.option(
-        "--json",
-        "json_output",
-        help=(
-            "Emit a single JSON object on stdout describing the result, and send every "
-            "human-readable line to stderr. The shape is documented in "
-            "visivo/commands/json_output.py. The exit code is unchanged."
-        ),
-        is_flag=True,
-        default=False,
-    )(function)
-    return function

--- a/visivo/commands/options.py
+++ b/visivo/commands/options.py
@@ -222,3 +222,18 @@ def no_deprecation_warnings(function):
         default=False,
     )(function)
     return function
+
+
+def json_output(function):
+    click.option(
+        "--json",
+        "json_output",
+        help=(
+            "Emit a single JSON object on stdout describing the result, and send every "
+            "human-readable line to stderr. The shape is documented in "
+            "visivo/commands/json_output.py. The exit code is unchanged."
+        ),
+        is_flag=True,
+        default=False,
+    )(function)
+    return function

--- a/visivo/commands/run.py
+++ b/visivo/commands/run.py
@@ -1,4 +1,5 @@
 import click
+from visivo.commands.json_output import json_output
 from visivo.commands.options import (
     working_dir,
     output_dir,
@@ -10,7 +11,6 @@ from visivo.commands.options import (
     skip_compile,
     port,
     no_deprecation_warnings,
-    json_output,
 )
 
 

--- a/visivo/commands/run.py
+++ b/visivo/commands/run.py
@@ -10,6 +10,7 @@ from visivo.commands.options import (
     skip_compile,
     port,
     no_deprecation_warnings,
+    json_output,
 )
 
 
@@ -24,6 +25,7 @@ from visivo.commands.options import (
 @skip_compile
 @port
 @no_deprecation_warnings
+@json_output
 def run(
     output_dir,
     working_dir,
@@ -35,38 +37,52 @@ def run(
     skip_compile,
     port,
     no_deprecation_warnings,
+    json_output,
 ):
     """
     Compiles the project and then runs the model and insight queries to fetch the data that powers your dashboards. Writes all data to the output directory. Can skip the compile with the --skip-compile flag.
     """
     from visivo.logger.logger import Logger
     from visivo.commands.parse_project_phase import parse_project_phase
-    from visivo.commands.serve_phase import serve_phase
 
     Logger.instance().debug("Running")
 
-    # Parse project first
-    project = parse_project_phase(
-        working_dir=working_dir,
-        output_dir=output_dir,
-        default_source=source,
-        dbt_profile=dbt_profile,
-        dbt_target=dbt_target,
-    )
+    def _run(defer_exit):
+        # Parse project first
+        project = parse_project_phase(
+            working_dir=working_dir,
+            output_dir=output_dir,
+            default_source=source,
+            dbt_profile=dbt_profile,
+            dbt_target=dbt_target,
+        )
 
-    from visivo.commands.run_phase import run_phase
+        from visivo.commands.run_phase import run_phase
 
-    run_phase(
-        default_source=source,
-        output_dir=output_dir,
-        working_dir=working_dir,
-        dag_filter=dag_filter,
-        threads=threads,
-        dbt_profile=dbt_profile,
-        dbt_target=dbt_target,
-        skip_compile=skip_compile,
-        project=project,
-        no_deprecation_warnings=no_deprecation_warnings,
-    )
+        runner = run_phase(
+            default_source=source,
+            output_dir=output_dir,
+            working_dir=working_dir,
+            dag_filter=dag_filter,
+            threads=threads,
+            dbt_profile=dbt_profile,
+            dbt_target=dbt_target,
+            skip_compile=skip_compile,
+            project=project,
+            no_deprecation_warnings=no_deprecation_warnings,
+            defer_exit=defer_exit,
+        )
+        return project, runner
+
+    if json_output:
+        from visivo.commands.json_output import json_command, run_errors, run_result
+
+        with json_command("run") as state:
+            project, runner = _run(defer_exit=True)
+            state["result"] = run_result(runner=runner, project=project, output_dir=output_dir)
+            state["errors"] = run_errors(runner)
+        return
+
+    _run(defer_exit=False)
 
     Logger.instance().success("Done")

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -28,7 +28,23 @@ def run_phase(
     server_url: str = None,
     no_deprecation_warnings: bool = False,
     run_id: str = DEFAULT_RUN_ID,
+    defer_exit: bool = False,
 ):
+    """
+    ``defer_exit`` hands failure reporting back to the caller instead of ending
+    the process inside the runner. Used by ``visivo run --json``, which has to
+    print its JSON envelope before the process ends; the returned runner's
+    ``failed_job_results`` then says whether the run actually succeeded, and the
+    caller picks the exit code.
+
+    It works by running soft: ``DagRunner`` calls ``sys.exit(1)`` on a failed job
+    unless ``soft_failure`` is set, and that exit unwinds ``FilteredRunner.run()``
+    before it can aggregate the per-job results the JSON envelope reports. Two
+    consequences worth knowing: every filtered DAG is attempted rather than
+    stopping at the first failing one (so ``--json`` reports every broken object
+    in one pass), and the ``SystemExit`` guard below is belt-and-braces for any
+    other code path that decides to exit mid-run.
+    """
     from visivo.logger.logger import Logger
     from visivo.jobs.filtered_runner import FilteredRunner
     from time import time
@@ -91,11 +107,17 @@ def run_phase(
         project=project,
         output_dir=output_dir,
         threads=threads,
-        soft_failure=soft_failure,
+        soft_failure=soft_failure or defer_exit,
         dag_filter=dag_filter,
         server_url=server_url,
         working_dir=working_dir,
         run_id=run_id,
     )
-    runner.run()
+    if defer_exit:
+        try:
+            runner.run()
+        except SystemExit:
+            pass
+    else:
+        runner.run()
     return runner

--- a/visivo/commands/schema.py
+++ b/visivo/commands/schema.py
@@ -3,6 +3,15 @@ import click
 
 @click.command()
 @click.option(
+    "--core",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit the core authoring subset (~90 KB). This is the default; the flag "
+        "exists so a script can say what it means."
+    ),
+)
+@click.option(
     "--full",
     is_flag=True,
     default=False,
@@ -41,7 +50,7 @@ import click
     type=int,
     help="Pretty-print with this many spaces of indentation. Default is compact.",
 )
-def schema(full, prop_type, layout, output, indent):
+def schema(core, full, prop_type, layout, output, indent):
     """
     Writes the Visivo project JSON Schema to stdout, for an agent (or an editor) to read.
 
@@ -58,7 +67,9 @@ def schema(full, prop_type, layout, output, indent):
     from visivo.commands.schema_phase import SchemaSelectionError, schema_phase
 
     try:
-        schema_string = schema_phase(full=full, prop_type=prop_type, layout=layout, indent=indent)
+        schema_string = schema_phase(
+            core=core, full=full, prop_type=prop_type, layout=layout, indent=indent
+        )
     except SchemaSelectionError as error:
         raise click.ClickException(str(error))
 

--- a/visivo/commands/schema.py
+++ b/visivo/commands/schema.py
@@ -1,0 +1,75 @@
+import click
+
+
+@click.command()
+@click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit the complete project schema (~3.3 MB), including the vendored Plotly "
+        "trace-prop and layout vocabularies. This is what the viewer validates against."
+    ),
+)
+@click.option(
+    "--props",
+    "prop_type",
+    default=None,
+    metavar="TYPE",
+    help=(
+        "Emit the full Plotly property schema for one insight props type "
+        "(e.g. --props bar). This is the vocabulary the core subset prunes."
+    ),
+)
+@click.option(
+    "--layout",
+    is_flag=True,
+    default=False,
+    help="Emit the full Plotly layout schema (what a chart's `layout` accepts).",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="Write the schema to this file instead of stdout.",
+)
+@click.option(
+    "--indent",
+    default=None,
+    type=int,
+    help="Pretty-print with this many spaces of indentation. Default is compact.",
+)
+def schema(full, prop_type, layout, output, indent):
+    """
+    Writes the Visivo project JSON Schema to stdout, for an agent (or an editor) to read.
+
+    With no options this emits the CORE subset: the objects you author by hand in
+    project.visivo.yml -- sources, models, metrics, dimensions, relations, insights,
+    charts, tables, markdowns, inputs, dashboards and tests -- at roughly 90 KB
+    instead of the full schema's 3.3 MB, which is far too large to put in a prompt.
+
+    The subset is derived mechanically; the rule is documented in
+    visivo/commands/schema_phase.py so it can be re-derived rather than hand-maintained.
+    """
+    import sys
+
+    from visivo.commands.schema_phase import SchemaSelectionError, schema_phase
+
+    try:
+        schema_string = schema_phase(full=full, prop_type=prop_type, layout=layout, indent=indent)
+    except SchemaSelectionError as error:
+        raise click.ClickException(str(error))
+
+    if output:
+        with open(output, "w") as file:
+            file.write(schema_string)
+        # stderr, so that stdout carries the schema and nothing else no matter
+        # which flags were passed.
+        click.echo(f"Schema written to {output} ({len(schema_string)} bytes)", err=True)
+    else:
+        # Straight to stdout, unbuffered by click's styling, so that
+        # `visivo schema | jq` and `visivo schema > core.json` both work.
+        sys.stdout.write(schema_string)
+        sys.stdout.write("\n")

--- a/visivo/commands/schema.py
+++ b/visivo/commands/schema.py
@@ -7,7 +7,7 @@ import click
     is_flag=True,
     default=False,
     help=(
-        "Emit the core authoring subset (~90 KB). This is the default; the flag "
+        "Emit the core authoring subset (~95 KB). This is the default; the flag "
         "exists so a script can say what it means."
     ),
 )
@@ -56,7 +56,7 @@ def schema(core, full, prop_type, layout, output, indent):
 
     With no options this emits the CORE subset: the objects you author by hand in
     project.visivo.yml -- sources, models, metrics, dimensions, relations, insights,
-    charts, tables, markdowns, inputs, dashboards and tests -- at roughly 90 KB
+    charts, tables, markdowns, inputs, dashboards and tests -- at roughly 95 KB
     instead of the full schema's 3.3 MB, which is far too large to put in a prompt.
 
     The subset is derived mechanically; the rule is documented in

--- a/visivo/commands/schema_phase.py
+++ b/visivo/commands/schema_phase.py
@@ -211,7 +211,7 @@ def full_schema() -> Dict[str, Any]:
 
 
 def core_schema() -> Dict[str, Any]:
-    """The authoring subset, derived by the five steps in the module docstring."""
+    """The authoring subset, derived by the six steps in the module docstring."""
     from visivo.version import VISIVO_VERSION
 
     source = _pydantic_project_schema()
@@ -307,6 +307,7 @@ def _vendored_schema(file_name: str) -> Dict[str, Any]:
 
 
 def schema_phase(
+    core: bool = False,
     full: bool = False,
     prop_type: Optional[str] = None,
     layout: bool = False,
@@ -315,9 +316,12 @@ def schema_phase(
     """Return the requested schema as a JSON string.
 
     Exactly one selector may be given. With none, the core authoring subset is
-    returned, because that is the one an agent should be reading.
+    returned, because that is the one an agent should be reading; ``core=True``
+    asks for the same thing explicitly.
     """
-    selectors = [name for name, on in (("--full", full), ("--layout", layout)) if on]
+    selectors = [
+        name for name, on in (("--core", core), ("--full", full), ("--layout", layout)) if on
+    ]
     if prop_type:
         selectors.append("--props")
     if len(selectors) > 1:

--- a/visivo/commands/schema_phase.py
+++ b/visivo/commands/schema_phase.py
@@ -6,12 +6,12 @@ across 103 ``$defs``.  It is the right thing for the viewer (which validates
 every Plotly property client side) and the wrong thing for an LLM: nobody can
 put 3.3 MB in a prompt, so agents guess at Visivo's grammar instead of reading
 it.  ``visivo schema`` exists to hand an agent the part of that schema that
-describes *a Visivo project* -- roughly 90 KB, ~23k tokens, cacheable.
+describes *a Visivo project* -- roughly 95 KB, ~24k tokens, cacheable.
 
 THE CORE SELECTION RULE
 =======================
 
-The subset is *derived*, not hand-maintained.  Five mechanical steps, each of
+The subset is *derived*, not hand-maintained.  Seven mechanical steps, each of
 which can be re-run against a future version of the models without anyone
 curating a list of type names:
 
@@ -42,14 +42,32 @@ curating a list of type names:
    ``$def`` nothing reaches.
 
 4. **Delete the machine-set fields** (``MACHINE_SET_FIELDS``) from every
-   object.  The CLI fills these in; an agent that writes them is making a
-   mistake, and they cost ~9 KB across 45 defs.
+   object *that inherits them*.  The CLI fills these in; an agent that writes
+   them is making a mistake, and they cost ~9 KB across 45 defs.  A name alone
+   is not proof, though: a concrete model may redeclare one of those names as a
+   field an agent has to write.  ``Include.path`` is exactly that -- it is the
+   only way to write ``includes:`` at all -- so the rule asks *which class
+   declared the field*, and keeps it when the answer is not one of the models
+   that carry it for the CLI's benefit.
 
 5. **Delete Pydantic's auto-generated property titles.**  ``"title": "Source
    Name"`` above a property literally named ``source_name`` is ~4 KB of
    restatement.  Titles on the ``$defs`` themselves are kept.
 
-6. **Restore the Python-keyword aliases.**  ``Test.if_`` and ``Alert.if_`` carry
+6. **Repair the unsatisfiable ``oneOf``s.**  Pydantic renders a union with a
+   *callable* discriminator -- ``SecretStrOrEnvVar`` is
+   ``Union[EnvVarString, SecretStr]``, chosen at runtime by a regex on the
+   value -- as a JSON Schema ``oneOf``.  The discriminator is Python and does
+   not survive the dump, so both branches come out as ``{"type": "string"}``
+   (one of them wearing ``format: password``), and ``oneOf`` requires *exactly*
+   one match.  Every string matches both, so the schema rejects every
+   ``password:`` on every source type.  Where two branches of a ``oneOf`` are
+   identical once the annotation-only keywords are set aside, they accept
+   exactly the same values, the ``oneOf`` is unsatisfiable, and the keyword is
+   rewritten to ``anyOf``.  Unions that really do discriminate -- the source
+   type union, whose branches are distinct ``$ref``s -- are untouched.
+
+7. **Restore the Python-keyword aliases.**  ``Test.if_`` and ``Alert.if_`` carry
    a trailing underscore because ``if`` is a reserved word in Python; the key
    people actually write in YAML -- and that every doc example shows -- is
    ``if``.  The schema is dumped with ``by_alias=False``, so any property named
@@ -65,6 +83,15 @@ rejects a document that carries them -- notably the ``project.json`` the CLI
 writes at compile time, and any object round-tripped out of the server API.
 Validate hand-written YAML with ``--core``; validate compiler output with
 ``--full``.
+
+The same ``extra="forbid"`` is why step 2 does not simply *drop* the omitted
+root fields.  Five of the eight are machine-set and stay out for the reason
+above, but ``alerts``, ``destinations`` and ``dbt`` are hand-authored and legal;
+omitting them from a root that forbids unknown keys would turn "not described
+here" into "not allowed here", so a real project that uses them would fail to
+validate and an agent would be told the user's ``alerts:`` block is an illegal
+key.  Each of the three is therefore emitted as a permissive stub carrying its
+reason -- described nowhere, accepted everywhere.
 """
 
 import json
@@ -109,7 +136,9 @@ OMITTED_PROJECT_PROPERTIES: Dict[str, str] = {
     "destinations": "Notification targets for alerts; orthogonal to building a dashboard.",
 }
 
-#: Step 4: fields the CLI fills in, removed from every object in the subset.
+#: Step 4: fields the CLI fills in, removed from every object that *inherits*
+#: them. See ``_authored_machine_set_fields`` for why inheritance, and not the
+#: bare name, is the test.
 MACHINE_SET_FIELDS: Set[str] = {
     "path",
     "file_path",
@@ -164,8 +193,78 @@ def _reachable_defs(roots: Iterable[str], defs: Dict[str, Any]) -> Set[str]:
     return seen
 
 
+def _machine_set_owners() -> tuple:
+    """The models that declare a ``MACHINE_SET_FIELDS`` name for the CLI's use.
+
+    ``BaseModel`` declares ``path``, ``NamedModel`` declares ``file_path``, and
+    ``Project`` declares ``project_file_path``/``project_dir``/``cli_version``.
+    A field inherited from one of these is bookkeeping; a field declared
+    anywhere else happens to share the name and is the agent's to write.
+    """
+    from visivo.models.base.base_model import BaseModel
+    from visivo.models.base.named_model import NamedModel
+    from visivo.models.project import Project
+
+    return (BaseModel, NamedModel, Project)
+
+
+def _model_classes() -> Dict[str, Any]:
+    """``{class name: class}`` for every model reachable from ``BaseModel``.
+
+    A name shared by two classes maps to ``None``: a ``$defs`` key cannot be
+    traced back to one class, so the caller declines to strip anything for it.
+    """
+    from visivo.models.base.base_model import BaseModel
+
+    _machine_set_owners()  # imports Project, and with it the whole model tree.
+
+    found: Dict[str, Any] = {}
+    seen: Set[Any] = set()
+    stack: List[Any] = [BaseModel]
+    while stack:
+        for subclass in stack.pop().__subclasses__():
+            if subclass in seen:
+                continue
+            seen.add(subclass)
+            stack.append(subclass)
+            found[subclass.__name__] = subclass if subclass.__name__ not in found else None
+    return found
+
+
+def _authored_machine_set_fields(model_name: str, classes: Dict[str, Any]) -> Set[str]:
+    """The ``MACHINE_SET_FIELDS`` ``model_name`` declares itself, and so keeps.
+
+    ``MACHINE_SET_FIELDS`` is a list of *names*, and a name is not proof.
+    ``Include`` redeclares ``path`` as "the path or git reference to external
+    yml files to include" -- the only key an include has -- so stripping it by
+    name leaves a definition that, being ``additionalProperties: false``,
+    rejects the very example printed in ``Include``'s own description, and with
+    it every project in the repo that splits itself across files.
+
+    So the question asked here is *which class declared this field*: one of the
+    models in ``_machine_set_owners`` (bookkeeping, strip it) or the concrete
+    model itself (authoring surface, keep it).
+    """
+    model = classes.get(model_name)
+    if model is None:
+        # Nothing to ask. Keeping a machine-set field costs a few bytes;
+        # deleting an authored one costs the agent a valid document, so keep.
+        return set(MACHINE_SET_FIELDS)
+
+    owners = _machine_set_owners()
+    authored = set()
+    for field in MACHINE_SET_FIELDS:
+        declaring = next(
+            (base for base in model.__mro__ if field in vars(base).get("__annotations__", {})),
+            None,
+        )
+        if declaring is not None and declaring not in owners:
+            authored.add(field)
+    return authored
+
+
 def _restore_keyword_aliases(definition: Dict[str, Any]) -> None:
-    """Step 6: ``if_`` also accepted (and preferred) as ``if``."""
+    """Step 7: ``if_`` also accepted (and preferred) as ``if``."""
     import keyword
 
     properties = definition.get("properties")
@@ -183,6 +282,58 @@ def _restore_keyword_aliases(definition: Dict[str, Any]) -> None:
             f"Deprecated spelling of `{alias}`; write `{alias}` instead. "
             + str(properties[name].get("description") or "")
         ).strip()
+
+
+#: JSON Schema keywords that annotate rather than constrain: two branches that
+#: differ only in these accept exactly the same set of values.
+_ANNOTATION_KEYWORDS = frozenset(
+    {
+        "$comment",
+        "default",
+        "deprecated",
+        "description",
+        "examples",
+        "format",
+        "readOnly",
+        "title",
+        "writeOnly",
+    }
+)
+
+
+def _validation_shape(branch: Any) -> str:
+    """``branch`` reduced to the part that decides whether a value validates."""
+    if not isinstance(branch, dict):
+        return json.dumps(branch, sort_keys=True)
+    return json.dumps(
+        {key: value for key, value in branch.items() if key not in _ANNOTATION_KEYWORDS},
+        sort_keys=True,
+    )
+
+
+def _repair_unsatisfiable_one_ofs(node: Any) -> None:
+    """Step 6: ``oneOf`` -> ``anyOf`` where the branches cannot discriminate.
+
+    ``oneOf`` demands that *exactly* one branch match. Two branches that are
+    identical apart from annotations match together or not at all, so nothing
+    can satisfy the keyword -- which is how the core schema came to reject
+    every ``password:`` on every source type.
+    """
+    if isinstance(node, dict):
+        branches = node.get("oneOf")
+        if isinstance(branches, list) and "anyOf" not in node:
+            # A sibling `anyOf` would have to be intersected rather than
+            # replaced; no such node exists in the dump, and the guard test
+            # asserts no unsatisfiable `oneOf` survives, so one appearing shows
+            # up as a failure rather than as a silent no-op.
+            shapes = [_validation_shape(branch) for branch in branches]
+            if len(set(shapes)) < len(shapes):
+                node["anyOf"] = node.pop("oneOf")
+        for value in node.values():
+            _repair_unsatisfiable_one_ofs(value)
+    elif isinstance(node, list):
+        for value in node:
+            _repair_unsatisfiable_one_ofs(value)
 
 
 def _strip_property_titles(node: Any) -> None:
@@ -211,7 +362,7 @@ def full_schema() -> Dict[str, Any]:
 
 
 def core_schema() -> Dict[str, Any]:
-    """The authoring subset, derived by the six steps in the module docstring."""
+    """The authoring subset, derived by the seven steps in the module docstring."""
     from visivo.version import VISIVO_VERSION
 
     source = _pydantic_project_schema()
@@ -238,19 +389,42 @@ def core_schema() -> Dict[str, Any]:
         if name in source_properties
     }
 
+    # The root forbids unknown keys, so "omitted" would otherwise read as
+    # "prohibited". That is right for the machine-set fields -- a document
+    # carrying them is compiler output, not something an agent wrote -- and
+    # wrong for the rest, which a human writes by hand and which a project may
+    # legitimately already contain. Describe those nowhere; accept them
+    # everywhere.
+    permissive_properties = {
+        name: {
+            "description": (
+                f"{reason} Not described in the core subset -- run "
+                "`visivo schema --full` for its schema. Accepted here so that a "
+                "project already using it still validates."
+            )
+        }
+        for name, reason in OMITTED_PROJECT_PROPERTIES.items()
+        if name not in MACHINE_SET_FIELDS and name in source_properties
+    }
+
     roots: Set[str] = set()
     _ref_names(kept_properties, roots)
     reachable = _reachable_defs(roots, defs)
 
     kept_defs = {name: deepcopy(defs[name]) for name in sorted(reachable)}
-    for definition in kept_defs.values():
+    classes = _model_classes()
+    for name, definition in kept_defs.items():
         properties = definition.get("properties")
         if isinstance(properties, dict):
-            for field in MACHINE_SET_FIELDS:
+            strip = MACHINE_SET_FIELDS - _authored_machine_set_fields(name, classes)
+            for field in strip:
                 properties.pop(field, None)
             required = definition.get("required")
             if isinstance(required, list):
-                definition["required"] = [f for f in required if f not in MACHINE_SET_FIELDS]
+                definition["required"] = [f for f in required if f not in strip]
+
+    _repair_unsatisfiable_one_ofs(kept_defs)
+    _repair_unsatisfiable_one_ofs(kept_properties)
 
     for definition in kept_defs.values():
         _restore_keyword_aliases(definition)
@@ -276,7 +450,7 @@ def core_schema() -> Dict[str, Any]:
             "pruned_vocabularies": PRUNED_VOCABULARY_NOTE,
             "full_schema_command": "visivo schema --full",
         },
-        "properties": kept_properties,
+        "properties": {**kept_properties, **permissive_properties},
         "$defs": kept_defs,
     }
     return schema

--- a/visivo/commands/schema_phase.py
+++ b/visivo/commands/schema_phase.py
@@ -1,0 +1,337 @@
+"""
+Emit the Visivo project JSON Schema in a form an agent can actually consume.
+
+The schema that ships in ``visivo/src/visivo_project_schema.json`` is ~3.3 MB
+across 103 ``$defs``.  It is the right thing for the viewer (which validates
+every Plotly property client side) and the wrong thing for an LLM: nobody can
+put 3.3 MB in a prompt, so agents guess at Visivo's grammar instead of reading
+it.  ``visivo schema`` exists to hand an agent the part of that schema that
+describes *a Visivo project* -- roughly 90 KB, ~23k tokens, cacheable.
+
+THE CORE SELECTION RULE
+=======================
+
+The subset is *derived*, not hand-maintained.  Five mechanical steps, each of
+which can be re-run against a future version of the models without anyone
+curating a list of type names:
+
+1. **Build from the Pydantic-native schema, not the merged one.**
+   ``schema_generator.generate_project_schema()`` is the Pydantic dump of
+   ``Project``; ``schema_generator.generate_schema()`` is that dump with the
+   vendored Plotly JSON (``visivo/schema/*.schema.json``) merged on top.  The
+   merge is the entire size problem: it adds the 48 trace-prop ``$defs`` plus
+   ``Layout`` (423,983 bytes on its own) and takes the file from 115 KB to
+   3.3 MB.  Choosing the un-merged function prunes all of it in one step --
+   and prunes it *by construction*, so a new Plotly trace type added
+   tomorrow is excluded automatically.
+
+   Nothing dangles as a result: in the Pydantic-native schema ``Insight.props``
+   is already ``InsightProps`` (``type`` required, any other key allowed) and
+   ``Layout`` is already an open object.  An agent that needs the real Plotly
+   vocabulary for one chart type asks for it explicitly with
+   ``visivo schema --props bar``.
+
+2. **Keep only the authoring surface at the root.**  ``CORE_PROJECT_PROPERTIES``
+   below lists the ``Project`` fields a human or an agent writes by hand in
+   ``project.visivo.yml``.  ``OMITTED_PROJECT_PROPERTIES`` lists the rest with
+   the reason each one is out.  Every ``Project`` field must appear in exactly
+   one of the two -- ``test_schema_phase.py`` fails if the model grows a field
+   that neither list mentions, so this stays honest as the model evolves.
+
+3. **Transitively close over ``$ref`` from those roots** and drop every
+   ``$def`` nothing reaches.
+
+4. **Delete the machine-set fields** (``MACHINE_SET_FIELDS``) from every
+   object.  The CLI fills these in; an agent that writes them is making a
+   mistake, and they cost ~9 KB across 45 defs.
+
+5. **Delete Pydantic's auto-generated property titles.**  ``"title": "Source
+   Name"`` above a property literally named ``source_name`` is ~4 KB of
+   restatement.  Titles on the ``$defs`` themselves are kept.
+
+6. **Restore the Python-keyword aliases.**  ``Test.if_`` and ``Alert.if_`` carry
+   a trailing underscore because ``if`` is a reserved word in Python; the key
+   people actually write in YAML -- and that every doc example shows -- is
+   ``if``.  The schema is dumped with ``by_alias=False``, so any property named
+   ``<keyword>_`` is emitted under the bare keyword as well, and the underscore
+   spelling is marked ``deprecated`` so an agent picks the right one.  The test
+   is ``name[:-1] in keyword.kwlist``, which is why this does *not* drag in the
+   1.0-era ``targets``/``target`` aliases that ``by_alias=True`` would.
+
+Caveat, stated plainly because step 4 has a real edge: the core schema is an
+*authoring* contract.  Because ``Project`` and its objects are
+``extra="forbid"``, stripping the machine-set fields means the core schema
+rejects a document that carries them -- notably the ``project.json`` the CLI
+writes at compile time, and any object round-tripped out of the server API.
+Validate hand-written YAML with ``--core``; validate compiler output with
+``--full``.
+"""
+
+import json
+from copy import deepcopy
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+# ---------------------------------------------------------------------------
+# Step 2: the authoring surface.
+# ---------------------------------------------------------------------------
+
+#: ``Project`` fields an agent writes by hand.  Order is the order they should
+#: appear in a project file, which is also the order they are emitted in.
+CORE_PROJECT_PROPERTIES: List[str] = [
+    "name",
+    "defaults",
+    "includes",
+    "sources",
+    "models",
+    "metrics",
+    "dimensions",
+    "relations",
+    "insights",
+    "charts",
+    "tables",
+    "markdowns",
+    "inputs",
+    "dashboards",
+    "tests",
+]
+
+#: ``Project`` fields deliberately left out of the core subset, each with the
+#: reason.  Kept as data (not a comment) so the guard test can assert that
+#: CORE + OMITTED covers every field ``Project`` actually has.
+OMITTED_PROJECT_PROPERTIES: Dict[str, str] = {
+    "path": "Machine-set: the CLI assigns it while parsing.",
+    "file_path": "Machine-set: the CLI records which file the object came from.",
+    "project_file_path": "Machine-set: the path of the root project file.",
+    "project_dir": "Machine-set: the directory of the root project file.",
+    "cli_version": "Machine-set: stamped by the CLI that wrote the project.",
+    "dbt": "Imports models and sources from an external dbt project rather than authoring Visivo objects.",
+    "alerts": "Notification wiring that fires after `visivo test`; orthogonal to building a dashboard.",
+    "destinations": "Notification targets for alerts; orthogonal to building a dashboard.",
+}
+
+#: Step 4: fields the CLI fills in, removed from every object in the subset.
+MACHINE_SET_FIELDS: Set[str] = {
+    "path",
+    "file_path",
+    "project_file_path",
+    "project_dir",
+    "cli_version",
+}
+
+#: Where an agent goes for the vocabularies step 1 pruned.
+PRUNED_VOCABULARY_NOTE = {
+    "insight_props": (
+        "`props` accepts any Plotly property valid for its `type`. Run "
+        "`visivo schema --props <type>` (e.g. `--props bar`) for the full "
+        "property schema of one chart type."
+    ),
+    "layout": (
+        "`layout` accepts any Plotly layout property. Run "
+        "`visivo schema --layout` for the full layout schema."
+    ),
+}
+
+
+class SchemaSelectionError(Exception):
+    """Raised when a caller asks for a schema slice that does not exist."""
+
+
+def _ref_names(node: Any, into: Set[str]) -> None:
+    """Collect every local ``$defs`` name referenced anywhere under ``node``."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/$defs/"):
+            into.add(ref[len("#/$defs/") :])
+        for value in node.values():
+            _ref_names(value, into)
+    elif isinstance(node, list):
+        for value in node:
+            _ref_names(value, into)
+
+
+def _reachable_defs(roots: Iterable[str], defs: Dict[str, Any]) -> Set[str]:
+    """Step 3: transitive ``$ref`` closure over ``defs`` starting at ``roots``."""
+    seen: Set[str] = set()
+    stack = list(roots)
+    while stack:
+        name = stack.pop()
+        if name in seen or name not in defs:
+            continue
+        seen.add(name)
+        children: Set[str] = set()
+        _ref_names(defs[name], children)
+        stack.extend(children - seen)
+    return seen
+
+
+def _restore_keyword_aliases(definition: Dict[str, Any]) -> None:
+    """Step 6: ``if_`` also accepted (and preferred) as ``if``."""
+    import keyword
+
+    properties = definition.get("properties")
+    if not isinstance(properties, dict):
+        return
+    for name in list(properties):
+        if not name.endswith("_") or not keyword.iskeyword(name[:-1]):
+            continue
+        alias = name[:-1]
+        if alias in properties:
+            continue
+        properties[alias] = deepcopy(properties[name])
+        properties[name]["deprecated"] = True
+        properties[name]["description"] = (
+            f"Deprecated spelling of `{alias}`; write `{alias}` instead. "
+            + str(properties[name].get("description") or "")
+        ).strip()
+
+
+def _strip_property_titles(node: Any) -> None:
+    """Step 5: drop Pydantic's auto-generated titles below the ``$def`` level."""
+    if isinstance(node, dict):
+        node.pop("title", None)
+        for value in node.values():
+            _strip_property_titles(value)
+    elif isinstance(node, list):
+        for value in node:
+            _strip_property_titles(value)
+
+
+def _pydantic_project_schema() -> Dict[str, Any]:
+    """Step 1: the Pydantic-native schema, before the Plotly merge."""
+    from visivo.parsers.schema_generator import generate_project_schema
+
+    return json.loads(generate_project_schema())
+
+
+def full_schema() -> Dict[str, Any]:
+    """The complete schema, Plotly vocabularies included (~3.3 MB)."""
+    from visivo.parsers.schema_generator import generate_schema
+
+    return json.loads(generate_schema())
+
+
+def core_schema() -> Dict[str, Any]:
+    """The authoring subset, derived by the five steps in the module docstring."""
+    from visivo.version import VISIVO_VERSION
+
+    source = _pydantic_project_schema()
+    source_properties = source.get("properties", {})
+    defs = source.get("$defs", {})
+
+    unknown = [
+        name
+        for name in source_properties
+        if name not in CORE_PROJECT_PROPERTIES and name not in OMITTED_PROJECT_PROPERTIES
+    ]
+    if unknown:
+        raise SchemaSelectionError(
+            "Project gained field(s) "
+            + ", ".join(sorted(unknown))
+            + " that the core-schema selection rule does not classify. Add each one to "
+            "CORE_PROJECT_PROPERTIES or OMITTED_PROJECT_PROPERTIES in "
+            "visivo/commands/schema_phase.py."
+        )
+
+    kept_properties = {
+        name: deepcopy(source_properties[name])
+        for name in CORE_PROJECT_PROPERTIES
+        if name in source_properties
+    }
+
+    roots: Set[str] = set()
+    _ref_names(kept_properties, roots)
+    reachable = _reachable_defs(roots, defs)
+
+    kept_defs = {name: deepcopy(defs[name]) for name in sorted(reachable)}
+    for definition in kept_defs.values():
+        properties = definition.get("properties")
+        if isinstance(properties, dict):
+            for field in MACHINE_SET_FIELDS:
+                properties.pop(field, None)
+            required = definition.get("required")
+            if isinstance(required, list):
+                definition["required"] = [f for f in required if f not in MACHINE_SET_FIELDS]
+
+    for definition in kept_defs.values():
+        _restore_keyword_aliases(definition)
+
+    for definition in kept_defs.values():
+        for prop in (definition.get("properties") or {}).values():
+            _strip_property_titles(prop)
+    for prop in kept_properties.values():
+        _strip_property_titles(prop)
+
+    schema: Dict[str, Any] = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": source.get("title", "Project"),
+        "description": source.get("description"),
+        "type": source.get("type", "object"),
+        "additionalProperties": source.get("additionalProperties", False),
+        "x-visivo-schema": {
+            "mode": "core",
+            "cli_version": VISIVO_VERSION,
+            "generated_by": "visivo schema --core",
+            "selection_rule": "visivo/commands/schema_phase.py -- see the module docstring",
+            "omitted_project_properties": OMITTED_PROJECT_PROPERTIES,
+            "pruned_vocabularies": PRUNED_VOCABULARY_NOTE,
+            "full_schema_command": "visivo schema --full",
+        },
+        "properties": kept_properties,
+        "$defs": kept_defs,
+    }
+    return schema
+
+
+def props_schema(prop_type: str) -> Dict[str, Any]:
+    """The full Plotly property schema for one insight ``props.type``."""
+    from visivo.models.props.types import PropType
+
+    valid = [member.value for member in PropType]
+    normalized = (prop_type or "").strip().lower()
+    if normalized not in valid:
+        raise SchemaSelectionError(
+            f"Unknown insight props type '{prop_type}'. Valid types: " + ", ".join(sorted(valid))
+        )
+    return _vendored_schema(f"{normalized}.schema.json")
+
+
+def layout_schema() -> Dict[str, Any]:
+    """The full Plotly layout schema (what ``Chart.layout`` accepts)."""
+    return _vendored_schema("layout.schema.json")
+
+
+def _vendored_schema(file_name: str) -> Dict[str, Any]:
+    from importlib.resources import files
+
+    return json.loads(files("visivo.schema").joinpath(file_name).read_text())
+
+
+def schema_phase(
+    full: bool = False,
+    prop_type: Optional[str] = None,
+    layout: bool = False,
+    indent: Optional[int] = None,
+) -> str:
+    """Return the requested schema as a JSON string.
+
+    Exactly one selector may be given. With none, the core authoring subset is
+    returned, because that is the one an agent should be reading.
+    """
+    selectors = [name for name, on in (("--full", full), ("--layout", layout)) if on]
+    if prop_type:
+        selectors.append("--props")
+    if len(selectors) > 1:
+        raise SchemaSelectionError(
+            "Pass only one of " + ", ".join(selectors) + ". They select different schemas."
+        )
+
+    if full:
+        schema = full_schema()
+    elif layout:
+        schema = layout_schema()
+    elif prop_type:
+        schema = props_schema(prop_type)
+    else:
+        schema = core_schema()
+
+    return json.dumps(schema, indent=indent)

--- a/visivo/commands/test.py
+++ b/visivo/commands/test.py
@@ -1,5 +1,11 @@
 import click
-from visivo.commands.options import output_dir, working_dir, source, no_deprecation_warnings
+from visivo.commands.options import (
+    output_dir,
+    working_dir,
+    source,
+    no_deprecation_warnings,
+    json_output,
+)
 
 
 @click.command()
@@ -7,7 +13,8 @@ from visivo.commands.options import output_dir, working_dir, source, no_deprecat
 @working_dir
 @output_dir
 @no_deprecation_warnings
-def test(output_dir, working_dir, source, no_deprecation_warnings):
+@json_output
+def test(output_dir, working_dir, source, no_deprecation_warnings, json_output):
     """
     Runs the project's tests, asserting on computed insight values to ensure the charts being produced have the characteristics that you expect.
     """
@@ -15,12 +22,25 @@ def test(output_dir, working_dir, source, no_deprecation_warnings):
 
     Logger.instance().debug("Testing")
 
-    from visivo.commands.test_phase import test_phase
+    def _test(defer_exit):
+        from visivo.commands.test_phase import test_phase
 
-    test_phase(
-        default_source=source,
-        output_dir=output_dir,
-        working_dir=working_dir,
-        no_deprecation_warnings=no_deprecation_warnings,
-    )
+        return test_phase(
+            default_source=source,
+            output_dir=output_dir,
+            working_dir=working_dir,
+            no_deprecation_warnings=no_deprecation_warnings,
+            defer_exit=defer_exit,
+        )
+
+    if json_output:
+        from visivo.commands.json_output import json_command, test_errors, test_result
+
+        with json_command("test") as state:
+            project, test_run = _test(defer_exit=True)
+            state["result"] = test_result(test_run=test_run, project=project, output_dir=output_dir)
+            state["errors"] = test_errors(test_run, project=project)
+        return
+
+    _test(defer_exit=False)
     Logger.instance().success("Done")

--- a/visivo/commands/test.py
+++ b/visivo/commands/test.py
@@ -1,10 +1,10 @@
 import click
+from visivo.commands.json_output import json_output
 from visivo.commands.options import (
     output_dir,
     working_dir,
     source,
     no_deprecation_warnings,
-    json_output,
 )
 
 

--- a/visivo/commands/test_phase.py
+++ b/visivo/commands/test_phase.py
@@ -10,7 +10,14 @@ def test_phase(
     default_source: str,
     working_dir: str,
     no_deprecation_warnings: bool = False,
+    defer_exit: bool = False,
 ):
+    """
+    ``defer_exit`` suppresses the ``sys.exit(1)`` on a failing assertion so the
+    caller can report the failures itself and choose the exit code. Used by
+    ``visivo test --json``, which has to print its JSON envelope before the
+    process ends. Returns the ``TestRun`` either way.
+    """
     project = compile_phase(
         default_source=default_source,
         working_dir=working_dir,
@@ -28,8 +35,10 @@ def test_phase(
         output_dir=output_dir,
         dag=dag,
     )
-    if not test_runner.run().success:
+    test_run = test_runner.run()
+    if not test_run.success and not defer_exit:
         sys.exit(1)
+    return project, test_run
 
 
 test_phase.__test__ = False


### PR DESCRIPTION
## Why

An LLM cannot author a Visivo project from the schema we ship. `visivo/src/visivo_project_schema.json` is **3,363,103 bytes across 103 `$defs`**, and over 98% of that is vendored Plotly: `Layout` alone is 423,983 bytes, plus one definition per trace type. Nobody puts that in a prompt, so agents guess at the grammar instead of reading it.

And there is no structured way to read what a command did. An agent has to scrape human log lines and an exit code, so `visivo compile` failing on a dangling ref tells it "1" and nothing else.

This PR ships both halves of the agent contract from the Guided First Run dossier (W7).

## 1. `visivo schema`

```bash
visivo schema                  # core authoring subset (default) -- 93,173 bytes
visivo schema --core           # the same, said explicitly
visivo schema --full           # everything, Plotly included     -- 3,363,104 bytes
visivo schema --props bar      # the Plotly vocabulary --core prunes, one type
visivo schema --layout         # the Plotly layout vocabulary
visivo schema -o core.json     # write to a file
visivo schema --indent 2       # pretty-print
```

Follows the existing command pattern: `visivo/commands/schema.py` for the Click command, `visivo/commands/schema_phase.py` for the logic.

`--core` is the **default**, because emitting 3.3 MB into a terminal on a bare `visivo schema` would be hostile, and because the core subset is the one an agent should be reading.

### The selection rule (re-derivable, not hand-maintained)

The subset is derived from the live models on **every invocation**. Six mechanical steps, documented in full in the `schema_phase.py` module docstring:

1. **Build from `generate_project_schema()`, not `generate_schema()`.** `generate_schema()` *is* the function that merges the vendored Plotly JSON on top of the Pydantic dump — it is what takes the file from 115 KB to 3.3 MB. Choosing the un-merged function prunes every trace-prop `$def` and the big `Layout` in one step, **by construction**, so a Plotly trace type added next year is excluded automatically with no list to update. Nothing dangles: in the Pydantic-native schema `Insight.props` is already `InsightProps` (`type` required, any other key allowed) and `Layout` is already an open object.
2. **Keep only the authoring surface at the root.** `CORE_PROJECT_PROPERTIES` names what an agent writes by hand; `OMITTED_PROJECT_PROPERTIES` names the rest *with a reason each*, as data rather than a comment.
3. **Transitive `$ref` closure**, dropping every unreachable `$def`.
4. **Delete the machine-set fields** (`path`, `file_path`, `project_file_path`, `project_dir`, `cli_version`) from every object — the CLI fills them in, and an agent that writes them is making a mistake. ~9 KB across 45 defs.
5. **Delete Pydantic's auto-generated property titles** — `"title": "Source Name"` above a property named `source_name` is ~4 KB of restatement.
6. **Restore the Python-keyword aliases.** `Test.if_` carries an underscore only because `if` is reserved in Python; every doc example writes `if:`. Any property named `<keyword>_` is emitted under the bare keyword too, and the underscore spelling is marked `deprecated`. The test is `keyword.iskeyword(name[:-1])`, which is *why* this does not drag in the 1.0-era `targets`/`target` aliases that a blanket `by_alias=True` would.

The rule cannot silently go stale: `test_core_schema_classifies_every_project_field` fails, and `core_schema()` raises `SchemaSelectionError` naming the offending field, if `Project` ever grows a field neither list classifies.

The emitted document carries an `x-visivo-schema` block naming the mode, CLI version, what was omitted and why, and the commands that return the omitted parts — so an agent reading only the JSON knows what it is missing and how to get it.

### Two deliberate deviations from the dossier, and why

- **Size: 93 KB, not the dossier's ~55 KB.** The 55,338-byte figure came from 17 defs including only "common sources". Getting there means dropping `SnowflakeSource` (7,389 bytes as `BigQuerySource`), `BigQuerySource`, `RedshiftSource` and `ClickhouseSource` — i.e. the contract would lie about what Visivo connects to, and an agent asked to wire up Snowflake would have no schema for it. I kept every source type. 93 KB is ~23k tokens, still cacheable, and comfortably under the dossier's own stated acceptance bar ("writes a file under 100KB").
- **No committed `visivo_core_schema.json`.** The dossier proposed a second committed artifact beside `write-schema-json`. A second committed schema doubles the parity-ring surface that just went red on clean main (#642). Generating on demand takes 30 ms, can never be stale, and needs no CI check. Say the word if you'd rather have the file.

`Layout` survives as the ~90-byte open-object stub the `$ref`s need, rather than dangling the reference — which satisfies the dossier's "exclude Layout" in the sense that matters (the 423,983-byte Plotly one is gone).

## 2. `--json` on compile, run and test

One JSON object on **stdout**, every human-readable line on **stderr**, exit code unchanged — so `visivo schema > core.json` and `visivo compile --json | jq` work, and `visivo run --json && visivo test --json` still short-circuits.

Stdout purity is enforced structurally: the command body runs inside `redirect_stdout(sys.stderr)`, which catches the `Logger`, the test runner's `.`/`F` dots, and any stray `print` deep in a job. `command_line.py` also refuses to start the Halo spinner (which writes escape codes straight to stdout) for `--json` or `schema` invocations, and suppresses the "Starting Visivo..." banner and the trailing execution-time line.

Three of the tests shell out to `python -m visivo.command_line` rather than using `CliRunner`, because `CliRunner` invokes the subcommand directly and never runs `command_line.py` — which is exactly where the banner, the timing line, the spinner and the error routing live. That gap was real: `visivo schema --core --full` was routing its error through `Logger` to **stdout**, so `visivo schema > core.json` on a bad invocation wrote the error message into the file the agent was about to parse. Fixed in `b80ea1f9`.

### The envelope (stable; every key always present)

```json
{
  "visivo_json_version": 1,
  "command": "compile",
  "success": true,
  "cli_version": "2.1.1",
  "duration_ms": 812,
  "result": { },
  "errors": [ ]
}
```

`errors` is always a list, empty on success, of objects with seven stable keys:

```json
{
  "code": "bad_reference",
  "name": "total_units_kpi",
  "message": "The reference \"ref(does_not_exist)\" on item \"total_units_kpi\" does not point to an object.",
  "file": "/work/project.visivo.yml",
  "line": 16,
  "object_path": "project.insights[0]",
  "details": null
}
```

`name`/`file`/`line` are filled in even when the Pydantic error does not carry them: `_resolve_in_files` re-parses the project YAML with the line-annotating loader and looks the object up **structurally** (no pattern matching), either by `name` or by the `(collection, index)` location — and reports nothing rather than the wrong object when `includes` make the index ambiguous.

`result` is command-specific and documented in `visivo/commands/json_output.py` and `mkdocs/reference/agent-contract.md`: `compile` returns the object names actually parsed per collection; `run` returns one entry per job with the runner's alignment dots stripped and the exception text and artifact path pulled out of the formatted line; `test` returns every assertion with its own name resolved off the project.

### Two behaviour notes

- `run_phase` and `test_phase` gain `defer_exit`. `DagRunner.run()` calls `sys.exit(1)` on a failed job, which would end the process before the envelope is printed — and, worse, unwinds `FilteredRunner.run()` before it aggregates the per-job results the envelope reports. `defer_exit` runs soft and hands the exit code back to the caller. One visible consequence, documented: **`run --json` attempts every filtered DAG and reports every failing job in one pass**, instead of stopping at the first failing dashboard.
- If anything deep in the stack calls `sys.exit()` anyway, `json_command` still emits an envelope (`"code": "exited"`) before honouring the code. An agent that got no JSON cannot tell a crash from a clean run.

### PR #650 (diagnostics)

`visivo/models/diagnostic.py` is **not touched**. `json_output.py` deliberately defines its own flat error shape instead of emitting `Diagnostic`s. Once #650 lands, `_error` should be replaced by the Diagnostic contract and `visivo_json_version` bumped to 2 — noted in the module docstring so it does not get lost.

## Schema JSON

`visivo/src/visivo_project_schema.json` was **not regenerated** — no Pydantic model changed in this PR. `git diff --name-only origin/main` touches nothing under `visivo/models/`.

## Tests

`tests/commands/test_schema_phase.py` (22), `test_schema.py` (15), `test_json_mode.py` (12), `test_json_output.py` (16) — 65 new tests.

Coverage of the acceptance criteria:
- the command emits valid JSON, and stdout carries nothing but the document (both with and without `-o`);
- `--core` compiles as a JSON Schema (`jsonschema_rs.validator_for` raises on a dangling `$ref`), is under 100 KB, is <1/20th of `--full`, keeps `SqlModel`/`Metric`/`Dimension`/`Relation`/`Insight`/`InsightInteraction`/`Chart`/`Dashboard`/`Row`/`Item` **and all ten source types**, and excludes every Plotly trace-prop def, `xaxis`/`yaxis`/`colorscale`, and the fat `Layout`;
- **`--core` validates all three real sample projects** in `visivo/templates/samples/` (parametrised over the glob, so a new sample is covered automatically) — and still rejects a misspelled key at the root and inside an object, so the "it validates everything" failure mode is ruled out;
- `--json` on each of compile/run/test is parseable and **stable across a success and a failure case** — the envelope key set and the per-entry key sets are asserted identical in both.

Full suite: **2535 passed, 2 skipped, 5 xfailed, 1 xpassed**. `black --check --target-version py312 .` clean.

### Falsification

Every guard was proved to fail with its implementation removed (stash the impl, keep the test, run, restore). 16 mutations, 16 caught:

| Mutation | Test | Result |
| --- | --- | --- |
| `core_schema` built from `generate_schema()` (Plotly not pruned) | `test_core_schema_prunes_the_plotly_vocabulary` | FAILED — "Plotly trace-prop defs leaked into the core subset" |
| machine-set fields left in every def | `test_core_schema_drops_machine_set_fields_everywhere` | FAILED — "Attachment still exposes machine-set field(s) ['path']" |
| keyword aliases not restored | `test_core_schema_restores_python_keyword_aliases` | FAILED — `'if' in {...}` |
| unclassified `Project` field silently ignored | `test_core_schema_raises_when_a_project_field_is_unclassified` | FAILED — "DID NOT RAISE SchemaSelectionError" |
| root `additionalProperties: true` | `test_core_schema_rejects_a_misspelled_key` | FAILED — "a misspelled key at the project root must be rejected" |
| `insights` dropped from the authoring surface | `test_core_schema_validates_the_shipped_sample_projects` | FAILED on all 3 samples |
| `_resolve_in_files` disabled | `test_compile_json_failure_carries_name_message_file_and_line` | FAILED — `file` is `None` |
| `redirect_stdout` removed | `test_compile_json_keeps_human_output_off_stdout` | FAILED — log line landed in the JSON stream |
| `defer_exit` no longer implies `soft_failure` | `test_run_json_failure_reports_the_failing_job` | FAILED — exit 0, no job errors |
| `SystemExit` escapes `json_command` without emitting | `test_json_command_still_emits_when_the_body_calls_sys_exit` | FAILED — `JSONDecodeError` on empty stdout |
| `test_errors` returns nothing | `test_test_json_failure_reports_each_failing_assertion` | FAILED — exit 0 |
| `_PROJECT_COLLECTIONS` drifts from the schema's authoring surface | `test_compile_result_covers_every_authorable_collection` | FAILED — and `test_compile_json_success` PASSED, so this guard is the only thing catching a collection silently vanishing from the report |
| `_split_location` call removed from the ClickException branch | `test_errors_from_a_yaml_syntax_click_exception_carry_file_and_line` | FAILED — `assert None == '/work/my project/project.visivo.yml'` |
| `x-visivo-schema` advertises a flag that does not exist | `test_every_command_the_schema_advertises_actually_runs` | FAILED — "No such option: --core-subset" |
| `AGENT_INVOCATION` dropped from `QUIET_INVOCATION` (banner not suppressed) | `test_end_to_end_schema_stdout_is_only_the_document` + `..._compile_json_stdout_is_only_the_envelope` | BOTH FAILED — `JSONDecodeError` at char 0 |
| `SCHEMA_INVOCATION` branch removed from `_report_error_for_agent` | `test_end_to_end_schema_error_leaves_stdout_empty` | FAILED — the error message landed in stdout |

The first pass of mutation 5 did **not** fail, because the guard only checked a misspelled key *inside* an object; the test was strengthened to cover the project root too, and then it failed as shown.

## Docs

New `mkdocs/reference/agent-contract.md` (+ one nav line): both surfaces, the selection rule, the envelope, all three `result` shapes, and a minimal agent loop. `visivo schema` also appears automatically in `reference/cli.md`, which generates from Click. codespell clean.

## Out of scope / found along the way

Building the `--json` failure fixtures turned up a pre-existing bug that `run --json` makes obvious, and it is worse than it first looked. **`visivo run` on all three shipped sample projects runs zero jobs and exits 0.**

Each sample names its single dashboard the same as the project (`EV Sales` / `College Football` / `GitHub Releases`). `run_phase` builds its default `dag_filter` as `+<dashboard name>+`, the DAG then holds two nodes with that name — the `Project` and the `Dashboard` — and `filter_dag("+EV Sales+")` returns **zero** sub-DAGs. No jobs, no error, exit 0, and an empty dashboard for anyone following the guided first run.

Isolated (my first guess, the space in the name, was wrong):

| project name | dashboard name | jobs run |
| --- | --- | --- |
| `EV Sales` | `EV Sales` | **0** |
| `EV Sales` | `EV Sales Overview` | 7 |
| `EV Sales` | `EVSales` | 7 |
| `ev-project` | `EV Sales` | 7 |

Not fixed here — it is a `filter_dag` name-resolution question, and `visivo/query/**` / the DAG are hot in other open PRs. Filed separately as **VIS-1324**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U
