### PR TITLE
"+ New Metric" stops refusing when the server can't infer columns

### DIFF
--- a/viewer/src/stores/inlineCreateStore.js
+++ b/viewer/src/stores/inlineCreateStore.js
@@ -1,4 +1,4 @@
-import { fetchModelColumnNames } from '../api/modelSchema';
+import { fetchModelSchema } from '../api/modelSchema';
 import { generateUniqueName } from '../utils/uniqueName';
 import { createRow } from '../components/views/workspace/itemMutations';
 
@@ -53,32 +53,29 @@ const needsAModel = kind =>
   `A ${kind} references a model, and this project has none yet. Create a model first.`;
 
 /**
- * A real column on `modelName`, inferred server-side (SQLGlot against the
- * source's cached schema — no query, no run required).
+ * A real column on `modelName`, inferred server-side, or null when the server
+ * has none to offer.
  *
  * The scaffolds used to hardcode `id`. Most models don't have one, so "+ New
  * Metric" produced `count(${ref(orders).id})` against a column that isn't
- * there: valid to the parser, broken the moment it runs, and the user had no
- * reason to suspect the column rather than their own edit. Guess the model —
- * that is a starting point with a name attached — but never the column.
+ * there. Guess the model — that is a starting point with a name attached —
+ * but never the column.
  *
- * @returns {Promise<string|null>} null when the columns can't be determined,
- *   which the caller turns into a refusal rather than a fabricated reference.
+ * Null is NOT a failure. Inference is best-effort: in cloud it resolves against
+ * the source's cached schema, so a source nobody has introspected yet answers
+ * 200 with no columns and `source_schema_cached: false`. Treating that as "this
+ * model is broken" blamed the user's SQL and connection for a schema cache they
+ * had never been asked to populate, and refused to create anything.
  */
 const firstColumnOf = async (state, modelName) => {
   if (!modelName) return null;
   try {
-    const columns = await fetchModelColumnNames(modelName, { projectId: state.project?.id });
-    return columns?.[0] || null;
+    const schema = await fetchModelSchema(modelName, { projectId: state.project?.id });
+    return schema?.columns?.[0]?.name || null;
   } catch {
     return null;
   }
 };
-
-/** Why a draft can't be built when a model's columns are unknown. */
-const unknownColumns = modelName =>
-  `Could not read any columns from model '${modelName}', so there is nothing to reference yet. ` +
-  `Check the model's SQL and its source connection.`;
 
 export const CREATE_TEMPLATES = {
   dashboard: {
@@ -145,9 +142,12 @@ export const CREATE_TEMPLATES = {
     config: async state => {
       const model = firstModelName(state);
       const column = await firstColumnOf(state, model);
-      if (!column) throw new Error(unknownColumns(model));
-      // eslint-disable-next-line no-template-curly-in-string
-      return { expression: `\${ref(${model}).${column}}` };
+      // Without a known column, reference the model alone: still a real ref,
+      // still valid, and the pill's picker fills the rest in.
+      return {
+        // eslint-disable-next-line no-template-curly-in-string
+        expression: column ? `\${ref(${model}).${column}}` : `\${ref(${model})}`,
+      };
     },
   },
   metric: {
@@ -159,9 +159,10 @@ export const CREATE_TEMPLATES = {
     config: async state => {
       const model = firstModelName(state);
       const column = await firstColumnOf(state, model);
-      if (!column) throw new Error(unknownColumns(model));
-      // eslint-disable-next-line no-template-curly-in-string
-      return { expression: `count(\${ref(${model}).${column}})` };
+      return {
+        // eslint-disable-next-line no-template-curly-in-string
+        expression: column ? `count(\${ref(${model}).${column}})` : `count(\${ref(${model})})`,
+      };
     },
   },
   relation: {
@@ -182,12 +183,15 @@ export const CREATE_TEMPLATES = {
         firstColumnOf(state, left),
         firstColumnOf(state, right),
       ]);
-      if (!leftColumn) throw new Error(unknownColumns(left));
-      if (!rightColumn) throw new Error(unknownColumns(right));
+      // A condition needs a property on each side (`bareRefs: false`), so with
+      // no columns to offer this falls back to a placeholder the user replaces
+      // — the validator flags it inline rather than blocking the create.
+      const leftKey = leftColumn || 'id';
+      const rightKey = rightColumn || 'id';
       return {
         join_type: 'inner',
         // eslint-disable-next-line no-template-curly-in-string
-        condition: `\${ref(${left}).${leftColumn}} = \${ref(${right}).${rightColumn}}`,
+        condition: `\${ref(${left}).${leftKey}} = \${ref(${right}).${rightKey}}`,
       };
     },
   },

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -197,6 +197,7 @@ describe('createWorkspaceObject', () => {
     // cached schema, so a source nobody has introspected answers 200 with no
     // columns — which is not "this model is broken" and must not block the
     // create. It used to, blaming the user's SQL and source connection.
+    /* eslint-disable no-template-curly-in-string */
     test.each([
       ['metric', 'count(${ref(orders)})'],
       ['dimension', '${ref(orders)}'],
@@ -216,6 +217,7 @@ describe('createWorkspaceObject', () => {
       // — just without a column nobody could confirm exists.
       expect(save.mock.calls[0][1].expression).toBe(expected);
     });
+    /* eslint-enable no-template-curly-in-string */
 
     test('a create survives the schema endpoint throwing outright', async () => {
       fetchModelSchema.mockRejectedValue(new Error('network'));

--- a/viewer/src/stores/inlineCreateStore.test.js
+++ b/viewer/src/stores/inlineCreateStore.test.js
@@ -6,17 +6,23 @@
  */
 import useStore from './store';
 import { CREATE_TEMPLATES } from './inlineCreateStore';
-import { fetchModelColumnNames } from '../api/modelSchema';
+import { fetchModelSchema } from '../api/modelSchema';
 
 // The metric/dimension/relation scaffolds ask the server which columns a model
 // actually has, rather than hardcoding `id` (which most models don't have).
 jest.mock('../api/modelSchema', () => ({
-  fetchModelColumnNames: jest.fn(async () => ['order_id', 'amount']),
+  fetchModelSchema: jest.fn(async () => ({
+    available: true,
+    columns: [{ name: 'order_id' }, { name: 'amount' }],
+  })),
 }));
 
 beforeEach(() => {
-  fetchModelColumnNames.mockClear();
-  fetchModelColumnNames.mockResolvedValue(['order_id', 'amount']);
+  fetchModelSchema.mockClear();
+  fetchModelSchema.mockResolvedValue({
+    available: true,
+    columns: [{ name: 'order_id' }, { name: 'amount' }],
+  });
 });
 
 describe('createWorkspaceObject', () => {
@@ -171,7 +177,7 @@ describe('createWorkspaceObject', () => {
     test('a metric counts a REAL column of the first model', async () => {
       // eslint-disable-next-line no-template-curly-in-string
       expect((await draftConfig('metric')).expression).toBe('count(${ref(orders).order_id})');
-      expect(fetchModelColumnNames).toHaveBeenCalledWith('orders', expect.anything());
+      expect(fetchModelSchema).toHaveBeenCalledWith('orders', expect.anything());
     });
 
     test('a dimension selects a REAL column of the first model', async () => {
@@ -187,24 +193,43 @@ describe('createWorkspaceObject', () => {
       expect(config.expression).not.toContain('.id}');
     });
 
-    test.each(['metric', 'dimension'])(
-      'a %s refuses to draft when the columns cannot be read',
-      async type => {
-        fetchModelColumnNames.mockResolvedValue([]);
-        const save = jest.fn(async () => ({ success: true }));
-        useStore.setState({
-          models: [{ name: 'orders' }],
-          [CREATE_TEMPLATES[type].collectionKey]: [],
-          [CREATE_TEMPLATES[type].saveKey]: save,
-        });
+    // Inference is BEST-EFFORT. In cloud it resolves against the source's
+    // cached schema, so a source nobody has introspected answers 200 with no
+    // columns — which is not "this model is broken" and must not block the
+    // create. It used to, blaming the user's SQL and source connection.
+    test.each([
+      ['metric', 'count(${ref(orders)})'],
+      ['dimension', '${ref(orders)}'],
+    ])('a %s still drafts when no columns come back', async (type, expected) => {
+      fetchModelSchema.mockResolvedValue({ available: true, columns: [] });
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({
+        models: [{ name: 'orders' }],
+        [CREATE_TEMPLATES[type].collectionKey]: [],
+        [CREATE_TEMPLATES[type].saveKey]: save,
+      });
 
-        const result = await useStore.getState().createWorkspaceObject(type);
+      const result = await useStore.getState().createWorkspaceObject(type);
 
-        expect(result.success).toBe(false);
-        expect(result.error).toMatch(/columns/i);
-        expect(save).not.toHaveBeenCalled();
-      }
-    );
+      expect(result.success).toBe(true);
+      // A real model ref, so it still satisfies the project-level minRefs rule
+      // — just without a column nobody could confirm exists.
+      expect(save.mock.calls[0][1].expression).toBe(expected);
+    });
+
+    test('a create survives the schema endpoint throwing outright', async () => {
+      fetchModelSchema.mockRejectedValue(new Error('network'));
+      const save = jest.fn(async () => ({ success: true }));
+      useStore.setState({
+        models: [{ name: 'orders' }],
+        metrics: [],
+        saveMetric: save,
+      });
+
+      const result = await useStore.getState().createWorkspaceObject('metric');
+
+      expect(result.success).toBe(true);
+    });
 
     test.each(['metric', 'dimension'])(
       'a %s says WHY it cannot draft one with no models, rather than posting a doomed config',


### PR DESCRIPTION
```
Could not read any columns from model 'ev_sales', so there is nothing to
reference yet. Check the model's SQL and its source connection.
```

That message is mine (#647) and it's wrong twice over: it refuses to create anything, and it blames the user's SQL and source connection for something that is usually neither.

## What's actually happening

Model-schema inference is **best-effort**. Cloud resolves it with SQLGlot against the source's **cached** schema, so a source nobody has introspected yet answers `200` with an empty column list.

Core's own view documents exactly this distinction:

```python
# False when nobody has introspected this source. The columns are still the
# best available answer, but a caller showing an empty list can tell
# "nothing resolved" from "nothing to resolve against" ...
"source_schema_cached": row is not None,
```

I discarded it. `fetchModelColumnNames` maps the response down to names and drops both `available` and `source_schema_cached` — so I read the resulting `[]` as "this model is broken" and hard-stopped.

## The fix

Read the full schema, and treat an empty answer as what it is: *no column to suggest*.

| | before | after |
|---|---|---|
| columns known | `count(${ref(orders).amount})` | unchanged |
| no columns | **refuses to create** | `count(${ref(orders)})` |

The fallback is still a real reference, still satisfies the project-level `minRefs` rule, and still invents nothing. The pill's property picker fills in the rest — which is what it's for.

A relation needs a property on each side (`bareRefs: false`), so it falls back to a placeholder the inline validator flags, rather than blocking.

**The original bug stands: never fabricate a column name.** Refusing to create the object was the overcorrection.

## Not addressed here

**Why cloud inference returned nothing for a source whose columns the canvas was displaying.** Those are two different questions with two different pipelines:

- the canvas reads the **source schema envelope** — "what tables and columns does this source physically have?"
- inference reads a `SourceSchemaJob` row and **derives** from it — "what will this model's SQL output?"

So not two sources of truth for one fact; the second is derived from the first. But the derivation failing while the base data plainly exists is a real problem and deserves its own investigation — filed separately.

Viewer **7100 passed**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3