### PR TITLE
Let a :memory: DuckDB source connect when read_only is requested

### DIFF
--- a/tests/models/sources/test_duckdb_source.py
+++ b/tests/models/sources/test_duckdb_source.py
@@ -17,3 +17,19 @@ def test_DuckdbSource_missing_data():
 
     assert error["msg"] == "Field required"
     assert error["type"] == "missing"
+
+
+def test_DuckdbSource_memory_database_ignores_read_only():
+    """DuckDB rejects read_only=True on ':memory:' outright ("Cannot launch
+    in-memory database in read-only mode!"), but every schema/query path
+    defaults to read_only=True — so a ':memory:' primary (the shape used to
+    host an `attach:`ed source) could never connect at all."""
+    source = DuckdbSource(name="source", database=":memory:", type="duckdb")
+
+    connection = source.get_connection(read_only=True)
+    try:
+        # An in-memory database has nothing on disk for "read-only" to
+        # protect — prove the connection is actually writable.
+        connection.execute("CREATE TABLE t (x INTEGER)")
+    finally:
+        connection.close()

--- a/visivo/models/sources/duckdb_source.py
+++ b/visivo/models/sources/duckdb_source.py
@@ -83,6 +83,15 @@ class DuckdbSource(ServerSource, BaseDuckdbSource):
             if working_dir:
                 database_path = str(working_dir / Path(self.database))
 
+            # An in-memory database is never persisted, so read-only has
+            # nothing to protect — and DuckDB rejects read_only=True on
+            # ":memory:" outright ("Cannot launch in-memory database in
+            # read-only mode!"). Every introspection/query path defaults to
+            # read_only=True, so a ":memory:" primary (e.g. one that exists
+            # only to host `attach:`ed sources) would otherwise never connect.
+            if database_path == ":memory:":
+                read_only = False
+
             # Ensure database file exists for write operations
             if not read_only and not os.path.exists(database_path):
                 Logger.instance().debug(


### PR DESCRIPTION
## Summary
Reported while wiring a remote database (a `.duckdb` file over HTTPS) into a project via the existing `attach:` feature — the only way to reach a remote DuckDB file today, since `DuckdbSource.get_connection()` can't open an http(s) URL directly as the primary `database:` (it path-joins/treats it as a local file). That workaround needs a `":memory:"` primary source to host the attachment, and schema building failed on every run:

```
Schema building error: Error connecting to source 'nyc-db'. Ensure the database
exists and the connection properties are correct. Full Error: Catalog Error:
Cannot launch in-memory database in read-only mode!
```

Root cause: DuckDB rejects `read_only=True` on `":memory:"` outright, and every introspection/query path (`get_schema`, `list_databases`, `_get_available_tables_from_duckdb`, …) defaults to `read_only=True`. A `":memory:"` primary could therefore never connect for anything but a write-flagged call.

Fix: an in-memory database is never persisted, so read-only has nothing to protect — force `read_only=False` whenever `database == ":memory:"`, before it reaches `duckdb.connect()`.

Note this doesn't make `attach:`-based remote sources fully first-class: `get_schema()` only introspects the primary connection's `main` schema, so attached tables won't show up for column autocomplete/ERD even though model SQL querying `schema.table` works fine at run time. Flagging in case a follow-up to support `database: <url>` directly is wanted — that would sidestep this gap entirely since the remote db's tables would just be `main`.

## Test plan
- [x] New test `test_DuckdbSource_memory_database_ignores_read_only`: confirms `get_connection(read_only=True)` on a `":memory:"` source connects and is actually writable. Confirmed it reproduces the exact reported error against the pre-fix code.
- [x] `poetry run pytest tests/` — 2596 passed.
- [x] `poetry run black --check visivo/ tests/models/sources/test_duckdb_source.py` — clean.
- [x] Reproduced live against the real reported URL (`https://github.com/visivo-io/nyc-cuisine-dashboard/raw/refs/heads/main/nyc_food.duckdb`) via `attach:` through the actual `DuckdbSource`/`DuckdbAttachment` classes — `get_schema()` now returns cleanly instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)