### PR TITLE
Fail deploy loudly when the project has no name, instead of KeyError

### DIFF
--- a/tests/commands/test_deploy_phase.py
+++ b/tests/commands/test_deploy_phase.py
@@ -183,6 +183,33 @@ def test_deploy_with_insights_and_inputs_success(requests_mock, httpx_mock, caps
     assert "/api/charts/" in posted_paths
 
 
+def test_deploy_requires_a_project_name():
+    """`Project.name` is Optional (like every NamedModel) and `exclude_none=True`
+    drops it from project_json entirely when unset, so a project file with no
+    top-level `name:` parses and runs fine but crashed deploy with a bare
+    KeyError on project_json["name"] — hit in practice on a hand-authored
+    project file that never went through `visivo init` (whose template does
+    set `name:`). Fail loudly with an actionable message instead."""
+    project = ProjectFactory()
+    project_dict = json.loads(project.model_dump_json())
+    project_dict.pop("name", None)
+
+    tmp = temp_yml_file(dict=project_dict, name=PROJECT_FILE_NAME)
+    working_dir = os.path.dirname(tmp)
+    temp_file(PROFILE_FILE_NAME, "token: value", working_dir + "/.visivo")
+
+    with pytest.raises(click.ClickException) as exc:
+        deploy_phase(
+            stage="stage",
+            working_dir=working_dir,
+            user_dir=working_dir,
+            output_dir=temp_folder(),
+            host="http://host",
+        )
+
+    assert "name" in str(exc.value)
+
+
 def test_start_files_declares_purpose_and_identity(httpx_mock):
     """Core builds an artifact's object path when it signs the upload URL —
     before it has seen a byte — so anything the deploy fails to declare here is

--- a/visivo/commands/deploy_phase.py
+++ b/visivo/commands/deploy_phase.py
@@ -1124,6 +1124,18 @@ def deploy_phase(
     project_json = json.loads(serializer.dereference().model_dump_json(exclude_none=True))
     send_progress(f"Project Compiled in {time() - deploy_start_time:.2f} seconds", "success")
 
+    # `name` is Optional on every NamedModel (Project included), so a project
+    # file with no top-level `name:` parses fine and runs fine — but the cloud
+    # uses the name to identify which project a deploy belongs to, and
+    # `exclude_none=True` above drops the key entirely rather than sending
+    # null. Catch it here with an actionable message instead of a bare
+    # KeyError on project_json["name"] below.
+    if not project_json.get("name"):
+        raise click.ClickException(
+            "Project has no `name`. Add a top-level `name:` to your project file "
+            "before deploying — the cloud uses it to identify the project."
+        )
+
     # Prepare request payloads and headers. The monolithic ``project_json``
     # blob is no longer sent — each object is posted to its own endpoint below
     # (decomposed deploy). ``project_json`` is still computed for the project


### PR DESCRIPTION
## Summary
Reported on 2.1.3: `visivo deploy` crashes with a bare `KeyError: 'name'` in `deploy_phase.py:1132` on any project file with no top-level `name:`.

`Project.name` is `Optional[str] = None` (inherited from `NamedModel`, same as every other object) — a nameless project parses and runs fine. But `deploy_phase` serializes with `exclude_none=True`, which drops the `name` key from `project_json` entirely rather than sending `null`, and the deploy body construction unconditionally reads `project_json["name"]`.

`visivo init`'s template does seed `name: {project_name}`, so this only bites projects that were hand-authored or edited outside that flow — confirmed by reproducing against the reporter's project, which has no `name:` field in its YAML at all.

Fix: check for a name right after `project_json` is computed (matching the file's existing pattern of validating before building the request — see `table_sql_error`, `verify_run_output`) and raise a `click.ClickException` that says what to do, instead of crashing with a traceback deep in request-body construction.

## Test plan
- [x] New test `test_deploy_requires_a_project_name`, calling `deploy_phase()` end-to-end against a project file with `name` stripped out; confirmed it reproduces the exact reported `KeyError: 'name'` against the pre-fix code, and gets the new actionable message after.
- [x] `poetry run pytest tests/` — 2557 passed.
- [x] `poetry run black --check visivo/ tests/commands/test_deploy_phase.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)