### PR TITLE
Drop the docs handoff that PR #658 discharged

### DIFF
--- a/tests/docs/test_docs_examples.py
+++ b/tests/docs/test_docs_examples.py
@@ -92,19 +92,8 @@ PACKAGE_DIR = REPO_ROOT / "visivo"
 # the handoff exists to leave alone. The fingerprint follows the fence around the
 # page and stops matching only when the fence's *content* changes, which is
 # exactly when the handoff genuinely needs re-examining.
-#
-#   mkdocs/index.md (line 67 at the time of writing) — `layout: {title: "Monthly
-#   Revenue"}`. Plotly's layout schema requires `title` to be an object, so
-#   Visivo rejects the string form (see the same fix applied across
-#   topics/annotations.md in this PR). PR #658 is rewriting mkdocs/index.md; the
-#   fix belongs there.
 # ---------------------------------------------------------------------------
-HANDOFFS = {
-    (
-        "mkdocs/index.md",
-        "fcb7e485a014",
-    ): "PR #658 owns mkdocs/index.md — layout.title must be `title: {text: ...}`",
-}
+HANDOFFS = {}
 
 
 # ===========================================================================


### PR DESCRIPTION
`main` is red, and every open PR inherits it:

```
FAILED tests/docs/test_docs_examples.py::test_handoffs_are_still_needed
FAILED tests/docs/test_docs_examples.py::test_every_handoff_entry_matches_a_fence_that_still_fails

HANDOFFS entry ('mkdocs/index.md', 'fcb7e485a014') matched no fence
  — PR #658 owns mkdocs/index.md — layout.title must be `title: {text: ...}`
```

## What happened

The `HANDOFFS` entry deferred one broken example — `layout: {title: "Monthly Revenue"}`, which Plotly's schema rejects because `title` must be an object — to the PR that was rewriting that page rather than editing a file another PR owned.

**#658 merged and fixed it.** `mkdocs/index.md` now reads:

```yaml
layout:
  title:
    text: "EV units sold by quarter"
```

So the handoff outlived the bug it described — which is exactly what `test_handoffs_are_still_needed` exists to catch. The mechanism worked; the entry goes.

Worth noting the fence isn't merely *un-excused*: with the handoff removed it runs through the normal validation path and passes. The registry is left in place (now empty) with its explanatory comment, since it's meant to be populated again the next time a page is mid-rewrite. The stale prose describing that specific deferral is removed with it.

## Verification

`pytest tests/docs/` — **52 passed**. Full suite `pytest tests/` — **2538 passed**. `black --check` clean.

Unblocks #667 and #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3