### PR TITLE
Local rename: the primitive the cloud has had since VIS-917 (VIS-1209)

### DIFF
--- a/tests/server/test_rename_service.py
+++ b/tests/server/test_rename_service.py
@@ -1,0 +1,218 @@
+import pytest
+
+from visivo.server.managers.object_manager import ObjectStatus
+from visivo.server.rename_service import RenameError, rename_impact, rename_object
+
+
+class FakeManager:
+    """The two-tier manager surface the rename service uses."""
+
+    def __init__(self, published=None, cached=None):
+        self.published_objects = dict(published or {})
+        self.cached_objects = dict(cached or {})
+        self._renames = {}
+
+    def save_from_config(self, config):
+        raise NotImplementedError  # set per-test
+
+    def record_rename(self, old_name, new_name):
+        self._renames[new_name] = self._renames.pop(old_name, old_name)
+
+    def renamed_from(self, name):
+        return self._renames.get(name)
+
+    def get_status(self, name):
+        if name in self.cached_objects:
+            if name in self._renames:
+                return ObjectStatus.RENAMED
+            return ObjectStatus.NEW if name not in self.published_objects else ObjectStatus.MODIFIED
+        return ObjectStatus.PUBLISHED if name in self.published_objects else None
+
+
+class RecordingManager(FakeManager):
+    def save_from_config(self, config):
+        self.saved = getattr(self, "saved", [])
+        self.saved.append(config)
+        self.cached_objects[config["name"]] = _Obj(config)
+
+
+class _Obj:
+    """Stands in for a Pydantic object: only `model_dump` is used."""
+
+    def __init__(self, config):
+        self._config = config
+        self.name = config.get("name")
+
+    def model_dump(self, **_kwargs):
+        return dict(self._config)
+
+
+class FakeApp:
+    def __init__(self, **managers):
+        for attr in (
+            "source_manager",
+            "model_manager",
+            "metric_manager",
+            "dimension_manager",
+            "relation_manager",
+            "insight_manager",
+            "chart_manager",
+            "table_manager",
+            "markdown_manager",
+            "input_manager",
+            "dashboard_manager",
+        ):
+            setattr(self, attr, RecordingManager())
+        for attr, manager in managers.items():
+            setattr(self, attr, manager)
+
+
+def _app():
+    """A project where `orders` is referenced from two other objects."""
+    return FakeApp(
+        source_manager=RecordingManager(published={"db": _Obj({"name": "db"})}),
+        model_manager=RecordingManager(
+            published={
+                "orders": _Obj({"name": "orders", "source": "${ref(db)}"}),
+                "joined": _Obj({"name": "joined", "sql": "select * from ${ref(orders)} o"}),
+            }
+        ),
+        insight_manager=RecordingManager(
+            published={"i1": _Obj({"name": "i1", "model": "${ref(orders)}"})}
+        ),
+    )
+
+
+class TestImpact:
+    def test_it_lists_every_object_that_would_be_rewritten(self):
+        impact = rename_impact(_app(), type_key="models", old_name="orders", new_name="purchases")
+
+        assert impact["target"]["name"] == "orders"
+        assert impact["target"]["new_name"] == "purchases"
+        assert [(r["type"], r["name"]) for r in impact["references"]] == [
+            ("insights", "i1"),
+            ("models", "joined"),
+        ]
+
+    def test_an_object_that_does_not_reference_it_is_absent(self):
+        impact = rename_impact(_app(), type_key="models", old_name="orders", new_name="purchases")
+
+        assert "db" not in [r["name"] for r in impact["references"]]
+
+    def test_the_target_is_not_a_reference_to_itself(self):
+        impact = rename_impact(_app(), type_key="models", old_name="orders", new_name="purchases")
+
+        assert "orders" not in [r["name"] for r in impact["references"]]
+
+    def test_it_changes_nothing(self):
+        app = _app()
+        rename_impact(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert app.model_manager.cached_objects == {}
+        assert set(app.model_manager.published_objects) == {"orders", "joined"}
+
+    def test_a_quoted_ref_is_matched_and_its_quoting_preserved(self):
+        app = _app()
+        app.chart_manager.published_objects["c"] = _Obj({"name": "c", "x": "${ref('orders')}"})
+
+        impact = rename_impact(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert ("charts", "c") in [(r["type"], r["name"]) for r in impact["references"]]
+
+    def test_a_name_that_merely_contains_the_old_one_is_not_a_match(self):
+        """`${ref(orders_archive)}` must survive renaming `orders`."""
+        app = _app()
+        app.chart_manager.published_objects["c"] = _Obj(
+            {"name": "c", "x": "${ref(orders_archive)}"}
+        )
+
+        impact = rename_impact(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert "c" not in [r["name"] for r in impact["references"]]
+
+
+class TestValidation:
+    def test_an_unknown_type_is_400(self):
+        with pytest.raises(RenameError) as caught:
+            rename_impact(_app(), type_key="nonsense", old_name="a", new_name="b")
+        assert caught.value.status == 400
+
+    def test_the_same_name_is_400(self):
+        with pytest.raises(RenameError) as caught:
+            rename_impact(_app(), type_key="models", old_name="orders", new_name="orders")
+        assert caught.value.status == 400
+
+    def test_a_missing_object_is_404(self):
+        with pytest.raises(RenameError) as caught:
+            rename_impact(_app(), type_key="models", old_name="ghost", new_name="x")
+        assert caught.value.status == 404
+
+    def test_a_collision_is_409_across_types(self):
+        """visivo names are project-global, so a model cannot take a source's
+        name."""
+        with pytest.raises(RenameError) as caught:
+            rename_impact(_app(), type_key="models", old_name="orders", new_name="db")
+        assert caught.value.status == 409
+
+    def test_a_collision_with_an_uncommitted_draft_is_still_a_collision(self):
+        app = _app()
+        app.chart_manager.cached_objects["draft"] = _Obj({"name": "draft"})
+
+        with pytest.raises(RenameError) as caught:
+            rename_impact(app, type_key="models", old_name="orders", new_name="draft")
+        assert caught.value.status == 409
+
+    def test_a_name_freed_by_a_pending_delete_is_available(self):
+        app = _app()
+        app.source_manager.cached_objects["db"] = None  # tombstoned
+
+        impact = rename_impact(app, type_key="models", old_name="orders", new_name="db")
+
+        assert impact["target"]["new_name"] == "db"
+
+
+class TestApply:
+    def test_the_target_is_cached_under_its_new_name(self):
+        app = _app()
+
+        rename_object(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert "purchases" in app.model_manager.cached_objects
+        assert app.model_manager.renamed_from("purchases") == "orders"
+
+    def test_every_reference_is_rewritten_into_the_draft(self):
+        app = _app()
+
+        rename_object(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert (
+            app.model_manager.cached_objects["joined"].model_dump()["sql"]
+            == "select * from ${ref(purchases)} o"
+        )
+        assert app.insight_manager.cached_objects["i1"].model_dump()["model"] == "${ref(purchases)}"
+
+    def test_the_renamed_object_reports_RENAMED_not_NEW(self):
+        """The distinction is what stops the commit writing a duplicate and
+        leaving the original behind."""
+        app = _app()
+
+        rename_object(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert app.model_manager.get_status("purchases") == ObjectStatus.RENAMED
+
+    def test_a_chained_rename_still_points_at_the_published_name(self):
+        """a→b→c must tell the commit to find `a` in the YAML; `b` was never
+        written there."""
+        app = _app()
+
+        rename_object(app, type_key="models", old_name="orders", new_name="temp")
+        rename_object(app, type_key="models", old_name="temp", new_name="purchases")
+
+        assert app.model_manager.renamed_from("purchases") == "orders"
+
+    def test_it_returns_what_it_changed(self):
+        app = _app()
+
+        applied = rename_object(app, type_key="models", old_name="orders", new_name="purchases")
+
+        assert [r["name"] for r in applied["references"]] == ["i1", "joined"]

--- a/tests/server/views/test_commit_views_coverage.py
+++ b/tests/server/views/test_commit_views_coverage.py
@@ -67,6 +67,10 @@ def env():
         manager.cached_objects = {}
         manager.published_objects = {}
         manager.has_unpublished_changes.return_value = False
+        # A real None, not a Mock: commit asks every child whether it was
+        # renamed, and a Mock's truthy return would send the published lookup
+        # after a name that doesn't exist.
+        manager.renamed_from.return_value = None
         manager.get_status.return_value = ObjectStatus.PUBLISHED
         setattr(flask_app, attr, manager)
 

--- a/viewer/src/api/rename.js
+++ b/viewer/src/api/rename.js
@@ -1,0 +1,52 @@
+import { getUrl, isAvailable } from '../contexts/URLContext';
+import { apiFetch } from './utils';
+
+/**
+ * Rename a resource and rewrite every `${ref()}` that pointed at it.
+ *
+ * Local and cloud expose the same `{target, references}` contract
+ * (`visivo/server/views/rename_views.py`, core's `ProjectRenameView`), so a
+ * caller does not branch on environment.
+ */
+
+const NOT_SUPPORTED = {
+  supported: false,
+  target: null,
+  references: [],
+};
+
+async function post(urlName, { type, oldName, newName }) {
+  if (!isAvailable(urlName)) {
+    return NOT_SUPPORTED;
+  }
+  const response = await apiFetch(getUrl(urlName), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, old_name: oldName, new_name: newName }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(body.error || `Rename failed (${response.status})`);
+    error.status = response.status;
+    throw error;
+  }
+  return { supported: true, ...body };
+}
+
+/**
+ * What the rename would change, without changing it.
+ *
+ * Throws with `.status` on a rejection — notably 409 for a name collision, so
+ * the caller can say so before the user confirms rather than after.
+ *
+ * @returns {Promise<{supported: boolean, target: object, references: Array}>}
+ */
+export const fetchRenameImpact = (type, oldName, newName) =>
+  post('renameImpact', { type, oldName, newName });
+
+/** Apply the rename. Answers the same shape, describing what changed. */
+export const renameResource = (type, oldName, newName) =>
+  post('rename', { type, oldName, newName });
+
+/** Whether this server offers rename at all. */
+export const renameSupported = () => isAvailable('rename');

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -15,6 +15,8 @@ import { parseRefValue, formatRef } from '../../../utils/refString';
 import EmbeddedPill from '../lineage/EmbeddedPill';
 import Dropdown from '../../common/Dropdown';
 import AddInsightMenu from '../workspace/AddInsightMenu';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * ChartEditForm - Form component for editing/creating charts
@@ -33,6 +35,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   // Form state
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'chart', recordName: chart?.name || '', name });
   const [insights, setInsights] = useState([]);
   const [layoutValues, setLayoutValues] = useState({});
 
@@ -164,6 +167,18 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
   };
 
   const handleSave = async () => {
+
+    // A changed name in edit mode is a RENAME — its own server operation,
+
+    // confirmed first, because every `${ref()}` to this object moves with it.
+
+    if (isEditMode && rename.nameChanged) {
+
+      rename.start();
+
+      return;
+
+    }
     if (!validateForm()) return;
 
     setSaving(true);
@@ -253,6 +268,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -265,7 +281,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
             nameLabel="Chart Name"
             nameValue={name}
             onNameChange={e => setName(e.target.value)}
-            nameDisabled={isEditMode}
+            nameDisabled={isEditMode && !rename.supported}
             nameError={errors.name}
             layoutTitle="Layout Configuration (Optional)"
             layoutSchema={layoutSchema}

--- a/viewer/src/components/views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.test.jsx
@@ -21,10 +21,19 @@ jest.mock('../../../schemas/schemas', () => ({
 // SchemaEditor from './SchemaEditor/SchemaEditor' — mock THAT path.
 jest.mock('./SchemaEditor/SchemaEditor', () => ({
   __esModule: true,
-  SchemaEditor: ({ onChange }) => (
-    <button type="button" data-testid="mock-schema-clear" onClick={() => onChange(undefined)}>
-      clear layout
-    </button>
+  SchemaEditor: ({ value, onChange }) => (
+    <>
+      <button type="button" data-testid="mock-schema-clear" onClick={() => onChange(undefined)}>
+        clear layout
+      </button>
+      <button
+        type="button"
+        data-testid="mock-schema-touch"
+        onClick={() => onChange({ ...(value || {}), showlegend: true })}
+      >
+        touch layout
+      </button>
+    </>
   ),
 }));
 
@@ -160,16 +169,20 @@ describe('ChartEditForm — insight fetch guard', () => {
 });
 
 // VIS-1133: Save is disabled on an untouched edit-mode form, so tests that
-// exercise the SAVE PATH must first make a real edit. The name field is
-// orthogonal to `config.insights` / `config.layout` (it travels as its own
-// argument to onSave), so touching it leaves every config assertion intact.
-const makeDirty = () =>
-  fireEvent.change(screen.getByLabelText(/Chart Name/), { target: { value: 'edited_name' } });
+// exercise the SAVE PATH must first make a real edit. It cannot be the name — a
+// changed name in edit mode is a rename, which intercepts the save. The layout
+// editor is the one config field the save-path assertions below don't pin, so
+// it is what these tests touch; it only renders once a schema has resolved.
+const withLayoutSchema = () =>
+  jest.requireMock('../../../schemas/schemas').getSchema.mockResolvedValueOnce({ type: 'object' });
+
+const makeDirty = async () => fireEvent.click(await screen.findByTestId('mock-schema-touch'));
 
 describe('ChartEditForm — embedded insights on save', () => {
   const embeddedInsight = { name: 'inline_insight', props: { type: 'scatter' } };
 
   test('a chart whose insights are ALL embedded objects can still be saved', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -182,7 +195,7 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByText('Embedded Insights');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -192,6 +205,7 @@ describe('ChartEditForm — embedded insights on save', () => {
   });
 
   test('saving preserves the original ref/embedded insight order', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -208,7 +222,7 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -255,6 +269,7 @@ describe('ChartEditForm — validation & save paths', () => {
   });
 
   test('non-empty layout values are carried into the saved config', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -271,18 +286,23 @@ describe('ChartEditForm — validation & save paths', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave.mock.calls[0][2].layout).toEqual({ title: { text: 'Revenue' } });
+    // The pre-existing title survives alongside the edit that dirtied the form.
+    expect(onSave.mock.calls[0][2].layout).toEqual({
+      title: { text: 'Revenue' },
+      showlegend: true,
+    });
   });
 
   test('a failed save surfaces the backend error and keeps the form open', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: false, error: 'chart save exploded' }));
     await renderForm({ onSave });
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(await screen.findByText('chart save exploded')).toBeInTheDocument();

--- a/viewer/src/components/views/common/DashboardEditForm.jsx
+++ b/viewer/src/components/views/common/DashboardEditForm.jsx
@@ -12,6 +12,8 @@ import {
   createRow,
 } from '../workspace/itemMutations';
 import RowEditForm from './RowEditForm';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * DashboardEditForm - Form for creating/editing Dashboard
@@ -25,6 +27,8 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const openWorkspaceTab = useStore(state => state.openWorkspaceTab);
 
   const [name, setName] = useState('');
+
+  const rename = useRenameFlow({ type: 'dashboard', recordName: dashboard?.name || '', name });
   const [rows, setRows] = useState([]);
   const [description, setDescription] = useState('');
   const [saving, setSaving] = useState(false);
@@ -62,6 +66,13 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   }, [dashboard]);
 
   const handleSubmit = async e => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (!isCreate && rename.nameChanged) {
+      e.preventDefault();
+      rename.start();
+      return;
+    }
     e.preventDefault();
     setError(null);
     setSaving(true);
@@ -191,6 +202,7 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
 
   return (
     <div className="flex-1 overflow-y-auto p-4">
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <FormAlert variant="error">{error}</FormAlert>}
 
@@ -199,7 +211,7 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
           label="Name"
           value={name}
           onChange={e => setName(e.target.value)}
-          disabled={!isCreate}
+          disabled={!isCreate && !rename.supported}
           helperText={!isCreate ? 'Dashboard names cannot be changed after creation.' : undefined}
         />
 

--- a/viewer/src/components/views/common/InputEditForm.jsx
+++ b/viewer/src/components/views/common/InputEditForm.jsx
@@ -13,6 +13,8 @@ import Select from '../../common/Select';
 import useFormBaseline from '../../../hooks/useFormBaseline';
 import { validateName } from './namedModel';
 import { validateInputDraft, buildInputConfig } from './inputConfigValidation';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 const INPUT_TYPES = [
   { value: 'single-select', label: 'Single Select' },
@@ -125,6 +127,10 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
   const hydratedRef = useRef(false);
 
   const isEditMode = !!input && !isCreate;
+
+  const recordName = input?.name || '';
+
+  const rename = useRenameFlow({ type: 'input', recordName, name });
   const isNewObject = input?.status === ObjectStatus.NEW;
 
   // VIS-1133: snapshot the last-saved values so the form can report dirtiness
@@ -257,6 +263,12 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
   };
 
   const handleSave = async () => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
     const draft = {
       name,
       inputType,
@@ -319,7 +331,7 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
             label="Name"
             value={name}
             onChange={e => setName(e.target.value)}
-            disabled={isEditMode}
+            disabled={isEditMode && !rename.supported}
             error={errors.name}
             helperText={isEditMode ? 'Input names cannot be changed after creation.' : undefined}
           />
@@ -493,6 +505,9 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
           />
         </div>
       </div>
+
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
+
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -15,6 +15,8 @@ import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
 import { REF_INSERT_HINT } from './RefTextArea';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 import {
   SectionContainer,
   EmptyState,
@@ -42,6 +44,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
 
   // Form state - Basic fields
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'insight', recordName: insight?.name || '', name });
   const [description, setDescription] = useState('');
 
   // Props state - the insight's Plotly props object (carries `.type`). Fully
@@ -163,6 +166,18 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
   };
 
   const handleSave = async () => {
+
+    // A changed name in edit mode is a RENAME — its own server operation,
+
+    // confirmed first, because every `${ref()}` to this object moves with it.
+
+    if (isEditMode && rename.nameChanged) {
+
+      rename.start();
+
+      return;
+
+    }
     if (!validateForm()) return;
 
     setSaving(true);
@@ -243,6 +258,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -265,7 +281,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
             nameId="insightName"
             nameValue={name}
             onNameChange={e => setName(e.target.value)}
-            nameDisabled={isEditMode}
+            nameDisabled={isEditMode && !rename.supported}
             nameError={errors.name}
             showDescription
             description={description}

--- a/viewer/src/components/views/common/InsightEditForm.test.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.test.jsx
@@ -329,7 +329,7 @@ describe('InsightEditForm — edit mode', () => {
 
     const nameInput = screen.getByLabelText(/Insight Name/);
     expect(nameInput).toHaveValue('rev');
-    expect(nameInput).toBeDisabled();
+    expect(nameInput).toBeEnabled();
     expect(screen.getByLabelText('Description')).toHaveValue('revenue insight');
     // The stored props (with their type) seed the controlled editor.
     expect(screen.getByTestId('tpe-type')).toHaveTextContent('bar');

--- a/viewer/src/components/views/common/MarkdownEditForm.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.jsx
@@ -7,6 +7,8 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { validateName } from './namedModel';
 import Select from '../../common/Select';
 import useRecordSave from '../../../hooks/useRecordSave';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * MarkdownEditForm - Form component for editing/creating markdowns
@@ -45,6 +47,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!markdown && !isCreate;
+
+  const recordName = markdown?.name || '';
+
+  const rename = useRenameFlow({ type: 'markdown', recordName, name });
   const isNewObject = markdown?.status === ObjectStatus.NEW;
 
   // Unified optimistic save backbone (VIS-1018 step 2) — `saveNow` shares the
@@ -108,6 +114,12 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -167,6 +179,7 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -183,7 +196,7 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
                 id="markdownName"
                 value={name}
                 onChange={e => setName(e.target.value)}
-                disabled={isEditMode}
+                disabled={isEditMode && !rename.supported}
                 placeholder=" "
                 className={`
                   block w-full px-3 py-2.5 text-sm text-gray-900

--- a/viewer/src/components/views/common/MarkdownEditForm.test.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.test.jsx
@@ -147,7 +147,9 @@ describe('MarkdownEditForm — edit mode', () => {
     };
     renderForm({ markdown, isCreate: false });
     expect(screen.getByLabelText(/Markdown Name/)).toHaveValue('md1');
-    expect(screen.getByLabelText(/Markdown Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Markdown Name/)).toBeEnabled();
     expect(screen.getByLabelText(/Content/)).toHaveValue('Hi there');
 
     // Explicit save (no auto-save): a field change buffers locally and persists

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -9,6 +9,8 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { getTypeByValue } from './objectTypeConfigs';
 import InlineFieldEditor from './InlineFieldEditor';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * ModelEditForm - Form for creating/editing SqlModel
@@ -36,6 +38,7 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
 
   // Form state
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'model', recordName: model?.name || '', name });
   const [sql, setSql] = useState('');
   const [source, setSource] = useState(null); // Stored as ref(name) format
   const [dimensions, setDimensions] = useState([]); // Inline dimensions
@@ -110,6 +113,12 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
   };
 
   const handleSave = async () => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (!isCreate && rename.nameChanged) {
+      rename.start();
+      return;
+    }
     setError(null);
     setSaving(true);
 
@@ -183,6 +192,7 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
     // height to fill — the other leaf forms return a fragment and inherit that
     // from the rail, but this one owns a <form> element in between.
     <form onSubmit={handleFormSubmit} className="flex h-full flex-col">
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       <FormLayout>
         {error && <FormAlert variant="error">{error}</FormAlert>}
 
@@ -191,8 +201,12 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
           label="Model Name"
           value={name}
           onChange={e => setName(e.target.value)}
-          disabled={!isCreate}
-          helperText={!isCreate ? 'Model names cannot be changed after creation.' : undefined}
+          disabled={!isCreate && !rename.supported}
+          helperText={
+            !isCreate && rename.nameChanged
+              ? 'Saving will rename this model and update everything that references it.'
+              : undefined
+          }
         />
 
         {/* SQL field - Monaco Editor doesn't fit the standard form pattern */}

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -150,7 +150,9 @@ describe('ModelEditForm — edit mode initialization and save', () => {
   it('initializes fields from the model and locks the name', () => {
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
     expect(screen.getByLabelText(/Model Name/)).toHaveValue('orders');
-    expect(screen.getByLabelText(/Model Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Model Name/)).toBeEnabled();
     expect(screen.getByLabelText('code')).toHaveValue('select * from orders');
     expect(screen.getByTestId('ref-selector')).toHaveValue('ref(warehouse)');
     expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -19,6 +19,8 @@ import { getTypeByValue } from './objectTypeConfigs';
 import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import SeedsEditor, { sourceTypeSupportsSeeds } from './SeedsEditor';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * SourceEditForm - Form component for editing/creating sources
@@ -48,6 +50,10 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!source && !isCreate;
+
+  const recordName = source?.name || '';
+
+  const rename = useRenameFlow({ type: 'source', recordName, name });
   const isNewObject = source?.status === ObjectStatus.NEW;
   const isEmbedded = isEmbeddedObject(source);
   const parentName = source?._embedded?.parentName;
@@ -176,6 +182,12 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -241,7 +253,7 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             label="Source Name"
             value={name}
             onChange={e => setName(e.target.value)}
-            disabled={isEditMode}
+            disabled={isEditMode && !rename.supported}
             required
             error={errors.name}
           />
@@ -344,6 +356,9 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
 
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
       </FormLayout>
+
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
+
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/common/SourceEditForm.test.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.test.jsx
@@ -148,7 +148,9 @@ describe('SourceEditForm — edit mode', () => {
     const onSave = jest.fn(async () => ({ success: true }));
     renderForm({ source: publishedSqlite, isCreate: false, onSave });
     expect(screen.getByLabelText(/Source Name/)).toHaveValue('s1');
-    expect(screen.getByLabelText(/Source Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Source Name/)).toBeEnabled();
     expect(screen.getByTestId('source-type-value')).toHaveTextContent('sqlite');
     expect(screen.getByLabelText(/Database Path/)).toHaveValue('prod.db');
 
@@ -166,7 +168,9 @@ describe('SourceEditForm — edit mode', () => {
   test('lets you switch the source type when editing, keeping the name locked (VIS-1208)', () => {
     renderForm({ source: publishedSqlite, isCreate: false });
     // Name stays locked (it's the record key)...
-    expect(screen.getByLabelText(/Source Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Source Name/)).toBeEnabled();
     expect(screen.getByLabelText(/Database Path/)).toHaveValue('prod.db');
 
     // ...but the type is switchable now (previously disabled in edit mode).
@@ -289,10 +293,10 @@ describe('SourceEditForm — test connection', () => {
 });
 
 // VIS-1133: Save is disabled on an untouched edit-mode form, so save-path
-// tests must make a real edit first. The source NAME is orthogonal to the
-// seeds/type assertions below, so touching it leaves them intact.
+// tests must make a real edit first. It cannot be the name — a changed name in
+// edit mode is a rename, which intercepts the save instead of performing it.
 const makeDirty = () =>
-  fireEvent.change(screen.getByLabelText(/Source Name/), { target: { value: 'edited_name' } });
+  fireEvent.change(screen.getByLabelText(/Database Path/), { target: { value: 'edited.db' } });
 
 describe('SourceEditForm — embedded sources', () => {
   const embedded = {

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -13,6 +13,8 @@ import { parseRefValue, formatRef } from '../../../utils/refString';
 import ExpressionField from './ExpressionField';
 import Select from '../../common/Select';
 import { REF_INSERT_HINT } from './RefTextArea';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * TableEditForm - Form component for editing/creating tables
@@ -54,6 +56,10 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!table && !isCreate;
+
+  const recordName = table?.name || '';
+
+  const rename = useRenameFlow({ type: 'table', recordName, name });
   const isNewObject = table?.status === ObjectStatus.NEW;
 
   // Combine insights and models for the data source dropdown
@@ -172,6 +178,12 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -218,6 +230,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -234,7 +247,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
                 id="tableName"
                 value={name}
                 onChange={e => setName(e.target.value)}
-                disabled={isEditMode}
+                disabled={isEditMode && !rename.supported}
                 placeholder=" "
                 className={`
                   block w-full px-3 py-2.5 text-sm text-gray-900

--- a/viewer/src/components/views/common/TableEditForm.test.jsx
+++ b/viewer/src/components/views/common/TableEditForm.test.jsx
@@ -324,7 +324,9 @@ describe('TableEditForm — save payloads', () => {
     });
 
     expect(screen.getByLabelText(/Table Name/)).toHaveValue('t1');
-    expect(screen.getByLabelText(/Table Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Table Name/)).toBeEnabled();
     // A data-ref table hides the pivot section entirely.
     expect(screen.getByText('Data Source')).toBeInTheDocument();
     expect(screen.queryByText('Pivot Configuration')).not.toBeInTheDocument();

--- a/viewer/src/components/views/workspace/RenameImpactDialog.jsx
+++ b/viewer/src/components/views/workspace/RenameImpactDialog.jsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { PiArrowRight, PiPencilSimple } from 'react-icons/pi';
+import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
+
+/**
+ * RenameImpactDialog — what a rename will change, before it changes it.
+ *
+ * A rename is not a local edit. Every `${ref(old)}` in the project is rewritten
+ * with it, and each rewrite makes a published object uncommitted. Confirming it
+ * blind means agreeing to edits across objects you may not have open.
+ *
+ * The list comes from the server's impact query, which walks the same traversal
+ * the rename applies (`rename_service.rename_impact`, core's `rename_impact`),
+ * so it cannot promise something the rename then does differently.
+ *
+ * Props:
+ *   impact    {target, references} | null — null while loading
+ *   error     string | null — a rejection, e.g. a 409 name collision
+ *   loading   boolean
+ *   onConfirm / onCancel
+ */
+
+const SINGULAR = {
+  sources: 'source',
+  models: 'model',
+  metrics: 'metric',
+  dimensions: 'dimension',
+  relations: 'relation',
+  insights: 'insight',
+  charts: 'chart',
+  tables: 'table',
+  markdowns: 'markdown',
+  inputs: 'input',
+  dashboards: 'dashboard',
+};
+
+const typeOf = plural => SINGULAR[plural] || plural;
+
+function ReferenceRow({ reference }) {
+  const type = typeOf(reference.type);
+  const Icon = getTypeIcon(type);
+  const { bg, text } = getTypeColors(type);
+  return (
+    <li
+      data-testid={`rename-impact-reference-${reference.name}`}
+      className="flex items-center gap-2 px-3 py-1.5 text-[12.5px] text-gray-800"
+    >
+      <span
+        className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded ${bg} ${text}`}
+      >
+        {Icon && <Icon style={{ fontSize: 11 }} />}
+      </span>
+      <span className="truncate font-medium">{reference.name}</span>
+      <span className="ml-auto shrink-0 text-[11px] text-gray-400">
+        {reference.status === 'published' ? 'becomes uncommitted' : reference.status}
+      </span>
+    </li>
+  );
+}
+
+const RenameImpactDialog = ({ impact, error, loading, onConfirm, onCancel }) => {
+  const cancelRef = useRef(null);
+
+  useEffect(() => {
+    if (cancelRef.current) cancelRef.current.focus();
+    const onKey = e => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel && onCancel();
+      }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [onCancel]);
+
+  const target = impact?.target;
+  const references = impact?.references || [];
+  // Every listed object is rewritten; `published` ones are the ones this rename
+  // turns dirty, which is the part the user is being asked to accept.
+  const newlyDirty = references.filter(r => r.status === 'published').length;
+
+  return createPortal(
+    <div
+      data-testid="rename-impact-backdrop"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/30"
+      onPointerDown={e => {
+        if (e.target === e.currentTarget) onCancel && onCancel();
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="rename-impact-title"
+        data-testid="rename-impact-dialog"
+        className="w-[460px] max-w-[calc(100vw-32px)] rounded-lg bg-white p-5 shadow-xl ring-1 ring-gray-200"
+      >
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-100 text-primary">
+            <PiPencilSimple style={{ fontSize: 20 }} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 id="rename-impact-title" className="text-[15px] font-semibold text-gray-900">
+              Rename this {target ? typeOf(target.type) : 'object'}?
+            </h2>
+
+            {target && (
+              <div className="mt-1.5 flex items-center gap-1.5 text-[13px] text-gray-700">
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">{target.name}</code>
+                <PiArrowRight className="shrink-0 text-gray-400" style={{ fontSize: 12 }} />
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">
+                  {target.new_name}
+                </code>
+              </div>
+            )}
+
+            {loading && (
+              <p data-testid="rename-impact-loading" className="mt-3 text-[12.5px] text-gray-500">
+                Checking what this affects…
+              </p>
+            )}
+
+            {error && (
+              <p
+                data-testid="rename-impact-error"
+                className="mt-3 text-[12.5px] font-medium text-highlight-600"
+              >
+                {error}
+              </p>
+            )}
+
+            {!loading && !error && impact && (
+              <div className="mt-3">
+                {references.length === 0 ? (
+                  <p data-testid="rename-impact-empty" className="text-[12.5px] text-gray-500">
+                    Nothing else references it, so only this object changes.
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-[12.5px] text-gray-600">
+                      {references.length === 1
+                        ? '1 other object references it'
+                        : `${references.length} other objects reference it`}{' '}
+                      and will be updated
+                      {newlyDirty > 0 && (
+                        <>
+                          {' '}
+                          — <strong>{newlyDirty}</strong>{' '}
+                          {newlyDirty === 1 ? 'of them is' : 'of them are'} currently published, so{' '}
+                          {newlyDirty === 1 ? 'it becomes an uncommitted change' : 'they become uncommitted changes'}
+                        </>
+                      )}
+                      .
+                    </p>
+                    <ul
+                      data-testid="rename-impact-references"
+                      className="mt-2 max-h-52 overflow-y-auto rounded-md border border-gray-200 divide-y divide-gray-100"
+                    >
+                      {references.map(reference => (
+                        <ReferenceRow
+                          key={`${reference.type}:${reference.name}`}
+                          reference={reference}
+                        />
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            data-testid="rename-impact-cancel"
+            onClick={onCancel}
+            className="rounded-md px-3 py-1.5 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="rename-impact-confirm"
+            onClick={onConfirm}
+            disabled={loading || !!error || !impact}
+            className="rounded-md bg-primary px-3 py-1.5 text-[13px] font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:bg-gray-300"
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default RenameImpactDialog;

--- a/viewer/src/components/views/workspace/RenameImpactDialog.test.jsx
+++ b/viewer/src/components/views/workspace/RenameImpactDialog.test.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RenameImpactDialog from './RenameImpactDialog';
+
+const impact = {
+  target: { type: 'models', name: 'orders', new_name: 'purchases', status: 'published' },
+  references: [
+    { type: 'insights', name: 'i1', status: 'published' },
+    { type: 'metrics', name: 'total', status: 'new' },
+  ],
+};
+
+const renderDialog = (props = {}) =>
+  render(
+    <RenameImpactDialog
+      impact={impact}
+      error={null}
+      loading={false}
+      onConfirm={jest.fn()}
+      onCancel={jest.fn()}
+      {...props}
+    />
+  );
+
+describe('what the rename will change', () => {
+  test('it names both ends of the rename', () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId('rename-impact-dialog');
+    expect(dialog).toHaveTextContent('orders');
+    expect(dialog).toHaveTextContent('purchases');
+  });
+
+  test('every affected object is listed', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('rename-impact-reference-i1')).toBeInTheDocument();
+    expect(screen.getByTestId('rename-impact-reference-total')).toBeInTheDocument();
+  });
+
+  // The cost of a rename is not the rewrite, it is that clean objects become
+  // dirty and have to be committed.
+  test('it counts how many were published and are about to become uncommitted', () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId('rename-impact-dialog');
+    expect(dialog).toHaveTextContent('2 other objects reference it');
+    // Only `i1` was published; `total` was already new, so the count is 1 and
+    // the sentence has to agree with it.
+    expect(dialog).toHaveTextContent('1 of them is currently published');
+    expect(dialog).toHaveTextContent('it becomes an uncommitted change');
+    // `i1` was published; `total` was already new, so it is not counted.
+    expect(screen.getByTestId('rename-impact-reference-i1')).toHaveTextContent(
+      'becomes uncommitted'
+    );
+    expect(screen.getByTestId('rename-impact-reference-total')).toHaveTextContent('new');
+  });
+
+  test('the sentence agrees with the count', () => {
+    const { unmount } = renderDialog({
+      impact: { ...impact, references: [impact.references[0]] },
+    });
+    expect(screen.getByTestId('rename-impact-dialog')).toHaveTextContent(
+      '1 other object references it'
+    );
+    unmount();
+
+    renderDialog();
+    expect(screen.getByTestId('rename-impact-dialog')).toHaveTextContent(
+      '2 other objects reference it'
+    );
+  });
+
+  test('nothing referencing it says so plainly', () => {
+    renderDialog({ impact: { ...impact, references: [] } });
+
+    expect(screen.getByTestId('rename-impact-empty')).toHaveTextContent('only this object changes');
+  });
+});
+
+describe('it cannot be confirmed until the answer is known', () => {
+  test('confirm waits while the impact is loading', () => {
+    renderDialog({ impact: null, loading: true });
+
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+    expect(screen.getByTestId('rename-impact-loading')).toBeInTheDocument();
+  });
+
+  test('a rejection is shown and blocks confirming', () => {
+    renderDialog({ impact: null, error: "A resource named 'joined' already exists." });
+
+    expect(screen.getByTestId('rename-impact-error')).toHaveTextContent('already exists');
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+  });
+});
+
+describe('dismissal', () => {
+  test('Cancel calls back', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.click(screen.getByTestId('rename-impact-cancel'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('Escape cancels — a rename is never the accidental outcome', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('a backdrop click cancels, a click inside does not', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.pointerDown(screen.getByTestId('rename-impact-dialog'));
+    expect(onCancel).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(screen.getByTestId('rename-impact-backdrop'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('focus starts on Cancel, so Enter does not rename', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('rename-impact-cancel')).toHaveFocus();
+  });
+});
+
+test('Confirm calls back once the impact is known', () => {
+  const onConfirm = jest.fn();
+  renderDialog({ onConfirm });
+
+  fireEvent.click(screen.getByTestId('rename-impact-confirm'));
+
+  expect(onConfirm).toHaveBeenCalled();
+});

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -11,6 +11,8 @@ import { getTypeByValue } from '../common/objectTypeConfigs';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { FormShell } from './FormShell';
 import { SAVE_ACTION, DELETE_ACTION } from './collectionKeys';
+import RenameImpactDialog from './RenameImpactDialog';
+import useRenameFlow from '../../../hooks/useRenameFlow';
 import { unwrapConfig } from './unwrapRecordConfig';
 import { getObjectSchemaSync } from '../../../schemas/projectSchema';
 import { useFieldParentModel } from './fields/useFieldParentModel';
@@ -186,6 +188,7 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   }, [record, isCreate, type]);
 
   const name = config.name || '';
+  const rename = useRenameFlow({ type, recordName, name });
 
   // Edits update the working config; nothing persists until an explicit Save.
   const applyChange = useCallback(nextConfig => setConfig(nextConfig), []);
@@ -229,6 +232,11 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   // ---- save / delete ----
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a rename, not a field edit.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
     setSaving(true);
     setSaveError(null);
     // Carry the scope through the round trip; see `parentModelName` above.
@@ -354,9 +362,17 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
             label={`${singular.charAt(0).toUpperCase() + singular.slice(1)} Name`}
             value={name}
             onChange={e => applyChange({ ...config, name: e.target.value })}
-            disabled={isEditMode}
+            // Editable in edit mode only where the server can carry the
+            // rename through: changing it here without the `${ref()}` rewrite
+            // would orphan every reference to this object.
+            disabled={isEditMode && !rename.supported}
             required
             error={mergedErrors.name}
+            helperText={
+              isEditMode && rename.supported && rename.nameChanged
+                ? 'Saving will rename this object and update everything that references it.'
+                : undefined
+            }
           />
         )}
 
@@ -376,6 +392,8 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
           </FormAlert>
         )}
       </FormLayout>
+
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import SchemaLeafForm from './SchemaLeafForm';
+import * as renameApi from '../../../api/rename';
 
 const mockActions = {
   saveDimension: jest.fn(),
@@ -22,6 +23,10 @@ const mockActions = {
   saveRelation: jest.fn(),
   deleteRelation: jest.fn(),
   checkCommitStatus: jest.fn(),
+  openWorkspaceTab: jest.fn(),
+  closeWorkspaceTab: jest.fn(),
+  fetchMetrics: jest.fn(),
+  fetchCharts: jest.fn(),
 };
 const mockSaveNow = jest.fn();
 const mockScheduleSave = jest.fn();
@@ -35,6 +40,11 @@ jest.mock('../../../stores/store', () => ({
   __esModule: true,
   ObjectStatus: { NEW: 'NEW', MODIFIED: 'MODIFIED', PUBLISHED: 'PUBLISHED', DELETED: 'DELETED' },
   default: () => mockActions,
+}));
+jest.mock('../../../api/rename', () => ({
+  fetchRenameImpact: jest.fn(),
+  renameResource: jest.fn(),
+  renameSupported: jest.fn(() => true),
 }));
 jest.mock('../common/RefTextArea', () => ({
   __esModule: true,
@@ -74,6 +84,9 @@ const CASES = [
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // `mockReturnValue` survives `clearAllMocks`, so a test that turns rename
+  // off would otherwise leak into every later describe.
+  renameApi.renameSupported.mockReturnValue(true);
   Object.values(mockActions).forEach(fn => fn.mockResolvedValue({ success: true }));
   mockSaveNow.mockResolvedValue({ success: true });
   mockScheduleSave.mockClear();
@@ -83,6 +96,125 @@ beforeEach(() => {
     status: 'idle',
     errors: null,
   };
+});
+
+// VIS-1209: a name change in edit mode is a RENAME, not a field edit — the
+// name is the identity key for the store collection, the workspace tab, the
+// URL and every `${ref()}`, so the server has to carry it and the user has to
+// see what it touches first.
+describe('renaming through the edit form', () => {
+  const record = {
+    name: 'orders',
+    status: 'PUBLISHED',
+    config: { name: 'orders', expression: 'sum(${ref(x).a})' },
+  };
+
+  const renderEdit = async () => {
+    mockRecordSave = {
+      scheduleSave: mockScheduleSave,
+      saveNow: mockSaveNow,
+      status: 'idle',
+      errors: null,
+    };
+    return renderAndSettle(
+      <SchemaLeafForm type="metric" record={record} onClose={jest.fn()} onSave={jest.fn()} />
+    );
+  };
+
+  beforeEach(() => {
+    renameApi.renameSupported.mockReturnValue(true);
+    renameApi.fetchRenameImpact.mockResolvedValue({
+      supported: true,
+      target: { type: 'metrics', name: 'orders', new_name: 'purchases', status: 'published' },
+      references: [{ type: 'charts', name: 'c1', status: 'published' }],
+    });
+    renameApi.renameResource.mockResolvedValue({
+      renamed: true,
+      target: { type: 'metrics', name: 'orders', new_name: 'purchases' },
+      references: [{ type: 'charts', name: 'c1', status: 'published' }],
+    });
+  });
+
+  test('a changed name opens the impact dialog instead of saving', async () => {
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByTestId('rename-impact-dialog')).toBeInTheDocument();
+    expect(renameApi.fetchRenameImpact).toHaveBeenCalledWith('metrics', 'orders', 'purchases');
+    // The ordinary save path must not also fire.
+    expect(mockSaveNow).not.toHaveBeenCalled();
+  });
+
+  test('an unchanged name saves normally', async () => {
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText('Expression'), {
+      target: { value: 'sum(${ref(x).b})' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockSaveNow).toHaveBeenCalled());
+    expect(renameApi.fetchRenameImpact).not.toHaveBeenCalled();
+  });
+
+  test('cancelling leaves the object alone', async () => {
+    await renderEdit();
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByTestId('rename-impact-dialog');
+
+    fireEvent.click(screen.getByTestId('rename-impact-cancel'));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('rename-impact-dialog')).not.toBeInTheDocument()
+    );
+    expect(renameApi.renameResource).not.toHaveBeenCalled();
+  });
+
+  test('confirming renames and re-points the open tab', async () => {
+    await renderEdit();
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByTestId('rename-impact-dialog');
+
+    fireEvent.click(screen.getByTestId('rename-impact-confirm'));
+
+    await waitFor(() =>
+      expect(renameApi.renameResource).toHaveBeenCalledWith('metrics', 'orders', 'purchases')
+    );
+    // The tab and URL are keyed `type:name`, so both have to follow the rename.
+    await waitFor(() =>
+      expect(mockActions.closeWorkspaceTab).toHaveBeenCalledWith('metric:orders')
+    );
+    expect(mockActions.openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'metric:purchases',
+      type: 'metric',
+      name: 'purchases',
+    });
+  });
+
+  test('a collision is shown in the dialog and nothing is renamed', async () => {
+    renameApi.fetchRenameImpact.mockRejectedValue(
+      Object.assign(new Error("A resource named 'purchases' already exists."), { status: 409 })
+    );
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByTestId('rename-impact-error')).toHaveTextContent('already exists');
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+    expect(renameApi.renameResource).not.toHaveBeenCalled();
+  });
+
+  test('a server without rename keeps the name field locked', async () => {
+    renameApi.renameSupported.mockReturnValue(false);
+    await renderEdit();
+
+    expect(screen.getByLabelText(/Metric Name/)).toBeDisabled();
+  });
 });
 
 describe.each(CASES)('SchemaLeafForm $label', ({ type, word, nameLabel, save, del }) => {
@@ -140,7 +272,9 @@ describe.each(CASES)('SchemaLeafForm $label', ({ type, word, nameLabel, save, de
     await renderAndSettle(
       <SchemaLeafForm type={type} record={record} onClose={onClose} onSave={jest.fn()} />
     );
-    expect(screen.getByLabelText(nameLabel)).toBeDisabled();
+    // The name is editable in edit mode now that a rename can carry the
+    // `${ref()}` rewrite with it (VIS-1209); deleting is unaffected.
+    expect(screen.getByLabelText(nameLabel)).toBeEnabled();
     fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
     await waitFor(() => expect(del()).toHaveBeenCalledWith('x1'));

--- a/viewer/src/components/views/workspace/collectionKeys.js
+++ b/viewer/src/components/views/workspace/collectionKeys.js
@@ -62,4 +62,24 @@ export const DELETE_ACTION = {
   input: 'deleteInput',
 };
 
+/**
+ * FETCH_ACTION — the store action that reloads a collection from the server.
+ * A rename rewrites `${ref()}` across other objects server-side, so the client
+ * has to refetch rather than patch: it cannot know which configs changed
+ * without redoing the server's traversal.
+ */
+export const FETCH_ACTION = {
+  source: 'fetchSources',
+  model: 'fetchModels',
+  dimension: 'fetchDimensions',
+  metric: 'fetchMetrics',
+  relation: 'fetchRelations',
+  insight: 'fetchInsights',
+  markdown: 'fetchMarkdowns',
+  chart: 'fetchCharts',
+  table: 'fetchTables',
+  dashboard: 'fetchDashboards',
+  input: 'fetchInputs',
+};
+
 export default COLLECTION_KEY;

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -132,6 +132,8 @@ const URL_PATTERNS = {
     commitPending: '/api/commit/pending/',
     commit: '/api/commit/',
     commitDiscard: '/api/commit/discard/',
+    rename: '/api/rename/',
+    renameImpact: '/api/rename/impact/',
 
     // ---- Stateless compute ----------------------------------------------
     // No stored resource behind any of these: request in, answer out. That is

--- a/viewer/src/hooks/useRenameFlow.js
+++ b/viewer/src/hooks/useRenameFlow.js
@@ -1,0 +1,106 @@
+import { useCallback, useState } from 'react';
+import useStore from '../stores/store';
+import {
+  COLLECTION_KEY,
+  FETCH_ACTION,
+} from '../components/views/workspace/collectionKeys';
+import { fetchRenameImpact, renameResource, renameSupported } from '../api/rename';
+
+/**
+ * useRenameFlow — the confirm-then-rename cycle, once, for every edit form.
+ *
+ * The name is the identity key: store collections, the workspace tab
+ * (`type:name`), the URL (`?edit=type:name`) and every `${ref()}` are keyed by
+ * it. So a changed name is not part of the save — it is its own server
+ * operation, and one the user should see the consequences of first.
+ *
+ * Every edit form needs the same four things, which is why this is a hook
+ * rather than copied into each: ask what the rename affects, show it, apply it,
+ * then move the tab and refetch what the server rewrote.
+ *
+ * @param {object} params
+ * @param {string} params.type      viewer singular type, e.g. 'metric'
+ * @param {string} params.recordName the name as saved
+ * @param {string} params.name       the name in the form
+ * @returns {{
+ *   supported: boolean,
+ *   isRenaming: boolean,
+ *   nameChanged: boolean,
+ *   start: () => void,
+ *   dialogProps: {impact, error, loading, onConfirm, onCancel} | null,
+ * }}
+ */
+export default function useRenameFlow({ type, recordName, name }) {
+  const store = useStore();
+  const [pending, setPending] = useState(null);
+  const [impact, setImpact] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const typeKey = COLLECTION_KEY[type];
+  const nameChanged = Boolean(recordName && name && name !== recordName);
+
+  const start = useCallback(async () => {
+    setPending({ oldName: recordName, newName: name });
+    setImpact(null);
+    setError(null);
+    setLoading(true);
+    try {
+      setImpact(await fetchRenameImpact(typeKey, recordName, name));
+    } catch (caught) {
+      setError(caught.message || 'Could not check what this rename affects');
+    } finally {
+      setLoading(false);
+    }
+  }, [typeKey, recordName, name]);
+
+  const cancel = useCallback(() => {
+    setPending(null);
+    setImpact(null);
+    setError(null);
+  }, []);
+
+  const confirm = useCallback(async () => {
+    if (!pending) return;
+    const { oldName, newName } = pending;
+    setLoading(true);
+    try {
+      const applied = await renameResource(typeKey, oldName, newName);
+      // The server rewrote refs inside other objects' configs. The client
+      // cannot know which without redoing that traversal, so it refetches
+      // exactly the collections the server named.
+      const singularOf = Object.fromEntries(
+        Object.entries(COLLECTION_KEY).map(([singular, plural]) => [plural, singular])
+      );
+      const touched = new Set([
+        type,
+        ...(applied.references || []).map(reference => singularOf[reference.type]),
+      ]);
+      await Promise.all(
+        [...touched]
+          .map(each => FETCH_ACTION[each])
+          .filter(action => typeof store[action] === 'function')
+          .map(action => store[action]())
+      );
+      if (store.closeWorkspaceTab) store.closeWorkspaceTab(`${type}:${oldName}`);
+      if (store.openWorkspaceTab) {
+        store.openWorkspaceTab({ id: `${type}:${newName}`, type, name: newName });
+      }
+      if (store.checkCommitStatus) await store.checkCommitStatus();
+      cancel();
+    } catch (caught) {
+      setError(caught.message || `Failed to rename ${type}`);
+      setLoading(false);
+    }
+  }, [pending, typeKey, type, store, cancel]);
+
+  return {
+    supported: renameSupported(),
+    isRenaming: Boolean(pending),
+    nameChanged,
+    start,
+    dialogProps: pending
+      ? { impact, error, loading, onConfirm: confirm, onCancel: cancel }
+      : null,
+  };
+}

--- a/visivo/server/managers/object_manager.py
+++ b/visivo/server/managers/object_manager.py
@@ -17,6 +17,7 @@ class ObjectStatus(str, Enum):
     MODIFIED = "modified"  # In both cached and published (cached differs)
     PUBLISHED = "published"  # In published_objects only (no cached changes)
     DELETED = "deleted"  # Marked for deletion (None in cache, exists in published)
+    RENAMED = "renamed"  # Cached under a new name; the published object holds the old one
 
 
 class ObjectManager(ABC, Generic[T]):
@@ -34,6 +35,10 @@ class ObjectManager(ABC, Generic[T]):
     def __init__(self):
         self._cached_objects: Dict[str, T] = {}
         self._published_objects: Dict[str, T] = {}
+        # {new_name: old_name} for objects renamed in the draft. Without it a
+        # rename is indistinguishable from "new object, plus an untouched old
+        # one", and the commit would write a duplicate instead of renaming.
+        self._renames: Dict[str, str] = {}
         self._lock = Lock()
 
     @property
@@ -131,6 +136,23 @@ class ObjectManager(ABC, Generic[T]):
         """
         return list(self.get_all_objects().values())
 
+    @property
+    def renames(self) -> Dict[str, str]:
+        """{new_name: old_name} for objects renamed in the draft."""
+        return self._renames
+
+    def record_rename(self, old_name: str, new_name: str) -> None:
+        """Remember that `new_name` is `old_name` renamed.
+
+        Chained renames collapse to the original: renaming a→b→c has to tell
+        the commit to find `a` in the YAML, not the `b` that was never written.
+        """
+        self._renames[new_name] = self._renames.pop(old_name, old_name)
+
+    def renamed_from(self, name: str) -> Optional[str]:
+        """The published name this object was renamed from, if it was."""
+        return self._renames.get(name)
+
     def get_status(self, name: str) -> Optional[ObjectStatus]:
         """
         Determine the status of an object by name.
@@ -155,7 +177,9 @@ class ObjectManager(ABC, Generic[T]):
                 # Only return DELETED if it exists in published (something to delete)
                 return ObjectStatus.DELETED if in_published else None
             elif not in_published:
-                return ObjectStatus.NEW
+                # A renamed object is also absent from published under its new
+                # name; only the rename record tells it apart from a new one.
+                return ObjectStatus.RENAMED if name in self._renames else ObjectStatus.NEW
             else:
                 # Compare actual values to determine if truly modified
                 published_obj = self._published_objects[name]

--- a/visivo/server/project_writer.py
+++ b/visivo/server/project_writer.py
@@ -93,7 +93,7 @@ class ProjectWriter:
                 case "Modified":
                     self._update(child_name)
                 case "Renamed":
-                    self._rename(child_name, child_name)
+                    self._rename(child_info["old_name"], child_name)
 
     def write(self):
         """
@@ -203,8 +203,37 @@ class ProjectWriter:
         self._new(child_name)
 
     def _rename(self, old_child_name: str, new_child_name: str):
-        """Find and replace the old child name with the new child name in all file refs & in the named_child"""
-        raise NotImplementedError("Rename is not implemented yet.")
+        """Write the renamed object over the entry the YAML still holds under
+        its old name.
+
+        `_update` cannot do this: it locates an object by matching `name:`
+        against the name it is given, and the file still says the old one, so
+        the search would miss and the change would be silently dropped.
+
+        Only the object's own entry is handled here. Every `${ref(old)}`
+        elsewhere belongs to a DIFFERENT object whose config genuinely changed,
+        so those arrive as ordinary `Modified` children and take `_update`.
+        """
+        new_object = self._get_named_child_config(new_child_name)
+
+        def recurse(current):
+            if isinstance(current, dict):
+                items = current.values()
+            elif isinstance(current, list):
+                items = current
+            else:
+                return False
+            for value in items:
+                if isinstance(value, dict) and value.get("name") == old_child_name:
+                    diff_result = diff(value, new_object)
+                    apply_diff(value, diff_result)
+                    return True
+                if isinstance(value, (dict, list)) and recurse(value):
+                    return True
+            return False
+
+        file_path = self.named_children[new_child_name]["file_path"]
+        recurse(self.files_to_write[file_path])
 
     def _get_named_child_config(self, named_child_name: str) -> dict:
         """

--- a/visivo/server/rename_service.py
+++ b/visivo/server/rename_service.py
@@ -1,0 +1,187 @@
+"""Rename an object and rewrite every `${ref(old)}` that pointed at it.
+
+The cloud half has existed since VIS-917 (`core`'s `services/rename.py`);
+locally there was nothing — `ProjectWriter._rename` raised `NotImplementedError`
+and no route reached it. This is the local equivalent, working against the
+manager's cached (draft) tier so a rename commits like any other edit.
+
+WHY REFERENCES BECOME MODIFIED
+
+A reference's config genuinely changes — `${ref(orders)}` becomes
+`${ref(purchases)}` — so marking it modified is not bookkeeping, it is the
+truth. It also does real work: `ProjectWriter` only loads the files of changed
+objects, so a reference living in an otherwise-untouched file would not have its
+file loaded, and the rewrite would be silently dropped on commit.
+
+The renamed object itself cannot ride that path. `_update` finds an object in
+YAML by matching `name:` against the name it is called with, and after a rename
+the YAML still holds the old one — the search would miss and the update would
+no-op. That is what `_rename(old, new)` is for, and why the stub always took two
+names.
+
+Refs are `${ref(name)}` template tokens resolved pre-compile, not SQL, so they
+are rewritten with the same pattern the codebase uses to extract them. sqlglot
+cannot parse a `${ref()}` token and is not involved.
+
+Nested metrics/dimensions are out of scope: they are not their own record, so
+they have no row to rename.
+"""
+
+import re
+
+TYPE_TO_MANAGER = {
+    "sources": "source_manager",
+    "models": "model_manager",
+    "metrics": "metric_manager",
+    "dimensions": "dimension_manager",
+    "relations": "relation_manager",
+    "insights": "insight_manager",
+    "charts": "chart_manager",
+    "tables": "table_manager",
+    "markdowns": "markdown_manager",
+    "inputs": "input_manager",
+    "dashboards": "dashboard_manager",
+}
+
+
+class RenameError(Exception):
+    """A rename failure carrying the HTTP status the view should return."""
+
+    def __init__(self, message, status):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def _ref_pattern(old_name):
+    """Matches ref(old), ref("old"), ref('old') — bare or inside ${...}.
+
+    The back-referenced quote group pins the exact name and preserves whichever
+    quoting style the author used. Mirrors core's `_ref_pattern` so the two
+    halves rewrite identically.
+    """
+    return re.compile(r"ref\(\s*([\"']?)" + re.escape(old_name) + r"\1\s*\)")
+
+
+def _rewrite(value, pattern, new_name):
+    if isinstance(value, str):
+        return pattern.sub(lambda m: f"ref({m.group(1)}{new_name}{m.group(1)})", value)
+    if isinstance(value, list):
+        return [_rewrite(v, pattern, new_name) for v in value]
+    if isinstance(value, dict):
+        return {k: _rewrite(v, pattern, new_name) for k, v in value.items()}
+    return value
+
+
+def _managers(flask_app):
+    for type_key, attribute in TYPE_TO_MANAGER.items():
+        manager = getattr(flask_app, attribute, None)
+        if manager is not None:
+            yield type_key, manager
+
+
+def _current_objects(manager):
+    """Every object the manager knows, cached tier winning over published.
+
+    A rename has to see the draft state — renaming onto a name that only exists
+    as an uncommitted draft is still a collision.
+    """
+    objects = dict(manager.published_objects)
+    for name, obj in manager.cached_objects.items():
+        if obj is None:
+            objects.pop(name, None)  # marked for deletion
+        else:
+            objects[name] = obj
+    return objects
+
+
+def _config_of(obj):
+    return obj.model_dump(mode="json", exclude_none=True)
+
+
+def _all_names(flask_app):
+    names = set()
+    for _type_key, manager in _managers(flask_app):
+        names.update(_current_objects(manager).keys())
+    return names
+
+
+def _validate(flask_app, type_key, old_name, new_name):
+    """The manager and object being renamed, or raise."""
+    if type_key not in TYPE_TO_MANAGER:
+        raise RenameError(f"Unknown resource type '{type_key}'.", 400)
+    if not new_name or new_name == old_name:
+        raise RenameError("A different new name is required.", 400)
+
+    manager = getattr(flask_app, TYPE_TO_MANAGER[type_key], None)
+    if manager is None:
+        raise RenameError(f"Unknown resource type '{type_key}'.", 400)
+
+    target = _current_objects(manager).get(old_name)
+    if target is None:
+        raise RenameError(f"No {type_key} named '{old_name}'.", 404)
+
+    # visivo names are project-global, so a collision crosses every type.
+    if new_name in _all_names(flask_app):
+        raise RenameError(f"A resource named '{new_name}' already exists.", 409)
+
+    return manager, target
+
+
+def rename_impact(flask_app, *, type_key, old_name, new_name):
+    """What the rename would change, without changing it.
+
+    Same validation and the same traversal `rename_object` applies, so a preview
+    cannot promise something the rename then refuses.
+    """
+    manager, target = _validate(flask_app, type_key, old_name, new_name)
+    pattern = _ref_pattern(old_name)
+
+    references = []
+    for other_type, other_manager in _managers(flask_app):
+        for name, obj in _current_objects(other_manager).items():
+            if other_type == type_key and name == old_name:
+                continue
+            config = _config_of(obj)
+            if _rewrite(config, pattern, new_name) == config:
+                continue
+            status = other_manager.get_status(name)
+            references.append(
+                {
+                    "type": other_type,
+                    "name": name,
+                    "status": status.value if status else "published",
+                }
+            )
+
+    references.sort(key=lambda entry: (entry["type"], entry["name"]))
+    target_status = manager.get_status(old_name)
+    return {
+        "target": {
+            "type": type_key,
+            "name": old_name,
+            "new_name": new_name,
+            "status": target_status.value if target_status else "published",
+        },
+        "references": references,
+    }
+
+
+def rename_object(flask_app, *, type_key, old_name, new_name):
+    """Apply the rename to the cached tier. Returns the same shape as the
+    preview, describing what was changed."""
+    impact = rename_impact(flask_app, type_key=type_key, old_name=old_name, new_name=new_name)
+    manager, target = _validate(flask_app, type_key, old_name, new_name)
+    pattern = _ref_pattern(old_name)
+
+    config = _config_of(target)
+    config["name"] = new_name
+    manager.save_from_config(config)
+    manager.record_rename(old_name, new_name)
+
+    for reference in impact["references"]:
+        other_manager = getattr(flask_app, TYPE_TO_MANAGER[reference["type"]])
+        obj = _current_objects(other_manager)[reference["name"]]
+        other_manager.save_from_config(_rewrite(_config_of(obj), pattern, new_name))
+
+    return impact

--- a/visivo/server/views/__init__.py
+++ b/visivo/server/views/__init__.py
@@ -32,6 +32,7 @@ from visivo.server.views.insight_execute_views import register_insight_execute_v
 from visivo.server.views.run_views import register_run_views
 from visivo.server.views.preferences_views import register_preferences_views
 from visivo.server.views.model_schema_views import register_model_schema_views
+from visivo.server.views.rename_views import register_rename_views
 from visivo.server.views.restore_views import register_restore_views
 
 
@@ -73,4 +74,5 @@ def register_views(app, flask_app, output_dir):
     register_model_schema_views(app, flask_app, output_dir)
     # Registered LAST: its route is a catch-all over `/api/<segment>/<name>/`,
     # so the concrete per-resource routes must claim their paths first.
+    register_rename_views(app, flask_app)
     register_restore_views(app, flask_app)

--- a/visivo/server/views/commit_views.py
+++ b/visivo/server/views/commit_views.py
@@ -307,7 +307,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=source,
                         status=status,
-                        published_obj=flask_app.source_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.source_manager, name),
                         type_key="sources",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -322,7 +322,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=model,
                         status=status,
-                        published_obj=flask_app.model_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.model_manager, name),
                         type_key="models",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -337,7 +337,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=dimension,
                         status=status,
-                        published_obj=flask_app.dimension_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.dimension_manager, name),
                         type_key="dimensions",
                         project_file_path=flask_app.project.project_file_path,
                         flask_app=flask_app,
@@ -353,7 +353,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=metric,
                         status=status,
-                        published_obj=flask_app.metric_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.metric_manager, name),
                         type_key="metrics",
                         project_file_path=flask_app.project.project_file_path,
                         flask_app=flask_app,
@@ -369,7 +369,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=relation,
                         status=status,
-                        published_obj=flask_app.relation_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.relation_manager, name),
                         type_key="relations",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -384,7 +384,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=insight,
                         status=status,
-                        published_obj=flask_app.insight_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.insight_manager, name),
                         type_key="insights",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -399,7 +399,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=markdown,
                         status=status,
-                        published_obj=flask_app.markdown_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.markdown_manager, name),
                         type_key="markdowns",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -414,7 +414,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=chart,
                         status=status,
-                        published_obj=flask_app.chart_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.chart_manager, name),
                         type_key="charts",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -429,7 +429,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=table,
                         status=status,
-                        published_obj=flask_app.table_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.table_manager, name),
                         type_key="tables",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -444,7 +444,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=dashboard,
                         status=status,
-                        published_obj=flask_app.dashboard_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.dashboard_manager, name),
                         type_key="dashboards",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -459,7 +459,7 @@ def register_commit_views(app, flask_app, output_dir):
                         name=name,
                         obj=input_obj,
                         status=status,
-                        published_obj=flask_app.input_manager.published_objects.get(name),
+                        **_renamed_child_args(flask_app.input_manager, name),
                         type_key="inputs",
                         project_file_path=flask_app.project.project_file_path,
                     )
@@ -696,6 +696,20 @@ def _validate_pending_project(flask_app):
     return None
 
 
+def _renamed_child_args(manager, name):
+    """`published_obj` and `old_name` for a child, honouring a draft rename.
+
+    A renamed object is cached under its NEW name, so looking `published_obj`
+    up by that name finds nothing and the writer would treat it as new. The
+    published record — and the file it lives in — are under the OLD name.
+    """
+    old_name = manager.renamed_from(name)
+    return {
+        "published_obj": manager.published_objects.get(old_name or name),
+        "old_name": old_name,
+    }
+
+
 def _build_child_info(
     name,
     obj,
@@ -704,6 +718,7 @@ def _build_child_info(
     type_key,
     project_file_path,
     flask_app=None,
+    old_name=None,
 ):
     """Build the child info dict for ProjectWriter.
 
@@ -722,6 +737,7 @@ def _build_child_info(
         ObjectStatus.NEW: "New",
         ObjectStatus.MODIFIED: "Modified",
         ObjectStatus.DELETED: "Deleted",
+        ObjectStatus.RENAMED: "Renamed",
     }
     writer_status = status_map.get(status, "Unchanged")
 
@@ -759,7 +775,8 @@ def _build_child_info(
         new_file_path = file_path
         config = {}  # No config needed for deletion
     else:
-        # Modified objects use path from published version
+        # Modified and renamed objects use the path from the published version,
+        # which for a rename was resolved under the OLD name.
         file_path = _get_file_path(published_obj, project_file_path)
         new_file_path = file_path
         config = (
@@ -773,6 +790,10 @@ def _build_child_info(
         "type_key": type_key,
         "config": config,
     }
+    if status == ObjectStatus.RENAMED and old_name:
+        # The writer finds the object in YAML under this, and writes `config`
+        # (which carries the new name) over it.
+        info["old_name"] = old_name
     if parent_model_name:
         info["parent_model"] = parent_model_name
     return info

--- a/visivo/server/views/rename_views.py
+++ b/visivo/server/views/rename_views.py
@@ -1,0 +1,55 @@
+"""Rename a resource and rewrite every `${ref()}` that pointed at it.
+
+Mirrors the cloud endpoints (`core`'s `ProjectRenameView` /
+`ProjectRenameImpactView`) so the viewer talks to one shape in both modes:
+
+    POST /api/rename/         {type, old_name, new_name}  -> apply
+    POST /api/rename/impact/  {type, old_name, new_name}  -> preview only
+
+Both answer with the same `{target, references}` body, so a caller can show
+what a rename will change before doing it.
+"""
+
+from flask import jsonify, request
+
+from visivo.server.rename_service import RenameError, rename_impact, rename_object
+
+
+def _args():
+    """(type_key, old_name, new_name), or an error response."""
+    body = request.get_json(silent=True) or {}
+    type_key = body.get("type")
+    old_name = body.get("old_name")
+    new_name = body.get("new_name")
+    if not (type_key and old_name and new_name):
+        return None, (jsonify({"error": "type, old_name and new_name are required."}), 400)
+    return (type_key, old_name, new_name), None
+
+
+def register_rename_views(app, flask_app):
+    @app.route("/api/rename/impact/", methods=["POST"])
+    def rename_impact_view():
+        args, error = _args()
+        if error is not None:
+            return error
+        type_key, old_name, new_name = args
+        try:
+            return jsonify(
+                rename_impact(flask_app, type_key=type_key, old_name=old_name, new_name=new_name)
+            )
+        except RenameError as exc:
+            return jsonify({"error": exc.message}), exc.status
+
+    @app.route("/api/rename/", methods=["POST"])
+    def rename_view():
+        args, error = _args()
+        if error is not None:
+            return error
+        type_key, old_name, new_name = args
+        try:
+            applied = rename_object(
+                flask_app, type_key=type_key, old_name=old_name, new_name=new_name
+            )
+        except RenameError as exc:
+            return jsonify({"error": exc.message}), exc.status
+        return jsonify({"renamed": True, **applied})


### PR DESCRIPTION
The local half of VIS-1209. Pairs with core#385 (the cloud preview); together they give the rename modal one contract in both modes.

## The hole

`visivo serve` could not rename anything:

- `ProjectWriter._rename` raised `NotImplementedError`
- the `"Renamed"` status that would reach it was never produced
- there was no route

Cloud has had the whole thing since VIS-917 — with zero frontend callers.

## Endpoints

```
POST /api/rename/         {type, old_name, new_name}  -> apply
POST /api/rename/impact/  {type, old_name, new_name}  -> preview only
```

Both answer `{target, references}` — the same shape core#385 added.

## What makes it a rename and not delete+create

A renamed object is cached under its **new** name, which is indistinguishable from a brand-new object. Left there, the commit would write the new one and leave the original sitting in the YAML.

So the manager records `{new_name: old_name}` and reports `ObjectStatus.RENAMED`. `_build_child_info` turns that into the writer's `"Renamed"` with the old name attached, and `_rename` uses it to find the entry the file still holds.

Chained renames collapse to the original: `a→b→c` has to send the commit looking for `a`, because `b` was never written to disk.

## References are ordinary Modified children

`${ref(orders)}` → `${ref(purchases)}` is a real config change, so each referencing object is saved to the draft and rides the existing `_update` path.

That's also load-bearing rather than cosmetic: `ProjectWriter` only loads the files of **changed** objects, so a reference living in an otherwise-untouched file would never have its file opened, and the rewrite would be silently dropped on commit.

Only the renamed object itself needs `_rename` — `_update` locates an object by matching `name:` against the name it's given, and the file still says the old one, so the search would miss and the change would vanish. That's why the stub always took two names.

## Verified end to end

Scratch project on an isolated port:

| step | result |
|---|---|
| preview | lists the referencing metric; **nothing changed** |
| preview, colliding name | **409** before confirming |
| rename | lands in the draft, **YAML untouched** |
| commit | `orders` renamed **in place** (line 7, not appended), `sum(${ref(orders).amount})` → `sum(${ref(purchases).amount})` |

No `orders` left anywhere in the file, no parse errors, structure and ordering preserved.

## Out of scope

**Nested metrics/dimensions** (confirmed) — they aren't their own record, so there's nothing to rename in place.

## Tests

17 new service tests covering the impact query, validation (400/404/409 including cross-type collisions and names freed by a pending delete), quoted refs, the `orders` vs `orders_archive` prefix trap, and chained renames. Suite **2556 passed**, `black --check` clean.

One test-fixture change: `test_commit_views_coverage`'s mock managers now return a real `None` from `renamed_from`, since a `Mock`'s truthy return would send the published lookup after a name that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3