### PR TITLE
Stop injecting name_hash/structure into single/multi-select input dumps

### DIFF
--- a/tests/models/inputs/test_multi_select_coverage.py
+++ b/tests/models/inputs/test_multi_select_coverage.py
@@ -89,9 +89,22 @@ class TestStructureHelpers:
         assert input_obj.is_range_based() is True
         assert input_obj.is_list_based() is False
 
-    def test_serializer_marks_structure(self):
+    def test_serializer_stringifies_static_options(self):
         input_obj = MultiSelectInput(name="regions", options=["East", "West"])
         dumped = input_obj.model_dump()
-        assert dumped["structure"] == "options"
         assert dumped["options"] == ["East", "West"]
-        assert "name_hash" in dumped
+
+    # name_hash/structure used to be injected into every dump ("for the
+    # viewer to construct JSON URL"/"for frontend to know how to handle this
+    # input"), but nothing ever read them off this dump — the run artifact
+    # JSON is hand-built in run_input_job.py, and the viewer reads structure
+    # from THAT, not from the CRUD config. Left in, they round-trip back
+    # through Project(**dump) reconstruction (the commit-validation gate,
+    # VIS-1327) and fail: neither is a declared field, so `extra="forbid"`
+    # rejects the input outright — no single or multi-select input could
+    # ever be committed.
+    def test_serializer_does_not_leak_non_fields(self):
+        input_obj = MultiSelectInput(name="regions", options=["East", "West"])
+        dumped = input_obj.model_dump()
+        assert "name_hash" not in dumped
+        assert "structure" not in dumped

--- a/tests/models/test_input.py
+++ b/tests/models/test_input.py
@@ -41,8 +41,6 @@ class TestSingleSelectInput:
         assert "options" in dumped
         assert "${ref(products_model)}" in dumped["options"]
         assert "select distinct(category)" in dumped["options"]
-        assert "name_hash" in dumped
-        assert dumped["name_hash"] == input_obj.name_hash()
 
     def test_query_multiple_references_fails(self):
         with pytest.raises(ValueError) as exc_info:
@@ -88,7 +86,11 @@ class TestSingleSelectInput:
 
         assert len(children) == 0
 
-    def test_static_options_include_name_hash(self):
+    def test_dump_does_not_leak_name_hash(self):
+        """name_hash used to be injected into every dump ("for the viewer to
+        construct JSON URL") — nothing read it, and reconstructing a Project
+        from that dump tripped extra_forbidden on every commit touching a
+        single-select input (VIS-1327)."""
         data = {
             "name": "category_filter",
             "options": ["Option A", "Option B", "Option C"],
@@ -97,8 +99,7 @@ class TestSingleSelectInput:
         dumped = input_obj.model_dump()
 
         assert dumped["options"] == ["Option A", "Option B", "Option C"]
-        assert "name_hash" in dumped
-        assert dumped["name_hash"] == input_obj.name_hash()
+        assert "name_hash" not in dumped
 
 
 class TestMultiSelectInput:
@@ -201,7 +202,8 @@ class TestMultiSelectInput:
 
         assert len(children) == 0
 
-    def test_serialize_with_name_hash(self):
+    def test_dump_does_not_leak_name_hash(self):
+        """See SingleSelectInput's version of this test — same bug (VIS-1327)."""
         data = {
             "name": "multi_input",
             "options": ["A", "B", "C"],
@@ -209,5 +211,4 @@ class TestMultiSelectInput:
         input_obj = MultiSelectInput(**data)
         dumped = input_obj.model_dump()
 
-        assert "name_hash" in dumped
-        assert dumped["name_hash"] == input_obj.name_hash()
+        assert "name_hash" not in dumped

--- a/tests/server/views/test_commit_views.py
+++ b/tests/server/views/test_commit_views.py
@@ -502,6 +502,19 @@ class TestPendingProjectValidation:
         assert error is not None
         assert "must reference at least one model" in error
 
+    def test_a_draft_single_select_input_is_not_blocked(self):
+        """The old serializer injected name_hash into every dump ("for the
+        viewer to construct JSON URL") — nothing actually read it, and
+        reconstructing a Project from that dump tripped extra_forbidden on
+        every commit touching a single or multi-select input (VIS-1327)."""
+        from tests.factories.model_factories import SingleSelectInputFactory
+        from visivo.server.views.commit_views import _validate_pending_project
+
+        draft = SingleSelectInputFactory(name="new_input", options=["a", "b"])
+        flask_app = self._flask_app(self._project(), input={"new_input": draft})
+
+        assert _validate_pending_project(flask_app) is None
+
     def test_a_MODEL_SCOPED_draft_is_re_nested_and_allowed(self):
         """`inject_cached_objects` appends every cached object to the matching
         TOP-LEVEL list, so a model-scoped draft arrives looking standalone. Left

--- a/visivo/models/inputs/types/multi_select.py
+++ b/visivo/models/inputs/types/multi_select.py
@@ -305,20 +305,9 @@ class MultiSelectInput(Input):
 
     @model_serializer(mode="wrap")
     def serialize_model(self, serializer, _info):
-        """
-        Custom serializer for multi-select inputs.
-
-        Adds name_hash and structure type for client-side handling.
-        """
+        """Custom serializer for multi-select inputs: static list options as strings."""
         model = serializer(self)
 
-        # Add name_hash for viewer to construct JSON URL
-        model["name_hash"] = self.name_hash()
-
-        # Add structure type for frontend to know how to handle this input
-        model["structure"] = "range" if self.is_range_based() else "options"
-
-        # Convert static list options to strings
         if isinstance(self.options, list):
             model["options"] = [str(option) for option in self.options]
 

--- a/visivo/models/inputs/types/single_select.py
+++ b/visivo/models/inputs/types/single_select.py
@@ -176,17 +176,9 @@ class SingleSelectInput(Input):
 
     @model_serializer(mode="wrap")
     def serialize_model(self, serializer, _info):
-        """
-        Custom serializer for single-select inputs.
-
-        Adds name_hash for client-side JSON file lookup.
-        """
+        """Custom serializer for single-select inputs: static list options as strings."""
         model = serializer(self)
 
-        # Add name_hash for viewer to construct JSON URL
-        model["name_hash"] = self.name_hash()
-
-        # Convert static list options to strings
         if isinstance(self.options, list):
             model["options"] = [str(option) for option in self.options]
 


### PR DESCRIPTION
## Summary

Found while testing PR #667's ref-field-affordances fix, but unrelated to
it — reproduces with a plain static-list input, no refs or query strings
involved.

- `SingleSelectInput`/`MultiSelectInput`'s `@model_serializer` injected
  `name_hash` (and, for multi-select, `structure`) into every
  `model_dump()`, "for the viewer to construct JSON URL" / "for frontend to
  know how to handle this input". Neither is actually read anywhere: the run
  artifact JSON (`target/.../inputs/<name>.json`) is hand-built in
  `run_input_job.py` independent of `model_dump()`, and grepping both repos'
  frontends turns up no reads of `config.name_hash` / `config.structure`
  from the CRUD/edit-form response.
- The commit-time safety gate (`_validate_pending_project`, added to catch a
  project the commit would leave unparseable) reconstructs
  `Project(**pending.model_dump(...))` to re-run full validation before
  writing YAML. Since neither field is declared and `BaseModel` sets
  `extra="forbid"`, that reconstruction throws
  `Extra inputs are not permitted` on `inputs.0.single-select.name_hash` —
  which blocked commit of **any** new or modified single/multi-select input.

Removed both injections; `is_range_based()`/`is_list_based()` remain
available directly on the model for any Python-side caller that needs to
know the structure.

## Test plan
- [x] New regression test in `test_commit_views.py`
  (`test_a_draft_single_select_input_is_not_blocked`) calling
  `_validate_pending_project` directly with a draft `SingleSelectInput`;
  confirmed it fails with the exact reported error against the pre-fix
  serializer, passes after.
- [x] Updated three tests in `test_input.py` / `test_multi_select_coverage.py`
  that had pinned the old (buggy) `name_hash`/`structure`-in-dump behavior as
  expected — now assert those keys are absent.
- [x] `poetry run pytest tests/` — 2488 passed, 2 skipped, 5 xfailed, 1 xpassed.
- [x] `poetry run black --check visivo/ tests/` — clean.
- [x] Reproduced live against the `ev_sales` quickstart project via
  `visivo serve`: commit of a new single-select input 400'd with the exact
  reported error before the fix, and succeeded (writing clean YAML with no
  stray `name_hash` key) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)