### PR TITLE
Sweep run artifacts that name nothing in the project (VIS-1325)

### DIFF
--- a/tests/commands/test_sweep_artifacts.py
+++ b/tests/commands/test_sweep_artifacts.py
@@ -1,0 +1,172 @@
+import os
+
+from tests.factories.model_factories import (
+    InsightFactory,
+    ProjectFactory,
+    SingleSelectInputFactory,
+    SqlModelFactory,
+)
+from tests.support.utils import temp_folder
+from visivo.commands.sweep_artifacts import find_orphaned_artifacts, sweep_orphaned_artifacts
+from visivo.models.base.named_model import alpha_hash
+
+
+def _run_dir(**dirs):
+    """A run directory holding `{subdir: [filenames]}`."""
+    root = temp_folder()
+    for subdir, filenames in dirs.items():
+        path = os.path.join(root, subdir)
+        os.makedirs(path, exist_ok=True)
+        for filename in filenames:
+            with open(os.path.join(path, filename), "w") as f:
+                f.write("{}")
+    return root
+
+
+def _project(**kwargs):
+    """A project with the noisy defaults cleared, so a test declares exactly
+    the objects it means to."""
+    defaults = {"insights": [], "charts": [], "dashboards": []}
+    defaults.update(kwargs)
+    return ProjectFactory(**defaults)
+
+
+class TestFindOrphanedArtifacts:
+    """The residue that made `visivo dist` ship every object twice.
+
+    Before VIS-1128 artifacts were named `alpha_hash(name)`; now they are
+    `<name>`. A run only ever adds, so both generations sit in the directory and
+    anything that globs it sees each object once per naming scheme.
+    """
+
+    def test_the_pre_vis_1128_hashed_artifact_is_residue(self):
+        project = _project(insights=[InsightFactory(name="station-bubbles")])
+        run_dir = _run_dir(
+            insights=[
+                "station-bubbles.json",
+                f"{alpha_hash('station-bubbles')}.json",
+            ]
+        )
+
+        orphans = find_orphaned_artifacts(project, run_dir)
+
+        assert [os.path.basename(o) for o in orphans] == [f"{alpha_hash('station-bubbles')}.json"]
+
+    def test_an_artifact_left_by_a_rename_is_residue(self):
+        project = _project(insights=[InsightFactory(name="revenue_by_month")])
+        run_dir = _run_dir(insights=["revenue_by_month.json", "revenue.json"])
+
+        assert [os.path.basename(o) for o in find_orphaned_artifacts(project, run_dir)] == [
+            "revenue.json"
+        ]
+
+    def test_a_live_object_is_never_residue(self):
+        project = _project(
+            insights=[InsightFactory(name="a"), InsightFactory(name="b")],
+            models=[SqlModelFactory(name="orders")],
+        )
+        run_dir = _run_dir(insights=["a.json", "a.parquet", "b.json"], models=["orders.parquet"])
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+
+class TestInputSuffixes:
+    """An input writes `<name>.json` beside `<name>_<key>.parquet`, so a stem
+    does not always equal the object's name."""
+
+    def test_the_options_parquet_belongs_to_its_input(self):
+        project = _project(inputs=[SingleSelectInputFactory(name="cuisine-select")])
+        run_dir = _run_dir(
+            inputs=["cuisine-select.json", "cuisine-select_options.parquet"],
+        )
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+    def test_a_suffixed_file_whose_input_is_gone_is_residue(self):
+        project = _project(inputs=[SingleSelectInputFactory(name="cuisine-select")])
+        run_dir = _run_dir(
+            inputs=[
+                "cuisine-select.json",
+                f"{alpha_hash('cuisine-select')}_options.parquet",
+            ]
+        )
+
+        assert [os.path.basename(o) for o in find_orphaned_artifacts(project, run_dir)] == [
+            f"{alpha_hash('cuisine-select')}_options.parquet"
+        ]
+
+    def test_an_ambiguous_suffix_keeps_the_file(self):
+        """`region_totals_options.parquet` could be a deleted `region_totals`
+        input's options, OR a live `region` input's `totals_options` key. The
+        `<name>_<key>` shape cannot tell them apart.
+
+        So it is KEPT. When the rule is ambiguous the safe error is leaving a
+        stale file behind; the unsafe one is deleting data on a guess.
+        """
+        project = _project(inputs=[SingleSelectInputFactory(name="region")])
+        run_dir = _run_dir(inputs=["region.json", "region_totals_options.parquet"])
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+    def test_a_suffixed_file_matching_no_input_at_all_is_residue(self):
+        """No such ambiguity here — nothing in the project is a prefix of it."""
+        project = _project(inputs=[SingleSelectInputFactory(name="region")])
+        run_dir = _run_dir(inputs=["region.json", "cuisine_options.parquet"])
+
+        assert [os.path.basename(o) for o in find_orphaned_artifacts(project, run_dir)] == [
+            "cuisine_options.parquet"
+        ]
+
+
+class TestSafety:
+    def test_an_empty_collection_sweeps_nothing(self):
+        """A project that never had insights looks identical to one whose parse
+        dropped them. Deleting the directory's contents on that basis would
+        turn a parse problem into data loss."""
+        project = _project(insights=[])
+        run_dir = _run_dir(insights=["something.json", "another.json"])
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+    def test_untracked_directories_are_left_alone(self):
+        """`files/` (pre-VIS-1128 parquet) and the schema caches are not
+        per-object artifacts; sweeping them is a separate judgement."""
+        project = _project(insights=[InsightFactory(name="a")])
+        run_dir = _run_dir(
+            insights=["a.json"],
+            files=["mfvvjxtzogiwfwkjczyjvkxbrjypa.parquet"],
+            schemas=["nyc-db.json"],
+        )
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+    def test_a_missing_run_dir_is_not_an_error(self):
+        assert find_orphaned_artifacts(_project(), "does/not/exist") == []
+        assert find_orphaned_artifacts(None, None) == []
+
+    def test_subdirectories_are_never_removed(self):
+        project = _project(insights=[InsightFactory(name="a")])
+        run_dir = _run_dir(insights=["a.json"])
+        nested = os.path.join(run_dir, "insights", "orphan_dir")
+        os.makedirs(nested, exist_ok=True)
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+        assert os.path.isdir(nested)
+
+
+class TestSweep:
+    def test_it_removes_exactly_what_it_reported(self):
+        project = _project(insights=[InsightFactory(name="keep")])
+        run_dir = _run_dir(insights=["keep.json", "keep.parquet", "drop.json", "drop.parquet"])
+
+        removed = sweep_orphaned_artifacts(project, run_dir)
+
+        assert sorted(os.path.basename(r) for r in removed) == ["drop.json", "drop.parquet"]
+        remaining = sorted(os.listdir(os.path.join(run_dir, "insights")))
+        assert remaining == ["keep.json", "keep.parquet"]
+
+    def test_nothing_to_do_is_not_an_error(self):
+        project = _project(insights=[InsightFactory(name="a")])
+        run_dir = _run_dir(insights=["a.json"])
+
+        assert sweep_orphaned_artifacts(project, run_dir) == []

--- a/tests/commands/test_sweep_artifacts.py
+++ b/tests/commands/test_sweep_artifacts.py
@@ -32,12 +32,8 @@ def _project(**kwargs):
 
 
 class TestFindOrphanedArtifacts:
-    """The residue that made `visivo dist` ship every object twice.
-
-    Before VIS-1128 artifacts were named `alpha_hash(name)`; now they are
-    `<name>`. A run only ever adds, so both generations sit in the directory and
-    anything that globs it sees each object once per naming scheme.
-    """
+    """Before VIS-1128 artifacts were named `alpha_hash(name)`; now `<name>`.
+    Both generations can sit in the directory at once."""
 
     def test_the_pre_vis_1128_hashed_artifact_is_residue(self):
         project = _project(insights=[InsightFactory(name="station-bubbles")])
@@ -71,17 +67,9 @@ class TestFindOrphanedArtifacts:
 
 
 class TestObjectsDefinedInline:
-    """An object does not have to be top-level.
-
-    The integration project defines `double-simple-line` inline inside a chart,
-    inside a dashboard item. It is a real insight with a real artifact — and
-    reading `project.insights` (the TOP-LEVEL list) called it residue and
-    deleted it. CI caught that; no unit fixture here had a project shaped that
-    way, because they all declared their objects at the top level.
-
-    Membership comes from the DAG, which is the same flattening `child_items()`
-    feeds and the same thing the rest of the system means by "in the project".
-    """
+    """An object need not be top-level (e.g. an insight nested inside a chart
+    inside a dashboard item) — membership comes from the DAG, not
+    `project.insights`."""
 
     def _project_with_a_chart_nested_insight(self):
         from tests.factories.model_factories import (
@@ -146,20 +134,14 @@ class TestInputSuffixes:
         ]
 
     def test_an_ambiguous_suffix_keeps_the_file(self):
-        """`region_totals_options.parquet` could be a deleted `region_totals`
-        input's options, OR a live `region` input's `totals_options` key. The
-        `<name>_<key>` shape cannot tell them apart.
-
-        So it is KEPT. When the rule is ambiguous the safe error is leaving a
-        stale file behind; the unsafe one is deleting data on a guess.
-        """
+        # region_totals_options.parquet could be a deleted region_totals
+        # input's options, or a live region input's totals_options key.
         project = _project(inputs=[SingleSelectInputFactory(name="region")])
         run_dir = _run_dir(inputs=["region.json", "region_totals_options.parquet"])
 
         assert find_orphaned_artifacts(project, run_dir) == []
 
     def test_a_suffixed_file_matching_no_input_at_all_is_residue(self):
-        """No such ambiguity here — nothing in the project is a prefix of it."""
         project = _project(inputs=[SingleSelectInputFactory(name="region")])
         run_dir = _run_dir(inputs=["region.json", "cuisine_options.parquet"])
 
@@ -170,17 +152,13 @@ class TestInputSuffixes:
 
 class TestSafety:
     def test_an_empty_collection_sweeps_nothing(self):
-        """A project that never had insights looks identical to one whose parse
-        dropped them. Deleting the directory's contents on that basis would
-        turn a parse problem into data loss."""
+        # Indistinguishable from a parse that dropped every insight.
         project = _project(insights=[])
         run_dir = _run_dir(insights=["something.json", "another.json"])
 
         assert find_orphaned_artifacts(project, run_dir) == []
 
     def test_untracked_directories_are_left_alone(self):
-        """`files/` (pre-VIS-1128 parquet) and the schema caches are not
-        per-object artifacts; sweeping them is a separate judgement."""
         project = _project(insights=[InsightFactory(name="a")])
         run_dir = _run_dir(
             insights=["a.json"],

--- a/tests/commands/test_sweep_artifacts.py
+++ b/tests/commands/test_sweep_artifacts.py
@@ -70,6 +70,56 @@ class TestFindOrphanedArtifacts:
         assert find_orphaned_artifacts(project, run_dir) == []
 
 
+class TestObjectsDefinedInline:
+    """An object does not have to be top-level.
+
+    The integration project defines `double-simple-line` inline inside a chart,
+    inside a dashboard item. It is a real insight with a real artifact — and
+    reading `project.insights` (the TOP-LEVEL list) called it residue and
+    deleted it. CI caught that; no unit fixture here had a project shaped that
+    way, because they all declared their objects at the top level.
+
+    Membership comes from the DAG, which is the same flattening `child_items()`
+    feeds and the same thing the rest of the system means by "in the project".
+    """
+
+    def _project_with_a_chart_nested_insight(self):
+        from tests.factories.model_factories import (
+            ChartFactory,
+            DashboardFactory,
+            ItemFactory,
+            RowFactory,
+        )
+
+        model = SqlModelFactory(name="model")
+        nested = InsightFactory(name="double-simple-line", model=model)
+        chart = ChartFactory(name="fibonacci-times-2", insights=[nested])
+        dashboard = DashboardFactory(
+            name="dash", rows=[RowFactory(items=[ItemFactory(chart=chart)])]
+        )
+        # Deliberately NOT passed as `insights=[...]` — that is the whole point.
+        return ProjectFactory(models=[model], charts=[], insights=[], dashboards=[dashboard])
+
+    def test_an_insight_declared_inside_a_chart_is_not_residue(self):
+        project = self._project_with_a_chart_nested_insight()
+        run_dir = _run_dir(insights=["double-simple-line.json"])
+
+        assert find_orphaned_artifacts(project, run_dir) == []
+
+    def test_residue_beside_an_inline_insight_still_goes(self):
+        project = self._project_with_a_chart_nested_insight()
+        run_dir = _run_dir(
+            insights=[
+                "double-simple-line.json",
+                f"{alpha_hash('double-simple-line')}.json",
+            ]
+        )
+
+        assert [os.path.basename(o) for o in find_orphaned_artifacts(project, run_dir)] == [
+            f"{alpha_hash('double-simple-line')}.json"
+        ]
+
+
 class TestInputSuffixes:
     """An input writes `<name>.json` beside `<name>_<key>.parquet`, so a stem
     does not always equal the object's name."""

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -100,18 +100,8 @@ def run_phase(
     )
     runner.run()
 
-    # Housekeeping, after the work and only when the work went cleanly: drop
-    # artifacts that name no object in the project. A run has only ever ADDED
-    # files, so a rename, a delete, or the VIS-1128 naming-scheme change left
-    # residue behind forever — invisible until something globbed the directory,
-    # which is how `visivo dist` came to ship every object twice and 404 on its
-    # own data.
-    #
-    # Gated on a clean run because a failed job can leave a half-written
-    # artifact, and the sweep should not be the thing that decides its fate.
-    # NOT gated on `dag_filter`: the test is membership in the project, which is
-    # fully parsed either way — "this run didn't build it" is a different
-    # question, and not the one being asked.
+    # See sweep_artifacts.py for what this removes and why. Gated on a clean
+    # run: a failed job can leave a half-written artifact.
     if not runner.failed_job_results:
         from visivo.commands.sweep_artifacts import sweep_orphaned_artifacts
 
@@ -124,7 +114,6 @@ def run_phase(
                     f"Removed {len(removed)} artifact(s) no longer in the project"
                 )
         except Exception as error:
-            # Never let housekeeping fail a run that otherwise succeeded.
             Logger.instance().debug(f"Artifact sweep skipped: {error}")
 
     return runner

--- a/visivo/commands/run_phase.py
+++ b/visivo/commands/run_phase.py
@@ -1,5 +1,6 @@
 from visivo.models.dashboard import Dashboard
 from visivo.models.project import Project
+import os
 from visivo.constants import DEFAULT_RUN_ID
 
 
@@ -98,4 +99,32 @@ def run_phase(
         run_id=run_id,
     )
     runner.run()
+
+    # Housekeeping, after the work and only when the work went cleanly: drop
+    # artifacts that name no object in the project. A run has only ever ADDED
+    # files, so a rename, a delete, or the VIS-1128 naming-scheme change left
+    # residue behind forever — invisible until something globbed the directory,
+    # which is how `visivo dist` came to ship every object twice and 404 on its
+    # own data.
+    #
+    # Gated on a clean run because a failed job can leave a half-written
+    # artifact, and the sweep should not be the thing that decides its fate.
+    # NOT gated on `dag_filter`: the test is membership in the project, which is
+    # fully parsed either way — "this run didn't build it" is a different
+    # question, and not the one being asked.
+    if not runner.failed_job_results:
+        from visivo.commands.sweep_artifacts import sweep_orphaned_artifacts
+
+        try:
+            removed = sweep_orphaned_artifacts(project, os.path.join(output_dir, run_id))
+            for artifact in removed:
+                Logger.instance().debug(f"Removed orphaned artifact: {artifact}")
+            if removed:
+                Logger.instance().info(
+                    f"Removed {len(removed)} artifact(s) no longer in the project"
+                )
+        except Exception as error:
+            # Never let housekeeping fail a run that otherwise succeeded.
+            Logger.instance().debug(f"Artifact sweep skipped: {error}")
+
     return runner

--- a/visivo/commands/sweep_artifacts.py
+++ b/visivo/commands/sweep_artifacts.py
@@ -1,0 +1,124 @@
+"""Remove run artifacts that name no object in the project.
+
+A run only ever ADDS files under ``target/``. Nothing removed the ones a
+rename, a delete, or a naming-scheme change orphaned, so the directories
+accumulated indefinitely. That was invisible until something globbed them:
+``visivo dist`` shipped every object twice — once from ``station-bubbles.json``
+and once from ``mifawvncyzdkmlywzcggvituhvlwb.json``, the pre-VIS-1128 name for
+the same insight — and the stale copy pointed at a parquet nobody had written
+in six months, so a hosted bundle 404'd on its own data.
+
+WHAT COUNTS AS RESIDUE
+
+Membership in the project, not "did this run build it". Those are different
+questions and only the first one is safe to answer:
+
+* A filtered run (``-d``) builds a subset, so "this run didn't write it" says
+  nothing about whether the artifact is still wanted.
+* The project, by contrast, is fully parsed regardless of the filter. An
+  artifact whose name matches no object of its type cannot be reached by
+  anything, however the run was invoked.
+
+So the filter does not restrict the sweep — it never had a bearing on the
+question being asked.
+
+WHAT THIS DELIBERATELY DOES NOT TOUCH
+
+* ``files/`` — the pre-VIS-1128 parquet location. Nothing writes it today, which
+  makes it entirely residue, but "this whole directory is obsolete" is a
+  different judgement from "this file names nothing" and deserves its own
+  change.
+* ``schema/`` and ``schemas/`` — source-level schema caches, not per-object
+  artifacts.
+* Directories. Only files are removed, so an empty leftover directory stays.
+"""
+
+import os
+from glob import glob
+
+# Each entry: the directory under the run dir, the project attribute holding the
+# objects that may legitimately own a file there, and whether a file's stem can
+# carry a `_suffix` after the object name (inputs write
+# `<name>_<key>.parquet` beside `<name>.json`).
+_ARTIFACT_DIRS = (
+    ("insights", "insights", False),
+    ("models", "models", False),
+    ("inputs", "inputs", True),
+)
+
+
+def _object_names(project, attribute):
+    return {
+        obj.name for obj in (getattr(project, attribute, None) or []) if getattr(obj, "name", None)
+    }
+
+
+def _owner_of(stem, names, allow_suffix):
+    """The object a file belongs to, or None when nothing claims it.
+
+    Exact stem match is the normal case. `allow_suffix` additionally accepts
+    `<name>_<anything>`, which is how an input writes its options parquet.
+
+    That prefix rule is deliberately PERMISSIVE. `region_totals_options.parquet`
+    could be a deleted `region_totals` input's options, or a live `region`
+    input's `totals_options` key — the `<name>_<key>` shape cannot distinguish
+    them. Any live name that could own the file claims it, so the ambiguous case
+    is kept. Leaving a stale file behind is the recoverable error; deleting
+    someone's data on a guess is not.
+
+    The longest match is returned when several could claim it, so the answer
+    doesn't depend on set ordering.
+    """
+    if stem in names:
+        return stem
+    if not allow_suffix:
+        return None
+    candidates = [name for name in names if stem.startswith(f"{name}_")]
+    return max(candidates, key=len) if candidates else None
+
+
+def find_orphaned_artifacts(project, run_dir):
+    """Every file under ``run_dir`` that names no object in ``project``.
+
+    Pure — it removes nothing. Split out so the decision can be tested, and
+    logged, separately from the deletion.
+
+    :returns: a sorted list of absolute-ish paths, as globbed.
+    """
+    if not project or not run_dir or not os.path.isdir(run_dir):
+        return []
+
+    orphans = []
+    for directory, attribute, allow_suffix in _ARTIFACT_DIRS:
+        path = os.path.join(run_dir, directory)
+        if not os.path.isdir(path):
+            continue
+        names = _object_names(project, attribute)
+        # No objects of this type at all is ambiguous: a project that never had
+        # any looks identical to one whose parse dropped them. Leave the
+        # directory alone rather than delete everything in it.
+        if not names:
+            continue
+        for artifact in glob(os.path.join(path, "*")):
+            if not os.path.isfile(artifact):
+                continue
+            stem = os.path.splitext(os.path.basename(artifact))[0]
+            if _owner_of(stem, names, allow_suffix) is None:
+                orphans.append(artifact)
+    return sorted(orphans)
+
+
+def sweep_orphaned_artifacts(project, run_dir):
+    """Delete the orphans and return what was removed.
+
+    FAILS OPEN. A sweep is housekeeping; it must never turn a successful run
+    into a failed one. An unremovable file is skipped and the rest proceed.
+    """
+    removed = []
+    for artifact in find_orphaned_artifacts(project, run_dir):
+        try:
+            os.remove(artifact)
+            removed.append(artifact)
+        except OSError:
+            continue
+    return removed

--- a/visivo/commands/sweep_artifacts.py
+++ b/visivo/commands/sweep_artifacts.py
@@ -1,36 +1,11 @@
-"""Remove run artifacts that name no object in the project.
+"""Delete run artifacts under ``target/`` that name no object in the project.
 
-A run only ever ADDS files under ``target/``. Nothing removed the ones a
-rename, a delete, or a naming-scheme change orphaned, so the directories
-accumulated indefinitely. That was invisible until something globbed them:
-``visivo dist`` shipped every object twice — once from ``station-bubbles.json``
-and once from ``mifawvncyzdkmlywzcggvituhvlwb.json``, the pre-VIS-1128 name for
-the same insight — and the stale copy pointed at a parquet nobody had written
-in six months, so a hosted bundle 404'd on its own data.
+Membership in the (fully-parsed) project decides this, not whether the current
+run built the file — a filtered run (``-d``) is a subset and says nothing about
+whether an unbuilt artifact is still wanted.
 
-WHAT COUNTS AS RESIDUE
-
-Membership in the project, not "did this run build it". Those are different
-questions and only the first one is safe to answer:
-
-* A filtered run (``-d``) builds a subset, so "this run didn't write it" says
-  nothing about whether the artifact is still wanted.
-* The project, by contrast, is fully parsed regardless of the filter. An
-  artifact whose name matches no object of its type cannot be reached by
-  anything, however the run was invoked.
-
-So the filter does not restrict the sweep — it never had a bearing on the
-question being asked.
-
-WHAT THIS DELIBERATELY DOES NOT TOUCH
-
-* ``files/`` — the pre-VIS-1128 parquet location. Nothing writes it today, which
-  makes it entirely residue, but "this whole directory is obsolete" is a
-  different judgement from "this file names nothing" and deserves its own
-  change.
-* ``schema/`` and ``schemas/`` — source-level schema caches, not per-object
-  artifacts.
-* Directories. Only files are removed, so an empty leftover directory stays.
+Does not touch ``files/`` (pre-VIS-1128 location, a separate cleanup),
+``schema*/`` (source-level, not per-object), or directories.
 """
 
 import os
@@ -38,14 +13,8 @@ from glob import glob
 
 
 def _artifact_dirs():
-    """The per-object directories, and the type that may own a file in each.
-
-    Imported lazily — this module is pulled in at the end of a run and the model
-    package is heavy.
-
-    The third element says whether a file's stem may carry a `_suffix` after the
-    object name: inputs write `<name>_<key>.parquet` beside `<name>.json`.
-    """
+    """(directory, node type, allow_suffix — inputs write `<name>_<key>.parquet`)."""
+    # Imported lazily: pulled in at the end of every run, and the model package is heavy.
     from visivo.models.inputs.input import Input
     from visivo.models.insight import Insight
     from visivo.models.models.model import Model
@@ -58,24 +27,15 @@ def _artifact_dirs():
 
 
 def _object_names(project, node_type):
-    """Every name of `node_type` in the project, wherever it is declared.
-
-    From the DAG, NOT from `project.<collection>`. An object does not have to be
-    top-level: the integration project defines `double-simple-line` inline
-    inside a chart, inside a dashboard item, and it is a real insight with a
-    real artifact. Reading the top-level list called it residue and deleted it
-    — caught by CI, which was the only place a project shaped like that existed.
-
-    The DAG is the same flattening `child_items()` feeds, so this asks exactly
-    the question the rest of the system means by "in the project".
+    """Every name of `node_type` in the project, via the DAG (not
+    `project.<collection>` — that misses objects declared inline, e.g. an
+    insight nested inside a chart inside a dashboard item).
 
     :returns: the set of names, or None when the DAG cannot answer.
     """
     try:
         nodes = project.dag().get_nodes_by_types([node_type], True)
     except Exception:
-        # A project whose DAG will not build cannot answer the question, and
-        # guessing would delete real artifacts.
         return None
     return {node.name for node in nodes if getattr(node, "name", None)}
 
@@ -83,18 +43,11 @@ def _object_names(project, node_type):
 def _owner_of(stem, names, allow_suffix):
     """The object a file belongs to, or None when nothing claims it.
 
-    Exact stem match is the normal case. `allow_suffix` additionally accepts
-    `<name>_<anything>`, which is how an input writes its options parquet.
-
-    That prefix rule is deliberately PERMISSIVE. `region_totals_options.parquet`
-    could be a deleted `region_totals` input's options, or a live `region`
-    input's `totals_options` key — the `<name>_<key>` shape cannot distinguish
-    them. Any live name that could own the file claims it, so the ambiguous case
-    is kept. Leaving a stale file behind is the recoverable error; deleting
-    someone's data on a guess is not.
-
-    The longest match is returned when several could claim it, so the answer
-    doesn't depend on set ordering.
+    `allow_suffix` also accepts `<name>_<anything>` (an input's options
+    parquet). Deliberately permissive: `<name>_<key>` is ambiguous between a
+    deleted `region_totals` and a live `region`'s `totals_options`, and any
+    live name that could own it keeps the file — a stale file is recoverable,
+    a wrong deletion is not. Longest match wins so the answer is order-independent.
     """
     if stem in names:
         return stem
@@ -107,10 +60,8 @@ def _owner_of(stem, names, allow_suffix):
 def find_orphaned_artifacts(project, run_dir):
     """Every file under ``run_dir`` that names no object in ``project``.
 
-    Pure — it removes nothing. Split out so the decision can be tested, and
-    logged, separately from the deletion.
-
-    :returns: a sorted list of absolute-ish paths, as globbed.
+    Pure — removes nothing, so the decision can be tested and logged
+    separately from the deletion.
     """
     if not project or not run_dir or not os.path.isdir(run_dir):
         return []
@@ -121,10 +72,8 @@ def find_orphaned_artifacts(project, run_dir):
         if not os.path.isdir(path):
             continue
         names = _object_names(project, node_type)
-        # None means the DAG could not answer. Empty means the project genuinely
-        # has none of this type — indistinguishable from a parse that dropped
-        # them, and deleting the directory's contents on that basis would turn a
-        # parse problem into data loss. Neither one sweeps.
+        # None (DAG failed) and empty (genuinely no objects of this type) both
+        # skip: neither is distinguishable from a parse that dropped them.
         if not names:
             continue
         for artifact in glob(os.path.join(path, "*")):
@@ -139,8 +88,7 @@ def find_orphaned_artifacts(project, run_dir):
 def sweep_orphaned_artifacts(project, run_dir):
     """Delete the orphans and return what was removed.
 
-    FAILS OPEN. A sweep is housekeeping; it must never turn a successful run
-    into a failed one. An unremovable file is skipped and the rest proceed.
+    Fails open: an unremovable file is skipped rather than failing the run.
     """
     removed = []
     for artifact in find_orphaned_artifacts(project, run_dir):

--- a/visivo/commands/sweep_artifacts.py
+++ b/visivo/commands/sweep_artifacts.py
@@ -36,21 +36,48 @@ WHAT THIS DELIBERATELY DOES NOT TOUCH
 import os
 from glob import glob
 
-# Each entry: the directory under the run dir, the project attribute holding the
-# objects that may legitimately own a file there, and whether a file's stem can
-# carry a `_suffix` after the object name (inputs write
-# `<name>_<key>.parquet` beside `<name>.json`).
-_ARTIFACT_DIRS = (
-    ("insights", "insights", False),
-    ("models", "models", False),
-    ("inputs", "inputs", True),
-)
+
+def _artifact_dirs():
+    """The per-object directories, and the type that may own a file in each.
+
+    Imported lazily — this module is pulled in at the end of a run and the model
+    package is heavy.
+
+    The third element says whether a file's stem may carry a `_suffix` after the
+    object name: inputs write `<name>_<key>.parquet` beside `<name>.json`.
+    """
+    from visivo.models.inputs.input import Input
+    from visivo.models.insight import Insight
+    from visivo.models.models.model import Model
+
+    return (
+        ("insights", Insight, False),
+        ("models", Model, False),
+        ("inputs", Input, True),
+    )
 
 
-def _object_names(project, attribute):
-    return {
-        obj.name for obj in (getattr(project, attribute, None) or []) if getattr(obj, "name", None)
-    }
+def _object_names(project, node_type):
+    """Every name of `node_type` in the project, wherever it is declared.
+
+    From the DAG, NOT from `project.<collection>`. An object does not have to be
+    top-level: the integration project defines `double-simple-line` inline
+    inside a chart, inside a dashboard item, and it is a real insight with a
+    real artifact. Reading the top-level list called it residue and deleted it
+    — caught by CI, which was the only place a project shaped like that existed.
+
+    The DAG is the same flattening `child_items()` feeds, so this asks exactly
+    the question the rest of the system means by "in the project".
+
+    :returns: the set of names, or None when the DAG cannot answer.
+    """
+    try:
+        nodes = project.dag().get_nodes_by_types([node_type], True)
+    except Exception:
+        # A project whose DAG will not build cannot answer the question, and
+        # guessing would delete real artifacts.
+        return None
+    return {node.name for node in nodes if getattr(node, "name", None)}
 
 
 def _owner_of(stem, names, allow_suffix):
@@ -89,14 +116,15 @@ def find_orphaned_artifacts(project, run_dir):
         return []
 
     orphans = []
-    for directory, attribute, allow_suffix in _ARTIFACT_DIRS:
+    for directory, node_type, allow_suffix in _artifact_dirs():
         path = os.path.join(run_dir, directory)
         if not os.path.isdir(path):
             continue
-        names = _object_names(project, attribute)
-        # No objects of this type at all is ambiguous: a project that never had
-        # any looks identical to one whose parse dropped them. Leave the
-        # directory alone rather than delete everything in it.
+        names = _object_names(project, node_type)
+        # None means the DAG could not answer. Empty means the project genuinely
+        # has none of this type — indistinguishable from a parse that dropped
+        # them, and deleting the directory's contents on that basis would turn a
+        # parse problem into data loss. Neither one sweeps.
         if not names:
             continue
         for artifact in glob(os.path.join(path, "*")):


### PR DESCRIPTION
Closes VIS-1325.

A run has only ever **added** files under `target/`. Nothing removed the ones a rename, a delete, or the VIS-1128 naming-scheme change orphaned, so the directories accumulated indefinitely — invisible until something globbed them. That's how `visivo dist` came to ship every object twice:

```
station-bubbles.json                  Aug   <- current
mifawvncyzdkmlywzcggvituhvlwb.json    Feb   <- alpha_hash('station-bubbles')
```

with the stale copy pointing at a parquet nobody had written in six months. #657 made dist immune to the residue; this removes it.

## Membership, not "did this run build it"

The card assumed a filtered run must be excluded, because it "deletes the artifacts of everything it didn't build". That's true of a rule based on *what the run wrote* — and that's the wrong rule.

The project is fully parsed regardless of `--dag-filter`, so *"does any object of this type still have this name?"* is answerable either way, and an artifact that names nothing cannot be reached however the run was invoked. **The filter never had a bearing on the question**, so it doesn't gate the sweep.

What *does* gate it is a clean run — a failed job can leave a half-written artifact, and the sweep shouldn't be what decides its fate.

## Deliberately conservative

| Decision | Why |
|---|---|
| Only `insights/`, `models/`, `inputs/` | The per-object directories. `files/` (pre-VIS-1128 parquet, written by nothing today) and the schema caches are left alone — "this whole directory is obsolete" is a different judgement |
| An **empty** collection sweeps nothing | A project that never had insights looks identical to one whose parse dropped them; deleting on that basis turns a parse problem into data loss |
| Files only, never directories | — |
| An ambiguous input suffix **keeps** the file | `region_totals_options.parquet` could be a deleted `region_totals` input's options, or a live `region` input's `totals_options` key. `<name>_<key>` can't distinguish them, and leaving a stale file is the recoverable error |
| Fails open | Housekeeping must never turn a successful run into a failed one |

`find_orphaned_artifacts` is pure and separately tested, so the *decision* can be verified without exercising the deletion.

## Verification

On the project that surfaced this:

```
$ visivo run
Removed 3 artifact(s) no longer in the project

insights/  restaurant-markers.json  station-bubbles.json      (was 4)
inputs/    cuisine-select.json  cuisine-select_options.parquet (was 3)
```

A `--dag-filter` run that builds nothing deletes nothing.

13 new unit tests; `pytest tests/` 2484 passed; `black --check` clean.

## Not addressed

The dead `traces` / `targets` / `selectors` entries in `Project.coerce_null_list_fields`, noted on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3

---

## Correction: membership comes from the DAG, not the top-level list

The first version read `project.insights` / `.models` / `.inputs`. CI caught what nothing local could — every unit fixture here declares its objects at the top level, so that was always the right answer. The integration project doesn't:

```yaml
dashboards: … items:
  - chart:
      name: fibonacci-times-2
      insights:
        - name: double-simple-line     # declared INLINE, inside a chart
```

`double-simple-line` is a real insight with a real artifact, and it is **not** in `project.insights`. The sweep called its file residue and deleted it — six database integration suites failed with *"Expected 30 insight files, found 29"*.

Membership now comes from `project.dag().get_nodes_by_types(...)` — the same flattening `child_items()` feeds, and what the rest of the system means by "in the project" regardless of where an object is declared. A DAG that won't build reports `None` and sweeps nothing, on the same principle as an empty collection.

The regression test uses a chart-nested insight and asserts both halves: the inline object survives, and pre-VIS-1128 residue beside it still goes. Verified against `test-projects/integration` — 32 insight artifacts before and after, `double-simple-line` intact.

**All checks green**, including all six database suites.
