### PR TITLE
Refuse to build a schema from unaliased SELECT columns (VIS-1329)

### DIFF
--- a/tests/jobs/test_run_sql_model_job.py
+++ b/tests/jobs/test_run_sql_model_job.py
@@ -3,6 +3,8 @@
 import json
 import os
 
+import click
+
 import pytest
 from visivo.models.models.sql_model import SqlModel
 from visivo.models.inputs.types.single_select import SingleSelectInput
@@ -152,3 +154,49 @@ class TestSqlModelSchemaArtifact:
         legacy = data[model_hash]
         assert set(legacy.keys()) == {"id", "name"}
         assert all(isinstance(v, str) for v in legacy.values())
+
+
+class TestUnaliasedColumnsFailTheRun:
+    """VIS-1329: a model whose SELECT has unaliased expression columns used to
+    preview fine and then fail deep inside an insight with "Column 'x' not
+    found", offering `_col_0` as the alternative. The run refuses instead."""
+
+    def _model(self, sql):
+        source = SourceFactory()
+        return SqlModel(name="m", sql=sql, source=f"ref({source.name})"), source
+
+    def test_an_unaliased_projection_stops_the_run(self):
+        from visivo.jobs.run_sql_model_job import _build_and_write_schema
+
+        model, source = self._model(
+            "SELECT date_trunc('day', created_at), count(*) FROM release_notes GROUP BY 1"
+        )
+
+        with pytest.raises(click.ClickException) as excinfo:
+            _build_and_write_schema(model, source, temp_folder())
+
+        message = str(excinfo.value)
+        # Names the model, both offending positions, and what to do about it.
+        assert "'m'" in message
+        assert "column 1" in message and "column 2" in message
+        assert "no alias" in message
+        assert "${ref(m)" in message
+
+    def test_the_aliased_form_writes_its_schema(self):
+        from visivo.jobs.run_sql_model_job import _build_and_write_schema
+
+        model, source = self._model("SELECT 1 as x")
+
+        schema = _build_and_write_schema(model, source, temp_folder())
+
+        assert list(schema[model.name_hash()]) == ["x"]
+
+    def test_the_placeholder_name_never_reaches_a_written_schema(self):
+        """The specific failure: `_col_0` in a schema file is unusable, because
+        the database returns `count_star()` and the author wrote neither."""
+        from visivo.jobs.run_sql_model_job import _build_and_write_schema
+
+        model, source = self._model("SELECT count(*) FROM t")
+
+        with pytest.raises(click.ClickException):
+            _build_and_write_schema(model, source, temp_folder())

--- a/tests/query/test_sqlglot_utils.py
+++ b/tests/query/test_sqlglot_utils.py
@@ -18,6 +18,7 @@ from visivo.query.sqlglot_utils import (
     has_aggregate_function,
     has_window_function,
     find_non_aggregated_expressions,
+    unaliased_projections,
     normalize_identifier_for_dialect,
 )
 
@@ -849,3 +850,41 @@ class TestNormalizeIdentifierForDialect:
         assert result.this == "MyMixedCase"
         sql = result.sql(dialect="clickhouse")
         assert sql == '"MyMixedCase"'
+
+
+class TestUnaliasedProjections:
+    """VIS-1329: an unaliased projection is named `_col_N` by SQLGlot and
+    something else entirely by the database, so a schema built from it names
+    columns no engine returns and no `${ref()}` can reach."""
+
+    def test_the_aliased_and_unaliased_forms_of_one_query_differ(self):
+        """The card's repro: identical SQL, one aliased, one not."""
+        aliased = (
+            "SELECT date_trunc('day', created_at) as date_trunc, count(*) as count "
+            "FROM release_notes GROUP BY 1"
+        )
+        unaliased = "SELECT date_trunc('day', created_at), count(*) FROM release_notes GROUP BY 1"
+
+        assert unaliased_projections(aliased, "duckdb") == []
+        assert [position for position, _ in unaliased_projections(unaliased, "duckdb")] == [1, 2]
+
+    def test_it_reports_the_expression_so_the_message_can_name_it(self):
+        found = unaliased_projections("SELECT count(*) FROM t", "duckdb")
+
+        assert found == [(1, "COUNT(*)")]
+
+    def test_names_the_database_already_agrees_on_are_left_alone(self):
+        """A bare column, a qualified one, and both star forms all arrive with a
+        name the engine will return."""
+        assert unaliased_projections("SELECT a, t.b, t.*, * FROM t", "duckdb") == []
+
+    def test_only_the_outermost_select_is_checked(self):
+        """A CTE's columns are not the model's output columns."""
+        sql = "WITH c AS (SELECT count(*) FROM t) SELECT x AS y FROM c"
+
+        assert unaliased_projections(sql, "duckdb") == []
+
+    def test_positions_point_at_the_offending_column_only(self):
+        sql = "SELECT a, count(*), b AS c FROM t"
+
+        assert unaliased_projections(sql, "duckdb") == [(2, "COUNT(*)")]

--- a/tests/server/test_model_sql_validation_views.py
+++ b/tests/server/test_model_sql_validation_views.py
@@ -1,0 +1,109 @@
+"""VIS-1329: a model's SQL is checked when it is saved, not only when it is run.
+
+Two checks and only two — it parses, and every projection carries a name the
+database will return. Both are true or false regardless of what the source
+contains, which is what makes them safe to enforce at save time: no cached
+source schema is needed, so a project that has never been introspected is
+judged the same as one that has.
+"""
+
+import json
+import os
+
+import pytest
+
+from visivo.server.flask_app import FlaskApp
+from tests.factories.model_factories import ProjectFactory
+
+
+@pytest.fixture
+def client(tmp_path):
+    project = ProjectFactory.build()
+    output_dir = str(tmp_path / "target")
+    os.makedirs(os.path.join(output_dir, "main"), exist_ok=True)
+    app = FlaskApp(output_dir=output_dir, project=project).app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _save(client, sql, name="m"):
+    return client.post(
+        f"/api/models/{name}/",
+        data=json.dumps({"name": name, "sql": sql}),
+        content_type="application/json",
+    )
+
+
+def test_sql_that_does_not_parse_is_refused(client):
+    response = _save(client, "SELECT FROM WHERE ORDER (")
+
+    assert response.status_code == 400
+    assert "does not parse" in response.get_json()["error"]
+
+
+def test_an_unaliased_projection_is_refused(client):
+    response = _save(client, "SELECT date_trunc('day', created_at), count(*) FROM t GROUP BY 1")
+
+    assert response.status_code == 400
+    error = response.get_json()["error"]
+    assert "no alias" in error
+    assert "column 1" in error and "column 2" in error
+    # Says what to write, not just what is wrong.
+    assert "${ref(m)" in error
+
+
+def test_the_aliased_form_saves(client):
+    response = _save(
+        client,
+        "SELECT date_trunc('day', created_at) as day, count(*) as row_count FROM t GROUP BY 1",
+    )
+
+    assert response.status_code in (200, 201)
+
+
+def test_a_star_select_saves(client):
+    """`*` carries whatever names the source has — nothing to object to."""
+    assert _save(client, "SELECT * FROM t").status_code in (200, 201)
+
+
+def test_an_unknown_table_still_saves(client):
+    """Deliberately NOT validated here: answering it needs the source's cached
+    schema, and a source that has never been introspected has none — so asking
+    would reject good SQL from exactly the projects least able to prove
+    otherwise. The run still checks it."""
+    assert _save(client, "SELECT a AS b FROM a_table_that_does_not_exist").status_code in (200, 201)
+
+
+def test_the_validate_endpoint_reports_the_same_problem(client):
+    response = client.post(
+        "/api/models/m/validate/",
+        data=json.dumps({"name": "m", "sql": "SELECT count(*) FROM t"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["valid"] is False
+    assert "no alias" in body["error"]
+
+
+def test_a_model_with_no_sql_is_not_blocked(client):
+    """Not every model carries SQL, and an empty editor is not an error."""
+    response = client.post(
+        "/api/models/m/",
+        data=json.dumps({"name": "m", "sql": ""}),
+        content_type="application/json",
+    )
+
+    assert response.status_code != 400
+
+
+def test_a_dialect_that_cannot_be_resolved_never_condemns_the_sql():
+    """A source we can't resolve yields a garbage dialect, and that is not the
+    author's fault — perfectly good SQL must not be reported as unparseable."""
+    from visivo.server.model_sql_validation import validate_model_sql
+
+    assert validate_model_sql("SELECT a AS b FROM t", object(), "m") is None
+    assert validate_model_sql("SELECT a AS b FROM t", "not_a_real_dialect", "m") is None
+    # The alias check still runs once it falls back to the generic parse.
+    assert "no alias" in validate_model_sql("SELECT count(*) FROM t", "not_a_real_dialect", "m")

--- a/tests/server/test_run_views.py
+++ b/tests/server/test_run_views.py
@@ -329,17 +329,17 @@ class TestDataAffectingGate:
 
     def test_model_config_change_runs(self, integration_client):
         with patch("visivo.server.views.run_views.request_run") as req:
-            integration_client.post("/api/models/m/", json={"sql": "select 1"})
+            integration_client.post("/api/models/m/", json={"sql": "select 1 as x"})
             req.reset_mock()
-            integration_client.post("/api/models/m/", json={"sql": "select 2"})
+            integration_client.post("/api/models/m/", json={"sql": "select 2 as x"})
             req.assert_called_once()
             assert req.call_args[0][1] == ["m"]
 
     def test_idempotent_save_skips_run(self, integration_client):
         with patch("visivo.server.views.run_views.request_run") as req:
-            integration_client.post("/api/models/m/", json={"sql": "select 1"})
+            integration_client.post("/api/models/m/", json={"sql": "select 1 as x"})
             req.reset_mock()
-            integration_client.post("/api/models/m/", json={"sql": "select 1"})
+            integration_client.post("/api/models/m/", json={"sql": "select 1 as x"})
             req.assert_not_called()
 
     def test_deleting_a_data_producing_resource_runs(self, integration_client):

--- a/tests/server/views/test_commit_views.py
+++ b/tests/server/views/test_commit_views.py
@@ -384,7 +384,7 @@ class TestExplorationCommitExclusion:
         # A dirty exploration (create + draft edit + rename) sits alongside a
         # genuinely dirty model, so /changes/'s response is non-trivial and
         # this isn't just "the endpoint returns an empty list either way".
-        integration_client.post("/api/models/exploration_gap_model/", json={"sql": "select 1"})
+        integration_client.post("/api/models/exploration_gap_model/", json={"sql": "select 1 as x"})
 
         created = integration_client.post("/api/explorations/", json={"name": "Scratch"}).get_json()
         integration_client.post(

--- a/visivo/jobs/run_sql_model_job.py
+++ b/visivo/jobs/run_sql_model_job.py
@@ -25,7 +25,11 @@ from visivo.query.sql_table_extractor import (
     extract_table_references,
     extract_schema_references,
 )
-from visivo.query.sqlglot_utils import schema_from_sql, unaliased_projections
+from visivo.query.sqlglot_utils import (
+    schema_from_sql,
+    unaliased_projection_message,
+    unaliased_projections,
+)
 from visivo.query.model_schema_inference import infer_model_columns
 from visivo.constants import DEFAULT_RUN_ID
 
@@ -62,13 +66,7 @@ def _build_and_write_schema(
     # "Column 'x' not found" inside an insight, listing `_col_0` as the choice.
     unaliased = unaliased_projections(sql, sqlglot_dialect)
     if unaliased:
-        listed = "\n".join(f"  column {position}: {text}" for position, text in unaliased)
-        raise click.ClickException(
-            f"Model '{sql_model.name}' has SELECT columns with no alias, so nothing "
-            f"can reference them:\n{listed}\n"
-            f"Give each one an alias (e.g. `count(*) as row_count`) so "
-            f"${{ref({sql_model.name}).<name>}} can resolve it."
-        )
+        raise click.ClickException(unaliased_projection_message(sql_model.name, unaliased))
 
     # Use cached provider if available (performance optimization)
     if schema_cache is not None:

--- a/visivo/jobs/run_sql_model_job.py
+++ b/visivo/jobs/run_sql_model_job.py
@@ -1,5 +1,6 @@
 import os
 import json
+import click
 from time import time
 from typing import Optional
 from sqlglot import exp
@@ -24,7 +25,7 @@ from visivo.query.sql_table_extractor import (
     extract_table_references,
     extract_schema_references,
 )
-from visivo.query.sqlglot_utils import schema_from_sql
+from visivo.query.sqlglot_utils import schema_from_sql, unaliased_projections
 from visivo.query.model_schema_inference import infer_model_columns
 from visivo.constants import DEFAULT_RUN_ID
 
@@ -55,6 +56,19 @@ def _build_and_write_schema(
     sql = sql_model.sql
 
     Logger.instance().debug(f"Building schema for model {sql_model.name}")
+
+    # Refuse to write a schema naming columns the database will not return. The
+    # run is where the author can still act; three steps later this surfaces as
+    # "Column 'x' not found" inside an insight, listing `_col_0` as the choice.
+    unaliased = unaliased_projections(sql, sqlglot_dialect)
+    if unaliased:
+        listed = "\n".join(f"  column {position}: {text}" for position, text in unaliased)
+        raise click.ClickException(
+            f"Model '{sql_model.name}' has SELECT columns with no alias, so nothing "
+            f"can reference them:\n{listed}\n"
+            f"Give each one an alias (e.g. `count(*) as row_count`) so "
+            f"${{ref({sql_model.name}).<name>}} can resolve it."
+        )
 
     # Use cached provider if available (performance optimization)
     if schema_cache is not None:

--- a/visivo/query/sqlglot_utils.py
+++ b/visivo/query/sqlglot_utils.py
@@ -470,6 +470,21 @@ def unaliased_projections(sql: str, sqlglot_dialect: str) -> list:
     ]
 
 
+def unaliased_projection_message(model_name: str, unaliased: list) -> str:
+    """The one wording for "these columns have no alias".
+
+    Shared by the save-time check and the run's backstop so the two cannot
+    drift into describing the same problem differently.
+    """
+    listed = "\n".join(f"  column {position}: {text}" for position, text in unaliased)
+    return (
+        f"Model '{model_name}' has SELECT columns with no alias, so nothing "
+        f"can reference them:\n{listed}\n"
+        f"Give each one an alias (e.g. `count(*) as row_count`) so "
+        f"${{ref({model_name}).<name>}} can resolve it."
+    )
+
+
 def schema_from_sql(
     sqlglot_dialect: str,
     sql: str,

--- a/visivo/query/sqlglot_utils.py
+++ b/visivo/query/sqlglot_utils.py
@@ -446,6 +446,30 @@ def _describe_available(schema: dict) -> str:
     return f"Available tables: {shown}{suffix}"
 
 
+def unaliased_projections(sql: str, sqlglot_dialect: str) -> list:
+    """The SELECT columns a run could never address, as ``[(position, sql)]``.
+
+    SQLGlot names an unaliased expression ``_col_N``, while the database returns
+    something else entirely — DuckDB answers ``count_star()`` for ``count(*)``.
+    A schema built from the first is unusable against the second: every
+    ``${ref(model).column}`` resolves against names no engine will ever return.
+    An aliased projection, a bare column and a star all carry a name the
+    database agrees with; nothing else does.
+
+    Positions are 1-based, because the message they end up in is read against
+    the SELECT list.
+    """
+    expr = sqlglot.parse_one(sql, read=sqlglot_dialect)
+    select = expr.find(exp.Select)
+    if select is None:
+        return []
+    return [
+        (position, projection.sql(dialect=sqlglot_dialect))
+        for position, projection in enumerate(select.expressions, start=1)
+        if not isinstance(projection, (exp.Alias, exp.Column, exp.Star))
+    ]
+
+
 def schema_from_sql(
     sqlglot_dialect: str,
     sql: str,

--- a/visivo/server/model_sql_validation.py
+++ b/visivo/server/model_sql_validation.py
@@ -1,0 +1,112 @@
+"""Validate a model's SQL when it is saved, not when it is run (VIS-1329).
+
+Two checks, and deliberately only two: the SQL has to parse, and every
+projection has to carry a name the database will return. Both are wrong
+regardless of what the source contains, so neither needs a cached source schema
+and both give the same answer whoever is asking.
+
+Whether the tables and columns exist is a different question. Answering it
+means qualifying against the source's cached schema, and a source that has
+never been introspected has none — so asking it here would reject good SQL for
+the projects least able to prove otherwise. That check belongs where the schema
+is known, and the run already does it.
+"""
+
+import sqlglot
+
+from visivo.models.base.context_string import ContextString
+from visivo.query.patterns import REF_PROPERTY_PATTERN, extract_ref_names
+from visivo.query.sqlglot_utils import (
+    unaliased_projection_message,
+    unaliased_projections,
+)
+
+
+def source_ref_name(value) -> str:
+    """The source NAME out of a model's ``source`` field, in any form it takes.
+
+    A saved config carries it as ``${ref(wh)}`` or ``ref(wh)``; a literal name
+    is also accepted, since that is what a hand-written project may hold.
+    """
+    if isinstance(value, ContextString):
+        return value.get_reference()
+    if not isinstance(value, str):
+        return None
+    names = extract_ref_names(value)
+    if names:
+        return next(iter(names))
+    import re
+
+    match = re.match(REF_PROPERTY_PATTERN, value.strip())
+    if match:
+        return match.group("model_name")
+    return value.strip() or None
+
+
+def dialect_for_model(flask_app, config) -> str:
+    """The SQLGlot dialect this model will be run against, or ``None``.
+
+    ``None`` is a valid answer, not a failure: an unresolvable source means the
+    generic dialect, which still parses ordinary SQL. Refusing to validate would
+    be worse than validating a little less precisely.
+    """
+    name = source_ref_name((config or {}).get("source"))
+    if not name:
+        project = getattr(flask_app, "project", None)
+        defaults = getattr(project, "defaults", None)
+        name = getattr(defaults, "source_name", None)
+    if not isinstance(name, str) or not name:
+        return None
+
+    source = _source_named(flask_app, name)
+    if source is None:
+        return None
+    try:
+        dialect = source.get_sqlglot_dialect()
+    except Exception:
+        return None
+    return dialect if isinstance(dialect, str) and dialect else None
+
+
+def validate_model_sql(sql, sqlglot_dialect, model_name):
+    """The problem with ``sql``, as a message, or ``None`` when there isn't one."""
+    if not sql or not str(sql).strip():
+        return None
+
+    dialect = sqlglot_dialect if isinstance(sqlglot_dialect, str) and sqlglot_dialect else None
+    try:
+        sqlglot.parse_one(sql, read=dialect)
+    except Exception as error:
+        # A dialect this parser does not know is not the author's fault. Only
+        # the generic parse failing too is evidence against the SQL itself.
+        if dialect is None:
+            return f"Model '{model_name}' has SQL that does not parse: {error}"
+        try:
+            sqlglot.parse_one(sql)
+        except Exception:
+            return f"Model '{model_name}' has SQL that does not parse: {error}"
+        dialect = None
+
+    unaliased = unaliased_projections(sql, dialect)
+    if unaliased:
+        return unaliased_projection_message(model_name, unaliased)
+    return None
+
+
+def _source_named(flask_app, name):
+    """Draft cache first, then the committed project — the order every other
+    lookup here uses, so a source created in the editor resolves too."""
+    manager = getattr(flask_app, "source_manager", None)
+    getter = getattr(manager, "get", None)
+    if callable(getter):
+        try:
+            found = getter(name)
+            if found is not None:
+                return found
+        except Exception:
+            pass
+    project = getattr(flask_app, "project", None)
+    for source in getattr(project, "sources", None) or []:
+        if getattr(source, "name", None) == name:
+            return source
+    return None

--- a/visivo/server/views/models_views.py
+++ b/visivo/server/views/models_views.py
@@ -2,6 +2,7 @@ from flask import jsonify, request
 from pydantic import ValidationError
 from visivo.logger.logger import Logger
 from visivo.server.managers.object_manager import ObjectStatus
+from visivo.server.model_sql_validation import dialect_for_model, validate_model_sql
 
 
 def register_models_views(app, flask_app, output_dir):
@@ -39,6 +40,14 @@ def register_models_views(app, flask_app, output_dir):
 
             # Ensure name matches URL parameter
             model_config["name"] = model_name
+
+            problem = validate_model_sql(
+                model_config.get("sql"),
+                dialect_for_model(flask_app, model_config),
+                model_name,
+            )
+            if problem:
+                return jsonify({"error": problem}), 400
 
             model = flask_app.model_manager.save_from_config(model_config)
             status = flask_app.model_manager.get_status(model_name)
@@ -98,6 +107,14 @@ def register_models_views(app, flask_app, output_dir):
 
             # Ensure name matches URL parameter
             model_config["name"] = model_name
+
+            problem = validate_model_sql(
+                model_config.get("sql"),
+                dialect_for_model(flask_app, model_config),
+                model_name,
+            )
+            if problem:
+                return jsonify({"valid": False, "error": problem}), 400
 
             result = flask_app.model_manager.validate_config(model_config)
             if result.get("valid"):


### PR DESCRIPTION
Closes VIS-1329.

## The bug

A model whose SELECT has unaliased expression columns previews fine and then fails the run:

```sql
-- works
SELECT date_trunc('day', created_at) as date_trunc, count(*) as count
FROM release_notes GROUP BY 1

-- query runs, run fails
SELECT date_trunc('day', created_at), count(*)
FROM release_notes GROUP BY 1
```

```
Failed job for insight i-unaliased ....... [FAILURE]
  error: Column 'date_trunc' not found on model 'm_unaliased'.
  Available columns:
    _col_0      | UNKNOWN
    _col_1      | BIGINT
```

`_col_N` appears nowhere in `visivo/` — it is **SQLGlot's placeholder for an unaliased projection**. The database returns something else entirely (DuckDB answers `count_star()` for `count(*)`; Postgres says `count`). So the stored schema named columns *no engine will ever return and no author can reference*, and `${ref(model).column}` had nothing to resolve against.

The model's quick **Run** disagreed because it executes the SQL and renders the driver's real result columns. Same SQL, two different notions of "the columns" — and the one you watched succeed is not the one that fails.

## The change

Per the card's recommended option (1): refuse to infer, at the model, where the author can still act.

`unaliased_projections(sql, dialect)` returns the offending `(position, sql)` pairs, and `_build_and_write_schema` raises before writing anything:

```
Model 'm_unaliased' has SELECT columns with no alias, so nothing can reference them:
  column 1: DATE_TRUNC('day', created_at)
  column 2: COUNT(*)
Give each one an alias (e.g. `count(*) as row_count`) so ${ref(m_unaliased).<name>} can resolve it.
```

That also answers the card's "also worth fixing": the old message offered `_col_0` and `_col_1` as if they were choices.

Two deliberate details:

- **Detection is on the parsed AST, not the `_col_N` string.** An aliased expression, a bare column (`a`, `t.b`) and both star forms (`*`, `t.*`) all arrive carrying a name the database agrees with; nothing else does. Sniffing for `_col_\d+` would also misfire on a real column genuinely named that.
- **Only the outermost SELECT is checked** — a CTE's columns are not the model's output columns. This matches how `schema_from_sql` already picks the select it reads.

The guard sits in the job rather than in `infer_model_columns`, for two reasons: the job's two branches (cached provider vs. stored schema) both pass through it, and inference is shared with the editor endpoints, which must stay tolerant — half-written SQL is the normal state there, not an error.

## Validated on save, not only on run

The run refusing bad SQL is a backstop, not the right moment — by then the author has moved on. `POST /api/models/<name>/` (and `.../validate/`) now runs the same two checks and returns 400 with the same message, so the editor, a direct API write and a promoted exploration all get told at the point of writing.

Deliberately **only** those two checks — the SQL parses, and every projection carries a name the database will return. Both hold regardless of what the source contains, so neither needs a cached source schema and a project that has never been introspected is judged the same as one that has. Whether the tables and columns *exist* is left to the run, where the schema is known: asking it at save would reject good SQL from exactly the projects least able to prove otherwise (see VIS-1330/VIS-1331 for that failure mode).

Two robustness details, both found by existing tests rather than guessed at:

- **A dialect we could not resolve is not evidence against the author's SQL.** An unresolvable source yields no dialect rather than a failure, and a dialect the parser rejects falls back to the generic parse. Without this, a project whose source can't be resolved had all of its perfectly good SQL reported as unparseable.
- **Exploration draft queries are untouched.** `POST /api/explorations/<id>/` with `draft.queries` is not a model save and is not validated here; only saved models are.

The message now lives in one place (`unaliased_projection_message`), shared by the save check and the run's backstop so the two can't drift.

### Behaviour change worth a look

`select 1` is no longer a valid model — it produces `_col_0`, which nothing can reference. Four tests in this repo used it as a throwaway model and now say `select 1 as x`. That's the rule working as intended, but it does mean an existing scratch model without aliases will start failing to save, with a message naming the column and what to write.


## Verification

- 8 tests on the save endpoint: parse failure, unaliased projection, the aliased form saving, `SELECT *`, an unknown table still saving (deliberately not our business), the validate endpoint reporting the same thing, empty SQL, and the unresolvable-dialect guard.
- 5 unit tests on the detector: the card's exact aliased/unaliased pair, the reported expression text, names the database already agrees on, CTE scoping, position accuracy.
- 3 job-level tests: the run refuses and the message names the model / both positions / the fix; the aliased form still writes its schema; `SELECT count(*)` never reaches a written schema.
- Full Python suite: **2555 passed**, 2 skipped, 5 xfailed. `black` clean.
- Scanned every model in `test-projects/` through the new detector: **0 would newly fail**, so the integration projects CI runs are unaffected.

## Note on scope

This makes an unaliased expression column a hard error rather than a silently-wrong schema. That is the intent — such a column is not addressable by design — but it does mean a project that previously "ran" with an unreachable column now fails until an alias is added. The message says exactly which column and what to write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3

