### PR TITLE
Show the stages that hold the same project

### DIFF
--- a/viewer/src/components/common/TopNav.jsx
+++ b/viewer/src/components/common/TopNav.jsx
@@ -109,6 +109,12 @@ function StageMenu({ stages, currentStage, onPick, onAllStages, close }) {
   const [q, setQ] = React.useState('');
   const starred = stages.filter(s => s.starred);
   const def = stages.filter(s => s.isDefault);
+  // Stages the project you are looking at also lives on. Without a section of
+  // their own they were reachable only by typing into the search box, so the
+  // one switch someone actually wants — "show me this project over there" —
+  // was the one the menu did not offer. The host sets `hasProject`; absent it,
+  // nothing extra renders.
+  const withProject = stages.filter(s => s.hasProject && !s.isDefault && !s.starred);
   const results = q
     ? stages.filter(s => `${s.name} ${s.kind || ''} ${s.desc || ''}`.toLowerCase().includes(q.toLowerCase()))
     : null;
@@ -128,6 +134,8 @@ function StageMenu({ stages, currentStage, onPick, onAllStages, close }) {
           {def.map(s => <StageRow key={s.id} s={s} active={s.id === currentStage.id} onPick={pick(s)} />)}
           {starred.length > 0 && <MenuLabel>STARRED</MenuLabel>}
           {starred.map(s => <StageRow key={s.id} s={s} active={s.id === currentStage.id} onPick={pick(s)} />)}
+          {withProject.length > 0 && <MenuLabel>THIS PROJECT</MenuLabel>}
+          {withProject.map(s => <StageRow key={s.id} s={s} active={s.id === currentStage.id} onPick={pick(s)} />)}
         </div>
       )}
       <div style={{ padding: q ? '10px 12px 6px' : '8px 12px 10px', borderTop: q ? 'none' : '1px solid #f3f4f6' }}>

--- a/viewer/src/components/common/TopNav.test.jsx
+++ b/viewer/src/components/common/TopNav.test.jsx
@@ -214,6 +214,72 @@ describe('TopNav', () => {
     expect(def.compareDocumentPosition(starred) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  describe('stages holding the same project', () => {
+    // These were reachable only by typing into the search box, so the one
+    // switch someone actually wants — "show me this project over there" — was
+    // the one the menu did not offer.
+    const stages = [
+      { id: 'local', name: 'Local', isDefault: true },
+      { id: 'new-stage', name: 'new-stage', hasProject: true },
+      { id: 'other', name: 'other' },
+    ];
+    const openStageMenu = () => {
+      renderNav({
+        stages,
+        currentStage: stages[0],
+        projects: [{ id: 'p', name: 'p' }],
+        currentProject: { id: 'p', name: 'p' },
+      });
+      fireEvent.click(screen.getByText('Local'));
+    };
+
+    it('lists them under their own heading', () => {
+      openStageMenu();
+
+      expect(screen.getByText('THIS PROJECT')).toBeInTheDocument();
+      expect(screen.getByText('new-stage')).toBeInTheDocument();
+    });
+
+    it('leaves stages without the project to the search box', () => {
+      openStageMenu();
+
+      expect(screen.queryByText('other')).not.toBeInTheDocument();
+    });
+
+    it('comes after DEFAULT, which is still where you are', () => {
+      openStageMenu();
+
+      const def = screen.getByText('DEFAULT');
+      const section = screen.getByText('THIS PROJECT');
+      // eslint-disable-next-line no-bitwise
+      expect(def.compareDocumentPosition(section) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('does not repeat a stage already shown as default or starred', () => {
+      renderNav({
+        stages: [{ id: 'local', name: 'Local', isDefault: true, hasProject: true }],
+        currentStage: { id: 'local', name: 'Local' },
+        projects: [{ id: 'p', name: 'p' }],
+        currentProject: { id: 'p', name: 'p' },
+      });
+      fireEvent.click(screen.getByText('Local'));
+
+      expect(screen.queryByText('THIS PROJECT')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing extra when the host sets no flag', () => {
+      renderNav({
+        stages: [{ id: 'local', name: 'Local', isDefault: true }, { id: 'other', name: 'other' }],
+        currentStage: { id: 'local', name: 'Local' },
+        projects: [{ id: 'p', name: 'p' }],
+        currentProject: { id: 'p', name: 'p' },
+      });
+      fireEvent.click(screen.getByText('Local'));
+
+      expect(screen.queryByText('THIS PROJECT')).not.toBeInTheDocument();
+    });
+  });
+
   describe('user menu (cloud)', () => {
     // The avatar trigger shows the user's initial; click it to open the menu.
     const openMenu = props => {


### PR DESCRIPTION
Reported from a running instance: an account with four stages showed **one** in the switcher.

## Why ordering wasn't enough

The menu renders *sections*, not a flat list:

```js
const starred = stages.filter(s => s.starred);
const def     = stages.filter(s => s.isDefault);
```

Only those two are drawn. Everything else is reachable **only by typing into the search box** — so core#403's reordering of the `stages` array was invisible, and the one switch someone actually wants ("show me this project over there") was the one the menu did not offer.

## The section

Stages carrying the same project get their own heading, **after** DEFAULT and STARRED so where you are stays first. Any stage those two already list is skipped rather than shown twice.

The host sets `hasProject`, since only it knows which stages a project is on — core computes that set already (`/api/projects/stages/`). Absent the flag nothing extra renders, which is every caller today.

## Verification

`viewer`: **7130+ passing**, 5 new on the stage menu — including that a stage without the project stays out (search still finds it), that a default stage carrying the project isn't duplicated, and that a host setting no flag renders nothing new. Lint clean at `--max-warnings=0`.

Pairs with core#403, which sets the flag.