### PR TITLE
Round-trip fidelity harness (VIS-1198)

### DIFF
--- a/tests/server/test_round_trip_fidelity.py
+++ b/tests/server/test_round_trip_fidelity.py
@@ -1,0 +1,178 @@
+"""VIS-1198: the fidelity gate for anything that writes a customer's repo.
+
+Runs the real projects in `test-projects/` through parse → write → re-parse and
+asserts nothing is lost, plus adversarial fixtures for the shapes most likely to
+break a YAML round trip.
+"""
+
+import os
+
+import pytest
+
+from tests.support.round_trip import (
+    assert_round_trips,
+    comparable,
+    copy_project,
+    parse_project,
+)
+
+TEST_PROJECTS = os.path.join(os.path.dirname(__file__), "..", "..", "test-projects")
+
+# Projects that parse without external services. `dbt` needs a compiled dbt
+# target and `demo`/`homepage-assets` reach for data that is not in the repo, so
+# they are covered by the integration suite rather than here.
+ROUND_TRIP_PROJECTS = [
+    "integration",
+    "complex-project",
+    "docs-interactivity",
+    "explorer-publish-e2e",
+    "test",
+]
+
+
+@pytest.mark.parametrize("project_name", ROUND_TRIP_PROJECTS)
+def test_a_real_project_survives_being_rewritten(project_name, tmp_path):
+    source = os.path.join(TEST_PROJECTS, project_name)
+    if not os.path.exists(os.path.join(source, "project.visivo.yml")):
+        pytest.skip(f"{project_name} has no project file")
+
+    working_dir = copy_project(source, tmp_path / project_name)
+
+    assert_round_trips(working_dir)
+
+
+def _write(tmp_path, name, text):
+    (tmp_path / name).write_text(text)
+    return str(tmp_path)
+
+
+class TestAdversarialShapes:
+    """The shapes a YAML round trip is most likely to mangle."""
+
+    def test_multi_file_includes(self, tmp_path):
+        (tmp_path / "models.visivo.yml").write_text(
+            "models:\n  - name: orders\n    sql: SELECT 1 as x\n    source: ${ref(db)}\n"
+        )
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n"
+            "includes:\n"
+            "  - path: models.visivo.yml\n"
+            "sources:\n"
+            "  - name: db\n    type: duckdb\n    database: local.duckdb\n",
+        )
+
+        assert_round_trips(working_dir)
+
+    def test_non_ascii_and_quoted_scalars(self, tmp_path):
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n"
+            "sources:\n"
+            "  - name: db\n    type: duckdb\n    database: local.duckdb\n"
+            "models:\n"
+            "  - name: cafe_orders\n"
+            "    sql: SELECT '¿qué?' as q, 'naïve' as n\n"
+            "    source: ${ref(db)}\n"
+            "metrics:\n"
+            "  - name: total\n"
+            "    expression: sum(${ref(cafe_orders).q})\n"
+            '    description: "quoted: with colon — em dash, ünïcode"\n',
+        )
+
+        assert_round_trips(working_dir)
+
+    def test_multiline_sql_block_scalar(self, tmp_path):
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n"
+            "sources:\n"
+            "  - name: db\n    type: duckdb\n    database: local.duckdb\n"
+            "models:\n"
+            "  - name: m\n"
+            "    source: ${ref(db)}\n"
+            "    sql: |\n"
+            "      SELECT 1 as x\n"
+            "      FROM t\n"
+            "      WHERE y = 2\n",
+        )
+
+        assert_round_trips(working_dir)
+
+    def test_model_scoped_metrics_and_dimensions(self, tmp_path):
+        """Nested fields are surfaced at top level by the assembler, which is a
+        known asymmetry — the round trip must still put them back nested."""
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n"
+            "sources:\n"
+            "  - name: db\n    type: duckdb\n    database: local.duckdb\n"
+            "models:\n"
+            "  - name: orders\n"
+            "    source: ${ref(db)}\n"
+            "    sql: SELECT 1 as amount, 'x' as region\n"
+            "    metrics:\n"
+            "      - name: total\n        expression: sum(amount)\n"
+            "    dimensions:\n"
+            "      - name: region\n        expression: region\n",
+        )
+
+        assert_round_trips(working_dir)
+
+    def test_comments_in_awkward_positions(self, tmp_path):
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "# leading\n"
+            "name: p  # trailing on a scalar\n"
+            "sources:\n"
+            "  # before an item\n"
+            "  - name: db\n"
+            "    type: duckdb  # trailing on a nested key\n"
+            "    database: local.duckdb\n"
+            "# dangling at the end\n",
+        )
+
+        assert_round_trips(working_dir)
+        assert "# leading" in (tmp_path / "project.visivo.yml").read_text()
+
+    def test_an_empty_project_is_not_a_crash(self, tmp_path):
+        working_dir = _write(tmp_path, "project.visivo.yml", "name: p\n")
+
+        assert_round_trips(working_dir)
+
+
+class TestTheHarnessItself:
+    """A harness that cannot fail is worse than no harness."""
+
+    def test_it_notices_a_dropped_object(self, tmp_path):
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n" "sources:\n" "  - name: db\n    type: duckdb\n    database: local.duckdb\n",
+        )
+        before = comparable(parse_project(working_dir))
+
+        (tmp_path / "project.visivo.yml").write_text("name: p\n")
+        after = comparable(parse_project(working_dir))
+
+        assert set(before) - set(after) == {"db"}
+
+    def test_it_notices_a_changed_value(self, tmp_path):
+        working_dir = _write(
+            tmp_path,
+            "project.visivo.yml",
+            "name: p\n" "sources:\n" "  - name: db\n    type: duckdb\n    database: local.duckdb\n",
+        )
+        before = comparable(parse_project(working_dir))
+
+        (tmp_path / "project.visivo.yml").write_text(
+            "name: p\n" "sources:\n" "  - name: db\n    type: duckdb\n    database: OTHER.duckdb\n"
+        )
+        after = comparable(parse_project(working_dir))
+
+        assert before["db"] != after["db"]

--- a/tests/support/round_trip.py
+++ b/tests/support/round_trip.py
@@ -1,0 +1,128 @@
+"""VIS-1198: parse → write → re-parse must not lose anything.
+
+The gate on everything that writes to a customer's repo. If a write silently
+drops a key the parser did not model, the repo loses user config — and because
+the repo is the source of truth, that loss is authoritative. It is invisible in
+review (the diff looks fine) and surfaces later as a dashboard that stopped
+rendering.
+
+The round trip exercised here is the visivo half:
+
+    parse → named_child_nodes() → ProjectWriter → re-parse
+
+``assemble_project`` — the other stage the card names — lives in **core**
+(`apps/deploys/services/assembler.py`), not here, so the cloud half of the round
+trip needs its own harness on that side.
+"""
+
+import os
+import shutil
+
+from visivo.discovery.discover import Discover
+from visivo.parsers.parser_factory import ParserFactory
+from visivo.server.project_writer import ProjectWriter
+
+# The Project root is not an object the writer edits, and an inline-defined
+# child is written as part of whatever contains it — rewriting either as a
+# standalone top-level entry would be a change the round trip never makes.
+SKIP_TYPES = ("Project",)
+
+
+def plain(value):
+    """A plain-dict view, for comparison.
+
+    Never compare loaded YAML mappings directly: `setup_yaml_ordered_dict()`
+    registers `YamlOrderedDict` globally on `yaml.SafeLoader`, and it extends
+    `OrderedDict`, whose `__eq__` is ORDER-SENSITIVE. A fidelity harness that
+    compares those reports every key reorder as data loss — which is the one
+    thing it must not do, since the formatter reorders keys on purpose.
+    """
+    if isinstance(value, dict):
+        return {key: plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [plain(item) for item in value]
+    return value
+
+
+def parse_project(working_dir):
+    discover = Discover(working_dir=working_dir, output_dir=os.path.join(working_dir, "target"))
+    return ParserFactory().build(project_file=discover.project_file, files=discover.files).parse()
+
+
+def comparable(project):
+    """What the round trip compares: every named object's config, by name.
+
+    Configs rather than raw file text, because the writer is allowed to move a
+    key or requote a scalar — it is not allowed to change what the project
+    means. Comparing bytes would fail on formatting; comparing parsed configs
+    fails only on lost or altered data, which is the actual risk.
+    """
+    return {
+        name: plain(entry.get("config"))
+        for name, entry in project.named_child_nodes().items()
+        if entry.get("type") not in SKIP_TYPES
+    }
+
+
+def rewrite_every_object(working_dir):
+    """Feed every object back through ProjectWriter as an unchanged edit.
+
+    Marking everything ``Modified`` is the worst case a cloud commit can
+    produce, and the one most likely to expose a lossy write path: a real commit
+    only touches what changed, so a bug here would otherwise surface only for
+    whichever object happened to be edited.
+    """
+    project = parse_project(working_dir)
+    lineage_keyed = project.named_child_nodes()
+
+    # `named_child_nodes()` keys model-scoped metrics/dimensions by
+    # `<model>.<name>`, because a bare name may repeat across models. But the
+    # inline/ref markers embedded in configs carry the BARE name, and
+    # `ProjectWriter._get_named_child_config` looks them up with it — so its
+    # dict has to be bare-keyed, which is what `commit_views` passes (its keys
+    # come from `cached_objects`). Feeding the lineage-keyed map straight in
+    # KeyErrors on the first model-scoped field.
+    # Every entry has to STAY in the map even when it is not being rewritten:
+    # a parent's config holds a marker for its inline children, and
+    # `__reconstruct_named_child_config` resolves those with
+    # `named_children[name]`. Dropping them KeyErrors on the first inline chart.
+    named_children = {}
+    for key, entry in lineage_keyed.items():
+        bare_name = key.split(".")[-1]
+        is_model_scoped = key != bare_name
+        # A model-scoped field is written as part of its model's config rather
+        # than standalone, so it is still exercised — it rides along inside the
+        # model marked Modified below.
+        skip_write = (
+            entry.get("type") in SKIP_TYPES or entry.get("is_inline_defined") or is_model_scoped
+        )
+        entry["status"] = "Unchanged" if skip_write else "Modified"
+        # On a bare-name collision prefer the top-level object over a
+        # model-scoped alias, since that is what a marker means by the name.
+        if bare_name not in named_children or not is_model_scoped:
+            named_children[bare_name] = entry
+
+    writer = ProjectWriter(named_children)
+    writer.update_file_contents()
+    writer.write()
+
+
+def copy_project(source_dir, destination_dir):
+    """Work on a copy — the harness writes files."""
+    shutil.copytree(source_dir, destination_dir, dirs_exist_ok=True)
+    return str(destination_dir)
+
+
+def assert_round_trips(working_dir):
+    """Rewrite every object, re-parse, and assert nothing changed."""
+    before = comparable(parse_project(working_dir))
+    rewrite_every_object(working_dir)
+    after = comparable(parse_project(working_dir))
+
+    missing = sorted(set(before) - set(after))
+    added = sorted(set(after) - set(before))
+    assert not missing, f"objects lost by the round trip: {missing}"
+    assert not added, f"objects invented by the round trip: {added}"
+
+    changed = {name: (before[name], after[name]) for name in before if before[name] != after[name]}
+    assert not changed, f"configs changed by the round trip: {sorted(changed)}"


### PR DESCRIPTION
Closes VIS-1198 (Urgent). Targets `feature-git-linked-projects`, per the project's branching rule.

## What it does

```
parse → named_child_nodes() → ProjectWriter → re-parse → compare
```

Run over five real projects in `test-projects/` (`integration`, `complex-project`, `docs-interactivity`, `explorer-publish-e2e`, `test`) plus adversarial fixtures: multi-file includes, non-ASCII and quoted scalars, multi-line SQL block scalars, model-scoped metrics/dimensions, comments in awkward positions, and an empty project.

Three deliberate choices:

- **Every object is marked `Modified`**, not just changed ones. That's the worst case a cloud commit can produce and the one most likely to expose a lossy path — a realistic commit would only exercise whichever object happened to be edited.
- **Compare parsed configs, not bytes.** The writer is allowed to move a key or requote a scalar; it is not allowed to change what the project *means*. Byte comparison would fail on formatting and hide the real risk.
- **Never compare loaded YAML mappings directly.** `setup_yaml_ordered_dict()` registers `YamlOrderedDict` globally on `yaml.SafeLoader`, and it extends `OrderedDict`, whose `__eq__` is **order-sensitive**. A harness that compares those reports every key reorder as data loss — which matters immediately, because VIS-1196's formatter reorders keys on purpose.

There are also tests **on the harness itself** — that it notices a dropped object and a changed value. A fidelity gate that cannot fail is worse than none.

## Two sharp edges found while wiring it up

Both are real traps for the next person, and both are now documented in the harness:

**1. `named_child_nodes()` output cannot be fed straight to `ProjectWriter`.** It keys model-scoped metrics/dimensions by `<model>.<name>` (deliberately — a bare name may repeat across models). But the inline/ref markers embedded in configs carry the **bare** name, and `ProjectWriter._get_named_child_config` resolves them with it. Feeding the lineage-keyed map in KeyErrors on the first model-scoped field. Production is unaffected: `commit_views` builds its map from `cached_objects`, which is bare-keyed.

**2. Entries must stay in the map even when they are not being rewritten.** A parent's config holds a marker for each inline child, and `__reconstruct_named_child_config` resolves it through `named_children[name]`. Dropping unwritten entries KeyErrors on the first inline chart. They're kept and marked `Unchanged` instead.

Model-scoped fields are still exercised — they ride along inside the model that is marked `Modified`, which is also the correct behaviour: nested stays nested.

## Scope note

The card describes the round trip as `parse → assemble_project() → ProjectWriter → re-parse`. **`assemble_project` lives in core** (`apps/deploys/services/assembler.py`), not visivo, so this covers the visivo half — the one that actually writes YAML. The cloud half needs its own harness on the core side, and the card's note about the assembler re-referencing inline objects back to `${ref(name)}` applies there.

The card also raises making this a **runtime precondition** — the cloud refusing to push when re-parsing its own output doesn't reproduce the intended project. Not done here: there's no push path yet (VIS-1202), and the fail-closed-vs-warn decision belongs with it. The harness is written as reusable functions in `tests/support/round_trip.py` so it can move into `visivo/` when there is something to guard.

## Verification

13 tests, full Python suite **2569 passed**, `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PKHBKaGsHFoDbpHnwTJg3
