### PR TITLE
Add `visivo format` — a canonical project writer (VIS-1196)

### DIFF
--- a/tests/commands/test_format_phase.py
+++ b/tests/commands/test_format_phase.py
@@ -1,0 +1,80 @@
+"""VIS-1196: which files `visivo format` is allowed to touch.
+
+`Discover.files` is built for parsing, so it deliberately returns more than a
+formatter may write to. Getting this wrong is not a cosmetic bug: formatting a
+git-backed include dirties a clone of somebody else's repository, and formatting
+the profile rewrites the user's credentials file.
+"""
+
+import os
+
+from visivo.commands.format_phase import _project_files, format_phase
+
+PROJECT = """\
+name: demo
+models:
+  - sql: SELECT 1
+    name: orders
+"""
+
+
+def _project(tmp_path):
+    (tmp_path / "project.visivo.yml").write_text(PROJECT)
+    return str(tmp_path)
+
+
+class TestWhichFilesAreFormatted:
+    def test_the_project_file_is_included(self, tmp_path):
+        working_dir = _project(tmp_path)
+
+        files = _project_files(working_dir, os.path.join(working_dir, "target"), ())
+
+        assert [os.path.basename(f) for f in files] == ["project.visivo.yml"]
+
+    def test_git_backed_includes_are_left_alone(self, tmp_path):
+        """`.visivo_cache` holds clones of other people's repositories."""
+        working_dir = _project(tmp_path)
+        cache = tmp_path / ".visivo_cache" / "someone-else"
+        cache.mkdir(parents=True)
+        (cache / "models.yml").write_text(PROJECT)
+
+        files = _project_files(working_dir, os.path.join(working_dir, "target"), ())
+
+        assert not any(".visivo_cache" in f for f in files)
+
+    def test_the_output_directory_is_left_alone(self, tmp_path):
+        working_dir = _project(tmp_path)
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "generated.yml").write_text(PROJECT)
+
+        files = _project_files(working_dir, str(target), ())
+
+        assert not any("target" in f for f in files)
+
+    def test_explicit_paths_win(self, tmp_path):
+        working_dir = _project(tmp_path)
+        other = tmp_path / "other.yml"
+        other.write_text(PROJECT)
+
+        files = _project_files(working_dir, os.path.join(working_dir, "target"), (str(other),))
+
+        assert files == [str(other)]
+
+
+class TestCheckMode:
+    def test_check_reports_without_writing(self, tmp_path):
+        working_dir = _project(tmp_path)
+        before = (tmp_path / "project.visivo.yml").read_text()
+
+        changed = format_phase(working_dir, os.path.join(working_dir, "target"), check=True)
+
+        assert changed == 1
+        assert (tmp_path / "project.visivo.yml").read_text() == before
+
+    def test_formatting_then_checking_is_clean(self, tmp_path):
+        working_dir = _project(tmp_path)
+        output_dir = os.path.join(working_dir, "target")
+
+        assert format_phase(working_dir, output_dir) == 1
+        assert format_phase(working_dir, output_dir, check=True) == 0

--- a/tests/parsers/test_canonical_yaml.py
+++ b/tests/parsers/test_canonical_yaml.py
@@ -1,0 +1,171 @@
+"""VIS-1196: the canonical project formatter.
+
+The property that matters most is that formatting is **information-preserving**.
+Once the cloud writes YAML into a customer's repo the repo is the source of
+truth, so a key silently dropped or a value silently changed is authoritative
+data loss — invisible in review, surfacing later as a dashboard that stopped
+rendering.
+"""
+
+import yaml
+
+from visivo.parsers.canonical_yaml import (
+    canonicalize,
+    format_text,
+    key_order_for_project_key,
+    project_key_order,
+)
+
+
+def plain(value):
+    """Compare as plain dicts, never as loaded YAML mappings.
+
+    `setup_yaml_ordered_dict()` registers `YamlOrderedDict` globally on
+    `yaml.SafeLoader`, and it extends `OrderedDict` — whose `__eq__` is
+    ORDER-SENSITIVE. So once anything in the process has triggered that
+    registration, `yaml.safe_load(a) == yaml.safe_load(b)` reports every
+    reordering as a difference, which is precisely what this formatter does on
+    purpose. The test passes alone and fails in the full suite otherwise.
+
+    Worth carrying to VIS-1198: the round-trip fidelity harness compares parsed
+    structures, so it has to convert the same way or it will fail on key order
+    rather than on lost data.
+    """
+    if isinstance(value, dict):
+        return {key: plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [plain(item) for item in value]
+    return value
+
+
+UNFORMATTED = """\
+name: demo
+
+models:
+  - sql: SELECT 1 as x
+    name: orders
+    source: ${ref(db)}
+
+sources:
+  - database: local.db
+    type: sqlite
+    name: db
+"""
+
+
+class TestNothingIsLost:
+    def test_formatting_never_changes_meaning(self):
+        assert plain(yaml.safe_load(format_text(UNFORMATTED))) == plain(yaml.safe_load(UNFORMATTED))
+
+    def test_a_key_the_formatter_does_not_know_is_kept(self):
+        """An unknown key is far more likely to be a newer Visivo version's
+        field than a mistake. Dropping it would be data loss."""
+        text = "sources:\n  - name: db\n    type: sqlite\n    some_future_key: keep me\n"
+
+        formatted = format_text(text)
+
+        assert "some_future_key: keep me" in formatted
+        assert plain(yaml.safe_load(formatted)) == plain(yaml.safe_load(text))
+
+    def test_comments_survive(self):
+        text = "# top comment\nname: demo\nmodels:\n  # about orders\n  - name: orders\n    sql: SELECT 1\n"
+
+        formatted = format_text(text)
+
+        assert "# top comment" in formatted
+        assert "# about orders" in formatted
+
+    def test_an_empty_document_is_returned_unchanged(self):
+        assert format_text("") == ""
+        assert format_text("# just a comment\n") == "# just a comment\n"
+
+
+class TestCanonicalOrder:
+    def test_name_leads_and_type_follows_it(self):
+        """`name` is identity and `type` is the discriminator, whatever order
+        the model happens to declare them in — SqliteSource declares `type`
+        tenth, which is an inheritance artifact rather than an authoring order.
+        """
+        order = key_order_for_project_key("sources")
+
+        assert order[0] == "name"
+        assert order[1] == "type"
+
+    def test_order_is_derived_from_the_models(self):
+        """Not a hand-maintained list — a model's own field order, so the
+        formatter cannot drift from the schema."""
+        assert key_order_for_project_key("models")[:3] == ["name", "sql", "source"]
+
+    def test_every_project_key_resolves_its_variants(self):
+        """`sources` is ten classes and `dashboards` two, wrapped in NewType and
+        Annotated layers by generate_ref_field. If unwrapping regresses, the
+        order silently becomes empty and nothing gets sorted."""
+        for project_key in ("sources", "models", "dashboards", "inputs", "metrics"):
+            assert key_order_for_project_key(project_key), project_key
+
+    def test_keys_are_reordered_within_an_object(self):
+        formatted = format_text(UNFORMATTED)
+        model_block = formatted.split("models:")[1]
+
+        assert model_block.index("name: orders") < model_block.index("sql:")
+
+    def test_tool_written_keys_sort_after_authored_ones(self):
+        """`cli_version` and friends are written by tooling, so they belong
+        after the content rather than between `name` and `includes`."""
+        order = project_key_order()
+
+        assert "cli_version" not in order
+        assert order[:2] == ["name", "defaults"]
+
+
+class TestIdempotence:
+    def test_formatting_twice_changes_nothing_the_second_time(self):
+        once = format_text(UNFORMATTED)
+
+        assert format_text(once) == once
+
+    def test_an_already_canonical_document_is_untouched(self):
+        once = format_text(UNFORMATTED)
+
+        assert format_text(once) == once
+
+
+class TestScalars:
+    def test_multiline_sql_becomes_a_block_scalar(self):
+        text = 'models:\n  - name: m\n    sql: "SELECT 1\\nFROM t"\n'
+
+        formatted = format_text(text)
+
+        assert "sql: |-" in formatted or "sql: |" in formatted
+        assert yaml.safe_load(formatted)["models"][0]["sql"] == "SELECT 1\nFROM t"
+
+    def test_a_single_line_string_stays_inline(self):
+        formatted = format_text("models:\n  - name: m\n    sql: SELECT 1\n")
+
+        assert "sql: SELECT 1" in formatted
+
+
+class TestListOrder:
+    def test_list_order_is_never_changed(self):
+        """Dashboard rows and their items render in the order they appear, and
+        there is no way to tell a semantic list from an incidental one without
+        knowing the type — so none are sorted."""
+        text = (
+            "dashboards:\n"
+            "  - name: d\n"
+            "    rows:\n"
+            "      - height: medium\n"
+            "      - height: small\n"
+            "      - height: large\n"
+        )
+
+        heights = [
+            row["height"] for row in yaml.safe_load(format_text(text))["dashboards"][0]["rows"]
+        ]
+
+        assert heights == ["medium", "small", "large"]
+
+
+def test_canonicalize_returns_non_mapping_input_untouched():
+    assert canonicalize(None) is None
+    assert canonicalize([1, 2]) == [1, 2]

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -98,14 +98,3 @@ def test_format_is_registered_on_the_cli():
     from visivo.command_line import visivo
 
     assert "format" in visivo.commands
-
-
-def test_format_import_does_not_shadow_the_builtin():
-    """`from ... import format` would rebind `format` for the whole module, so a
-    later bare `format(...)` in command_line.py would silently call the click
-    command instead of the builtin. It is imported aliased for that reason."""
-    import visivo.command_line as command_line
-
-    # The module must not bind the name at all — it imports `format_command`.
-    assert not hasattr(command_line, "format")
-    assert hasattr(command_line, "format_command")

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -86,3 +86,26 @@ def test_generic_exception_still_reports_the_issue_url():
 
     assert "An unexpected error has occurred" in output
     assert "Click here to report this issue" in output
+
+
+def test_format_is_registered_on_the_cli():
+    """VIS-1196: a command that exists but isn't wired up is invisible.
+
+    Registration lives in two places (the import and `add_command`), so it is
+    easy to half-do — and the failure looks like "no such command", which reads
+    as a stale install rather than a missing line.
+    """
+    from visivo.command_line import visivo
+
+    assert "format" in visivo.commands
+
+
+def test_format_import_does_not_shadow_the_builtin():
+    """`from ... import format` would rebind `format` for the whole module, so a
+    later bare `format(...)` in command_line.py would silently call the click
+    command instead of the builtin. It is imported aliased for that reason."""
+    import visivo.command_line as command_line
+
+    # The module must not bind the name at all — it imports `format_command`.
+    assert not hasattr(command_line, "format")
+    assert hasattr(command_line, "format_command")

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -31,8 +31,7 @@ from visivo.commands.run import run
 from visivo.commands.dist import dist
 from visivo.commands.compile import compile
 
-# Aliased: a bare `format` here would shadow the builtin for the whole module.
-from visivo.commands.format import format as format_command
+from visivo.commands.format import format
 from visivo.commands.init import init
 from visivo.commands.create import create
 from visivo.commands.test import test
@@ -82,7 +81,7 @@ def visivo(env_file, profile, verbose):
 visivo.add_command(init)
 visivo.add_command(dbt)
 visivo.add_command(compile)
-visivo.add_command(format_command)
+visivo.add_command(format)
 visivo.add_command(run)
 visivo.add_command(serve)
 visivo.add_command(deploy)

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -30,7 +30,9 @@ from visivo.commands.serve import serve
 from visivo.commands.run import run
 from visivo.commands.dist import dist
 from visivo.commands.compile import compile
-from visivo.commands.format import format
+
+# Aliased: a bare `format` here would shadow the builtin for the whole module.
+from visivo.commands.format import format as format_command
 from visivo.commands.init import init
 from visivo.commands.create import create
 from visivo.commands.test import test
@@ -80,7 +82,7 @@ def visivo(env_file, profile, verbose):
 visivo.add_command(init)
 visivo.add_command(dbt)
 visivo.add_command(compile)
-visivo.add_command(format)
+visivo.add_command(format_command)
 visivo.add_command(run)
 visivo.add_command(serve)
 visivo.add_command(deploy)

--- a/visivo/command_line.py
+++ b/visivo/command_line.py
@@ -30,6 +30,7 @@ from visivo.commands.serve import serve
 from visivo.commands.run import run
 from visivo.commands.dist import dist
 from visivo.commands.compile import compile
+from visivo.commands.format import format
 from visivo.commands.init import init
 from visivo.commands.create import create
 from visivo.commands.test import test
@@ -79,6 +80,7 @@ def visivo(env_file, profile, verbose):
 visivo.add_command(init)
 visivo.add_command(dbt)
 visivo.add_command(compile)
+visivo.add_command(format)
 visivo.add_command(run)
 visivo.add_command(serve)
 visivo.add_command(deploy)

--- a/visivo/commands/format.py
+++ b/visivo/commands/format.py
@@ -1,0 +1,38 @@
+import click
+from visivo.commands.options import output_dir, working_dir
+
+
+@click.command()
+@click.argument("paths", nargs=-1, type=click.Path())
+@working_dir
+@output_dir
+@click.option(
+    "--check",
+    is_flag=True,
+    default=False,
+    help="Report files that are not canonical and exit non-zero. Writes nothing.",
+)
+def format(working_dir, output_dir, paths, check):
+    """
+    Rewrites your project's YAML in a canonical style: a fixed key order per object type,
+    consistent indentation and quoting, and multi-line SQL as a block scalar. Comments are
+    preserved. With no PATHS, formats every file in the project.
+
+    Use --check in CI to fail when a file is not already formatted.
+    """
+    from visivo.logger.logger import Logger
+
+    from visivo.commands.format_phase import format_phase
+
+    changed = format_phase(
+        working_dir=working_dir,
+        output_dir=output_dir,
+        paths=paths,
+        check=check,
+    )
+
+    if check and changed:
+        raise click.ClickException(f"{changed} file(s) are not formatted. Run 'visivo format'.")
+
+    if not check and changed:
+        Logger.instance().success(f"Formatted {changed} file(s)")

--- a/visivo/commands/format_phase.py
+++ b/visivo/commands/format_phase.py
@@ -1,0 +1,65 @@
+import os
+
+from visivo.discovery.discover import Discover
+from visivo.logger.logger import Logger
+from visivo.parsers.canonical_yaml import format_file
+
+
+def _project_files(working_dir, output_dir, paths):
+    """The files to format: the ones given, or every file in the project.
+
+    Two things ``Discover.files`` returns that must not be formatted:
+
+    * ``~/.visivo/profile.yml`` — the user's credentials, outside the project.
+    * ``.visivo_cache/...`` — git-backed includes, which are clones of somebody
+      else's repository. Reformatting those would dirty a checkout the user does
+      not own and cannot commit.
+
+    The output directory is skipped too: it holds generated artifacts.
+    """
+    if paths:
+        return [os.path.abspath(path) for path in paths]
+
+    discover = Discover(working_dir=working_dir, output_dir=output_dir)
+    root = os.path.abspath(working_dir)
+    excluded = (
+        os.path.abspath(os.path.join(working_dir, ".visivo_cache")),
+        os.path.abspath(output_dir),
+    )
+
+    files = []
+    for file in discover.files:
+        absolute = os.path.abspath(str(file))
+        if not absolute.startswith(root + os.sep):
+            continue
+        if any(absolute.startswith(path + os.sep) for path in excluded):
+            continue
+        if absolute not in files:
+            files.append(absolute)
+    return files
+
+
+def format_phase(working_dir, output_dir, paths=(), check=False):
+    """Format project YAML, or report what is not canonical.
+
+    Returns the number of files that were not already canonical, so ``--check``
+    can exit non-zero without the phase knowing about exit codes.
+    """
+    files = _project_files(working_dir, output_dir, paths)
+    changed = []
+
+    for file in files:
+        if not os.path.exists(file):
+            Logger.instance().error(f"\tNo such file: {file}")
+            continue
+        if format_file(file, write=not check):
+            changed.append(file)
+
+    for file in changed:
+        relative = os.path.relpath(file, os.path.abspath(working_dir))
+        Logger.instance().info(f"\t{'Would reformat' if check else 'Reformatted'} {relative}")
+
+    if not changed:
+        Logger.instance().success(f"{len(files)} files already formatted")
+
+    return len(changed)

--- a/visivo/parsers/canonical_yaml.py
+++ b/visivo/parsers/canonical_yaml.py
@@ -1,0 +1,197 @@
+"""Canonical YAML formatting for project files (VIS-1196).
+
+Once the cloud writes YAML into a customer's repo, every write risks reordering
+keys or re-quoting scalars and producing a diff that buries the one real change.
+A canonical style makes a commit's diff exactly the semantic change.
+
+**Key order comes from the Pydantic models, not a hand-maintained list.** The
+order a type declares its fields in is already the order a person would write
+them, and deriving it means the formatter cannot drift from the schema: add a
+field to a model and it lands in the right place here for free.
+
+Formatting is done with the same ``ruamel.yaml.YAML(typ="rt")`` round-trip
+instance ``ProjectWriter`` uses, so **comments survive**. Plain ``yaml.dump``
+would destroy them, which is why the new-project writers in
+``server/views/utils.py`` are not a model to follow here.
+"""
+
+import typing
+from typing import Annotated
+
+import ruamel.yaml
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import LiteralScalarString
+
+# Set on every object by the parser, never authored by a person. They are
+# dropped from the canonical order so they sort after anything real rather than
+# ahead of `name`.
+INTERNAL_KEYS = ("path", "file_path")
+
+# Project-level keys tooling writes rather than people: they belong after the
+# authored content, not between `name` and `includes` where the model happens
+# to declare them.
+MACHINE_KEYS = ("project_file_path", "project_dir", "cli_version")
+
+# `name` is the object's identity and `type` is its discriminator, so both lead
+# regardless of where a model happens to declare them — SqliteSource puts `type`
+# tenth, which is an artifact of inheritance rather than an authoring order.
+LEADING_KEYS = ("name", "type")
+
+_MAX_DEPTH = 12
+
+
+def _variant_classes(annotation, found=None, depth=0):
+    """Every Pydantic class reachable from a Project field's annotation.
+
+    A project key is rarely one class: ``sources`` is ten, ``dashboards`` two.
+    The annotations are wrapped by ``generate_ref_field`` in ``NewType`` and
+    ``Annotated`` layers, both of which have to be unwrapped before the
+    ``model_fields`` check — ``Annotated`` forwards attribute access, so it
+    answers to ``model_fields`` while not being a model.
+    """
+    found = found if found is not None else []
+    if annotation is None or depth > _MAX_DEPTH:
+        return found
+
+    supertype = getattr(annotation, "__supertype__", None)
+    if supertype is not None:
+        return _variant_classes(supertype, found, depth + 1)
+
+    if typing.get_origin(annotation) is Annotated:
+        return _variant_classes(typing.get_args(annotation)[0], found, depth + 1)
+
+    if isinstance(annotation, type) and hasattr(annotation, "model_fields"):
+        if annotation not in found:
+            found.append(annotation)
+        return found
+
+    for argument in typing.get_args(annotation):
+        _variant_classes(argument, found, depth + 1)
+    return found
+
+
+def _merged_field_order(classes):
+    """One order covering every variant, first declaration wins."""
+    order = []
+    for cls in classes:
+        for field in cls.model_fields:
+            if field not in order and field not in INTERNAL_KEYS:
+                order.append(field)
+    leading = [key for key in LEADING_KEYS if key in order]
+    return leading + [key for key in order if key not in leading]
+
+
+def key_order_for_project_key(project_key):
+    """Canonical key order for the objects under a top-level project key."""
+    from visivo.models.project import Project
+
+    field = Project.model_fields.get(project_key)
+    if field is None:
+        return []
+    return _merged_field_order(_variant_classes(field.annotation))
+
+
+def project_key_order():
+    """Canonical order of the top-level keys of a project file."""
+    from visivo.models.project import Project
+
+    skip = INTERNAL_KEYS + MACHINE_KEYS
+    return [key for key in Project.model_fields if key not in skip]
+
+
+def _reorder(mapping, order):
+    """Reorder a CommentedMap in place to ``order``, unknown keys last.
+
+    ``move_to_end`` is what keeps the comments: ruamel keys comment attributes
+    by key name, so moving a key carries its comment with it. Rebuilding the
+    map instead would strip them.
+    """
+    if not isinstance(mapping, CommentedMap):
+        return
+    present = [key for key in order if key in mapping]
+    remaining = [key for key in mapping if key not in present]
+    for key in present + remaining:
+        mapping.move_to_end(key)
+
+
+def _blockify(mapping):
+    """Multi-line strings become ``|`` blocks rather than escaped one-liners."""
+    if isinstance(mapping, CommentedMap):
+        for key, value in mapping.items():
+            if (
+                isinstance(value, str)
+                and "\n" in value
+                and not isinstance(value, LiteralScalarString)
+            ):
+                mapping[key] = LiteralScalarString(value)
+            else:
+                _blockify(value)
+    elif isinstance(mapping, list):
+        for item in mapping:
+            _blockify(item)
+
+
+def canonicalize(data):
+    """Apply the canonical style to a parsed project document, in place.
+
+    List ORDER is never touched. Some lists are semantic — dashboard rows and
+    their items render in the order they appear — and there is no way to tell
+    those from the incidental ones without knowing the type, so none are sorted.
+    """
+    if not isinstance(data, CommentedMap):
+        return data
+
+    _reorder(data, project_key_order())
+
+    for project_key, value in data.items():
+        if not isinstance(value, list):
+            continue
+        order = key_order_for_project_key(project_key)
+        if not order:
+            continue
+        for item in value:
+            _reorder(item, order)
+
+    _blockify(data)
+    return data
+
+
+def _yaml():
+    """The round-trip instance, configured exactly as ``ProjectWriter``'s.
+
+    Same settings on purpose: a file this formats and a file ProjectWriter
+    edits have to come out the same, or a cloud edit reformats the whole file
+    and the diff stops being the change.
+    """
+    yaml = ruamel.yaml.YAML(typ="rt")
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.preserve_quotes = True
+    yaml.width = float("inf")
+    return yaml
+
+
+def format_text(text):
+    """Canonical form of a YAML document's text."""
+    import io
+
+    yaml = _yaml()
+    data = yaml.load(text)
+    if data is None:
+        return text
+    canonicalize(data)
+    stream = io.StringIO()
+    yaml.dump(data, stream)
+    return stream.getvalue()
+
+
+def format_file(path, write=True):
+    """Format ``path``. Returns True when the file was not already canonical."""
+    with open(path, "r") as handle:
+        original = handle.read()
+
+    formatted = format_text(original)
+    changed = formatted != original
+    if changed and write:
+        with open(path, "w") as handle:
+            handle.write(formatted)
+    return changed


### PR DESCRIPTION
Closes VIS-1196. First card of **Git-Linked Projects: Repo as Source of Truth**, which lists this one as *"Blocks: everything else in this project."*

## Why a formatter is a prerequisite, not a nicety

Once the cloud writes YAML into a customer's repo, every write risks reordering keys or re-quoting scalars and producing a diff that buries the one real change. A canonical style makes a cloud commit's diff exactly the semantic change and nothing else. It's independently useful to CLI users today, which is why it ships first.

## Key order is derived, not hand-maintained

The interesting decision. Rather than a per-type ordering table someone has to keep current, the order comes from **the Pydantic models' own field declaration order**:

```
sources -> ['name', 'type', 'after_connect', 'host', 'port', 'database', ...]
models  -> ['name', 'sql', 'source', 'metrics', 'dimensions']
```

That is already the order a person would write them, and deriving it means the formatter cannot drift from the schema — add a field to a model and it lands in the right place here for free.

Two adjustments on top:

- **`name` and `type` are pinned to the front.** `SqliteSource` declares `type` tenth, which is an inheritance artifact rather than an authoring order.
- **`project_file_path` / `project_dir` / `cli_version` sort after the authored content.** They're written by tooling, so they don't belong between `name` and `includes` where the model happens to declare them.

Resolving the variants took some care: a project key is rarely one class (`sources` is ten, `dashboards` two), and `generate_ref_field` wraps them in `NewType` and `Annotated` layers. `Annotated` forwards attribute access, so it answers to `model_fields` while not being a model — it has to be unwrapped first, and there's a test pinning that all 11 keys still resolve, because if unwrapping regresses the order silently becomes empty and nothing gets sorted.

## What it deliberately does not do

**List order is never changed.** Dashboard rows and their items render in the order they appear, and nothing distinguishes a semantic list from an incidental one without knowing the type — so none are sorted.

**No key is ever dropped.** An unknown key is far more likely to be a newer Visivo version's field than a mistake, and this project makes the repo authoritative, so dropping one would be real data loss. Pinned by a test.

## Comments survive

Uses the same `ruamel.yaml.YAML(typ="rt")` instance `ProjectWriter` uses, with identical settings — deliberately, because a file this formats and a file ProjectWriter edits have to come out the same, or a cloud edit reformats the whole file and the diff stops being the change. Reordering is done with `move_to_end`, which carries comments along since ruamel keys them by key name; rebuilding the map would strip them.

## Two things found while building

**It was formatting `.visivo_cache/`** — git-backed includes, which are clones of *someone else's repository*. Reformatting those dirties a checkout the user doesn't own and can't commit. `Discover.files` is built for parsing, so it returns more than a formatter may write to: that cache, and `~/.visivo/profile.yml` (the user's credentials). Both now excluded, with tests.

**`yaml.safe_load` comparison is order-sensitive in this repo.** `setup_yaml_ordered_dict()` globally registers `YamlOrderedDict` on `yaml.SafeLoader`, and it extends `OrderedDict`, whose `__eq__` compares order. So a "did meaning change?" assertion written the obvious way passes alone and fails in the full suite, reporting every reordering as a difference. **This matters for VIS-1198** — the round-trip fidelity harness compares parsed structures, so it must convert to plain dicts or it will fail on key order rather than on lost data. Noted in the test.

## Verification

- 21 new tests: information preservation (meaning unchanged, unknown keys kept, comments survive), derived key order, idempotence, block scalars, list order untouched, and which files the phase may write to.
- Formatted a copy of `test-projects/integration/` and **compiled it** — clean.
- Round-trip on that project: semantically identical, all 97 comments preserved, `format(format(x)) == format(x)`.
- Full Python suite: **2577 passed**. `black` clean.

## Not in this PR

Making `ProjectWriter` emit canonical form for the nodes it touches (so a formatted repo stays formatted after a cloud edit) is the second half of the card. It's a natural follow-up once this is agreed, and it wants the fidelity harness from VIS-1198 alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3
