### PR TITLE
Stop polling socket.io forever on a dist build (VIS-1326)

### DIFF
--- a/viewer/src/components/views/workspace/useProjectChangeListener.js
+++ b/viewer/src/components/views/workspace/useProjectChangeListener.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { io } from 'socket.io-client';
 import useStore from '../../../stores/store';
 import { emitWorkspaceEvent } from './telemetry';
+import { isAvailable } from '../../../contexts/URLContext';
 
 /**
  * useProjectChangeListener — VIS-808 (Track H H-2).
@@ -21,9 +22,14 @@ import { emitWorkspaceEvent } from './telemetry';
  *
  * The socket connects to the page origin; the vite dev server proxies
  * `/socket.io` to the Flask backend (see vite.config.mjs).
+ *
+ * No-ops on a dist build (VIS-1326): static files have no Socket.IO server
+ * to connect to, so it polled `/socket.io/` 404s forever otherwise.
  */
 export default function useProjectChangeListener() {
   useEffect(() => {
+    if (!isAvailable('socketIo')) return;
+
     window.__VISIVO_SOFT_RELOAD__ = true;
     const socket = io({
       // The Flask-SocketIO server runs in threading mode — polling is its

--- a/viewer/src/components/views/workspace/useProjectChangeListener.test.js
+++ b/viewer/src/components/views/workspace/useProjectChangeListener.test.js
@@ -11,6 +11,7 @@ import { io } from 'socket.io-client';
 import useStore from '../../../stores/store';
 import useProjectChangeListener from './useProjectChangeListener';
 import { setWorkspaceTelemetryListener } from './telemetry';
+import { setGlobalURLConfig, createURLConfig } from '../../../contexts/URLContext';
 
 jest.mock('socket.io-client', () => {
   const handlers = {};
@@ -84,5 +85,23 @@ describe('useProjectChangeListener (VIS-808)', () => {
     } finally {
       unsubscribe();
     }
+  });
+
+  // VIS-1326: a dist build is static files with no Socket.IO server, so the
+  // connection 404-polled forever. Gated on the same server-vs-dist signal
+  // the router uses (urls.js's `socketIo` key).
+  describe('on a dist build', () => {
+    afterEach(() => {
+      setGlobalURLConfig(createURLConfig({ environment: 'server' }));
+    });
+
+    test('never opens the socket, and sets no soft-reload flag', () => {
+      setGlobalURLConfig(createURLConfig({ environment: 'dist' }));
+
+      renderHook(() => useProjectChangeListener());
+
+      expect(io).not.toHaveBeenCalled();
+      expect(window.__VISIVO_SOFT_RELOAD__).toBeUndefined();
+    });
   });
 });

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -167,6 +167,12 @@ const URL_PATTERNS = {
     // The local Flask server relays workspace events through the CLI's PostHog
     // client so the CLI telemetry opt-out + anonymization apply (VIS-822).
     workspaceTelemetry: '/api/telemetry/workspace-event/',
+
+    // ---- Realtime ---------------------------------------------------------
+    // Not a REST call — useProjectChangeListener gates its socket.io connect
+    // on this key (VIS-1326). A dist build is static files with nothing to
+    // hot-reload, so the connection can never succeed there.
+    socketIo: '/socket.io/',
   },
 
   // A dist build is static files — there is no server, so almost nothing


### PR DESCRIPTION
## Summary
- Confirms this is a real Visivo bug, not a local script: `DistRouter` renders `Project.jsx` directly (the ticket's initial suspicion was `Workspace`, which `DistRouter` indeed never mounts — but `Project.jsx` does, and it also calls `useProjectChangeListener()` unconditionally).
- A dist bundle is static files with no Socket.IO server, so the connection 404-polls forever, retrying past `reconnectionAttempts`.
- Adds a `socketIo` key to `urls.js` (null in dist, same as every other server-only endpoint) and gates the hook on `isAvailable('socketIo')` — the same idiom already used to degrade source introspection in dist/cloud (`useSourceOutline.js`, `SourceErd.jsx`).

## Test plan
- [x] `useProjectChangeListener.test.js`: new test confirms `io()` is never called and no soft-reload flag is set on a dist build; confirmed it fails (double-fires `io()`) against the pre-fix hook, then passes after.
- [x] `yarn test --watchAll=false` — full suite green except one pre-existing, unrelated flake (`useSourceSchema.test.js`, passes in isolation, untouched by this diff).
- [x] `yarn lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)