### PR TITLE
Every sample ran zero jobs: a dashboard may not shadow its project (VIS-1324)

### DIFF
--- a/tests/templates/test_samples.py
+++ b/tests/templates/test_samples.py
@@ -21,16 +21,27 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from visivo.commands.init_phase import (
     SAMPLE_DIR_MAP,
     _bundled_samples_root,
     load_example_project,
 )
+from visivo.models.dashboard import Dashboard
 from visivo.models.example_type import ExampleTypeEnum
 from visivo.parsers.parser_factory import ParserFactory
 
 SAMPLES = list(SAMPLE_DIR_MAP.items())
+
+
+def _default_run_filter(project):
+    """The DAG filter `visivo run` builds when the user passes none.
+
+    Mirrors visivo/commands/run_phase.py so the tests below exercise the
+    real selection, not an approximation of it.
+    """
+    return ",".join(f"+{d.name}+" for d in project.dag().get_nodes_by_types([Dashboard], True))
 
 
 @pytest.fixture
@@ -96,12 +107,60 @@ def test_bundled_sample_parses_with_current_schema(example_type, sample_dir, tmp
 
 
 @pytest.mark.parametrize("example_type,sample_dir", SAMPLES, ids=[s[1] for s in SAMPLES])
+def test_bundled_sample_selects_jobs_to_run(example_type, sample_dir, tmp_path, monkeypatch):
+    """The default run filter must actually select something.
+
+    A sample whose dashboard shares the project's name puts two nodes
+    of that name in the DAG, `filter_dag` resolves the ambiguity to
+    nothing, and `visivo run` does no work, prints no error and exits
+    0 — a blank dashboard with no signal that anything went wrong.
+    Exit status cannot catch that, so assert on the selection itself.
+    """
+    # Copy the sample VERBATIM — deliberately not through
+    # load_example_project, which stamps a caller-supplied project name
+    # into the YAML and so masks a name the sample itself ships with.
+    target = tmp_path / "project"
+    target.mkdir()
+    for f in (_bundled_samples_root() / sample_dir).iterdir():
+        if f.is_file():
+            shutil.copy2(f, target)
+
+    monkeypatch.chdir(target)
+    project = ParserFactory().build(project_file=target / "project.visivo.yml", files=[]).parse()
+
+    dag_filter = _default_run_filter(project)
+    assert dag_filter, f"{sample_dir} exposes no dashboard for the default filter"
+    assert len(project.dag().filter_dag(dag_filter)) > 0, (
+        f"{sample_dir}: the default filter {dag_filter!r} selected no sub-DAGs, "
+        f"so `visivo run` would do nothing and still exit 0"
+    )
+
+
+@pytest.mark.parametrize("example_type,sample_dir", SAMPLES, ids=[s[1] for s in SAMPLES])
+def test_bundled_sample_dashboard_does_not_shadow_the_project(example_type, sample_dir):
+    """A dashboard may not reuse its project's name.
+
+    This is the specific collision behind the zero-job run above, held
+    against the shipped YAML so a future sample cannot reintroduce it.
+    """
+    project_file = _bundled_samples_root() / sample_dir / "project.visivo.yml"
+    data = yaml.safe_load(project_file.read_text())
+    project_name = data["name"]
+    shadowing = [d["name"] for d in data.get("dashboards", []) if d.get("name") == project_name]
+    assert not shadowing, (
+        f"{sample_dir}: dashboard {shadowing} reuses the project name {project_name!r}; "
+        f"the DAG then holds two nodes of that name and the default run filter selects nothing"
+    )
+
+
+@pytest.mark.parametrize("example_type,sample_dir", SAMPLES, ids=[s[1] for s in SAMPLES])
 def test_bundled_sample_runs_end_to_end(example_type, sample_dir, tmp_path):
-    """`visivo run` succeeds on a copied sample.
+    """`visivo run` succeeds on a copied sample, and actually runs jobs.
 
     Slower than the parse test (executes the CSV models + data
     pipeline) but catches runtime issues like missing data files,
-    malformed CSV, or query-time SQL errors.
+    malformed CSV, or query-time SQL errors. Exit status alone is not
+    enough: a run that selects zero jobs also exits 0.
     """
     target = tmp_path / "project"
     target.mkdir()
@@ -125,6 +184,17 @@ def test_bundled_sample_runs_end_to_end(example_type, sample_dir, tmp_path):
     )
     assert result.returncode == 0, (
         f"`visivo run` failed for {sample_dir}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+    # A zero-job run is indistinguishable from success by exit code, so
+    # require evidence that work happened: the run writes per-insight
+    # artifacts under the target directory.
+    produced = list((target / "target").rglob("*.json")) if (target / "target").exists() else []
+    assert produced, (
+        f"`visivo run` exited 0 for {sample_dir} but produced no artifacts — "
+        f"it almost certainly selected zero jobs\n"
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )

--- a/visivo/templates/samples/college-football/project.visivo.yml
+++ b/visivo/templates/samples/college-football/project.visivo.yml
@@ -87,7 +87,7 @@ charts:
         text: "Average attendance by home team"
 
 dashboards:
-  - name: College Football
+  - name: College Football Overview
     rows:
       - height: compact
         items:

--- a/visivo/templates/samples/ev-sales/project.visivo.yml
+++ b/visivo/templates/samples/ev-sales/project.visivo.yml
@@ -91,7 +91,7 @@ charts:
         text: "BEV vs PHEV (cumulative)"
 
 dashboards:
-  - name: EV Sales
+  - name: EV Sales Overview
     rows:
       - height: compact
         items:

--- a/visivo/templates/samples/github-releases/project.visivo.yml
+++ b/visivo/templates/samples/github-releases/project.visivo.yml
@@ -90,7 +90,7 @@ charts:
         text: "Average contributors per release"
 
 dashboards:
-  - name: GitHub Releases
+  - name: GitHub Releases Overview
     rows:
       - height: compact
         items:


### PR DESCRIPTION
> 🤖 Posted by **Claude Code** running on Jared's machine — written by Claude, not by Jared.

## The bug

All three shipped samples name their dashboard exactly what they name the project:

| sample | project | dashboard |
| -- | -- | -- |
| `ev-sales` | `EV Sales` | `EV Sales` |
| `college-football` | `College Football` | `College Football` |
| `github-releases` | `GitHub Releases` | `GitHub Releases` |

`run_phase` builds its default filter as `+<dashboard name>+` (`visivo/commands/run_phase.py:67-73`). The DAG then holds **two** nodes with that name — the `Project` and the `Dashboard` — and `filter_dag` resolves the ambiguity to **nothing**. `DagRunner` never runs, `FilteredRunner` aggregates nothing, and neither the failure branch nor the "No jobs run" branch is reached.

So `visivo run` does no work, prints no error, and **exits 0**. A first-run user who picks a sample gets an empty dashboard with no indication anything went wrong — on the exact path the 2.1 activation gate depends on.

Verified against the shipped YAML before touching it:

```
college-football  project='College Football'  filter='+College Football+'  sub_dags=0  nodes_named_project=[('Project', 'College Football'), ('Dashboard', 'College Football')]
ev-sales          project='EV Sales'          filter='+EV Sales+'          sub_dags=0  nodes_named_project=[('Project', 'EV Sales'), ('Dashboard', 'EV Sales')]
github-releases   project='GitHub Releases'   filter='+GitHub Releases+'   sub_dags=0  nodes_named_project=[('Project', 'GitHub Releases'), ('Dashboard', 'GitHub Releases')]
```

## What this PR does — and does not

**Does:** renames the three dashboards (`EV Sales Overview`, etc.). That is the cheap half, and it unblocks the sample path today.

**Does not:** fix the underlying defect — `filter_dag` silently resolving an ambiguous name to nothing, and a zero-job run exiting 0 in silence. That belongs in `visivo/jobs/`, which is hot in open PR #650, and is tracked as the second half of VIS-1324. At minimum a run selecting no jobs should be loud; ideally name resolution should prefer the dashboard or refuse the ambiguity by naming both nodes.

## Why CI did not catch it

`test_bundled_sample_runs_end_to_end` asserted only `returncode == 0` — and a zero-job run exits 0. The test passed while the samples produced nothing. It now also requires the run to have produced artifacts.

Two new guards:
- `test_bundled_sample_selects_jobs_to_run` — exercises the real mechanism (mirrors `run_phase`'s filter construction, asserts `filter_dag` selects > 0). It copies the sample **verbatim** rather than through `load_example_project`, which stamps a caller-supplied name into the YAML and would mask a name the sample itself ships with. Written the obvious way first, it passed vacuously for exactly that reason.
- `test_bundled_sample_dashboard_does_not_shadow_the_project` — pins the specific collision against the shipped YAML.

## Falsification

Reverting only the YAML rename, keeping the tests, fails all 6 new assertions with the real diagnostic:

```
test_bundled_sample_selects_jobs_to_run[ev-sales] - AssertionError: ev-sales: the default filter '+EV Sales+' selected no sub-DAGs, so `visivo run` would do nothing and still exit 0
test_bundled_sample_dashboard_does_not_shadow_the_project[ev-sales] - AssertionError: ev-sales: dashboard ['EV Sales'] reuses the project name 'EV Sales' ...
6 failed, 12 passed
```

Restored: 18 passed.

## Tests

- `tests/templates/test_samples.py` — 18 passed (was 12)
- Full suite — 2477 passed, 2 skipped, 5 xfailed, 1 xpassed
- `black --check --target-version py312` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cc4b4J7oX3zQbBsjQ2U