### PR TITLE
Let a host supply the top bar's action button

### DIFF
--- a/viewer/src/components/common/TopNav.jsx
+++ b/viewer/src/components/common/TopNav.jsx
@@ -478,6 +478,11 @@ const TopNav = ({
   // cloud-only: Edit/Branch entry node, rendered in the action cluster at
   // project depth. Absent locally ⇒ nothing extra renders.
   branchControls = null,
+  // cloud-only: replaces the built-in Commit/Deploy button outright. Core folds
+  // Commit together with Discard into one split control, which it can only do
+  // if it owns the whole node — the dirty-state choice below cannot express
+  // "one button with a menu hanging off it".
+  renderAction,
   // Deploy is only meaningful where deploy exists (local CLI). Cloud has no
   // deploy yet, so it passes showDeploy=false to hide the button entirely.
   showDeploy = true,
@@ -528,11 +533,16 @@ const TopNav = ({
   // Commit and Deploy are mutually exclusive by dirty state: a dirty project
   // shows Commit (changes must be committed before they can ship), and a clean
   // project shows Deploy where deploy exists (nothing to commit, ready to ship).
-  const action = hasUncommittedChanges ? (
-    <CommitButton onClick={onCommitClick} compact={narrow} count={commitCount} />
-  ) : showDeploy ? (
-    <DeployButton onClick={onDeployClick} compact={narrow} />
-  ) : null;
+  // `renderAction` overrides the pair; `null` is a deliberate "no action at
+  // all", which is why the check is against undefined rather than falsiness.
+  const action =
+    renderAction !== undefined ? (
+      renderAction
+    ) : hasUncommittedChanges ? (
+      <CommitButton onClick={onCommitClick} compact={narrow} count={commitCount} />
+    ) : showDeploy ? (
+      <DeployButton onClick={onDeployClick} compact={narrow} />
+    ) : null;
 
   const banner = inHistory && (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: '#f6ddda', borderBottom: '1px solid #edbcb5', color: '#7e352a', padding: '0 16px', height: 38, flexShrink: 0, fontSize: 13 }}>

--- a/viewer/src/components/common/TopNav.test.jsx
+++ b/viewer/src/components/common/TopNav.test.jsx
@@ -111,6 +111,31 @@ describe('TopNav', () => {
     expect(screen.queryByTitle('Deploy')).not.toBeInTheDocument();
   });
 
+  it('renderAction replaces the built-in Commit/Deploy pair', () => {
+    // Core folds Commit together with Discard into one split control, which it
+    // can only do by owning the whole node.
+    renderNav({
+      hasUncommittedChanges: true,
+      renderAction: <button>Commit and more</button>,
+    });
+    expect(screen.getByRole('button', { name: 'Commit and more' })).toBeInTheDocument();
+    expect(screen.queryByTitle('Commit changes')).not.toBeInTheDocument();
+  });
+
+  it('renderAction also replaces Deploy on a clean project', () => {
+    renderNav({ hasUncommittedChanges: false, renderAction: <button>Mine</button> });
+    expect(screen.getByRole('button', { name: 'Mine' })).toBeInTheDocument();
+    expect(screen.queryByTitle('Deploy')).not.toBeInTheDocument();
+  });
+
+  it('renderAction={null} means no action at all, not "fall back"', () => {
+    // Hence the undefined check: null is a deliberate choice, and treating it
+    // as absent would put Commit back on a host that asked for nothing.
+    renderNav({ hasUncommittedChanges: true, renderAction: null });
+    expect(screen.queryByTitle('Commit changes')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Deploy')).not.toBeInTheDocument();
+  });
+
   it('badges the Commit button with the pending-change count', () => {
     renderNav({ hasUncommittedChanges: true, commitCount: 3 });
     expect(screen.getByTitle('Commit changes')).toHaveTextContent(/Commit\s*3/);


### PR DESCRIPTION
Groundwork for a core change (VIS-1348): folding **Commit** together with **Discard Draft** into one split button, and **Edit** with **Branch** into another, with the linked GitHub repo in the dropdown.

## Why a prop rather than doing it in core

`TopNav` picks between Commit and Deploy from dirty state:

```js
const action = hasUncommittedChanges ? <CommitButton/> : showDeploy ? <DeployButton/> : null;
```

That shape cannot express "one button with a menu hanging off it", and the Commit button is rendered by `TopNav` while Discard comes from core's `branchControls` — so the two live on opposite sides of the vendoring boundary.

The alternative was for core to pass `hasUncommittedChanges={false}` to suppress the button and render its own control in `branchControls`. That works by lying to `TopNav` about dirty state, and the next reader has no way to know why. This is the honest version.

## `undefined`, not falsy

`renderAction={null}` is a deliberate "no action at all". Checking falsiness would put Commit back on a host that explicitly asked for nothing — there's a test pinning it.

Nothing changes for a caller that doesn't pass it, which is every caller today.

## Verification

`viewer`: **7130 passing** (3 new on `TopNav`), lint clean at `--max-warnings=0`.

## Ordering note

core's CI clones visivo at `ref: main`, so this needs to be on `main` before the core PR can go green.