### PR TITLE
Rename from the edit form, with the impact shown first (VIS-1209)

### DIFF
--- a/viewer/src/api/rename.js
+++ b/viewer/src/api/rename.js
@@ -1,0 +1,52 @@
+import { getUrl, isAvailable } from '../contexts/URLContext';
+import { apiFetch } from './utils';
+
+/**
+ * Rename a resource and rewrite every `${ref()}` that pointed at it.
+ *
+ * Local and cloud expose the same `{target, references}` contract
+ * (`visivo/server/views/rename_views.py`, core's `ProjectRenameView`), so a
+ * caller does not branch on environment.
+ */
+
+const NOT_SUPPORTED = {
+  supported: false,
+  target: null,
+  references: [],
+};
+
+async function post(urlName, { type, oldName, newName }) {
+  if (!isAvailable(urlName)) {
+    return NOT_SUPPORTED;
+  }
+  const response = await apiFetch(getUrl(urlName), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, old_name: oldName, new_name: newName }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(body.error || `Rename failed (${response.status})`);
+    error.status = response.status;
+    throw error;
+  }
+  return { supported: true, ...body };
+}
+
+/**
+ * What the rename would change, without changing it.
+ *
+ * Throws with `.status` on a rejection — notably 409 for a name collision, so
+ * the caller can say so before the user confirms rather than after.
+ *
+ * @returns {Promise<{supported: boolean, target: object, references: Array}>}
+ */
+export const fetchRenameImpact = (type, oldName, newName) =>
+  post('renameImpact', { type, oldName, newName });
+
+/** Apply the rename. Answers the same shape, describing what changed. */
+export const renameResource = (type, oldName, newName) =>
+  post('rename', { type, oldName, newName });
+
+/** Whether this server offers rename at all. */
+export const renameSupported = () => isAvailable('rename');

--- a/viewer/src/components/views/common/ChartEditForm.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.jsx
@@ -15,6 +15,8 @@ import { parseRefValue, formatRef } from '../../../utils/refString';
 import EmbeddedPill from '../lineage/EmbeddedPill';
 import Dropdown from '../../common/Dropdown';
 import AddInsightMenu from '../workspace/AddInsightMenu';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * ChartEditForm - Form component for editing/creating charts
@@ -33,6 +35,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   // Form state
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'chart', recordName: chart?.name || '', name });
   const [insights, setInsights] = useState([]);
   const [layoutValues, setLayoutValues] = useState({});
 
@@ -164,6 +167,18 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
   };
 
   const handleSave = async () => {
+
+    // A changed name in edit mode is a RENAME — its own server operation,
+
+    // confirmed first, because every `${ref()}` to this object moves with it.
+
+    if (isEditMode && rename.nameChanged) {
+
+      rename.start();
+
+      return;
+
+    }
     if (!validateForm()) return;
 
     setSaving(true);
@@ -253,6 +268,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -265,7 +281,7 @@ const ChartEditForm = ({ chart, isCreate, onClose, onSave, onNavigateToEmbedded,
             nameLabel="Chart Name"
             nameValue={name}
             onNameChange={e => setName(e.target.value)}
-            nameDisabled={isEditMode}
+            nameDisabled={isEditMode && !rename.supported}
             nameError={errors.name}
             layoutTitle="Layout Configuration (Optional)"
             layoutSchema={layoutSchema}

--- a/viewer/src/components/views/common/ChartEditForm.test.jsx
+++ b/viewer/src/components/views/common/ChartEditForm.test.jsx
@@ -21,10 +21,19 @@ jest.mock('../../../schemas/schemas', () => ({
 // SchemaEditor from './SchemaEditor/SchemaEditor' — mock THAT path.
 jest.mock('./SchemaEditor/SchemaEditor', () => ({
   __esModule: true,
-  SchemaEditor: ({ onChange }) => (
-    <button type="button" data-testid="mock-schema-clear" onClick={() => onChange(undefined)}>
-      clear layout
-    </button>
+  SchemaEditor: ({ value, onChange }) => (
+    <>
+      <button type="button" data-testid="mock-schema-clear" onClick={() => onChange(undefined)}>
+        clear layout
+      </button>
+      <button
+        type="button"
+        data-testid="mock-schema-touch"
+        onClick={() => onChange({ ...(value || {}), showlegend: true })}
+      >
+        touch layout
+      </button>
+    </>
   ),
 }));
 
@@ -160,16 +169,20 @@ describe('ChartEditForm — insight fetch guard', () => {
 });
 
 // VIS-1133: Save is disabled on an untouched edit-mode form, so tests that
-// exercise the SAVE PATH must first make a real edit. The name field is
-// orthogonal to `config.insights` / `config.layout` (it travels as its own
-// argument to onSave), so touching it leaves every config assertion intact.
-const makeDirty = () =>
-  fireEvent.change(screen.getByLabelText(/Chart Name/), { target: { value: 'edited_name' } });
+// exercise the SAVE PATH must first make a real edit. It cannot be the name — a
+// changed name in edit mode is a rename, which intercepts the save. The layout
+// editor is the one config field the save-path assertions below don't pin, so
+// it is what these tests touch; it only renders once a schema has resolved.
+const withLayoutSchema = () =>
+  jest.requireMock('../../../schemas/schemas').getSchema.mockResolvedValueOnce({ type: 'object' });
+
+const makeDirty = async () => fireEvent.click(await screen.findByTestId('mock-schema-touch'));
 
 describe('ChartEditForm — embedded insights on save', () => {
   const embeddedInsight = { name: 'inline_insight', props: { type: 'scatter' } };
 
   test('a chart whose insights are ALL embedded objects can still be saved', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -182,7 +195,7 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByText('Embedded Insights');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -192,6 +205,7 @@ describe('ChartEditForm — embedded insights on save', () => {
   });
 
   test('saving preserves the original ref/embedded insight order', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -208,7 +222,7 @@ describe('ChartEditForm — embedded insights on save', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -255,6 +269,7 @@ describe('ChartEditForm — validation & save paths', () => {
   });
 
   test('non-empty layout values are carried into the saved config', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: true }));
     render(
       <ChartEditForm
@@ -271,18 +286,23 @@ describe('ChartEditForm — validation & save paths', () => {
     );
     await screen.findByTestId('ref-insight-row-0');
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave.mock.calls[0][2].layout).toEqual({ title: { text: 'Revenue' } });
+    // The pre-existing title survives alongside the edit that dirtied the form.
+    expect(onSave.mock.calls[0][2].layout).toEqual({
+      title: { text: 'Revenue' },
+      showlegend: true,
+    });
   });
 
   test('a failed save surfaces the backend error and keeps the form open', async () => {
+    withLayoutSchema();
     const onSave = jest.fn(async () => ({ success: false, error: 'chart save exploded' }));
     await renderForm({ onSave });
 
-    makeDirty();
+    await makeDirty();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(await screen.findByText('chart save exploded')).toBeInTheDocument();

--- a/viewer/src/components/views/common/DashboardEditForm.jsx
+++ b/viewer/src/components/views/common/DashboardEditForm.jsx
@@ -12,6 +12,8 @@ import {
   createRow,
 } from '../workspace/itemMutations';
 import RowEditForm from './RowEditForm';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * DashboardEditForm - Form for creating/editing Dashboard
@@ -25,6 +27,8 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   const openWorkspaceTab = useStore(state => state.openWorkspaceTab);
 
   const [name, setName] = useState('');
+
+  const rename = useRenameFlow({ type: 'dashboard', recordName: dashboard?.name || '', name });
   const [rows, setRows] = useState([]);
   const [description, setDescription] = useState('');
   const [saving, setSaving] = useState(false);
@@ -62,6 +66,13 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
   }, [dashboard]);
 
   const handleSubmit = async e => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (!isCreate && rename.nameChanged) {
+      e.preventDefault();
+      rename.start();
+      return;
+    }
     e.preventDefault();
     setError(null);
     setSaving(true);
@@ -191,6 +202,7 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
 
   return (
     <div className="flex-1 overflow-y-auto p-4">
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <FormAlert variant="error">{error}</FormAlert>}
 
@@ -199,7 +211,7 @@ const DashboardEditForm = ({ dashboard, isCreate, onSave, onClose }) => {
           label="Name"
           value={name}
           onChange={e => setName(e.target.value)}
-          disabled={!isCreate}
+          disabled={!isCreate && !rename.supported}
           helperText={!isCreate ? 'Dashboard names cannot be changed after creation.' : undefined}
         />
 

--- a/viewer/src/components/views/common/InputEditForm.jsx
+++ b/viewer/src/components/views/common/InputEditForm.jsx
@@ -13,6 +13,8 @@ import Select from '../../common/Select';
 import useFormBaseline from '../../../hooks/useFormBaseline';
 import { validateName } from './namedModel';
 import { validateInputDraft, buildInputConfig } from './inputConfigValidation';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 const INPUT_TYPES = [
   { value: 'single-select', label: 'Single Select' },
@@ -125,6 +127,10 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
   const hydratedRef = useRef(false);
 
   const isEditMode = !!input && !isCreate;
+
+  const recordName = input?.name || '';
+
+  const rename = useRenameFlow({ type: 'input', recordName, name });
   const isNewObject = input?.status === ObjectStatus.NEW;
 
   // VIS-1133: snapshot the last-saved values so the form can report dirtiness
@@ -257,6 +263,12 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
   };
 
   const handleSave = async () => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
     const draft = {
       name,
       inputType,
@@ -319,7 +331,7 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
             label="Name"
             value={name}
             onChange={e => setName(e.target.value)}
-            disabled={isEditMode}
+            disabled={isEditMode && !rename.supported}
             error={errors.name}
             helperText={isEditMode ? 'Input names cannot be changed after creation.' : undefined}
           />
@@ -493,6 +505,9 @@ const InputEditForm = ({ input, isCreate, onClose, onSave, onDirtyChange }) => {
           />
         </div>
       </div>
+
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
+
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/common/InsightEditForm.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.jsx
@@ -15,6 +15,8 @@ import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { useDebounce } from '../../../hooks/useDebounce';
 import { REF_INSERT_HINT } from './RefTextArea';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 import {
   SectionContainer,
   EmptyState,
@@ -42,6 +44,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
 
   // Form state - Basic fields
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'insight', recordName: insight?.name || '', name });
   const [description, setDescription] = useState('');
 
   // Props state - the insight's Plotly props object (carries `.type`). Fully
@@ -163,6 +166,18 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
   };
 
   const handleSave = async () => {
+
+    // A changed name in edit mode is a RENAME — its own server operation,
+
+    // confirmed first, because every `${ref()}` to this object moves with it.
+
+    if (isEditMode && rename.nameChanged) {
+
+      rename.start();
+
+      return;
+
+    }
     if (!validateForm()) return;
 
     setSaving(true);
@@ -243,6 +258,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -265,7 +281,7 @@ const InsightEditForm = ({ insight, isCreate, onClose, onSave, onGoBack, isPrevi
             nameId="insightName"
             nameValue={name}
             onNameChange={e => setName(e.target.value)}
-            nameDisabled={isEditMode}
+            nameDisabled={isEditMode && !rename.supported}
             nameError={errors.name}
             showDescription
             description={description}

--- a/viewer/src/components/views/common/InsightEditForm.test.jsx
+++ b/viewer/src/components/views/common/InsightEditForm.test.jsx
@@ -329,7 +329,7 @@ describe('InsightEditForm — edit mode', () => {
 
     const nameInput = screen.getByLabelText(/Insight Name/);
     expect(nameInput).toHaveValue('rev');
-    expect(nameInput).toBeDisabled();
+    expect(nameInput).toBeEnabled();
     expect(screen.getByLabelText('Description')).toHaveValue('revenue insight');
     // The stored props (with their type) seed the controlled editor.
     expect(screen.getByTestId('tpe-type')).toHaveTextContent('bar');

--- a/viewer/src/components/views/common/MarkdownEditForm.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.jsx
@@ -7,6 +7,8 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { validateName } from './namedModel';
 import Select from '../../common/Select';
 import useRecordSave from '../../../hooks/useRecordSave';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * MarkdownEditForm - Form component for editing/creating markdowns
@@ -45,6 +47,10 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!markdown && !isCreate;
+
+  const recordName = markdown?.name || '';
+
+  const rename = useRenameFlow({ type: 'markdown', recordName, name });
   const isNewObject = markdown?.status === ObjectStatus.NEW;
 
   // Unified optimistic save backbone (VIS-1018 step 2) — `saveNow` shares the
@@ -108,6 +114,12 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -167,6 +179,7 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -183,7 +196,7 @@ const MarkdownEditForm = ({ markdown, isCreate, onClose, onSave }) => {
                 id="markdownName"
                 value={name}
                 onChange={e => setName(e.target.value)}
-                disabled={isEditMode}
+                disabled={isEditMode && !rename.supported}
                 placeholder=" "
                 className={`
                   block w-full px-3 py-2.5 text-sm text-gray-900

--- a/viewer/src/components/views/common/MarkdownEditForm.test.jsx
+++ b/viewer/src/components/views/common/MarkdownEditForm.test.jsx
@@ -147,7 +147,9 @@ describe('MarkdownEditForm — edit mode', () => {
     };
     renderForm({ markdown, isCreate: false });
     expect(screen.getByLabelText(/Markdown Name/)).toHaveValue('md1');
-    expect(screen.getByLabelText(/Markdown Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Markdown Name/)).toBeEnabled();
     expect(screen.getByLabelText(/Content/)).toHaveValue('Hi there');
 
     // Explicit save (no auto-save): a field change buffers locally and persists

--- a/viewer/src/components/views/common/ModelEditForm.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.jsx
@@ -9,6 +9,8 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { getTypeByValue } from './objectTypeConfigs';
 import InlineFieldEditor from './InlineFieldEditor';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * ModelEditForm - Form for creating/editing SqlModel
@@ -36,6 +38,7 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
 
   // Form state
   const [name, setName] = useState('');
+  const rename = useRenameFlow({ type: 'model', recordName: model?.name || '', name });
   const [sql, setSql] = useState('');
   const [source, setSource] = useState(null); // Stored as ref(name) format
   const [dimensions, setDimensions] = useState([]); // Inline dimensions
@@ -110,6 +113,12 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
   };
 
   const handleSave = async () => {
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (!isCreate && rename.nameChanged) {
+      rename.start();
+      return;
+    }
     setError(null);
     setSaving(true);
 
@@ -183,6 +192,7 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
     // height to fill — the other leaf forms return a fragment and inherit that
     // from the rail, but this one owns a <form> element in between.
     <form onSubmit={handleFormSubmit} className="flex h-full flex-col">
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       <FormLayout>
         {error && <FormAlert variant="error">{error}</FormAlert>}
 
@@ -191,8 +201,12 @@ const ModelEditForm = ({ model, onSave, onCancel, onNavigateToEmbedded, onDirtyC
           label="Model Name"
           value={name}
           onChange={e => setName(e.target.value)}
-          disabled={!isCreate}
-          helperText={!isCreate ? 'Model names cannot be changed after creation.' : undefined}
+          disabled={!isCreate && !rename.supported}
+          helperText={
+            !isCreate && rename.nameChanged
+              ? 'Saving will rename this model and update everything that references it.'
+              : undefined
+          }
         />
 
         {/* SQL field - Monaco Editor doesn't fit the standard form pattern */}

--- a/viewer/src/components/views/common/ModelEditForm.test.jsx
+++ b/viewer/src/components/views/common/ModelEditForm.test.jsx
@@ -150,7 +150,9 @@ describe('ModelEditForm — edit mode initialization and save', () => {
   it('initializes fields from the model and locks the name', () => {
     render(<ModelEditForm model={editModel()} onSave={jest.fn()} onCancel={jest.fn()} />);
     expect(screen.getByLabelText(/Model Name/)).toHaveValue('orders');
-    expect(screen.getByLabelText(/Model Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Model Name/)).toBeEnabled();
     expect(screen.getByLabelText('code')).toHaveValue('select * from orders');
     expect(screen.getByTestId('ref-selector')).toHaveValue('ref(warehouse)');
     expect(screen.getByRole('button', { name: /region/ })).toBeInTheDocument();

--- a/viewer/src/components/views/common/SourceEditForm.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.jsx
@@ -19,6 +19,8 @@ import { getTypeByValue } from './objectTypeConfigs';
 import { isEmbeddedObject } from './embeddedObjectUtils';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import SeedsEditor, { sourceTypeSupportsSeeds } from './SeedsEditor';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * SourceEditForm - Form component for editing/creating sources
@@ -48,6 +50,10 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!source && !isCreate;
+
+  const recordName = source?.name || '';
+
+  const rename = useRenameFlow({ type: 'source', recordName, name });
   const isNewObject = source?.status === ObjectStatus.NEW;
   const isEmbedded = isEmbeddedObject(source);
   const parentName = source?._embedded?.parentName;
@@ -176,6 +182,12 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -241,7 +253,7 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
             label="Source Name"
             value={name}
             onChange={e => setName(e.target.value)}
-            disabled={isEditMode}
+            disabled={isEditMode && !rename.supported}
             required
             error={errors.name}
           />
@@ -344,6 +356,9 @@ const SourceEditForm = ({ source, isCreate, onClose, onSave, onGoBack, onDirtyCh
 
         {saveError && <FormAlert variant="error">{saveError}</FormAlert>}
       </FormLayout>
+
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
+
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/common/SourceEditForm.test.jsx
+++ b/viewer/src/components/views/common/SourceEditForm.test.jsx
@@ -148,7 +148,9 @@ describe('SourceEditForm — edit mode', () => {
     const onSave = jest.fn(async () => ({ success: true }));
     renderForm({ source: publishedSqlite, isCreate: false, onSave });
     expect(screen.getByLabelText(/Source Name/)).toHaveValue('s1');
-    expect(screen.getByLabelText(/Source Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Source Name/)).toBeEnabled();
     expect(screen.getByTestId('source-type-value')).toHaveTextContent('sqlite');
     expect(screen.getByLabelText(/Database Path/)).toHaveValue('prod.db');
 
@@ -166,7 +168,9 @@ describe('SourceEditForm — edit mode', () => {
   test('lets you switch the source type when editing, keeping the name locked (VIS-1208)', () => {
     renderForm({ source: publishedSqlite, isCreate: false });
     // Name stays locked (it's the record key)...
-    expect(screen.getByLabelText(/Source Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Source Name/)).toBeEnabled();
     expect(screen.getByLabelText(/Database Path/)).toHaveValue('prod.db');
 
     // ...but the type is switchable now (previously disabled in edit mode).
@@ -289,10 +293,10 @@ describe('SourceEditForm — test connection', () => {
 });
 
 // VIS-1133: Save is disabled on an untouched edit-mode form, so save-path
-// tests must make a real edit first. The source NAME is orthogonal to the
-// seeds/type assertions below, so touching it leaves them intact.
+// tests must make a real edit first. It cannot be the name — a changed name in
+// edit mode is a rename, which intercepts the save instead of performing it.
 const makeDirty = () =>
-  fireEvent.change(screen.getByLabelText(/Source Name/), { target: { value: 'edited_name' } });
+  fireEvent.change(screen.getByLabelText(/Database Path/), { target: { value: 'edited.db' } });
 
 describe('SourceEditForm — embedded sources', () => {
   const embedded = {

--- a/viewer/src/components/views/common/TableEditForm.jsx
+++ b/viewer/src/components/views/common/TableEditForm.jsx
@@ -13,6 +13,8 @@ import { parseRefValue, formatRef } from '../../../utils/refString';
 import ExpressionField from './ExpressionField';
 import Select from '../../common/Select';
 import { REF_INSERT_HINT } from './RefTextArea';
+import useRenameFlow from '../../../hooks/useRenameFlow';
+import RenameImpactDialog from '../workspace/RenameImpactDialog';
 
 /**
  * TableEditForm - Form component for editing/creating tables
@@ -54,6 +56,10 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
   const [deleting, setDeleting] = useState(false);
 
   const isEditMode = !!table && !isCreate;
+
+  const recordName = table?.name || '';
+
+  const rename = useRenameFlow({ type: 'table', recordName, name });
   const isNewObject = table?.status === ObjectStatus.NEW;
 
   // Combine insights and models for the data source dropdown
@@ -172,6 +178,12 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a RENAME — its own server operation,
+    // confirmed first, because every `${ref()}` to this object moves with it.
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
+      return;
+    }
 
     setSaving(true);
     setSaveError(null);
@@ -218,6 +230,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
 
   return (
     <>
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
       {/* Scrollable Form Content */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-6">
@@ -234,7 +247,7 @@ const TableEditForm = ({ table, isCreate, onClose, onSave, onNavigateToEmbedded,
                 id="tableName"
                 value={name}
                 onChange={e => setName(e.target.value)}
-                disabled={isEditMode}
+                disabled={isEditMode && !rename.supported}
                 placeholder=" "
                 className={`
                   block w-full px-3 py-2.5 text-sm text-gray-900

--- a/viewer/src/components/views/common/TableEditForm.test.jsx
+++ b/viewer/src/components/views/common/TableEditForm.test.jsx
@@ -324,7 +324,9 @@ describe('TableEditForm — save payloads', () => {
     });
 
     expect(screen.getByLabelText(/Table Name/)).toHaveValue('t1');
-    expect(screen.getByLabelText(/Table Name/)).toBeDisabled();
+    // Editable in edit mode now that a rename carries the `${ref()}` rewrite
+    // with it (VIS-1209); a server without the endpoint keeps it locked.
+    expect(screen.getByLabelText(/Table Name/)).toBeEnabled();
     // A data-ref table hides the pivot section entirely.
     expect(screen.getByText('Data Source')).toBeInTheDocument();
     expect(screen.queryByText('Pivot Configuration')).not.toBeInTheDocument();

--- a/viewer/src/components/views/workspace/RenameImpactDialog.jsx
+++ b/viewer/src/components/views/workspace/RenameImpactDialog.jsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { PiArrowRight, PiPencilSimple } from 'react-icons/pi';
+import { getTypeColors, getTypeIcon } from '../common/objectTypeConfigs';
+
+/**
+ * RenameImpactDialog — what a rename will change, before it changes it.
+ *
+ * A rename is not a local edit. Every `${ref(old)}` in the project is rewritten
+ * with it, and each rewrite makes a published object uncommitted. Confirming it
+ * blind means agreeing to edits across objects you may not have open.
+ *
+ * The list comes from the server's impact query, which walks the same traversal
+ * the rename applies (`rename_service.rename_impact`, core's `rename_impact`),
+ * so it cannot promise something the rename then does differently.
+ *
+ * Props:
+ *   impact    {target, references} | null — null while loading
+ *   error     string | null — a rejection, e.g. a 409 name collision
+ *   loading   boolean
+ *   onConfirm / onCancel
+ */
+
+const SINGULAR = {
+  sources: 'source',
+  models: 'model',
+  metrics: 'metric',
+  dimensions: 'dimension',
+  relations: 'relation',
+  insights: 'insight',
+  charts: 'chart',
+  tables: 'table',
+  markdowns: 'markdown',
+  inputs: 'input',
+  dashboards: 'dashboard',
+};
+
+const typeOf = plural => SINGULAR[plural] || plural;
+
+function ReferenceRow({ reference }) {
+  const type = typeOf(reference.type);
+  const Icon = getTypeIcon(type);
+  const { bg, text } = getTypeColors(type);
+  return (
+    <li
+      data-testid={`rename-impact-reference-${reference.name}`}
+      className="flex items-center gap-2 px-3 py-1.5 text-[12.5px] text-gray-800"
+    >
+      <span
+        className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded ${bg} ${text}`}
+      >
+        {Icon && <Icon style={{ fontSize: 11 }} />}
+      </span>
+      <span className="truncate font-medium">{reference.name}</span>
+      <span className="ml-auto shrink-0 text-[11px] text-gray-400">
+        {reference.status === 'published' ? 'becomes uncommitted' : reference.status}
+      </span>
+    </li>
+  );
+}
+
+const RenameImpactDialog = ({ impact, error, loading, onConfirm, onCancel }) => {
+  const cancelRef = useRef(null);
+
+  useEffect(() => {
+    if (cancelRef.current) cancelRef.current.focus();
+    const onKey = e => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel && onCancel();
+      }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [onCancel]);
+
+  const target = impact?.target;
+  const references = impact?.references || [];
+  // Every listed object is rewritten; `published` ones are the ones this rename
+  // turns dirty, which is the part the user is being asked to accept.
+  const newlyDirty = references.filter(r => r.status === 'published').length;
+
+  return createPortal(
+    <div
+      data-testid="rename-impact-backdrop"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/30"
+      onPointerDown={e => {
+        if (e.target === e.currentTarget) onCancel && onCancel();
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="rename-impact-title"
+        data-testid="rename-impact-dialog"
+        className="w-[460px] max-w-[calc(100vw-32px)] rounded-lg bg-white p-5 shadow-xl ring-1 ring-gray-200"
+      >
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-100 text-primary">
+            <PiPencilSimple style={{ fontSize: 20 }} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 id="rename-impact-title" className="text-[15px] font-semibold text-gray-900">
+              Rename this {target ? typeOf(target.type) : 'object'}?
+            </h2>
+
+            {target && (
+              <div className="mt-1.5 flex items-center gap-1.5 text-[13px] text-gray-700">
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">{target.name}</code>
+                <PiArrowRight className="shrink-0 text-gray-400" style={{ fontSize: 12 }} />
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">
+                  {target.new_name}
+                </code>
+              </div>
+            )}
+
+            {loading && (
+              <p data-testid="rename-impact-loading" className="mt-3 text-[12.5px] text-gray-500">
+                Checking what this affects…
+              </p>
+            )}
+
+            {error && (
+              <p
+                data-testid="rename-impact-error"
+                className="mt-3 text-[12.5px] font-medium text-highlight-600"
+              >
+                {error}
+              </p>
+            )}
+
+            {!loading && !error && impact && (
+              <div className="mt-3">
+                {references.length === 0 ? (
+                  <p data-testid="rename-impact-empty" className="text-[12.5px] text-gray-500">
+                    Nothing else references it, so only this object changes.
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-[12.5px] text-gray-600">
+                      {references.length === 1
+                        ? '1 other object references it'
+                        : `${references.length} other objects reference it`}{' '}
+                      and will be updated
+                      {newlyDirty > 0 && (
+                        <>
+                          {' '}
+                          — <strong>{newlyDirty}</strong>{' '}
+                          {newlyDirty === 1 ? 'of them is' : 'of them are'} currently published, so{' '}
+                          {newlyDirty === 1 ? 'it becomes an uncommitted change' : 'they become uncommitted changes'}
+                        </>
+                      )}
+                      .
+                    </p>
+                    <ul
+                      data-testid="rename-impact-references"
+                      className="mt-2 max-h-52 overflow-y-auto rounded-md border border-gray-200 divide-y divide-gray-100"
+                    >
+                      {references.map(reference => (
+                        <ReferenceRow
+                          key={`${reference.type}:${reference.name}`}
+                          reference={reference}
+                        />
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            data-testid="rename-impact-cancel"
+            onClick={onCancel}
+            className="rounded-md px-3 py-1.5 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="rename-impact-confirm"
+            onClick={onConfirm}
+            disabled={loading || !!error || !impact}
+            className="rounded-md bg-primary px-3 py-1.5 text-[13px] font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:bg-gray-300"
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default RenameImpactDialog;

--- a/viewer/src/components/views/workspace/RenameImpactDialog.test.jsx
+++ b/viewer/src/components/views/workspace/RenameImpactDialog.test.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RenameImpactDialog from './RenameImpactDialog';
+
+const impact = {
+  target: { type: 'models', name: 'orders', new_name: 'purchases', status: 'published' },
+  references: [
+    { type: 'insights', name: 'i1', status: 'published' },
+    { type: 'metrics', name: 'total', status: 'new' },
+  ],
+};
+
+const renderDialog = (props = {}) =>
+  render(
+    <RenameImpactDialog
+      impact={impact}
+      error={null}
+      loading={false}
+      onConfirm={jest.fn()}
+      onCancel={jest.fn()}
+      {...props}
+    />
+  );
+
+describe('what the rename will change', () => {
+  test('it names both ends of the rename', () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId('rename-impact-dialog');
+    expect(dialog).toHaveTextContent('orders');
+    expect(dialog).toHaveTextContent('purchases');
+  });
+
+  test('every affected object is listed', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('rename-impact-reference-i1')).toBeInTheDocument();
+    expect(screen.getByTestId('rename-impact-reference-total')).toBeInTheDocument();
+  });
+
+  // The cost of a rename is not the rewrite, it is that clean objects become
+  // dirty and have to be committed.
+  test('it counts how many were published and are about to become uncommitted', () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId('rename-impact-dialog');
+    expect(dialog).toHaveTextContent('2 other objects reference it');
+    // Only `i1` was published; `total` was already new, so the count is 1 and
+    // the sentence has to agree with it.
+    expect(dialog).toHaveTextContent('1 of them is currently published');
+    expect(dialog).toHaveTextContent('it becomes an uncommitted change');
+    // `i1` was published; `total` was already new, so it is not counted.
+    expect(screen.getByTestId('rename-impact-reference-i1')).toHaveTextContent(
+      'becomes uncommitted'
+    );
+    expect(screen.getByTestId('rename-impact-reference-total')).toHaveTextContent('new');
+  });
+
+  test('the sentence agrees with the count', () => {
+    const { unmount } = renderDialog({
+      impact: { ...impact, references: [impact.references[0]] },
+    });
+    expect(screen.getByTestId('rename-impact-dialog')).toHaveTextContent(
+      '1 other object references it'
+    );
+    unmount();
+
+    renderDialog();
+    expect(screen.getByTestId('rename-impact-dialog')).toHaveTextContent(
+      '2 other objects reference it'
+    );
+  });
+
+  test('nothing referencing it says so plainly', () => {
+    renderDialog({ impact: { ...impact, references: [] } });
+
+    expect(screen.getByTestId('rename-impact-empty')).toHaveTextContent('only this object changes');
+  });
+});
+
+describe('it cannot be confirmed until the answer is known', () => {
+  test('confirm waits while the impact is loading', () => {
+    renderDialog({ impact: null, loading: true });
+
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+    expect(screen.getByTestId('rename-impact-loading')).toBeInTheDocument();
+  });
+
+  test('a rejection is shown and blocks confirming', () => {
+    renderDialog({ impact: null, error: "A resource named 'joined' already exists." });
+
+    expect(screen.getByTestId('rename-impact-error')).toHaveTextContent('already exists');
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+  });
+});
+
+describe('dismissal', () => {
+  test('Cancel calls back', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.click(screen.getByTestId('rename-impact-cancel'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('Escape cancels — a rename is never the accidental outcome', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('a backdrop click cancels, a click inside does not', () => {
+    const onCancel = jest.fn();
+    renderDialog({ onCancel });
+
+    fireEvent.pointerDown(screen.getByTestId('rename-impact-dialog'));
+    expect(onCancel).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(screen.getByTestId('rename-impact-backdrop'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('focus starts on Cancel, so Enter does not rename', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('rename-impact-cancel')).toHaveFocus();
+  });
+});
+
+test('Confirm calls back once the impact is known', () => {
+  const onConfirm = jest.fn();
+  renderDialog({ onConfirm });
+
+  fireEvent.click(screen.getByTestId('rename-impact-confirm'));
+
+  expect(onConfirm).toHaveBeenCalled();
+});

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -10,7 +10,9 @@ import { isEmbeddedObject } from '../common/embeddedObjectUtils';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { FormShell } from './FormShell';
-import { SAVE_ACTION, DELETE_ACTION } from './collectionKeys';
+import { SAVE_ACTION, DELETE_ACTION, FETCH_ACTION, COLLECTION_KEY } from './collectionKeys';
+import RenameImpactDialog from './RenameImpactDialog';
+import { fetchRenameImpact, renameResource, renameSupported } from '../../../api/rename';
 import { unwrapConfig } from './unwrapRecordConfig';
 import { getObjectSchemaSync } from '../../../schemas/projectSchema';
 import { useFieldParentModel } from './fields/useFieldParentModel';
@@ -81,6 +83,11 @@ export const TYPE_CONFIG = {
   },
 };
 
+/** Plural type key (what the rename API speaks) back to the viewer's singular. */
+const SINGULAR_TYPE = Object.fromEntries(
+  Object.entries(COLLECTION_KEY).map(([singular, plural]) => [plural, singular])
+);
+
 /** Fields the host renders as chrome — withheld from the generated groups. */
 const CHROME_FIELDS = ['name'];
 
@@ -92,6 +99,8 @@ const fieldLabel = (schema, name) =>
 const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoBack, onDirtyChange }) => {
   const store = useStore();
   const checkCommitStatus = store.checkCommitStatus;
+  const openWorkspaceTab = store.openWorkspaceTab;
+  const closeWorkspaceTab = store.closeWorkspaceTab;
 
   const isEmbedded = isEmbeddedObject(record);
   // MODEL-SCOPED is not the same thing as EMBEDDED, and conflating them was a
@@ -134,6 +143,12 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   const [saveError, setSaveError] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Rename runs its own confirm cycle: a name change rewrites `${ref()}` across
+  // other objects, so the user sees the list before it happens.
+  const [renameImpact, setRenameImpact] = useState(null);
+  const [renameError, setRenameError] = useState(null);
+  const [renameLoading, setRenameLoading] = useState(false);
+  const [renamePending, setRenamePending] = useState(null);
 
   const recordName = record?.config?.name || record?.name || '';
 
@@ -226,9 +241,67 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
     return Object.keys(errs).length === 0;
   };
 
+  // ---- rename ----
+  // The name is the identity key: collections, the workspace tab, the URL and
+  // every `${ref()}` are all keyed by it. So a name change is not part of the
+  // save — it is its own server operation, confirmed first.
+  const openRenameDialog = useCallback(async () => {
+    setRenamePending({ oldName: recordName, newName: name });
+    setRenameImpact(null);
+    setRenameError(null);
+    setRenameLoading(true);
+    try {
+      const impact = await fetchRenameImpact(COLLECTION_KEY[type], recordName, name);
+      setRenameImpact(impact);
+    } catch (error) {
+      setRenameError(error.message || 'Could not check what this rename affects');
+    } finally {
+      setRenameLoading(false);
+    }
+  }, [recordName, name, type]);
+
+  const closeRenameDialog = useCallback(() => {
+    setRenamePending(null);
+    setRenameImpact(null);
+    setRenameError(null);
+  }, []);
+
+  const confirmRename = useCallback(async () => {
+    if (!renamePending) return;
+    const { oldName, newName } = renamePending;
+    setRenameLoading(true);
+    try {
+      const applied = await renameResource(COLLECTION_KEY[type], oldName, newName);
+      // The server rewrote refs in other objects' configs; the client cannot
+      // know which without redoing that traversal, so refetch what it named.
+      const touched = new Set([type, ...(applied.references || []).map(r => SINGULAR_TYPE[r.type])]);
+      await Promise.all(
+        [...touched]
+          .map(t => FETCH_ACTION[t])
+          .filter(action => typeof store[action] === 'function')
+          .map(action => store[action]())
+      );
+      // The open tab and the URL are keyed `type:name`; both must follow.
+      if (closeWorkspaceTab) closeWorkspaceTab(`${type}:${oldName}`);
+      if (openWorkspaceTab) {
+        openWorkspaceTab({ id: `${type}:${newName}`, type, name: newName });
+      }
+      if (checkCommitStatus) await checkCommitStatus();
+      closeRenameDialog();
+    } catch (error) {
+      setRenameError(error.message || `Failed to rename ${type}`);
+      setRenameLoading(false);
+    }
+  }, [renamePending, type, store, closeWorkspaceTab, openWorkspaceTab, checkCommitStatus, closeRenameDialog]);
+
   // ---- save / delete ----
   const handleSave = async () => {
     if (!validateForm()) return;
+    // A changed name in edit mode is a rename, not a field edit.
+    if (isEditMode && name !== recordName) {
+      openRenameDialog();
+      return;
+    }
     setSaving(true);
     setSaveError(null);
     // Carry the scope through the round trip; see `parentModelName` above.
@@ -354,9 +427,17 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
             label={`${singular.charAt(0).toUpperCase() + singular.slice(1)} Name`}
             value={name}
             onChange={e => applyChange({ ...config, name: e.target.value })}
-            disabled={isEditMode}
+            // Editable in edit mode only where the server can carry the
+            // rename through: changing it here without the `${ref()}` rewrite
+            // would orphan every reference to this object.
+            disabled={isEditMode && !renameSupported()}
             required
             error={mergedErrors.name}
+            helperText={
+              isEditMode && renameSupported() && name !== recordName
+                ? 'Saving will rename this object and update everything that references it.'
+                : undefined
+            }
           />
         )}
 
@@ -376,6 +457,16 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
           </FormAlert>
         )}
       </FormLayout>
+
+      {renamePending && (
+        <RenameImpactDialog
+          impact={renameImpact}
+          error={renameError}
+          loading={renameLoading}
+          onConfirm={confirmRename}
+          onCancel={closeRenameDialog}
+        />
+      )}
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/workspace/SchemaLeafForm.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.jsx
@@ -10,9 +10,9 @@ import { isEmbeddedObject } from '../common/embeddedObjectUtils';
 import { getTypeByValue } from '../common/objectTypeConfigs';
 import { BackNavigationButton } from '../../styled/BackNavigationButton';
 import { FormShell } from './FormShell';
-import { SAVE_ACTION, DELETE_ACTION, FETCH_ACTION, COLLECTION_KEY } from './collectionKeys';
+import { SAVE_ACTION, DELETE_ACTION } from './collectionKeys';
 import RenameImpactDialog from './RenameImpactDialog';
-import { fetchRenameImpact, renameResource, renameSupported } from '../../../api/rename';
+import useRenameFlow from '../../../hooks/useRenameFlow';
 import { unwrapConfig } from './unwrapRecordConfig';
 import { getObjectSchemaSync } from '../../../schemas/projectSchema';
 import { useFieldParentModel } from './fields/useFieldParentModel';
@@ -83,11 +83,6 @@ export const TYPE_CONFIG = {
   },
 };
 
-/** Plural type key (what the rename API speaks) back to the viewer's singular. */
-const SINGULAR_TYPE = Object.fromEntries(
-  Object.entries(COLLECTION_KEY).map(([singular, plural]) => [plural, singular])
-);
-
 /** Fields the host renders as chrome — withheld from the generated groups. */
 const CHROME_FIELDS = ['name'];
 
@@ -99,8 +94,6 @@ const fieldLabel = (schema, name) =>
 const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoBack, onDirtyChange }) => {
   const store = useStore();
   const checkCommitStatus = store.checkCommitStatus;
-  const openWorkspaceTab = store.openWorkspaceTab;
-  const closeWorkspaceTab = store.closeWorkspaceTab;
 
   const isEmbedded = isEmbeddedObject(record);
   // MODEL-SCOPED is not the same thing as EMBEDDED, and conflating them was a
@@ -143,12 +136,6 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   const [saveError, setSaveError] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  // Rename runs its own confirm cycle: a name change rewrites `${ref()}` across
-  // other objects, so the user sees the list before it happens.
-  const [renameImpact, setRenameImpact] = useState(null);
-  const [renameError, setRenameError] = useState(null);
-  const [renameLoading, setRenameLoading] = useState(false);
-  const [renamePending, setRenamePending] = useState(null);
 
   const recordName = record?.config?.name || record?.name || '';
 
@@ -201,6 +188,7 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
   }, [record, isCreate, type]);
 
   const name = config.name || '';
+  const rename = useRenameFlow({ type, recordName, name });
 
   // Edits update the working config; nothing persists until an explicit Save.
   const applyChange = useCallback(nextConfig => setConfig(nextConfig), []);
@@ -241,65 +229,12 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
     return Object.keys(errs).length === 0;
   };
 
-  // ---- rename ----
-  // The name is the identity key: collections, the workspace tab, the URL and
-  // every `${ref()}` are all keyed by it. So a name change is not part of the
-  // save — it is its own server operation, confirmed first.
-  const openRenameDialog = useCallback(async () => {
-    setRenamePending({ oldName: recordName, newName: name });
-    setRenameImpact(null);
-    setRenameError(null);
-    setRenameLoading(true);
-    try {
-      const impact = await fetchRenameImpact(COLLECTION_KEY[type], recordName, name);
-      setRenameImpact(impact);
-    } catch (error) {
-      setRenameError(error.message || 'Could not check what this rename affects');
-    } finally {
-      setRenameLoading(false);
-    }
-  }, [recordName, name, type]);
-
-  const closeRenameDialog = useCallback(() => {
-    setRenamePending(null);
-    setRenameImpact(null);
-    setRenameError(null);
-  }, []);
-
-  const confirmRename = useCallback(async () => {
-    if (!renamePending) return;
-    const { oldName, newName } = renamePending;
-    setRenameLoading(true);
-    try {
-      const applied = await renameResource(COLLECTION_KEY[type], oldName, newName);
-      // The server rewrote refs in other objects' configs; the client cannot
-      // know which without redoing that traversal, so refetch what it named.
-      const touched = new Set([type, ...(applied.references || []).map(r => SINGULAR_TYPE[r.type])]);
-      await Promise.all(
-        [...touched]
-          .map(t => FETCH_ACTION[t])
-          .filter(action => typeof store[action] === 'function')
-          .map(action => store[action]())
-      );
-      // The open tab and the URL are keyed `type:name`; both must follow.
-      if (closeWorkspaceTab) closeWorkspaceTab(`${type}:${oldName}`);
-      if (openWorkspaceTab) {
-        openWorkspaceTab({ id: `${type}:${newName}`, type, name: newName });
-      }
-      if (checkCommitStatus) await checkCommitStatus();
-      closeRenameDialog();
-    } catch (error) {
-      setRenameError(error.message || `Failed to rename ${type}`);
-      setRenameLoading(false);
-    }
-  }, [renamePending, type, store, closeWorkspaceTab, openWorkspaceTab, checkCommitStatus, closeRenameDialog]);
-
   // ---- save / delete ----
   const handleSave = async () => {
     if (!validateForm()) return;
     // A changed name in edit mode is a rename, not a field edit.
-    if (isEditMode && name !== recordName) {
-      openRenameDialog();
+    if (isEditMode && rename.nameChanged) {
+      rename.start();
       return;
     }
     setSaving(true);
@@ -430,11 +365,11 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
             // Editable in edit mode only where the server can carry the
             // rename through: changing it here without the `${ref()}` rewrite
             // would orphan every reference to this object.
-            disabled={isEditMode && !renameSupported()}
+            disabled={isEditMode && !rename.supported}
             required
             error={mergedErrors.name}
             helperText={
-              isEditMode && renameSupported() && name !== recordName
+              isEditMode && rename.supported && rename.nameChanged
                 ? 'Saving will rename this object and update everything that references it.'
                 : undefined
             }
@@ -458,15 +393,7 @@ const SchemaLeafForm = ({ type, record, isCreate = false, onClose, onSave, onGoB
         )}
       </FormLayout>
 
-      {renamePending && (
-        <RenameImpactDialog
-          impact={renameImpact}
-          error={renameError}
-          loading={renameLoading}
-          onConfirm={confirmRename}
-          onCancel={closeRenameDialog}
-        />
-      )}
+      {rename.dialogProps && <RenameImpactDialog {...rename.dialogProps} />}
 
       <FormFooter
         onCancel={isEditMode ? discard : onClose}

--- a/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
+++ b/viewer/src/components/views/workspace/SchemaLeafForm.test.jsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import SchemaLeafForm from './SchemaLeafForm';
+import * as renameApi from '../../../api/rename';
 
 const mockActions = {
   saveDimension: jest.fn(),
@@ -22,6 +23,10 @@ const mockActions = {
   saveRelation: jest.fn(),
   deleteRelation: jest.fn(),
   checkCommitStatus: jest.fn(),
+  openWorkspaceTab: jest.fn(),
+  closeWorkspaceTab: jest.fn(),
+  fetchMetrics: jest.fn(),
+  fetchCharts: jest.fn(),
 };
 const mockSaveNow = jest.fn();
 const mockScheduleSave = jest.fn();
@@ -35,6 +40,11 @@ jest.mock('../../../stores/store', () => ({
   __esModule: true,
   ObjectStatus: { NEW: 'NEW', MODIFIED: 'MODIFIED', PUBLISHED: 'PUBLISHED', DELETED: 'DELETED' },
   default: () => mockActions,
+}));
+jest.mock('../../../api/rename', () => ({
+  fetchRenameImpact: jest.fn(),
+  renameResource: jest.fn(),
+  renameSupported: jest.fn(() => true),
 }));
 jest.mock('../common/RefTextArea', () => ({
   __esModule: true,
@@ -74,6 +84,9 @@ const CASES = [
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // `mockReturnValue` survives `clearAllMocks`, so a test that turns rename
+  // off would otherwise leak into every later describe.
+  renameApi.renameSupported.mockReturnValue(true);
   Object.values(mockActions).forEach(fn => fn.mockResolvedValue({ success: true }));
   mockSaveNow.mockResolvedValue({ success: true });
   mockScheduleSave.mockClear();
@@ -83,6 +96,125 @@ beforeEach(() => {
     status: 'idle',
     errors: null,
   };
+});
+
+// VIS-1209: a name change in edit mode is a RENAME, not a field edit — the
+// name is the identity key for the store collection, the workspace tab, the
+// URL and every `${ref()}`, so the server has to carry it and the user has to
+// see what it touches first.
+describe('renaming through the edit form', () => {
+  const record = {
+    name: 'orders',
+    status: 'PUBLISHED',
+    config: { name: 'orders', expression: 'sum(${ref(x).a})' },
+  };
+
+  const renderEdit = async () => {
+    mockRecordSave = {
+      scheduleSave: mockScheduleSave,
+      saveNow: mockSaveNow,
+      status: 'idle',
+      errors: null,
+    };
+    return renderAndSettle(
+      <SchemaLeafForm type="metric" record={record} onClose={jest.fn()} onSave={jest.fn()} />
+    );
+  };
+
+  beforeEach(() => {
+    renameApi.renameSupported.mockReturnValue(true);
+    renameApi.fetchRenameImpact.mockResolvedValue({
+      supported: true,
+      target: { type: 'metrics', name: 'orders', new_name: 'purchases', status: 'published' },
+      references: [{ type: 'charts', name: 'c1', status: 'published' }],
+    });
+    renameApi.renameResource.mockResolvedValue({
+      renamed: true,
+      target: { type: 'metrics', name: 'orders', new_name: 'purchases' },
+      references: [{ type: 'charts', name: 'c1', status: 'published' }],
+    });
+  });
+
+  test('a changed name opens the impact dialog instead of saving', async () => {
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByTestId('rename-impact-dialog')).toBeInTheDocument();
+    expect(renameApi.fetchRenameImpact).toHaveBeenCalledWith('metrics', 'orders', 'purchases');
+    // The ordinary save path must not also fire.
+    expect(mockSaveNow).not.toHaveBeenCalled();
+  });
+
+  test('an unchanged name saves normally', async () => {
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText('Expression'), {
+      target: { value: 'sum(${ref(x).b})' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockSaveNow).toHaveBeenCalled());
+    expect(renameApi.fetchRenameImpact).not.toHaveBeenCalled();
+  });
+
+  test('cancelling leaves the object alone', async () => {
+    await renderEdit();
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByTestId('rename-impact-dialog');
+
+    fireEvent.click(screen.getByTestId('rename-impact-cancel'));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('rename-impact-dialog')).not.toBeInTheDocument()
+    );
+    expect(renameApi.renameResource).not.toHaveBeenCalled();
+  });
+
+  test('confirming renames and re-points the open tab', async () => {
+    await renderEdit();
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByTestId('rename-impact-dialog');
+
+    fireEvent.click(screen.getByTestId('rename-impact-confirm'));
+
+    await waitFor(() =>
+      expect(renameApi.renameResource).toHaveBeenCalledWith('metrics', 'orders', 'purchases')
+    );
+    // The tab and URL are keyed `type:name`, so both have to follow the rename.
+    await waitFor(() =>
+      expect(mockActions.closeWorkspaceTab).toHaveBeenCalledWith('metric:orders')
+    );
+    expect(mockActions.openWorkspaceTab).toHaveBeenCalledWith({
+      id: 'metric:purchases',
+      type: 'metric',
+      name: 'purchases',
+    });
+  });
+
+  test('a collision is shown in the dialog and nothing is renamed', async () => {
+    renameApi.fetchRenameImpact.mockRejectedValue(
+      Object.assign(new Error("A resource named 'purchases' already exists."), { status: 409 })
+    );
+    await renderEdit();
+
+    fireEvent.change(screen.getByLabelText(/Metric Name/), { target: { value: 'purchases' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByTestId('rename-impact-error')).toHaveTextContent('already exists');
+    expect(screen.getByTestId('rename-impact-confirm')).toBeDisabled();
+    expect(renameApi.renameResource).not.toHaveBeenCalled();
+  });
+
+  test('a server without rename keeps the name field locked', async () => {
+    renameApi.renameSupported.mockReturnValue(false);
+    await renderEdit();
+
+    expect(screen.getByLabelText(/Metric Name/)).toBeDisabled();
+  });
 });
 
 describe.each(CASES)('SchemaLeafForm $label', ({ type, word, nameLabel, save, del }) => {
@@ -140,7 +272,9 @@ describe.each(CASES)('SchemaLeafForm $label', ({ type, word, nameLabel, save, de
     await renderAndSettle(
       <SchemaLeafForm type={type} record={record} onClose={onClose} onSave={jest.fn()} />
     );
-    expect(screen.getByLabelText(nameLabel)).toBeDisabled();
+    // The name is editable in edit mode now that a rename can carry the
+    // `${ref()}` rewrite with it (VIS-1209); deleting is unaffected.
+    expect(screen.getByLabelText(nameLabel)).toBeEnabled();
     fireEvent.click(screen.getByTitle('Delete'));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
     await waitFor(() => expect(del()).toHaveBeenCalledWith('x1'));

--- a/viewer/src/components/views/workspace/collectionKeys.js
+++ b/viewer/src/components/views/workspace/collectionKeys.js
@@ -62,4 +62,24 @@ export const DELETE_ACTION = {
   input: 'deleteInput',
 };
 
+/**
+ * FETCH_ACTION — the store action that reloads a collection from the server.
+ * A rename rewrites `${ref()}` across other objects server-side, so the client
+ * has to refetch rather than patch: it cannot know which configs changed
+ * without redoing the server's traversal.
+ */
+export const FETCH_ACTION = {
+  source: 'fetchSources',
+  model: 'fetchModels',
+  dimension: 'fetchDimensions',
+  metric: 'fetchMetrics',
+  relation: 'fetchRelations',
+  insight: 'fetchInsights',
+  markdown: 'fetchMarkdowns',
+  chart: 'fetchCharts',
+  table: 'fetchTables',
+  dashboard: 'fetchDashboards',
+  input: 'fetchInputs',
+};
+
 export default COLLECTION_KEY;

--- a/viewer/src/config/urls.js
+++ b/viewer/src/config/urls.js
@@ -132,6 +132,8 @@ const URL_PATTERNS = {
     commitPending: '/api/commit/pending/',
     commit: '/api/commit/',
     commitDiscard: '/api/commit/discard/',
+    rename: '/api/rename/',
+    renameImpact: '/api/rename/impact/',
 
     // ---- Stateless compute ----------------------------------------------
     // No stored resource behind any of these: request in, answer out. That is

--- a/viewer/src/hooks/useRenameFlow.js
+++ b/viewer/src/hooks/useRenameFlow.js
@@ -1,0 +1,106 @@
+import { useCallback, useState } from 'react';
+import useStore from '../stores/store';
+import {
+  COLLECTION_KEY,
+  FETCH_ACTION,
+} from '../components/views/workspace/collectionKeys';
+import { fetchRenameImpact, renameResource, renameSupported } from '../api/rename';
+
+/**
+ * useRenameFlow — the confirm-then-rename cycle, once, for every edit form.
+ *
+ * The name is the identity key: store collections, the workspace tab
+ * (`type:name`), the URL (`?edit=type:name`) and every `${ref()}` are keyed by
+ * it. So a changed name is not part of the save — it is its own server
+ * operation, and one the user should see the consequences of first.
+ *
+ * Every edit form needs the same four things, which is why this is a hook
+ * rather than copied into each: ask what the rename affects, show it, apply it,
+ * then move the tab and refetch what the server rewrote.
+ *
+ * @param {object} params
+ * @param {string} params.type      viewer singular type, e.g. 'metric'
+ * @param {string} params.recordName the name as saved
+ * @param {string} params.name       the name in the form
+ * @returns {{
+ *   supported: boolean,
+ *   isRenaming: boolean,
+ *   nameChanged: boolean,
+ *   start: () => void,
+ *   dialogProps: {impact, error, loading, onConfirm, onCancel} | null,
+ * }}
+ */
+export default function useRenameFlow({ type, recordName, name }) {
+  const store = useStore();
+  const [pending, setPending] = useState(null);
+  const [impact, setImpact] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const typeKey = COLLECTION_KEY[type];
+  const nameChanged = Boolean(recordName && name && name !== recordName);
+
+  const start = useCallback(async () => {
+    setPending({ oldName: recordName, newName: name });
+    setImpact(null);
+    setError(null);
+    setLoading(true);
+    try {
+      setImpact(await fetchRenameImpact(typeKey, recordName, name));
+    } catch (caught) {
+      setError(caught.message || 'Could not check what this rename affects');
+    } finally {
+      setLoading(false);
+    }
+  }, [typeKey, recordName, name]);
+
+  const cancel = useCallback(() => {
+    setPending(null);
+    setImpact(null);
+    setError(null);
+  }, []);
+
+  const confirm = useCallback(async () => {
+    if (!pending) return;
+    const { oldName, newName } = pending;
+    setLoading(true);
+    try {
+      const applied = await renameResource(typeKey, oldName, newName);
+      // The server rewrote refs inside other objects' configs. The client
+      // cannot know which without redoing that traversal, so it refetches
+      // exactly the collections the server named.
+      const singularOf = Object.fromEntries(
+        Object.entries(COLLECTION_KEY).map(([singular, plural]) => [plural, singular])
+      );
+      const touched = new Set([
+        type,
+        ...(applied.references || []).map(reference => singularOf[reference.type]),
+      ]);
+      await Promise.all(
+        [...touched]
+          .map(each => FETCH_ACTION[each])
+          .filter(action => typeof store[action] === 'function')
+          .map(action => store[action]())
+      );
+      if (store.closeWorkspaceTab) store.closeWorkspaceTab(`${type}:${oldName}`);
+      if (store.openWorkspaceTab) {
+        store.openWorkspaceTab({ id: `${type}:${newName}`, type, name: newName });
+      }
+      if (store.checkCommitStatus) await store.checkCommitStatus();
+      cancel();
+    } catch (caught) {
+      setError(caught.message || `Failed to rename ${type}`);
+      setLoading(false);
+    }
+  }, [pending, typeKey, type, store, cancel]);
+
+  return {
+    supported: renameSupported(),
+    isRenaming: Boolean(pending),
+    nameChanged,
+    start,
+    dialogProps: pending
+      ? { impact, error, loading, onConfirm: confirm, onCancel: cancel }
+      : null,
+  };
+}


### PR DESCRIPTION
> **Stacked on #674** — that PR is the backend this calls. Base retargets to `main` once it merges.

The name field has been `disabled` in every edit form since the beginning, for a good reason: changing a name without rewriting `${ref(name)}` orphans every reference to the object. Both servers can now carry that rewrite (#674 local, core#385 cloud), so the field opens up — behind a confirmation that says what it will touch.

```
name changed + Save  ->  ask the server what this affects
                     ->  show it
                     ->  confirm  ->  rename  ->  refetch, re-point tab
```

## The dialog

Lists every object that will be updated, and counts how many are currently **published** — because the cost of a rename isn't the rewrite, it's that clean objects become uncommitted work you now have to deal with.

A collision comes back **409 from the impact query** and is shown *before* the user commits to anything, not after.

## Why this isn't part of the save

The name is the **identity key**: store collections, the workspace tab (`type:name`), the URL (`?edit=type:name`) and every `${ref()}` are all keyed by it. So a changed name diverts out of the save path entirely and becomes its own server operation, after which the client:

- **refetches the collections the server said it touched** — it can't know which configs were rewritten without redoing the server's traversal;
- **closes `type:old` and opens `type:new`**, so the tab and URL follow the rename.

## A vertical slice, not all eight forms

Per the card's own advice: API client + dialog + `SchemaLeafForm` end to end. The remaining forms keep their disabled name field until this shape is confirmed.

`renameSupported()` gates the field, so a server without the endpoints leaves it locked rather than offering an action that 404s.

## Verified in the sandbox

Against the integration project — renaming `composite_metric`:

```
[api] 200 /rename/impact/
DIALOG: Rename this metric? | composite_metric | composite_renamed |
        1 other object references it and will be updated — 1 of them is currently
        published, so it becomes an uncommitted change. |
        composite-scatter-insight | becomes uncommitted | Cancel | Rename
[api] 200 /rename/
URL: ...?edit=metric%3Acomposite_renamed
```

That run also caught a copy bug — the summary read *"1 other object reference it"*. Fixed, along with the singular of the published count, and both are now pinned by tests.

## Tests

12 dialog tests (the affected list, the published count, loading/error states blocking confirm, Escape/backdrop/focus, grammar agreement) and 6 flow tests in `SchemaLeafForm` (a changed name opens the dialog instead of saving; an unchanged name saves normally; cancel changes nothing; confirm renames and re-points the tab; a 409 is shown and nothing is renamed; an unsupporting server keeps the field locked).

`yarn test` — 367 suites, **7117 passed**. `yarn lint` clean.

One test-hygiene fix: `renameSupported.mockReturnValue` survives `clearAllMocks`, so the "server without rename" case was leaking into later describes. Reset suite-wide.

## Every edit form, not just the leaf form

`SchemaLeafForm` (metric / dimension / relation) was the only panel that could rename. Its confirm-then-rename cycle is now `viewer/src/hooks/useRenameFlow.js`, and the other eight forms are wired to it: **source, table, markdown, input, model, dashboard, chart, insight**.

The contract is identical everywhere — the name field is editable in edit mode only where the server supports rename, a changed name intercepts the save and opens the impact dialog rather than writing a second object, and confirming refetches exactly the collections the server reported rewriting.

The refactor came first and left `SchemaLeafForm`'s 48 tests untouched and green, which is what pins the hook as behaviour-preserving.

Because the name is no longer a free-form field, several edit-mode tests that used it purely to dirty the form now dirty a config field instead (`SourceEditForm` the database path, `ChartEditForm` the layout editor) — the name edit they relied on is now a rename, which is the behaviour this PR adds.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3
