### PR TITLE
Explorer: exploration results survive a tab switch (M27 tier 1)

### DIFF
--- a/viewer/e2e/stories/exploration-result-continuity.spec.mjs
+++ b/viewer/e2e/stories/exploration-result-continuity.spec.mjs
@@ -23,7 +23,11 @@
  *      to remove.
  *   2. Edit the SQL first, and coming back shows the run-your-query state
  *      rather than rows that answer a question the user has stopped asking.
- *   3. A sibling exploration never sees them.
+ *   3. A sibling exploration never sees them — asserted with the SAME SQL
+ *      typed into the sibling's chip, so every part of the cache key matches
+ *      except the exploration. Left with the sibling's default empty buffer
+ *      the assertion is vacuous: an empty query switches caching off outright,
+ *      so the grid would be empty whether or not the key isolates.
  *
  * Tier 2 (surviving a hard RELOAD, via a parquet twin under `target/`) is
  * deliberately out of scope and unasserted here — see the cache module's
@@ -175,15 +179,28 @@ test.describe('Exploration results survive a tab switch (M27)', () => {
     await gotoExplorerHome(page);
     await newExploration(page);
 
-    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    const sql = `SELECT * FROM ${TABLE}`;
+    await typeSql(page, sql);
     await runQuery(page);
     await expect(resultsGrid(page)).toBeVisible({ timeout: 20000 });
 
     await backToHome(page);
     await newExploration(page);
 
-    // A brand-new exploration whose chip may well carry the same generic
-    // name: its grid is empty until IT runs something.
+    // TYPE THE SAME SQL, and do not run it. This is what makes the test an
+    // isolation test rather than a coincidence: a brand-new exploration's
+    // auto-created chip starts with an EMPTY buffer, and
+    // `explorationResultCacheKey` returns null for empty sql — so caching is
+    // off for that tab no matter what the key is made of, and an empty grid
+    // would prove nothing. With the same SQL in the buffer, the sibling's
+    // chip carries the same generic name against the same source running the
+    // same text, and every component of the key MATCHES except
+    // `explorationId`. `useModelTabPrefill` reads on the keystroke, so if the
+    // exploration were ever dropped from the key this grid would fill with
+    // the other document's rows — which is the failure that must be
+    // impossible.
+    await typeSql(page, sql);
+
     await expect(emptyResults(page)).toBeVisible({ timeout: 20000 });
     await expect(resultsGrid(page)).toHaveCount(0);
   });

--- a/viewer/e2e/stories/exploration-result-continuity.spec.mjs
+++ b/viewer/e2e/stories/exploration-result-continuity.spec.mjs
@@ -1,0 +1,190 @@
+/**
+ * Story: exploration results survive a tab switch (M27, tier 1).
+ *
+ * THE BUG the field test reported: run a query, glance at another
+ * exploration, come back — the grid is empty and every query has to be run
+ * again. `ExplorationPane` parks the legacy `explorerStore` singleton on
+ * deactivate and rehydrates it from the persisted draft on activate, and that
+ * draft deliberately carries no `queryResult` (it is meant to stay a small
+ * JSON document, `explorerStore.js`'s snapshot docstring). So the rows were
+ * simply gone.
+ *
+ * THE FIX: `viewer/src/stores/explorationResultCache.js` — a page-lifetime,
+ * bounded LRU keyed by exploration + query chip + source + the SQL that
+ * actually ran. `CenterPanel` writes on run completion; `useModelTabPrefill`
+ * reads on mount and hands the rows back through `setModelQueryResult`.
+ *
+ * The three tests below are the three claims that matter, and two of them are
+ * refusals:
+ *
+ *   1. Come back and the rows are there — with NO new query job started. The
+ *      network assertion is the real one: "the grid has rows" could also be
+ *      satisfied by silently re-running, which is the very cost this exists
+ *      to remove.
+ *   2. Edit the SQL first, and coming back shows the run-your-query state
+ *      rather than rows that answer a question the user has stopped asking.
+ *   3. A sibling exploration never sees them.
+ *
+ * Tier 2 (surviving a hard RELOAD, via a parquet twin under `target/`) is
+ * deliberately out of scope and unasserted here — see the cache module's
+ * docstring for why that half needs a product decision first.
+ *
+ * Precondition: sandbox running (integration project), e.g.
+ *   VISIVO_SANDBOX_NAME=resultContinuity VISIVO_SANDBOX_BACKEND_PORT=8061 \
+ *   VISIVO_SANDBOX_FRONTEND_PORT=3061 bash scripts/sandbox.sh start
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3061 npx playwright test exploration-result-continuity
+ *
+ * Mints/mutates real backend exploration records — runs in the serial
+ * `exploration-mutations` playwright project (playwright.config.mjs), never
+ * `parallel`. See the DOUBLE-REGISTRATION RULE note in playwright.config.mjs:
+ * this filename must appear in BOTH `exploration-mutations`'s `testMatch` and
+ * `parallel`'s `testIgnore`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { typeSql, runQuery } from '../helpers/explorer.mjs';
+import { BASE_URL, API } from '../helpers/sandbox.mjs';
+
+const TABLE = 'test_table';
+
+async function listExplorationIds(page) {
+  const res = await page.request.get(`${API}/api/explorations/`).catch(() => null);
+  if (!res || !res.ok()) return [];
+  const data = await res.json().catch(() => []);
+  return (data || []).map(e => e.id);
+}
+
+async function gotoExplorerHome(page) {
+  await page.goto(`${BASE_URL}/workspace/exploration`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByTestId('workspace-middle-explorer')).toBeVisible({ timeout: 30000 });
+}
+
+async function newExploration(page) {
+  await page.getByTestId('explorer-home-new-exploration').click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  // `useExplorerWorkbenchInit`'s "auto-create a model tab when empty" effect
+  // lands asynchronously on a cold load; typing before it does silently
+  // vanishes (`setActiveModelSql` no-ops with no active model).
+  await page.waitForFunction(() => !!window.useStore.getState().explorerActiveModelName, {
+    timeout: 10000,
+  });
+  await page.waitForURL(/\/workspace\/exploration\/exp_/, { timeout: 10000 });
+  return new URL(page.url()).pathname.split('/').pop();
+}
+
+/** Back to Explorer Home, so a second exploration can be minted. */
+async function backToHome(page) {
+  await page.getByTestId('workspace-view-switcher-explorer').click();
+  await expect(page.getByTestId('explorer-home-gallery')).toBeVisible({ timeout: 30000 });
+}
+
+async function activateTab(page, id) {
+  await page.getByTestId(`workspace-tab-select-exploration:${id}`).click();
+  await expect(page.getByTestId('workspace-middle-exploration')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(
+    explorationId => window.location.pathname.endsWith(explorationId),
+    id,
+    { timeout: 10000 }
+  );
+}
+
+const resultsGrid = page => page.getByTestId('explorer-results-grid');
+const emptyResults = page => page.getByTestId('empty-results');
+
+// The grid virtualises its rows into absolutely-positioned divs (no <tbody>),
+// so the honest "how much data is on screen" signal is DataTable's own footer
+// count rather than a DOM row tally.
+const rowCountLabel = page => resultsGrid(page).getByText(/total rows/);
+
+test.describe('Exploration results survive a tab switch (M27)', () => {
+  // Multi-step: mint two explorations, run a real query job, switch twice.
+  // The 30s global default is tight for that once this project's
+  // combined-load contention with `parallel` is in play.
+  test.describe.configure({ timeout: 90000 });
+
+  let idsBeforeTest = [];
+
+  test.beforeEach(async ({ page }) => {
+    idsBeforeTest = await listExplorationIds(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    const idsAfterTest = await listExplorationIds(page);
+    for (const id of idsAfterTest.filter(id => !idsBeforeTest.includes(id))) {
+      await page.request.delete(`${API}/api/explorations/${id}/`).catch(() => {});
+    }
+  });
+
+  test('run a query, park the tab, come back — same rows, no re-run', async ({ page }) => {
+    await gotoExplorerHome(page);
+    const idA = await newExploration(page);
+
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+    await expect(resultsGrid(page)).toBeVisible({ timeout: 20000 });
+    const rowsBefore = await rowCountLabel(page).textContent();
+    expect(rowsBefore).toMatch(/^[1-9]/); // real rows landed, not an empty result
+
+    // Park A by activating a second exploration, exactly as a user reading
+    // something else would.
+    await backToHome(page);
+    const idB = await newExploration(page);
+    expect(idB).not.toBe(idA);
+
+    // Count query jobs started from HERE on. A silent re-run would satisfy
+    // "the grid has rows" just as well as a cache hit does — and it is the
+    // cost this whole feature exists to remove, so it is what gets asserted.
+    const startedJobs = [];
+    page.on('request', req => {
+      if (req.method() === 'POST' && req.url().includes('/api/model-query-jobs/')) {
+        startedJobs.push(req.url());
+      }
+    });
+
+    await activateTab(page, idA);
+
+    await expect(resultsGrid(page)).toBeVisible({ timeout: 20000 });
+    await expect(rowCountLabel(page)).toHaveText(rowsBefore, { timeout: 10000 });
+    expect(startedJobs).toEqual([]);
+  });
+
+  test('edit the SQL first, and coming back asks you to run it — it does not show the old rows', async ({
+    page,
+  }) => {
+    await gotoExplorerHome(page);
+    const idA = await newExploration(page);
+
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+    await expect(resultsGrid(page)).toBeVisible({ timeout: 20000 });
+
+    // The query changes. These rows now answer a question the user has
+    // stopped asking, and nothing on screen would say so.
+    await typeSql(page, `SELECT 1 AS untried FROM ${TABLE}`);
+
+    await backToHome(page);
+    await newExploration(page);
+    await activateTab(page, idA);
+
+    await expect(emptyResults(page)).toBeVisible({ timeout: 20000 });
+    await expect(resultsGrid(page)).toHaveCount(0);
+  });
+
+  test('a sibling exploration is never shown the rows', async ({ page }) => {
+    await gotoExplorerHome(page);
+    await newExploration(page);
+
+    await typeSql(page, `SELECT * FROM ${TABLE}`);
+    await runQuery(page);
+    await expect(resultsGrid(page)).toBeVisible({ timeout: 20000 });
+
+    await backToHome(page);
+    await newExploration(page);
+
+    // A brand-new exploration whose chip may well carry the same generic
+    // name: its grid is empty until IT runs something.
+    await expect(emptyResults(page)).toBeVisible({ timeout: 20000 });
+    await expect(resultsGrid(page)).toHaveCount(0);
+  });
+});

--- a/viewer/playwright.config.mjs
+++ b/viewer/playwright.config.mjs
@@ -126,6 +126,10 @@ export default defineConfig({
         // edit, type switch): mints a real exploration + computed columns
         // against the shared `.visivo/explorations/` repository.
         '**/exploration-chart-build-updates.spec.mjs',
+        // M27 (results survive a tab switch): mints TWO real exploration
+        // records and runs a real query job against the shared
+        // `.visivo/explorations/` repository — same isolation need.
+        '**/exploration-result-continuity.spec.mjs',
         // Docs specs run against the docs sandbox (:8003) via
         // playwright.docs.config.mjs — never against the viewer sandbox.
         '**/e2e/docs/**',
@@ -296,6 +300,9 @@ export default defineConfig({
         // the draft compile/execute endpoints — same shared-repository
         // isolation need as its computed-column siblings above.
         '**/exploration-computed-metric-grouping.spec.mjs',
+        // M27 (results survive a tab switch) — see the 'parallel' project's
+        // testIgnore entry for the same file for why.
+        '**/exploration-result-continuity.spec.mjs',
       ],
       fullyParallel: false,
       workers: 1,

--- a/viewer/src/components/explorer/CenterPanel.jsx
+++ b/viewer/src/components/explorer/CenterPanel.jsx
@@ -25,6 +25,10 @@ import { inferColumnTypes } from '../../utils/inferColumnTypes';
 import { computeColumnProfile } from '../../utils/computeColumnProfile';
 import { usePanelResize } from '../../hooks/usePanelResize';
 import useExplorerDuckDB from '../../hooks/useExplorerDuckDB';
+import {
+  putCachedExplorationResult,
+  invalidateExplorationResults,
+} from '../../stores/explorationResultCache';
 
 const NARROW_THRESHOLD = 600;
 
@@ -50,6 +54,14 @@ const CenterPanel = ({
   // Explore 2.0 Phase 3a (D9): opts the SQL editor into being a Library
   // column/table drop target. Default false.
   enableLibraryDrop = false,
+  // M27: the exploration this panel belongs to, threaded down from
+  // `ExplorationPane`. It is the isolation half of the result-cache key — two
+  // explorations with an identically-named chip running identical SQL are
+  // still two different documents, and neither may ever be shown the other's
+  // rows. Omitted (the default) means "not inside an exploration", which
+  // switches the session result cache off entirely rather than guessing at a
+  // scope; see `explorationResultCache.js`.
+  explorationId = null,
 }) => {
   const activeModelName = useStore((s) => s.explorerActiveModelName);
   const sourceName = useStore(selectActiveModelSourceName);
@@ -59,10 +71,16 @@ const CenterPanel = ({
   const setSql = useStore((s) => s.setActiveModelSql);
   const queryResult = useStore(selectActiveModelQueryResult);
 
-  // Show the last run's rows when a model tab opens with none, instead of an
-  // empty grid beside a parquet that already exists. Never overwrites a query
+  // Fill a tab that opened with no rows: first from THIS session's own result
+  // for exactly this query (M27 — parking an exploration tab drops results
+  // from the draft on purpose, so coming back used to mean re-running
+  // everything), then from the last build's parquet. Never overwrites a query
   // the user just ran (see the hook).
-  useModelTabPrefill(activeModelName, Boolean(queryResult));
+  useModelTabPrefill(activeModelName, Boolean(queryResult), {
+    explorationId,
+    sourceName,
+    sql,
+  });
   const queryError = useStore(selectActiveModelQueryError);
   const setModelQueryResult = useStore((s) => s.setModelQueryResult);
   const setModelQueryError = useStore((s) => s.setModelQueryError);
@@ -170,18 +188,37 @@ const CenterPanel = ({
   }, [queryResult]);
 
   const handleQueryComplete = useCallback(
-    ({ result, error, context }) => {
+    ({ result, error, context, executedSql, executedSourceName }) => {
       // Deliver to the model tab that started the run (captured by SQLEditor
       // at execute time) — the user may have switched tabs mid-flight.
       const targetModel = context || activeModelName;
       if (result) {
         setModelQueryResult(targetModel, result);
+        // Park the rows so parking this exploration tab doesn't throw them
+        // away (M27). Keyed on what was EXECUTED — `executedSql` may be a
+        // selection rather than the whole buffer, and the user may have typed
+        // on while the job ran; the live editor text would file these rows
+        // under a query that never produced them.
+        putCachedExplorationResult(
+          {
+            explorationId,
+            modelName: targetModel,
+            sourceName: executedSourceName,
+            sql: executedSql,
+          },
+          result
+        );
       }
       if (error) {
         setModelQueryError(targetModel, error);
+        // A run that failed retires whatever that chip had parked. When the
+        // same query that succeeded a minute ago now errors — a source went
+        // away, a table was dropped — its old rows are exactly the rows that
+        // must not come back on the next tab switch.
+        invalidateExplorationResults(explorationId, targetModel);
       }
     },
-    [setModelQueryResult, setModelQueryError, activeModelName]
+    [setModelQueryResult, setModelQueryError, activeModelName, explorationId]
   );
 
 

--- a/viewer/src/components/explorer/CenterPanel.test.jsx
+++ b/viewer/src/components/explorer/CenterPanel.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import selectEvent from 'react-select-event';
 import CenterPanel from './CenterPanel';
 import useStore from '../../stores/store';
+import { _resetExplorationResultCacheForTests } from '../../stores/explorationResultCache';
 
 // Mock DraggableColumnHeader (requires @dnd-kit/core)
 jest.mock('./DraggableColumnHeader', () => {
@@ -12,11 +13,16 @@ jest.mock('./DraggableColumnHeader', () => {
   };
 });
 
-// Mock SQLEditor — mirrors the real editor's run-context snapshot: the
-// "capture" button records queryContext (as handleRun does at execute time)
-// and the completion buttons deliver results with that captured context.
+// Mock SQLEditor — mirrors the real editor's run snapshot: the "capture"
+// button records queryContext AND the sql/source in flight (as handleRun does
+// at execute time) and the completion buttons deliver results with that
+// captured snapshot. Keeping the sql/source in the snapshot is what lets
+// CenterPanel key M27's result cache on what actually ran rather than on
+// whatever the editor holds when the rows land.
 jest.mock('./SQLEditor', () => {
   let capturedContext;
+  let capturedSql;
+  let capturedSource;
   return function MockSQLEditor({
     sourceName,
     initialValue,
@@ -40,6 +46,8 @@ jest.mock('./SQLEditor', () => {
           data-testid="trigger-run-capture"
           onClick={() => {
             capturedContext = queryContext;
+            capturedSql = (initialValue || '').trim();
+            capturedSource = sourceName;
           }}
         >
           Run (capture context)
@@ -51,6 +59,8 @@ jest.mock('./SQLEditor', () => {
               result: { columns: ['id'], rows: [{ id: 1 }], row_count: 1 },
               error: null,
               context: capturedContext,
+              executedSql: capturedSql,
+              executedSourceName: capturedSource,
             })
           }
         >
@@ -63,6 +73,8 @@ jest.mock('./SQLEditor', () => {
               result: null,
               error: 'SQL error',
               context: capturedContext,
+              executedSql: capturedSql,
+              executedSourceName: capturedSource,
             })
           }
         >
@@ -725,6 +737,184 @@ describe('CenterPanel', () => {
         rafSpy.mockRestore();
         dispatchSpy.mockRestore();
       }
+    });
+  });
+
+  /**
+   * M27 — results survive a tab switch.
+   *
+   * These drive the FULL round trip through the real store and the real cache
+   * module: run a query, then reproduce exactly what parking an exploration
+   * tab does (`ExplorationPane`'s deactivate/activate pair — unmount, and
+   * rebuild the model state from the persisted draft, which by design carries
+   * no `queryResult`), then mount again and assert what the grid shows.
+   *
+   * Asserting on the rendered grid rather than on store internals is the
+   * point: "the rows came back" is the user-visible claim, and the empty
+   * state is the honest alternative whenever the cache must miss.
+   */
+  describe('exploration result cache (M27)', () => {
+    const EXPLORATION_ID = 'exp-a';
+
+    // Exactly what restoreExplorerWorkingState does on activate: rebuild the
+    // model state from the draft, which never carried the rows.
+    const parkAndResume = (overrides = {}) => {
+      useStore.setState({
+        explorerModelStates: {
+          test_model: makeModelState({
+            sql: 'SELECT 1',
+            sourceName: 'test_source',
+            ...overrides,
+          }),
+        },
+      });
+    };
+
+    const runAQuery = () => {
+      fireEvent.click(screen.getByTestId('trigger-run-capture'));
+      fireEvent.click(screen.getByTestId('trigger-query-complete'));
+    };
+
+    beforeEach(() => {
+      _resetExplorationResultCacheForTests();
+    });
+
+    it('returning to the tab shows the same rows again, without re-running', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+
+      view.unmount();
+      parkAndResume();
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+      expect(screen.getByTestId('dt-row-count')).toHaveTextContent('1');
+      expect(screen.queryByTestId('empty-results')).not.toBeInTheDocument();
+    });
+
+    it('shows the run-your-query state after the SQL is edited', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      view.unmount();
+
+      // Resume with edited SQL — the rows on hand answer a question the user
+      // is no longer asking.
+      parkAndResume({ sql: 'SELECT 2' });
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+      expect(screen.queryByTestId('data-table')).not.toBeInTheDocument();
+    });
+
+    it('shows the run-your-query state after the source is changed', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      view.unmount();
+
+      useStore.setState({
+        explorerSources: [
+          { source_name: 'test_source', source_type: 'postgresql' },
+          { source_name: 'other_source', source_type: 'postgresql' },
+        ],
+      });
+      parkAndResume({ sourceName: 'other_source' });
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+    });
+
+    it('shows the run-your-query state after the chip is renamed', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      view.unmount();
+
+      // A rename moves the whole model state to a new key — which is exactly
+      // what the promote-naming rail does.
+      useStore.setState({
+        explorerActiveModelName: 'test_model_renamed',
+        explorerModelTabs: ['test_model_renamed'],
+        explorerModelStates: {
+          test_model_renamed: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+        },
+      });
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+    });
+
+    it('never shows a sibling exploration the rows', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      view.unmount();
+
+      parkAndResume();
+      render(<CenterPanel explorationId="exp-b" />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+    });
+
+    it('does not resurrect rows once the same query starts failing', () => {
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+      runAQuery();
+      // Same SQL, same source — it just errors now (a dropped table, a source
+      // that went away). The rows it used to return are precisely the rows
+      // that must not come back.
+      fireEvent.click(screen.getByTestId('trigger-query-error'));
+      view.unmount();
+
+      parkAndResume();
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
+    });
+
+    it('parks the rows under the query that RAN, not the tab that is active when they land', () => {
+      // The user starts a run on `test_model` and switches to `other_model`
+      // while it is in flight. The rows belong to `test_model`'s query — key
+      // them by whatever the editor happens to be showing when they arrive
+      // and this chip's cache entry describes a query that never ran.
+      useStore.setState({
+        explorerActiveModelName: 'test_model',
+        explorerModelTabs: ['test_model', 'other_model'],
+        explorerModelStates: {
+          test_model: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+          other_model: makeModelState({ sql: 'SELECT 999', sourceName: 'test_source' }),
+        },
+      });
+      const view = render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      fireEvent.click(screen.getByTestId('trigger-run-capture'));
+      act(() => {
+        useStore.setState({ explorerActiveModelName: 'other_model' });
+      });
+      fireEvent.click(screen.getByTestId('trigger-query-complete'));
+      view.unmount();
+
+      // Resume with test_model active and holding the SQL it actually ran.
+      useStore.setState({
+        explorerActiveModelName: 'test_model',
+        explorerModelStates: {
+          test_model: makeModelState({ sql: 'SELECT 1', sourceName: 'test_source' }),
+          other_model: makeModelState({ sql: 'SELECT 999', sourceName: 'test_source' }),
+        },
+      });
+      render(<CenterPanel explorationId={EXPLORATION_ID} />);
+
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+
+    it('parks nothing when the panel is not inside an exploration', () => {
+      // `explorationId` omitted — CenterPanel's default. Nothing is keyed,
+      // so nothing is stored and nothing is served.
+      const view = render(<CenterPanel />);
+      runAQuery();
+      view.unmount();
+
+      parkAndResume();
+      render(<CenterPanel />);
+
+      expect(screen.getByTestId('empty-results')).toBeInTheDocument();
     });
   });
 });

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -37,10 +37,25 @@ const SQLEditor = ({
   const handleRunRef = useRef(null);
   const handleCancelRef = useRef(null);
   const isRunningRef = useRef(false);
-  // Snapshot of queryContext at execute time — passed back through
+  // Snapshot of the RUN at execute time — passed back through
   // onQueryComplete so the caller can route results to the tab/model that
   // started the run even if the context changed while the job was in flight.
+  //
+  // `sql`/`sourceName` are part of that snapshot for the same reason `context`
+  // is, and M27's result cache depends on it: what was actually sent may be a
+  // SELECTION rather than the whole buffer, and the user can keep typing (or
+  // change source) while the job runs. A caller that keyed a cached result on
+  // whatever the editor holds when the rows land would file one query's rows
+  // under another query's identity.
   const runContextRef = useRef(null);
+  const runSqlRef = useRef(null);
+  const runSourceRef = useRef(null);
+
+  const completionPayload = () => ({
+    context: runContextRef.current,
+    executedSql: runSqlRef.current,
+    executedSourceName: runSourceRef.current,
+  });
 
   const [sql, setSql] = useState(initialValue);
   const [showError, setShowError] = useState(true);
@@ -70,13 +85,13 @@ const SQLEditor = ({
   // Notify parent when query completes
   useEffect(() => {
     if (onQueryComplete && result) {
-      onQueryComplete({ result, error: null, context: runContextRef.current });
+      onQueryComplete({ result, error: null, ...completionPayload() });
     }
   }, [result]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (onQueryComplete && error) {
-      onQueryComplete({ result: null, error, context: runContextRef.current });
+      onQueryComplete({ result: null, error, ...completionPayload() });
     }
   }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -119,8 +134,11 @@ const SQLEditor = ({
     }
 
     setShowError(true);
+    const executed = queryText.trim();
     runContextRef.current = queryContext ?? null;
-    executeQuery(sourceName, queryText.trim());
+    runSqlRef.current = executed;
+    runSourceRef.current = sourceName;
+    executeQuery(sourceName, executed);
     recordOnboardingAction('query_run');
   }, [sourceName, sql, executeQuery, queryContext]);
 

--- a/viewer/src/components/explorer/SQLEditor.jsx
+++ b/viewer/src/components/explorer/SQLEditor.jsx
@@ -37,17 +37,15 @@ const SQLEditor = ({
   const handleRunRef = useRef(null);
   const handleCancelRef = useRef(null);
   const isRunningRef = useRef(false);
-  // Snapshot of the RUN at execute time — passed back through
-  // onQueryComplete so the caller can route results to the tab/model that
-  // started the run even if the context changed while the job was in flight.
-  //
-  // `sql`/`sourceName` are part of that snapshot for the same reason `context`
-  // is, and M27's result cache depends on it: what was actually sent may be a
-  // SELECTION rather than the whole buffer, and the user can keep typing (or
-  // change source) while the job runs. A caller that keyed a cached result on
-  // whatever the editor holds when the rows land would file one query's rows
-  // under another query's identity.
-  const runContextRef = useRef(null);
+  // M27: what was actually SENT, snapshotted at execute time for the same
+  // reason `runContextRef` below is. The text sent may be a SELECTION rather
+  // than the whole buffer, and the user can keep typing (or change source)
+  // while the job runs — so a caller that keyed a cached result on whatever
+  // the editor holds when the rows land would file one query's rows under
+  // another query's identity. Declared here, and assigned ahead of
+  // `runContextRef` in `handleRun`, deliberately: PR #659 is adding its own
+  // ref and its own statement at exactly those two anchors, and leaving its
+  // context lines untouched keeps the two merges apart.
   const runSqlRef = useRef(null);
   const runSourceRef = useRef(null);
 
@@ -56,6 +54,11 @@ const SQLEditor = ({
     executedSql: runSqlRef.current,
     executedSourceName: runSourceRef.current,
   });
+
+  // Snapshot of queryContext at execute time — passed back through
+  // onQueryComplete so the caller can route results to the tab/model that
+  // started the run even if the context changed while the job was in flight.
+  const runContextRef = useRef(null);
 
   const [sql, setSql] = useState(initialValue);
   const [showError, setShowError] = useState(true);
@@ -134,11 +137,13 @@ const SQLEditor = ({
     }
 
     setShowError(true);
-    const executed = queryText.trim();
-    runContextRef.current = queryContext ?? null;
-    runSqlRef.current = executed;
+    // M27 — the run snapshot, taken before the job starts. Assigned above
+    // `runContextRef` rather than below `executeQuery` so the three lines that
+    // follow stay byte-identical to main; see the ref declarations.
+    runSqlRef.current = queryText.trim();
     runSourceRef.current = sourceName;
-    executeQuery(sourceName, executed);
+    runContextRef.current = queryContext ?? null;
+    executeQuery(sourceName, queryText.trim());
     recordOnboardingAction('query_run');
   }, [sourceName, sql, executeQuery, queryContext]);
 

--- a/viewer/src/components/explorer/SQLEditor.test.jsx
+++ b/viewer/src/components/explorer/SQLEditor.test.jsx
@@ -383,6 +383,8 @@ describe('SQLEditor', () => {
           result: { columns: ['id'], rows: [{ id: 1 }], row_count: 1 },
           error: null,
           context: { modelName: 'model_a' },
+          executedSql: 'SELECT 1',
+          executedSourceName: 'test_source',
         });
       });
     });
@@ -432,8 +434,80 @@ describe('SQLEditor', () => {
           result: null,
           error: 'boom',
           context: null,
+          executedSql: null,
+          executedSourceName: null,
         });
       });
+    });
+
+    /**
+     * M27 — the run snapshot carries the SQL and source that were actually
+     * SENT, not what the editor holds when the rows land. `CenterPanel` keys
+     * its result cache on these; keying on the live buffer instead would file
+     * one query's rows under a query that never produced them.
+     */
+    it('reports the SELECTION that ran, not the whole buffer', async () => {
+      const onQueryComplete = jest.fn();
+      mockSelectionIsEmpty = false;
+      mockSelectedText = 'SELECT 2';
+
+      const { rerender } = render(
+        <SQLEditor
+          initialValue={'SELECT 1;\nSELECT 2'}
+          sourceName="test_source"
+          onQueryComplete={onQueryComplete}
+        />
+      );
+      // Wait for the mocked Monaco's deferred onMount — without the editor
+      // ref there is no selection to read.
+      await waitFor(() => expect(mockEditor.addCommand).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByRole('button', { name: /run/i }));
+      await waitFor(() => expect(mockExecuteQuery).toHaveBeenCalledWith('test_source', 'SELECT 2'));
+
+      mockQueryJobState = { ...mockQueryJobState, result: { columns: [], rows: [], row_count: 0 } };
+      rerender(
+        <SQLEditor
+          initialValue={'SELECT 1;\nSELECT 2'}
+          sourceName="test_source"
+          onQueryComplete={onQueryComplete}
+        />
+      );
+
+      await waitFor(() =>
+        expect(onQueryComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ executedSql: 'SELECT 2' })
+        )
+      );
+    });
+
+    it('reports the SQL that ran even after the user keeps typing mid-flight', async () => {
+      const onQueryComplete = jest.fn();
+      const { rerender } = render(
+        <SQLEditor initialValue="SELECT 1" sourceName="test_source" onQueryComplete={onQueryComplete} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /run/i }));
+      await waitFor(() => expect(mockExecuteQuery).toHaveBeenCalled());
+
+      // The buffer and the source both move on while the job is in flight.
+      mockQueryJobState = { ...mockQueryJobState, result: { columns: [], rows: [], row_count: 0 } };
+      rerender(
+        <SQLEditor
+          initialValue="SELECT 999"
+          sourceName="a_different_source"
+          onQueryComplete={onQueryComplete}
+        />
+      );
+
+      await waitFor(() =>
+        expect(onQueryComplete).toHaveBeenCalledWith(
+          expect.objectContaining({
+            executedSql: 'SELECT 1',
+            executedSourceName: 'test_source',
+          })
+        )
+      );
     });
 
     it('passes context null when no queryContext prop is provided', async () => {

--- a/viewer/src/components/views/workspace/ExplorationPane.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.jsx
@@ -496,7 +496,7 @@ const ExplorationPane = ({ id }) => {
           onDismiss={handleDismissStaleness}
         />
       )}
-      <ExplorationWorkbench />
+      <ExplorationWorkbench explorationId={id} />
     </section>
   );
 };

--- a/viewer/src/components/views/workspace/ExplorationPane.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationPane.test.jsx
@@ -17,7 +17,9 @@ import { setWorkspaceTelemetryListener } from './telemetry';
 
 jest.mock('./ExplorationWorkbench', () => ({
   __esModule: true,
-  default: () => <div data-testid="exploration-workbench-mock" />,
+  default: ({ explorationId }) => (
+    <div data-testid="exploration-workbench-mock" data-exploration-id={explorationId || 'none'} />
+  ),
 }));
 
 const record = overrides => ({
@@ -77,6 +79,18 @@ describe('ExplorationPane — ready state', () => {
     expect(screen.getByText('Churn dig')).toBeInTheDocument();
     expect(screen.getByTestId('exploration-duplicate-button')).toBeInTheDocument();
     expect(screen.getByTestId('exploration-workbench-mock')).toBeInTheDocument();
+  });
+
+  // M27: the pane is the only place that knows WHICH exploration is hot in
+  // the shared legacy singleton, so it is the only place that can scope the
+  // session result cache. Drop this and two explorations share one cache key.
+  test('hands the workbench this exploration’s id', () => {
+    seed({ workspaceExplorations: { byId: { exp_1: record() }, order: ['exp_1'] } });
+    render(<ExplorationPane id="exp_1" />);
+    expect(screen.getByTestId('exploration-workbench-mock')).toHaveAttribute(
+      'data-exploration-id',
+      'exp_1'
+    );
   });
 
   test('restores the legacy working state from the record draft on mount', () => {

--- a/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
+++ b/viewer/src/components/views/workspace/ExplorationWorkbench.jsx
@@ -58,7 +58,7 @@ import ExplorationQueryChips from './ExplorationQueryChips';
  * mount on the per-exploration state restore having already landed — see
  * `useExplorerWorkbenchInit`'s docstring.
  */
-const ExplorationWorkbench = () => {
+const ExplorationWorkbench = ({ explorationId = null }) => {
   useExplorerWorkbenchInit();
 
   return (
@@ -66,7 +66,16 @@ const ExplorationWorkbench = () => {
       className="flex min-h-0 flex-1 overflow-hidden bg-gray-50"
       data-testid="exploration-workbench"
     >
-      <CenterPanel modelTabBar={<ExplorationQueryChips />} enableLibraryDrop />
+      {/* `explorationId` is passed for ONE reason: it scopes M27's session
+          result cache, so parking this tab and coming back restores the rows
+          you were looking at — and so a sibling exploration with an
+          identically-named chip can never be handed them. Everything else
+          here still reads the shared `explorerStore` singleton. */}
+      <CenterPanel
+        modelTabBar={<ExplorationQueryChips />}
+        enableLibraryDrop
+        explorationId={explorationId}
+      />
     </div>
   );
 };

--- a/viewer/src/components/views/workspace/ExplorationWorkbench.test.jsx
+++ b/viewer/src/components/views/workspace/ExplorationWorkbench.test.jsx
@@ -15,9 +15,13 @@ import ExplorationWorkbench from './ExplorationWorkbench';
 import useStore from '../../../stores/store';
 
 jest.mock('../../explorer/CenterPanel', () => {
-  return function MockCenterPanel({ modelTabBar, enableLibraryDrop }) {
+  return function MockCenterPanel({ modelTabBar, enableLibraryDrop, explorationId }) {
     return (
-      <div data-testid="center-panel" data-enable-library-drop={enableLibraryDrop ? 'true' : 'false'}>
+      <div
+        data-testid="center-panel"
+        data-enable-library-drop={enableLibraryDrop ? 'true' : 'false'}
+        data-exploration-id={explorationId || 'none'}
+      >
         CenterPanel
         {modelTabBar}
       </div>
@@ -67,6 +71,20 @@ describe('ExplorationWorkbench', () => {
   test('opts CenterPanel into the Library SQL-editor drop target (D9)', () => {
     render(<ExplorationWorkbench />);
     expect(screen.getByTestId('center-panel')).toHaveAttribute('data-enable-library-drop', 'true');
+  });
+
+  // M27: the exploration id is the isolation half of the session result
+  // cache's key — without it two explorations with an identically-named chip
+  // running identical SQL would be one cache entry, and one document would be
+  // shown the other's rows.
+  test('hands CenterPanel the exploration id so parked results stay per-document', () => {
+    render(<ExplorationWorkbench explorationId="exp_1" />);
+    expect(screen.getByTestId('center-panel')).toHaveAttribute('data-exploration-id', 'exp_1');
+  });
+
+  test('passes no exploration id when it has none — the cache stays off rather than guessing', () => {
+    render(<ExplorationWorkbench />);
+    expect(screen.getByTestId('center-panel')).toHaveAttribute('data-exploration-id', 'none');
   });
 
   test('sizes to fill its container (no fixed viewport height, unlike the standalone route)', () => {

--- a/viewer/src/hooks/useModelTabPrefill.js
+++ b/viewer/src/hooks/useModelTabPrefill.js
@@ -4,27 +4,44 @@ import useStore from '../stores/store';
 import { DEFAULT_RUN_ID } from '../constants';
 import { processModel } from './useModelsData';
 import { fetchModelJobs } from '../api/modelJobs';
+import { getCachedExplorationResult } from '../stores/explorationResultCache';
 
 /**
- * Fill a freshly-opened model tab with the LAST RUN's rows.
+ * Fill a model tab that has no rows — from this session's own results first,
+ * and only then from the last BUILD's parquet.
  *
- * Opening a model used to show an empty grid until you pressed Run, even though
- * the previous run's parquet was sitting right there. `explorerStore` used to do
- * this itself, and lost the ability when `api/modelData.js` was removed: the
- * rows now come from the parquet via DuckDB, and DuckDB is reachable from a
- * hook, not from a Zustand store.
+ * Two sources, in that order, because they answer two different questions:
  *
- * So it lives here rather than in the store. The alternative — exposing a DuckDB
- * singleton for the store to reach into — is smaller but puts a browser resource
- * behind a synchronous state container, where nothing owns its lifecycle.
+ * 1. THIS SESSION'S RESULT (M27). Switching to another exploration tab parks
+ *    the current one, and parking deliberately drops query results from the
+ *    persisted draft (`explorerStore`'s snapshot/restore docstring) — so
+ *    coming back used to mean re-running every query you had on screen.
+ *    `explorationResultCache.js` keeps those rows for the life of the page,
+ *    keyed by the exploration + chip + source + executed SQL, and this hook
+ *    hands a hit back through `setModelQueryResult` — the same door a real run
+ *    comes through, so `useExplorerDuckDB` re-registers the DuckDB table and
+ *    computed columns / the column profiler keep working. A hit is synchronous
+ *    and makes no network request at all.
+ *
+ * 2. THE LAST BUILD. Opening a model used to show an empty grid until you
+ *    pressed Run, even though the previous run's parquet was sitting right
+ *    there. `explorerStore` used to do this itself, and lost the ability when
+ *    `api/modelData.js` was removed: the rows now come from the parquet via
+ *    DuckDB, and DuckDB is reachable from a hook, not from a Zustand store.
+ *
+ * So it lives here rather than in the store. The alternative — exposing a
+ * DuckDB singleton for the store to reach into — is smaller but puts a browser
+ * resource behind a synchronous state container, where nothing owns its
+ * lifecycle.
  *
  * Deliberately conservative:
  *
  * - It only fills a tab that has NO result. A query you just ran is never
- *   overwritten by a stale build.
- * - It attempts each model at most once per mount, whether it succeeded or not.
- *   A model that has never been built has no parquet, and a 404 per keystroke
- *   is worse than an empty grid.
+ *   overwritten, by either source.
+ * - The session cache is consulted every time (it is a Map lookup), but the
+ *   BUILD is attempted at most once per model per mount, whether it succeeded
+ *   or not. A model that has never been built has no parquet, and a 404 per
+ *   keystroke is worse than an empty grid.
  * - A failure is silent. This is a convenience; the Run button is the
  *   authoritative path and reports its own errors.
  *
@@ -35,8 +52,13 @@ import { fetchModelJobs } from '../api/modelJobs';
  *
  * @param {string|null} modelName - the active model tab, or null
  * @param {boolean} hasResult - whether that tab already has rows
+ * @param {{explorationId?: string|null, sourceName?: string|null, sql?: string}} [cacheScope]
+ *   The identity of the query this tab currently holds. Omit it (or leave
+ *   `explorationId` empty) and the session cache is simply off — the hook then
+ *   behaves exactly as it did before M27. `sourceName`/`sql` MUST describe the
+ *   tab being asked about, not some other tab.
  */
-export const useModelTabPrefill = (modelName, hasResult) => {
+export const useModelTabPrefill = (modelName, hasResult, cacheScope = null) => {
   const db = useDuckDB();
   const setModelQueryResult = useStore(state => state.setModelQueryResult);
   const projectId = useStore(state => state.project?.id);
@@ -44,9 +66,33 @@ export const useModelTabPrefill = (modelName, hasResult) => {
   // doesn't re-fetch, and a model with no parquet is asked for exactly once.
   const attemptedRef = useRef(new Set());
 
+  const explorationId = cacheScope?.explorationId || null;
+  const scopeSourceName = cacheScope?.sourceName || null;
+  const scopeSql = cacheScope?.sql || '';
+
   useEffect(() => {
-    if (!db || !modelName || hasResult) return;
-    if (attemptedRef.current.has(modelName)) return;
+    if (!modelName || hasResult) return undefined;
+
+    // (1) This session's own result for exactly this query. Checked BEFORE the
+    // last-build fetch and before `attemptedRef` is touched: it needs no
+    // DuckDB handle, no network, and it is what the user was looking at a
+    // moment ago, so it outranks whatever the project last built.
+    const cached = getCachedExplorationResult({
+      explorationId,
+      modelName,
+      sourceName: scopeSourceName,
+      sql: scopeSql,
+    });
+    if (cached) {
+      // `from_cache` marks the provenance for anything downstream that cares;
+      // the rows themselves are exactly what the run produced.
+      setModelQueryResult(modelName, { ...cached, from_cache: true });
+      return undefined;
+    }
+
+    // (2) The last build's parquet.
+    if (!db) return undefined;
+    if (attemptedRef.current.has(modelName)) return undefined;
     attemptedRef.current.add(modelName);
 
     let cancelled = false;
@@ -81,7 +127,16 @@ export const useModelTabPrefill = (modelName, hasResult) => {
     return () => {
       cancelled = true;
     };
-  }, [db, modelName, hasResult, setModelQueryResult, projectId]);
+  }, [
+    db,
+    modelName,
+    hasResult,
+    setModelQueryResult,
+    projectId,
+    explorationId,
+    scopeSourceName,
+    scopeSql,
+  ]);
 };
 
 export default useModelTabPrefill;

--- a/viewer/src/hooks/useModelTabPrefill.js
+++ b/viewer/src/hooks/useModelTabPrefill.js
@@ -50,6 +50,31 @@ import { getCachedExplorationResult } from '../stores/explorationResultCache';
  * cloud as well as locally. A model that has no built data just leaves the grid
  * empty.
  *
+ * ── WHY TWO EFFECTS AND NOT ONE ───────────────────────────────────────────
+ *
+ * The two sources have genuinely different triggers, and collapsing them into
+ * one effect broke the older one.
+ *
+ * The cache read must re-fire whenever the SCOPE changes: `sourceName` is
+ * rebound after `defaults` land (VIS-1082's `applyResolvedDefaultSource`), and
+ * `sql` is the live editor buffer, which `SQLEditor`'s `onSave` updates on
+ * every keystroke.
+ *
+ * The build fetch must NOT. It is asynchronous, and its cleanup cancels the
+ * in-flight request — while `attemptedRef` refuses to start a second one for
+ * the same name. Put the scope in that effect's dependency array and a single
+ * keystroke (or the VIS-1082 source rebind) during the fetch cancels it
+ * permanently: the resolved response is discarded, the re-run returns early on
+ * `attemptedRef`, and the grid stays empty for the rest of the mount beside a
+ * parquet that exists. That regression is what the two-effect split exists to
+ * prevent, and `useModelTabPrefill.test.js` proves it with a deferred fetch.
+ *
+ * `servedFromCacheRef` is the handoff between them. Effects run in declaration
+ * order, so on the commit where the cache hits, the build effect sees the ref
+ * already set and skips — without it the build effect would still be looking
+ * at the stale `hasResult === false` from that same render and would race the
+ * cached rows it just replaced.
+ *
  * @param {string|null} modelName - the active model tab, or null
  * @param {boolean} hasResult - whether that tab already has rows
  * @param {{explorationId?: string|null, sourceName?: string|null, sql?: string}} [cacheScope]
@@ -65,32 +90,47 @@ export const useModelTabPrefill = (modelName, hasResult, cacheScope = null) => {
   // Names already attempted this mount — keyed so switching tabs back and forth
   // doesn't re-fetch, and a model with no parquet is asked for exactly once.
   const attemptedRef = useRef(new Set());
+  // The model whose rows the cache effect just served, so the build effect —
+  // which runs on the same commit, still holding that render's stale
+  // `hasResult === false` — doesn't fetch a parquet to overwrite them with.
+  const servedFromCacheRef = useRef(null);
 
   const explorationId = cacheScope?.explorationId || null;
   const scopeSourceName = cacheScope?.sourceName || null;
   const scopeSql = cacheScope?.sql || '';
 
+  // (1) THIS SESSION'S OWN RESULT for exactly this query. It outranks the last
+  // build: it needs no DuckDB handle and no network, and it is what the user
+  // was looking at a moment ago. Keyed on the live scope, so it re-fires when
+  // the source is rebound or the buffer changes — see the two-effect note.
   useEffect(() => {
-    if (!modelName || hasResult) return undefined;
+    if (!modelName || hasResult) return;
 
-    // (1) This session's own result for exactly this query. Checked BEFORE the
-    // last-build fetch and before `attemptedRef` is touched: it needs no
-    // DuckDB handle, no network, and it is what the user was looking at a
-    // moment ago, so it outranks whatever the project last built.
     const cached = getCachedExplorationResult({
       explorationId,
       modelName,
       sourceName: scopeSourceName,
       sql: scopeSql,
     });
-    if (cached) {
-      // `from_cache` marks the provenance for anything downstream that cares;
-      // the rows themselves are exactly what the run produced.
-      setModelQueryResult(modelName, { ...cached, from_cache: true });
-      return undefined;
+    if (!cached) {
+      // A miss releases the build effect again: the entry may have been
+      // invalidated (a failed re-run, a promote) since it last hit.
+      servedFromCacheRef.current = null;
+      return;
     }
+    servedFromCacheRef.current = modelName;
+    // `from_cache` marks the provenance for anything downstream that cares;
+    // the rows themselves are exactly what the run produced.
+    setModelQueryResult(modelName, { ...cached, from_cache: true });
+  }, [modelName, hasResult, setModelQueryResult, explorationId, scopeSourceName, scopeSql]);
 
-    // (2) The last build's parquet.
+  // (2) THE LAST BUILD'S PARQUET. Deliberately NOT scope-dependent — see the
+  // two-effect note above; this dependency list is the pre-M27 one.
+  useEffect(() => {
+    if (!modelName || hasResult) return undefined;
+    // The cache already answered for this tab on this commit.
+    if (servedFromCacheRef.current === modelName) return undefined;
+
     if (!db) return undefined;
     if (attemptedRef.current.has(modelName)) return undefined;
     attemptedRef.current.add(modelName);
@@ -127,16 +167,7 @@ export const useModelTabPrefill = (modelName, hasResult, cacheScope = null) => {
     return () => {
       cancelled = true;
     };
-  }, [
-    db,
-    modelName,
-    hasResult,
-    setModelQueryResult,
-    projectId,
-    explorationId,
-    scopeSourceName,
-    scopeSql,
-  ]);
+  }, [db, modelName, hasResult, setModelQueryResult, projectId]);
 };
 
 export default useModelTabPrefill;

--- a/viewer/src/hooks/useModelTabPrefill.js
+++ b/viewer/src/hooks/useModelTabPrefill.js
@@ -119,8 +119,14 @@ export const useModelTabPrefill = (modelName, hasResult, cacheScope = null) => {
       return;
     }
     servedFromCacheRef.current = modelName;
-    // `from_cache` marks the provenance for anything downstream that cares;
-    // the rows themselves are exactly what the run produced.
+    // `from_cache` is provenance on the payload. Nothing reads it today — and
+    // neither does anything read `from_last_run` below, which has been on the
+    // build path since before M27 — so it is not a signal the UI can be said
+    // to give the user yet. It is here for the first surface that wants to say
+    // where the rows came from, and it is deliberately NOT load-bearing:
+    // everything the cache must get right, it gets right by never storing or
+    // serving an entry it should not. The rows themselves are exactly what the
+    // run produced.
     setModelQueryResult(modelName, { ...cached, from_cache: true });
   }, [modelName, hasResult, setModelQueryResult, explorationId, scopeSourceName, scopeSql]);
 

--- a/viewer/src/hooks/useModelTabPrefill.test.js
+++ b/viewer/src/hooks/useModelTabPrefill.test.js
@@ -17,6 +17,7 @@ import { fetchModelJobs } from '../api/modelJobs';
 import { useDuckDB } from '../contexts/DuckDBContext';
 import {
   putCachedExplorationResult,
+  invalidateExplorationResults,
   _resetExplorationResultCacheForTests,
 } from '../stores/explorationResultCache';
 
@@ -262,6 +263,142 @@ describe('session result cache', () => {
 
     await Promise.resolve();
     expect(setModelQueryResult).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The regression the two-effect split exists to prevent.
+   *
+   * These are NOT about the cache. They are about what threading the cache
+   * scope through this hook must not cost the OLDER of its two jobs — the
+   * last-build parquet prefill, which predates M27. `CenterPanel` feeds
+   * `sql` straight from `selectActiveModelSql`, and `SQLEditor`'s `onSave`
+   * updates that on every keystroke; `sourceName` moves too, when VIS-1082's
+   * `applyResolvedDefaultSource` rebinds an auto-created tab once `defaults`
+   * land. Both fire routinely while the parquet fetch is in the air.
+   *
+   * Put the scope in the build effect's dependency array and either one is
+   * fatal: the cleanup sets `cancelled = true`, the resolved response is
+   * dropped, and `attemptedRef` — which already holds the name — refuses to
+   * start another fetch. The grid then stays empty for the whole mount beside
+   * a parquet that exists.
+   *
+   * A deferred `fetchModelJobs` is what makes that window real in a test:
+   * without it the fetch resolves before the rerender and nothing is proven.
+   */
+  describe('a scope change mid-fetch does not cancel the last-build prefill', () => {
+    const deferredJobs = () => {
+      let resolve;
+      const promise = new Promise(r => {
+        resolve = r;
+      });
+      fetchModelJobs.mockReturnValue(promise);
+      return () => resolve([jobFor('orders')]);
+    };
+
+    it('survives a keystroke in the SQL editor while the parquet is loading', async () => {
+      const settle = deferredJobs();
+      processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+      const { rerender } = renderHook(({ sql }) => useModelTabPrefill('orders', false, { ...SCOPE, sql }), {
+        initialProps: { sql: 'SELECT * FROM orders' },
+      });
+      await waitFor(() => expect(fetchModelJobs).toHaveBeenCalledTimes(1));
+
+      // One character, mid-flight.
+      rerender({ sql: 'SELECT * FROM orders w' });
+      settle();
+
+      await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+      expect(setModelQueryResult.mock.calls[0][1].from_last_run).toBe(true);
+      // And it did not paper over the cancellation by re-fetching, which would
+      // be a 404 per keystroke for a model that has never been built.
+      expect(fetchModelJobs).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives the source being rebound while the parquet is loading', async () => {
+      const settle = deferredJobs();
+      processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+      const { rerender } = renderHook(
+        ({ sourceName }) => useModelTabPrefill('orders', false, { ...SCOPE, sourceName }),
+        { initialProps: { sourceName: 'pending_fallback' } }
+      );
+      await waitFor(() => expect(fetchModelJobs).toHaveBeenCalledTimes(1));
+
+      rerender({ sourceName: 'warehouse' });
+      settle();
+
+      await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+      expect(setModelQueryResult.mock.calls[0][1].from_last_run).toBe(true);
+    });
+
+    it('a cache HIT still suppresses the build fetch entirely', async () => {
+      // The other half of the split: the two effects run on the same commit,
+      // and the build effect is still holding that render's stale
+      // `hasResult === false`. Without the handoff ref it would fetch a
+      // parquet and overwrite the rows the cache effect just restored.
+      park();
+
+      renderHook(() => useModelTabPrefill('orders', false, SCOPE));
+
+      await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+      expect(setModelQueryResult).toHaveBeenCalledTimes(1);
+      expect(setModelQueryResult.mock.calls[0][1].from_cache).toBe(true);
+      expect(fetchModelJobs).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the build after a hit is invalidated', async () => {
+      // The handoff ref must not latch: once the entry is gone, the tab is
+      // owed the last build again rather than nothing.
+      park();
+      processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+      const { rerender } = renderHook(({ has }) => useModelTabPrefill('orders', has, SCOPE), {
+        initialProps: { has: false },
+      });
+      await waitFor(() => expect(setModelQueryResult).toHaveBeenCalledTimes(1));
+      expect(setModelQueryResult.mock.calls[0][1].from_cache).toBe(true);
+
+      // The chip's run fails, so `CenterPanel` retires its parked rows; the
+      // tab is emptied and re-asked.
+      invalidateExplorationResults('exp-a', 'orders');
+      rerender({ has: true });
+      rerender({ has: false });
+
+      await waitFor(() => expect(setModelQueryResult).toHaveBeenCalledTimes(2));
+      expect(setModelQueryResult.mock.calls[1][1].from_last_run).toBe(true);
+    });
+  });
+
+  /**
+   * A deliberate affordance, pinned here so it stays deliberate.
+   *
+   * The read is keyed on the LIVE editor buffer and re-fires while a tab has
+   * no result, so typing a query's text back in can fill the grid without a
+   * Run press. That is not a stale serve: `put` keeps at most ONE entry per
+   * (exploration, chip), always the newest run's, so a key match means these
+   * really are the rows that chip last produced for exactly this source and
+   * exactly this text — the same rows a tab switch would have restored. It is
+   * still surprising enough to be worth a test that says so out loud.
+   */
+  it('fills the grid mid-typing when the buffer returns to a parked query', async () => {
+    park();
+    // Nothing built for this model, so the cache is the only thing that can
+    // put rows on screen here.
+    fetchModelJobs.mockResolvedValue([]);
+
+    const { rerender } = renderHook(({ sql }) => useModelTabPrefill('orders', false, { ...SCOPE, sql }), {
+      initialProps: { sql: 'SELECT * FROM ord' },
+    });
+    // Half-typed: a miss, and an empty grid.
+    await waitFor(() => expect(fetchModelJobs).toHaveBeenCalled());
+    expect(setModelQueryResult).not.toHaveBeenCalled();
+
+    // The last character lands and the key matches — no Run press involved.
+    rerender({ sql: 'SELECT * FROM orders' });
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+    expect(setModelQueryResult.mock.calls[0][1].from_cache).toBe(true);
   });
 
   it('still restores on a SECOND return, unlike the once-per-mount build fetch', async () => {

--- a/viewer/src/hooks/useModelTabPrefill.test.js
+++ b/viewer/src/hooks/useModelTabPrefill.test.js
@@ -15,6 +15,10 @@ import { useModelTabPrefill } from './useModelTabPrefill';
 import { processModel } from './useModelsData';
 import { fetchModelJobs } from '../api/modelJobs';
 import { useDuckDB } from '../contexts/DuckDBContext';
+import {
+  putCachedExplorationResult,
+  _resetExplorationResultCacheForTests,
+} from '../stores/explorationResultCache';
 
 jest.mock('./useModelsData', () => ({ processModel: jest.fn() }));
 jest.mock('../api/modelJobs', () => ({ fetchModelJobs: jest.fn() }));
@@ -33,6 +37,7 @@ let setModelQueryResult;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  _resetExplorationResultCacheForTests();
   useDuckDB.mockReturnValue(DB);
   // Default: the model has built data. Tests that need "not built" override.
   fetchModelJobs.mockImplementation(names => Promise.resolve([jobFor(names[0])]));
@@ -138,4 +143,142 @@ it('does nothing without an active model', async () => {
 
   await Promise.resolve();
   expect(processModel).not.toHaveBeenCalled();
+});
+
+/**
+ * M27 — the session result cache.
+ *
+ * Parking an exploration tab drops query results from the persisted draft on
+ * purpose, so returning to a tab used to mean re-running every query. These
+ * cover the read half: what the hook restores, and — mostly — what it refuses
+ * to restore.
+ */
+describe('session result cache', () => {
+  const SCOPE = {
+    explorationId: 'exp-a',
+    sourceName: 'warehouse',
+    sql: 'SELECT * FROM orders',
+  };
+  const CACHED = { columns: ['id', 'region'], rows: ROWS, row_count: 2 };
+
+  const park = (overrides = {}) =>
+    putCachedExplorationResult(
+      { explorationId: 'exp-a', modelName: 'orders', sourceName: 'warehouse', sql: 'SELECT * FROM orders', ...overrides },
+      CACHED
+    );
+
+  it('restores the parked rows on return, with no network call at all', async () => {
+    park();
+
+    renderHook(() => useModelTabPrefill('orders', false, SCOPE));
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+    const [name, result] = setModelQueryResult.mock.calls[0];
+    expect(name).toBe('orders');
+    expect(result.rows).toEqual(ROWS);
+    expect(result.row_count).toBe(2);
+    // Provenance: these are this session's own rows, not the last build's.
+    expect(result.from_cache).toBe(true);
+    expect(result.from_last_run).toBeUndefined();
+    // The whole point — a return is free.
+    expect(fetchModelJobs).not.toHaveBeenCalled();
+    expect(processModel).not.toHaveBeenCalled();
+  });
+
+  it('restores before DuckDB is ready — the rows need no browser resource', async () => {
+    useDuckDB.mockReturnValue(null);
+    park();
+
+    renderHook(() => useModelTabPrefill('orders', false, SCOPE));
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+    expect(setModelQueryResult.mock.calls[0][1].from_cache).toBe(true);
+  });
+
+  it('MISSES after the query is edited, and falls through to the last build', async () => {
+    park();
+    processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+    renderHook(() => useModelTabPrefill('orders', false, { ...SCOPE, sql: 'SELECT 1 FROM orders' }));
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+    // Not the parked rows — the build's, which is the honest answer for a
+    // query that has never been run.
+    expect(setModelQueryResult.mock.calls[0][1].from_cache).toBeUndefined();
+    expect(setModelQueryResult.mock.calls[0][1].from_last_run).toBe(true);
+  });
+
+  it('MISSES after the chip is renamed', async () => {
+    park();
+
+    renderHook(() => useModelTabPrefill('orders_2', false, SCOPE));
+
+    await waitFor(() => expect(fetchModelJobs).toHaveBeenCalled());
+    expect(setModelQueryResult).not.toHaveBeenCalledWith(
+      'orders_2',
+      expect.objectContaining({ from_cache: true })
+    );
+  });
+
+  it('MISSES after the source is changed', async () => {
+    park();
+
+    renderHook(() => useModelTabPrefill('orders', false, { ...SCOPE, sourceName: 'other_db' }));
+
+    await waitFor(() => expect(fetchModelJobs).toHaveBeenCalled());
+    expect(setModelQueryResult).not.toHaveBeenCalledWith(
+      'orders',
+      expect.objectContaining({ from_cache: true })
+    );
+  });
+
+  it('never hands one exploration another’s rows', async () => {
+    park();
+
+    renderHook(() => useModelTabPrefill('orders', false, { ...SCOPE, explorationId: 'exp-b' }));
+
+    await waitFor(() => expect(fetchModelJobs).toHaveBeenCalled());
+    expect(setModelQueryResult).not.toHaveBeenCalledWith(
+      'orders',
+      expect.objectContaining({ from_cache: true })
+    );
+  });
+
+  it('is off entirely outside an exploration — the pre-M27 behaviour', async () => {
+    park();
+    processModel.mockResolvedValue({ orders: { name: 'orders', data: ROWS } });
+
+    // No third argument at all: every existing caller keeps its old contract.
+    renderHook(() => useModelTabPrefill('orders', false));
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalled());
+    expect(setModelQueryResult.mock.calls[0][1].from_last_run).toBe(true);
+  });
+
+  it('never overwrites a tab that already has rows', async () => {
+    park();
+
+    renderHook(() => useModelTabPrefill('orders', true, SCOPE));
+
+    await Promise.resolve();
+    expect(setModelQueryResult).not.toHaveBeenCalled();
+  });
+
+  it('still restores on a SECOND return, unlike the once-per-mount build fetch', async () => {
+    // The build is asked for at most once per model per mount (a 404 per tab
+    // switch is worse than an empty grid); the cache is a Map lookup, so it
+    // has no reason to be rationed the same way.
+    park();
+    const { rerender } = renderHook(({ name, has }) => useModelTabPrefill(name, has, SCOPE), {
+      initialProps: { name: 'orders', has: false },
+    });
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalledTimes(1));
+
+    // Leave the tab (rows land elsewhere), then come back to an empty tab.
+    rerender({ name: 'users', has: false });
+    rerender({ name: 'orders', has: false });
+
+    await waitFor(() => expect(setModelQueryResult).toHaveBeenCalledTimes(2));
+    expect(setModelQueryResult.mock.calls[1][1].from_cache).toBe(true);
+  });
 });

--- a/viewer/src/stores/explorationResultCache.js
+++ b/viewer/src/stores/explorationResultCache.js
@@ -63,7 +63,18 @@
  *
  *   - Editing the SQL, or picking a different source: the key changes, so the
  *     read misses. Nothing to do.
- *   - Renaming the query chip: the key changes, so the read misses.
+ *   - Renaming the query chip: the key changes, so the read misses. The entry
+ *     under the old name is then an ORPHAN — unreachable, but still counted
+ *     against both bounds. It is left to the LRU rather than invalidated
+ *     explicitly, and that is a considered choice, not an oversight: an
+ *     orphan is by definition never read again, so it never moves to the
+ *     recently-used end and is always evicted ahead of a live entry. It
+ *     serves nothing wrong; it costs a slot until pressure arrives. Doing
+ *     better would mean teaching `explorerStore.renameModelTab` — the legacy
+ *     singleton, which knows nothing about which exploration is on screen —
+ *     an exploration identity, and that coupling is a larger correctness risk
+ *     than the slot is worth. `explorationResultCache.test.js` pins the LRU
+ *     ordering that makes this safe.
  *   - Re-running: `put` drops EVERY other entry for that (exploration, model)
  *     before inserting. One live result per query chip, always the newest. So
  *     re-running a second query and then typing the first one's text back in
@@ -71,6 +82,16 @@
  *   - A run that FAILS: `CenterPanel` calls `invalidateExplorationResults` for
  *     that chip. If the same SQL that succeeded a minute ago now errors, the
  *     rows it produced are exactly the rows that must not come back.
+ *   - EDITING OR DELETING THE SOURCE ITSELF: `sourceStore.saveSource` /
+ *     `deleteSource` call `invalidateResultsForSource`. This one is not
+ *     optional. The key identifies a source by NAME, and a name is not a
+ *     connection: repoint `local` from `a.duckdb` to `b.duckdb`, or change its
+ *     schema or credentials, and every key still matches while the rows behind
+ *     them came out of a database the user has stopped pointing at. Nothing
+ *     downstream reads `from_cache`, so there is no visible signal either —
+ *     the grid would simply be wrong. Folding a config hash into the key would
+ *     also work, but invalidating is honest about the fact that the app itself
+ *     made the change and therefore knows exactly when to forget.
  *   - Promoting a model: `promoteExploration` invalidates that chip. Once a
  *     model is a project object, its rows belong to the project's own build
  *     (which `useModelTabPrefill`'s last-build path serves), and a session
@@ -91,12 +112,37 @@
  * A single result too big to fit the whole budget is not cached at all, rather
  * than evicting everything else to make room for something that still would
  * not fit.
+ *
+ * The bounds are the ONLY thing that limits this cache — it is not cleared on
+ * leaving the Explorer, and deliberately so: the navigation it must survive
+ * (park an exploration, read another, come back) is indistinguishable at the
+ * component level from the navigation that would clear it, and a clear-on-exit
+ * hook that fired on the wrong one would delete the feature. So the numbers
+ * below have to be defensible on their own, for the life of the page.
  */
 
-// Defaults are deliberately small: this exists so a user who tabs away gets
-// their screen back, not so a session accumulates every result it ever saw.
 const DEFAULT_MAX_ENTRIES = 8;
-const DEFAULT_MAX_CELLS = 1_000_000;
+
+/**
+ * The cell budget, shared across every parked result.
+ *
+ * Sized, not guessed. An entry retains the run's own row objects (the cache
+ * stores the SAME array the store was handed, so a parked result costs one
+ * copy, not two) — call it 100–200 bytes per cell for JS objects with string
+ * keys. 250k cells is therefore roughly 25–50 MB at full budget, held for the
+ * page's lifetime. That comfortably covers what a person actually tabs between
+ * — 8 chips of a few thousand rows each, or one 25k × 10 result — while
+ * staying an order of magnitude below the point where the tab itself is in
+ * trouble.
+ *
+ * There is no server-side row cap on `/api/model-query-jobs/`
+ * (`model_query_jobs_views.py` applies no LIMIT), so `SELECT * FROM big_table`
+ * really can return more than this. That result is simply not cached: the
+ * `cells > maxCells` refusal above declines it rather than evicting eight live
+ * results for one that would still not fit, and the Run button remains the way
+ * back to it. Erring toward "not cached" is the right side for a convenience.
+ */
+const DEFAULT_MAX_CELLS = 250_000;
 
 let maxEntries = DEFAULT_MAX_ENTRIES;
 let maxCells = DEFAULT_MAX_CELLS;
@@ -235,6 +281,26 @@ export const invalidateExplorationResults = (explorationId, modelName) => {
       entry.explorationId === explorationId &&
       (modelName === undefined || entry.modelName === modelName)
   );
+};
+
+/**
+ * Forget every parked result that was produced by one SOURCE, across every
+ * exploration.
+ *
+ * Called when the source's own definition changes or goes away
+ * (`sourceStore.saveSource` / `deleteSource`). The key carries the source's
+ * NAME, and editing a source in place keeps the name while changing what it
+ * connects to — so without this, every entry still matches a source that no
+ * longer produces those rows. Scoped by source rather than by exploration
+ * because a source is shared: one edit can invalidate results in several
+ * explorations at once.
+ *
+ * @param {string} sourceName
+ * @returns {number} entries dropped.
+ */
+export const invalidateResultsForSource = sourceName => {
+  if (!sourceName) return 0;
+  return dropWhere(entry => entry.sourceName === sourceName);
 };
 
 /** Observability (and what the bound tests assert against). */

--- a/viewer/src/stores/explorationResultCache.js
+++ b/viewer/src/stores/explorationResultCache.js
@@ -1,0 +1,265 @@
+/**
+ * explorationResultCache.js — M27 tier 1: exploration query results survive a
+ * tab switch.
+ *
+ * THE BUG. Only one exploration's working state is ever "hot" in the legacy
+ * `explorerStore` singleton (see `ExplorationPane`'s park/resume docstring),
+ * and `snapshotExplorerWorkingState` deliberately strips `queryResult` /
+ * `enrichedResult` from the snapshot — they are large, and the persisted draft
+ * is meant to stay a small JSON document. `restoreExplorerWorkingState` then
+ * rebuilds every model state from `createEmptyModelState`, whose `queryResult`
+ * is `null`. So switching to another exploration tab and back throws away
+ * every result you had on screen, and the only way back is to re-run every
+ * query — which is exactly what a user who looked away for a minute reports.
+ *
+ * THE FIX (tier 1). Keep the rows OUT of the draft (that stays small and
+ * correct) and park them here instead: a module-level, bounded, LRU cache that
+ * lives as long as the page does. `CenterPanel` writes an entry when a run
+ * completes; `useModelTabPrefill` reads one back when a tab mounts with no
+ * result, and hands it to `setModelQueryResult` so the normal downstream
+ * pipeline runs (`useExplorerDuckDB` re-registers the DuckDB table, so
+ * computed columns and the column profiler keep working).
+ *
+ * Tier 2 — surviving a hard reload / a `visivo serve` restart by writing a
+ * parquet twin under `target/exploration-<id>/` — is deliberately NOT here.
+ * It needs a product decision about whether the Django (cloud) path gets a
+ * parquet twin at all, so this cache is honest about its lifetime: one page
+ * session. A reload starts empty, and an empty cache is simply a miss.
+ *
+ * ── WHAT THE KEY IS, AND WHY ──────────────────────────────────────────────
+ *
+ * A cache is only as good as the honesty of its key. The key here is the full
+ * tuple that DETERMINES the rows:
+ *
+ *     [explorationId, modelName, sourceName, sql]
+ *
+ * serialised with `JSON.stringify` so no separator can be forged by a name
+ * that happens to contain the separator character.
+ *
+ *   - `explorationId` — isolation. Exploration B must never see A's rows even
+ *     when both have a query chip called `orders` running the same SQL against
+ *     the same source; they are different documents and a user reading one
+ *     must never be shown the other's data.
+ *   - `modelName` — a RENAME MISSES, deliberately. The name is not what
+ *     determines the rows, so the cheaper key would drop it; but the name is
+ *     what every downstream consumer (the DuckDB table, computed-column
+ *     parenting, the promote checklist) uses to decide what these rows ARE.
+ *     Serving rows recorded under one identity to a tab that now claims a
+ *     different one is the kind of quiet mismatch that is much more expensive
+ *     than the re-run it saves.
+ *   - `sourceName` + `sql` — the actual determinants. Both are taken from what
+ *     was EXECUTED (`SQLEditor` snapshots them at run time and hands them back
+ *     through `onQueryComplete`), never from whatever the editor holds when
+ *     the result lands: the user may have typed on, or run a SELECTION rather
+ *     than the whole buffer. Caching under the current buffer text would serve
+ *     one query's rows under another query's name, which is the precise
+ *     failure this cache must never have.
+ *
+ * `sql` is compared as an exact string (only end-trimmed, matching what
+ * `SQLEditor.handleRun` actually sends). No normalisation, no parsing — a
+ * whitespace-only edit misses, and that is the correct side to err on.
+ *
+ * ── WHAT INVALIDATES ──────────────────────────────────────────────────────
+ *
+ *   - Editing the SQL, or picking a different source: the key changes, so the
+ *     read misses. Nothing to do.
+ *   - Renaming the query chip: the key changes, so the read misses.
+ *   - Re-running: `put` drops EVERY other entry for that (exploration, model)
+ *     before inserting. One live result per query chip, always the newest. So
+ *     re-running a second query and then typing the first one's text back in
+ *     is a miss, not a resurrection of rows from before the re-run.
+ *   - A run that FAILS: `CenterPanel` calls `invalidateExplorationResults` for
+ *     that chip. If the same SQL that succeeded a minute ago now errors, the
+ *     rows it produced are exactly the rows that must not come back.
+ *   - Promoting a model: `promoteExploration` invalidates that chip. Once a
+ *     model is a project object, its rows belong to the project's own build
+ *     (which `useModelTabPrefill`'s last-build path serves), and a session
+ *     result must not shadow it.
+ *
+ * ── WHAT BOUNDS IT ────────────────────────────────────────────────────────
+ *
+ * An unbounded result cache is a memory leak with a friendly name. Two bounds,
+ * both enforced on every write, least-recently-USED evicted first (a read
+ * counts as a use):
+ *
+ *   - `DEFAULT_MAX_ENTRIES` — how many parked results may exist at once.
+ *   - `DEFAULT_MAX_CELLS` — `rows × columns` summed over all entries, as an
+ *     O(1) proxy for bytes. Measuring real retained size would mean
+ *     serialising the rows, which for a 100k-row result costs more than the
+ *     cache saves.
+ *
+ * A single result too big to fit the whole budget is not cached at all, rather
+ * than evicting everything else to make room for something that still would
+ * not fit.
+ */
+
+// Defaults are deliberately small: this exists so a user who tabs away gets
+// their screen back, not so a session accumulates every result it ever saw.
+const DEFAULT_MAX_ENTRIES = 8;
+const DEFAULT_MAX_CELLS = 1_000_000;
+
+let maxEntries = DEFAULT_MAX_ENTRIES;
+let maxCells = DEFAULT_MAX_CELLS;
+
+/**
+ * key -> {explorationId, modelName, sourceName, sql, result, cells, ranAt}
+ *
+ * A `Map` iterates in insertion order, which is all an LRU list needs: a read
+ * re-inserts its entry at the end, so the FIRST key is always the least
+ * recently used one. Module-level (not Zustand state) for the same reason
+ * `workspaceExplorationsStore`'s `_pendingSyncTimers` is: this is ephemeral
+ * session bookkeeping that nothing renders, and putting megabytes of rows in a
+ * reactive store would re-render every subscriber on every write.
+ */
+const entries = new Map();
+
+let totalCells = 0;
+
+/** Cheap O(1) memory proxy for a result — see DEFAULT_MAX_CELLS above. */
+const cellsIn = result => {
+  const rowCount = Array.isArray(result?.rows) ? result.rows.length : 0;
+  const colCount = Array.isArray(result?.columns) ? result.columns.length : 0;
+  // A result with rows but no declared columns still costs memory; charge it
+  // at least one cell per row so it can never look free.
+  return rowCount * Math.max(1, colCount);
+};
+
+/**
+ * The cache key for one query chip's result, or `null` when the scope isn't
+ * complete enough to key by (no exploration, no chip, no source) — callers
+ * treat `null` as "caching is off here", which is what a CenterPanel mounted
+ * outside an exploration gets.
+ */
+export const explorationResultCacheKey = ({
+  explorationId,
+  modelName,
+  sourceName,
+  sql,
+} = {}) => {
+  if (!explorationId || !modelName || !sourceName) return null;
+  const text = typeof sql === 'string' ? sql.trim() : '';
+  if (!text) return null;
+  return JSON.stringify([explorationId, modelName, sourceName, text]);
+};
+
+/** Drop every entry matching a predicate, keeping `totalCells` honest. */
+const dropWhere = predicate => {
+  let dropped = 0;
+  for (const [key, entry] of entries) {
+    if (!predicate(entry)) continue;
+    entries.delete(key);
+    totalCells -= entry.cells;
+    dropped += 1;
+  }
+  return dropped;
+};
+
+/** Evict least-recently-used entries until both bounds hold. */
+const evictToBounds = () => {
+  while (entries.size > maxEntries || totalCells > maxCells) {
+    const oldest = entries.keys().next();
+    if (oldest.done) break;
+    const entry = entries.get(oldest.value);
+    entries.delete(oldest.value);
+    totalCells -= entry.cells;
+  }
+};
+
+/**
+ * Read the parked result for a scope, or `null`.
+ *
+ * A hit counts as a use: the entry moves to the most-recently-used end, so the
+ * explorations you actually keep coming back to are the last ones evicted.
+ */
+export const getCachedExplorationResult = scope => {
+  const key = explorationResultCacheKey(scope);
+  if (!key) return null;
+  const entry = entries.get(key);
+  if (!entry) return null;
+  entries.delete(key);
+  entries.set(key, entry);
+  return entry.result;
+};
+
+/**
+ * Park the result of a completed run.
+ *
+ * `scope.sql` / `scope.sourceName` MUST be what was executed, not what the
+ * editor holds now — see the key docstring above.
+ *
+ * @returns {boolean} whether the result was actually stored (a result too
+ *   large for the whole budget is refused rather than allowed to evict the
+ *   entire cache for itself).
+ */
+export const putCachedExplorationResult = (scope, result) => {
+  const key = explorationResultCacheKey(scope);
+  if (!key || !result) return false;
+
+  const { explorationId, modelName, sourceName } = scope;
+
+  // One live result per query chip: a re-run supersedes whatever that chip had
+  // parked, including results for SQL it no longer holds. Without this, typing
+  // an earlier query's text back in would resurrect rows from before the
+  // re-run.
+  dropWhere(entry => entry.explorationId === explorationId && entry.modelName === modelName);
+
+  const cells = cellsIn(result);
+  if (cells > maxCells) return false;
+
+  entries.set(key, {
+    explorationId,
+    modelName,
+    sourceName,
+    sql: typeof scope.sql === 'string' ? scope.sql.trim() : '',
+    result,
+    cells,
+    ranAt: Date.now(),
+  });
+  totalCells += cells;
+  evictToBounds();
+  return entries.has(key);
+};
+
+/**
+ * Forget results for one exploration, or for one query chip inside it.
+ *
+ * @param {string} explorationId
+ * @param {string} [modelName] - omit to drop the whole exploration's results
+ *   (a delete, a discard, a promote of the exploration as a whole).
+ * @returns {number} entries dropped.
+ */
+export const invalidateExplorationResults = (explorationId, modelName) => {
+  if (!explorationId) return 0;
+  return dropWhere(
+    entry =>
+      entry.explorationId === explorationId &&
+      (modelName === undefined || entry.modelName === modelName)
+  );
+};
+
+/** Observability (and what the bound tests assert against). */
+export const explorationResultCacheStats = () => ({
+  entries: entries.size,
+  cells: totalCells,
+  maxEntries,
+  maxCells,
+});
+
+/** Test-only: empty the cache and restore the shipped bounds. */
+export const _resetExplorationResultCacheForTests = () => {
+  entries.clear();
+  totalCells = 0;
+  maxEntries = DEFAULT_MAX_ENTRIES;
+  maxCells = DEFAULT_MAX_CELLS;
+};
+
+/**
+ * Test-only: shrink the bounds so eviction is reachable without allocating a
+ * million-cell result inside a unit test. `_resetExplorationResultCacheForTests`
+ * puts the shipped numbers back.
+ */
+export const _setExplorationResultCacheBoundsForTests = bounds => {
+  if (typeof bounds?.maxEntries === 'number') maxEntries = bounds.maxEntries;
+  if (typeof bounds?.maxCells === 'number') maxCells = bounds.maxCells;
+  evictToBounds();
+};

--- a/viewer/src/stores/explorationResultCache.test.js
+++ b/viewer/src/stores/explorationResultCache.test.js
@@ -1,0 +1,257 @@
+/**
+ * M27 tier 1 — the session result cache.
+ *
+ * The behaviour worth protecting here is almost entirely what it REFUSES to
+ * serve. A cache that hands back rows for a query that has since been edited,
+ * for a chip that has since been renamed, or for a run that has since been
+ * repeated, is strictly worse than no cache at all: the user cannot tell by
+ * looking that the grid is lying to them. So every miss below is a deliberate
+ * miss, and each one is asserted against the exact hit it is a near-neighbour
+ * of — proving the key discriminates, not just that some lookup failed.
+ */
+import {
+  explorationResultCacheKey,
+  getCachedExplorationResult,
+  putCachedExplorationResult,
+  invalidateExplorationResults,
+  explorationResultCacheStats,
+  _resetExplorationResultCacheForTests,
+  _setExplorationResultCacheBoundsForTests,
+} from './explorationResultCache';
+
+const SCOPE = {
+  explorationId: 'exp-a',
+  modelName: 'orders',
+  sourceName: 'warehouse',
+  sql: 'SELECT 1',
+};
+
+const resultOf = (label, rows = 1, cols = 1) => ({
+  label,
+  columns: Array.from({ length: cols }, (_, i) => `c${i}`),
+  rows: Array.from({ length: rows }, (_, i) => ({ i })),
+  row_count: rows,
+});
+
+beforeEach(() => {
+  _resetExplorationResultCacheForTests();
+});
+
+describe('the key', () => {
+  it('returns a hit for the scope that produced the entry', () => {
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult(SCOPE)?.label).toBe('first');
+  });
+
+  it('MISSES after the query is edited', () => {
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult({ ...SCOPE, sql: 'SELECT 2' })).toBeNull();
+    // ...and the original scope still hits, so the miss is the key
+    // discriminating, not the entry having vanished.
+    expect(getCachedExplorationResult(SCOPE)?.label).toBe('first');
+  });
+
+  it('MISSES on a whitespace-only edit inside the query', () => {
+    // No normalisation, no parsing: any edit at all is a miss. Erring toward
+    // re-running is the cheap side of this trade.
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult({ ...SCOPE, sql: 'SELECT  1' })).toBeNull();
+  });
+
+  it('ignores leading/trailing whitespace, matching what SQLEditor sends', () => {
+    // `handleRun` executes `queryText.trim()`, so the stored key is trimmed;
+    // the tab's own buffer usually is not. If these two disagreed, a plain
+    // "run, switch away, switch back" would miss for a trailing newline.
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult({ ...SCOPE, sql: '  SELECT 1\n' })?.label).toBe('first');
+  });
+
+  it('MISSES after the chip is renamed', () => {
+    // The name does not determine the ROWS, but it determines what every
+    // downstream consumer thinks the rows ARE (the DuckDB table, computed
+    // column parenting, the promote checklist). Serving rows recorded under
+    // one identity to a tab claiming another is not worth the saved re-run.
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'orders_2' })).toBeNull();
+  });
+
+  it('MISSES after the source is changed', () => {
+    putCachedExplorationResult(SCOPE, resultOf('first'));
+    expect(getCachedExplorationResult({ ...SCOPE, sourceName: 'other_db' })).toBeNull();
+  });
+
+  it('never serves one exploration the rows of another', () => {
+    // Same chip name, same source, same SQL — different documents.
+    putCachedExplorationResult(SCOPE, resultOf('A rows'));
+    putCachedExplorationResult({ ...SCOPE, explorationId: 'exp-b' }, resultOf('B rows'));
+
+    expect(getCachedExplorationResult(SCOPE)?.label).toBe('A rows');
+    expect(getCachedExplorationResult({ ...SCOPE, explorationId: 'exp-b' })?.label).toBe('B rows');
+  });
+
+  it('cannot be forged by a name containing the separator', () => {
+    // The key is JSON-serialised rather than string-joined, so no name can
+    // impersonate a different (exploration, chip) pair.
+    const forged = { ...SCOPE, explorationId: 'exp', modelName: 'a", "b' };
+    const honest = { ...SCOPE, explorationId: 'exp', modelName: 'a', sourceName: 'b' };
+    expect(explorationResultCacheKey(forged)).not.toBe(explorationResultCacheKey(honest));
+  });
+
+  it('is null — caching off — when the scope is incomplete', () => {
+    expect(explorationResultCacheKey({ ...SCOPE, explorationId: null })).toBeNull();
+    expect(explorationResultCacheKey({ ...SCOPE, modelName: null })).toBeNull();
+    expect(explorationResultCacheKey({ ...SCOPE, sourceName: null })).toBeNull();
+    expect(explorationResultCacheKey({ ...SCOPE, sql: '   ' })).toBeNull();
+    expect(explorationResultCacheKey()).toBeNull();
+  });
+
+  it('stores nothing for an incomplete scope, and reads nothing back', () => {
+    expect(putCachedExplorationResult({ ...SCOPE, explorationId: null }, resultOf('x'))).toBe(false);
+    expect(explorationResultCacheStats().entries).toBe(0);
+    expect(getCachedExplorationResult({ ...SCOPE, explorationId: null })).toBeNull();
+  });
+
+  it('stores nothing for a missing result', () => {
+    expect(putCachedExplorationResult(SCOPE, null)).toBe(false);
+    expect(explorationResultCacheStats().entries).toBe(0);
+  });
+});
+
+describe('re-running', () => {
+  it('replaces the entry for the same query', () => {
+    putCachedExplorationResult(SCOPE, resultOf('stale'));
+    putCachedExplorationResult(SCOPE, resultOf('fresh'));
+
+    expect(getCachedExplorationResult(SCOPE)?.label).toBe('fresh');
+    expect(explorationResultCacheStats().entries).toBe(1);
+  });
+
+  it('retires the chip’s PREVIOUS query, so reverting the text is a miss', () => {
+    // Run Q1, edit to Q2, run Q2. Typing Q1's text back in must not resurrect
+    // rows from before the re-run — the underlying data may have moved on and
+    // nothing on screen would say so.
+    putCachedExplorationResult(SCOPE, resultOf('Q1 rows'));
+    putCachedExplorationResult({ ...SCOPE, sql: 'SELECT 2' }, resultOf('Q2 rows'));
+
+    expect(getCachedExplorationResult(SCOPE)).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, sql: 'SELECT 2' })?.label).toBe('Q2 rows');
+    expect(explorationResultCacheStats().entries).toBe(1);
+  });
+
+  it('retires only THAT chip’s results, not its neighbours’', () => {
+    putCachedExplorationResult(SCOPE, resultOf('orders rows'));
+    putCachedExplorationResult({ ...SCOPE, modelName: 'users' }, resultOf('users rows'));
+    putCachedExplorationResult({ ...SCOPE, sql: 'SELECT 2' }, resultOf('orders rerun'));
+
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'users' })?.label).toBe('users rows');
+  });
+});
+
+describe('invalidation', () => {
+  it('drops one chip’s result and leaves the rest of the exploration alone', () => {
+    putCachedExplorationResult(SCOPE, resultOf('orders rows'));
+    putCachedExplorationResult({ ...SCOPE, modelName: 'users' }, resultOf('users rows'));
+
+    expect(invalidateExplorationResults('exp-a', 'orders')).toBe(1);
+    expect(getCachedExplorationResult(SCOPE)).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'users' })?.label).toBe('users rows');
+  });
+
+  it('drops a whole exploration when no chip is named', () => {
+    putCachedExplorationResult(SCOPE, resultOf('orders rows'));
+    putCachedExplorationResult({ ...SCOPE, modelName: 'users' }, resultOf('users rows'));
+    putCachedExplorationResult({ ...SCOPE, explorationId: 'exp-b' }, resultOf('B rows'));
+
+    expect(invalidateExplorationResults('exp-a')).toBe(2);
+    expect(explorationResultCacheStats().entries).toBe(1);
+    expect(getCachedExplorationResult({ ...SCOPE, explorationId: 'exp-b' })?.label).toBe('B rows');
+  });
+
+  it('is a no-op without an exploration id', () => {
+    putCachedExplorationResult(SCOPE, resultOf('orders rows'));
+    expect(invalidateExplorationResults(null)).toBe(0);
+    expect(invalidateExplorationResults(undefined, 'orders')).toBe(0);
+    expect(explorationResultCacheStats().entries).toBe(1);
+  });
+
+  it('gives the freed budget back', () => {
+    putCachedExplorationResult(SCOPE, resultOf('big', 100, 4));
+    expect(explorationResultCacheStats().cells).toBe(400);
+    invalidateExplorationResults('exp-a');
+    expect(explorationResultCacheStats().cells).toBe(0);
+  });
+});
+
+describe('bounds', () => {
+  it('evicts the least recently used entry at the shipped entry cap', () => {
+    // No test seam here on purpose: this asserts the DEFAULT the product
+    // actually ships with is enforced, not a number a test invented.
+    const { maxEntries } = explorationResultCacheStats();
+    for (let i = 0; i < maxEntries; i += 1) {
+      putCachedExplorationResult({ ...SCOPE, modelName: `chip_${i}` }, resultOf(`rows ${i}`));
+    }
+    expect(explorationResultCacheStats().entries).toBe(maxEntries);
+
+    putCachedExplorationResult({ ...SCOPE, modelName: 'chip_last' }, resultOf('last'));
+
+    expect(explorationResultCacheStats().entries).toBe(maxEntries);
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'chip_0' })).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'chip_1' })?.label).toBe('rows 1');
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'chip_last' })?.label).toBe('last');
+  });
+
+  it('counts a READ as a use, so the tab you keep returning to survives', () => {
+    _setExplorationResultCacheBoundsForTests({ maxEntries: 2 });
+    putCachedExplorationResult({ ...SCOPE, modelName: 'a' }, resultOf('a'));
+    putCachedExplorationResult({ ...SCOPE, modelName: 'b' }, resultOf('b'));
+
+    // Return to 'a' — that is the whole point of this cache, and it must
+    // count as recency, or the tab a user keeps coming back to is the first
+    // one thrown away.
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'a' })?.label).toBe('a');
+
+    putCachedExplorationResult({ ...SCOPE, modelName: 'c' }, resultOf('c'));
+
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'a' })?.label).toBe('a');
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'b' })).toBeNull();
+  });
+
+  it('evicts on the cell budget as well as the entry count', () => {
+    _setExplorationResultCacheBoundsForTests({ maxCells: 100 });
+    putCachedExplorationResult({ ...SCOPE, modelName: 'a' }, resultOf('a', 20, 3)); // 60
+    putCachedExplorationResult({ ...SCOPE, modelName: 'b' }, resultOf('b', 10, 3)); // 30 -> 90
+    expect(explorationResultCacheStats().entries).toBe(2);
+
+    putCachedExplorationResult({ ...SCOPE, modelName: 'c' }, resultOf('c', 10, 3)); // 30 -> 120
+
+    expect(explorationResultCacheStats().cells).toBeLessThanOrEqual(100);
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'a' })).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'b' })?.label).toBe('b');
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'c' })?.label).toBe('c');
+  });
+
+  it('refuses a single result too big for the whole budget rather than emptying itself', () => {
+    _setExplorationResultCacheBoundsForTests({ maxCells: 100 });
+    putCachedExplorationResult({ ...SCOPE, modelName: 'small' }, resultOf('small', 5, 2));
+
+    expect(putCachedExplorationResult({ ...SCOPE, modelName: 'huge' }, resultOf('huge', 500, 3))).toBe(
+      false
+    );
+
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'huge' })).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'small' })?.label).toBe('small');
+  });
+
+  it('charges at least one cell per row for a result with no declared columns', () => {
+    // A malformed result still costs memory; it must never look free and slip
+    // past the budget.
+    putCachedExplorationResult(SCOPE, { rows: [{ a: 1 }, { a: 2 }], columns: [] });
+    expect(explorationResultCacheStats().cells).toBe(2);
+  });
+
+  it('keeps the budget honest when an entry is replaced', () => {
+    putCachedExplorationResult(SCOPE, resultOf('big', 50, 2)); // 100
+    putCachedExplorationResult(SCOPE, resultOf('small', 2, 2)); // 4
+    expect(explorationResultCacheStats().cells).toBe(4);
+  });
+});

--- a/viewer/src/stores/explorationResultCache.test.js
+++ b/viewer/src/stores/explorationResultCache.test.js
@@ -14,6 +14,7 @@ import {
   getCachedExplorationResult,
   putCachedExplorationResult,
   invalidateExplorationResults,
+  invalidateResultsForSource,
   explorationResultCacheStats,
   _resetExplorationResultCacheForTests,
   _setExplorationResultCacheBoundsForTests,
@@ -182,6 +183,56 @@ describe('invalidation', () => {
   });
 });
 
+/**
+ * The key names a source; a name is not a connection.
+ *
+ * Repoint `local` from `a.duckdb` to `b.duckdb`, or change its schema or
+ * credentials, and every parked key still matches while the rows behind them
+ * came out of a database the user has stopped pointing at. Nothing on screen
+ * would say so — `from_cache` is provenance for the module's own tests, not a
+ * banner. This is the one stale serve the key alone cannot prevent, and the
+ * app itself makes the change, so it can be invalidated exactly.
+ */
+describe('a source whose definition changes', () => {
+  it('drops every result it produced, across explorations', () => {
+    putCachedExplorationResult(SCOPE, resultOf('from warehouse'));
+    putCachedExplorationResult(
+      { ...SCOPE, explorationId: 'exp-b', modelName: 'other' },
+      resultOf('also from warehouse')
+    );
+    putCachedExplorationResult(
+      { ...SCOPE, modelName: 'untouched', sourceName: 'other_db' },
+      resultOf('from other_db')
+    );
+
+    expect(invalidateResultsForSource('warehouse')).toBe(2);
+
+    expect(getCachedExplorationResult(SCOPE)).toBeNull();
+    expect(
+      getCachedExplorationResult({ ...SCOPE, explorationId: 'exp-b', modelName: 'other' })
+    ).toBeNull();
+    // A different source is untouched: this invalidates by source, not by
+    // panic.
+    expect(
+      getCachedExplorationResult({ ...SCOPE, modelName: 'untouched', sourceName: 'other_db' })?.label
+    ).toBe('from other_db');
+  });
+
+  it('gives the freed budget back', () => {
+    putCachedExplorationResult(SCOPE, resultOf('rows', 10, 3));
+    expect(explorationResultCacheStats().cells).toBe(30);
+    invalidateResultsForSource('warehouse');
+    expect(explorationResultCacheStats().cells).toBe(0);
+  });
+
+  it('is a no-op without a source name', () => {
+    putCachedExplorationResult(SCOPE, resultOf('rows'));
+    expect(invalidateResultsForSource(undefined)).toBe(0);
+    expect(invalidateResultsForSource('')).toBe(0);
+    expect(getCachedExplorationResult(SCOPE)?.label).toBe('rows');
+  });
+});
+
 describe('bounds', () => {
   it('evicts the least recently used entry at the shipped entry cap', () => {
     // No test seam here on purpose: this asserts the DEFAULT the product
@@ -253,5 +304,84 @@ describe('bounds', () => {
     putCachedExplorationResult(SCOPE, resultOf('big', 50, 2)); // 100
     putCachedExplorationResult(SCOPE, resultOf('small', 2, 2)); // 4
     expect(explorationResultCacheStats().cells).toBe(4);
+  });
+
+  /**
+   * The cell bound tests above all run against an INJECTED `maxCells`, which
+   * would let a mis-sized shipped constant ship green. These exercise the
+   * number the product actually carries.
+   *
+   * A holey `new Array(n)` is what makes that affordable: `cellsIn` only reads
+   * `.length`, and V8 allocates nothing for the elements, so a result can
+   * claim a quarter of a million cells without a quarter of a million objects
+   * existing.
+   */
+  describe('at the SHIPPED cell budget', () => {
+    const sized = (label, cells) => ({
+      label,
+      columns: ['c0'],
+      rows: new Array(cells),
+      row_count: cells,
+    });
+
+    it('accepts a result that exactly fills it', () => {
+      const { maxCells } = explorationResultCacheStats();
+      expect(putCachedExplorationResult(SCOPE, sized('exact', maxCells))).toBe(true);
+      expect(explorationResultCacheStats().cells).toBe(maxCells);
+    });
+
+    it('refuses one cell more, rather than emptying itself for it', () => {
+      const { maxCells } = explorationResultCacheStats();
+      putCachedExplorationResult({ ...SCOPE, modelName: 'live' }, resultOf('live'));
+
+      expect(
+        putCachedExplorationResult({ ...SCOPE, modelName: 'huge' }, sized('huge', maxCells + 1))
+      ).toBe(false);
+
+      expect(getCachedExplorationResult({ ...SCOPE, modelName: 'huge' })).toBeNull();
+      expect(getCachedExplorationResult({ ...SCOPE, modelName: 'live' })?.label).toBe('live');
+    });
+
+    it('evicts on the shipped budget, not just the injected one', () => {
+      const { maxCells } = explorationResultCacheStats();
+      putCachedExplorationResult({ ...SCOPE, modelName: 'a' }, sized('a', maxCells - 10));
+      putCachedExplorationResult({ ...SCOPE, modelName: 'b' }, sized('b', 20));
+
+      expect(explorationResultCacheStats().cells).toBeLessThanOrEqual(maxCells);
+      expect(getCachedExplorationResult({ ...SCOPE, modelName: 'a' })).toBeNull();
+      expect(getCachedExplorationResult({ ...SCOPE, modelName: 'b' })?.label).toBe('b');
+    });
+  });
+
+  /**
+   * Renaming a chip leaves the entry under the old name unreachable but still
+   * counted. It is left to the LRU on purpose (see the module docstring), and
+   * this is the property that makes that safe: an orphan is never read, so it
+   * never moves to the recently-used end, so it goes first — a live result the
+   * user is still tabbing between is never evicted to make room while an
+   * orphan is sitting there.
+   */
+  it('evicts a renamed chip’s orphaned entry ahead of a live one', () => {
+    _setExplorationResultCacheBoundsForTests({ maxEntries: 2 });
+
+    // One real session, in order:
+    //   1. run `orders` — parked, and the user keeps coming back to it.
+    putCachedExplorationResult({ ...SCOPE, modelName: 'orders' }, resultOf('live'));
+    //   2. add a second chip, run it as `query_1`, then rename it. The entry
+    //      under `query_1` is now stranded: no key will ever reach it again.
+    //      Note it was inserted AFTER `orders`, so insertion order alone would
+    //      throw `orders` away first.
+    putCachedExplorationResult({ ...SCOPE, modelName: 'query_1' }, resultOf('orphan'));
+    //   3. the user tabs back to `orders`.
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'orders' })?.label).toBe('live');
+    //   4. the renamed chip runs, and parks under its new name.
+    putCachedExplorationResult({ ...SCOPE, modelName: 'revenue' }, resultOf('newest'));
+
+    // The orphan is the one that goes, because it is the only entry nothing
+    // has used. Recency — not arrival order — is what protects the result the
+    // user is actually working with.
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'query_1' })).toBeNull();
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'orders' })?.label).toBe('live');
+    expect(getCachedExplorationResult({ ...SCOPE, modelName: 'revenue' })?.label).toBe('newest');
   });
 });

--- a/viewer/src/stores/sourceStore.js
+++ b/viewer/src/stores/sourceStore.js
@@ -1,3 +1,4 @@
+import { invalidateResultsForSource } from './explorationResultCache';
 import * as sourcesApi from '../api/sources';
 
 // Object status constants (matches backend ObjectStatus enum)
@@ -40,6 +41,13 @@ const createSourceSlice = (set, get) => ({
     try {
       const projectId = get().project?.id;
       const result = await sourcesApi.saveSource(name, config, projectId);
+      // M27: this source no longer connects to what it connected to a moment
+      // ago — a different database file, schema, or credential — while the
+      // name every parked exploration result is keyed by is unchanged. Those
+      // rows came out of the old definition, so they stop being an answer to
+      // anything. Dropping them costs one re-run; keeping them would show the
+      // wrong database's rows with nothing on screen saying so.
+      invalidateResultsForSource(name);
       // Refresh sources list to get updated status
       await get().fetchSources();
       // Trigger commit status check
@@ -57,6 +65,10 @@ const createSourceSlice = (set, get) => ({
     try {
       const projectId = get().project?.id;
       await sourcesApi.deleteSource(name, projectId);
+      // M27: same reasoning as `saveSource`, in its sharpest form — the source
+      // that produced these rows is gone, so nothing can re-derive or verify
+      // them.
+      invalidateResultsForSource(name);
       await get().fetchSources();
       // Trigger commit status check
       if (get().checkCommitStatus) {

--- a/viewer/src/stores/sourceStore.resultCache.test.js
+++ b/viewer/src/stores/sourceStore.resultCache.test.js
@@ -1,0 +1,90 @@
+/**
+ * M27 — editing or deleting a source retires the exploration results it
+ * produced.
+ *
+ * `explorationResultCache`'s key identifies a source by NAME, and a name is
+ * not a connection. Repoint `local` from `a.duckdb` to `b.duckdb` — or change
+ * its schema, host, or credentials — and the name is unchanged, so every
+ * parked key still matches while the rows behind them came out of a database
+ * the user has stopped pointing at. `useModelTabPrefill` would hit, and
+ * `setModelQueryResult` would paint the old database's rows as the current
+ * result with no re-run and nothing on screen saying so.
+ *
+ * The saving grace is that the APP makes this change, so it knows exactly when
+ * to forget. These pin that it actually does.
+ *
+ * Deliberately narrow: this is a wiring test for the invalidation, not a
+ * general `sourceStore` suite. The cache's own semantics live in
+ * `explorationResultCache.test.js`.
+ */
+import useStore from './store';
+import * as sourcesApi from '../api/sources';
+import {
+  getCachedExplorationResult,
+  putCachedExplorationResult,
+  _resetExplorationResultCacheForTests,
+} from './explorationResultCache';
+
+jest.mock('../api/sources');
+
+const SCOPE = {
+  explorationId: 'exp-a',
+  modelName: 'orders',
+  sourceName: 'local',
+  sql: 'SELECT * FROM t',
+};
+const RESULT = { columns: ['id'], rows: [{ id: 1 }], row_count: 1 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetExplorationResultCacheForTests();
+  sourcesApi.fetchAllSources.mockResolvedValue({ sources: [] });
+  sourcesApi.saveSource.mockResolvedValue({ name: 'local' });
+  sourcesApi.deleteSource.mockResolvedValue({});
+  // `checkCommitStatus` belongs to another slice and is irrelevant here.
+  useStore.setState({ checkCommitStatus: jest.fn().mockResolvedValue(undefined) });
+});
+
+it('saveSource retires the results that source produced', async () => {
+  putCachedExplorationResult(SCOPE, RESULT);
+  expect(getCachedExplorationResult(SCOPE)).not.toBeNull();
+
+  // The source now points at a different database file. Same name.
+  await useStore.getState().saveSource('local', { type: 'duckdb', database: 'b.duckdb' });
+
+  expect(getCachedExplorationResult(SCOPE)).toBeNull();
+});
+
+it('deleteSource retires them too', async () => {
+  putCachedExplorationResult(SCOPE, RESULT);
+
+  await useStore.getState().deleteSource('local');
+
+  expect(getCachedExplorationResult(SCOPE)).toBeNull();
+});
+
+it('leaves results from OTHER sources alone', async () => {
+  // Invalidating by source must not be a panic-clear: a user editing one
+  // connection should not lose every exploration result they have.
+  putCachedExplorationResult(SCOPE, RESULT);
+  const other = { ...SCOPE, modelName: 'revenue', sourceName: 'warehouse' };
+  putCachedExplorationResult(other, RESULT);
+
+  await useStore.getState().saveSource('local', { type: 'duckdb', database: 'b.duckdb' });
+
+  expect(getCachedExplorationResult(SCOPE)).toBeNull();
+  expect(getCachedExplorationResult(other)).not.toBeNull();
+});
+
+it('keeps the parked rows when the save FAILS', async () => {
+  // The definition did not change, so the rows are still an honest answer —
+  // and throwing them away would charge the user a re-run for the backend's
+  // error.
+  putCachedExplorationResult(SCOPE, RESULT);
+  sourcesApi.saveSource.mockRejectedValue(new Error('connection refused'));
+
+  const outcome = await useStore.getState().saveSource('local', { type: 'duckdb' });
+
+  expect(outcome.success).toBe(false);
+  expect(getCachedExplorationResult(SCOPE)).not.toBeNull();
+});

--- a/viewer/src/stores/workspaceExplorationsStore.js
+++ b/viewer/src/stores/workspaceExplorationsStore.js
@@ -85,6 +85,7 @@ import {
   draftToLegacyState,
 } from '../components/views/workspace/explorationLegacyBridge';
 import { buildPromoteChecklist } from './promoteChecklist';
+import { invalidateExplorationResults } from './explorationResultCache';
 import { SAVE_ACTION } from '../components/views/workspace/collectionKeys';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
 import { emitWorkspaceEvent, markExplorationCreated } from '../components/views/workspace/telemetry';
@@ -453,6 +454,10 @@ const createWorkspaceExplorationsSlice = (set, get) => {
         return { success: false, error: error.message };
       }
       clearPendingSyncTimer(id);
+      // M27: the document is gone — so are any results parked for it. Nothing
+      // can read them again, and holding rows for a deleted exploration is
+      // just retained memory.
+      invalidateExplorationResults(id);
       const tabId = `exploration:${id}`;
       const wasOpen = (get().workspaceTabs || []).some(t => t.id === tabId);
       get().closeWorkspaceTab?.(tabId);
@@ -887,6 +892,16 @@ const createWorkspaceExplorationsSlice = (set, get) => {
 
         if (row.type === 'insight' && frozenSignaturesByInsightName[row.name]) {
           get().recordPromotedInsightSignature?.(row.name, frozenSignaturesByInsightName[row.name]);
+        }
+
+        // M27: a promoted model's rows stop being this session's private
+        // scratch result and become the project's. From here on the
+        // authoritative rows for that name are whatever the project builds
+        // (`useModelTabPrefill`'s last-build path), and the promoted config is
+        // the checklist's — not necessarily the raw text the chip last ran. A
+        // session-cached result must not shadow either.
+        if (row.type === 'model') {
+          invalidateExplorationResults(id, row.name);
         }
 
         if (row.type === 'metric' || row.type === 'dimension') {

--- a/viewer/src/stores/workspaceExplorationsStore.test.js
+++ b/viewer/src/stores/workspaceExplorationsStore.test.js
@@ -21,6 +21,12 @@ import { buildPromoteChecklist } from './promoteChecklist';
 import { setWorkspaceTelemetryListener } from '../components/views/workspace/telemetry';
 import { findReclassifiedSlots } from '../components/views/common/pillFieldSwap';
 import { buildInsightFreshnessSignature } from '../utils/insightFreshnessSignature';
+import {
+  putCachedExplorationResult,
+  getCachedExplorationResult,
+  explorationResultCacheStats,
+  _resetExplorationResultCacheForTests,
+} from './explorationResultCache';
 
 jest.mock('../api/explorations');
 jest.mock('./promoteChecklist', () => ({ buildPromoteChecklist: jest.fn() }));
@@ -94,6 +100,7 @@ const reset = () => {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
+  _resetExplorationResultCacheForTests();
   reset();
 });
 
@@ -2480,5 +2487,130 @@ describe('flywheel telemetry (VIS-1072)', () => {
       await useStore.getState().discardExploration('exp_1');
     });
     expect(events.find(e => e.eventName === 'exploration_discarded')).toBeUndefined();
+  });
+});
+
+/**
+ * M27 — the session result cache is not allowed to outlive the reason the
+ * rows were trustworthy.
+ *
+ * `explorationResultCache.js` keys itself so that an edited query, a renamed
+ * chip or a changed source simply misses. These are the two invalidations the
+ * KEY cannot express, because nothing about the key changes when they happen —
+ * they have to be told.
+ */
+describe('exploration result cache invalidation (M27)', () => {
+  const scopeFor = (id, modelName) => ({
+    explorationId: id,
+    modelName,
+    sourceName: 'warehouse',
+    sql: 'select 1',
+  });
+  const park = (id, modelName) =>
+    putCachedExplorationResult(scopeFor(id, modelName), {
+      columns: ['a'],
+      rows: [{ a: 1 }],
+      row_count: 1,
+    });
+
+  const checklistRow = overrides => ({
+    tier: 'model',
+    type: 'model',
+    name: 'orders_q',
+    parentModel: null,
+    status: 'new',
+    valid: true,
+    error: null,
+    config: { sql: 'select 1' },
+    ...overrides,
+  });
+
+  test('promoting a model retires that chip’s parked rows', async () => {
+    // Once the model is a project object its rows belong to the project's own
+    // build (`useModelTabPrefill`'s last-build path), and the promoted config
+    // is the checklist's — not necessarily the raw text the chip last ran.
+    // A session result must not shadow either.
+    park('exp_1', 'orders_q');
+    buildPromoteChecklist.mockResolvedValue([checklistRow()]);
+    seedRecord();
+    act(() => {
+      useStore.setState({ saveModel: jest.fn().mockResolvedValue({ success: true }) });
+    });
+    explorationsApi.recordPromotion.mockResolvedValue(wireExploration());
+
+    await act(async () => {
+      await useStore.getState().promoteExploration('exp_1', [{ type: 'model', name: 'orders_q' }]);
+    });
+
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'orders_q'))).toBeNull();
+  });
+
+  test('a promote that FAILS to save leaves the parked rows alone', async () => {
+    // Nothing changed hands — the chip is still an exploration chip and its
+    // rows are still the honest answer to its query.
+    park('exp_1', 'orders_q');
+    buildPromoteChecklist.mockResolvedValue([checklistRow()]);
+    seedRecord();
+    act(() => {
+      useStore.setState({
+        saveModel: jest.fn().mockResolvedValue({ success: false, error: 'nope' }),
+      });
+    });
+
+    await act(async () => {
+      await useStore.getState().promoteExploration('exp_1', [{ type: 'model', name: 'orders_q' }]);
+    });
+
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'orders_q'))).not.toBeNull();
+  });
+
+  test('promoting an INSIGHT leaves the model chip’s parked rows alone', async () => {
+    // Only a model promotion hands rows to the project; an insight promotion
+    // says nothing about where the underlying rows should come from.
+    park('exp_1', 'orders_q');
+    buildPromoteChecklist.mockResolvedValue([
+      checklistRow({ type: 'insight', tier: 'insight', name: 'churn', config: { props: {} } }),
+    ]);
+    seedRecord();
+    act(() => {
+      useStore.setState({ saveInsight: jest.fn().mockResolvedValue({ success: true }) });
+    });
+    explorationsApi.recordPromotion.mockResolvedValue(wireExploration());
+
+    await act(async () => {
+      await useStore.getState().promoteExploration('exp_1', [{ type: 'insight', name: 'churn' }]);
+    });
+
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'orders_q'))).not.toBeNull();
+  });
+
+  test('deleting an exploration drops every result parked for it', async () => {
+    park('exp_1', 'orders_q');
+    park('exp_1', 'users_q');
+    park('exp_other', 'orders_q');
+    seedRecord();
+    explorationsApi.deleteExploration.mockResolvedValueOnce(true);
+
+    await act(async () => {
+      await useStore.getState().deleteExploration('exp_1');
+    });
+
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'orders_q'))).toBeNull();
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'users_q'))).toBeNull();
+    // A different document's rows are none of this delete's business.
+    expect(getCachedExplorationResult(scopeFor('exp_other', 'orders_q'))).not.toBeNull();
+    expect(explorationResultCacheStats().entries).toBe(1);
+  });
+
+  test('a delete that FAILS keeps the parked rows — the exploration is still there', async () => {
+    park('exp_1', 'orders_q');
+    seedRecord();
+    explorationsApi.deleteExploration.mockRejectedValueOnce(new Error('locked'));
+
+    await act(async () => {
+      await useStore.getState().deleteExploration('exp_1');
+    });
+
+    expect(getCachedExplorationResult(scopeFor('exp_1', 'orders_q'))).not.toBeNull();
   });
 });


### PR DESCRIPTION
> **Review round 2 (`1897fcaf`).** The first pass shipped a regression: threading
> the cache scope into `useModelTabPrefill` put it in the *same* dependency array
> as the pre-existing last-build parquet fetch, so a single keystroke mid-fetch
> cancelled that fetch permanently. Fixed by splitting the hook into two effects.
> Also fixed: editing a source in place was a silent stale serve; a real merge
> conflict with the still-open #659 in `SQLEditor.jsx`; an over-large cell budget;
> and a vacuous e2e assertion. Details in the review comment on this PR.

## The bug (M27)

Run a query in an exploration, glance at another one, come back — the grid is empty and every query has to be run again. A user who looks away loses their whole screen.

It is not a leak; it is a design gap. `ExplorationPane` parks the legacy `explorerStore` singleton on deactivate and rehydrates it from the persisted draft on activate, and that draft deliberately carries no rows — `snapshotExplorerWorkingState` strips `queryResult`/`enrichedResult` so the backend document stays a small JSON file. `restoreExplorerWorkingState` then rebuilds each model state from `createEmptyModelState`, whose `queryResult` is `null`. The rows only ever lived in memory, and nothing on the way back could get them.

## The fix — tier 1 only

Keep the rows **out** of the draft (that part is right) and park them in a new module-level, bounded LRU: **`viewer/src/stores/explorationResultCache.js`**.

- `CenterPanel` writes an entry when a run completes.
- A generalised `useModelTabPrefill` reads one back when a tab mounts with no result and hands it to `setModelQueryResult` — the same door a real run comes through, so `useExplorerDuckDB` re-registers the DuckDB table and computed columns / the column profiler keep working.
- A hit is a `Map` lookup. No network request at all (asserted in the e2e).

**Tier 2 is deliberately not here.** Surviving a hard reload needs a parquet twin under `target/`, and the dossier flags an open product decision — does the Django/cloud path get a twin? Without that call, tier 2 would ship a durability guarantee that only holds locally. The cache's docstring says out loud that its lifetime is one page session.

## The key, and why

```
[explorationId, modelName, sourceName, sql]   // JSON.stringify'd
```

| part | why it is in the key |
| --- | --- |
| `explorationId` | Isolation. Two explorations with an identically-named chip running identical SQL are two documents; neither may be shown the other's rows. |
| `modelName` | **A rename misses, deliberately.** The name does not determine the rows, but it determines what every downstream consumer (the DuckDB table, computed-column parenting, the promote checklist) thinks the rows *are*. That quiet mismatch costs more than the re-run it would save. |
| `sourceName` + `sql` | The actual determinants — taken from what was **executed**, never from the live buffer. |

`JSON.stringify` rather than a string join, so no name containing the separator can forge a different (exploration, chip) pair. `sql` is compared exactly (end-trimmed only, matching what `SQLEditor.handleRun` sends) — no normalisation, no parsing; a whitespace-only edit misses, which is the correct side to err on.

Getting "what was executed" honest required one small change to `SQLEditor`: it already snapshotted `queryContext` at run time so a mid-flight tab switch couldn't misroute the result — it now snapshots the SQL and source alongside it and returns them through `onQueryComplete`. The live buffer is the wrong key: the user may have run a **selection**, or typed on while the job was in flight.

## What invalidates

Three change the key, so the read simply misses — nothing to do:

- editing the SQL
- changing the source
- renaming the query chip

A rename's stranded entry is left to the LRU rather than invalidated: an orphan is by definition never read, so it never moves to the recently-used end and is **always evicted ahead of a live entry**. Reaching it would mean teaching `explorerStore.renameModelTab` — the legacy singleton, which knows nothing about which exploration is on screen — an exploration identity, and that coupling costs more than the slot. A test pins the LRU ordering that makes it safe.

Four the key cannot express, so they are told explicitly:

- **A re-run** drops every other entry for that (exploration, chip) before inserting. One live result per chip, always the newest — so re-running a second query and then typing the first one's text back in is a miss, not a resurrection of rows from before the re-run.
- **A failed run** retires that chip's rows. The same SQL erroring now (a dropped table, a source that went away) is exactly when its old rows must not come back.
- **Editing or deleting the SOURCE** (round 2). The key identifies a source by *name*, and a name is not a connection: repoint `local` from `a.duckdb` to `b.duckdb` — or change its schema, host, or credentials — and every key still matches while the rows came out of a database the user has stopped pointing at. Nothing reads `from_cache`, so there is no signal either; the grid would simply be wrong. `sourceStore.saveSource`/`deleteSource` now call `invalidateResultsForSource`, scoped to that source (editing one connection must not cost a user every result they have), and a save that *fails* keeps the rows because nothing changed.
- **Promoting a model** — and deleting the exploration — drops the entries. Once the model is a project object its rows belong to the project's build (`useModelTabPrefill`'s last-build path), and the promoted config is the checklist's, not necessarily the raw text the chip last ran.

## What bounds it

`8` entries and `250,000` cells (`rows × columns`, an O(1) proxy for bytes — serialising a 100k-row result just to measure it costs more than the cache saves). Least-recently-**used** evicted first, with a read counting as a use, so the tab you keep coming back to is the last one dropped. A single result too large for the whole budget is refused outright rather than emptying the cache for something that still would not fit.

The cell number is **sized, not guessed** (round 2 — it was 1,000,000, described in the docstring as "deliberately small", which it was not). An entry retains the run's own row objects — the cache stores the *same* array the store was handed, so a parked result costs one copy, not two — at roughly 100–200 bytes per cell for JS objects with string keys. 250k cells is therefore ~25–50 MB at full budget: eight chips of a few thousand rows, or one 25k × 10 result. There is no server-side row cap on `/api/model-query-jobs/`, so a `SELECT *` on a large table really can exceed it; that result is simply not cached, and the Run button remains the way back to it.

These bounds are the **only** thing that limits the cache — it is not cleared on leaving the Explorer, deliberately: the navigation it must survive (park an exploration, read another, come back) is indistinguishable at the component level from the navigation that would clear it, so a clear-on-exit hook that fired on the wrong one would delete the feature.

## Tests

- `explorationResultCache.test.js` — 33 unit tests: hit, miss-on-edit, miss-on-rename, miss-on-source-change, cross-exploration isolation, separator forging, re-run supersession, invalidation, LRU eviction at the **shipped** entry cap, cell-budget eviction, read-as-use recency, oversize refusal, budget accounting.
  Round 2 adds: source-scoped invalidation and its two negatives; the cell bound exercised **at the shipped value** rather than only at an injected `maxCells: 100` (holey `new Array(n)` makes a quarter-million cells free to allege, since `cellsIn` only reads `.length`); and the LRU ordering that makes a renamed chip's orphan safe, modelled on the real sequence (orphan inserted *after* the live entry, so insertion order alone would evict the wrong one).
- `useModelTabPrefill.test.js` — 14 new: restores with no network call, restores before DuckDB is ready, every miss falls through to the last-build path, never overwrites live rows, off entirely outside an exploration (the pre-M27 contract for existing callers).
  Round 2 adds the regression suite: a keystroke mid-fetch and a source rebind mid-fetch must not cancel the last-build prefill (both use a **deferred** `fetchModelJobs` — without one the fetch resolves before the rerender and nothing is proven); a cache hit still suppresses the build fetch entirely; the handoff ref does not latch after an invalidation; and the mid-typing restore is pinned as a deliberate affordance rather than left implicit.
- `sourceStore.resultCache.test.js` — **new**, 4 tests: `saveSource`/`deleteSource` retire that source's results, other sources are untouched, and a save that fails keeps the rows.
- `CenterPanel.test.jsx` — 8 new, driving the **full** round trip through the real store and the real cache: run → unmount → rebuild the model state from the draft (exactly what activate does) → assert the rendered grid. Includes "parks the rows under the query that RAN, not the tab that is active when they land".
- `SQLEditor.test.jsx` — 2 new: reports the selection that ran; reports the SQL/source that ran even after the user keeps typing mid-flight.
- `workspaceExplorationsStore.test.js` — 5 new: promote/delete invalidation, and the negatives (a promote that fails, an insight promote, a delete that fails all leave the rows alone).
- **New e2e story** `exploration-result-continuity.spec.mjs` (3 tests, registered in both `exploration-mutations`'s `testMatch` and `parallel`'s `testIgnore` per the double-registration rule).

### Gates

| gate | result |
| --- | --- |
| `yarn test --watchAll=false` | **368 suites / 7133 tests passed** |
| `yarn lint` | **0 errors** |
| e2e `exploration-result-continuity` (sandbox :8061/:3061) | **3 passed** |
| `black --check --target-version py312 .` | 543 files unchanged |
| Python | **no Python files touched** — tier 1 is viewer-only |
| `git merge-tree` vs #659 | **clean** (was conflicting in `SQLEditor.jsx` — see Conflict discipline) |

A wider run of the whole serial `exploration-mutations` project (well beyond this lane's gates) shows failures across `exploration-dnd-pull-in`, `exploration-preview`, `dashboard-newchart` and others. **They are not this PR's.** Setting `explorationId={null}` in `ExplorationWorkbench` switches the M27 cache off entirely — at which point `useModelTabPrefill` behaves exactly as `origin/main` — and `exploration-dnd-pull-in` fails with the identical four tests. Those specs are red in this sandbox independently of M27.

### Falsification

Every guard was removed one at a time, tests kept, and the failure recorded. All 16 mutations failed; the restored tree is green (289 tests across the 7 touched suites).

| mutation | tests that failed |
| --- | --- |
| key drops `modelName` | 10, incl. `the key › MISSES after the chip is renamed`, `session result cache › MISSES after the chip is renamed`, `CenterPanel › … after the chip is renamed` |
| key drops `sql` | 5, incl. `the key › MISSES after the query is edited`, `re-running › retires the chip's PREVIOUS query…`, `CenterPanel › … after the SQL is edited` |
| key drops `explorationId` | 4, incl. `the key › never serves one exploration the rows of another`, `CenterPanel › never shows a sibling exploration the rows` |
| key drops `sourceName` | 3, incl. `the key › MISSES after the source is changed` |
| re-run no longer drops siblings | `retires the chip's PREVIOUS query, so reverting the text is a miss` (+ budget accounting) |
| eviction removed | `evicts the least recently used entry at the shipped entry cap`, `evicts on the cell budget…`, `counts a READ as a use…` |
| read no longer bumps recency | `counts a READ as a use, so the tab you keep returning to survives` |
| oversize refusal removed | `refuses a single result too big for the whole budget…` |
| hook never reads the cache | 5, incl. `restores the parked rows on return, with no network call at all`; **and the e2e** `run a query, park the tab, come back — same rows, no re-run` |
| failed-run invalidation removed | `does not resurrect rows once the same query starts failing` |
| cache keyed on the live buffer | `parks the rows under the query that RAN, not the tab that is active when they land` |
| `SQLEditor` stops snapshotting the run | 3, incl. `reports the SELECTION that ran, not the whole buffer` |
| promote invalidation removed | `promoting a model retires that chip's parked rows` |
| delete invalidation removed | `deleting an exploration drops every result parked for it` |
| pane stops passing `explorationId` | `hands the workbench this exploration's id` |
| workbench stops passing `explorationId` | `hands CenterPanel the exploration id so parked results stay per-document` |

**Round 2** adds nine more, same method — one implementation detail stashed at a time, tests untouched, restored green (58 tests across the three suites):

| mutation | tests that failed |
| --- | --- |
| collapse the two effects back into one (**the regression**) | `survives a keystroke in the SQL editor while the parquet is loading`, `survives the source being rebound while the parquet is loading` |
| drop the `servedFromCacheRef` handoff | `a cache HIT still suppresses the build fetch entirely`, `restores the parked rows on return, with no network call at all`, `still restores on a SECOND return…` |
| let `servedFromCacheRef` latch | `falls back to the build after a hit is invalidated` |
| stop invalidating on `saveSource` | `saveSource retires the results that source produced`, `leaves results from OTHER sources alone` |
| stop invalidating on `deleteSource` | `deleteSource retires them too` |
| make source invalidation a panic-clear | `drops every result it produced, across explorations`, `leaves results from OTHER sources alone` |
| drop the oversize refusal (at the **shipped** `maxCells`) | `at the SHIPPED cell budget › refuses one cell more, rather than emptying itself for it` |
| stop evicting on the cell budget (at the **shipped** `maxCells`) | `at the SHIPPED cell budget › evicts on the shipped budget, not just the injected one` |
| stop counting a read as a use | `counts a READ as a use…`, `evicts a renamed chip's orphaned entry ahead of a live one` |

The e2e was falsified against the live sandbox rather than argued about. With `explorationId` deleted from the key: the **old** test 3 still passed (it was vacuous — the sibling's chip had an empty buffer, and empty sql switches caching off outright), the **new** test 3 failed. With the key correct, all three pass.

## Conflict discipline

None of the 16 open-PR files were touched. `workspaceExplorationsStore.js` takes two lines (one inside the existing promote loop, one in `deleteExploration`) plus an import; `ExplorationPromoteModal.jsx`, `promoteChecklist.js`, `Chart.jsx`, `ExplorerChartPreview.jsx`, `explorerStore.js` and everything under `visivo/` are untouched.

Round 2 went further and removed a *textual* conflict that was not on any owned-file list. This branch and the still-open #659 both touch `SQLEditor.jsx` and `sourceStore.js`:

```
$ git merge-tree --write-tree <round-1 tip> <#659 tip>
CONFLICT (content): Merge conflict in viewer/src/components/explorer/SQLEditor.jsx
exit=1

$ git merge-tree --write-tree <round-2 tip> <#659 tip>
exit=0                                       # clean, zero conflicts
```

Both PRs were adding a ref immediately after `runContextRef` and a statement immediately after `executeQuery`. Nothing here needed those anchors: the new refs are declared **above** the `runContextRef` comment and assigned **above** its statement, and the `sourceStore` import goes above the existing one — leaving #659's context lines byte-identical to main. #659's patch now applies to this branch with plain `git apply`, and the merged file carries both PRs' additions correctly. No behaviour changed to achieve it.

Linear: VIS-1309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U

